### PR TITLE
[bgfx]: Update to 1.127.8725.469

### DIFF
--- a/ports/bgfx/portfile.cmake
+++ b/ports/bgfx/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     ARCHIVE_FILE
     URLS https://github.com/bkaradzic/bgfx.cmake/releases/download/v${VERSION}/bgfx.cmake.v${VERSION}.tar.gz
     FILENAME bgfx.cmake.v${VERSION}.tar.gz
-    SHA512 369943ce0f8f2b5332d7334247d3a9ef0e28a6b1ff5ee250a01f83d1a0bd865687397da791e4c861d1c1b18ec4285f50153139f3c0e398611c7f3b672d1c751c
+    SHA512 8aea4f3e548f8a79e8899c9d47ec3ca78dae48f77ae039d6f5df325ba73a8ddb70c9b7c1f0cb4129ac488b445e8a8523f36a964e509133bb4a449e073ebf6112
 )
 
 vcpkg_extract_source_archive(
@@ -26,6 +26,13 @@ endif ()
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-inject-packages.cmake" DESTINATION "${SOURCE_PATH}")
 
+# It's important to have `${CMAKE_CURRENT_LIST_DIR}` verbatim escaped in bgfxConfig.cmake
+if (WIN32)
+  set(BGFX_ADDITIONAL_TOOL_PATHS "\$\$\{CMAKE_CURRENT_LIST_DIR}/../../../${HOST_TRIPLET}/tools/bgfx \$\$\{CMAKE_CURRENT_LIST_DIR}/../../../bgfx_${HOST_TRIPLET}/tools/bgfx")
+else()
+  set(BGFX_ADDITIONAL_TOOL_PATHS "\"\\\$\$\{CMAKE_CURRENT_LIST_DIR}/../../../${HOST_TRIPLET}/tools/bgfx \\\$\$\{CMAKE_CURRENT_LIST_DIR}/../../../bgfx_${HOST_TRIPLET}/tools/bgfx\"")
+endif()
+
 vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS -DBGFX_LIBRARY_TYPE=${BGFX_LIBRARY_TYPE}
@@ -34,6 +41,8 @@ vcpkg_cmake_configure(
           -DBGFX_BUILD_EXAMPLES=OFF
           -DBGFX_OPENGLES_VERSION=30
           -DBGFX_CMAKE_USER_SCRIPT=vcpkg-inject-packages.cmake
+          # #25529: Need to inject an extra path because VCPKG_HOST_TARGET is not determined automatically
+          -DBGFX_ADDITIONAL_TOOL_PATHS=${BGFX_ADDITIONAL_TOOL_PATHS}
           ${FEATURE_OPTIONS}
 )
 
@@ -41,7 +50,7 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 vcpkg_copy_pdbs()
 
-if (BGFX_BUILD_TOOLS)
+if ("tools" IN_LIST FEATURES)
   vcpkg_copy_tools(
     TOOL_NAMES bin2c shaderc geometryc geometryv texturec texturev AUTO_CLEAN
   )

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bgfx",
-  "version": "1.122.8595-458",
+  "version": "1.127.8725-469",
   "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
   "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
   "homepage": "https://bkaradzic.github.io/bgfx/overview.html",

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "df7b82514ae7d190569f8e85e7c65cfec55cdc82",
+      "version": "1.127.8725-469",
+      "port-version": 0
+    },
+    {
       "git-tree": "c5af63ea2a285a9577943683a6e1347d17487402",
       "version": "1.122.8595-458",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -617,7 +617,7 @@
       "port-version": 0
     },
     "bgfx": {
-      "baseline": "1.122.8595-458",
+      "baseline": "1.127.8725-469",
       "port-version": 0
     },
     "bigint": {


### PR DESCRIPTION
This new version of bgfx removes support for D3D9 and WebGPU.
The package has been updated so tools better support cross compilation by being able to generate a config cmake file which is installed linking the proper host tools path. Prior to this, it assumed that all hosts were x64 which prevented cross compiling from apple sillicon and raspberry pis for example.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.