### PR TITLE
[liborigin] fix x64-linux-dynamic

### DIFF
--- a/ports/liborigin/portfile.cmake
+++ b/ports/liborigin/portfile.cmake
@@ -23,12 +23,8 @@ vcpkg_cmake_install()
 
 vcpkg_fixup_pkgconfig()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-else()
-  file(GLOB EXES "${CURRENT_PACKAGES_DIR}/bin/*.exe" "${CURRENT_PACKAGES_DIR}/debug/bin/*.exe")
-  file(REMOVE_RECURSE ${EXES})
-endif()
+vcpkg_copy_tools(TOOL_NAMES opj2dat AUTO_CLEAN)
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/liborigin/vcpkg.json
+++ b/ports/liborigin/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "liborigin",
   "version": "3.0.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for reading OriginLab OPJ project files.",
   "homepage": "https://sourceforge.net/projects/liborigin/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4774,7 +4774,7 @@
     },
     "liborigin": {
       "baseline": "3.0.2",
-      "port-version": 1
+      "port-version": 2
     },
     "libosdp": {
       "baseline": "3.0.5",

--- a/versions/l-/liborigin.json
+++ b/versions/l-/liborigin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dfd4df45866d1fbcaeaf73592a12ce6564dfb6f9",
+      "version": "3.0.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "1af8619df06f9a9519e035cd59b7bfe89f25b59d",
       "version": "3.0.2",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.