### PR TITLE
[cpptrace] Add 0.6.1

### DIFF
--- a/ports/cpptrace/portfile.cmake
+++ b/ports/cpptrace/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jeremy-rifkin/cpptrace
     REF "v${VERSION}"
-    SHA512 c5ebd1a733e22006abe2ef2b5e65a9f967ef2a433194d1c2dbed2dea7a81034a56717ad54698eaad20b3c53b941a2766587dc32936b3703ef87fda29eafc5dbf
+    SHA512 76f82aa11fb9e786cb246d9620c30de6f4c24353136e2597767f567f9d6fc83652120250fe8ca36aff6e3d95044a3edbc11a2607f72c46d3c2bfe168c3b9bcbb
     HEAD_REF main
 )
 

--- a/ports/cpptrace/vcpkg.json
+++ b/ports/cpptrace/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpptrace",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Simple, portable, and self-contained stacktrace library for C++11 and newer",
   "homepage": "https://github.com/jeremy-rifkin/cpptrace",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1957,7 +1957,7 @@
       "port-version": 4
     },
     "cpptrace": {
-      "baseline": "0.6.0",
+      "baseline": "0.6.1",
       "port-version": 0
     },
     "cppunit": {

--- a/versions/c-/cpptrace.json
+++ b/versions/c-/cpptrace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64f2b677dc99637be42a062d6c6a91c824230751",
+      "version": "0.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "089e867a1e7c29c5daf0cd95ac52c4c4547040d9",
       "version": "0.6.0",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
