### PR TITLE
[qt] update to 6.7.1

### DIFF
--- a/ports/qt/vcpkg.json
+++ b/ports/qt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "A cross-platform application and UI framework.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qt3d/vcpkg.json
+++ b/ports/qt3d/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt3d",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt wrapper for existing OPC UA stacks",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qt5compat/vcpkg.json
+++ b/ports/qt5compat/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5compat",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt 5 Core Compat module contains the Qt 5 Core APIs that were removed in Qt 6. The module facilitates the transition to Qt 6.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtactiveqt/vcpkg.json
+++ b/ports/qtactiveqt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtactiveqt",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "ActiveQt",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtapplicationmanager/vcpkg.json
+++ b/ports/qtapplicationmanager/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtapplicationmanager",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt component for application lifecycle management",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtbase/cmake/qt_port_details.cmake
+++ b/ports/qtbase/cmake/qt_port_details.cmake
@@ -7,7 +7,7 @@
 ## 6. The build should fail with "Done downloading version and emitting hashes." This will have changed out the vcpkg.json versions of the qt ports and rewritten qt_port_data.cmake
 ## 7. Set QT_UPDATE_VERSION back to 0
 
-set(QT_VERSION 6.7.0)
+set(QT_VERSION 6.7.1)
 set(QT_DEV_BRANCH 0)
 
 set(QT_UPDATE_VERSION 0)

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtbase",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtcharts/vcpkg.json
+++ b/ports/qtcharts/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtcharts",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Charts module provides a set of easy-to-use chart components. It uses the Qt Graphics View Framework to integrate charts with modern user interfaces.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtcoap/vcpkg.json
+++ b/ports/qtcoap/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtcoap",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt CoAP implements the client side of CoAP.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtconnectivity/vcpkg.json
+++ b/ports/qtconnectivity/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtconnectivity",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Connectivity module provides access to Bluetooth and NFC hardware.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtdatavis3d/vcpkg.json
+++ b/ports/qtdatavis3d/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtdatavis3d",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Data Visualization module enables you to visualize data in 3D as bar, scatter, and surface graphs.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtdeclarative/vcpkg.json
+++ b/ports/qtdeclarative/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtdeclarative",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt Declarative (Quick 2)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtdeviceutilities/vcpkg.json
+++ b/ports/qtdeviceutilities/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtdeviceutilities",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt Device Utilities provides functionality that is useful for controlling settings in embedded applications.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtdoc/vcpkg.json
+++ b/ports/qtdoc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtdoc",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt documentation.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtgraphs/vcpkg.json
+++ b/ports/qtgraphs/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtgraphs",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Graphs module enables you to visualize data in 3D as bar, scatter, and surface graphs.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtgrpc/vcpkg.json
+++ b/ports/qtgrpc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtgrpc",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt GRPC and Qt Protobuf modules together allow you to define data and messages in proto files, and then use the code generators, which generate client code allowing accessors for fields and gRPC services in the Qt framework.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qthttpserver/vcpkg.json
+++ b/ports/qthttpserver/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qthttpserver",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt HTTP Server supports building HTTP server functionality into an application.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtimageformats/vcpkg.json
+++ b/ports/qtimageformats/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtimageformats",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Image Formats add-on module provides optional support for other image file formats.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtinterfaceframework/vcpkg.json
+++ b/ports/qtinterfaceframework/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtinterfaceframework",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Interface Framework module provides both the tools and the core APIs, for you to implement Middleware APIs, Middleware Back ends, and Middleware Services.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtlanguageserver/vcpkg.json
+++ b/ports/qtlanguageserver/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtlanguageserver",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "An implementation of the Language Server Protocol.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtlocation/vcpkg.json
+++ b/ports/qtlocation/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtlocation",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Location API helps you create viable mapping solutions using the data available from some of the popular location services.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtlottie/vcpkg.json
+++ b/ports/qtlottie/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtlottie",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Lottie is a family of player software for a certain json-based file format for describing 2d vector graphics animations. These files are created/exported directly from After Effects by a plugin called Bodymovin.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtmqtt/vcpkg.json
+++ b/ports/qtmqtt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtmqtt",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt MQTT module provides a standard compliant implementation of the MQTT protocol specification.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtmultimedia/vcpkg.json
+++ b/ports/qtmultimedia/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtmultimedia",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt Multimedia is an add-on module that provides a rich set of QML types and C++ classes to handle multimedia content.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtnetworkauth/vcpkg.json
+++ b/ports/qtnetworkauth/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtnetworkauth",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt Network Authorization provides a set of APIs that enable Qt applications to obtain limited access to online accounts and HTTP services without exposing users' passwords.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtopcua/vcpkg.json
+++ b/ports/qtopcua/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtopcua",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt OPC UA module implements a Qt API to interact with OPC UA on top of a 3rd party OPC UA stack.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtpositioning/vcpkg.json
+++ b/ports/qtpositioning/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtpositioning",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Positioning API provides positioning information via QML and C++ interfaces.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtquick3d/vcpkg.json
+++ b/ports/qtquick3d/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtquick3d",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt Quick 3D provides a high-level API for creating 3D content and 3D user interfaces based on Qt Quick.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtquick3dphysics/vcpkg.json
+++ b/ports/qtquick3dphysics/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtquick3dphysics",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt Quick 3D Physics provides a high-level API for physics simulation.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtquickeffectmaker/vcpkg.json
+++ b/ports/qtquickeffectmaker/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtquickeffectmaker",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt Quick Effect Maker is a tool for creating shader effects for Qt Quick with high productivity and performance.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtquicktimeline/vcpkg.json
+++ b/ports/qtquicktimeline/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtquicktimeline",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Quick Timeline module enables keyframe-based animations and parameterization.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtremoteobjects/vcpkg.json
+++ b/ports/qtremoteobjects/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtremoteobjects",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt Remote Objects (QtRO) is an Inter-Process Communication (IPC) module developed for Qt. This module extends Qt's existing functionalities to enable information exchange between processes or computers, easily.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtscxml/vcpkg.json
+++ b/ports/qtscxml/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtscxml",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt SCXML module provides functionality to create state machines from SCXML files.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtsensors/vcpkg.json
+++ b/ports/qtsensors/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtsensors",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Sensors API provides access to sensor hardware via QML and C++ interfaces. The Qt Sensors API also provides a motion gesture recognition API for devices.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtserialbus/vcpkg.json
+++ b/ports/qtserialbus/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtserialbus",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Serial Bus API provides classes and functions to access the various industrial serial buses and protocols, such as CAN, ModBus, and others.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtserialport/vcpkg.json
+++ b/ports/qtserialport/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtserialport",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt Serial Port provides basic functionality for configuration, I/O operations, and getting and setting the control signals of the RS-232 pinouts.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtshadertools/vcpkg.json
+++ b/ports/qtshadertools/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtshadertools",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Shader Tools module is designed to provide a set of tools and utilities to work with graphics shaders.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtspeech/vcpkg.json
+++ b/ports/qtspeech/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtspeech",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Speech module enables a Qt application to support accessibility features such as text-to-speech, which is useful for end-users who are visually challenged or cannot access the application for whatever reason.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtsvg/vcpkg.json
+++ b/ports/qtsvg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtsvg",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt SVG provides classes for rendering and displaying SVG drawings in widgets and on other paint devices.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qttools/vcpkg.json
+++ b/ports/qttools/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qttools",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "A collection of tools and utilities that come with the Qt framework to assist developers in the creation, management, and deployment of Qt applications.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qttranslations/vcpkg.json
+++ b/ports/qttranslations/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qttranslations",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt translations.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtvirtualkeyboard/vcpkg.json
+++ b/ports/qtvirtualkeyboard/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtvirtualkeyboard",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt Virtual Keyboard project provides an input framework and reference keyboard frontend for Qt 6 on Linux Desktop/X11, Windows Desktop, and Boot2Qt targets.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtwayland/vcpkg.json
+++ b/ports/qtwayland/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtwayland",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "A toolbox for making Qt based Wayland compositors",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtwebchannel/vcpkg.json
+++ b/ports/qtwebchannel/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtwebchannel",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt WebChannel enables peer-to-peer communication between a server (QML/C++ application) and a client (HTML/JavaScript or QML application).",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtwebengine/vcpkg.json
+++ b/ports/qtwebengine/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "$comment": "x86-windows is not within the upstream support matrix of Qt6",
   "name": "qtwebengine",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt WebEngine provides functionality for rendering regions of dynamic web content.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtwebsockets/vcpkg.json
