### PR TITLE
[folly related] update to 05.20

### DIFF
--- a/ports/cachelib/portfile.cmake
+++ b/ports/cachelib/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/CacheLib
     REF "v${VERSION}"
-    SHA512 f94993acf78e1b6aa5352b91d33a226a4378a66c8c61c6e47fb58f23cb20cebfa618a6d5957cf743caebddd60a951347d834ca05e6180905ecb825631db766a8
-    HEAD_REF master
+    SHA512 9da8944bc1c40798a9d6564953d3b68007a4cce54577fc8bc180039a47c3a931a3eeab10724cf12d231b47377a9ce7cc65a6b642bc552ae2c52b725354c7feb9
+    HEAD_REF main
     PATCHES
         fix-build.patch
         fix-glog.patch

--- a/ports/cachelib/vcpkg.json
+++ b/ports/cachelib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cachelib",
-  "version-string": "2024.05.06.00",
+  "version-string": "2024.05.20.00",
   "description": "Pluggable caching engine to build and scale high performance cache services.",
   "homepage": "https://github.com/facebook/CacheLib",
   "license": "Apache-2.0",

--- a/ports/fbthrift/portfile.cmake
+++ b/ports/fbthrift/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/fbthrift
     REF "v${VERSION}"
-    SHA512 7c55d0fe747467e890c9bbf8f81bafeb622c08a41e31ec0074ff0435111b3987b05337ddf8c9b29f42e08f3c2dcd1d403a1823f9e9ec73221e3fbd31959d5f46
-    HEAD_REF master
+    SHA512 f4339d9986881cc883683e982e3266db17be0511f46f5baf80baf1c183996871a924b8ad7fc88f1c533d8ce5edcae5ae0aedc5c7fa4043a0e64f06845240319f
+    HEAD_REF main
     PATCHES 
         fix-glog.patch
         0002-fix-dependency.patch

--- a/ports/fbthrift/vcpkg.json
+++ b/ports/fbthrift/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fbthrift",
-  "version-string": "2024.05.06.00",
+  "version-string": "2024.05.20.00",
   "description": "Facebook's branch of Apache Thrift, including a new C++ server.",
   "homepage": "https://github.com/facebook/fbthrift",
   "license": "Apache-2.0",

--- a/ports/fizz/portfile.cmake
+++ b/ports/fizz/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebookincubator/fizz
     REF "v${VERSION}"
-    SHA512 c81a759ffb0508696fda8d5ad864d11b40bb972d52fed4376b295f536d27d55b0d83b696b735b79fe2150209fbde353bace0cd9960a81e002d6af79fe7d91129
-    HEAD_REF master
+    SHA512 b4242fbbab4954588cfc3daf4a29891f9267ac12ac07ef7b45f547ee6d00a47f9c8fe7df1ecbaad2d75f4449db07a268431482c9ea1248979d0fe4b2ba6fb6e7
+    HEAD_REF main
     PATCHES
         fix-build.patch
 )

--- a/ports/fizz/vcpkg.json
+++ b/ports/fizz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fizz",
-  "version-string": "2024.05.06.00",
+  "version-string": "2024.05.20.00",
   "description": "a TLS 1.3 implementation by Facebook",
   "homepage": "https://github.com/facebookincubator/fizz",
   "license": "BSD-3-Clause",

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/folly
     REF "v${VERSION}"
-    SHA512 3eea9182a631a51739f860176f955db5211b885f50e57ad895b43bd2e33925412d7581399800bbdce89a17ce36b22c7381a23b01b7928ed57a4853c8569923fe
+    SHA512 a305ac3d76a248b47428907a2e1115ca08bfd17f1e109ef187b1a52a1c121031495af61ffac1ffb9760e584f86df5b255f0eb9c0c19f75b1a1be01c9aec85a66
     HEAD_REF main
     PATCHES
         disable-non-underscore-posix-names.patch

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "folly",
-  "version-string": "2024.05.06.00",
+  "version-string": "2024.05.20.00",
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/ports/mvfst/portfile.cmake
+++ b/ports/mvfst/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/mvfst
     REF "v${VERSION}"
-    SHA512 191774b946bde7d906c7537830678df52025df0c34892f42ed784cd7ffb7f906e00991795700fe039a4c6ec94234ef7c0b19b915fbd15b16d682cfa6f3055eb2
+    SHA512 0306e27fda395be85b9dee803bc2b0088bf5a0aabe09203c6bbd57a7dc153703c6ca3241c84180f8714291691b7ae3e985935f77ddd1930b0f0356ce2728de48
     HEAD_REF main
 )
 
