### PR TITLE
[sleef] update to 3.6

### DIFF
--- a/ports/sleef/portfile.cmake
+++ b/ports/sleef/portfile.cmake
@@ -1,48 +1,29 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO shibatch/sleef
-    REF 3.5.1
-    SHA512 e8e4e5028db52998c6b82bd462622c08d670e4e85273327f1c3bdbd900827dd7793b217c2876ca1229b6f672493bb96f40140e14366390cccea0e6780689e128
+    REF ${VERSION}
+    SHA512 c3a21fb7c72ff2176f9496b18edb562387d3ebd543a5e4bd6329479a1ebf719bcd4429970274f0df66104b322bdcdd1c11e5e92d9af68fefdb350d7fcd8ab49f
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBUILD_LIBM=ON
-        -DBUILD_DFT=ON
-        -DBUILD_QUAD=ON
-        -DBUILD_GNUABI_LIBS=${VCPKG_TARGET_IS_LINUX}
-        -DBUILD_TESTS=OFF
-        -DBUILD_INLINE_HEADERS=OFF
+        -DSLEEF_BUILD_LIBM=ON
+        -DSLEEF_BUILD_DFT=ON
+        -DSLEEF_BUILD_QUAD=ON
+        -DSLEEF_BUILD_GNUABI_LIBS=${VCPKG_TARGET_IS_LINUX}
+        -DSLEEF_BUILD_TESTS=OFF
+        -DSLEEF_BUILD_INLINE_HEADERS=OFF
 )
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/sleef")
+
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/dummy")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/dummy")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
-# Install DLL and PDB files
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-        if(VCPKG_TARGET_IS_WINDOWS)
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleef.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleef.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleefdft.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleefdft.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleefquad.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleefquad.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-        endif()
-    endif()
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-        if(VCPKG_TARGET_IS_WINDOWS)
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleef.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleef.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleefdft.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleefdft.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleefquad.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleefquad.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-        endif()
-    endif()
-endif()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/sleef/vcpkg.json
+++ b/ports/sleef/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sleef",
-  "version": "3.5.1",
-  "port-version": 4,
+  "version": "3.6",
   "description": "SIMD Library for Evaluating Elementary Functions, vectorized libm and DFT",
   "homepage": "https://sleef.org/",
   "license": "BSL-1.0",
@@ -9,6 +8,10 @@
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8177,8 +8177,8 @@
       "port-version": 2
     },
     "sleef": {
-      "baseline": "3.5.1",
-      "port-version": 4
+      "baseline": "3.6",
+      "port-version": 0
     },
     "sleepy-discord": {
       "baseline": "2022-02-05",

--- a/versions/s-/sleef.json
+++ b/versions/s-/sleef.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb5e8b6a7265fe2d404a297fc387340dcfdb864f",
+      "version": "3.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "12afaa5146f51bf2912339befaafd1776e10442a",
       "version": "3.5.1",
       "port-version": 4


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39133
- Add a call to vcpkg_cmake_config_fixup().
- Remove unnecessary code.
- Fix the incorrect file structure.

Usage test passed with x64-windows triplet.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
