### PR TITLE
[vcpkg-tool-meson] Fix warnings, cmake, llvm 18

### DIFF
--- a/ports/vcpkg-tool-meson/meson-1.4-llvm-18.diff
+++ b/ports/vcpkg-tool-meson/meson-1.4-llvm-18.diff
@@ -1,0 +1,13 @@
+diff --git a/mesonbuild/environment.py b/mesonbuild/environment.py
+index 86bbbb1368b8..54fb50af117d 100644
+--- a/mesonbuild/environment.py
++++ b/mesonbuild/environment.py
+@@ -188,6 +188,8 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
+     # unless it becomes a stable release.
+     suffixes = [
+         '', # base (no suffix)
++        '-18.1', '18.1',
++        '-18',  '18',
+         '-17',  '17',
+         '-16',  '16',
+         '-15',  '15',

--- a/ports/vcpkg-tool-meson/meson.template.in
+++ b/ports/vcpkg-tool-meson/meson.template.in
@@ -20,6 +20,7 @@ pkg-config= ['@PKGCONFIG@']
 [properties]
 cmake_toolchain_file  = '@SCRIPTS@/buildsystems/vcpkg.cmake'
 [cmake]
+CMAKE_BUILD_TYPE = '@buildconfig@'
 VCPKG_TARGET_TRIPLET = '@TARGET_TRIPLET@'
 VCPKG_HOST_TRIPLET = '@_HOST_TRIPLET@'
 VCPKG_CHAINLOAD_TOOLCHAIN_FILE = '@VCPKG_CHAINLOAD_TOOLCHAIN_FILE@'

--- a/ports/vcpkg-tool-meson/portfile.cmake
+++ b/ports/vcpkg-tool-meson/portfile.cmake
@@ -4,35 +4,39 @@
 
 set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
 
-set(files 
-  vcpkg.json
-  portfile.cmake
-  vcpkg-port-config.cmake
-  vcpkg_configure_meson.cmake
-  vcpkg_install_meson.cmake
+set(patches
   meson-intl.patch
   adjust-python-dep.patch
   adjust-args.patch
   remove-freebsd-pcfile-specialization.patch
+)
+set(scripts
+  vcpkg-port-config.cmake
+  vcpkg_configure_meson.cmake
+  vcpkg_install_meson.cmake
   meson.template.in
 )
-
-set(MESON_PATH_HASH "")
-foreach(to_hash IN LISTS files)
-  file(SHA1 ${CMAKE_CURRENT_LIST_DIR}/${to_hash} to_append)
-  string(APPEND MESON_PATH_HASH "${to_append}")
+set(to_hash 
+  "${CMAKE_CURRENT_LIST_DIR}/vcpkg.json"
+  "${CMAKE_CURRENT_LIST_DIR}/portfile.cmake"
+)
+foreach(file IN LISTS patches scripts)
+  set(filepath  "${CMAKE_CURRENT_LIST_DIR}/${file}")
+  list(APPEND to_hash "${filepath}")
+  file(COPY "${filepath}" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 endforeach()
-string(SHA512 MESON_PATH_HASH "${MESON_PATH_HASH}")
 
+set(meson_path_hash "")
+foreach(filepath IN LISTS to_hash)
+  file(SHA1 "${filepath}" to_append)
+  string(APPEND meson_path_hash "${to_append}")
+endforeach()
+string(SHA512 meson_path_hash "${meson_path_hash}")
+
+string(SUBSTRING "${meson_path_hash}" 0 6 MESON_SHORT_HASH)
+list(TRANSFORM patches REPLACE [[^(..*)$]] [["${CMAKE_CURRENT_LIST_DIR}/\0"]])
+list(JOIN patches "\n            " PATCHES)
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-port-config.cmake" @ONLY)
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg_configure_meson.cmake"
-          "${CMAKE_CURRENT_LIST_DIR}/vcpkg_install_meson.cmake"
-          "${CMAKE_CURRENT_LIST_DIR}/meson-intl.patch"
-          "${CMAKE_CURRENT_LIST_DIR}/adjust-python-dep.patch"
-          "${CMAKE_CURRENT_LIST_DIR}/adjust-args.patch"
-          "${CMAKE_CURRENT_LIST_DIR}/remove-freebsd-pcfile-specialization.patch"
-          "${CMAKE_CURRENT_LIST_DIR}/meson.template.in"
-          DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_install_copyright(FILE_LIST "${VCPKG_ROOT_DIR}/LICENSE.txt")
 

--- a/ports/vcpkg-tool-meson/portfile.cmake
+++ b/ports/vcpkg-tool-meson/portfile.cmake
@@ -9,6 +9,7 @@ set(patches
   adjust-python-dep.patch
   adjust-args.patch
   remove-freebsd-pcfile-specialization.patch
+  meson-1.4-llvm-18.diff
 )
 set(scripts
   vcpkg-port-config.cmake

--- a/ports/vcpkg-tool-meson/vcpkg-port-config.cmake
+++ b/ports/vcpkg-tool-meson/vcpkg-port-config.cmake
@@ -2,8 +2,7 @@
 include("${CMAKE_CURRENT_LIST_DIR}/vcpkg_configure_meson.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/vcpkg_install_meson.cmake")
 
-set(meson_path_hash @MESON_PATH_HASH@)
-string(SUBSTRING "${meson_path_hash}" 0 6 meson_short_hash)
+set(meson_short_hash @MESON_SHORT_HASH@)
 
 # Setup meson:
 set(program MESON)
@@ -34,10 +33,7 @@ if(NOT SCRIPT_MESON)
     z_vcpkg_apply_patches(
         SOURCE_PATH "${path_to_search}-tmp/meson-${ref}"
         PATCHES
-            "${CMAKE_CURRENT_LIST_DIR}/adjust-args.patch"
-            "${CMAKE_CURRENT_LIST_DIR}/meson-intl.patch"
-            "${CMAKE_CURRENT_LIST_DIR}/adjust-python-dep.patch"
-            "${CMAKE_CURRENT_LIST_DIR}/remove-freebsd-pcfile-specialization.patch"
+            @PATCHES@
     )
     file(MAKE_DIRECTORY "${path_to_search}")
     file(RENAME "${path_to_search}-tmp/meson-${ref}/meson.py" "${path_to_search}/meson.py")

--- a/ports/vcpkg-tool-meson/vcpkg.json
+++ b/ports/vcpkg-tool-meson/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vcpkg-tool-meson",
   "version": "1.3.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Meson build system",
   "homepage": "https://github.com/mesonbuild/meson",
   "license": "Apache-2.0",

--- a/ports/vcpkg-tool-meson/vcpkg_configure_meson.cmake
+++ b/ports/vcpkg-tool-meson/vcpkg_configure_meson.cmake
@@ -356,7 +356,7 @@ function(vcpkg_configure_meson)
         set(meson_input_file_${buildname} "${CURRENT_BUILDTREES_DIR}/meson-${TARGET_TRIPLET}-${suffix_${buildname}}.log")
     endif()
 
-    vcpkg_list(APPEND arg_OPTIONS --backend ninja --wrap-mode nodownload -Dbuildtype=plain -Doptimization=plain)
+    vcpkg_list(APPEND arg_OPTIONS --backend ninja --wrap-mode nodownload -Doptimization=plain)
 
     z_vcpkg_get_build_and_host_system(MESON_HOST_MACHINE MESON_BUILD_MACHINE IS_CROSS)
 
@@ -434,7 +434,7 @@ function(vcpkg_configure_meson)
         configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/meson.template.in" "${meson_input_file_${buildtype}}" @ONLY)
 
         vcpkg_execute_required_process(
-            COMMAND ${MESON} ${arg_OPTIONS} ${arg_OPTIONS_${buildtype}} ${arg_SOURCE_PATH}
+            COMMAND ${MESON} setup ${arg_OPTIONS} ${arg_OPTIONS_${buildtype}} ${arg_SOURCE_PATH}
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${suffix_${buildtype}}"
             LOGNAME config-${TARGET_TRIPLET}-${suffix_${buildtype}}
             SAVE_LOG_FILES

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9098,7 +9098,7 @@
     },
     "vcpkg-tool-meson": {
       "baseline": "1.3.2",
-      "port-version": 2
+      "port-version": 3
     },
     "vcpkg-tool-mozbuild": {
       "baseline": "4.0.2",

--- a/versions/v-/vcpkg-tool-meson.json
+++ b/versions/v-/vcpkg-tool-meson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fbf4e4c53dcb75ef6bd7d62c7985fe7a4225b6e0",
+      "version": "1.3.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "8408112396883b134bd25e2522f9a806ceaae3ea",
       "version": "1.3.2",
       "port-version": 2


### PR DESCRIPTION
Cherry-picked and extended from https://github.com/microsoft/vcpkg/pull/38658.
And a minor refactoring for easier management of patches.
llvm 18 changes for https://github.com/microsoft/vcpkg/pull/37599, squashed from https://github.com/microsoft/vcpkg/pull/37599#issuecomment-2112721881.