### PR TITLE
[directx-dxc, directx12-agility] updates ports for latest releases

### DIFF
--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -1,7 +1,7 @@
 set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 
-set(DIRECTX_DXC_TAG v1.8.2403.2)
-set(DIRECTX_DXC_VERSION 2024_03_29)
+set(DIRECTX_DXC_TAG v1.8.2405)
+set(DIRECTX_DXC_VERSION 2024_05_24)
 
 if (NOT VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
    message(STATUS "Note: ${PORT} always requires dynamic library linkage at runtime.")
@@ -11,13 +11,13 @@ if (VCPKG_TARGET_IS_LINUX)
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/microsoft/DirectXShaderCompiler/releases/download/${DIRECTX_DXC_TAG}/linux_dxc_${DIRECTX_DXC_VERSION}.x86_64.tar.gz"
         FILENAME "linux_dxc_${DIRECTX_DXC_VERSION}.tar.gz"
-        SHA512 5d62ad6e05ffbffdd46e45ad4cf1aa0cd16ab240798a00a4f9e46ec51a4cdff2aeb19cca8167a20ce384b42a6a6ec34e3fde1a75cc08b5f0ff2dac42edda826b
+        SHA512 6ae58c86a061225b9ee8ed0f7900f2216017af3789bad35db84620c9ab31b65344ebdf8f816a6453a0c571e2db592fbc0148923f1566a43c651f83411c037673
     )
 else()
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/microsoft/DirectXShaderCompiler/releases/download/${DIRECTX_DXC_TAG}/dxc_${DIRECTX_DXC_VERSION}.zip"
         FILENAME "dxc_${DIRECTX_DXC_VERSION}.zip"
-        SHA512 d8d33aaf9d1399d63237965567d179236edf6b4a003270ecd03fc5e31710995a68df74357a3059eafe03bd8b9e4fcaa5b540adb53e7360db455016164cfac052
+        SHA512 4df0131694e2fd551ffd91fde6ae876329308af3481826c16539b760004f4353aedaf90131e62f22fde64ff3ded4dc8981717cf8992b41ecf34b0808ba3b357f
     )
 endif()
 

--- a/ports/directx-dxc/vcpkg.json
+++ b/ports/directx-dxc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx-dxc",
-  "version-date": "2024-03-29",
+  "version-date": "2024-05-28",
   "description": "DirectX Shader Compiler (LLVM/Clang)",
   "homepage": "https://github.com/microsoft/DirectXShaderCompiler",
   "documentation": "https://github.com/microsoft/DirectXShaderCompiler/wiki",

--- a/ports/directx12-agility/portfile.cmake
+++ b/ports/directx12-agility/portfile.cmake
@@ -6,7 +6,7 @@ set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/${VERSION}"
     FILENAME "Microsoft.Direct3D.D3D12.${VERSION}.zip"
-    SHA512 9703445beb09808f1edf1320605d870fdfbd74b728227df2c9c99a560400c653f38960b6f54f45dc36fcb2609acb412d30307391ee02df53bc636e2c4c89f22c
+    SHA512 aab78de3a9db35b1b11b2c2498d2dd19e66a71cdcd1cb426f0469d551fcd6917f4d80734be8b6d0c0b20f7f6ae4b5b9936b0b0aedb229ea49265932b36aee11e
 )
 
 vcpkg_extract_source_archive(

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx12-agility",
-  "version": "1.613.0",
+  "version": "1.614.0",
   "description": "DirectX 12 Agility SDK",
   "homepage": "https://aka.ms/directx12agility",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2233,7 +2233,7 @@
       "port-version": 0
     },
     "directx-dxc": {
-      "baseline": "2024-03-29",
+      "baseline": "2024-05-28",
       "port-version": 0
     },
     "directx-headers": {
@@ -2241,7 +2241,7 @@
       "port-version": 0
     },
     "directx12-agility": {
-      "baseline": "1.613.0",
+      "baseline": "1.614.0",
       "port-version": 0
     },
     "directxmath": {

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "58cc9de22a56117b73df3e41f284efc7d0e78dc2",
+      "version-date": "2024-05-28",
+      "port-version": 0
+    },
+    {
       "git-tree": "d250ca11acd097e948e7085316d0755889429ffd",
       "version-date": "2024-03-29",
       "port-version": 0

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a435eb1c37fae2f189768a78bf22315940da5657",
+      "version": "1.614.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ff3410dacd22191327748dd1949cfcaf8e337f4",
       "version": "1.613.0",
       "port-version": 0


### PR DESCRIPTION
Update for latest releases of the DirectXCompiler and DirectX  12 Agility SDK.

https://devblogs.microsoft.com/directx/agility-sdk-1-614-0/

https://devblogs.microsoft.com/directx/dxc-1-8-2405-available/