### PR TITLE
[libvorbis] Fix libogg find_package

### DIFF
--- a/ports/libvorbis/0004-ogg-find-dependency.patch
+++ b/ports/libvorbis/0004-ogg-find-dependency.patch
@@ -7,7 +7,7 @@ index 6fc07941..c762ba55 100644
  
  include(CMakeFindDependencyMacro)
 -find_dependency(Ogg REQUIRED)
-+find_dependency(Ogg CONFIG REQUIRED)
++find_dependency(Ogg CONFIG)
  
  include(${CMAKE_CURRENT_LIST_DIR}/VorbisTargets.cmake)
  

--- a/ports/libvorbis/0004-ogg-find-dependency.patch
+++ b/ports/libvorbis/0004-ogg-find-dependency.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/VorbisConfig.cmake.in b/cmake/VorbisConfig.cmake.in
+index 6fc07941..c762ba55 100644
+--- a/cmake/VorbisConfig.cmake.in
++++ b/cmake/VorbisConfig.cmake.in
+@@ -1,7 +1,7 @@
+ @PACKAGE_INIT@
+ 
+ include(CMakeFindDependencyMacro)
+-find_dependency(Ogg REQUIRED)
++find_dependency(Ogg CONFIG REQUIRED)
+ 
+ include(${CMAKE_CURRENT_LIST_DIR}/VorbisTargets.cmake)
+ 

--- a/ports/libvorbis/portfile.cmake
+++ b/ports/libvorbis/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         0001-Dont-export-vorbisenc-functions.patch
         0002-Fixup-pkgconfig-libs.patch
         0003-def-mingw-compat.patch
+        0004-ogg-find-dependency.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/libvorbis/vcpkg.json
+++ b/ports/libvorbis/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libvorbis",
   "version": "1.3.7",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format",
   "homepage": "https://github.com/xiph/vorbis",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5162,7 +5162,7 @@
     },
     "libvorbis": {
       "baseline": "1.3.7",
-      "port-version": 2
+      "port-version": 3
     },
     "libvpx": {
       "baseline": "1.13.1",

--- a/versions/l-/libvorbis.json
+++ b/versions/l-/libvorbis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0bed5ff19f96c974b72603276a74111d9510dec3",
+      "version": "1.3.7",
+      "port-version": 3
+    },
+    {
       "git-tree": "c4c646a26ce3e6ad63992d3e4a55cb185159b23c",
       "version": "1.3.7",
       "port-version": 2

--- a/versions/l-/libvorbis.json
+++ b/versions/l-/libvorbis.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0bed5ff19f96c974b72603276a74111d9510dec3",
+      "git-tree": "23d11198ff2df7a3af54f1c4645ef71a141f2a85",
       "version": "1.3.7",
       "port-version": 3
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

---

Fix Ogg find_package.

Libogg now ships with an `OggConfig.cmake` file and the current way to find it does not work anymore.
All the patch does adds the CONFIG notation to the find_package function.

---

Repro case:

1. Add this to your own `vcpkg.json`
```json
{
  "name": "test",
  "version": "0.0.1",
  "dependencies": [
    {
      "name": "ffmpeg",
      "default-features": false,
      "features": [
        "vorbis"
      ],
      "platform": "windows"
    }
  ]
}
```

2. Add this line to your own `CMakeLists.txt`
```cmake
find_package(FFmpeg COMPONENTS AVFORMAT AVUTIL AVCODEC SWRESAMPLE)
```

3. See CMake failing with an error similar to this one:
```
CMake Error at REDACTED/vcpkg_installed/x86-windows-static/share/Vorbis/VorbisTargets.cmake:60 (set_target_properties):
  The link interface of target "Vorbis::vorbis" contains:

    Ogg::ogg

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  REDACTED/vcpkg_installed/x86-windows-static/share/Vorbis/VorbisConfig.cmake:30 (include)
  C:/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
  REDACTED/vcpkg_installed/x86-windows-static/share/ffmpeg/vcpkg-cmake-wrapper.cmake:190 (find_package)
  C:/vcpkg/scripts/buildsystems/vcpkg.cmake:813 (include)
  CMakeLists.txt:1 (find_package)
```