### PR TITLE
[libmagic] Update dependency specifications.

### DIFF
--- a/ports/libmagic/unofficial-libmagic-config.cmake.in
+++ b/ports/libmagic/unofficial-libmagic-config.cmake.in
@@ -45,11 +45,11 @@ set_target_properties(unofficial::libmagic::libmagic PROPERTIES
 if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
     set_target_properties(unofficial::libmagic::libmagic PROPERTIES
         INTERFACE_LINK_LIBRARIES
-            "\$<LINK_ONLY:$<$<BOOL:${WIN32}>:unofficial::tre::tre>>"
+            "\$<LINK_ONLY:$<$<BOOL:${WIN32}>:unofficial::tre::tre;shlwapi>>"
             "\$<LINK_ONLY:$<@has_zlib@:ZLIB::ZLIB>>"
             "\$<LINK_ONLY:$<@has_bzip2@:BZip2::BZip2>>"
             "\$<LINK_ONLY:$<@has_lzma@:LibLZMA::LibLZMA>>"
-            "\$<LINK_ONLY:$<@has_zstd@:$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>>>"
+            "\$<LINK_ONLY:$<@has_zstd@:zstd::libzstd>"
     )
 endif()
 

--- a/ports/libmagic/vcpkg.json
+++ b/ports/libmagic/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmagic",
   "version": "5.45",
-  "port-version": 2,
+  "port-version": 3,
   "description": "This library can be used to classify files according to magic number tests.",
   "homepage": "https://github.com/file/file",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4630,7 +4630,7 @@
     },
     "libmagic": {
       "baseline": "5.45",
-      "port-version": 2
+      "port-version": 3
     },
     "libmariadb": {
       "baseline": "3.3.1",

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "167ff0a6360284c7c139765c23367ace49ce68b6",
+      "version": "5.45",
+      "port-version": 3
+    },
+    {
       "git-tree": "c845ff89796041876594f8b6ef8691e8debb1c82",
       "version": "5.45",
       "port-version": 2


### PR DESCRIPTION
* Use the unified zstd target. (facebook/zstd#3811)

* Link to `shlwapi` on Windows. (https://github.com/teo-tsirpanis/vcpkg/blob/1d36bc123de029ec8f556fea6cb072e46533b143/ports/libmagic/0001-Use-libtre.patch#L34)

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
