### PR TITLE
[gdk-pixbuf] Update to 2.42.12

### DIFF
--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/gdk-pixbuf
     REF "${VERSION}"
-    SHA512 5b7ddb6e816a88ffd2b7f85583c841ea92719bef7da1acbd6f5714afebf8538660c5d391809f959eb1887613f9579cf51c85d6796c84335cedbf7af975d790c9
+    SHA512 f95c92974ed6efac9845790ef5c4ed74dd6e28b182ea3732013c46b016166e92f8bc10c1994358d79ff53e988c615c43cb1a2130c6ef531ef9d84c2fdcc87e52
     HEAD_REF master
     PATCHES
         fix_build_error_windows.patch

--- a/ports/gdk-pixbuf/vcpkg.json
+++ b/ports/gdk-pixbuf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gdk-pixbuf",
-  "version": "2.42.10",
-  "port-version": 6,
+  "version": "2.42.12",
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2969,8 +2969,8 @@
       "port-version": 1
     },
     "gdk-pixbuf": {
-      "baseline": "2.42.10",
-      "port-version": 6
+      "baseline": "2.42.12",
+      "port-version": 0
     },
     "gemmlowp": {
       "baseline": "2021-09-28",

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bbf12c7f576f4ecae98d0b4d8cdc0f5fc07f24fb",
+      "version": "2.42.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "20f10a57d8a363c929b92c881e25750db32f59fe",
       "version": "2.42.10",
       "port-version": 6


### PR DESCRIPTION
Fixes #38788 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