+++ b/ports/qtwebsockets/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtwebsockets",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "The Qt WebSockets module provides C++ and QML interfaces that enable Qt applications to act as a server that can process WebSocket requests, or a client that can consume data received from the server, or both.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtwebview/vcpkg.json
+++ b/ports/qtwebview/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtwebview",
-  "version": "6.7.0",
+  "version": "6.7.1",
+  "port-version": 1,
   "description": "Qt WebView provides a way to display web content in a QML application without necessarily including a full web browser stack by using native APIs where it makes sense.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7121,16 +7121,16 @@
       "port-version": 1
     },
     "qt": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qt-advanced-docking-system": {
       "baseline": "4.3.0",
       "port-version": 0
     },
     "qt3d": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qt5": {
       "baseline": "5.15.13",
@@ -7305,68 +7305,68 @@
       "port-version": 1
     },
     "qt5compat": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtactiveqt": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtapplicationmanager": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtbase": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtcharts": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtcoap": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtconnectivity": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtdatavis3d": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtdeclarative": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtdeviceutilities": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtdoc": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtgraphs": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtgrpc": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qthttpserver": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtimageformats": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtinterfaceframework": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtkeychain": {
       "baseline": "0.14.1",
@@ -7377,120 +7377,120 @@
       "port-version": 1
     },
     "qtlanguageserver": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtlocation": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtlottie": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtmqtt": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtmultimedia": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtnetworkauth": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtopcua": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtpositioning": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtquick3d": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtquick3dphysics": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtquickcontrols2": {
       "baseline": "deprecated",
       "port-version": 1
     },
     "qtquickeffectmaker": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtquicktimeline": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtremoteobjects": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtscxml": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtsensors": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtserialbus": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtserialport": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtshadertools": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtspeech": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtsvg": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qttools": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qttranslations": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtvirtualkeyboard": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtwayland": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtwebchannel": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtwebengine": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtwebsockets": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "qtwebview": {
-      "baseline": "6.7.0",
-      "port-version": 0
+      "baseline": "6.7.1",
+      "port-version": 1
     },
     "quadtree": {
       "baseline": "2022-04-24",

--- a/versions/q-/qt.json
+++ b/versions/q-/qt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a74c137d6324f2c5111954283d811adac25f3de7",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "b43b9441f148fedaf603d7f8a7b76912b94e098e",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qt3d.json
+++ b/versions/q-/qt3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b0261be0efc944a50fbc4ae62c9c1a6a45cc3e2",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "7c8531931f5eec48995ff96ddfc254c327ea2432",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qt5compat.json
+++ b/versions/q-/qt5compat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98d6097de3c8a87e8ac1dbb64f5a561499127617",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d44957feee30c5249b904fd1d0c03477be1ba2e9",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtactiveqt.json
+++ b/versions/q-/qtactiveqt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "866a3cface5d663a520fd49094caaed8ef3f9bbc",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "06b8bf07f2430bcd6c5048eced238bac26b5d010",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtapplicationmanager.json
+++ b/versions/q-/qtapplicationmanager.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ed5bc2c3fb46cd4003a3952a0b741548f6f7762",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "1fcf4c410373cf2d043515dc8a5163b7f5e56efa",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4caa0b6f876ff755362c4d995a4aa2f1d187cc3b",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "2143fc719b61ad45e2f017348969a393b243e1d7",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtcharts.json
+++ b/versions/q-/qtcharts.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc93ce937dbd1cd6cab4a01dd147f366784f5272",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "fbef96eaf13bdfbb0c4b787b6a76f9da2014385e",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtcoap.json
+++ b/versions/q-/qtcoap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e466bfdf9bc6360044d236681d00654bf23ef6b6",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "5534a6aeb5a5fd0cb5c84657546400a9c2a72fb2",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtconnectivity.json
+++ b/versions/q-/qtconnectivity.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1782a9deb637c32bf14b55fda08e401397f0e9fd",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "6a758c0ed77b654e3803dbafa3abb4597642addf",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtdatavis3d.json
+++ b/versions/q-/qtdatavis3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35610ecc8113d49c4e6616c8d7f7bcff48e3874f",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e05eefa831261dd71a45ef0cea2c2d3ab19d02fe",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtdeclarative.json
+++ b/versions/q-/qtdeclarative.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03ce6b0e022fb888beb6e28434d09c4cccf7b7f5",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "c7735c31022b2d41f5e0af9e727fc73cd4146a52",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtdeviceutilities.json
+++ b/versions/q-/qtdeviceutilities.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d2b36d5a34cb689336e755cc81319931669ea2c",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "066ff3fa9d072a8471de75a9c7711746f86f38f8",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtdoc.json
+++ b/versions/q-/qtdoc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb157d1152119dedb32bc8568c96239b36df6e22",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "a6347a56a9c0e1fb4544e47f2a288441f1662f59",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtgraphs.json
+++ b/versions/q-/qtgraphs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e85e2fd7c15a8eff6aa9a71d4fae72cdf4f7cdd6",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "4ba6a7e04f99787dc5b9d5103042660cb315df9b",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtgrpc.json
+++ b/versions/q-/qtgrpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e77d8d8e5dfbbb037a5971dd194a6ac101e38cf",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf3f735ecbdb3d211b1a52d67878a520c94d0403",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qthttpserver.json
+++ b/versions/q-/qthttpserver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "415e9717a3d75d926f4a82b0a2ecda30046c2d22",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "c87d262931a261de01ff88aa103a1e043bdf5a70",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtimageformats.json
+++ b/versions/q-/qtimageformats.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d68c81456899e7c0548ac775ec11077e804fa195",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "9abe1d0a6b86b45eb8c0732fc62b78b8973b9b51",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtinterfaceframework.json
+++ b/versions/q-/qtinterfaceframework.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e46a75c74c8cebb85daa818df793f491960f317",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "f42b78256d78f322fb0a0a053c7704b9cd9702ab",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtlanguageserver.json
+++ b/versions/q-/qtlanguageserver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "814e5827244bd44843e7343758664cfbd904d2a0",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "005e513608d94c53c277371e5603573ad5ac761f",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtlocation.json
+++ b/versions/q-/qtlocation.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c73532e50aaec10a956585eae7694d99e0176ae4",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e6a04402f28300dd168bcbe060c36ee9f8c3b809",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtlottie.json
+++ b/versions/q-/qtlottie.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "429218ced5afc0ac965145f0d1dadab182ce8749",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d7fae04dfb5b4dbd6515059e5cb4d3c49e68ce03",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtmqtt.json
+++ b/versions/q-/qtmqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64eed000ffe4595bdf41d1cd8b526c09cdeaa02c",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "2da6398d1756c14c3469d088434168a2117a99d4",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtmultimedia.json
+++ b/versions/q-/qtmultimedia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1449932e13e23973f5a5f87ccfca520917e622f",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "36765211a0ab3857e4d483a72a0d8a19027286cf",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtnetworkauth.json
+++ b/versions/q-/qtnetworkauth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f096189f131724b7f4bcd6dd37ba19c6a86abcd3",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d236629382d95c0e6916d99d736676624b7590fa",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtopcua.json
+++ b/versions/q-/qtopcua.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6c780e99eb95441057ea2576e751f5ceb71e219f",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "6ccc54814fa0de5f91425e29f2258c96e42e48cb",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtpositioning.json
+++ b/versions/q-/qtpositioning.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f133fc8b8b54648f7c875e3b84979699f9b99064",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "51005f6846a15b618957bd166832cbb7136ea966",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtquick3d.json
+++ b/versions/q-/qtquick3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "627897dbd0230669da005050ab5b68f93817882f",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "147c5f1ed97c1e49e4613896c87cbaa46ee072dd",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtquick3dphysics.json
+++ b/versions/q-/qtquick3dphysics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "900f1b02409032154341e0d1d9283f9860bc1948",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "0dac3440b94cd294030abe5ed8bad54d3424e282",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtquickeffectmaker.json
+++ b/versions/q-/qtquickeffectmaker.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4f44e1a88568fd1397d289e03921b178b77afec4",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "baf37c060ae3957c4341cf27cf89fce5f99770a2",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtquicktimeline.json
+++ b/versions/q-/qtquicktimeline.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "94f957986c3bd35422cdf63c81a9df57cc244eeb",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "71e2abff296b873154d58545db18f2a0de441a8f",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtremoteobjects.json
+++ b/versions/q-/qtremoteobjects.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ee8fadd4b28067dcf980eec056fe868e95cda9f5",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "57ccb94acf0107e957028aeee1050b58f0d4f590",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtscxml.json
+++ b/versions/q-/qtscxml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ecb4aee7e05d6230ff563a25f20e0a74407c46ee",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "02bc794d25e33f277c7593addc1523f216630491",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtsensors.json
+++ b/versions/q-/qtsensors.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1dacf1e47b996fab4836bc8e42c08f82a273196b",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "c5e35b91c7054b6432bd37137e4b2a05dba1ca13",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtserialbus.json
+++ b/versions/q-/qtserialbus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51cce25b4126f3ad626c53bc827cfffc0a7572fd",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "cc7a8d6eb48940b5165aac93bf981c2971370ee5",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtserialport.json
+++ b/versions/q-/qtserialport.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efa8a83791cdd815a7f49431a118dffff1704723",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "96a632c2073454232bdc68f415d8a8d0145af9ff",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtshadertools.json
+++ b/versions/q-/qtshadertools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d00ac0ce22efb4d5c18a7ad65c67366dc2e63b7a",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e24ecbe5c79d5146cf9c87fb444e6e16fdf435c8",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtspeech.json
+++ b/versions/q-/qtspeech.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c2db9e0ebbafe4a3713a706bd48c76577e5298c",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "ec196949a1f05c2fc567426a298954e26543ef3b",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtsvg.json
+++ b/versions/q-/qtsvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dd23b1df5d77d7c2eefe175617e147b4ca99b9ef",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "3e700d8443cc4dff407ac2d39c9f0a8b9ad1a73d",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qttools.json
+++ b/versions/q-/qttools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef17003a69db2d51d6bad05480bf356944db15db",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "db60b03c6a66d957671dbf1ca32f996ccf80633d",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qttranslations.json
+++ b/versions/q-/qttranslations.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51b291b53558dfa466c3554648aa3f33e5b80437",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "7cbc96fb9f79ad3be6a1e072daf10eb1670791a6",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtvirtualkeyboard.json
+++ b/versions/q-/qtvirtualkeyboard.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e43b508a9849e81a49b0b43f73eea0775d7a606e",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "587f852a33aae5bc30d1f0add8b74671469d36a5",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtwayland.json
+++ b/versions/q-/qtwayland.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29b34b4cb0360315531124e8134a1664c7ca1f8c",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "bd707e68a11ac8c4dbfa7b154e665cdc5dea69b9",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtwebchannel.json
+++ b/versions/q-/qtwebchannel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad917645149495a46ba4ee62283cd8d2292f552b",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "5ef675d7bb6f920135408059a4410d1eef62d911",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtwebengine.json
+++ b/versions/q-/qtwebengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7841ca50baabb836d5c9bd7cf387fb207ba088a2",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "100603c883257132007e43ace417903c75e99d94",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtwebsockets.json
+++ b/versions/q-/qtwebsockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "61d90da039776e397ba347f6cdb24ee76126b6e3",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "09b4dcf0f7ca43aa0d204d1d01fd714bf4faf12d",
       "version": "6.7.0",
       "port-version": 0

--- a/versions/q-/qtwebview.json
+++ b/versions/q-/qtwebview.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80a6b78ea52a09adf0da91daa159a4da2480420c",
+      "version": "6.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "744b3381bfe8505c8a61b91fc54fb77fcdc77ba6",
       "version": "6.7.0",
       "port-version": 0


### PR DESCRIPTION
Simple update from 6.7.0 to 6.7.1.

Fixes #38835

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
