### PR TITLE
[google-cloud-cpp] update to the latest release (v2.25.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
     REF "v${VERSION}"
-    SHA512 f0196fadab18164a1b1313717329063167c003279d0898ecedd18ca562c4344a4a5be302bd951fa5c95582078fe5e88a1a8debbc66db8c8dfafedfdf7a019522
+    SHA512 b8cb4f7055d287a2a9e0c49e1d9a300e37a1c1f8a007cf2d819eae5964d2b1b8fc6a40320d2436319179c2849b784ac9e5be6b6416065f62e63077e72c9847e4
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -1020,6 +1020,7 @@
           "name": "google-cloud-cpp",
           "default-features": false,
           "features": [
+            "monitoring",
             "rest-common",
             "trace"
           ]
@@ -1113,6 +1114,18 @@
     },
     "profiler": {
       "description": "Cloud Profiler API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "publicca": {
+      "description": "Public Certificate Authority API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3137,7 +3137,7 @@
       "port-version": 8
     },
     "google-cloud-cpp": {
-      "baseline": "2.24.0",
+      "baseline": "2.25.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6761c461a752e56986cbd9887198f9daced30b0d",
+      "version": "2.25.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "339cf73b54f41dadee8c436b55791521612fcce9",
       "version": "2.24.0",
       "port-version": 0


### PR DESCRIPTION
Updates google-cloud-cpp to the latest release (v2.25.0)

Tested locally (on x64-linux) with:

`for feature in <new_features>; do ./vcpkg remove google-cloud-cpp; ./vcpkg install "google-cloud-cpp[core,${feature}]" || break; done`

and

`./vcpkg remove google-cloud-cpp && ./vcpkg install 'google-cloud-cpp[*]'`
