### PR TITLE
[colmap] Fix feature tests link glog

### DIFF
--- a/ports/colmap/fix-link-glog.patch
+++ b/ports/colmap/fix-link-glog.patch
@@ -1,0 +1,36 @@
+diff --git a/src/colmap/feature/CMakeLists.txt b/src/colmap/feature/CMakeLists.txt
+index 78a2814..3680d05 100644
+--- a/src/colmap/feature/CMakeLists.txt
++++ b/src/colmap/feature/CMakeLists.txt
+@@ -40,6 +40,7 @@ COLMAP_ADD_LIBRARY(
+         utils.h utils.cc
+     PUBLIC_LINK_LIBS
+         Eigen3::Eigen
++        glog::glog
+     PRIVATE_LINK_LIBS
+         colmap_util
+         colmap_math
+diff --git a/src/colmap/image/CMakeLists.txt b/src/colmap/image/CMakeLists.txt
+index 64381cb..875bea2 100644
+--- a/src/colmap/image/CMakeLists.txt
++++ b/src/colmap/image/CMakeLists.txt
+@@ -38,6 +38,7 @@ COLMAP_ADD_LIBRARY(
+         warp.h warp.cc
+     PUBLIC_LINK_LIBS
+         Eigen3::Eigen
++        glog::glog
+     PRIVATE_LINK_LIBS
+         colmap_util
+         colmap_sensor
+diff --git a/src/colmap/retrieval/CMakeLists.txt b/src/colmap/retrieval/CMakeLists.txt
+index 2ff5dfd..687d8ea 100644
+--- a/src/colmap/retrieval/CMakeLists.txt
++++ b/src/colmap/retrieval/CMakeLists.txt
+@@ -43,6 +43,7 @@ COLMAP_ADD_LIBRARY(
+     PUBLIC_LINK_LIBS
+         Boost::graph
+         Eigen3::Eigen
++        glog::glog
+         flann
+         lz4
+     PRIVATE_LINK_LIBS

--- a/ports/colmap/portfile.cmake
+++ b/ports/colmap/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF "${COLMAP_REF}"
     SHA512 6ece735c403304c14887cd9b2b13a7e36bf07155fa959748c09d74854e0da6338766c11e6a371c26f983ccdb29f93b2600d685c907a5a137fe20d798b26805d8
     HEAD_REF main
+    PATCHES
+        fix-link-glog.patch
 )
 
 if (NOT TRIPLET_SYSTEM_ARCH STREQUAL "x64" AND ("cuda" IN_LIST FEATURES OR "cuda-redist" IN_LIST FEATURES))
@@ -84,6 +86,6 @@ file(REMOVE_RECURSE
 
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/COPYING.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.txt")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/colmap/vcpkg.json
+++ b/ports/colmap/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "colmap",
   "version-date": "2023-10-01",
+  "port-version": 1,
   "description": "COLMAP is a general-purpose Structure-from-Motion (SfM) and Multi-View Stereo (MVS) pipeline with a graphical and command-line interface. It offers a wide range of features for reconstruction of ordered and unordered image collections. The software is licensed under the new BSD license.",
   "homepage": "https://colmap.github.io/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1778,7 +1778,7 @@
     },
     "colmap": {
       "baseline": "2023-10-01",
-      "port-version": 0
+      "port-version": 1
     },
     "color-console": {
       "baseline": "2022-03-20",

--- a/versions/c-/colmap.json
+++ b/versions/c-/colmap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "085e4234e54332750bcde82ced25af0078000d2c",
+      "version-date": "2023-10-01",
+      "port-version": 1
+    },
+    {
       "git-tree": "c3482baa430e8733afa927fae4d3951e300a5c67",
       "version-date": "2023-10-01",
       "port-version": 0


### PR DESCRIPTION
Fixes #38897 
Should also fix issue https://github.com/microsoft/vcpkg/issues/38393.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Feature `colmap[core,tests]` passed with following triplets:
```
x86-windows
x64-windows
x64-linux
```
Usage test passed on `x64-windows`.
