### PR TITLE
[scintilla] Update to 5.5.0

### DIFF
--- a/ports/scintilla/0001-static-lib.patch
+++ b/ports/scintilla/0001-static-lib.patch
@@ -1,14 +1,13 @@
-diff --git a/win32/SciLexer.vcxproj b/win32/SciLexer.vcxproj
-index b2e993c..c8774f1 100644
---- a/win32/SciLexer.vcxproj
-+++ b/win32/SciLexer.vcxproj
-@@ -33,7 +33,7 @@
+diff --git a/win32/Scintilla.vcxproj b/win32/Scintilla.vcxproj
+index 82aa9b7..5eac42f 100644
+--- a/win32/Scintilla.vcxproj
++++ b/win32/Scintilla.vcxproj
+@@ -34,7 +34,7 @@
    </PropertyGroup>
    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
    <PropertyGroup>
 -    <ConfigurationType>DynamicLibrary</ConfigurationType>
 +    <ConfigurationType>StaticLibrary</ConfigurationType>
      <CharacterSet>Unicode</CharacterSet>
-     <PlatformToolset>v141</PlatformToolset>
+     <PlatformToolset>v143</PlatformToolset>
    </PropertyGroup>
--- 

--- a/ports/scintilla/0002-static-crt.patch
+++ b/ports/scintilla/0002-static-crt.patch
@@ -1,8 +1,8 @@
-diff --git a/win32/SciLexer.vcxproj b/win32/SciLexer.vcxproj
-index b2e993c..c8774f1 100644
---- a/win32/SciLexer.vcxproj
-+++ b/win32/SciLexer.vcxproj
-@@ -88,6 +88,7 @@
+diff --git a/win32/Scintilla.vcxproj b/win32/Scintilla.vcxproj
+index 82aa9b7..6b6f340 100644
+--- a/win32/Scintilla.vcxproj
++++ b/win32/Scintilla.vcxproj
+@@ -102,6 +102,7 @@
      <ClCompile>
        <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <LanguageStandard>stdcpp17</LanguageStandard>
@@ -10,7 +10,7 @@ index b2e993c..c8774f1 100644
      </ClCompile>
      <Link>
        <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
-@@ -97,6 +98,7 @@
+@@ -112,6 +113,7 @@
      <ClCompile>
        <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <LanguageStandard>stdcpp17</LanguageStandard>
@@ -18,7 +18,15 @@ index b2e993c..c8774f1 100644
      </ClCompile>
      <Link>
        <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
-@@ -117,6 +119,7 @@
+@@ -122,6 +124,7 @@
+     <ClCompile>
+       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <LanguageStandard>stdcpp17</LanguageStandard>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+@@ -133,6 +136,7 @@
        <IntrinsicFunctions>true</IntrinsicFunctions>
        <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <LanguageStandard>stdcpp17</LanguageStandard>
@@ -26,7 +34,7 @@ index b2e993c..c8774f1 100644
      </ClCompile>
      <Link>
        <EnableCOMDATFolding>true</EnableCOMDATFolding>
-@@ -129,6 +132,7 @@
+@@ -146,6 +150,7 @@
        <IntrinsicFunctions>true</IntrinsicFunctions>
        <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <LanguageStandard>stdcpp17</LanguageStandard>
@@ -34,4 +42,11 @@ index b2e993c..c8774f1 100644
      </ClCompile>
      <Link>
        <EnableCOMDATFolding>true</EnableCOMDATFolding>
--- 
+@@ -159,6 +164,7 @@
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <LanguageStandard>stdcpp17</LanguageStandard>
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/ports/scintilla/portfile.cmake
+++ b/ports/scintilla/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-  URLS "https://www.scintilla.org/scintilla446.zip"
-  FILENAME "scintilla446.zip"
-  SHA512 db6fa38283401497d8331f97dc5b57ea11d998988001f06b95892de769de5829b9f567635f3c1f2d9cfbc4384024d11666d28224ce90c5813ceef865b0dec255
+  URLS "https://www.scintilla.org/scintilla550.zip"
+  FILENAME "scintilla550.zip"
+  SHA512 6e6dac00a6be902e64abdb6687887ef3c956cbeaf0ea5e05ce99af6876b5b57898c3633b38b9f975e6b06d3d4e17c6e6b6d4c51b0982b5e3375422af046830d1
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
@@ -15,13 +15,13 @@ endif()
 vcpkg_extract_source_archive(
   SOURCE_PATH
   ARCHIVE ${ARCHIVE}
-  SOURCE_BASE 4.4.6
+  SOURCE_BASE 5.5.0
   PATCHES ${PATCHES}
 )
 
 vcpkg_install_msbuild(
   SOURCE_PATH "${SOURCE_PATH}"
-  PROJECT_SUBPATH Win32/SciLexer.vcxproj
+  PROJECT_SUBPATH Win32/Scintilla.vcxproj
 )
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.txt")

--- a/ports/scintilla/vcpkg.json
+++ b/ports/scintilla/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "scintilla",
-  "version": "4.4.6",
-  "port-version": 3,
+  "version": "5.5.0",
   "description": "A free source code editing component for Win32, GTK+, and OS X",
   "homepage": "https://www.scintilla.org/",
   "supports": "!(uwp | linux | osx)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7901,8 +7901,8 @@
       "port-version": 1
     },
     "scintilla": {
-      "baseline": "4.4.6",
-      "port-version": 3
+      "baseline": "5.5.0",
+      "port-version": 0
     },
     "sciplot": {
       "baseline": "0.3.1",

--- a/versions/s-/scintilla.json
+++ b/versions/s-/scintilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d311c9adf5b021fbc6b5e3b3bcf99e036472f44",
+      "version": "5.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8851877b637605265f10c086366f022205fcc1f7",
       "version": "4.4.6",
       "port-version": 3


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/38985

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Compile test pass with following triplets:
```
x64-windows
x64-windows-static
```