### PR TITLE
Update stormlib to 9.26

### DIFF
--- a/ports/stormlib/portfile.cmake
+++ b/ports/stormlib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ladislav-zezula/StormLib
     REF "v${VERSION}"
-    SHA512 0da78bda4bb89637da892fc73a0673b8a5f852ede4fdceba1029431d24dd1e59db9bfceafab1c5fb642e4b5d0d15d9865f7a138bfb190ce0c2d3601b22dd3023
+    SHA512 5f0ce75019cfbe3a2dfc07ea312825e2babf226dbf8aa77ed60456862ae739ac4689cbe7d4a185cdc148ad9910fd8137d3f11c04ffe6c532bbdacb08838ecfba
     HEAD_REF master
 )
 
@@ -11,6 +11,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME StormLib)
+vcpkg_copy_pdbs()
+
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/stormlib/vcpkg.json
+++ b/ports/stormlib/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "stormlib",
-  "version": "9.25",
+  "version": "9.26",
   "description": "StormLib is a library for opening and manipulating Blizzard MPQ files",
   "dependencies": [
     "bzip2",
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     },
     "zlib"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8485,7 +8485,7 @@
       "port-version": 1
     },
     "stormlib": {
-      "baseline": "9.25",
+      "baseline": "9.26",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/s-/stormlib.json
+++ b/versions/s-/stormlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f5b1e0a693bea5a8bcdec058ef72972c6104115",
+      "version": "9.26",
+      "port-version": 0
+    },
+    {
       "git-tree": "a3fc71772572a4bff064f754ef71c6631cb9bca9",
       "version": "9.25",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This PR updates stormlib to the latest version which now also installs cmake configs. This is supported by using `vcpkg_cmake_config_fixup()`.
