### PR TITLE
[scnlib] Fix include CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/ports/scnlib/portfile.cmake
+++ b/ports/scnlib/portfile.cmake
@@ -10,6 +10,16 @@ vcpkg_download_distfile(PATCH_20240406_2_5c4b91e
     SHA512 8af9695729ab906066aa7db16733796e45f824c7711ca72a13273438c510bed38d7fb2884861e70d1178f67c8b0e8ff4d0bff9a16ba434becb60a87dcb6269b5
     FILENAME 5c4b91ef1e2bbc29420e37b655bd8194afa19efc.patch
 )
+vcpkg_download_distfile(PATCH_20240515_3_15c3547
+    URLS https://github.com/eliaskosunen/scnlib/commit/15c3547b408391d7314e29bd23f35af36683a907.patch?full_index=1
+    SHA512 006378ad92c68b2786e14a7da76a7397a600cccb18163bf73e68ab0c3019067b9bec99ed2f86499d8cb2e2758d0ea1bf2c3ca98b6ab72e41f82037caeaff8298
+    FILENAME 15c3547b408391d7314e29bd23f35af36683a907.patch
+)
+vcpkg_download_distfile(PATCH_20240515_6_e149892
+    URLS https://github.com/eliaskosunen/scnlib/commit/e1498927e8f0367796d1643b65482861c1b4c9b1.patch?full_index=1
+    SHA512 d584b883a8dced18fdbec3846f93dfbf68633127354168199f986404c1404e80049798b7f4df5352315c9c2c5691ae5d5746fa5234c47631c38752aec73ad861
+    FILENAME e1498927e8f0367796d1643b65482861c1b4c9b1.patch
+)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -21,12 +31,14 @@ vcpkg_from_github(
         fix-SCN_HAS_STD_REGEX_MULTILINE-marco.patch
         "${PATCH_20240406_1_97baaf2}"
         "${PATCH_20240406_2_5c4b91e}"
+        "${PATCH_20240515_3_15c3547}"
+        "${PATCH_20240515_6_e149892}"
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-      -DSCN_TESTS=OFF 
+      -DSCN_TESTS=OFF
       -DSCN_EXAMPLES=OFF
       -DSCN_BENCHMARKS=OFF
       -DSCN_DOCS=OFF
@@ -37,12 +49,10 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/scn)
 
-file(REMOVE_RECURSE 
+file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
     "${CURRENT_PACKAGES_DIR}/share/scn"
 )
 
-file(INSTALL "${SOURCE_PATH}/LICENSE"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-    RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/scnlib/vcpkg.json
+++ b/ports/scnlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "scnlib",
   "version": "2.0.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "scnlib is a modern C++ library for replacing scanf and std::istream",
   "homepage": "https://scnlib.dev/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7910,7 +7910,7 @@
     },
     "scnlib": {
       "baseline": "2.0.2",
-      "port-version": 2
+      "port-version": 3
     },
     "scope-guard": {
       "baseline": "1.1.0",

--- a/versions/s-/scnlib.json
+++ b/versions/s-/scnlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14d61103894e6ff0c14d3b2db7727c18d725982a",
+      "version": "2.0.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "17567901d2d2e06776b74ce27ab8c612901cb9af",
       "version": "2.0.2",
       "port-version": 2


### PR DESCRIPTION
Fixes include `CMAKE_INSTALL_INCLUDEDIR` since target `scn::scn` lost `INTERFACE_INCLUDE_DIRECTORIES`,

Fixed by backporting upstream patches in https://github.com/eliaskosunen/scnlib/pull/111.

Format and unify `EOL` to `LF` of `portfile.cmake`.

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
The port usage tests pass with the following triplets:
* x64-linux
* x64-windows