### PR TITLE
[cmake-user] Bump cmake_minimum_required

### DIFF
--- a/ports/lapack/vcpkg-cmake-wrapper.cmake.in
+++ b/ports/lapack/vcpkg-cmake-wrapper.cmake.in
@@ -4,7 +4,12 @@
 
 _find_package(BLAS) # Find BLAS before setting BLA_VENDOR (Will set/unset BLA_VENDOR itself)
 set(BLA_VENDOR @BLA_VENDOR@)
-set(BLA_STATIC @BLA_STATIC@)
+if(APPLE AND "@BLA_STATIC@" AND CMAKE_VERSION VERSION_LESS "3.17.0")
+    # avoid `-Wl,--(start|end)-group` and wrong lib suffix
+    set(BLA_STATIC 0) 
+else()
+    set(BLA_STATIC @BLA_STATIC@)
+endif()
 _find_package(${ARGS})
 unset(BLA_VENDOR)
 unset(BLA_STATIC)

--- a/ports/lapack/vcpkg.json
+++ b/ports/lapack/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "Keep the platform expressions in sync with the wrappers installed by the portfiles!",
   "name": "lapack",
   "version-date": "2023-06-10",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Metapackage for packages which provide LAPACK",
   "license": null,
   "supports": "!android",

--- a/scripts/test_ports/cmake-user/portfile.cmake
+++ b/scripts/test_ports/cmake-user/portfile.cmake
@@ -184,6 +184,7 @@ function(test_cmake_project)
                 ${base_options}
                 ${arg_OPTIONS}
                 "-DFIND_PACKAGES=${package}"
+                --trace-expand
             OUTPUT_FILE "${log_out}"
             ERROR_FILE "${log_err}"
             RESULT_VARIABLE package_result

--- a/scripts/test_ports/cmake-user/project/CMakeLists.txt
+++ b/scripts/test_ports/cmake-user/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 project(cmake-user LANGUAGES C)
 
 message(STATUS "CMAKE_COMMAND: ${CMAKE_COMMAND}")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4086,7 +4086,7 @@
     },
     "lapack": {
       "baseline": "2023-06-10",
-      "port-version": 1
+      "port-version": 2
     },
     "lapack-reference": {
       "baseline": "3.11.0",

--- a/versions/l-/lapack.json
+++ b/versions/l-/lapack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "629522c4a52d924f0eeda0974bcf74c7d8f024fb",
+      "version-date": "2023-06-10",
+      "port-version": 2
+    },
+    {
       "git-tree": "6a41c325a45d83ce6d5ee28d55a15d792ac228fa",
       "version-date": "2023-06-10",
       "port-version": 1


### PR DESCRIPTION
Fixes:
~~~
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
~~~