### PR TITLE
[ffmpeg] Improve macOS patch based on upstream feedback.

### DIFF
--- a/ports/ffmpeg/0041-add-const-for-opengl-definition.patch
+++ b/ports/ffmpeg/0041-add-const-for-opengl-definition.patch
@@ -1,13 +1,16 @@
 diff --git a/libavdevice/opengl_enc.c b/libavdevice/opengl_enc.c
-index b2ac6eb..6351614 100644
+index 6f7a30ff9e..7805b641d1 100644
 --- a/libavdevice/opengl_enc.c
 +++ b/libavdevice/opengl_enc.c
-@@ -116,7 +116,7 @@ typedef void   (APIENTRY *FF_PFNGLATTACHSHADERPROC) (GLuint program, GLuint shad
+@@ -117,7 +117,11 @@ typedef void   (APIENTRY *FF_PFNGLATTACHSHADERPROC) (GLuint program, GLuint shad
  typedef GLuint (APIENTRY *FF_PFNGLCREATESHADERPROC) (GLenum type);
  typedef void   (APIENTRY *FF_PFNGLDELETESHADERPROC) (GLuint shader);
  typedef void   (APIENTRY *FF_PFNGLCOMPILESHADERPROC) (GLuint shader);
--typedef void   (APIENTRY *FF_PFNGLSHADERSOURCEPROC) (GLuint shader, GLsizei count, const char* *string, const GLint *length);
++#if defined(__APPLE__)
 +typedef void   (APIENTRY *FF_PFNGLSHADERSOURCEPROC) (GLuint shader, GLsizei count, const char* const *string, const GLint *length);
++#else
+ typedef void   (APIENTRY *FF_PFNGLSHADERSOURCEPROC) (GLuint shader, GLsizei count, const char* *string, const GLint *length);
++#endif
  typedef void   (APIENTRY *FF_PFNGLGETSHADERIVPROC) (GLuint shader, GLenum pname, GLint *params);
  typedef void   (APIENTRY *FF_PFNGLGETSHADERINFOLOGPROC) (GLuint shader, GLsizei bufSize, GLsizei *length, char *infoLog);
  

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "6.1.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2682,7 +2682,7 @@
     },
     "ffmpeg": {
       "baseline": "6.1.1",
-      "port-version": 6
+      "port-version": 7
     },
     "ffnvcodec": {
       "baseline": "12.1.14.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2396eaeb3bfc4b1e78ff7c1834e4390b0cd242e6",
+      "version": "6.1.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "bad8797d669a583736212969fbbf6298497880b2",
       "version": "6.1.1",
       "port-version": 6


### PR DESCRIPTION
This is a follow-up to the patch I added in https://github.com/microsoft/vcpkg/pull/38834 to fix ffmpeg builds on macOS 14.5.

See discussion with the upstream maintainer Andreas Rheinhardt: https://ffmpeg.org/pipermail/ffmpeg-devel/2024-June/328826.html

Do not merge until upstream has accepted the patch herein.