### PR TITLE
[vcpkg baseline][realm-core] Fix zlib lookup failure

### DIFF
--- a/ports/realm-core/fix-zlib.patch
+++ b/ports/realm-core/fix-zlib.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1d5710f..963ecd8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -333,7 +333,6 @@ if(NOT APPLE AND NOT EMSCRIPTEN AND NOT TARGET ZLIB::ZLIB)
+         set(_CMAKE_FIND_LIBRARY_SUFFIXES_orig ${CMAKE_FIND_LIBRARY_SUFFIXES})
+         set(CMAKE_FIND_LIBRARY_SUFFIXES .so)
+     endif()
+-    find_package(ZLIB REQUIRED)
+     if(ANDROID)
+         set(CMAKE_FIND_LIBRARY_SUFFIXES ${_CMAKE_FIND_LIBRARY_SUFFIXES_orig})
+     endif()
+diff --git a/src/realm/CMakeLists.txt b/src/realm/CMakeLists.txt
+index b5aebd5..f3e5ff6 100644
+--- a/src/realm/CMakeLists.txt
++++ b/src/realm/CMakeLists.txt
+@@ -392,6 +392,7 @@ if(REALM_HAVE_OPENSSL AND (UNIX OR WIN32))
+ endif()
+ 
+ # Use Zlib if the imported target is defined, otherise use -lz on Apple platforms
++find_package(ZLIB REQUIRED)
+ if(TARGET ZLIB::ZLIB)
+     target_link_libraries(Storage PUBLIC ZLIB::ZLIB)
+ elseif(APPLE)

--- a/ports/realm-core/fix-zlib.patch
+++ b/ports/realm-core/fix-zlib.patch
@@ -1,24 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1d5710f..963ecd8 100644
+index 1d5710f..c57e2dd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -333,7 +333,6 @@ if(NOT APPLE AND NOT EMSCRIPTEN AND NOT TARGET ZLIB::ZLIB)
+@@ -331,7 +331,6 @@ if(NOT APPLE AND NOT EMSCRIPTEN AND NOT TARGET ZLIB::ZLIB)
+         # We want to link against the stub library instead of statically linking anyway,
+         # so we hack find_library to only consider shared object libraries when looking for libz
          set(_CMAKE_FIND_LIBRARY_SUFFIXES_orig ${CMAKE_FIND_LIBRARY_SUFFIXES})
-         set(CMAKE_FIND_LIBRARY_SUFFIXES .so)
+-        set(CMAKE_FIND_LIBRARY_SUFFIXES .so)
      endif()
--    find_package(ZLIB REQUIRED)
+     find_package(ZLIB REQUIRED)
      if(ANDROID)
-         set(CMAKE_FIND_LIBRARY_SUFFIXES ${_CMAKE_FIND_LIBRARY_SUFFIXES_orig})
-     endif()
-diff --git a/src/realm/CMakeLists.txt b/src/realm/CMakeLists.txt
-index b5aebd5..f3e5ff6 100644
---- a/src/realm/CMakeLists.txt
-+++ b/src/realm/CMakeLists.txt
-@@ -392,6 +392,7 @@ if(REALM_HAVE_OPENSSL AND (UNIX OR WIN32))
- endif()
- 
- # Use Zlib if the imported target is defined, otherise use -lz on Apple platforms
-+find_package(ZLIB REQUIRED)
- if(TARGET ZLIB::ZLIB)
-     target_link_libraries(Storage PUBLIC ZLIB::ZLIB)
- elseif(APPLE)

--- a/ports/realm-core/portfile.cmake
+++ b/ports/realm-core/portfile.cmake
@@ -5,7 +5,9 @@ vcpkg_from_github(
         SHA512 "1bd11bfe70204213469687d1e224fabb2ff2798aa25f6d791b3d455acdcacf686248e7a692f23ed67148ef99faf1a7c1f823182f33a45340310477bc51b32bb7"
         HEAD_REF "master"
         PATCHES 
-            "UWP_index_set.patch")
+            "UWP_index_set.patch"
+            fix-zlib.patch
+)
 
 set(REALMCORE_CMAKE_OPTIONS -DREALM_CORE_SUBMODULE_BUILD=OFF)
 list(APPEND REALMCORE_CMAKE_OPTIONS -DREALM_BUILD_LIB_ONLY=ON)

--- a/ports/realm-core/vcpkg.json
+++ b/ports/realm-core/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "realm-core",
   "version": "14.6.2",
+  "port-version": 1,
   "description": "Realm is a mobile database that runs directly inside phones, tablets or wearables.",
   "homepage": "https://github.com/realm/realm-core",
   "license": "Apache-2.0",
@@ -17,6 +18,7 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
+    "zlib"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7638,7 +7638,7 @@
     },
     "realm-core": {
       "baseline": "14.6.2",
-      "port-version": 0
+      "port-version": 1
     },
     "realsense2": {
       "baseline": "2.54.2",

--- a/versions/r-/realm-core.json
+++ b/versions/r-/realm-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0cec9da49efce442130f7bd3189838b8216c130d",
+      "version": "14.6.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "6c9e380d9d5239dcd4652be4a9794aaff74bd6e6",
       "version": "14.6.2",
       "port-version": 0

--- a/versions/r-/realm-core.json
+++ b/versions/r-/realm-core.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0cec9da49efce442130f7bd3189838b8216c130d",
+      "git-tree": "102a758566531c3cc61b8803972dc950baacf946",
       "version": "14.6.2",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes regression: https://dev.azure.com/vcpkg/public/_build/results?buildId=103057&view=results
```
REGRESSION: realm-core:x64-android failed with BUILD_FAILED
REGRESSION: realm-core:arm-neon-android failed with BUILD_FAILED
REGRESSION: realm-core:arm64-android failed with BUILD_FAILED
```
Error:
```
CMake Error at /mnt/vcpkg-ci/installed/x64-android/share/zlib/vcpkg-cmake-wrapper.cmake:5 (message):
  Broken installation of vcpkg port zlib
Call Stack (most recent call first):
  /vcpkg/scripts/buildsystems/vcpkg.cmake:813 (include)
  CMakeLists.txt:336 (find_package)
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


Compile test pass with following triplets:
```
x64-android
arm64-android
```