### PR TITLE
[sail] Bump version to 0.9.5

### DIFF
--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO HappySeaFox/sail
     REF "v${VERSION}"
-    SHA512 75d797d3fb36e1712cfdd2f0cc13f9bb20b2fc1fe0546e2046ad4356b608adb0efb9c3d17dd1b3c131e445fd5399705c0598d04ba55b1140d271ba86c6e42744
+    SHA512 4d61489405f5468eac2fb0261ec0b54bfa6f619b1acdca405c4b09261c233d0b7063df71143add87f866bfa7ed9eabdf3a910f03f8494f14a62e4f124eb260be
     HEAD_REF master
     PATCHES
         fix-include-directory.patch

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sail",
-  "version-semver": "0.9.4",
-  "port-version": 1,
+  "version-semver": "0.9.5",
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7861,8 +7861,8 @@
       "port-version": 0
     },
     "sail": {
-      "baseline": "0.9.4",
-      "port-version": 1
+      "baseline": "0.9.5",
+      "port-version": 0
     },
     "sajson": {
       "baseline": "2018-09-21",

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "619ce5de34c2eafec5affc5f507a1617d843169e",
+      "version-semver": "0.9.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "d991b4f6cb2b948a9d483dd0c32d8b90dce0fae1",
       "version-semver": "0.9.4",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
