### PR TITLE
Update Arch Linux minimal requirements

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -77,7 +77,7 @@ vcpkgCheckRepoTool()
         echo "On SUSE Linux and derivatives:"
         echo "  sudo zypper install curl zip unzip tar"
         echo "On Arch Linux and derivatives:"
-        echo "  sudo pacman -S curl zip unzip tar cmake ninja"
+        echo "  sudo pacman -Syu base-devel git curl zip unzip tar cmake ninja"
         echo "On Alpine:"
         echo "  apk add build-base cmake ninja zip unzip curl git"
         echo "  (and export VCPKG_FORCE_SYSTEM_BINARIES=1)"


### PR DESCRIPTION
- Updated recommended pacman parameters as [partial updates](https://wiki.archlinux.org/title/system_maintenance#Partial_upgrades_are_unsupported) are unsupported and may break current environment, `-S` should not be an issue, but is recommended to also perform an update of the package database to ensure that the latest package is installed

- added missing packages required for Arch Linux