### PR TITLE
[krb5] More fixes

### DIFF
--- a/ports/krb5/define-des-zeroblock.diff
+++ b/ports/krb5/define-des-zeroblock.diff
@@ -1,0 +1,13 @@
+diff --git a/src/lib/crypto/builtin/des/f_aead.c b/src/lib/crypto/builtin/des/f_aead.c
+index f887735..26a5474 100644
+--- a/src/lib/crypto/builtin/des/f_aead.c
++++ b/src/lib/crypto/builtin/des/f_aead.c
+@@ -28,7 +28,7 @@
+ 
+ #ifdef K5_BUILTIN_DES
+ 
+-const mit_des_cblock mit_des_zeroblock /* = all zero */;
++const mit_des_cblock mit_des_zeroblock = { 0, 0, 0 };
+ 
+ void
+ krb5int_des_cbc_encrypt(krb5_crypto_iov *data, unsigned long num_data,

--- a/ports/krb5/portfile.cmake
+++ b/ports/krb5/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         static-deps.diff
+        define-des-zeroblock.diff
 )
 
 if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/krb5/portfile.cmake
+++ b/ports/krb5/portfile.cmake
@@ -1,10 +1,11 @@
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO krb5/krb5
     REF krb5-${VERSION}-final
     SHA512 184ef8645d7e17f30a8e3d4005364424d2095b3d0c96f26ecef0c2dd2f3a096a0dd40558ed113121483717e44f6af41e71be0e5e079c76a205535d0c11a2ea34
     HEAD_REF master
+    PATCHES
+        static-deps.diff
 )
 
 if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
@@ -74,16 +75,11 @@ if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
         endforeach()    
     endif()
 else()
-    if(VCPKG_TARGET_IS_OSX AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        vcpkg_replace_string("${SOURCE_PATH}/src/build-tools/mit-krb5.pc.in" "@COM_ERR_LIB@" "@COM_ERR_LIB@ -framework Kerberos")
-        set(OPTIONS_OSX "LDFLAGS=-framework Kerberos \$LDFLAGS")
-    endif()
     vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}/src"
         AUTOCONFIG
         OPTIONS
             "CFLAGS=-fcommon \$CFLAGS"
-            ${OPTIONS_OSX}
     )
     vcpkg_install_make()
 

--- a/ports/krb5/portfile.cmake
+++ b/ports/krb5/portfile.cmake
@@ -79,6 +79,8 @@ else()
         SOURCE_PATH "${SOURCE_PATH}/src"
         AUTOCONFIG
         OPTIONS
+            --disable-nls
+            --with-tls-impl=no
             "CFLAGS=-fcommon \$CFLAGS"
     )
     vcpkg_install_make()

--- a/ports/krb5/portfile.cmake
+++ b/ports/krb5/portfile.cmake
@@ -98,13 +98,18 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/var")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat1")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat5")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat7")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/krb5/cat8")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/krb5/")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/krb5/")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/var")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/var")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/debug/lib/krb5/"
+        "${CURRENT_PACKAGES_DIR}/lib/krb5/"
+    )
+endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/NOTICE")

--- a/ports/krb5/static-deps.diff
+++ b/ports/krb5/static-deps.diff
@@ -1,0 +1,23 @@
+diff --git a/src/build-tools/mit-krb5.pc.in b/src/build-tools/mit-krb5.pc.in
+index fdc5577..dc9c4b9 100644
+--- a/src/build-tools/mit-krb5.pc.in
++++ b/src/build-tools/mit-krb5.pc.in
+@@ -12,4 +12,4 @@ Description: An implementation of Kerberos network authentication
+ Version: @KRB5_VERSION@
+ Cflags: -I${includedir}
+ Libs: -L${libdir} -lkrb5 -lk5crypto @COM_ERR_LIB@
+-Libs.private: -lkrb5support
++Libs.private: -lkrb5support @GEN_LIB@ @MACOS_FRAMEWORK@ @LIBS@ @DL_LIB@
+diff --git a/src/config/pre.in b/src/config/pre.in
+index a0c60c7..a8432a8 100644
+--- a/src/config/pre.in
++++ b/src/config/pre.in
+@@ -379,7 +379,7 @@ SUPPORT_LIB			= -l$(SUPPORT_LIBNAME)
+ # HESIOD_LIBS is -lhesiod...
+ HESIOD_LIBS	= @HESIOD_LIBS@
+ 
+-KRB5_BASE_LIBS	= $(KRB5_LIB) $(K5CRYPTO_LIB) $(COM_ERR_LIB) $(SUPPORT_LIB) $(GEN_LIB) $(LIBS) $(DL_LIB)
++KRB5_BASE_LIBS	= $(KRB5_LIB) $(K5CRYPTO_LIB) $(COM_ERR_LIB) $(SUPPORT_LIB) $(GEN_LIB) @MACOS_FRAMEWORK@ $(LIBS) $(DL_LIB)
+ KDB5_LIBS	= $(KDB5_LIB) $(GSSRPC_LIBS)
+ GSS_LIBS	= $(GSS_KRB5_LIB)
+ # needs fixing if ever used on macOS!

--- a/ports/krb5/vcpkg.json
+++ b/ports/krb5/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "krb5",
   "version": "1.21.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "Kerberos is a network authentication protocol.",
     "It is designed to provide strong authentication for client/server applications by using secret-key cryptography.",
@@ -11,5 +11,5 @@
   ],
   "homepage": "https://web.mit.edu/kerberos/",
   "license": "MIT",
-  "supports": "linux | (x64 & !static & !uwp & windows) | osx"
+  "supports": "linux | osx | (x64 & windows & !static & !uwp)"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4054,7 +4054,7 @@
     },
     "krb5": {
       "baseline": "1.21.2",
-      "port-version": 3
+      "port-version": 4
     },
     "ktx": {
       "baseline": "4.3.1",

--- a/versions/k-/krb5.json
+++ b/versions/k-/krb5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "deb0f92c503d39f2c011c3d27ce58066ebea3ba9",
+      "version": "1.21.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "9a1fcab10fa739ff109f086e7e24b689294e3edc",
       "version": "1.21.2",
       "port-version": 3


### PR DESCRIPTION
- Fix export of static link libs
- Fix uncontrolled dependencies
- Fix build with Apple CLang 14.0.0 (and maybe other compilers)
- Don't remove plugins for dynamic linkage.