### PR TITLE
[jxrlib] Suppress gcc 14 warn into error of incompatible-pointer-types

### DIFF
--- a/ports/jxrlib/CMakeLists.txt
+++ b/ports/jxrlib/CMakeLists.txt
@@ -22,7 +22,11 @@ if(NOT WIN32)
   add_definitions(-D__ANSI__)
 endif()
 if(NOT MSVC)
-  add_compile_options(-Wno-error=implicit-function-declaration -Wno-endif-labels)
+  add_compile_options(
+    -Wno-error=implicit-function-declaration
+    -Wno-endif-labels
+    -Wno-incompatible-pointer-types             # https://gcc.gnu.org/gcc-14/porting_to.html#incompatible-pointer-types
+  )
 endif()
 
 include(TestBigEndian)

--- a/ports/jxrlib/vcpkg.json
+++ b/ports/jxrlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "jxrlib",
   "version": "2019.10.9",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Open source implementation of the jpegxr image format standard.",
   "homepage": "https://github.com/4creators/jxrlib",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3826,7 +3826,7 @@
     },
     "jxrlib": {
       "baseline": "2019.10.9",
-      "port-version": 6
+      "port-version": 7
     },
     "kaitai-struct-cpp-stl-runtime": {
       "baseline": "0.10.1",

--- a/versions/j-/jxrlib.json
+++ b/versions/j-/jxrlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d6cb4015844afea80f96aa9cd6c43fb2bdd1cc1",
+      "version": "2019.10.9",
+      "port-version": 7
+    },
+    {
       "git-tree": "3a114c06061c6e5a6e1dcc40eaadb21cecb7ac99",
       "version": "2019.10.9",
       "port-version": 6


### PR DESCRIPTION
Fix #39154. For `gcc-14` [incompatible-pointer-types](https://gcc.gnu.org/gcc-14/porting_to.html#incompatible-pointer-types), *GCC no longer allows implicitly casting all pointer types to all other pointer types*. Add the suppress option as workaround.

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
The port installation tests pass with the following triplets:
* x64-osx (`clang-15.0.0`)
* x64-linux (`gcc-12.2.0` and `gcc-14.1.1`)
* x64-windows