### PR TITLE
[ffmpeg] Handle -F from libs

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -816,6 +816,7 @@ x_vcpkg_pkgconfig_get_modules(PREFIX FFMPEG_PKGCONFIG MODULES ${FFMPEG_PKGCONFIG
 function(append_dependencies_from_libs out)
     cmake_parse_arguments(PARSE_ARGV 1 "arg" "" "LIBS" "")
     string(REGEX REPLACE "[ ]+" ";" contents "${arg_LIBS}")
+    list(FILTER contents EXCLUDE REGEX "^-F.+")
     list(FILTER contents EXCLUDE REGEX "^-framework$")
     list(FILTER contents EXCLUDE REGEX "^-L.+")
     list(FILTER contents EXCLUDE REGEX "^-libpath:.+")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "6.1.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2682,7 +2682,7 @@
     },
     "ffmpeg": {
       "baseline": "6.1.1",
-      "port-version": 3
+      "port-version": 4
     },
     "ffnvcodec": {
       "baseline": "12.1.14.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f5dac82c697daa8b59321a7e13596325efb8b278",
+      "version": "6.1.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "ae4cdc508093fc27af3254a179ec568e0f7f2add",
       "version": "6.1.1",
       "port-version": 3


### PR DESCRIPTION
Cherry-picked from #38658: Fixes errors like
~~~
CMake Error at /Users/vcpkg/Data/installed/x64-osx/share/ffmpeg/FindFFMPEG.cmake:70 (find_library):
  Could not find
  FFMPEG_DEPENDENCY_-F/Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/System/Library/Frameworks_RELEASE
  using the following names:
  -F/Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/System/Library/Frameworks
Call Stack (most recent call first):
  /Users/vcpkg/Data/installed/x64-osx/share/ffmpeg/FindFFMPEG.cmake:144 (append_dependencies)
  /Users/vcpkg/Data/installed/x64-osx/share/ffmpeg/vcpkg-cmake-wrapper.cmake:25 (_find_package)
  /Users/vcpkg/Data/work/1/s/scripts/buildsystems/vcpkg.cmake:813 (include)
  CMakeLists.txt:32 (find_package)
~~~