### PR TITLE
[breakpad] Fixed missing include for std::find_if

### DIFF
--- a/ports/breakpad/add-algorithm.patch
+++ b/ports/breakpad/add-algorithm.patch
@@ -1,0 +1,12 @@
+diff --git a/src/common/module.cc b/src/common/module.cc
+index 0eb5aad..b6f5da7 100644
+--- a/src/common/module.cc
++++ b/src/common/module.cc
+@@ -42,6 +42,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ 
++#include <algorithm>
+ #include <functional>
+ #include <iostream>
+ #include <memory>

--- a/ports/breakpad/portfile.cmake
+++ b/ports/breakpad/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF v2023.06.01
     SHA512 7a231bbaf88f94c79b1ace1c3e66bd520595905bfc8a7ffa1aa453ea6f056136b82aea3a321d97db4ccfd1212a41e8790badcc43222564d861e9e5c35e40a402
     HEAD_REF master
+    PATCHES
+        add-algorithm.patch # https://github.com/google/breakpad/commit/898a997855168c0e6a689072fefba89246271a5d
 )
 
 if(VCPKG_HOST_IS_LINUX OR VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_ANDROID)

--- a/ports/breakpad/vcpkg.json
+++ b/ports/breakpad/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "breakpad",
   "version-date": "2023-06-01",
+  "port-version": 1,
   "description": "a set of client and server components which implement a crash-reporting system.",
   "homepage": "https://github.com/google/breakpad",
   "license": "BSD-3-Clause",

--- a/versions/b-/breakpad.json
+++ b/versions/b-/breakpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d45fecc4d50811afb62537bb6b13abd8132c8fd9",
+      "version-date": "2023-06-01",
+      "port-version": 1
+    },
+    {
       "git-tree": "9760dbfbc2afeb14dc67a91a6582c177e46a7921",
       "version-date": "2023-06-01",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1358,7 +1358,7 @@
     },
     "breakpad": {
       "baseline": "2023-06-01",
-      "port-version": 0
+      "port-version": 1
     },
     "brigand": {
       "baseline": "1.3.0",


### PR DESCRIPTION
Fixes #39054
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
