### PR TITLE
[sqlite3] update to 3.46.0

### DIFF
--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -4,7 +4,7 @@ string(REGEX REPLACE "^([0-9]+),0*([0-9][0-9]),0*([0-9][0-9]),0*([0-9][0-9])," "
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sqlite.org/2024/sqlite-autoconf-${SQLITE_VERSION}.tar.gz"
     FILENAME "sqlite-autoconf-${SQLITE_VERSION}.zip"
-    SHA512 ab4bb99186ccf81d288bc5150dacd5f8a32561303fbc0c607c24b5bb5ad44e0974655cea57d05122c62e957329f5260d170d2a71cbcf818501af29903c99a391
+    SHA512 631ffe4b39dffbafdcb8ac09a6a84cd7959505ecc588d8ad9278d0ff0c3ea467f87c11167e1b1a3f56d62178e679780e2be313ae3badae8ea056709d71bd4817
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -51,7 +51,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS none # only using the script-mode side-
     INVERTED_FEATURES
         json1               SQLITE_OMIT_JSON
 )
-  
+
 if(VCPKG_TARGET_IS_WINDOWS)
     set(SQLITE_OS_WIN "1")
     if(VCPKG_TARGET_IS_UWP)

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -51,7 +51,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS none # only using the script-mode side-
     INVERTED_FEATURES
         json1               SQLITE_OMIT_JSON
 )
-
+  
 if(VCPKG_TARGET_IS_WINDOWS)
     set(SQLITE_OS_WIN "1")
     if(VCPKG_TARGET_IS_UWP)

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sqlite3",
-  "version": "3.45.3",
-  "port-version": 1,
+  "version": "3.46.0",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://sqlite.org/",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8385,8 +8385,8 @@
       "port-version": 2
     },
     "sqlite3": {
-      "baseline": "3.45.3",
-      "port-version": 1
+      "baseline": "3.46.0",
+      "port-version": 0
     },
     "sqlitecpp": {
       "baseline": "3.3.1",

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a6fa6eeed5647b1b79aafdf8e92578e675dcbded",
+      "version": "3.46.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e71c1765147d72e0fbe5fc0f3affd09d95b3ee8b",
       "version": "3.45.3",
       "port-version": 1

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "a6fa6eeed5647b1b79aafdf8e92578e675dcbded",
-      "version": "3.46.0",
-      "port-version": 0
-    },
-    {
       "git-tree": "e71c1765147d72e0fbe5fc0f3affd09d95b3ee8b",
       "version": "3.45.3",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
