### PR TITLE
[vcpkg-get-python-packages] Cache packages via pip precandidate

### DIFF
--- a/ports/vcpkg-tool-python-buildtime-e2e/portfile.cmake
+++ b/ports/vcpkg-tool-python-buildtime-e2e/portfile.cmake
@@ -1,0 +1,3 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_install_copyright(FILE_LIST "${VCPKG_ROOT_DIR}/LICENSE.txt")

--- a/ports/vcpkg-tool-python-buildtime-e2e/vcpkg.json
+++ b/ports/vcpkg-tool-python-buildtime-e2e/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "vcpkg-tool-python-buildtime-e2e",
+  "version-semver": "0.0.0-alpha.202405",
+  "description": "temp test",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-python-buildtime",
+      "host": true
+    }
+  ]
+}

--- a/ports/vcpkg-tool-python-buildtime/download.json
+++ b/ports/vcpkg-tool-python-buildtime/download.json
@@ -1,0 +1,112 @@
+{
+    "$comment": "Not implemented. It may be possible to allow downloading of declared network resources ahead of building",
+    "$version": "0.0.0-alpha.202405",
+    "$not-implemented-temp-config": {
+        "github-raw": {
+            "pip-24.0.pyz": {
+                "uri": "pypa/get-pip/raw/24.0/public/pip.pyz",
+                "sha512": "116663087f4aa45a2bae3d9a5fb01a754269b4034c4d913ac0364093882827ebe15e076d109b8ffb4e4256bf557cd64cc03b8fa375aa70287731fe3f0adb6f65",
+                "tags": [
+                    "pip.pyz",
+                    "private"
+                ]
+            },
+            "virtualenv-20.26.2.pyz": {
+                "uri": "pypa/get-virtualenv/raw/20.26.2/public/virtualenv.pyz",
+                "sha512": "2bfa9c0561eed6b87746b0719b15cce9caac392a59a661a4383b5eeae1fdff3370ae41c5453193100860bbbb563590b4fbf23443e2589a5363538e9cd81ab6c4",
+                "tags": [
+                    "private",
+                    "virtualenv.pyz"
+                ]
+            }
+        },
+        "pypi": {
+            "$mirrors": {
+                "https://files.pythonhosted.org/": [
+                    "https://pypi.tuna.tsinghua.edu.cn/"
+                ]
+            },
+            "pip-24.0-py3-none-any.whl": {
+                "blake2b-256": "8a6a19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b",
+                "sha512": "d212edd21ab99f50c2daf6080c68a3cc0eeed566f10e91f857e7eeb86513f33e9cde25b975db1030110c3b1714cfbfd4d3c9e2937b4a5ff2bb8971e605ecee85",
+                "tags": [
+                    "constraints",
+                    "private"
+                ]
+            },
+            "setuptools-69.5.1-py3-none-any.whl": {
+                "blake2b-256": "f72913965af254e3373bceae8fb9a0e6ea0d0e571171b80d6646932131d6439b",
+                "sha512": "d212edd21ab99f50c2daf6080c68a3cc0eeed566f10e91f857e7eeb86513f33e9cde25b975db1030110c3b1714cfbfd4d3c9e2937b4a5ff2bb8971e605ecee85",
+                "tags": [
+                    "constraints",
+                    "private"
+                ]
+            },
+            "wheel-0.43.0-py3-none-any.whl": {
+                "blake2b-256": "7dcdd7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce",
+                "sha512": "5a637264ee0eba127aa72a372b111fe8a61f454fbd3fc02b39590fd2c6bf6f5e9ac4b0e18fd16ff5fdbb9f4b046c9237fd56b055c4cb595fb042e5aa94b336c5",
+                "tags": [
+                    "constraints",
+                    "private"
+                ]
+            },
+            "packaging-24.0-py3-none-any.whl": {
+                "blake2b-256": "49df1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422",
+                "sha512": "9d2c31701a4d3fef553928c00528a48f9e1854ab5333528b50e358a214eba90029d687f039bcda5760b6fdf9f2de3bcf3784ae21a6374cf2a97a845d33b636c6",
+                "tags": [
+                    "constraints"
+                ]
+            },
+            "meson-1.4.0-py3-none-any.whl": {
+                "blake2b-256": "3375b1a37fa7b2dbca8c0dbb04d5cdd7e2720c8ef6febe41b4a74866350e041c",
+                "sha512": "481760e37958fdda993a8a2541cd0515a29eb95197847359673914dc05a1b623a9871a86616a8f35831051a20bef1c9d4f979c8653c7e3905d148e03291fbd63",
+                "tags": []
+            },
+            "meson-1.3.2-py3-none-any.whl": {
+                "blake2b-256": "397cff115bec047c5127567048db40818b83b47fd0d3bfcfd0d87630d44ed66f",
+                "sha512": "1b7061fc6e36ae9c62d43d47ccccbab8a14752db4756d5ad546a1a7d0730f58b7b026a305b41b252ce1cda0cec65681a88bc61bd996fd261585e582e3304c134",
+                "tags": [
+                    "constraints"
+                ]
+            }
+        }
+    },
+    "items": {
+        "python-3.12.3-embed-win32.zip": {
+            "url": "https://www.python.org/ftp/python/3.12.3/python-3.12.3-embed-win32.zip",
+            "sha512": "c26a80c3f1e5c8c684cd9ea8f2670c0cc8333222284c5e246441ea6c33b6e1e17b381eae638fca50b9c8feaf80e60dba87cc65592e1877bdaf99ae21627e4626"
+        },
+        "pip-24.0.pyz": {
+            "url": "https://github.com/pypa/get-pip/raw/24.0/public/pip.pyz?raw=true",
+            "sha512": "116663087f4aa45a2bae3d9a5fb01a754269b4034c4d913ac0364093882827ebe15e076d109b8ffb4e4256bf557cd64cc03b8fa375aa70287731fe3f0adb6f65"
+        },
+        "virtualenv-20.26.2.pyz": {
+            "url": "https://github.com/pypa/get-virtualenv/raw/20.26.2/public/virtualenv.pyz?raw=true",
+            "sha512": "2bfa9c0561eed6b87746b0719b15cce9caac392a59a661a4383b5eeae1fdff3370ae41c5453193100860bbbb563590b4fbf23443e2589a5363538e9cd81ab6c4"
+        },
+        "pip-24.0-py3-none-any.whl": {
+            "url": "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
+            "sha512": "9d2c31701a4d3fef553928c00528a48f9e1854ab5333528b50e358a214eba90029d687f039bcda5760b6fdf9f2de3bcf3784ae21a6374cf2a97a845d33b636c6"
+        },
+        "setuptools-69.5.1-py3-none-any.whl": {
+            "url": "https://files.pythonhosted.org/packages/f7/29/13965af254e3373bceae8fb9a0e6ea0d0e571171b80d6646932131d6439b/setuptools-69.5.1-py3-none-any.whl",
+            "sha512": "d212edd21ab99f50c2daf6080c68a3cc0eeed566f10e91f857e7eeb86513f33e9cde25b975db1030110c3b1714cfbfd4d3c9e2937b4a5ff2bb8971e605ecee85"
+        },
+        "wheel-0.43.0-py3-none-any.whl": {
+            "url": "https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl",
+            "sha512": "5a637264ee0eba127aa72a372b111fe8a61f454fbd3fc02b39590fd2c6bf6f5e9ac4b0e18fd16ff5fdbb9f4b046c9237fd56b055c4cb595fb042e5aa94b336c5"
+        },
+        "packaging-24.0-py3-none-any.whl": {
+            "url": "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
+            "sha512": "9d2c31701a4d3fef553928c00528a48f9e1854ab5333528b50e358a214eba90029d687f039bcda5760b6fdf9f2de3bcf3784ae21a6374cf2a97a845d33b636c6"
+        },
+        "meson-1.4.0-py3-none-any.whl": {
+            "url": "https://files.pythonhosted.org/packages/33/75/b1a37fa7b2dbca8c0dbb04d5cdd7e2720c8ef6febe41b4a74866350e041c/meson-1.4.0-py3-none-any.whl",
+            "sha512": "481760e37958fdda993a8a2541cd0515a29eb95197847359673914dc05a1b623a9871a86616a8f35831051a20bef1c9d4f979c8653c7e3905d148e03291fbd63"
+        },
+        "meson-1.3.2-py3-none-any.whl": {
+            "url": "https://files.pythonhosted.org/packages/33/75/b1a37fa7b2dbca8c0dbb04d5cdd7e2720c8ef6febe41b4a74866350e041c/meson-1.3.2-py3-none-any.whl",
+            "sha512": "1b7061fc6e36ae9c62d43d47ccccbab8a14752db4756d5ad546a1a7d0730f58b7b026a305b41b252ce1cda0cec65681a88bc61bd996fd261585e582e3304c134"
+        }
+    }
+}

