### PR TITLE
[avcpp] Update to 2.3.2

### DIFF
--- a/ports/avcpp/portfile.cmake
+++ b/ports/avcpp/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO h4tr3d/avcpp
     REF "v${VERSION}"
-    SHA512 10e3ab6bb52ceee2f7d6ea9364dbf5f09fdab5b10f34920f1a1df93ad853e0a4b3de9b554be8482d8444b62e10160c3e26f37907fee217bc9d5728329e06ad85
+    SHA512 b653dbc761f90ab9c91d8e20839e4763bc894cfa8c52943278237c5a0db1fa8683c47bd28b1b35c8c466d0a27339f34b162f7380ff74d99fbcdc82141eae3f84
     HEAD_REF master
     PATCHES
         0002-av_init_packet_deprecation.patch

--- a/ports/avcpp/vcpkg.json
+++ b/ports/avcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "avcpp",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "description": "Wrapper for the FFmpeg that simplify usage it from C++ projects.",
   "homepage": "https://github.com/h4tr3d/avcpp",
   "license": "LGPL-2.1-only OR BSD-3-Clause",

--- a/versions/a-/avcpp.json
+++ b/versions/a-/avcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35a98b8fdd34b26ecfcb2a8d79f4eb288c2a800b",
+      "version": "2.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "0536c50812252994282f92dc60c6be989da16ed3",
       "version": "2.3.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -353,7 +353,7 @@
       "port-version": 2
     },
     "avcpp": {
-      "baseline": "2.3.0",
+      "baseline": "2.3.2",
       "port-version": 0
     },
     "avisynthplus": {


### PR DESCRIPTION
Update `avcpp` to 2.3.2.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

