### PR TITLE
[vcpkg-ci-openimageio] Add missing commas

### DIFF
--- a/scripts/test_ports/vcpkg-ci-openimageio/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-openimageio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-ci-openimageio",
-  "version": "1",
+  "version": "2",
   "description": "OpenImageIO features testing within CI.",
   "license": "MIT",
   "dependencies": [
@@ -16,7 +16,7 @@
         {
           "name": "pybind11",
           "platform": "!(windows & static)"
-        }
+        },
         "tools",
         "webp"
       ]


### PR DESCRIPTION
Fixes #39276

vcpkg.json file in vcpkg/scripts/test_ports/vcpkg-ci-openimageio missing , character

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [ ] ~~Only one version is added to each modified port's versions file.~~