### PR TITLE
[gsl] update to 2.8

### DIFF
--- a/ports/gsl/0001-configure.patch
+++ b/ports/gsl/0001-configure.patch
@@ -5,61 +5,61 @@ index adab7a58d..f6dc2278e 100644
 +++ b/config.h
 @@ -11,19 +11,19 @@
  
- /* Define to 1 if you have the declaration of `acosh', and to 0 if you don't.
+ /* Define to 1 if you have the declaration of 'acosh', and to 0 if you don't.
     */
 -#undef HAVE_DECL_ACOSH
 +#define HAVE_DECL_ACOSH 1
  
- /* Define to 1 if you have the declaration of `asinh', and to 0 if you don't.
+ /* Define to 1 if you have the declaration of 'asinh', and to 0 if you don't.
     */
 -#undef HAVE_DECL_ASINH
 +#define HAVE_DECL_ASINH 1
  
- /* Define to 1 if you have the declaration of `atanh', and to 0 if you don't.
+ /* Define to 1 if you have the declaration of 'atanh', and to 0 if you don't.
     */
 -#undef HAVE_DECL_ATANH
 +#define HAVE_DECL_ATANH 1
  
- /* Define to 1 if you have the declaration of `expm1', and to 0 if you don't.
+ /* Define to 1 if you have the declaration of 'expm1', and to 0 if you don't.
     */
 -#undef HAVE_DECL_EXPM1
 +#define HAVE_DECL_EXPM1 1
  
- /* Define to 1 if you have the declaration of `feenableexcept', and to 0 if
+ /* Define to 1 if you have the declaration of 'feenableexcept', and to 0 if
     you don't. */
 @@ -43,31 +43,31 @@
  
- /* Define to 1 if you have the declaration of `frexp', and to 0 if you don't.
+ /* Define to 1 if you have the declaration of 'frexp', and to 0 if you don't.
     */
 -#undef HAVE_DECL_FREXP
 +#define HAVE_DECL_FREXP 1
  
- /* Define to 1 if you have the declaration of `hypot', and to 0 if you don't.
+ /* Define to 1 if you have the declaration of 'hypot', and to 0 if you don't.
     */
 -#undef HAVE_DECL_HYPOT
 +#define HAVE_DECL_HYPOT 1
  
- /* Define to 1 if you have the declaration of `isfinite', and to 0 if you
+ /* Define to 1 if you have the declaration of 'isfinite', and to 0 if you
     don't. */
 -#undef HAVE_DECL_ISFINITE
 +#define HAVE_DECL_ISFINITE 1
  
- /* Define to 1 if you have the declaration of `isinf', and to 0 if you don't.
+ /* Define to 1 if you have the declaration of 'isinf', and to 0 if you don't.
     */
 -#undef HAVE_DECL_ISINF
 +#define HAVE_DECL_ISINF 1
  
- /* Define to 1 if you have the declaration of `isnan', and to 0 if you don't.
+ /* Define to 1 if you have the declaration of 'isnan', and to 0 if you don't.
     */
 -#undef HAVE_DECL_ISNAN
 +#define HAVE_DECL_ISNAN 1
  
- /* Define to 1 if you have the declaration of `ldexp', and to 0 if you don't.
+ /* Define to 1 if you have the declaration of 'ldexp', and to 0 if you don't.
     */
 -#undef HAVE_DECL_LDEXP
 +#define HAVE_DECL_LDEXP 1
  
- /* Define to 1 if you have the declaration of `log1p', and to 0 if you don't.
+ /* Define to 1 if you have the declaration of 'log1p', and to 0 if you don't.
     */
 -#undef HAVE_DECL_LOG1P
 +#define HAVE_DECL_LOG1P 1
@@ -89,14 +89,14 @@ index adab7a58d..f6dc2278e 100644
 -#undef HAVE_INTTYPES_H
 +#define HAVE_INTTYPES_H 1
  
- /* Define to 1 if you have the `m' library (-lm). */
+ /* Define to 1 if you have the 'm' library (-lm). */
  #undef HAVE_LIBM
  
