### PR TITLE
[libgpiod] update to 2.1.2

### DIFF
--- a/ports/libgpiod/portfile.cmake
+++ b/ports/libgpiod/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-9068bb08dc3bf183eee6de2577ad266fe6b8f434.tar.gz
+    URLS https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${VERSION}.tar.gz
     FILENAME libgpiod-${VERSION}.tar.gz
-    SHA512 3c569471007d12d94cb74377187dfe8b979de08f3747dca6348a4212ffb6d5f699af1d1135c25c70bcd17d533b09499fd0f1b3c5deac7d0a2d1bbf31092033c3
+    SHA512 e3401d9d5b48e4da29494a5fa7738df80b1db7cb7e75e24067d44cc4bae5661cf7364e9722b5f588d4e813da8b2abd18dde29d5a118049b4a36d2a1df0c432a0
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/libgpiod/vcpkg.json
+++ b/ports/libgpiod/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgpiod",
-  "version": "2.1",
+  "version": "2.1.2",
   "description": "C library and tools for interacting with the linux GPIO character device",
   "homepage": "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4465,7 +4465,7 @@
       "port-version": 0
     },
     "libgpiod": {
-      "baseline": "2.1",
+      "baseline": "2.1.2",
       "port-version": 0
     },
     "libgpod": {

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "995bfe35a0f8c636bd8e811a886d6802e91c3658",
+      "version": "2.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "713a85c4d9f0bd1ac4875689d6fde524ba416f33",
       "version": "2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
