### PR TITLE
[VTK] Add IOOCCT feature to VTK.

### DIFF
--- a/ports/vtk/opencascade-7.8.0.patch
+++ b/ports/vtk/opencascade-7.8.0.patch
@@ -1,0 +1,83 @@
+diff --git a/IO/OCCT/CMakeLists.txt b/IO/OCCT/CMakeLists.txt
+index e81444eceb..4baddeb719 100644
+--- a/IO/OCCT/CMakeLists.txt
++++ b/IO/OCCT/CMakeLists.txt
+@@ -4,12 +4,25 @@ vtk_module_find_package(PRIVATE_IF_SHARED
+   VERSION_VAR "@OpenCASCADE_MAJOR_VERSION@.@OpenCASCADE_MINOR_VERSION@.@OpenCASCADE_MAINTENANCE_VERSION@"
+ )
+ 
+-set(opencascade_req_targets
+-  TKSTEP
+-  TKIGES
+-  TKMesh
+-  TKXDESTEP
+-  TKXDEIGES)
++if (OpenCASCADE_VERSION VERSION_GREATER_EQUAL "7.8.0")
++  set(opencascade_req_targets
++    TKDESTEP
++    TKDEIGES
++    TKernel
++    TKMath
++    TKMesh
++    TKBRep
++    TKXSBase
++    TKLCAF
++    TKXCAF)
++else()
++  set(opencascade_req_targets
++    TKSTEP
++    TKIGES
++    TKMesh
++    TKXDESTEP
++    TKXDEIGES)
++endif()
+ set(opencascade_missing_targets)
+ foreach (opencascade_req_target IN LISTS opencascade_req_targets)
+   if (NOT TARGET "${opencascade_req_target}")
+@@ -35,8 +48,7 @@ vtk_module_link(VTK::IOOCCT
+     ${opencascade_req_targets})
+ 
+ # OpenCASCADE started putting include directory usage requirements in 7.7.0.
+-set(OpenCASCADE_VERSION
+-  "${OpenCASCADE_MAJOR_VERSION}.${OpenCASCADE_MINOR_VERSION}.${OpenCASCADE_MAINTENANCE_VERSION}")
++
+ if (OpenCASCADE_VERSION VERSION_LESS "7.7.0")
+   vtk_module_include(VTK::IOOCCT PRIVATE "${OpenCASCADE_INCLUDE_DIR}")
+ endif ()
+diff --git a/IO/OCCT/vtkOCCTReader.cxx b/IO/OCCT/vtkOCCTReader.cxx
+index 52e76be72c..5aca5c93c8 100644
+--- a/IO/OCCT/vtkOCCTReader.cxx
++++ b/IO/OCCT/vtkOCCTReader.cxx
+@@ -345,11 +345,19 @@ public:
+   }
+ 
+   //----------------------------------------------------------------------------
++#if VTK_OCCT_VERSION(7, 8, 0) <= OCC_VERSION_HEX
++  size_t GetHash(const TDF_Label& label)
++  {
++    TopoDS_Shape aShape;
++    return this->ShapeTool->GetShape(label, aShape) ? std::hash<TopoDS_Shape>{}(aShape) : 0;
++  }
++#else
+   int GetHash(const TDF_Label& label)
+   {
+     TopoDS_Shape aShape;
+     return this->ShapeTool->GetShape(label, aShape) ? aShape.HashCode(INT_MAX) : 0;
+   }
++#endif
+ 
+   //----------------------------------------------------------------------------
+   static void GetMatrix(const TopLoc_Location& loc, vtkMatrix4x4* mat)
+@@ -381,8 +389,11 @@ public:
+       GetMatrix(hLoc->Get(), location);
+     }
+   }
+-
++#if VTK_OCCT_VERSION(7, 8, 0) <= OCC_VERSION_HEX
++  std::unordered_map<size_t, vtkSmartPointer<vtkPolyData>> ShapeMap;
++#else
+   std::unordered_map<int, vtkSmartPointer<vtkPolyData>> ShapeMap;
++#endif
+   Handle(XCAFDoc_ShapeTool) ShapeTool;
+   Handle(XCAFDoc_ColorTool) ColorTool;
+ 

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -39,6 +39,7 @@ vcpkg_from_github(
         10945.diff
         10972.diff
         hdf5helper.patch
+        opencascade-7.8.0.patch
 )
 
 # =============================================================================
@@ -121,6 +122,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS VTK_FEATURE_OPTIONS
         "openvr"      VTK_MODULE_ENABLE_VTK_RenderingOpenVR
         "gdal"        VTK_MODULE_ENABLE_VTK_IOGDAL
         "geojson"     VTK_MODULE_ENABLE_VTK_IOGeoJSON
+        "ioocct"      VTK_MODULE_ENABLE_VTK_IOOCCT
 )
 
 # Replace common value to vtk value

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.3.0-pv5.12.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": "BSD-3-Clause",
@@ -116,6 +116,15 @@
     },
     "geojson": {
       "description": "Convert Geo JSON format to vtkPolyData"
+    },
+    "ioocct": {
+      "description": "Build with IOOCCT module",
+      "dependencies": [
+        {
+          "name": "opencascade",
+          "default-features": false
+        }
+      ]
     },
     "mpi": {
       "description": "MPI functionality for VTK",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9214,7 +9214,7 @@
     },
     "vtk": {
       "baseline": "9.3.0-pv5.12.0",
-      "port-version": 3
+      "port-version": 4
     },
     "vtk-dicom": {
       "baseline": "0.8.14",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "679af6f82484acf134c028480564699523c988ed",
+      "version-semver": "9.3.0-pv5.12.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "0bb2f77c2eeff358d3be93b1d5f0d006573137b7",
       "version-semver": "9.3.0-pv5.12.0",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
