### PR TITLE
[qtbase] Add feature cups as a dependency on osx

### DIFF
--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -21,16 +21,16 @@
       "name": "qtbase",
       "default-features": false,
       "features": [
-        "cups"
-      ],
-      "platform": "osx"
+        "doubleconversion"
+      ]
     },
     {
       "name": "qtbase",
       "default-features": false,
       "features": [
-        "doubleconversion"
-      ]
+        "cups"
+      ],
+      "platform": "osx"
     },
     {
       "name": "qtbase",

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -61,10 +61,6 @@
   "default-features": [
     "brotli",
     "concurrent",
-    {
-      "name": "cups",
-      "platform": "osx"
-    },
     "dbus",
     "default-features",
     "doubleconversion",

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.7.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -16,6 +16,14 @@
       "name": "qtbase",
       "host": true,
       "default-features": false
+    },
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "cups"
+      ],
+      "platform": "osx"
     },
     {
       "name": "qtbase",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7322,7 +7322,7 @@
     },
     "qtbase": {
       "baseline": "6.7.0",
-      "port-version": 1
+      "port-version": 2
     },
     "qtcharts": {
       "baseline": "6.7.0",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "83f09860f7c32fa0f77b3e5ea5dff23400c19ecd",
+      "git-tree": "f03fb5aade729d1dd879cdff4679c06c57841043",
       "version": "6.7.0",
       "port-version": 2
     },

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "83f09860f7c32fa0f77b3e5ea5dff23400c19ecd",
+      "version": "6.7.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "ff2963c7602e8c8448e68a60739965a26cce7711",
       "version": "6.7.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39020
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
