### PR TITLE
[vcpkg baseline][mesa] Remove egl from default features

### DIFF
--- a/ports/mesa/vcpkg.json
+++ b/ports/mesa/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mesa",
   "version": "24.0.7",
+  "port-version": 1,
   "description": "Mesa - The 3D Graphics Library",
   "homepage": "https://www.mesa3d.org/",
   "license": "MIT AND BSL-1.0 AND SGI-B-2.0",
@@ -39,14 +40,6 @@
             "llvm"
           ],
           "platform": "x64"
-        },
-        {
-          "name": "mesa",
-          "default-features": false,
-          "features": [
-            "egl"
-          ],
-          "platform": "!osx"
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5702,7 +5702,7 @@
     },
     "mesa": {
       "baseline": "24.0.7",
-      "port-version": 0
+      "port-version": 1
     },
     "meschach": {
       "baseline": "1.2b",

--- a/versions/m-/mesa.json
+++ b/versions/m-/mesa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04738625c7b81104ce8e66f296fd807c9dc05bce",
+      "version": "24.0.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "24210567cde1f9242bca62ba46ef468467281c80",
       "version": "24.0.7",
       "port-version": 0


### PR DESCRIPTION
Mitigation for #39198.

Mesa CI is currently disabled for linux and osx, and also doesn't run for android.
So we see CI effects only for Windows. Improving CI situation for mesa is the subject of #36081. So keeping egl out of CI like before https://github.com/microsoft/vcpkg/pull/37599 is the best option at the moment.