### PR TITLE
[qtwebengine] Fix error C2275 and C2672 in MSVC

### DIFF
--- a/ports/qtwebengine/fix-error2275-2672.patch
+++ b/ports/qtwebengine/fix-error2275-2672.patch
@@ -1,0 +1,13 @@
+diff --git a/src/3rdparty/chromium/v8/src/compiler/backend/instruction-selector.cc b/src/3rdparty/chromium/v8/src/compiler/backend/instruction-selector.cc
+index ce06089..61534f1 100644
+--- a/src/3rdparty/chromium/v8/src/compiler/backend/instruction-selector.cc
++++ b/src/3rdparty/chromium/v8/src/compiler/backend/instruction-selector.cc
+@@ -875,7 +875,7 @@ class InstructionSelectorT<Adapter>::CachedStateValuesBuilder {
+   InstructionSelectorT<Adapter>::CachedStateValues* Build(Zone* zone) {
+     DCHECK(CanCache());
+     DCHECK(values_->nested_count() == nested_start_);
+-    return zone->New<InstructionSelectorT<Adapter>::CachedStateValues>(
++    return zone->New<typename InstructionSelectorT<Adapter>::CachedStateValues>(
+         zone, values_, values_start_, inputs_, inputs_start_);
+   }
+ 

--- a/ports/qtwebengine/portfile.cmake
+++ b/ports/qtwebengine/portfile.cmake
@@ -3,6 +3,7 @@ include("${SCRIPT_PATH}/qt_install_submodule.cmake")
 
 set(${PORT}_PATCHES 
       "clang-cl.patch"
+      "fix-error2275-2672.patch"
 )
 
 set(TOOL_NAMES gn QtWebEngineProcess qwebengine_convert_dict webenginedriver)

--- a/ports/qtwebengine/vcpkg.json
+++ b/ports/qtwebengine/vcpkg.json
@@ -2,6 +2,7 @@
   "$comment": "x86-windows is not within the upstream support matrix of Qt6",
   "name": "qtwebengine",
   "version": "6.7.0",
+  "port-version": 1,
   "description": "Qt WebEngine provides functionality for rendering regions of dynamic web content.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7486,7 +7486,7 @@
     },
     "qtwebengine": {
       "baseline": "6.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qtwebsockets": {
       "baseline": "6.7.0",

--- a/versions/q-/qtwebengine.json
+++ b/versions/q-/qtwebengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e12b173a87772bc006536e461d503caea8177b69",
+      "version": "6.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "100603c883257132007e43ace417903c75e99d94",
       "version": "6.7.0",
       "port-version": 0


### PR DESCRIPTION
In an internal version of Visual Studio, `qtwebengine` install failed with following error:
```
E:/l/qtwebengine/src/here-src-6-2748204f48.clean/src/3rdparty/chromium/v8/src/compiler/backend/instruction-selector.cc(878): error C2275: 'v8::internal::compiler::InstructionSelectorT<v8::internal::compiler::TurboshaftAdapter>::CachedStateValues': expected an expression instead of a type
E:/l/qtwebengine/src/here-src-6-2748204f48.clean/src/3rdparty/chromium/v8/src/compiler/backend/instruction-selector.cc(878): note: the template instantiation context (the oldest one first) is
E:/l/qtwebengine/src/here-src-6-2748204f48.clean/src/3rdparty/chromium/v8/src/compiler/backend/instruction-selector.cc(858): note: while compiling class 'v8::internal::compiler::InstructionSelectorT<v8::internal::compiler::TurboshaftAdapter>::CachedStateValuesBuilder'
E:/l/qtwebengine/src/here-src-6-2748204f48.clean/src/3rdparty/chromium/v8/src/compiler/backend/instruction-selector.cc(875): note: while compiling class template member function 'v8::internal::compiler::InstructionSelectorT<v8::internal::compiler::TurboshaftAdapter>::CachedStateValues *v8::internal::compiler::InstructionSelectorT<v8::internal::compiler::TurboshaftAdapter>::CachedStateValuesBuilder::Build(v8::internal::Zone *)'
E:/l/qtwebengine/src/here-src-6-2748204f48.clean/src/3rdparty/chromium/v8/src/compiler/backend/instruction-selector.cc(878): error C2672: 'v8::internal::Zone::New': no matching overloaded function found
E:/l/qtwebengine/src/here-src-6-2748204f48.clean/src/3rdparty/chromium/v8\src/zone/zone.h(112): note: could be 'T *v8::internal::Zone::New(Args ...)'
E:/l/qtwebengine/src/here-src-6-2748204f48.clean/src/3rdparty/chromium/v8/src/compiler/backend/instruction-selector.cc(878): note: 'v8::internal::Zone::New': invalid template argument for 'T', type expected
```
The reason is missing a `typename` keyword.
I have submitted an issue on upstream: https://bugreports.qt.io/browse/QTBUG-125607

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.