### PR TITLE
[kerbal] update to v2024.5.1; support installation of pretty-printer

### DIFF
--- a/ports/kerbal/portfile.cmake
+++ b/ports/kerbal/portfile.cmake
@@ -1,10 +1,41 @@
+
+set(KERBAL_SHA_CORE                a6b2a1108314f90ad8b04904df744a6727b1b638f7f224ea17d52caa78e33bfe2da4096200f62640668a28b1ca478654c856696b8a71c5dcba0e7338af72b912)
+set(KERBAL_SHA_PRETTY_PRINTER      213ee64385e9e372f7da4d015f24c2e6f71a8e8e68523114d945ae8c17114c963c79c919d1b3c330b55a56bbc1362f48ee866baef6ea18ea8e2dc7c1b1c87c48)
+
+
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO WentsingNee/Kerbal
         REF "v${VERSION}"
-        SHA512 1c3ce10da33679868c1f634eef02b596ce58c18711cd40751ab452a9ec01070434b842c4e5860ff9a5ed69f1bdab882aa0a9559e455f22e4e09b37c2b82bb2ec
+        SHA512 "${KERBAL_SHA_CORE}"
         HEAD_REF main
 )
+
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+        FEATURES
+            "pretty-printer"       WITH_PRETTY_PRINTER
+)
+
+if (WITH_PRETTY_PRINTER)
+    vcpkg_from_github(
+            OUT_SOURCE_PATH SOURCE_PATH_PRETTY_PRINTER
+            REPO WentsingNee/KerbalPrettyPrinter
+            REF "v${VERSION}"
+            SHA512 "${KERBAL_SHA_PRETTY_PRINTER}"
+            HEAD_REF main
+    )
+    file(GLOB pretty_printer_files
+            LIST_DIRECTORIES True
+            "${SOURCE_PATH_PRETTY_PRINTER}/*"
+    )
+    foreach (e IN LISTS pretty_printer_files)
+        file(
+            COPY "${e}"
+            DESTINATION "${SOURCE_PATH}/pretty_printer"
+        )
+    endforeach ()
+endif ()
 
 vcpkg_cmake_configure(
         SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/kerbal/vcpkg.json
+++ b/ports/kerbal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kerbal",
-  "version": "2024.4.1",
+  "version": "2024.5.1",
   "description": "Kerbal C++ Template Library",
   "homepage": "https://github.com/WentsingNee/Kerbal",
   "license": "LGPL-3.0",
@@ -13,5 +13,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "pretty-printer": {
+      "description": "Pretty printer support for kerbal"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3861,7 +3861,7 @@
       "port-version": 1
     },
     "kerbal": {
-      "baseline": "2024.4.1",
+      "baseline": "2024.5.1",
       "port-version": 0
     },
     "keystone": {

--- a/versions/k-/kerbal.json
+++ b/versions/k-/kerbal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5de9d0c7ccf591d54b34a2590a5168cb00bed6c0",
+      "version": "2024.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "cfb8465f5f690585caabbc481f752c51906bcaa1",
       "version": "2024.4.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.