### PR TITLE
[libtracepoint/libtracepoint-control] disable building tools

### DIFF
--- a/ports/libtracepoint-control/portfile.cmake
+++ b/ports/libtracepoint-control/portfile.cmake
@@ -8,7 +8,11 @@ vcpkg_from_github(
     HEAD_REF main)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/libtracepoint-control-cpp")
+    SOURCE_PATH "${SOURCE_PATH}/libtracepoint-control-cpp"
+    OPTIONS
+        -DBUILD_SAMPLES=OFF
+        -DBUILD_TESTS=OFF
+        -DBUILD_TOOLS=OFF)
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/libtracepoint-control/vcpkg.json
+++ b/ports/libtracepoint-control/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libtracepoint-control",
   "version": "1.3.3",
+  "port-version": 1,
   "description": "C++ classes for collecting Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",

--- a/ports/libtracepoint/portfile.cmake
+++ b/ports/libtracepoint/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/libtracepoint"
     OPTIONS
         -DBUILD_SAMPLES=OFF
+        -DBUILD_TOOLS=OFF
         -DBUILD_TESTS=OFF)
 
 vcpkg_cmake_install()

--- a/ports/libtracepoint/vcpkg.json
+++ b/ports/libtracepoint/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libtracepoint",
   "version": "1.3.3",
+  "port-version": 1,
   "description": "C/C++ interface for generating Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5078,11 +5078,11 @@
     },
     "libtracepoint": {
       "baseline": "1.3.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libtracepoint-control": {
       "baseline": "1.3.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libtracepoint-decode": {
       "baseline": "1.3.3",

--- a/versions/l-/libtracepoint-control.json
+++ b/versions/l-/libtracepoint-control.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b43d20ba774f4d86540350bd84f420e1bcaa386b",
+      "version": "1.3.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "a7ecad1d1d9fe9cebd7c2fa230a505d2de1b9087",
       "version": "1.3.3",
       "port-version": 0

--- a/versions/l-/libtracepoint.json
+++ b/versions/l-/libtracepoint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4f06adb290d6c05a65c1c62c8e37edc43f33eeac",
+      "version": "1.3.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "48afed6e8645bb1e96e453d14f730f984b41ba6c",
       "version": "1.3.3",
       "port-version": 0


### PR DESCRIPTION
libtracepoint should disable building tools/samples/examples. Some of this was already disabled but the settings need to be updated. Noticed because libtracepoint tool build fails if building in an environment that does not default to C++17 or later.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
