### PR TITLE
[vcpkg baseline][libsoup] disable search krb5 to fix ci pinpline error

### DIFF
--- a/ports/libsoup/portfile.cmake
+++ b/ports/libsoup/portfile.cmake
@@ -14,6 +14,8 @@ vcpkg_configure_meson(
         -Ddocs=disabled
         -Dtests=false
         -Ddoc_tests=false
+        -Dkrb5_config=false
+        -Dgssapi=disabled
     ADDITIONAL_BINARIES
         "gio-querymodules = '${CURRENT_HOST_INSTALLED_DIR}/tools/glib/gio-querymodules${CMAKE_EXECUTABLE_SUFFIX}'"
         "glib-compile-schemas = '${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-schemas${CMAKE_EXECUTABLE_SUFFIX}'"

--- a/ports/libsoup/vcpkg.json
+++ b/ports/libsoup/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libsoup",
   "version": "3.4.4",
+  "port-version": 1,
   "description": "HTTP Library for GLib",
   "homepage": "https://libsoup.org",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4978,7 +4978,7 @@
     },
     "libsoup": {
       "baseline": "3.4.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libspatialindex": {
       "baseline": "1.9.3",

--- a/versions/l-/libsoup.json
+++ b/versions/l-/libsoup.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cbe5884e8d78060a81c7d6b52ff1f69f059550d2",
+      "version": "3.4.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "967e4400de0619b73df7b3a48e392b36fa4cf6ba",
       "version": "3.4.4",
       "port-version": 0


### PR DESCRIPTION
Fixes  regression: https://dev.azure.com/vcpkg/public/_build/results?buildId=102737&view=results
````
REGRESSION: libsoup:x64-linux failed with BUILD_FAILED
````
Error:
````
/mnt/vcpkg-ci/b/krb5/x64-linux-dbg/util/et/../.././../src/krb5-1-8a38cd677f.clean/src/include/k5-thread.h:381: undefined reference to `k5_os_mutex_unlock'
````
Installation order issue. libsoup automatically detect the presence of krb5 and use it. Then the binary artifacts depend on krb5 binaries without declaring them. So disable auto-detection of krb5 in libsoup.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
