### PR TITLE
[harfbuzz] Update to 8.5.0

### DIFF
--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
     REF ${VERSION}
-    SHA512 c90fc8f67ed6d75536a6a0d83434c51756863e51631f00fa390d124d721b003cba4739777b51ac2e9f107914eb5e2ab3daa00dab257435800bb60ff6d5dd45f6
+    SHA512 e3f72335d574d34556149c688cead7c040c1d49e639c40dcaeda3b00c9c31441ff391c3ced65b89c1d082d26bbf46b9a3cac3a92ecd08c356ba92b41726d4ae5
     HEAD_REF master
     PATCHES
         fix-win32-build.patch

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "harfbuzz",
-  "version": "8.4.0",
-  "port-version": 1,
+  "version": "8.5.0",
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3353,8 +3353,8 @@
       "port-version": 0
     },
     "harfbuzz": {
-      "baseline": "8.4.0",
-      "port-version": 1
+      "baseline": "8.5.0",
+      "port-version": 0
     },
     "hash-library": {
       "baseline": "8",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d5e91f387f0b4347918c04f3ac94a0643fc72423",
+      "version": "8.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cf348ecae022fb9ccfd58be64fcd90008e1fb74d",
       "version": "8.4.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

