### PR TITLE
[armadillo] update to 12.6.7

### DIFF
--- a/ports/armadillo/portfile.cmake
+++ b/ports/armadillo/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO arma
     FILENAME "armadillo-${VERSION}.tar.xz"
-    SHA512 bf6a3db60256aa9789b52d92b33971a43816e73cd079d08e35350fcb251c213fba59604263595f886c4228147e75dd9308a5208ab9b290bb094128a1aee5da3d
+    SHA512 bf792ab2655b1cf957a29f1bdd7a692fd75c79f4f2df1eca35d84969908784f3542b82dd5a5b0a339ab88719c2c602a175dee7fd1e9dbd2884eb19a81d061fa3
     PATCHES
         cmake-config.patch
         dependencies.patch

--- a/ports/armadillo/vcpkg.json
+++ b/ports/armadillo/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "armadillo",
-  "version": "12.6.6",
-  "port-version": 1,
+  "version": "12.6.7",
   "description": "Armadillo is a high quality linear algebra library (matrix maths) for the C++ language, aiming towards a good balance between speed and ease of use",
   "homepage": "https://arma.sourceforge.net/",
   "license": "Apache-2.0",

--- a/versions/a-/armadillo.json
+++ b/versions/a-/armadillo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26b683ba7667590b73816c9be35d0f8255e200bb",
+      "version": "12.6.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "c2aff7478c5ce43b743299048915610189b0cece",
       "version": "12.6.6",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -229,8 +229,8 @@
       "port-version": 0
     },
     "armadillo": {
-      "baseline": "12.6.6",
-      "port-version": 1
+      "baseline": "12.6.7",
+      "port-version": 0
     },
     "arpack-ng": {
       "baseline": "3.9.1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.