### PR TITLE
[cudnn] add cudnn 9.1 compatibility

### DIFF
--- a/ports/cudnn/FindCUDNN.cmake
+++ b/ports/cudnn/FindCUDNN.cmake
@@ -23,13 +23,12 @@
 #
 
 include(FindPackageHandleStandardArgs)
-
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
-  PATH_SUFFIXES cuda/include include include/12.3)
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
+  PATH_SUFFIXES cuda/include include include/12.4 include/12.3 include/11.8)
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
-  PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/12.3/x64)
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
+  PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/12.4/x64 lib/12.3/x64 lib/11.8/x64)
 
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")
   file(READ ${CUDNN_INCLUDE_DIR}/cudnn.h CUDNN_HEADER_CONTENTS)

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -4,12 +4,12 @@ vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT OUT_CUDA_VERSION CUDA_VE
 
 # Try to find CUDNN if it exists; only download if it doesn't exist
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
-  PATH_SUFFIXES cuda/include include include/12.3)
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
+  PATH_SUFFIXES cuda/include include include/12.4 include/12.3 include/11.8)
 message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
-  PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/12.3/x64)
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
+  PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/12.4/x64 lib/12.3/x64 lib/11.8/x64)
 message(STATUS "CUDNN_LIBRARY: ${CUDNN_LIBRARY}")
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")
   file(READ ${CUDNN_INCLUDE_DIR}/cudnn.h CUDNN_HEADER_CONTENTS)

--- a/ports/cudnn/vcpkg.json
+++ b/ports/cudnn/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cudnn",
   "version": "7.6.5",
-  "port-version": 11,
+  "port-version": 12,
   "description": "NVIDIA's cuDNN deep neural network acceleration library.",
   "homepage": "https://developer.nvidia.com/cudnn",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2082,7 +2082,7 @@
     },
     "cudnn": {
       "baseline": "7.6.5",
-      "port-version": 11
+      "port-version": 12
     },
     "cunit": {
       "baseline": "2.1.3",

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a8687f7d446d544d2111cac62f5aa36681c2b223",
+      "version": "7.6.5",
+      "port-version": 12
+    },
+    {
       "git-tree": "78074072b367abf31b9f86ee6718309244ed1b50",
       "version": "7.6.5",
       "port-version": 11


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
