### PR TITLE
[sqlite3] Add guard:cf compile & link options for MSVC

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -7,6 +7,11 @@ option(SQLITE3_SKIP_TOOLS "Disable build sqlite3 executable" OFF)
 
 set(PKGCONFIG_LIBS_PRIVATE "")
 
+if(MSVC)
+    add_compile_options(/guard:cf)
+    add_link_options(/guard:cf)
+endif()
+
 add_library(sqlite3 sqlite3.c sqlite3.rc)
 
 target_include_directories(sqlite3 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include>)

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlite3",
   "version": "3.45.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://sqlite.org/",
   "license": "blessing",


### PR DESCRIPTION


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.