### PR TITLE
[hdr-histogram] add new port

### DIFF
--- a/ports/hdr-histogram/portfile.cmake
+++ b/ports/hdr-histogram/portfile.cmake
@@ -22,8 +22,6 @@ endif()
 # Do not build tests and examples
 list(APPEND FEATURE_OPTIONS "-DHDR_HISTOGRAM_BUILD_PROGRAMS:BOOL=OFF")
 
-message(STATUS "Using the following features: ${FEATURE_OPTIONS}")
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/hdr-histogram/portfile.cmake
+++ b/ports/hdr-histogram/portfile.cmake
@@ -3,6 +3,7 @@ vcpkg_from_github(
     REPO HdrHistogram/HdrHistogram_c
     REF ${VERSION}
     SHA512 2ede4b8412c4f0070d555515498e163397de5edebe7560eaea13adcb95a52b7fea99686aed06bbca0c6e8afdf65715483c3889d750f6b5b727bcf43c4fbe18d4
+    HEAD_REF main
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/hdr-histogram/portfile.cmake
+++ b/ports/hdr-histogram/portfile.cmake
@@ -1,3 +1,7 @@
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO HdrHistogram/HdrHistogram_c

--- a/ports/hdr-histogram/portfile.cmake
+++ b/ports/hdr-histogram/portfile.cmake
@@ -5,11 +5,28 @@ vcpkg_from_github(
     SHA512 2ede4b8412c4f0070d555515498e163397de5edebe7560eaea13adcb95a52b7fea99686aed06bbca0c6e8afdf65715483c3889d750f6b5b727bcf43c4fbe18d4
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        log HDR_LOG_REQUIRED
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    list(APPEND FEATURE_OPTIONS "-DHDR_HISTOGRAM_BUILD_STATIC:BOOL=OFF")
+    list(APPEND FEATURE_OPTIONS "-DHDR_HISTOGRAM_INSTALL_STATIC:BOOL=OFF")
+else()
+    list(APPEND FEATURE_OPTIONS "-DHDR_HISTOGRAM_BUILD_SHARED:BOOL=OFF")
+    list(APPEND FEATURE_OPTIONS "-DHDR_HISTOGRAM_INSTALL_SHARED:BOOL=OFF")
+endif()
+
+# Do not build tests and examples
+list(APPEND FEATURE_OPTIONS "-DHDR_HISTOGRAM_BUILD_PROGRAMS:BOOL=OFF")
+
+message(STATUS "Using the following features: ${FEATURE_OPTIONS}")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        # Do not build tests and examples
-        -DHDR_HISTOGRAM_BUILD_PROGRAMS="OFF"
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/hdr-histogram/portfile.cmake
+++ b/ports/hdr-histogram/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO HdrHistogram/HdrHistogram_c
+    REF ${VERSION}
+    SHA512 2ede4b8412c4f0070d555515498e163397de5edebe7560eaea13adcb95a52b7fea99686aed06bbca0c6e8afdf65715483c3889d750f6b5b727bcf43c4fbe18d4
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        # Do not build tests and examples
+        -DHDR_HISTOGRAM_BUILD_PROGRAMS="OFF"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME hdr_histogram
+    CONFIG_PATH lib/cmake/hdr_histogram
+)
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt" "${SOURCE_PATH}/COPYING.txt")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/hdr-histogram/portfile.cmake
+++ b/ports/hdr-histogram/portfile.cmake
@@ -49,9 +49,3 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt" "${SOURCE_PATH}/COPYING.txt")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
-# hdr_histogram needs zlib only for 'log' option, but cmake-config.in contains a hardcoded dependecy on zlib
-if("log" IN_LIST FEATURES)
-else()
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/hdr_histogram/hdr_histogram-config.cmake" "find_package(ZLIB)" "")
-endif()

--- a/ports/hdr-histogram/portfile.cmake
+++ b/ports/hdr-histogram/portfile.cmake
@@ -6,10 +6,11 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        log HDR_LOG_REQUIRED
-)
+if("log" IN_LIST FEATURES)
+    list(APPEND FEATURE_OPTIONS "-DHDR_LOG_REQUIRED=ON")
+else()
+    list(APPEND FEATURE_OPTIONS "-DHDR_LOG_REQUIRED=DISABLED")
+endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     list(APPEND FEATURE_OPTIONS "-DHDR_HISTOGRAM_BUILD_STATIC:BOOL=OFF")
@@ -44,3 +45,9 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt" "${SOURCE_PATH}/COPYING.txt")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+# hdr_histogram needs zlib only for 'log' option, but cmake-config.in contains a hardcoded dependecy on zlib
+if("log" IN_LIST FEATURES)
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/hdr_histogram/hdr_histogram-config.cmake" "find_package(ZLIB)" "")
+endif()

