### PR TITLE
[pulseaudio] Misc fixes

### DIFF
--- a/ports/pulseaudio/portfile.cmake
+++ b/ports/pulseaudio/portfile.cmake
@@ -14,12 +14,12 @@ vcpkg_replace_string ("${SOURCE_PATH}/meson.build"
 
 set(opts "")
 if(VCPKG_TARGET_IS_LINUX)
-  set(opts
+  list(APPEND opts
     -Dalsa=enabled
     -Doss-output=enabled
   )
 else()
-  set(opts
+  list(APPEND opts
     -Dalsa=disabled
     -Doss-output=disabled
   )
@@ -38,7 +38,7 @@ vcpkg_configure_meson(
       -Dbashcompletiondir=no
       -Dzshcompletiondir=no
       
-      -Dasyncns=disabled # rerquires port?
+      -Dasyncns=disabled # requires port?
       -Davahi=disabled
       -Dbluez5=disabled
       -Dbluez5-native-headset=false
@@ -80,9 +80,9 @@ endif()
 
 vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(PACKAGE_NAME PulseAudio CONFIG_PATH "lib/cmake/PulseAudio")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/PulseAudio")
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/bin/padsp" "${CURRENT_PACKAGES_DIR}" "$(dirname "$0")/../..")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/bin/padsp" "${CURRENT_PACKAGES_DIR}" [[$(dirname "$0")/../..]])
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/etc/pulse/client.conf" "${CURRENT_PACKAGES_DIR}" "<path-to-pulseaudio>")
 if(NOT VCPKG_BUILD_TYPE)
   vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/etc/pulse/client.conf" "${CURRENT_PACKAGES_DIR}" "<path-to-pulseaudio>")

--- a/ports/pulseaudio/vcpkg.json
+++ b/ports/pulseaudio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pulseaudio",
   "version": "17.0",
+  "port-version": 1,
   "description": "PulseAudio is a sound server, originally created to overcome the limitations of the Enlightened Sound Daemon (EsounD)",
   "homepage": "https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/Community/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7062,7 +7062,7 @@
     },
     "pulseaudio": {
       "baseline": "17.0",
-      "port-version": 0
+      "port-version": 1
     },
     "pulzed-mini": {
       "baseline": "0.9.14",

--- a/versions/p-/pulseaudio.json
+++ b/versions/p-/pulseaudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb9160ce88d38cfeb2a6b49a91620a3e53b368f8",
+      "version": "17.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "26c834504f848ba81304aacc552a16bac2c4dece",
       "version": "17.0",
       "port-version": 0


### PR DESCRIPTION
Fixes:
~~~
CMake Warning (dev) at ports/pulseaudio/portfile.cmake:85:
  Syntax Warning in cmake code at column 96

  Argument not separated from preceding token by whitespace.
~~~