### PR TITLE
[onnx] Add features to use ONNX build options

### DIFF
--- a/ports/onnx/fix-dependency-protobuf.patch
+++ b/ports/onnx/fix-dependency-protobuf.patch
@@ -10,3 +10,19 @@ index d81ac1d..9f97998 100644
  if((ONNX_USE_LITE_PROTO AND TARGET protobuf::libprotobuf-lite) OR ((NOT ONNX_USE_LITE_PROTO) AND TARGET protobuf::libprotobuf))
    # Sometimes we need to use protoc compiled for host architecture while linking
    # libprotobuf against target architecture. See https://github.com/caffe2/caffe
+diff --git a/cmake/ONNXConfig.cmake.in b/cmake/ONNXConfig.cmake.in
+index d588f8a..dbd4398 100644
+--- a/cmake/ONNXConfig.cmake.in
++++ b/cmake/ONNXConfig.cmake.in
+@@ -6,9 +6,8 @@
+ # library version information
+ set(ONNX_VERSION "@ONNX_VERSION@")
+ 
+-list(APPEND CMAKE_PREFIX_PATH "@PROTOBUF_DIR@")
+-set(Protobuf_INCLUDE_DIR "@PROTOBUF_INCLUDE_DIR@")
+-find_package(Protobuf REQUIRED)
++include(CMakeFindDependencyMacro)
++find_dependency(protobuf CONFIG)
+ 
+ # import targets
+ include ("${CMAKE_CURRENT_LIST_DIR}/ONNXTargets.cmake")

--- a/ports/onnx/portfile.cmake
+++ b/ports/onnx/portfile.cmake
@@ -64,10 +64,6 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ONNX)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/ONNXConfig.cmake" "# import targets" 
-[[# import targets
-include(CMakeFindDependencyMacro)
-find_dependency(protobuf CONFIG)]])
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/onnx/vcpkg.json
+++ b/ports/onnx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "onnx",
   "version-semver": "1.16.2",
+  "port-version": 1,
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://onnx.ai",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6610,7 +6610,7 @@
     },
     "onnx": {
       "baseline": "1.16.2",
-      "port-version": 0
+      "port-version": 1
     },
     "onnx-optimizer": {
       "baseline": "0.3.19",

--- a/versions/o-/onnx.json
+++ b/versions/o-/onnx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "262df4daa9534c3c514b1a4f7c048369b575568f",
+      "version-semver": "1.16.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "57d8f77c2964232239ba10b3f2ebf16698486d9a",
       "version-semver": "1.16.2",
       "port-version": 0


### PR DESCRIPTION
## Changes

Make the following CMake build options to features in vcpkg.json

https://github.com/onnx/onnx/blob/b86cc54efce19530fb953e4b21f57e6b3888534c/CMakeLists.txt#L27-L28

### References

* Help #36850
* https://github.com/luncliff/vcpkg-registry/pull/141

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

