### PR TITLE
[yara] Update yara to version 4.5.1

### DIFF
--- a/ports/yara/portfile.cmake
+++ b/ports/yara/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO VirusTotal/yara
   REF "v${VERSION}"
-  SHA512 c9fe8a89879d1a742236101f1754e6b25e70356cdf5c020b2583e3ac509600c3b462756c412b01f2ebcb17df351c83afcf04d1cfaa87e6753eb25bab0f797aa3
+  SHA512 8bf1df7089f9bc5a448dbae0999e04f4ecdec06b4478e2cb5f42a2a3201b99fce68379e3f8f7c67a9db201205366250d7befe5c38451cced807ed692d436422c
   HEAD_REF master
   PATCHES
     # Module elf request new library tlshc(https://github.com/avast/tlshc), the related upstream PR: https://github.com/VirusTotal/yara/pull/1624.

--- a/ports/yara/vcpkg.json
+++ b/ports/yara/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yara",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "The pattern matching swiss knife",
   "homepage": "https://github.com/VirusTotal/yara",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9585,7 +9585,7 @@
       "port-version": 1
     },
     "yara": {
-      "baseline": "4.5.0",
+      "baseline": "4.5.1",
       "port-version": 0
     },
     "yas": {

--- a/versions/y-/yara.json
+++ b/versions/y-/yara.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "812967f72f45b8689953677a3969d1146945543a",
+      "version": "4.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "36109d80198f355066776d9166f4ab7f564a91f3",
       "version": "4.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
