### PR TITLE
[cgltf] update to v1.14 

### DIFF
--- a/ports/cgltf/portfile.cmake
+++ b/ports/cgltf/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jkuhlmann/cgltf
-    REF v1.13
-    SHA512 b46d1f9db11b75a60eb0272e89834444cd5652fa1fa35c80ce8a78437ef1b3d9f871419cc39da2d0e021d594ffc3e3832362ec759df0a7857aa74e4639698435
+    REF "v${VERSION}"
+    SHA512 1f0e7dca353f1fca94f5936519895d59d4d2a3a1204545bf5420ff130c1d168158be4749010b2016c127ac9216929892f093ca10b5753fa622bea629aa3f194a
     HEAD_REF master
 )
 
@@ -12,4 +12,4 @@ file(COPY "${SOURCE_PATH}/cgltf.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include"
 file(COPY "${SOURCE_PATH}/cgltf_write.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 # Handle copyright
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cgltf/vcpkg.json
+++ b/ports/cgltf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cgltf",
-  "version": "1.13",
+  "version": "1.14",
   "description": "Single-file glTF 2.0 loader and writer written in C99",
   "homepage": "https://github.com/jkuhlmann/cgltf",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1569,7 +1569,7 @@
       "port-version": 0
     },
     "cgltf": {
-      "baseline": "1.13",
+      "baseline": "1.14",
       "port-version": 0
     },
     "cgns": {

--- a/versions/c-/cgltf.json
+++ b/versions/c-/cgltf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e21f85900222031c3343b9f2c69b48e32a37782",
+      "version": "1.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "2baab070728dce2d5193a80e1deb7c41caa041f1",
       "version": "1.13",
       "port-version": 0


### PR DESCRIPTION
Fixes #38772
Update port cgltf to the latest version 1.14

Note: no feature need to test

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
