### PR TITLE
[efsw] Update to 1.4.0

### DIFF
--- a/ports/efsw/portfile.cmake
+++ b/ports/efsw/portfile.cmake
@@ -2,15 +2,21 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SpartanJ/efsw
     REF "${VERSION}"
-    SHA512 f9503a17ff5b6bdb4770b24c69f8015689ee3bc589428696437d887510e0ab38fddd85cc8e75b6f256d2a6362911ded1cb6a37ab33bd38de51bd779dbdbc8321
+    SHA512 f1439c75b44acfa93a34cae21ee5470cfea5a475eeb6cbc83fbe8e39767b7c72abc37960d85184cb1071e61196740ae7649b86288f164f927df95792c4ece230
     HEAD_REF master
 )
 
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" EFSW_BUILD_SHARED_LIB)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" EFSW_BUILD_STATIC_LIB)
+
+# efsw CMakeLists sets up two targets "efsw" and "efsw-static" where the former is static or shared depending on BUILD_SHARED_LIBS and the latter is always static
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DVERBOSE=OFF
         -DBUILD_TEST_APP=OFF
+        -DBUILD_SHARED_LIBS=${EFSW_BUILD_SHARED_LIB}
+        -DBUILD_STATIC_LIBS=0
 )
 
 vcpkg_cmake_install()

--- a/ports/efsw/vcpkg.json
+++ b/ports/efsw/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "efsw",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "efsw is a C++ cross-platform file system watcher and notifier.",
   "homepage": "https://github.com/SpartanJ/efsw",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2477,7 +2477,7 @@
       "port-version": 0
     },
     "efsw": {
-      "baseline": "1.3.1",
+      "baseline": "1.4.0",
       "port-version": 0
     },
     "egl": {

--- a/versions/e-/efsw.json
+++ b/versions/e-/efsw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "adfa3eddacb589f59859318a4332754ba1478eb7",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cdbd9de7e4e09eca9f0937c5b90ca540a66f6409",
       "version": "1.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
