### PR TITLE
[7zip] Add export header file

### DIFF
--- a/ports/7zip/CMakeLists.txt
+++ b/ports/7zip/CMakeLists.txt
@@ -420,11 +420,17 @@ install(FILES ${HEADERS} DESTINATION "include/7zip/C")
 file(GLOB HEADERS "${CMAKE_CURRENT_LIST_DIR}/CPP/Common/*.h")
 install(FILES ${HEADERS} DESTINATION "include/7zip/CPP/Common")
 
+file(GLOB HEADERS "${CMAKE_CURRENT_LIST_DIR}/CPP/Windows/*.h")
+install(FILES ${HEADERS} DESTINATION "include/7zip/CPP/Windows")
+
 file(GLOB HEADERS "${CMAKE_CURRENT_LIST_DIR}/CPP/7zip/*.h")
 install(FILES ${HEADERS} DESTINATION "include/7zip/CPP/7zip")
 
 file(GLOB HEADERS "${CMAKE_CURRENT_LIST_DIR}/CPP/7zip/Archive/*.h")
 install (FILES ${HEADERS} DESTINATION "include/7zip/CPP/7zip/Archive")
+
+file(GLOB HEADERS "${CMAKE_CURRENT_LIST_DIR}/CPP/7zip/Common/*.h")
+install (FILES ${HEADERS} DESTINATION "include/7zip/CPP/7zip/Common")
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(

--- a/ports/7zip/vcpkg.json
+++ b/ports/7zip/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "7zip",
   "version-string": "23.01",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Library for archiving file with a high compression ratio.",
   "homepage": "https://www.7-zip.org",
   "license": "LGPL-2.1-or-later",

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cdfe657550edf92516a3b7c51331c619de7e72c0",
+      "version-string": "23.01",
+      "port-version": 3
+    },
+    {
       "git-tree": "23256cddd31991c2df4d96a07fc016fd446c2d2d",
       "version-string": "23.01",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6,7 +6,7 @@
     },
     "7zip": {
       "baseline": "23.01",
-      "port-version": 2
+      "port-version": 3
     },
     "ableton": {
       "baseline": "3.0.6",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/38761
Add the installation of header files `CPP\Windows` and `CPP\7zip\Common`.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
```