### PR TITLE
[vincentlaucsb-csv-parser] update to 2.2.3

### DIFF
--- a/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
+++ b/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e729a8b..c63edab 100644
+index 1b920b1..c56a142 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,6 +1,12 @@
@@ -15,7 +15,7 @@ index e729a8b..c63edab 100644
  if(CSV_CXX_STANDARD)
  	set(CMAKE_CXX_STANDARD ${CSV_CXX_STANDARD})
  else()
-@@ -38,16 +44,27 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
+@@ -40,10 +46,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
  
  include_directories(${CSV_INCLUDE_DIR})
  
@@ -27,9 +27,10 @@ index e729a8b..c63edab 100644
  
  ## Main Library
  add_subdirectory(${CSV_SOURCE_DIR})
+@@ -60,6 +63,23 @@ if (CSV_BUILD_PROGRAMS)
+     add_subdirectory("programs")
+ endif()
  
--## Executables
--add_subdirectory("programs")
 +install(TARGETS csv EXPORT unofficial-vincentlaucsb-csv-parser)
 +
 +install(
@@ -46,19 +47,21 @@ index e729a8b..c63edab 100644
 +    PATTERN "CMakeLists.txt" EXCLUDE
 +    PATTERN "external" EXCLUDE
 +)
- 
++
  ## Developer settings
  if (CSV_DEVELOPER)
+     # Allow for performance profiling
 diff --git a/include/internal/CMakeLists.txt b/include/internal/CMakeLists.txt
-index 42cac24..30ea9e7 100644
+index 4cbf58c..e9e65f8 100644
 --- a/include/internal/CMakeLists.txt
 +++ b/include/internal/CMakeLists.txt
-@@ -23,5 +23,9 @@ target_sources(csv
- 		data_type.h
+@@ -23,6 +23,9 @@ target_sources(csv
+ 		"data_type.hpp"
  		)
  
 -set_target_properties(csv PROPERTIES LINKER_LANGUAGE CXX)
 -target_link_libraries(csv PRIVATE Threads::Threads)
+-target_include_directories(csv INTERFACE ../)
 +set_target_properties(csv PROPERTIES LINKER_LANGUAGE CXX OUTPUT_NAME "vincentlaucsb-csv-parser-csv")
 +target_include_directories(csv
 +	PUBLIC ${HEDLEY_INCLUDE_DIRS}

--- a/ports/vincentlaucsb-csv-parser/002-fix-include.patch
+++ b/ports/vincentlaucsb-csv-parser/002-fix-include.patch
@@ -31,7 +31,7 @@ index c132bfb..dff4d03 100644
  namespace csv {
  #ifdef _MSC_VER
 diff --git a/include/internal/csv_reader.hpp b/include/internal/csv_reader.hpp
-index 798ef3b..007fa23 100644
+index 1cdf6e0..3077395 100644
 --- a/include/internal/csv_reader.hpp
 +++ b/include/internal/csv_reader.hpp
 @@ -15,7 +15,7 @@
@@ -42,4 +42,4 @@ index 798ef3b..007fa23 100644
 +#include "mio/mmap.hpp"
  #include "basic_csv_parser.hpp"
  #include "common.hpp"
- #include "data_type.h"
+ #include "data_type.hpp"

--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 26ed124ebe9592931ad141bdc53569537b7599de2ba6a7230d4a514cba27bf2684f2b320be9a39a7c5277fcfd75eb972aa3a39bd9613dd237f865b50f5437178
+    SHA512 44af73db1762e55f8c93d7f97e3f3b4b550c4f4043ace693d4bdbb41cce0b78450afdcd3fea8c9b4ee60e8100e4160facf72db27c31e3c579e35b6acbb8fff0c
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch
@@ -15,6 +15,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_PYTHON=OFF
+        -DCSV_BUILD_PROGRAMS=OFF
     MAYBE_UNUSED_VARIABLES
         BUILD_PYTHON
 )

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "2.1.3",
+  "version": "2.2.3",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9185,7 +9185,7 @@
       "port-version": 1
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "2.1.3",
+      "baseline": "2.2.3",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6bea0ccfd4832f3c1aeea917bd8c709c19750ebd",
+      "version": "2.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "85d641f84a8f718a13d9f7ac169a4f2542c4d7c8",
       "version": "2.1.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.