@@ -16,4 +16,4 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/mvfst)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/mvfst/vcpkg.json
+++ b/ports/mvfst/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mvfst",
-  "version-string": "2024.05.06.00",
+  "version-string": "2024.05.20.00",
   "description": "mvfst (Pronounced move fast) is a client and server implementation of IETF QUIC protocol in C++ by Facebook.",
   "homepage": "https://github.com/facebook/mvfst",
   "license": "MIT",

--- a/ports/proxygen/portfile.cmake
+++ b/ports/proxygen/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/proxygen
     REF "v${VERSION}"
-    SHA512 fc098abcb4fd352cb43fed79d6890bed511107cf2e15fac6f87dd3ad0d61b0a5f8183d2632f000052a66c7aa8e5cf838fed30889fda74cab1d41d1d7e9c8cf29
-    HEAD_REF master
+    SHA512 964d0134ed187a9c4f15b8c2a493c5e520530ece228af3db06a02e89b291787494fdf99daba42400d5b5e3243be3d3b9fc88ca5e6ded4c58b39de0c95e138e50
+    HEAD_REF main
     PATCHES
         remove-register.patch
         fix-zstd-zlib-dependency.patch

--- a/ports/proxygen/vcpkg.json
+++ b/ports/proxygen/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "proxygen",
-  "version-string": "2024.05.06.00",
+  "version-string": "2024.05.20.00",
   "description": "It comprises the core C++ HTTP abstractions used at Facebook.",
   "homepage": "https://github.com/facebook/proxygen",
   "license": "BSD-3-Clause",

