### PR TITLE
[mp3lame] Fix MinGW-w64 compatibility

### DIFF
--- a/ports/mp3lame/fix-mingw-w64-compatibility.patch
+++ b/ports/mp3lame/fix-mingw-w64-compatibility.patch
@@ -1,0 +1,101 @@
+diff --git a/configure.in b/configure.in
+index 3f9fddb..0695f42 100644
+--- a/configure.in
++++ b/configure.in
+@@ -421,6 +421,7 @@ AC_CHECK_HEADERS(ncurses/termcap.h)
+ AC_CHECK_LIB(termcap, initscr, HAVE_TERMCAP="termcap")
+ AC_CHECK_LIB(curses, initscr, HAVE_TERMCAP="curses")
+ AC_CHECK_LIB(ncurses, initscr, HAVE_TERMCAP="ncurses")
++AC_CHECK_HEADERS(langinfo.h, AC_CHECK_FUNCS(nl_langinfo))
+ 
+ AM_ICONV
+ 
+diff --git a/frontend/parse.c b/frontend/parse.c
+index 752613f..99dc032 100644
+--- a/frontend/parse.c
++++ b/frontend/parse.c
+@@ -70,9 +70,11 @@ char   *strchr(), *strrchr();
+ #ifdef HAVE_ICONV
+ #include <iconv.h>
+ #include <errno.h>
++#ifdef HAVE_LANGINFO_H
+ #include <locale.h>
+ #include <langinfo.h>
+ #endif
++#endif
+ 
+ #if defined _ALLOW_INTERNAL_OPTIONS
+ #define INTERNAL_OPTS 1
+@@ -146,6 +148,18 @@ strlenMultiByte(char const* str, size_t w)
+     return n;
+ }
+ 
++static char*
++currentCharacterEncoding()
++{
++#ifdef HAVE_LANGINFO_H
++    char* cur_code = nl_langinfo(CODESET);
++#else
++    char* env_lang = getenv("LANG");
++    char* xxx_code = env_lang == NULL ? NULL : strrchr(env_lang, '.');
++    char* cur_code = xxx_code == NULL ? "" : xxx_code+1;
++#endif
++    return cur_code;
++}
+ 
+ static size_t
+ currCharCodeSize(void)
+@@ -153,7 +167,7 @@ currCharCodeSize(void)
+     size_t n = 1;
+     char dst[32];
+     char* src = "A";
+-    char* cur_code = nl_langinfo(CODESET);
++    char* cur_code = currentCharacterEncoding();
+     iconv_t xiconv = iconv_open(cur_code, "ISO_8859-1");
+     if (xiconv != (iconv_t)-1) {
+         for (n = 0; n < 32; ++n) {
+@@ -181,7 +195,7 @@ char* fromLatin1( char* src )
+         size_t const n = l*4;
+         dst = calloc(n+4, 4);
+         if (dst != 0) {
+-            char* cur_code = nl_langinfo(CODESET);
++            char* cur_code = currentCharacterEncoding();
+             iconv_t xiconv = iconv_open(cur_code, "ISO_8859-1");
+             if (xiconv != (iconv_t)-1) {
+                 char* i_ptr = src;
+@@ -205,7 +219,7 @@ char* fromUtf16( char* src )
+         size_t const n = l*4;
+         dst = calloc(n+4, 4);
+         if (dst != 0) {
+-            char* cur_code = nl_langinfo(CODESET);
++            char* cur_code = currentCharacterEncoding();
+             iconv_t xiconv = iconv_open(cur_code, "UTF-16LE");
+             if (xiconv != (iconv_t)-1) {
+                 char* i_ptr = (char*)src;
+@@ -231,7 +245,7 @@ char* toLatin1( char* src )
+         size_t const n = l*4;
+         dst = calloc(n+4, 4);
+         if (dst != 0) {
+-            char* cur_code = nl_langinfo(CODESET);
++            char* cur_code = currentCharacterEncoding();
+             iconv_t xiconv = iconv_open("ISO_8859-1//TRANSLIT", cur_code);
+             if (xiconv != (iconv_t)-1) {
+                 char* i_ptr = (char*)src;
+@@ -257,7 +271,7 @@ char* toUtf16( char* src )
+         size_t const n = (l+1)*4;
+         dst = calloc(n+4, 4);
+         if (dst != 0) {
+-            char* cur_code = nl_langinfo(CODESET);
++            char* cur_code = currentCharacterEncoding();
+             iconv_t xiconv = iconv_open("UTF-16LE//TRANSLIT", cur_code);
+             dst[0] = 0xff;
+             dst[1] = 0xfe;
+@@ -1513,7 +1527,7 @@ parse_args_(lame_global_flags * gfp, int argc, char **argv,
+     enum TextEncoding id3_tenc = TENC_LATIN1;
+ #endif
+ 
+-#ifdef HAVE_ICONV
++#ifdef HAVE_LANGINFO_H
+     setlocale(LC_CTYPE, "");
+ #endif
+     inPath[0] = '\0';

--- a/ports/mp3lame/portfile.cmake
+++ b/ports/mp3lame/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_sourceforge(
         00001-msvc-upgrade-solution-up-to-vc11.patch
         remove_lame_init_old_from_symbol_list.patch # deprecated https://github.com/zlargon/lame/blob/master/include/lame.h#L169
         add-macos-universal-config.patch
+        fix-mingw-w64-compatibility.patch
 )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/mp3lame/vcpkg.json
+++ b/ports/mp3lame/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mp3lame",
   "version": "3.100",
-  "port-version": 13,
+  "port-version": 14,
   "description": "LAME is a high quality MPEG Audio Layer III (MP3) encoder licensed under the LGPL.",
   "homepage": "https://sourceforge.net/projects/lame",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5870,7 +5870,7 @@
     },
     "mp3lame": {
       "baseline": "3.100",
-      "port-version": 13
+      "port-version": 14
     },
     "mpark-patterns": {
       "baseline": "2019-10-03",

--- a/versions/m-/mp3lame.json
+++ b/versions/m-/mp3lame.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70565b18777c4bd7ebb7724be82f9957a5a17475",
+      "version": "3.100",
+      "port-version": 14
+    },
+    {
       "git-tree": "c8eb821fa81b048621273034a62460902331551d",
       "version": "3.100",
       "port-version": 13


### PR DESCRIPTION
Fixes https://sourceforge.net/p/lame/bugs/487/, allowing mp3lame to be built using the MinGW community triplets.

Patch copied from [Robert Hegemann](https://sourceforge.net/u/robert/profile/)'s upstream patches:
https://sourceforge.net/p/lame/svn/6410/
https://sourceforge.net/p/lame/svn/6416/

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.