### PR TITLE
[tcl] Fix missing zlib dependency.

### DIFF
--- a/ports/tcl/vcpkg.json
+++ b/ports/tcl/vcpkg.json
@@ -1,10 +1,13 @@
 {
   "name": "tcl",
   "version-string": "core-9-0-a1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Tcl provides a powerful platform for creating integration applications that tie together diverse applications, protocols, devices, and frameworks. When paired with the Tk toolkit, Tcl provides the fastest and most powerful way to create GUI applications that run on PCs, Unix, and Mac OS X. Tcl can also be used for a variety of web-related tasks and for creating powerful command languages for applications.",
   "homepage": "https://github.com/tcltk/tcl",
   "supports": "!android & !(windows & arm) & !uwp",
+  "dependencies": [
+    "zlib"
+  ],
   "features": {
     "profile": {
       "description": "Adds profiling hooks.  Map file is assumed."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8598,7 +8598,7 @@
     },
     "tcl": {
       "baseline": "core-9-0-a1",
-      "port-version": 6
+      "port-version": 7
     },
     "tclap": {
       "baseline": "1.2.5",

--- a/versions/t-/tcl.json
+++ b/versions/t-/tcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cf292d0782ec4b951e94467bd26a6b4a1db5874f",
+      "version-string": "core-9-0-a1",
+      "port-version": 7
+    },
+    {
       "git-tree": "e825eeb13189650d5919608370935891a5cba218",
       "version-string": "core-9-0-a1",
       "port-version": 6


### PR DESCRIPTION
Fixes the following build failure:

```
-- Fixing pkgconfig file: /home/bion/vcpkg/packages/tcl_x64-linux/lib/pkgconfig/tcl.pc
CMake Error at scripts/cmake/vcpkg_fixup_pkgconfig.cmake:134 (message):
  /bin/pkg-config --exists tcl failed with error code: 1

      ENV{PKG_CONFIG_PATH}: "/home/bion/vcpkg/packages/tcl_x64-linux/lib/pkgconfig:/home/bion/vcpkg/packages/tcl_x64-linux/share/pkgconfig:/home/bion/vcpkg/installed/x64-linux/lib/pkgconfig:/home/bion/vcpkg/installed/x64-linux/share/pkgconfig"
      output: Package zlib was not found in the pkg-config search path.

  Perhaps you should add the directory containing `zlib.pc'

  to the PKG_CONFIG_PATH environment variable

  Package 'zlib', required by 'tcl', not found
```

I discovered trying to fix sqlcipher on Linux.