--- a/ports/vcpkg-tool-python-buildtime/pip_constraints.txt
+++ b/ports/vcpkg-tool-python-buildtime/pip_constraints.txt
@@ -1,0 +1,5 @@
+meson==1.4.0
+packaging==24.0
+pip==24.0
+setuptools==69.5.1
+wheel==0.43.0

--- a/ports/vcpkg-tool-python-buildtime/pip_prepare_candidate.diff
+++ b/ports/vcpkg-tool-python-buildtime/pip_prepare_candidate.diff
@@ -1,0 +1,89 @@
+diff --git a/_internal/commands/__init__.py b/_internal/commands/__init__.py
+index 858a410..71d6f34 100644
+--- a/_internal/commands/__init__.py
++++ b/_internal/commands/__init__.py
+@@ -18,6 +18,11 @@ CommandInfo = namedtuple("CommandInfo", "module_path, class_name, summary")
+ # prefix, the full path makes testing easier (specifically when modifying
+ # `commands_dict` in test setup / teardown).
+ commands_dict: Dict[str, CommandInfo] = {
++    "prepare-candidate": CommandInfo(
++        "pip._internal.commands.prepare_candidate",
++        "PrepareCandidateCommand",
++        "Prepare candidate of packages.",
++    ),
+     "install": CommandInfo(
+         "pip._internal.commands.install",
+         "InstallCommand",
+diff --git a/_internal/commands/prepare_candidate.py b/_internal/commands/prepare_candidate.py
+new file mode 100644
+index 0000000..feebb30
+--- /dev/null
++++ b/_internal/commands/prepare_candidate.py
+@@ -0,0 +1,20 @@
++from optparse import Values
++from typing import List
++
++from pip._internal.cli.status_codes import SUCCESS
++from pip._internal.commands.install import InstallCommand
++
++import pip._internal.prepare_candidate_config as lic # type: ignore
++
++class PrepareCandidateCommand(InstallCommand):
++    def run(self, options: Values, args: List[str]) -> int:
++
++        lic.enable()
++        options.dry_run = True
++        try:
++            super().run(options, args)
++        except lic.PrepareCandidateException as e:
++            lic.prep_candidates_csv = str(e)
++
++        lic.print_prep_candidates()
++        return SUCCESS
+diff --git a/_internal/prepare_candidate_config.py b/_internal/prepare_candidate_config.py
+new file mode 100644
+index 0000000..024440c
+--- /dev/null
++++ b/_internal/prepare_candidate_config.py
+@@ -0,0 +1,23 @@
++import os
++from typing import List
++from urllib.parse import urlparse, unquote
++
++find_candidate: bool = False
++env_var: str = 'PREPARE_CANDIDATE_DOWNLOADED'
++candidates_downloaded: List[str] = []
++prep_candidates_csv: str = ''
++
++def enable() -> None:
++    global find_candidate
++    find_candidate = True
++    if env_var in os.environ:
++        candidates_downloaded.extend(os.environ[env_var].split(';'))
++
++def print_prep_candidates() -> None:
++    print(f'==PREP_CANDIDATES=[{prep_candidates_csv}]==')
++
++def filename_from_uri(uri:str) -> str:
++    return os.path.basename(unquote(urlparse(uri).path))
++
++class PrepareCandidateException(Exception):
++    pass
+diff --git a/_internal/resolution/resolvelib/factory.py b/_internal/resolution/resolvelib/factory.py
+index 4adeb43..e2305c4 100644
+--- a/_internal/resolution/resolvelib/factory.py
++++ b/_internal/resolution/resolvelib/factory.py
+@@ -301,6 +301,13 @@ class Factory:
+             )
+             icans = list(result.iter_applicable())
+ 
++            import pip._internal.prepare_candidate_config as lic # type: ignore
++            if lic.find_candidate:
++                cadicate_list = [lic.filename_from_uri(ican.link._url) for ican in icans]
++                prep_candidates = [candidate for candidate in cadicate_list if candidate not in lic.candidates_downloaded]
++                if prep_candidates:
++                    raise lic.PrepareCandidateException(';'.join(prep_candidates))
++
+             # PEP 592: Yanked releases are ignored unless the specifier
+             # explicitly pins a version (via '==' or '===') that can be
+             # solely satisfied by a yanked release.

--- a/ports/vcpkg-tool-python-buildtime/portfile.cmake
+++ b/ports/vcpkg-tool-python-buildtime/portfile.cmake
@@ -1,0 +1,12 @@
+set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
+
+file(INSTALL
+        "${CMAKE_CURRENT_LIST_DIR}/download.json"
+        "${CMAKE_CURRENT_LIST_DIR}/pip_constraints.txt"
+        "${CMAKE_CURRENT_LIST_DIR}/pip_prepare_candidate.diff"
+        "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake"
+        "${CMAKE_CURRENT_LIST_DIR}/vcpkg-tool-python-buildtime.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+vcpkg_install_copyright(FILE_LIST "${VCPKG_ROOT_DIR}/LICENSE.txt")

--- a/ports/vcpkg-tool-python-buildtime/vcpkg-port-config.cmake
+++ b/ports/vcpkg-tool-python-buildtime/vcpkg-port-config.cmake
@@ -1,0 +1,3 @@
+include("${CMAKE_CURRENT_LIST_DIR}/vcpkg-tool-python-buildtime.cmake")
+
+message("==== ports/vcpkg-tool-python-buildtime/vcpkg-port-config.cmake")

--- a/ports/vcpkg-tool-python-buildtime/vcpkg-tool-python-buildtime.cmake
+++ b/ports/vcpkg-tool-python-buildtime/vcpkg-tool-python-buildtime.cmake
@@ -1,0 +1,12 @@
+include_guard(GLOBAL)
+
+message("==== ports/vcpkg-tool-python-buildtime/vcpkg-tool-python-buildtime.cmake")
+
+function(x_vcpkg_tool_python_buildtime)
+    cmake_parse_arguments(PARSE_ARGV 0 arg
+        ""
+        ""
+        ""
+    )
+
+endfunction()

--- a/ports/vcpkg-tool-python-buildtime/vcpkg.json
+++ b/ports/vcpkg-tool-python-buildtime/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "vcpkg-tool-python-buildtime",
+  "version-semver": "0.0.0-alpha.202405+pypi-202405-cpython-3.12.3",
+  "description": "Find Python installation and packages, optionally download and create virtual environment as fallback",
+  "license": "MIT",
+  "supports": "native",
+  "features": {
+    "pre-download": {
+      "description": "Pre-download candidate resources for current port"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9128,6 +9128,14 @@
       "baseline": "16.18.0",
       "port-version": 1
     },
+    "vcpkg-tool-python-buildtime": {
+      "baseline": "0.0.0-alpha.202405+pypi-202405-cpython-3.12.3",
+      "port-version": 0
+    },
+    "vcpkg-tool-python-buildtime-e2e": {
+      "baseline": "0.0.0-alpha.202405",
+      "port-version": 0
+    },
     "vcpkg-tool-python2": {
       "baseline": "2.7.18",
       "port-version": 1

--- a/versions/v-/vcpkg-tool-python-buildtime-e2e.json
+++ b/versions/v-/vcpkg-tool-python-buildtime-e2e.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "15b70cbbbd966ceb10441bdbb0126cef70ca4bb9",
+      "version-semver": "0.0.0-alpha.202405",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/v-/vcpkg-tool-python-buildtime.json
+++ b/versions/v-/vcpkg-tool-python-buildtime.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2fc6f7ccee7087bbbf5636fac9d0aa73f2598e47",
+      "version-semver": "0.0.0-alpha.202405+pypi-202405-cpython-3.12.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
~WIP~
=

### Abstract

Download `pypi` packages by `vcpkg_download_distfile`, then install packages offline.

Fix https://github.com/microsoft/vcpkg/pull/37473#pullrequestreview-2044562448. And any other port that depends on `pip install`.

### Changes

* Bootstrap virtual environment with runtime which has neither standard library `venv` nor `pip` (i.e. Embedded Python)
* Add `pip` command `precandidate` to obtain the candidate package filename during local installation
* Download packages by `vcpkg_download_distfile`

~WIP~
=