### PR TITLE
[icu] update to 75.1

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS "https://github.com/unicode-org/icu/releases/download/release-${VERSION3}/icu4c-${VERSION2}-src.tgz"
     FILENAME "icu4c-${VERSION2}-src.tgz"
-    SHA512 e6c7876c0f3d756f3a6969cad9a8909e535eeaac352f3a721338b9cbd56864bf7414469d29ec843462997815d2ca9d0dab06d38c37cdd4d8feb28ad04d8781b0
+    SHA512 70ea842f0d5f1f6c6b65696ac71d96848c4873f4d794bebc40fd87af2ad4ef064c61a786bf7bc430ce4713ec6deabb8cc1a8cc0212eab148cee2d498a3683e45
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH
@@ -61,6 +61,10 @@ endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)
     list(APPEND CONFIGURE_OPTIONS --enable-icu-build-win)
+    if(NOT MINGW)
+        string(APPEND VCPKG_C_FLAGS "/std:c11")
+        string(APPEND VCPKG_CXX_FLAGS "/std:c++17")
+    endif()
 endif()
 
 if("tools" IN_LIST FEATURES)

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "icu",
-  "version": "74.2",
-  "port-version": 2,
+  "version": "75.1",
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3473,8 +3473,8 @@
       "port-version": 0
     },
     "icu": {
-      "baseline": "74.2",
-      "port-version": 2
+      "baseline": "75.1",
+      "port-version": 0
     },
     "ideviceinstaller": {
       "baseline": "2023-07-21",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54ddd0be5dbf1ec5f931d83b781d9edfed60e1f9",
+      "version": "75.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a36199768fe1f9676b61d5d28ed9ac36c9f041c0",
       "version": "74.2",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.