### PR TITLE
[robotraconteur-companion] Update to version 0.4.1

### DIFF
--- a/ports/robotraconteur-companion/portfile.cmake
+++ b/ports/robotraconteur-companion/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO robotraconteur/robotraconteur_companion
-    REF v0.3.1
-    SHA512 ba6ac3777eb37411d1c52d3639aad668bc8bb6aa1a39e77a6b0288b6c130756f5bbbc0adcbaa13bb07fb152e76e29462eccc36c1cf1baf6aa0bfb81e3566a32f
+    REF "v${VERSION}"
+    SHA512 9df5fc4afe635b86cf150e59f06a809b856f17921507e75872f6afe723d2b9654cbb0ecc43533d3c7d673c11fb96545d627f4bbacdbd351a1a61d0ee65d71381
     HEAD_REF master
 )
 
@@ -18,6 +18,8 @@ file(COPY ${ROBDEF_SOURCE_PATH}/group1 DESTINATION ${SOURCE_PATH}/robdef/)
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBUILD_TESTING=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/robotraconteur-companion/vcpkg.json
+++ b/ports/robotraconteur-companion/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "name": "robotraconteur-companion",
-  "version-semver": "0.3.1",
+  "version-semver": "0.4.1",
   "homepage": "https://github.com/robotraconteur/robotraconteur_companion",
   "license": "Apache-2.0",
-  "supports": "(windows & (x86 | x64)) | (linux & (x86 | x64 | arm64)) | (osx & (x64 | arm64))",
+  "supports": "(windows & (x86 | x64)) | (linux & (x86 | x64 | arm64 | arm32)) | (osx & (x64 | arm64))",
   "dependencies": [
     "eigen3",
+    "opencv",
     "robotraconteur",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7761,7 +7761,7 @@
       "port-version": 0
     },
     "robotraconteur-companion": {
-      "baseline": "0.3.1",
+      "baseline": "0.4.1",
       "port-version": 0
     },
     "rocksdb": {

--- a/versions/r-/robotraconteur-companion.json
+++ b/versions/r-/robotraconteur-companion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c1df5476994d65c9237315095c5be35461769979",
+      "version-semver": "0.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ea627026fece9dea23b555957a5298e894c665b5",
       "version-semver": "0.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Adds `arm32` Linux compatibility.