### PR TITLE
[xgboost] Add open-source library xgboost to vcpkg

### DIFF
--- a/ports/xgboost/portfile.cmake
+++ b/ports/xgboost/portfile.cmake
@@ -1,0 +1,47 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dmlc/xgboost
+    REF v${VERSION}
+    SHA512 4465f383df70ee415faaeb745459bfc413f71bff0d02e59e67173975188bed911044dbea1a456550496f8c5a7c0b50002275b6be72c87386a6118485e1e41829
+    HEAD_REF master
+)
+
+# Set the expected path of the dmlc-core directory inside the xgboost source directory
+vcpkg_from_github(
+    OUT_SOURCE_PATH DMLC_CORE_SRC
+    REPO dmlc/dmlc-core
+    REF 81db539486ce6525b31b971545edffee2754aced
+    SHA512 9b288fd1ceeef0015e80b0296b0d4015238d4cc1b7c36ba840d3eabce87508e62ed5b4fe61504f569dadcc414882903211fadf54aa0e162a896b03d7ca05e975
+    HEAD_REF master
+)
+
+# Custom CMake script to move dmlc-core to the correct location
+file(REMOVE_RECURSE "${SOURCE_PATH}/dmlc-core")
+file(RENAME "${DMLC_CORE_SRC}" "${SOURCE_PATH}/dmlc-core")
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+# Configure and build dmlc-core first
+# vcpkg_cmake_configure(
+#     SOURCE_PATH "${SOURCE_PATH}/dmlc-core"
+# )
+
+# vcpkg_cmake_install()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_cmake_install()
+
+# Adjustments to address the warnings
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(PACKAGE_NAME xgboost CONFIG_PATH "lib/cmake")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+

--- a/ports/xgboost/portfile.cmake
+++ b/ports/xgboost/portfile.cmake
@@ -21,13 +21,6 @@ file(RENAME "${DMLC_CORE_SRC}" "${SOURCE_PATH}/dmlc-core")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-# Configure and build dmlc-core first
-# vcpkg_cmake_configure(
-#     SOURCE_PATH "${SOURCE_PATH}/dmlc-core"
-# )
-
-# vcpkg_cmake_install()
-
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
 )

--- a/ports/xgboost/vcpkg.json
+++ b/ports/xgboost/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "xgboost",
+  "version": "1.7.6",
+  "description": [
+    "XGBoost is an optimized distributed gradient boosting library designed to be highly efficient, flexible and portable. It implements machine learning algorithms under the Gradient Boosting framework.",
+    "XGBoost provides a parallel tree boosting (also known as GBDT, GBM) that solve many data science problems in a fast and accurate way.",
+    "The same code runs on major distributed environment (Kubernetes, Hadoop, SGE, Dask, Spark, PySpark) and can solve problems beyond billions of examples."
+  ],
+  "homepage": "https://github.com/dmlc/xgboost",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9480,6 +9480,10 @@
       "baseline": "0.3.0",
       "port-version": 3
     },
+    "xgboost": {
+      "baseline": "1.7.6",
+      "port-version": 0
+    },
     "xlnt": {
       "baseline": "1.5.0",
       "port-version": 4

--- a/versions/x-/xgboost.json
+++ b/versions/x-/xgboost.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "91c2544c4e0b9935c1f06ea49f696529d58f7795",
+      "git-tree": "d32bb3395747b60ba0aba81d5cbe74c37bba82ca",
       "version": "1.7.6",
       "port-version": 0
     }

--- a/versions/x-/xgboost.json
+++ b/versions/x-/xgboost.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "91c2544c4e0b9935c1f06ea49f696529d58f7795",
+      "version": "1.7.6",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add open-source library xgboost to vcpkg
xgboost github repo: https://github.com/dmlc/xgboost/
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
