### PR TITLE
[zlib-ng] Fix pkg-config file for windows

### DIFF
--- a/ports/zlib-ng/portfile.cmake
+++ b/ports/zlib-ng/portfile.cmake
@@ -17,6 +17,34 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+
+# Condition in `WIN32`, from https://github.com/zlib-ng/zlib-ng/blob/2.1.5/CMakeLists.txt#L1081-L1100
+# (dynamic) for `zlib` or (static `MSVC) for `zlibstatic` or default `z`
+# i.e. (windows) and not (static mingw) https://learn.microsoft.com/en-us/vcpkg/maintainers/variables#vcpkg_target_is_system
+if(VCPKG_TARGET_IS_WINDOWS AND (NOT (VCPKG_LIBRARY_LINKAGE STREQUAL static AND VCPKG_TARGET_IS_MINGW)))
+    set(_port_suffix)
+    if(ZLIB_COMPAT)
+        set(_port_suffix "")
+    else()
+        set(_port_suffix "-ng")
+    endif()
+
+    set(_port_output_name)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        set(_port_output_name "zlib${_port_suffix}")
+    else()
+        set(_port_output_name "zlibstatic${_port_suffix}")
+    endif()
+
+    # CMAKE_DEBUG_POSTFIX from https://github.com/zlib-ng/zlib-ng/blob/2.1.5/CMakeLists.txt#L494
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zlib${_port_suffix}.pc" " -lz${_port_suffix}" " -l${_port_output_name}")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/zlib${_port_suffix}.pc" " -lz${_port_suffix}" " -l${_port_output_name}d")
+    endif()
+endif()
+
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"

--- a/ports/zlib-ng/vcpkg.json
+++ b/ports/zlib-ng/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zlib-ng",
   "version": "2.1.5",
+  "port-version": 1,
   "description": "zlib replacement with optimizations for 'next generation' systems",
   "homepage": "https://github.com/zlib-ng/zlib-ng",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9670,7 +9670,7 @@
     },
     "zlib-ng": {
       "baseline": "2.1.5",
-      "port-version": 0
+      "port-version": 1
     },
     "zlmediakit": {
       "baseline": "2024-03-30",

--- a/versions/z-/zlib-ng.json
+++ b/versions/z-/zlib-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3f7c39c070cb4f55a281ebe3a178b4f7e896dea8",
+      "version": "2.1.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "e612211a2cf602a9a95796202f9cba452c6f5ebc",
       "version": "2.1.5",
       "port-version": 0


### PR DESCRIPTION
Fix #39141. Fix the library name for `pkg-config` is `z-ng` but output name is `zlib-ng[d].lib` for windows.

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
The port usage tests pass on `Release` and `Debug` with the following triplets:
* x64-windows
* x64-windows-static