- /* Define to 1 if you have the `memcpy' function. */
+ /* Define to 1 if you have the 'memcpy' function. */
 -#undef HAVE_MEMCPY
 +#define HAVE_MEMCPY 1
  
- /* Define to 1 if you have the `memmove' function. */
+ /* Define to 1 if you have the 'memmove' function. */
 -#undef HAVE_MEMMOVE
 +#define HAVE_MEMMOVE 1
  
@@ -115,7 +115,7 @@ index adab7a58d..f6dc2278e 100644
 -#undef HAVE_STDLIB_H
 +#define HAVE_STDLIB_H 1
  
- /* Define to 1 if you have the `strdup' function. */
+ /* Define to 1 if you have the 'strdup' function. */
 -#undef HAVE_STRDUP
 +#define HAVE_STRDUP 1
  
@@ -126,11 +126,11 @@ index adab7a58d..f6dc2278e 100644
 -#undef HAVE_STRING_H
 +#define HAVE_STRING_H 1
  
- /* Define to 1 if you have the `strtol' function. */
+ /* Define to 1 if you have the 'strtol' function. */
 -#undef HAVE_STRTOL
 +#define HAVE_STRTOL 1
  
- /* Define to 1 if you have the `strtoul' function. */
+ /* Define to 1 if you have the 'strtoul' function. */
 -#undef HAVE_STRTOUL
 +#define HAVE_STRTOUL 1
  
@@ -139,14 +139,14 @@ index adab7a58d..f6dc2278e 100644
 @@ -145,7 +145,7 @@
  #undef HAVE_UNISTD_H
  
- /* Define to 1 if you have the `vprintf' function. */
+ /* Define to 1 if you have the 'vprintf' function. */
 -#undef HAVE_VPRINTF
 +#define HAVE_VPRINTF 1
  
  /* Define if you need to hide the static definitions of inline functions */
  #undef HIDE_INLINE_STATIC
 @@ -180,7 +180,7 @@
- /* Define to 1 if all of the C90 standard headers exist (not just the ones
+ /* Define to 1 if all of the C89 standard headers exist (not just the ones
     required in a freestanding environment). This macro is provided for
     backward compatibility; new code need not use it. */
 -#undef STDC_HEADERS

--- a/ports/gsl/portfile.cmake
+++ b/ports/gsl/portfile.cmake
@@ -1,9 +1,9 @@
-set(GSL_VERSION 2.7.1)
+set(GSL_VERSION 2.8)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnu.org/gnu/gsl/gsl-${GSL_VERSION}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gsl/gsl-${GSL_VERSION}.tar.gz"
     FILENAME "gsl-${GSL_VERSION}.tar.gz"
-    SHA512 3300a748b63b583374701d5ae2a9db7349d0de51061a9f98e7c145b2f7de9710b3ad58b3318d0be2a9a287ace4cc5735bb9348cdf48075b98c1f6cc1029df131
+    SHA512 4427f6ce59dc14eabd6d31ef1fcac1849b4d7357faf48873aef642464ddf21cc9b500d516f08b410f02a2daa9a6ff30220f3995584b0a6ae2f73c522d1abb66b
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gsl/vcpkg.json
+++ b/ports/gsl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gsl",
-  "version": "2.7.1",
-  "port-version": 3,
+  "version": "2.8",
   "description": "The GNU Scientific Library is a numerical library for C and C++ programmers",
   "homepage": "https://www.gnu.org/software/gsl/",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3209,8 +3209,8 @@
       "port-version": 2
     },
     "gsl": {
-      "baseline": "2.7.1",
-      "port-version": 3
+      "baseline": "2.8",
+      "port-version": 0
     },
     "gsl-lite": {
       "baseline": "0.41.0",

--- a/versions/g-/gsl.json
+++ b/versions/g-/gsl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "065963abda1b0c77fc000f1624636bc5aec7e876",
+      "version": "2.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "533b0147bfc479e315c3dc4c181675c302272ae4",
       "version": "2.7.1",
       "port-version": 3


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.