### PR TITLE
[lpeg] Add cmake Config file

### DIFF
--- a/ports/lpeg/CMakeLists.txt
+++ b/ports/lpeg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.11)
 project(lpeg)
 
 find_path(LUA_INCLUDE_DIR lua.h PATH_SUFFIXES lua)
@@ -19,7 +19,33 @@ target_include_directories(lpeg PRIVATE ${LPEG_INCLUDES})
 target_link_libraries(lpeg PRIVATE ${LPEG_LIBRARIES})
 
 install(TARGETS lpeg
+    EXPORT unofficial-lpeg-targets
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)
 install(FILES re.lua DESTINATION share/lua)
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/unofficial-${PROJECT_NAME}-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake"
+  INSTALL_DESTINATION "share/unofficial-${PROJECT_NAME}"
+)
+
+set(VERSION_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config-version.cmake")
+write_basic_package_version_file(
+  "${VERSION_FILE_PATH}"
+  VERSION       "${LPEG_VERSION}"
+  COMPATIBILITY SameMajorVersion
+)
+
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake"
+  DESTINATION "share/unofficial-${PROJECT_NAME}"
+)
+
+install(
+  EXPORT      "unofficial-${PROJECT_NAME}-targets"
+  NAMESPACE   "unofficial::${PROJECT_NAME}::"
+  DESTINATION "share/unofficial-${PROJECT_NAME}")

--- a/ports/lpeg/portfile.cmake
+++ b/ports/lpeg/portfile.cmake
@@ -11,18 +11,23 @@ vcpkg_extract_source_archive(
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/lpeg.def" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-lpeg-config.cmake.in" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DLPEG_VERSION=${VERSION}"
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "unofficial-lpeg")
 
 # Remove debug share
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/lpeg.html" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 # Allow empty include directory
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)

--- a/ports/lpeg/unofficial-lpeg-config.cmake.in
+++ b/ports/lpeg/unofficial-lpeg-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-lpeg-targets.cmake")
+set(UNOFFICIAL_LPEG_LUA_FILES "${PACKAGE_PREFIX_DIR}/share/lua/re.lua")
+check_required_components(lpeg)

--- a/ports/lpeg/usage
+++ b/ports/lpeg/usage
@@ -1,0 +1,13 @@
+lpeg provides CMake targets:
+
+  find_package(unofficial-lpeg CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE unofficial::lpeg::lpeg)
+
+UNOFFICIAL_LPEG_LUA_FILES will be set to the path of re.lua
+
+  add_custom_command(TARGET main POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${UNOFFICIAL_LPEG_LUA_FILES}
+    $<TARGET_FILE_DIR:main>)
+
+  install(FILES ${UNOFFICIAL_LPEG_LUA_FILES} DESTINATION my_lua_path)

--- a/ports/lpeg/vcpkg.json
+++ b/ports/lpeg/vcpkg.json
@@ -1,12 +1,18 @@
 {
   "name": "lpeg",
   "version": "1.1.0",
+  "port-version": 1,
   "description": "LPeg is a pattern-matching library for Lua, based on Parsing Expression Grammars (PEGs).",
   "homepage": "https://www.inf.puc-rio.br/~roberto/lpeg",
+  "license": "MIT",
   "dependencies": [
     "lua",
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5438,7 +5438,7 @@
     },
     "lpeg": {
       "baseline": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ltla-aarand": {
       "baseline": "2023-03-19",

--- a/versions/l-/lpeg.json
+++ b/versions/l-/lpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "933131ff56540fca7bbfb7a4ccd5fbf2612d4b0c",
+      "version": "1.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a1832dfc0fc6e11738a1653cdf7a65ccde8903ba",
       "version": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #38340 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

