### PR TITLE
[live555] update to 2024-05-15

### DIFF
--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://live555.com/liveMedia/public/live.2023.11.30.tar.gz"
-    FILENAME "live.2023.11.30.tar.gz"
-    SHA512 c91703197448f65d63a8a6e07597791da1ee63d3b59a0809454468a3869d86e21533c7fc434d0178a179d5a2e0e5614539e47daad813fbbe7468028419026892
+    URLS "http://live555.com/liveMedia/public/live.2024.05.15.tar.gz"
+    FILENAME "live.2024.05.15.tar.gz"
+    SHA512 55d6f2610bd5d99c5f369be00fa0480b10543845c1b3928a76b1fc648fb70e3abc5e55224ff4fb00a788d7c63f3126d180c279d6d5faad72e52019a88f743a37
 )
 
 vcpkg_extract_source_archive(

--- a/ports/live555/vcpkg.json
+++ b/ports/live555/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "live555",
-  "version-date": "2023-11-30",
-  "port-version": 1,
+  "version-date": "2024-05-15",
   "description": "A complete RTSP server application",
   "homepage": "http://www.live555.com/liveMedia",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5377,8 +5377,8 @@
       "port-version": 0
     },
     "live555": {
-      "baseline": "2023-11-30",
-      "port-version": 1
+      "baseline": "2024-05-15",
+      "port-version": 0
     },
     "llfio": {
       "baseline": "2023-11-06",

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9baf943b0dd1ba24e23bfad43690e9ba3234518d",
+      "version-date": "2024-05-15",
+      "port-version": 0
+    },
+    {
       "git-tree": "2402cdcc3405afe25f02e4a6d3c44ec1b1c68aaf",
       "version-date": "2023-11-30",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/38912
No feature needs to be tested.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.