### PR TITLE
[libslirp] Update to 4.8.0

### DIFF
--- a/ports/libslirp/portfile.cmake
+++ b/ports/libslirp/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO slirp/libslirp
-    REF v4.7.0
-    SHA512 387f4a6dad240ce633df2640bb49c6cb0041c8b3afc8d0ef38186d385f00dd9e4ef4443e93e1b71dbf05e22892b6f2771a87a202e815d8ec899ab5c147a1f09f
+    REF "v${VERSION}"
+    SHA512 eef9d77f1588c4e3dcf91cd53e54db235d624998fc64df75d389657411635f28bfcbe0c81cd3b0ede7792eea1eb7ef716b8a87a199a6be1e9a29da27ca4a1df4
     HEAD_REF master
 )
 
@@ -24,4 +24,4 @@ vcpkg_fixup_pkgconfig()
 
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libslirp" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")

--- a/ports/libslirp/vcpkg.json
+++ b/ports/libslirp/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "libslirp",
-  "version-semver": "4.7.0",
+  "version-semver": "4.8.0",
   "description": "libslirp is a user-mode networking library used by virtual machines, containers or various tools.",
   "homepage": "https://gitlab.freedesktop.org/slirp/libslirp",
   "license": "BSD-3-Clause",
-  "supports": "!windows | mingw",
   "dependencies": [
     "glib",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4945,7 +4945,7 @@
       "port-version": 1
     },
     "libslirp": {
-      "baseline": "4.7.0",
+      "baseline": "4.8.0",
       "port-version": 0
     },
     "libsm": {

--- a/versions/l-/libslirp.json
+++ b/versions/l-/libslirp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bef9b504fbf03a1210018f21a7cf76413a27e08d",
+      "version-semver": "4.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6946f40e08a89013e998d3bf397613bdf08cb581",
       "version-semver": "4.7.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #38910
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.