### PR TITLE
[ace] Update to 8.0.0

### DIFF
--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -8,14 +8,14 @@ if("tao" IN_LIST FEATURES)
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE%2BTAO-src-${VERSION}.tar.gz"
         FILENAME "ACE-TAO-${VERSION}.tar.gz"
-        SHA512 cf28ca68e460b163d1af2858dddf597306dac7a048ea1d8c69d74e65d671594ce16ecd5f3b1b571e2be6e0e860a7bbedf7372a2c6aea9427d1c8f83f73b99e12
+        SHA512 ee46897e13ba943c48d7b04c0792cef8ff48403b048af4eeced4bbfd874dece5ec1130a18216fd31fdbd610e3947673e56e306ab52ee3f1124975b1adaf21838
     )
 else()
     # Don't change to vcpkg_from_github! This points to a release and not an archive
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE-src-${VERSION}.tar.gz"
         FILENAME "ACE-src-${VERSION}.tar.gz"
-        SHA512 7eefc6ec2cb3ad862deffe341dab81e75a75a73acf429c8b64229e63de6ec2baa01e6bbef1643519cfd7312cc70564aa2836d57824667ea4f456659f01ba3fd5
+        SHA512 a29f8009e8f9e12c7c6d4ad9f39f76a62245baeb9fcfe08e346c1a004aedb5ab9d808a2390cde2dc71013be1b0de2ddd9d0dea26144536061e6416554233f547
     )
 endif()
 

--- a/ports/ace/vcpkg.json
+++ b/ports/ace/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ace",
-  "version": "7.1.4",
+  "version": "8.0.0",
   "maintainers": "Johnny Willemsen <jwillemsen@remedy.nl>",
   "description": "The ADAPTIVE Communication Environment",
   "homepage": "https://github.com/DOCGroup/ACE_TAO",

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6536f72ed3c2a3b49a014db1539df4bb95efd53a",
+      "version": "8.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "263db908e6fbd28ca7dc7bf9e107470674957f91",
       "version": "7.1.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -25,7 +25,7 @@
       "port-version": 3
     },
     "ace": {
-      "baseline": "7.1.4",
+      "baseline": "8.0.0",
       "port-version": 0
     },
     "acl": {


### PR DESCRIPTION
Fixes #38926, update to 8.0.0.

All features are tested successfully in the following triplets:
```
x64-windows
x64-windows-static
x86-windows
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
