### PR TITLE
[vulkan-memory-allocator-hpp] Update to 3.1.0

### DIFF
--- a/ports/vulkan-memory-allocator-hpp/portfile.cmake
+++ b/ports/vulkan-memory-allocator-hpp/portfile.cmake
@@ -1,17 +1,9 @@
-vcpkg_download_distfile(PATCH_39
-    URLS https://github.com/YaaZ/VulkanMemoryAllocator-Hpp/commit/73cdd838c425637c874d343ab0ceba5148189cbf.patch?full_index=1
-    SHA512 6a00c6261fbef850ba9387557d9125e4f25e136ad6e1de203dc6e98bf1ef4a52adb444d9bfb9a92aef910d4eb4eb5b7292cfbc0add19d01ee481add27393f076
-    FILENAME 9ebe4a22cad8a025b68a9594bdff3c047a111333.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO YaaZ/VulkanMemoryAllocator-Hpp
-    REF "v3.0.1-1"
-    SHA512 71709a889ea4527c2ee273521fe62b61bb87cda3e3c3ae2964cc18bd70ac69629aeed00b1e92d4470ba6cb08394813880018401847a6d4ed5c15e4ee1fb60ff1
+    REF "v${VERSION}"
+    SHA512 95f5a8930431c18683d7e768ce1363b4edcb2fa7ca527054c77dbc8b34355308f621eed8cd018a574a928ac93e8689d4a8991802e3d601f5c0d1204a9155aee6
     HEAD_REF master
-    PATCHES
-        "${PATCH_39}"
 )
 
 file(COPY "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")

--- a/ports/vulkan-memory-allocator-hpp/vcpkg.json
+++ b/ports/vulkan-memory-allocator-hpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vulkan-memory-allocator-hpp",
-  "version": "3.0.1.1",
-  "port-version": 1,
+  "version": "3.1.0",
   "description": "C++ bindings for VulkanMemoryAllocator (Development branch)",
   "homepage": "https://github.com/YaaZ/VulkanMemoryAllocator-Hpp",
   "license": "CC0-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9273,8 +9273,8 @@
       "port-version": 0
     },
     "vulkan-memory-allocator-hpp": {
-      "baseline": "3.0.1.1",
-      "port-version": 1
+      "baseline": "3.1.0",
+      "port-version": 0
     },
     "vulkan-sdk-components": {
       "baseline": "1.3.280.0",

--- a/versions/v-/vulkan-memory-allocator-hpp.json
+++ b/versions/v-/vulkan-memory-allocator-hpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b9f973889aed3d994bd84da71014effa986eb9c3",
+      "version": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "13f7806144f0e8ead19a05e5074367543f2254fb",
       "version": "3.0.1.1",
       "port-version": 1


### PR DESCRIPTION
Fix #39229.

Remove the `PATH_39` that has been released in `3.1.0`.

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
The port installation tests pass with the following triplets:
* x64-windows