### PR TITLE
[qtdeclarative] Fix post-build check problem

### DIFF
--- a/ports/qtdeclarative/portfile.cmake
+++ b/ports/qtdeclarative/portfile.cmake
@@ -25,6 +25,7 @@ set(${PORT}_PATCHES
         qmltc
         qmlls
         qmljsrootgen
+        svgtoqml
     )
 
 qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
@@ -34,7 +35,3 @@ qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
                      CONFIGURE_OPTIONS_RELEASE
                      CONFIGURE_OPTIONS_DEBUG
                     )
-
-if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/svgtoqml.exe")
-    vcpkg_copy_tools(TOOL_NAMES svgtoqml AUTO_CLEAN)
-endif()

--- a/ports/qtdeclarative/portfile.cmake
+++ b/ports/qtdeclarative/portfile.cmake
@@ -34,3 +34,7 @@ qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
                      CONFIGURE_OPTIONS_RELEASE
                      CONFIGURE_OPTIONS_DEBUG
                     )
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/svgtoqml.exe")
+    vcpkg_copy_tools(TOOL_NAMES svgtoqml AUTO_CLEAN)
+endif()

--- a/ports/qtdeclarative/vcpkg.json
+++ b/ports/qtdeclarative/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtdeclarative",
   "version": "6.7.0",
+  "port-version": 1,
   "description": "Qt Declarative (Quick 2)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7338,7 +7338,7 @@
     },
     "qtdeclarative": {
       "baseline": "6.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qtdeviceutilities": {
       "baseline": "6.7.0",

--- a/versions/q-/qtdeclarative.json
+++ b/versions/q-/qtdeclarative.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6bf46f28f34f0cca4c87a34a0c80757a0828d371",
+      "git-tree": "dfd28dda0cd26e82d30f9a9e627c951c28aa88a3",
       "version": "6.7.0",
       "port-version": 1
     },

--- a/versions/q-/qtdeclarative.json
+++ b/versions/q-/qtdeclarative.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6bf46f28f34f0cca4c87a34a0c80757a0828d371",
+      "version": "6.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c7735c31022b2d41f5e0af9e727fc73cd4146a52",
       "version": "6.7.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #38720. After installing `qtsvg`, a post-build check problem will occur when installing `qtdeclarative`. Fix it here:
```
-- Performing post-build validation
warning: The following EXEs were found in /bin or /debug/bin. EXEs are not valid distribution targets.

  E:\all\vcpkg\packages\qtdeclarative_x64-windows-release\bin\svgtoqml.exe

error: Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: E:\all\vcpkg\ports\qtdeclarative\portfile.cmake
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
