### PR TITLE
[sdl2] Update to 2.30.3

### DIFF
--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL
     REF "release-${VERSION}"
-    SHA512 0a774a321a6f2834c198cbb9515a0df9fa0515c10520da5be3ab8f336fadd554fefd0f59518be3c7edc3b269966b7b1e44c0e530714209e381fe455478926bf8
+    SHA512 3a7c6c0515205338a023ada230128e658f4ecff3ccd371d33cd9bb82eb4992db972241faf44f325f7d536c7dedb0a02ee1574b7a84ba3c9856cae9e6d25bdbdc
     HEAD_REF main
     PATCHES
         deps.patch

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl2",
-  "version": "2.30.1",
+  "version": "2.30.3",
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7969,7 +7969,7 @@
       "port-version": 6
     },
     "sdl2": {
-      "baseline": "2.30.1",
+      "baseline": "2.30.3",
       "port-version": 0
     },
     "sdl2-gfx": {

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "016040fbf13b72364c405d2dfeb733273efbae75",
+      "version": "2.30.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "71b609d356d21c9479ddeb27f4737ab70982f4a5",
       "version": "2.30.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39079
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
x64-windows-static
```