### PR TITLE
[poolstl] New Port

### DIFF
--- a/ports/poolstl/fix-find-dependency.patch
+++ b/ports/poolstl/fix-find-dependency.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/config.cmake.in b/cmake/config.cmake.in
+--- a/cmake/config.cmake.in
++++ b/cmake/config.cmake.in
+@@ -1,7 +1,10 @@
+ 
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(Threads)
++
+ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+ 
+ set_and_check(@PROJECT_NAME@_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+ check_required_components("@PROJECT_NAME@")

--- a/ports/poolstl/portfile.cmake
+++ b/ports/poolstl/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO alugowski/poolSTL
+    REF "v${VERSION}"
+    SHA512 a2d29056b29f32f034560f88e05f7257ff1f43b46579b940da3e340c97cf8bfbb7d886f5101044d5e22931af37bbcf72f956a0157e135cdf10c7a987e56ba081
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/poolSTL)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-BSD.txt" "${SOURCE_PATH}/LICENSE-Boost.txt" "${SOURCE_PATH}/LICENSE-MIT.txt")

--- a/ports/poolstl/portfile.cmake
+++ b/ports/poolstl/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 a2d29056b29f32f034560f88e05f7257ff1f43b46579b940da3e340c97cf8bfbb7d886f5101044d5e22931af37bbcf72f956a0157e135cdf10c7a987e56ba081
     HEAD_REF main
+    PATCHES fix-find-dependency.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/poolstl/portfile.cmake
+++ b/ports/poolstl/portfile.cmake
@@ -1,10 +1,13 @@
+set(VCPKG_BUILD_TYPE release) # header-only
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alugowski/poolSTL
     REF "v${VERSION}"
     SHA512 a2d29056b29f32f034560f88e05f7257ff1f43b46579b940da3e340c97cf8bfbb7d886f5101044d5e22931af37bbcf72f956a0157e135cdf10c7a987e56ba081
     HEAD_REF main
-    PATCHES fix-find-dependency.patch
+    PATCHES
+        fix-find-dependency.patch
 )
 
 vcpkg_cmake_configure(
@@ -13,7 +16,5 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/poolSTL)
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-BSD.txt" "${SOURCE_PATH}/LICENSE-Boost.txt" "${SOURCE_PATH}/LICENSE-MIT.txt")

--- a/ports/poolstl/portfile.cmake
+++ b/ports/poolstl/portfile.cmake
@@ -17,4 +17,14 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/poolSTL)
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-BSD.txt" "${SOURCE_PATH}/LICENSE-Boost.txt" "${SOURCE_PATH}/LICENSE-MIT.txt")
+vcpkg_install_copyright(
+    COMMENT [[
+poolSTL is triple-licensed under the BSD 2-Clause License,
+the Boost Software License 1.0, and the MIT license.
+You may select, at your option, one of the above-listed licenses.
+]]
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE-BSD.txt"
+        "${SOURCE_PATH}/LICENSE-Boost.txt"
+        "${SOURCE_PATH}/LICENSE-MIT.txt"
+)

--- a/ports/poolstl/vcpkg.json
+++ b/ports/poolstl/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "poolstl",
+  "version": "0.3.5",
+  "description": "Light and self-contained implementation of C++17 parallel algorithms.",
+  "homepage": "https://github.com/alugowski/poolSTL",
+  "license": "BSD-2-Clause OR BSL-1.0 OR MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6916,6 +6916,10 @@
       "baseline": "3.0.0",
       "port-version": 5
     },
+    "poolstl": {
+      "baseline": "0.3.5",
+      "port-version": 0
+    },
     "poppler": {
       "baseline": "24.3.0",
       "port-version": 1

--- a/versions/p-/poolstl.json
+++ b/versions/p-/poolstl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "36c335e265bfdd1065fa1fb81961ac8aa6b70213",
+      "version": "0.3.5",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/p-/poolstl.json
+++ b/versions/p-/poolstl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a60a15e3420a2693f2e7080ae41808411abcbf36",
+      "git-tree": "3322a557d5e862c04bffb13717ae224025d06557",
       "version": "0.3.5",
       "port-version": 0
     }

--- a/versions/p-/poolstl.json
+++ b/versions/p-/poolstl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "36c335e265bfdd1065fa1fb81961ac8aa6b70213",
+      "git-tree": "a60a15e3420a2693f2e7080ae41808411abcbf36",
       "version": "0.3.5",
       "port-version": 0
     }

--- a/versions/p-/poolstl.json
+++ b/versions/p-/poolstl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3322a557d5e862c04bffb13717ae224025d06557",
+      "git-tree": "cd389d672b95840dece30b7eda8aafc1c2b2c59a",
       "version": "0.3.5",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
