### PR TITLE
[vladimirshaleev-ipaddress] Update to 1.1.0

### DIFF
--- a/ports/vladimirshaleev-ipaddress/portfile.cmake
+++ b/ports/vladimirshaleev-ipaddress/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vladimirshaleev/ipaddress
     REF "v${VERSION}"
-    SHA512 dc8d37b5a28c80e6ddf4dfa0ffc6973b2625d20dc61cd56e77e1f2cfdc7d427937b73e2abb0d1d85cdfe54fc199fef4132c20fc01b1e91bab6a988650d6e9a6d
+    SHA512 a8ab2dc8563ff08a5afbe6d2157502b26a5d13f29d00ab3354b812ad4cb9e35cdc89cb26e4920929ced7d063ae2ad5aa79d30a4623409f65c76971ecbbcd5bfc
     HEAD_REF main
 )
 

--- a/ports/vladimirshaleev-ipaddress/vcpkg.json
+++ b/ports/vladimirshaleev-ipaddress/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vladimirshaleev-ipaddress",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A library for working and manipulating IPv4/IPv6 addresses and networks in modern C++.",
   "homepage": "https://vladimirshaleev.github.io/ipaddress/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9181,7 +9181,7 @@
       "port-version": 0
     },
     "vladimirshaleev-ipaddress": {
-      "baseline": "1.0.1",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "vlfeat": {

--- a/versions/v-/vladimirshaleev-ipaddress.json
+++ b/versions/v-/vladimirshaleev-ipaddress.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c4a128002e94b71cf2620c07f47b0380b3888802",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "641e48d99d750d904e1f9c2627640473d02fd89f",
       "version": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Hello everyone! It’s time to update the port version)
