### PR TITLE
[opencolorio] Fix cmake config

### DIFF
--- a/ports/opencolorio/fix-dependency.patch
+++ b/ports/opencolorio/fix-dependency.patch
@@ -49,7 +49,7 @@ diff --git a/src/cmake/Config.cmake.in b/src/cmake/Config.cmake.in
 index 6a4932a..2a08f5a 100644
 --- a/src/cmake/Config.cmake.in
 +++ b/src/cmake/Config.cmake.in
-@@ -1,6 +1,12 @@
+@@ -1,6 +1,11 @@
  @PACKAGE_INIT@
 
  include(CMakeFindDependencyMacro)
@@ -58,7 +58,6 @@ index 6a4932a..2a08f5a 100644
 +find_dependency(pystring CONFIG)
 +find_dependency(yaml-cpp CONFIG)
 +find_dependency(minizip-ng CONFIG)
-+find_dependency(lcms2 CONFIG)
 
  if (NOT @BUILD_SHARED_LIBS@) # NOT @BUILD_SHARED_LIBS@
      if (APPLE)

--- a/ports/opencolorio/vcpkg.json
+++ b/ports/opencolorio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencolorio",
   "version-semver": "2.2.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation. OCIO provides a straightforward and consistent user experience across all supporting applications while allowing for sophisticated back-end configuration options suitable for high-end production usage. OCIO is compatible with the Academy Color Encoding Specification (ACES) and is LUT-format agnostic, supporting many popular formats.",
   "homepage": "https://opencolorio.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6426,7 +6426,7 @@
     },
     "opencolorio": {
       "baseline": "2.2.1",
-      "port-version": 1
+      "port-version": 2
     },
     "opencsg": {
       "baseline": "1.6.0",

--- a/versions/o-/opencolorio.json
+++ b/versions/o-/opencolorio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "07ef1b1be3450c82b92fa80f767cc04555fe88b4",
+      "version-semver": "2.2.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "661b43b1d2c452e40476bbb64bb6e68dfc437c7b",
       "version-semver": "2.2.1",
       "port-version": 1


### PR DESCRIPTION
Fixes #38153.

lcms is only used by the `tools` feature. And only for executables, not in exported targets.