### PR TITLE
[vcpkg] Fix vcpkg.targets incorrect output

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -226,6 +226,15 @@
     <!-- Search %PATH% for pwsh.exe if it is available. -->
     <Exec
       Condition="'$(VcpkgXUseBuiltInApplocalDeps)' != 'true'"
+      Command="where.exe pwsh.exe &gt;NUL 2&gt;&amp;1"
+      IgnoreExitCode="true"
+      UseCommandProcessor="true">
+      <Output TaskParameter="ExitCode"
+              PropertyName="_ZSearchPwshInPathExitCode" />
+    </Exec>
+    <!-- Execute PowerShell Core commands to ensure compatibility with legacy code. -->
+    <Exec
+      Condition="'$(_ZSearchPwshInPathExitCode)' == '0'"
       Command="pwsh.exe $(_ZVcpkgAppLocalPowerShellCommonArguments)"
       IgnoreExitCode="true"
       UseCommandProcessor="false">


### PR DESCRIPTION
Fixes #38502

When building using `scripts\buildsystems\msbuild\vcpkg.targets `and using Windows PowerShell (rather than PowerShell Core), the build outputs an error message when it actually succeeds.
````
'pwsh.exe' is not recognized as an internal or external command,
````
As per @berryzplus' comment on line 229 it incorrectly calls pwsh.exe without checking if pwsh.exe is included in %PATH%
https://github.com/microsoft/vcpkg/blob/ad25766aefb5313b6bc4e2a4b78a2946f84fbf66/scripts/buildsystems/msbuild/vcpkg.targets#L226-L231

Using WHERE command to check if pwsh.exe is in a specific `%PATH%` fixes this bug

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [ ] ~~Only one version is added to each modified port's versions file.~~