### PR TITLE
[libnick] Update to 2024.6.2

### DIFF
--- a/ports/libnick/portfile.cmake
+++ b/ports/libnick/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NickvisionApps/libnick
     REF "${VERSION}"
-    SHA512 e565c2f69777490207ce668ec1fa2d9d741b22303e7940370e83f15ac4565970d0e651116d0da4b6402816bb783b1dd7f1b88bf3c9a6cf399a4a4df245f2e0d6
+    SHA512 d346a3faea76c5ee23d77cb4cf9a47c0aa2709abf6c2c2059095ea2d63e4bd00f4b470405fb1d9d84efe003a7cddebbb18501ca3cced38c18f67b69cd0e8e4de
     HEAD_REF main
 )
 

--- a/ports/libnick/vcpkg.json
+++ b/ports/libnick/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libnick",
-  "version": "2024.6.0",
+  "version": "2024.6.2",
   "maintainers": "Nicholas Logozzo nlogozzo225@gmail.com",
   "description": "A cross-platform base for native Nickvision applications.",
   "homepage": "https://github.com/NickvisionApps/libnick",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4717,7 +4717,7 @@
       "port-version": 4
     },
     "libnick": {
-      "baseline": "2024.6.0",
+      "baseline": "2024.6.2",
       "port-version": 0
     },
     "libnoise": {

--- a/versions/l-/libnick.json
+++ b/versions/l-/libnick.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "93c5e6ac4ea770dc4a67ead7367d0649c369b1d6",
+      "version": "2024.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "0070bd0d7d9bae8c6ec279b01d3a9ca5da6dd0e0",
       "version": "2024.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.