### PR TITLE
[yyjson] Update to 0.9.0

### DIFF
--- a/ports/yyjson/portfile.cmake
+++ b/ports/yyjson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ibireme/yyjson
     REF "${VERSION}"
-    SHA512 3872b46930fd0f4d659004a4d08cdb1c506ccc2bf2888f5ee50523929a2b72f9d8e72ee71dc958ebca630f1886858d4350521bffc18c300a27d25436833384a9
+    SHA512 4b9ca85096ccfe2f513a5869eb63b175f44c67785940e02414f6a586d7dd7b772fed77a1775d9416a5f1bf17f20e18a31f0dc4e65be263019d9b95bf95366219
     HEAD_REF master
 )
 
@@ -25,7 +25,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
-
+vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/yyjson/vcpkg.json
+++ b/ports/yyjson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yyjson",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A high performance JSON library written in ANSI C",
   "homepage": "https://github.com/ibireme/yyjson",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9617,7 +9617,7 @@
       "port-version": 0
     },
     "yyjson": {
-      "baseline": "0.8.0",
+      "baseline": "0.9.0",
       "port-version": 0
     },
     "z3": {

--- a/versions/y-/yyjson.json
+++ b/versions/y-/yyjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e80cb41258c66dc0707602eec0008a0ed1e7a6f",
+      "version": "0.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "23f8cd0e06d0c615ea534c70316b3f55a696912a",
       "version": "0.8.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/38868

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplet:

```
x64-windows
```