### PR TITLE
[imcce-openfa] initial port 20231011.0.3

### DIFF
--- a/ports/imcce-openfa/portfile.cmake
+++ b/ports/imcce-openfa/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_gitlab(
+    OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://gitlab.obspm.fr
+    REPO imcce_openfa/openfa
+    REF ${VERSION}
+    SHA512 8f4cd47c80afcf91514233ff77730d65d264a11d6fa7b6f4eb5382a336577af8ec683a582a14b7aa440fa19f9cdeb780a6010144ce94029b759cb4ee52f7c654
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "openfa" CONFIG_PATH "lib/cmake/openfa")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME readme.md)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/imcce-openfa/vcpkg.json
+++ b/ports/imcce-openfa/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "imcce-openfa",
+  "version": "20231011.0.3",
+  "description": "set of algorithms and procedures that implement standard models used in fundamental astronomy",
+  "homepage": "https://gitlab.obspm.fr/imcce_openfa/openfa",
+  "license": "BSD-3-Clause",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3600,6 +3600,10 @@
       "baseline": "3.1.11",
       "port-version": 0
     },
+    "imcce-openfa": {
+      "baseline": "20231011.0.3",
+      "port-version": 0
+    },
     "imgui": {
       "baseline": "1.90.6",
       "port-version": 1

--- a/versions/i-/imcce-openfa.json
+++ b/versions/i-/imcce-openfa.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5c9317bd279c211068a29e1b89f1df79b3d845d6",
+      "version": "20231011.0.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.