--- a/ports/rsocket/fix-c2665.patch
+++ b/ports/rsocket/fix-c2665.patch
@@ -1,0 +1,13 @@
+diff --git a/rsocket/RSocketServer.cpp b/rsocket/RSocketServer.cpp
+index 3a9f6b2..e749eb1 100644
+--- a/rsocket/RSocketServer.cpp
++++ b/rsocket/RSocketServer.cpp
+@@ -30,7 +30,7 @@ RSocketServer::RSocketServer(
+     std::shared_ptr<RSocketStats> stats)
+     : duplexConnectionAcceptor_(std::move(connectionAcceptor)),
+       setupResumeAcceptors_([] {
+-        return new rsocket::SetupResumeAcceptor{
++        return rsocket::SetupResumeAcceptor{
+             folly::EventBaseManager::get()->getExistingEventBase()};
+       }),
+       connectionSet_(std::make_unique<ConnectionSet>()),

--- a/ports/rsocket/portfile.cmake
+++ b/ports/rsocket/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
     fix-folly.patch
     fix-rsockserver-build-error.patch
     fix-yarpl.patch
+    fix-c2665.patch
 )
 
 vcpkg_cmake_configure(
@@ -43,4 +44,4 @@ file(REMOVE_RECURSE
   "${CURRENT_PACKAGES_DIR}/include/rsocket/test"
 )
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rsocket/vcpkg.json
+++ b/ports/rsocket/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rsocket",
   "version-string": "2021.08.30.00",
-  "port-version": 4,
+  "port-version": 5,
   "description": "C++ implementation of RSocket http://rsocket.io",
   "homepage": "https://github.com/rsocket/rsocket-cpp",
   "dependencies": [

--- a/ports/wangle/portfile.cmake
+++ b/ports/wangle/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/wangle
     REF "v${VERSION}"
-    SHA512 225c0bd7f33e3cc6e8a46d7b3fad8e86502c7f8d12317674116c2c2ad70624337e0fdab6b7f9d404d8d0ce2fbffc7711ba9ce9f6c660f169b865aca5732b68f7
-    HEAD_REF master
+    SHA512 46adf203677aef71aefb57d13e08dad2c69f13e94880966469835f4fbf238b9c3cbb8c1cedb6c4150414f6c9e0a36cdfb0adc5805f620055056a6b24cb6795eb
+    HEAD_REF main
     PATCHES
         fix-config-cmake.patch
         fix_dependency.patch

--- a/ports/wangle/vcpkg.json
+++ b/ports/wangle/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wangle",
-  "version-string": "2024.05.06.00",
+  "version-string": "2024.05.20.00",
   "description": "Wangle is a framework providing a set of common client/server abstractions for building services in a consistent, modular, and composable way.",
   "homepage": "https://github.com/facebook/wangle",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7798,7 +7798,7 @@
     },
     "rsocket": {
       "baseline": "2021.08.30.00",
-      "port-version": 4
+      "port-version": 5
     },
     "rtabmap": {
       "baseline": "0.21.4.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1445,7 +1445,7 @@
       "port-version": 0
     },
     "cachelib": {
-      "baseline": "2024.05.06.00",
+      "baseline": "2024.05.20.00",
       "port-version": 0
     },
     "caf": {
@@ -2665,7 +2665,7 @@
       "port-version": 0
     },
     "fbthrift": {
-      "baseline": "2024.05.06.00",
+      "baseline": "2024.05.20.00",
       "port-version": 0
     },
     "fcl": {
@@ -2709,7 +2709,7 @@
       "port-version": 0
     },
     "fizz": {
-      "baseline": "2024.05.06.00",
+      "baseline": "2024.05.20.00",
       "port-version": 0
     },
     "flagpp": {
@@ -2793,7 +2793,7 @@
       "port-version": 2
     },
     "folly": {
-      "baseline": "2024.05.06.00",
+      "baseline": "2024.05.20.00",
       "port-version": 0
     },
     "font-chef": {
@@ -5993,7 +5993,7 @@
       "port-version": 7
     },
     "mvfst": {
-      "baseline": "2024.05.06.00",
+      "baseline": "2024.05.20.00",
       "port-version": 0
     },
     "mygui": {
@@ -7017,7 +7017,7 @@
       "port-version": 0
     },
     "proxygen": {
-      "baseline": "2024.05.06.00",
+      "baseline": "2024.05.20.00",
       "port-version": 0
     },
     "psimd": {
@@ -9277,7 +9277,7 @@
       "port-version": 5
     },
     "wangle": {
-      "baseline": "2024.05.06.00",
+      "baseline": "2024.05.20.00",
       "port-version": 0
     },
     "wasmedge": {

--- a/versions/c-/cachelib.json
+++ b/versions/c-/cachelib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "01da6a9868cf626c3d8658f100f86f8df069eb65",
+      "version-string": "2024.05.20.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "c50db801a7cca549cee7de167964ad91c34e8498",
       "version-string": "2024.05.06.00",
       "port-version": 0

--- a/versions/f-/fbthrift.json
+++ b/versions/f-/fbthrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e41b10d9d9a06452a253a634d222d7d0c31227d2",
+      "version-string": "2024.05.20.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "cb718abbe531b32aa3431d8bcda375acd985505c",
       "version-string": "2024.05.06.00",
       "port-version": 0

--- a/versions/f-/fizz.json
+++ b/versions/f-/fizz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b014fa7dd0e31cda7f090ce6a3e709829349d2e3",
+      "version-string": "2024.05.20.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "2c9e978e5e5bd352b95f4373305778921dc2505d",
       "version-string": "2024.05.06.00",
       "port-version": 0

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd56eb7bf9f9edada5ed1bafb3b1cdf07985db9d",
+      "version-string": "2024.05.20.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "ec791d8ffeccaec543e734b44e58834d78b8cab0",
       "version-string": "2024.05.06.00",
       "port-version": 0

--- a/versions/m-/mvfst.json
+++ b/versions/m-/mvfst.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41f9b5d23fb34a90267c156bd583d176e38b3750",
+      "version-string": "2024.05.20.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "48f5fb37da14c150b05afeba4c41f8302e2a93dd",
       "version-string": "2024.05.06.00",
       "port-version": 0

--- a/versions/p-/proxygen.json
+++ b/versions/p-/proxygen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a2c1406a1bdbf4fec06d01d2380049a1252186b",
+      "version-string": "2024.05.20.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "083404f37b66ada6057404f727c559366c2b9506",
       "version-string": "2024.05.06.00",
       "port-version": 0

--- a/versions/r-/rsocket.json
+++ b/versions/r-/rsocket.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c0da11bfe773e995165d1a052406e5b95374cf0d",
+      "version-string": "2021.08.30.00",
+      "port-version": 5
+    },
+    {
       "git-tree": "50711928560987beb101dcf47148369fb993ba89",
       "version-string": "2021.08.30.00",
       "port-version": 4

--- a/versions/w-/wangle.json
+++ b/versions/w-/wangle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a8bad0b0011af20a5da9294392c26ff70f04e331",
+      "version-string": "2024.05.20.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "32f031078ffb85d73b0cfaf1f792c7d4622885aa",
       "version-string": "2024.05.06.00",
       "port-version": 0


### PR DESCRIPTION
Update `folly` and its related ports to the latest version `2024.05.20.00`.

The recent update to `folly` includes this commit: https://github.com/facebook/folly/commit/99767aa88e8fd77823c870491d639723cf570b9d, which caused downstream `rsocket` to fail with the following error during build. 
```
vcpkg\rsocket\src\84ec7fc921-d730564084\rsocket\RSocketServer.cpp(32): error C2665: 'folly::ThreadLocal<rsocket::SetupResumeAcceptor,rsocket::RSocketServer::SetupResumeAcceptorTag,void>::ThreadLocal': no overloaded function could convert all the argument types
```
A patch has now been submitted to fix this issue.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
