### PR TITLE
[bddisasm] Update to 2.1.4

### DIFF
--- a/ports/bddisasm/portfile.cmake
+++ b/ports/bddisasm/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bitdefender/bddisasm
     REF "v${VERSION}"
-    SHA512 307a341eeaddf6ba6858ee0f5c4c51d20e82ad5c5e977a9a40bed94266a5d1d05164a0dca0ee9bf3f6a0b4613e6c82a78a1118c09fc623c9b09fe8d0872da6d2
+    SHA512 60e823845318e2608c9909462299512f2b932323bf527e45b859f61958e884c6ccff6b11aecb40edb8d628278a57e37ac49f0ca2a351763746fc7e5f792381e1
     HEAD_REF master
 )
 
@@ -16,11 +16,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(INSTALL
-    ${SOURCE_PATH}/LICENSE
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
-    RENAME copyright
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/bddisasm)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/bddisasm/vcpkg.json
+++ b/ports/bddisasm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bddisasm",
-  "version": "2.1.0",
+  "version": "2.1.4",
   "maintainers": "Cristi Anichitei <ianichitei@bitdefender.com>",
   "description": "bddisasm is a fast, lightweight, x86/x64 instruction decoder and emulator.",
   "homepage": "https://github.com/bitdefender/bddisasm",

--- a/versions/b-/bddisasm.json
+++ b/versions/b-/bddisasm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f7d00a557af383dde3f48d12ddedecf4117c9ce",
+      "version": "2.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "26b6c5584f03700f47ff9d457df6f16dfdaebdba",
       "version": "2.1.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -553,7 +553,7 @@
       "port-version": 3
     },
     "bddisasm": {
-      "baseline": "2.1.0",
+      "baseline": "2.1.4",
       "port-version": 0
     },
     "bde": {


### PR DESCRIPTION
Update `bddisasm` to the latest version 2.1.4.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
