### PR TITLE
[yara 4.5.0] Fix broken Linux builds

### DIFF
--- a/ports/yara/fix-linux-build-issues.patch
+++ b/ports/yara/fix-linux-build-issues.patch
@@ -1,0 +1,54 @@
+diff --git a/configure.ac b/configure.ac
+index bc23ee9fba..4a518f181e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -32,9 +32,6 @@ AC_C_INLINE
+ # Defines WORDS_BIGENDIAN if building in a big-endian host.
+ AC_C_BIGENDIAN
+ 
+-# Arrange for 64-bit file offsets.
+-AC_SYS_LARGEFILE
+-
+ LT_INIT
+ AC_CANONICAL_HOST
+ 
+diff --git a/libyara/proc/linux.c b/libyara/proc/linux.c
+index 72f2ab48bc..9947d02001 100644
+--- a/libyara/proc/linux.c
++++ b/libyara/proc/linux.c
+@@ -29,6 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #if defined(USE_LINUX_PROC)
+ 
++#define _FILE_OFFSET_BITS 64
++
+ #include <assert.h>
+ #include <errno.h>
+ #include <fcntl.h>
+@@ -249,7 +251,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
+   // target process VM.
+   if (fd == -1)
+   {
+-    if (pread64(
++    if (pread(
+             proc_info->mem_fd,
+             (void*) context->buffer,
+             block->size,
+@@ -265,7 +267,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
+     {
+       goto _exit;
+     }
+-    if (pread64(
++    if (pread(
+             proc_info->pagemap_fd,
+             pagemap,
+             sizeof(uint64_t) * block->size / page_size,
+@@ -284,7 +286,7 @@ YR_API const uint8_t* yr_process_fetch_memory_block_data(YR_MEMORY_BLOCK* block)
+       // swap-backed and if it differs from our mapping.
+       uint8_t buffer[page_size];
+ 
+-      if (pread64(
++      if (pread(
+               proc_info->mem_fd,
+               buffer,
+               page_size,

--- a/ports/yara/portfile.cmake
+++ b/ports/yara/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
   PATCHES
     # Module elf request new library tlshc(https://github.com/avast/tlshc), the related upstream PR: https://github.com/VirusTotal/yara/pull/1624.
     Disable-module-elf.patch
+    # Linux builds are broken on various distributions (https://github.com/VirusTotal/yara/issues/2050), this is the backported fix for this issues
+    fix-linux-build-issues.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/yara/vcpkg.json
+++ b/ports/yara/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "yara",
   "version": "4.5.0",
+  "port-version": 1,
   "description": "The pattern matching swiss knife",
   "homepage": "https://github.com/VirusTotal/yara",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9586,7 +9586,7 @@
     },
     "yara": {
       "baseline": "4.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "yas": {
       "baseline": "7.1.0",

--- a/versions/y-/yara.json
+++ b/versions/y-/yara.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "df3fbbb41b3f1e87d91f1c361f13286c627b606b",
+      "version": "4.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "36109d80198f355066776d9166f4ab7f564a91f3",
       "version": "4.5.0",
       "port-version": 0


### PR DESCRIPTION
This pull request backports a fix for build issues on Linux that were introduced in yara 4.5.0. Further details:

https://github.com/VirusTotal/yara/pull/2048
https://github.com/VirusTotal/yara/issues/2050

Since builds are broken on multiple mainstream Linux distributions right now and there hasn't been a new release since this issue was fixed, I think it may be a good idea to backport the fix and apply it as a patch in vcpkg.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.