### PR TITLE
[pixman] Fix x86 builds not using MSVC

### DIFF
--- a/ports/pixman/portfile.cmake
+++ b/ports/pixman/portfile.cmake
@@ -4,8 +4,12 @@ if(VCPKG_TARGET_IS_UWP)
             -Dsse2=disabled
             -Dssse3=disabled)
 elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-    set(VCPKG_CXX_FLAGS "/arch:SSE2 ${VCPKG_CXX_FLAGS}") # TODO: /arch: flag requires compiler check. needs to be MSVC
-    set(VCPKG_C_FLAGS "/arch:SSE2 ${VCPKG_C_FLAGS}")
+    if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+        set(VCPKG_C_FLAGS "/arch:SSE2 ${VCPKG_C_FLAGS}")
+    endif()
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        set(VCPKG_CXX_FLAGS "/arch:SSE2 ${VCPKG_CXX_FLAGS}")
+    endif()
     list(APPEND OPTIONS
             -Dmmx=enabled
             -Dsse2=enabled

--- a/ports/pixman/vcpkg.json
+++ b/ports/pixman/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pixman",
   "version": "0.43.4",
+  "port-version": 1,
   "description": "Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.",
   "homepage": "https://www.cairographics.org/releases",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6802,7 +6802,7 @@
     },
     "pixman": {
       "baseline": "0.43.4",
-      "port-version": 0
+      "port-version": 1
     },
     "pkgconf": {
       "baseline": "2.2.0",

--- a/versions/p-/pixman.json
+++ b/versions/p-/pixman.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6b62aac8f96d7fe4e407759601cfdbc350afa9ae",
+      "version": "0.43.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "f7e1a97a6af1ad657489f901a6ca14db24652eff",
       "version": "0.43.4",
       "port-version": 0


### PR DESCRIPTION
Fixes the `#Todo` comment in pixman's portfile.cmale