### PR TITLE
[scripts/ci.baseline.txt] Fix incorrect entries [bde] Add some platform support

### DIFF
--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -1,9 +1,13 @@
 {
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "bde",
   "version": "4.8.0.0",
+  "port-version": 1,
   "description": "Basic Development Environment - a set of foundational C++ libraries used at Bloomberg.",
+  "homepage": "https://techatbloomberg.com/",
+  "documentation": "https://bloomberg.github.io/bde/",
   "license": "Apache-2.0",
-  "supports": "!windows & !arm & !android & !osx",
+  "supports": "!android & !(arm64 & windows) & !uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -21,10 +21,11 @@
 ##
 ##
 ## CI tested triplets:
-##    arm64-android
-##    arm64-windows
 ##    arm-neon-android
+##    arm64-android
+##    arm64-osx
 ##    arm64-uwp
+##    arm64-windows
 ##    x64-android
 ##    x64-linux
 ##    x64-osx
@@ -74,7 +75,13 @@ atliac-minitest:x64-uwp=fail
 backward-cpp:arm-neon-android=fail
 backward-cpp:arm64-android=fail
 backward-cpp:x64-android=fail
-bde:x64-linux=skip
+bde:arm64-osx               =skip   # conflict https://github.com/microsoft/vcpkg/pull/32645
+bde:x64-linux               =skip
+bde:x64-osx                 =skip
+bde:x64-windows-static-md   =skip
+bde:x64-windows-static      =skip
+bde:x64-windows             =skip
+bde:x86-windows             =skip
 bento4:arm-neon-android=fail
 berkeleydb:arm-neon-android=fail
 berkeleydb:arm64-android=fail
@@ -654,14 +661,17 @@ libtomcrypt:arm64-uwp=fail
 libusb-win32:arm64-uwp=fail
 libusb-win32:x64-uwp=fail
 #Skip detection to avoid upstream remove older releases
-libvmdk:x86-windows=skip
-libvmdk:x64-windows=skip
-libvmdk:x64-windows-static=skip
-libvmdk:x64-windows-static-md=skip
-libvmdk:arm64=skip
-libvmdk:x64-linux=skip
-libvmdk:x64-osx=skip
-libvmdk:arm64-osx=skip
+libvmdk:arm-neon-android        =skip   # upstream issue https://github.com/microsoft/vcpkg/pull/13765#issuecomment-699710253
+libvmdk:arm64-android           =skip
+libvmdk:arm64-osx               =skip
+libvmdk:arm64-windows           =skip
+libvmdk:x64-android             =skip
+libvmdk:x64-linux               =skip
+libvmdk:x64-osx                 =skip
+libvmdk:x64-windows-static-md   =skip
+libvmdk:x64-windows-static      =skip
+libvmdk:x64-windows             =skip
+libvmdk:x86-windows             =skip
 libwandio:arm-neon-android=fail
 libwandio:arm64-android=fail
 libwandio:x64-android=fail
@@ -1132,9 +1142,9 @@ tensorflow-cc:x64-windows=fail
 # Also skipping because our macOS machines are relatively underpowered and this saves 8 hours of CI
 # time for a relatively unpopular library / system combo.
 tensorflow:x64-osx=skip
-tensorflow:arm-osx=skip
+tensorflow:arm64-osx                =skip
 tensorflow-cc:x64-osx=skip
-tensorflow-cc:arm-osx=skip
+tensorflow-cc:arm64-osx             =skip
 
 thorvg:arm-neon-android=fail
 tinycthread:arm-neon-android=fail

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bcc715b2f958a15fb5f05a8a5f717b8091c35f05",
+      "version": "4.8.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "fa76296b5abefaf07a8f663ced20cea1a0c901b6",
       "version": "4.8.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -558,7 +558,7 @@
     },
     "bde": {
       "baseline": "4.8.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "bdwgc": {
       "baseline": "8.2.6",


### PR DESCRIPTION
Fix incorrect entries of `scripts/ci.baseline.txt`.

Fix #38787, won't fix downstream `rmqcpp` for #38736.

* Keep skip in CI
  -  Conflict dependencies `pcre2`, `ryu` in #32645
* Disable `android`
  - There is a weird error that failed to find `BdeBuildSystem/bbs_runtest.py` by `BdeBuildSystem/BdeBuildSystemConfig.cmake`
* Disable `arm64-windows`
  - Failed with `groups\bsl\bsls\bsls_platform.h(419): fatal error C1189: #error:  "Unable to identify CPU on which the MSVC compiler is running."`
* Disable `uwp`
  -  Failed with `groups\bdl\bdlb\bdlb_randomdevice.cpp(93): error C3861: 'CryptAcquireContext': identifier not found`
* Check `scripts/ci.baseline.txt`
  - Checked by `Get-Content ./scripts/ci.baseline.txt | Select-String -NotMatch '^#' | Select-String -NotMatch ':(arm-neon-android|arm64-android|arm64-osx|arm64-uwp|arm64-windows|x64-android|x64-linux|x64-osx|x64-uwp|x64-windows|x64-windows-static|x64-windows-static-md|x86-windows)\s*='`