### PR TITLE
[openldap] Fix feature cyrus-sasl compilation failure on Linux

### DIFF
--- a/ports/openldap/portfile.cmake
+++ b/ports/openldap/portfile.cmake
@@ -12,6 +12,14 @@ if(NOT "${AUTOCONF_VERSION_STR}" STREQUAL "" AND "${AUTOCONF_VERSION_STR}" MATCH
     vcpkg_list(APPEND EXTRA_PATCHES m4.patch)
 endif()
 
+if(VCPKG_TARGET_IS_LINUX)
+    message(
+" openldap currently requires the following libraries from the system package manager:
+    libsasl2-dev
+These can be installed on Ubuntu systems via sudo apt install libsasl2-dev"
+    )
+endif()
+
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"

--- a/ports/openldap/portfile.cmake
+++ b/ports/openldap/portfile.cmake
@@ -12,14 +12,6 @@ if(NOT "${AUTOCONF_VERSION_STR}" STREQUAL "" AND "${AUTOCONF_VERSION_STR}" MATCH
     vcpkg_list(APPEND EXTRA_PATCHES m4.patch)
 endif()
 
-if(VCPKG_TARGET_IS_LINUX)
-    message(
-" openldap currently requires the following libraries from the system package manager:
-    libsasl2-dev
-These can be installed on Ubuntu systems via sudo apt install libsasl2-dev"
-    )
-endif()
-
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
@@ -36,6 +28,11 @@ endif()
 
 if("cyrus-sasl" IN_LIST FEATURES)
     vcpkg_list(APPEND FEATURE_OPTIONS --with-cyrus-sasl)
+    message(
+" openldap currently requires the following libraries from the system package manager:
+    libsasl2-dev
+These can be installed on Ubuntu systems via sudo apt install libsasl2-dev"
+    )
 else()
     vcpkg_list(APPEND FEATURE_OPTIONS --without-cyrus-sasl)
 endif()

--- a/ports/openldap/vcpkg.json
+++ b/ports/openldap/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openldap",
   "version": "2.5.17",
+  "port-version": 1,
   "description": "OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.",
   "homepage": "https://www.openldap.org/software/",
   "license": "OLDAP-2.8",

--- a/ports/openldap/vcpkg.json
+++ b/ports/openldap/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "openldap",
   "version": "2.5.17",
   "port-version": 1,
-  "description": "OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.",
+  "description": "OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol. When using the cyrus-sasl feature on Linux, you need to install the libsasl2-dev development package.",
   "homepage": "https://www.openldap.org/software/",
   "license": "OLDAP-2.8",
   "supports": "!windows, (mingw & !x86)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6494,7 +6494,7 @@
     },
     "openldap": {
       "baseline": "2.5.17",
-      "port-version": 0
+      "port-version": 1
     },
     "openmama": {
       "baseline": "6.3.2",

--- a/versions/o-/openldap.json
+++ b/versions/o-/openldap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb2827dd0b7b6294233e53acb1e89950d6dfff96",
+      "version": "2.5.17",
+      "port-version": 1
+    },
+    {
       "git-tree": "feb109108e4779365dfc208d784f7fabe09f1f04",
       "version": "2.5.17",
       "port-version": 0

--- a/versions/o-/openldap.json
+++ b/versions/o-/openldap.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fb2827dd0b7b6294233e53acb1e89950d6dfff96",
+      "git-tree": "80cca47d69b1cae28a2e63250b07e6d0db126917",
       "version": "2.5.17",
       "port-version": 1
     },


### PR DESCRIPTION
Fix one of https://github.com/microsoft/vcpkg/issues/32398 issue.
`configure: error: Could not locate Cyrus SASL`
Added tips for installing libsasl2-dev development package under Linux.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

This feature passed with following triplet:

```
x64-linux
```