### PR TITLE
[libp7client] Fix cmake

### DIFF
--- a/ports/libp7client/portfile.cmake
+++ b/ports/libp7client/portfile.cmake
@@ -21,4 +21,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.txt")

--- a/ports/libp7client/vcpkg.json
+++ b/ports/libp7client/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libp7client",
   "version": "5.6",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Open source, cross-platform, fastest library for sending logs, telemetry & trace data from your application.",
   "homepage": "https://baical.net/",
   "supports": "!(arm | uwp | osx)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4802,7 +4802,7 @@
     },
     "libp7client": {
       "baseline": "5.6",
-      "port-version": 4
+      "port-version": 5
     },
     "libpcap": {
       "baseline": "1.10.4",

--- a/versions/l-/libp7client.json
+++ b/versions/l-/libp7client.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17e5bb124013cf1044fcfdf32566c791cf323fa9",
+      "version": "5.6",
+      "port-version": 5
+    },
+    {
       "git-tree": "e0cf3d22ea3a838a2190f5d0ed1c804c42364268",
       "version": "5.6",
       "port-version": 4


### PR DESCRIPTION
Fixes:
~~~
CMake Warning (dev) at ports/libp7client/portfile.cmake:24:
  Syntax Warning in cmake code at column 94

  Argument not separated from preceding token by whitespace.
