### PR TITLE
[libsodium] Fix relocation R_X86_64_PC32 against symbol `randombytes_sysrandom_implementation' can not be used when making a shared object; recompile with -fPIC

### DIFF
--- a/ports/libsodium/portfile.cmake
+++ b/ports/libsodium/portfile.cmake
@@ -42,9 +42,14 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
         endif()
     endblock()
 else()
+    if(NOT VCPKG_TARGET_IS_MINGW)
+        list(APPEND OPTIONS --with-pic=yes)
+    endif()
+    
     vcpkg_configure_make(
         AUTOCONFIG
         SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS ${OPTIONS}        
     )
     vcpkg_install_make()
 

--- a/ports/libsodium/portfile.cmake
+++ b/ports/libsodium/portfile.cmake
@@ -43,7 +43,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     endblock()
 else()
     if(NOT VCPKG_TARGET_IS_MINGW)
-        list(APPEND OPTIONS --with-pic=yes)
+        list(APPEND OPTIONS --disable-pie)
     endif()
     
     vcpkg_configure_make(

--- a/ports/libsodium/vcpkg.json
+++ b/ports/libsodium/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libsodium",
   "version": "1.0.20",
+  "port-version": 1,
   "description": "A modern and easy-to-use crypto library",
   "homepage": "https://libsodium.org/",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4970,7 +4970,7 @@
     },
     "libsodium": {
       "baseline": "1.0.20",
-      "port-version": 0
+      "port-version": 1
     },
     "libsonic": {
       "baseline": "0.2.0",

--- a/versions/l-/libsodium.json
+++ b/versions/l-/libsodium.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8ba772776f6cc10e0d54c99bb198cec439c28d2a",
+      "git-tree": "ab6a37dc1d297573d444a9ac29e2cbd496ff51c0",
       "version": "1.0.20",
       "port-version": 1
     },

--- a/versions/l-/libsodium.json
+++ b/versions/l-/libsodium.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ba772776f6cc10e0d54c99bb198cec439c28d2a",
+      "version": "1.0.20",
+      "port-version": 1
+    },
+    {
       "git-tree": "5ac7f4518f3cf6bd123fd625b19e32b98beb3e41",
       "version": "1.0.20",
       "port-version": 0


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vcpkg/issues/38982

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
