### PR TITLE
[taocpp-json] Misc fixes

### DIFF
--- a/ports/taocpp-json/portfile.cmake
+++ b/ports/taocpp-json/portfile.cmake
@@ -1,4 +1,4 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -10,7 +10,6 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DTAOCPP_JSON_BUILD_TESTS=OFF
         -DTAOCPP_JSON_BUILD_EXAMPLES=OFF
@@ -25,8 +24,10 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share/doc"
 )
 
-# Handle copyright
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright"COPYONLY)
-file(COPY "${SOURCE_PATH}/LICENSE.double-conversion" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(COPY "${SOURCE_PATH}/LICENSE.itoa" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(COPY "${SOURCE_PATH}/LICENSE.ryu" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/LICENSE.double-conversion"
+        "${SOURCE_PATH}/LICENSE.itoa"
+        "${SOURCE_PATH}/LICENSE.ryu"
+)

--- a/ports/taocpp-json/vcpkg.json
+++ b/ports/taocpp-json/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "taocpp-json",
   "version-date": "2020-09-14",
-  "port-version": 3,
+  "port-version": 4,
   "description": "C++ header-only JSON library",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8550,7 +8550,7 @@
     },
     "taocpp-json": {
       "baseline": "2020-09-14",
-      "port-version": 3
+      "port-version": 4
     },
     "tap-windows6": {
       "baseline": "9.21.2-0e30f5c",

--- a/versions/t-/taocpp-json.json
+++ b/versions/t-/taocpp-json.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0f65d42ce52c1a7c42635e90f51af98f786ae9b2",
+      "version-date": "2020-09-14",
+      "port-version": 4
+    },
+    {
       "git-tree": "3efce615deb5e4414df2c3731c1e8eae333d32c9",
       "version-date": "2020-09-14",
       "port-version": 3


### PR DESCRIPTION
Fixes:
~~~
CMake Warning (dev) at ports/taocpp-json/portfile.cmake:29:
  Syntax Warning in cmake code at column 90

  Argument not separated from preceding token by whitespace.
~~~