### PR TITLE
[libpsl] fix psl for static windows

### DIFF
--- a/ports/libpsl/portfile.cmake
+++ b/ports/libpsl/portfile.cmake
@@ -1,9 +1,14 @@
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(WINDOWS_STATIC_PATCH windows_statich.patch)
+endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rockdaboot/libpsl
     REF "${VERSION}"
     SHA512 "d8e224b2ce5d9a6ac78700eb8975d09aef4e5af7db29539e5e339c5cd100f1272371fe45757ab5383ddbcd569bdf9d697a78932ea9fdf43ff48d3cea02f644cd"
     HEAD_REF master
+    PATCHES
+        ${WINDOWS_STATIC_PATCH}
 )
 
 vcpkg_download_distfile(

--- a/ports/libpsl/vcpkg.json
+++ b/ports/libpsl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpsl",
   "version": "0.21.5",
+  "port-version": 1,
   "description": "C library for the Public Suffix List",
   "homepage": "rockdaboot.github.io/libpsl",
   "license": "MIT",

--- a/ports/libpsl/windows_statich.patch
+++ b/ports/libpsl/windows_statich.patch
@@ -1,0 +1,14 @@
+diff --git a/include/libpsl.h.in b/include/libpsl.h.in
+--- a/include/libpsl.h.in
++++ b/include/libpsl.h.in
+@@ -44,8 +44,10 @@
+ #ifndef __has_declspec_attribute
+ #  define __has_declspec_attribute(x) 0
+ #endif
+ 
++#define PSL_STATIC 1
++
+ #ifndef PSL_API
+ #if defined BUILDING_PSL && HAVE_VISIBILITY
+ #  define PSL_API __attribute__ ((__visibility__("default")))
+ #elif defined BUILDING_PSL && (defined _MSC_VER || __has_declspec_attribute(dllexport)) && !defined PSL_STATIC

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4846,7 +4846,7 @@
     },
     "libpsl": {
       "baseline": "0.21.5",
-      "port-version": 0
+      "port-version": 1
     },
     "libqcow": {
       "baseline": "20221124",

--- a/versions/l-/libpsl.json
+++ b/versions/l-/libpsl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "799a12e091bcccd028ed2d682cd5133eef5bbbf7",
+      "version": "0.21.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "6f4047fee938b55c21791aebff41556f270b510a",
       "version": "0.21.5",
       "port-version": 0


### PR DESCRIPTION
[libpsl] fix psl for static windows:
 - Add fix
 - Fix #38820 
 
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
