### PR TITLE
[vcpkg baseline][clockutils] Passing remove form fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -245,7 +245,6 @@ clblas:x64-android=fail
 clockutils:arm-neon-android=fail
 clockutils:arm64-android=fail
 clockutils:x64-android=fail
-clockutils:x64-linux=fail
 clrng:arm-neon-android=fail
 cnats:arm-neon-android=fail
 cnats:arm64-android=fail


### PR DESCRIPTION
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=103701&view=results.

Added `clockutils:x64-linux=fail` to `ci.baseline.txt` by #9203, which has been fixed by #38834.
```
PASSING, REMOVE FROM FAIL LIST: clockutils:x64-linux
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.