--- a/ports/hdr-histogram/usage
+++ b/ports/hdr-histogram/usage
@@ -1,0 +1,22 @@
+The package hdr_histogram can be used via CMake:
+
+  find_path(HDR_HISTOGRAM_INCLUDE_DIR NAMES "hdr/hdr_histogram.h" REQUIRED)
+  target_include_directories(main PRIVATE ${HDR_HISTOGRAM_INCLUDE_DIR})
+
+  find_library(HDR_HISTOGRAM_LIB_STATIC hdr_histogram_static REQUIRED)
+  target_link_libraries(main PRIVATE ${HDR_HISTOGRAM_LIB})
+
+  # Or you can also use dynamic linkage:
+  find_library(HDR_HISTOGRAM_LIB hdr_histogram REQUIRED)
+  target_link_libraries(main PRIVATE ${HDR_HISTOGRAM_LIB_STATIC})
+
+The package hdr_histogram can be imported via CMake FindPkgConfig module:
+
+  find_package(hdr_histogram CONFIG REQUIRED)
+
+  find_path(HDR_HISTOGRAM_INCLUDE_DIR NAMES "hdr/hdr_histogram.h" REQUIRED)
+  target_include_directories(main PRIVATE ${HDR_HISTOGRAM_INCLUDE_DIR})
+
+  target_link_libraries(main PRIVATE hdr_histogram::hdr_histogram_static)
+  # Or you can also use dynamic linkage:
+  target_link_libraries(main PRIVATE hdr_histogram::hdr_histogram)

--- a/ports/hdr-histogram/usage
+++ b/ports/hdr-histogram/usage
@@ -1,22 +1,4 @@
-The package hdr_histogram can be used via CMake:
-
-  find_path(HDR_HISTOGRAM_INCLUDE_DIR NAMES "hdr/hdr_histogram.h" REQUIRED)
-  target_include_directories(main PRIVATE ${HDR_HISTOGRAM_INCLUDE_DIR})
-
-  find_library(HDR_HISTOGRAM_LIB_STATIC hdr_histogram_static REQUIRED)
-  target_link_libraries(main PRIVATE ${HDR_HISTOGRAM_LIB})
-
-  # Or you can also use dynamic linkage:
-  find_library(HDR_HISTOGRAM_LIB hdr_histogram REQUIRED)
-  target_link_libraries(main PRIVATE ${HDR_HISTOGRAM_LIB_STATIC})
-
-The package hdr_histogram can be imported via CMake FindPkgConfig module:
+hdr_histogram provides CMake targets:
 
   find_package(hdr_histogram CONFIG REQUIRED)
-
-  find_path(HDR_HISTOGRAM_INCLUDE_DIR NAMES "hdr/hdr_histogram.h" REQUIRED)
-  target_include_directories(main PRIVATE ${HDR_HISTOGRAM_INCLUDE_DIR})
-
-  target_link_libraries(main PRIVATE hdr_histogram::hdr_histogram_static)
-  # Or you can also use dynamic linkage:
-  target_link_libraries(main PRIVATE hdr_histogram::hdr_histogram)
+  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:hdr_histogram::hdr_histogram>,hdr_histogram::hdr_histogram,hdr_histogram::hdr_histogram_static>)

--- a/ports/hdr-histogram/vcpkg.json
+++ b/ports/hdr-histogram/vcpkg.json
@@ -12,7 +12,14 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    "zlib"
-  ]
+    }
+  ],
+  "features": {
+    "log": {
+      "description": "Logging support for HdrHistogram",
+      "dependencies": [
+        "zlib"
+      ]
+    }
+  }
 }

--- a/ports/hdr-histogram/vcpkg.json
+++ b/ports/hdr-histogram/vcpkg.json
@@ -12,7 +12,8 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
+    "zlib"
   ],
   "features": {
     "log": {

--- a/ports/hdr-histogram/vcpkg.json
+++ b/ports/hdr-histogram/vcpkg.json
@@ -12,6 +12,7 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
+    "zlib"
   ]
 }

--- a/ports/hdr-histogram/vcpkg.json
+++ b/ports/hdr-histogram/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "hdr-histogram",
+  "version-semver": "0.11.8",
+  "description": "'C' port of High Dynamic Range (HDR) Histogram",
+  "homepage": "https://github.com/HdrHistogram/HdrHistogram_c",
+  "license": "CC0-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3376,6 +3376,10 @@
       "baseline": "1.14.2",
       "port-version": 0
     },
+    "hdr-histogram": {
+      "baseline": "0.11.8",
+      "port-version": 0
+    },
     "healpix": {
       "baseline": "1.12.10",
       "port-version": 9

--- a/versions/h-/hdr-histogram.json
+++ b/versions/h-/hdr-histogram.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ffa0e79cdd6c84b83167e0e543d43588e6386c12",
+      "git-tree": "20cb84e000ce2c777beb2f2f9eede50aa61395b1",
       "version-semver": "0.11.8",
       "port-version": 0
     }

--- a/versions/h-/hdr-histogram.json
+++ b/versions/h-/hdr-histogram.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1ec0bb5a30e4afe708b464a0cc9c19b8f26fbecd",
+      "git-tree": "23ce0cb5e86b6c3dd7df184512119dd0f33f68a3",
       "version-semver": "0.11.8",
       "port-version": 0
     }

--- a/versions/h-/hdr-histogram.json
+++ b/versions/h-/hdr-histogram.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ffa0e79cdd6c84b83167e0e543d43588e6386c12",
+      "version-semver": "0.11.8",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/h-/hdr-histogram.json
+++ b/versions/h-/hdr-histogram.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "20cb84e000ce2c777beb2f2f9eede50aa61395b1",
+      "git-tree": "1ec0bb5a30e4afe708b464a0cc9c19b8f26fbecd",
       "version-semver": "0.11.8",
       "port-version": 0
     }

--- a/versions/h-/hdr-histogram.json
+++ b/versions/h-/hdr-histogram.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "23ce0cb5e86b6c3dd7df184512119dd0f33f68a3",
+      "git-tree": "e7c8179ec8d0d5a49010bea92f143f011de137da",
       "version-semver": "0.11.8",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.