### PR TITLE
[protobuf] fix pc library reference

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -121,12 +121,28 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
 endif()
 
 vcpkg_copy_pdbs()
-set(packages protobuf protobuf-lite)
-foreach(_package IN LISTS packages)
-    set(_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${_package}.pc")
-    if(EXISTS "${_file}")
-        vcpkg_replace_string(${_file} "-l${_package}" "-l${_package}d")
+
+function(replace_package_string package)
+    set(debug_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${package}.pc")
+    set(release_file "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${package}.pc")
+
+    if(EXISTS "${release_file}")
+        vcpkg_replace_string(${release_file} "-l${package}" "-llib${package}")
     endif()
+
+    if(EXISTS "${debug_file}")
+        vcpkg_replace_string(${debug_file} "-l${package}" "-llib${package}d")
+    endif()
+endfunction()
+
+set(packages protobuf protobuf-lite)
+foreach(package IN LISTS packages)
+    replace_package_string(${package})
+endforeach()
+
+set(packages protobuf protobuf-lite)
+foreach(package IN LISTS packages)
+    replace_package_string(${package})
 endforeach()
 
 vcpkg_fixup_pkgconfig()

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -127,20 +127,25 @@ function(replace_package_string package)
     set(release_file "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${package}.pc")
 
     if(EXISTS "${release_file}")
-        vcpkg_replace_string(${release_file} "-l${package}" "-llib${package}")
+        if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+            vcpkg_replace_string(${release_file} "-l${package}" "-llib${package}")
+        endif()
     endif()
 
     if(EXISTS "${debug_file}")
-        vcpkg_replace_string(${debug_file} "-l${package}" "-llib${package}d")
+        if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+            vcpkg_replace_string(${debug_file} "-l${package}" "-llib${package}d")
+        else()
+            vcpkg_replace_string(${debug_file} "-l${package}" "-l${package}d")
+        endif()
     endif()
 endfunction()
 
 set(packages protobuf protobuf-lite)
-if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-    foreach(package IN LISTS packages)
-        replace_package_string(${package})
-    endforeach() 
-endif()
+foreach(package IN LISTS packages)
+    replace_package_string(${package})
+endforeach()
+
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -136,14 +136,11 @@ function(replace_package_string package)
 endfunction()
 
 set(packages protobuf protobuf-lite)
-foreach(package IN LISTS packages)
-    replace_package_string(${package})
-endforeach()
-
-set(packages protobuf protobuf-lite)
-foreach(package IN LISTS packages)
-    replace_package_string(${package})
-endforeach()
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    foreach(package IN LISTS packages)
+        replace_package_string(${package})
+    endforeach() 
+endif()
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "protobuf",
   "version": "3.21.12",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6982,7 +6982,7 @@
     },
     "protobuf": {
       "baseline": "3.21.12",
-      "port-version": 2
+      "port-version": 3
     },
     "protobuf-c": {
       "baseline": "1.4.1",

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5bb733680d0e49a693af6384933e6d185e125115",
+      "git-tree": "528c56d9b29635d840b284f3e2109a370556bd89",
       "version": "3.21.12",
       "port-version": 3
     },

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3cb0dceacc5929ccda1e5db58a2384ba48ebed5b",
+      "version": "3.21.12",
+      "port-version": 3
+    },
+    {
       "git-tree": "e189106689c1983cd5e19363fa48f35d3d3f419b",
       "version": "3.21.12",
       "port-version": 2

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3cb0dceacc5929ccda1e5db58a2384ba48ebed5b",
+      "git-tree": "5bb733680d0e49a693af6384933e6d185e125115",
       "version": "3.21.12",
       "port-version": 3
     },


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/38757

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
