### PR TITLE
Enable additional authentication mechanisms in librdkafka

### DIFF
--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -13,7 +13,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" RDKAFKA_BUILD_STATIC)
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         ssl     WITH_SSL
-        ssl     WITH_WITH_SASL_OAUTHBEARER
+        ssl     WITH_SASL_OAUTHBEARER
         ssl     WITH_SASL_SCRAM
         zlib    WITH_ZLIB
         zstd    WITH_ZSTD

--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -13,10 +13,13 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" RDKAFKA_BUILD_STATIC)
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         ssl     WITH_SSL
+        ssl     WITH_WITH_SASL_OAUTHBEARER
+        ssl     WITH_SASL_SCRAM
         zlib    WITH_ZLIB
         zstd    WITH_ZSTD
         snappy  WITH_SNAPPY
         curl    WITH_CURL
+        curl    WITH_OAUTHBEARER_OIDC
 )
 
 vcpkg_cmake_configure(

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "librdkafka",
   "version": "2.3.0",
+  "port-version": 1,
   "description": "The Apache Kafka C/C++ library",
   "homepage": "https://github.com/edenhill/librdkafka",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4882,7 +4882,7 @@
     },
     "librdkafka": {
       "baseline": "2.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libredwg": {
       "baseline": "0.13.3",

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "420acc8b75e00d2fec12c4b991f63d909b69e022",
+      "version": "2.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a84ea0202e606993c8377b34bdbea3c84e08d792",
       "version": "2.3.0",
       "port-version": 0


### PR DESCRIPTION
The main reasons from what I can tell for enabling SSL or CURL is to also be able to enabled additional authentication mechanisms


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
