### PR TITLE
[reactiveplusplus] update to 2.1.1

### DIFF
--- a/ports/reactiveplusplus/portfile.cmake
+++ b/ports/reactiveplusplus/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO victimsnino/ReactivePlusPlus
     REF "v${VERSION}"
-    SHA512 b19a164bf19f787ca182f88a616317eea122b76fea9ab0b90b2fe05e30ab94a7540b33aef1156003141dd4b0bc30b41bf2dc224a8cbe31707ab111bcfd7a3c5b
+    SHA512 d48e7e0d397c9fea2eef7c7f27f48f80738e814e2418437c367bcb35830baaaef73f570adf8408153bba2736c1f74769bd37ab41e7afbcea81b280112eb5e6b3
     HEAD_REF master
 )
 

--- a/ports/reactiveplusplus/vcpkg.json
+++ b/ports/reactiveplusplus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "reactiveplusplus",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "description": "ReactivePlusPlus is reactive programming library for C++ language",
   "homepage": "https://github.com/victimsnino/ReactivePlusPlus",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7613,7 +7613,7 @@
       "port-version": 2
     },
     "reactiveplusplus": {
-      "baseline": "2.0.0",
+      "baseline": "2.1.1",
       "port-version": 0
     },
     "readerwriterqueue": {

--- a/versions/r-/reactiveplusplus.json
+++ b/versions/r-/reactiveplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1407c20d8866c628e6e3b6b3723b349e7804403b",
+      "version": "2.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "774134fb825ed931da1baa9285611c9a6c606fb5",
       "version": "2.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
