### PR TITLE
[sqlite-orm] Fix test feature to support uwp

### DIFF
--- a/ports/sqlite-orm/fix-uwp.patch
+++ b/ports/sqlite-orm/fix-uwp.patch
@@ -1,0 +1,16 @@
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 945d275..8ca2de4 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -162,6 +162,11 @@ if (MSVC)
+             # C4458: declaration of 'symbol' hides class member
+             /wd4458)
+     endif()
++    if (CMAKE_CXX_FLAGS MATCHES "/D_UNICODE")
++        # explicitly set the entry point of the executable file,
++        # otherwise for some reason the linker will not pick up `wmain`, which is provided by the static Catch2 library
++        target_link_options(unit_tests PRIVATE "/ENTRY:wmainCRTStartup")
++    endif()
+ endif()
+ 
+ target_precompile_headers(unit_tests PRIVATE

--- a/ports/sqlite-orm/portfile.cmake
+++ b/ports/sqlite-orm/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES 
         fix-dependency.patch
+        fix-uwp.patch #https://github.com/fnc12/sqlite_orm/pull/1295
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/sqlite-orm/vcpkg.json
+++ b/ports/sqlite-orm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlite-orm",
   "version": "1.8.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "SQLite ORM light header only library for modern C++",
   "homepage": "https://github.com/fnc12/sqlite_orm",
   "license": "AGPL-3.0-or-later OR MIT",
@@ -22,7 +22,6 @@
     },
     "test": {
       "description": "Build sqlite_orm unit tests",
-      "supports": "!uwp",
       "dependencies": [
         "catch2"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8378,7 +8378,7 @@
     },
     "sqlite-orm": {
       "baseline": "1.8.2",
-      "port-version": 1
+      "port-version": 2
     },
     "sqlite3": {
       "baseline": "3.45.3",

--- a/versions/s-/sqlite-orm.json
+++ b/versions/s-/sqlite-orm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bcff94e1b22d04049a76d0a46dc0fbda9ca5bae7",
+      "version": "1.8.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "13e0d0b90109dcaf60af5d316ece18d4cf6ef50e",
       "version": "1.8.2",
       "port-version": 1


### PR DESCRIPTION
According to the upstream PR [1295](https://github.com/fnc12/sqlite_orm/pull/1295), fix the test feature to support uwp.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Test features passed with following triplet:

```
x64-uwp
```
