### PR TITLE
[ctre] update to 3.9.0

### DIFF
--- a/ports/ctre/portfile.cmake
+++ b/ports/ctre/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hanickadot/compile-time-regular-expressions
     REF "v${VERSION}"
-    SHA512 bc476728dbf7b099ad8fa547f586510f2994fb05d7c1d1334efd8bd49c041909d172097a447fde7ebb5b7588b462339c4aefc7a50d2b75945bc328773f964720
+    SHA512 252f4e8c516be8b240e4907de2751e17c97cb0154e6b0104f743e3ac70d58bcced24068fdca8eb3b56e16f52cfcbe8d549140033c1f7cd36269b60a80e017046
     HEAD_REF main
 )
 

--- a/ports/ctre/vcpkg.json
+++ b/ports/ctre/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ctre",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "A Compile time PCRE (almost) compatible regular expression matcher",
   "homepage": "https://github.com/hanickadot/compile-time-regular-expressions",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2057,7 +2057,7 @@
       "port-version": 2
     },
     "ctre": {
-      "baseline": "3.8.1",
+      "baseline": "3.9.0",
       "port-version": 0
     },
     "ctstraffic": {

--- a/versions/c-/ctre.json
+++ b/versions/c-/ctre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46132b3dc836ad3d4bd3be6a83ecef318800e844",
+      "version": "3.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0de95344cb3e667b9514cc77fefe7597648e7729",
       "version": "3.8.1",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
