### PR TITLE
Cppparser initial

### DIFF
--- a/ports/cppparser/portfile.cmake
+++ b/ports/cppparser/portfile.cmake
@@ -1,26 +1,23 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO agladilin/cppparser
     REF "${VERSION}"
-    SHA512 6fea5a6f7a172b8e828382871ad1dcb102ab700d617a1d2b753b6e0bfef7639e0b40778fdceb196e6b0b1b5e75c9173a1cb1eb667906ec7471118b74c5dbfce1
+    SHA512 024d4cbe4e492aad23b1aba6576dd93a26d4b887f8d5792732a0ca98afec01134d90891e379a31f26df84a65d648b9187723b3dc57826294dfdeb108ae3d665d
     HEAD_REF master
 )
 
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME "cppparser" CONFIG_PATH lib)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib)
 
 file(REMOVE_RECURSE
-    ${CURRENT_PACKAGES_DIR}/debug/include
+    "${CURRENT_PACKAGES_DIR}/debug/include"
 )
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
-
-#install(
-#    FILES ${config_version_file} ${install_config}
-#    DESTINATION "${CPPPARSER_INSTALL_CONFIG_DIR}"
-#)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cppparser/portfile.cmake
+++ b/ports/cppparser/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO agladilin/cppparser
+    REF "${VERSION}"
+    SHA512 6fea5a6f7a172b8e828382871ad1dcb102ab700d617a1d2b753b6e0bfef7639e0b40778fdceb196e6b0b1b5e75c9173a1cb1eb667906ec7471118b74c5dbfce1
+    HEAD_REF master
+)
+
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "cppparser" CONFIG_PATH lib)
+
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/debug/include
+)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
+
+#install(
+#    FILES ${config_version_file} ${install_config}
+#    DESTINATION "${CPPPARSER_INSTALL_CONFIG_DIR}"
+#)

--- a/ports/cppparser/usage
+++ b/ports/cppparser/usage
@@ -1,0 +1,4 @@
+cppparser provides CMake targets:
+
+find_package(cppparser CONFIG REQUIRED)
+target_link_libraries(main PRIVATE cppparser::cppparser)

--- a/ports/cppparser/usage
+++ b/ports/cppparser/usage
@@ -1,4 +1,4 @@
 cppparser provides CMake targets:
 
-find_package(cppparser CONFIG REQUIRED)
-target_link_libraries(main PRIVATE cppparser::cppparser)
+  find_package(cppparser CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE cppparser::cppparser)

--- a/ports/cppparser/vcpkg.json
+++ b/ports/cppparser/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "cppparser",
   "version": "0.1.0",
   "description": "An easy, fast, and robust library to parse C/C++ source.",
-  "homepage": "https://github.com/agladilin/cppparser/tree/master",
+  "homepage": "https://github.com/agladilin/cppparser/",
   "license": "MIT",
   "dependencies": [
     "boost-filesystem",

--- a/ports/cppparser/vcpkg.json
+++ b/ports/cppparser/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "cppparser",
+  "version": "0.1.0",
+  "description": "An easy, fast, and robust library to parse C/C++ source.",
+  "homepage": "https://github.com/agladilin/cppparser/tree/master",
+  "license": "MIT",
+  "dependencies": [
+    "boost-filesystem",
+    "boost-program-options",
+    "boost-system",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1944,6 +1944,10 @@
       "baseline": "2.1.0",
       "port-version": 0
     },
+    "cppparser": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "cpprestsdk": {
       "baseline": "2.10.19",
       "port-version": 1

--- a/versions/c-/cppparser.json
+++ b/versions/c-/cppparser.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5523b7b0c7915d842732844064784a22245b24a4",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

