### PR TITLE
[gloo] Fix illegal C++ standard functions

### DIFF
--- a/ports/gloo/fix-c++-standard.patch
+++ b/ports/gloo/fix-c++-standard.patch
@@ -1,0 +1,90 @@
+diff --git a/gloo/common/linux.cc b/gloo/common/linux.cc
+index 020ff09..107a93b 100644
+--- a/gloo/common/linux.cc
++++ b/gloo/common/linux.cc
+@@ -27,6 +27,9 @@
+ #include <fstream>
+ #include <map>
+ #include <mutex>
++#include <cstring>
++#include <cstdio>
++#include <cstdlib>
+ 
+ #include "gloo/common/logging.h"
+ 
+@@ -185,34 +188,44 @@ const std::string& infinibandToBusID(const std::string& name) {
+ }
+ 
+ static int getInterfaceSpeedGLinkSettings(int sock, struct ifreq* ifr) {
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
+-  constexpr auto link_mode_data_nwords = 3 * 127;
+-  struct {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
++    constexpr auto link_mode_data_nwords = 3 * 127;
+     struct ethtool_link_settings req;
+-    __u32 link_mode_data[link_mode_data_nwords];
+-  } ecmd;
+-  int rv;
++    __u32 *link_mode_data = (__u32 *)malloc(sizeof(__u32) * link_mode_data_nwords);
++    if (link_mode_data == nullptr) {
++        return SPEED_UNKNOWN;
++    }
+ 
+-  ifr->ifr_data = (__caddr_t)&ecmd;
+-  memset(&ecmd, 0, sizeof(ecmd));
+-  ecmd.req.cmd = ETHTOOL_GLINKSETTINGS;
++    int rv;
++    memset(&req, 0, sizeof(req));
++    memset(link_mode_data, 0, sizeof(__u32) * link_mode_data_nwords);
+ 
+-  rv = ioctl(sock, SIOCETHTOOL, ifr);
+-  if (rv < 0 || ecmd.req.link_mode_masks_nwords >= 0) {
+-    return SPEED_UNKNOWN;
+-  }
++    struct {
++        struct ethtool_link_settings *req;
++        __u32 *link_mode_data;
++    } ecmd = { &req, link_mode_data };
+ 
+-  ecmd.req.cmd = ETHTOOL_GLINKSETTINGS;
+-  ecmd.req.link_mode_masks_nwords = -ecmd.req.link_mode_masks_nwords;
+-  rv = ioctl(sock, SIOCETHTOOL, ifr);
+-  if (rv < 0) {
+-    return SPEED_UNKNOWN;
+-  }
++    ifr->ifr_data = (char*)&ecmd;
++    ecmd.req->cmd = ETHTOOL_GLINKSETTINGS;
++
++    rv = ioctl(sock, SIOCETHTOOL, ifr);
++    if (rv < 0 || ecmd.req->link_mode_masks_nwords >= 0) {
++        free(link_mode_data);
++        return SPEED_UNKNOWN;
++    }
++
++    ecmd.req->cmd = ETHTOOL_GLINKSETTINGS;
++    ecmd.req->link_mode_masks_nwords = -ecmd.req->link_mode_masks_nwords;
++    rv = ioctl(sock, SIOCETHTOOL, ifr);
++    if (rv < 0) {
++        free(link_mode_data);
++        return SPEED_UNKNOWN;
++    }
+ 
+-  return ecmd.req.speed;
++    int speed = ecmd.req->speed;
++    free(link_mode_data);
++    return speed;
+ #else
+-  (void)sock;
+-  (void)ifr;
+   return SPEED_UNKNOWN;
+ #endif
+ }
+@@ -221,7 +234,7 @@ static int getInterfaceSpeedGSet(int sock, struct ifreq* ifr) {
+   struct ethtool_cmd edata;
+   int rv;
+ 
+-  ifr->ifr_data = (__caddr_t)&edata;
++  ifr->ifr_data = (char*)&edata;
+   memset(&edata, 0, sizeof(edata));
+   edata.cmd = ETHTOOL_GSET;
+ 

--- a/ports/gloo/portfile.cmake
+++ b/ports/gloo/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
   HEAD_REF master
   PATCHES
       fix-array.patch #https://github.com/facebookincubator/gloo/issues/332
+      fix-c++-standard.patch
   )
 
 # Determine which backend to build via specified feature

--- a/ports/gloo/vcpkg.json
+++ b/ports/gloo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gloo",
   "version": "20201203",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Collective communications library with various primitives for multi-machine training.",
   "homepage": "https://github.com/facebookincubator/gloo",
   "supports": "x64 & linux",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3094,7 +3094,7 @@
     },
     "gloo": {
       "baseline": "20201203",
-      "port-version": 3
+      "port-version": 4
     },
     "glpk": {
       "baseline": "5.0",

--- a/versions/g-/gloo.json
+++ b/versions/g-/gloo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4be4c7e894fcae4f776b20152d43b27718c16cbe",
+      "version": "20201203",
+      "port-version": 4
+    },
+    {
       "git-tree": "cc506cd5c27f23c9b2f3fb1d3cfe5774c05e0364",
       "version": "20201203",
       "port-version": 3


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/38852

Upstream PR: https://github.com/facebookincubator/gloo/pull/384

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.