### PR TITLE
[arrow/concurrencpp/qtwebengine] Fix error C2039: 'string': is not a member of 'std'

### DIFF
--- a/ports/arrow/add-include-string.patch
+++ b/ports/arrow/add-include-string.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/src/arrow/json/object_writer.h b/cpp/src/arrow/json/object_writer.h
+index b15b09d..cf1ce62 100644
+--- a/cpp/src/arrow/json/object_writer.h
++++ b/cpp/src/arrow/json/object_writer.h
+@@ -18,6 +18,7 @@
+ #pragma once
+ 
+ #include <memory>
++#include <string>
+ #include <string_view>
+ 
+ #include "arrow/util/visibility.h"

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_extract_source_archive(
         utf8proc.patch
         thrift.patch
         remove-dll-suffix.patch #Upstream PR: https://github.com/apache/arrow/pull/41341
+        add-include-string.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "arrow",
   "version": "16.1.0",
+  "port-version": 1,
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",

--- a/ports/concurrencpp/add-include-string.patch
+++ b/ports/concurrencpp/add-include-string.patch
@@ -1,0 +1,12 @@
+diff --git a/include/concurrencpp/threads/thread.h b/include/concurrencpp/threads/thread.h
+index 82ca58b..ecdaa27 100644
+--- a/include/concurrencpp/threads/thread.h
++++ b/include/concurrencpp/threads/thread.h
+@@ -4,6 +4,7 @@
+ #include "concurrencpp/platform_defs.h"
+ 
+ #include <functional>
++#include <string>
+ #include <string_view>
+ #include <thread>
+ 

--- a/ports/concurrencpp/portfile.cmake
+++ b/ports/concurrencpp/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
   HEAD_REF master
   PATCHES
     fix-include-path.patch
+    add-include-string.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/concurrencpp/vcpkg.json
+++ b/ports/concurrencpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "concurrencpp",
   "version": "0.1.7",
+  "port-version": 1,
   "description": "concurrencpp is a tasking library for C++ allowing developers to write highly concurrent applications easily and safely by using tasks, executors and coroutines.",
   "homepage": "https://github.com/David-Haim/concurrencpp/",
   "license": "MIT",

--- a/ports/qtwebengine/add-include-string.patch
+++ b/ports/qtwebengine/add-include-string.patch
@@ -1,0 +1,12 @@
+diff --git a/src/3rdparty/gn/src/gn/escape.h b/src/3rdparty/gn/src/gn/escape.h
+index b5cfd6b..1b61eaa 100644
+--- a/src/3rdparty/gn/src/gn/escape.h
++++ b/src/3rdparty/gn/src/gn/escape.h
+@@ -6,6 +6,7 @@
+ #define TOOLS_GN_ESCAPE_H_
+ 
+ #include <iosfwd>
++#include <string>
+ #include <string_view>
+ 
+ enum EscapingMode {

--- a/ports/qtwebengine/portfile.cmake
+++ b/ports/qtwebengine/portfile.cmake
@@ -4,6 +4,7 @@ include("${SCRIPT_PATH}/qt_install_submodule.cmake")
 set(${PORT}_PATCHES 
       "clang-cl.patch"
       "fix-error2275-2672.patch"
+      "add-include-string.patch"
 )
 
 set(TOOL_NAMES gn QtWebEngineProcess qwebengine_convert_dict webenginedriver)

--- a/ports/qtwebengine/vcpkg.json
+++ b/ports/qtwebengine/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "x86-windows is not within the upstream support matrix of Qt6",
   "name": "qtwebengine",
   "version": "6.7.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qt WebEngine provides functionality for rendering regions of dynamic web content.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0fb85e8be36a721896cb65227bcc3c85a4f88ee",
+      "version": "16.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "282e423703e80ad83909c9e8d65119094436ebae",
       "version": "16.1.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -242,7 +242,7 @@
     },
     "arrow": {
       "baseline": "16.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "arsenalgear": {
       "baseline": "2.1.0",
@@ -1802,7 +1802,7 @@
     },
     "concurrencpp": {
       "baseline": "0.1.7",
-      "port-version": 0
+      "port-version": 1
     },
     "concurrentqueue": {
       "baseline": "1.0.4",
@@ -7486,7 +7486,7 @@
     },
     "qtwebengine": {
       "baseline": "6.7.0",
-      "port-version": 2
+      "port-version": 3
     },
     "qtwebsockets": {
       "baseline": "6.7.0",

--- a/versions/c-/concurrencpp.json
+++ b/versions/c-/concurrencpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "07b69be3721571f0f15bc80442fd735cf1f87b70",
+      "version": "0.1.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "5eb63527141d7d261b6e99945f81bf43e293cc8b",
       "version": "0.1.7",
       "port-version": 0

--- a/versions/q-/qtwebengine.json
+++ b/versions/q-/qtwebengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60030ab0ec25c556ddde211877164346d453a6f9",
+      "version": "6.7.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "99bc7a32df1475460b84b8d04028c70c2a1b1d4d",
       "version": "6.7.0",
       "port-version": 2


### PR DESCRIPTION
In an internal version of Visual Studio, `arrow`, `concurrencpp` and `qtwebengine` install failed with following error:
```
arrow:        \cpp\src\arrow/json/object_writer.h(39): error C2039: 'string': is not a member of 'std'
concurrencpp: \include\concurrencpp/threads/thread.h(23): error C2039: 'string': is not a member of 'std'
qtwebengine:  \src\3rdparty\gn\src\gn\escape.h(77): error C2039: 'string': is not a member of 'std'
```
This issue caused by the STL PR: https://github.com/microsoft/STL/pull/4633, and according to Stephan's suggestion, the affected files need to include the `Standard <string> header`.

I have submitted an issue on the qt upstream: https://bugreports.qt.io/browse/QTBUG-126156

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
