### PR TITLE
[poximan/cairo] Fix download address

### DIFF
--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -2,12 +2,15 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     set(PATCHES fix_clang-cl_build.patch)
 endif()
 
-vcpkg_from_gitlab(
-    OUT_SOURCE_PATH SOURCE_PATH
-    GITLAB_URL https://gitlab.freedesktop.org
-    REPO cairo/cairo
-    REF "${VERSION}"
-    SHA512 2ef3b948b354a9be5c3afe2bbf47f559a00a6114c67ef50ce19d54a1d4232218311f2277e271faad4df598e19e03492ba97af934ede9411494618ebe46f9eee9
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://cairographics.org/releases/cairo-${VERSION}.tar.xz"
+    FILENAME "cairo-${VERSION}.tar.xz"
+    SHA512 6366c7d5e3fd3e12df2edc43aa4ed4c3a517de2ef0b1b3b30dfa8b69a7cae1dd55765801228cec308d2e9792037d0704ae49d95b7b12c06f20df092fa0534e1c
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         cairo_static_fix.patch
         disable-atomic-ops-check.patch # See https://gitlab.freedesktop.org/cairo/cairo/-/issues/554

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cairo",
   "version": "1.18.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "LGPL-2.1-only OR MPL-1.1",

--- a/ports/pixman/portfile.cmake
+++ b/ports/pixman/portfile.cmake
@@ -46,12 +46,15 @@ if(VCPKG_TARGET_IS_OSX)
     list(APPEND OPTIONS -Da64-neon=disabled)
 endif()
 
-vcpkg_from_gitlab(
-    OUT_SOURCE_PATH SOURCE_PATH
-    GITLAB_URL https://gitlab.freedesktop.org
-    REPO pixman/pixman
-    REF "pixman-${VERSION}"
-    SHA512 daeb25d91e9cb8d450a6f050cbec1d91e239a03188e993ceb6286605c5ed33d97e08d6f57efaf1d5c6a8a1eedb1ebe6c113849a80d9028d5ea189c54601be424
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://cairographics.org/releases/pixman-${VERSION}.tar.gz"
+    FILENAME "pixman-${VERSION}.tar.gz"
+    SHA512 08802916648bab51fd804fc3fd823ac2c6e3d622578a534052b657491c38165696d5929d03639c52c4f29d8850d676a909f0299d1a4c76a07df18a34a896e43d
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         no-host-cpu-checks.patch
         fix_clang-cl.patch

--- a/ports/pixman/vcpkg.json
+++ b/ports/pixman/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pixman",
   "version": "0.43.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.",
   "homepage": "https://www.cairographics.org/releases",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1458,7 +1458,7 @@
     },
     "cairo": {
       "baseline": "1.18.0",
-      "port-version": 1
+      "port-version": 2
     },
     "cairomm": {
       "baseline": "1.17.1",
@@ -6806,7 +6806,7 @@
     },
     "pixman": {
       "baseline": "0.43.4",
-      "port-version": 1
+      "port-version": 2
     },
     "pkgconf": {
       "baseline": "2.2.0",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82dcd2931ebeed3593953f2034619ac0c49c1a19",
+      "version": "1.18.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "0fda02793cfc3911468cd200b0a889c65035db1d",
       "version": "1.18.0",
       "port-version": 1

--- a/versions/p-/pixman.json
+++ b/versions/p-/pixman.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11ae47836b450df178941abf73abae59a70b64ae",
+      "version": "0.43.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "6b62aac8f96d7fe4e407759601cfdbc350afa9ae",
       "version": "0.43.4",
       "port-version": 1


### PR DESCRIPTION
Currently the download address for `pixman` and `cairo` does not exist (404): 
https://gitlab.freedesktop.org/pixman/pixman
https://gitlab.freedesktop.org/cairo/cairo

So get the stable releases from the official website: 
https://cairographics.org/releases/

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.