### PR TITLE
[caf] Update to 0.19.6

### DIFF
--- a/ports/caf/fix_cxx17.patch
+++ b/ports/caf/fix_cxx17.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ed753b9..5dc80c2 100644
+index f088f6a..a8bcf80 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -131,7 +131,7 @@ endif()
+@@ -134,7 +134,7 @@ endif()
  
  if(NOT DEFINED CAF_USE_STD_FORMAT)
    set(CAF_USE_STD_FORMAT OFF CACHE BOOL "Enable std::format support" FORCE)
@@ -11,37 +11,30 @@ index ed753b9..5dc80c2 100644
      set(snippet "#include <format>
                   #include <iostream>
                   int main() { std::cout << std::format(\"{}\", \"ok\"); }")
-@@ -177,7 +177,6 @@ endif()
+@@ -180,8 +180,6 @@ endif()
  
  # -- create the libcaf_test target ahead of time for caf_core ------------------
  
 -add_library(libcaf_test)
- 
+-
  # -- add uninstall target if it does not exist yet -----------------------------
  
-@@ -289,8 +288,6 @@ function(caf_add_component name)
-       string(REPLACE "/" "-" test_name "${test_path}/${test_name}-test")
-       add_executable("${test_name}" ${source_file}
-                      $<TARGET_OBJECTS:${obj_lib_target}>)
--      target_link_libraries(${test_name} PRIVATE libcaf_test
--                            ${CAF_ADD_COMPONENT_DEPENDENCIES})
-       target_include_directories(${test_name} PRIVATE
-                                  "${CMAKE_CURRENT_SOURCE_DIR}"
-                                  "${CMAKE_CURRENT_BINARY_DIR}")
-@@ -314,8 +311,6 @@ function(caf_add_component name)
+ if(NOT TARGET uninstall)
+@@ -326,8 +324,6 @@ function(caf_add_component name)
+     list(APPEND targets ${tst_bin_target})
      add_executable(${tst_bin_target}
-                    ${CAF_ADD_COMPONENT_LEGACY_TEST_SOURCES}
-                    $<TARGET_OBJECTS:${obj_lib_target}>)
+                    ${CAF_ADD_COMPONENT_LEGACY_TEST_SOURCES})
 -    target_link_libraries(${tst_bin_target} PRIVATE libcaf_test
--                          ${CAF_ADD_COMPONENT_DEPENDENCIES})
+-                          ${CAF_ADD_COMPONENT_DEPENDENCIES} ${lib_target})
      target_include_directories(${tst_bin_target} PRIVATE
                                 "${CMAKE_CURRENT_SOURCE_DIR}/tests/legacy")
      if(CAF_ADD_COMPONENT_LEGACY_TEST_SUITES)
-@@ -373,7 +368,6 @@ endfunction()
+@@ -383,8 +379,6 @@ endfunction()
  
  add_subdirectory(libcaf_core)
  
 -add_subdirectory(libcaf_test)
- 
+-
  if(CAF_ENABLE_NET_MODULE)
    add_subdirectory(libcaf_net)
+ endif()

--- a/ports/caf/portfile.cmake
+++ b/ports/caf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO actor-framework/actor-framework
     REF "${VERSION}"
-    SHA512 97766b5b0a4db96b03be77c1ffd2198cc5536c09e2a06bb6fcff023ee78692f2c23ad213dc9698d6abfe950c61c4a2565bbfdfe871652cef816829e83d16ceab
+    SHA512 8a7aacbd9bf18318d9ca1f5fb30c101220c1eef2c4bfe82c53760024022473109038872c0deb5a60d732a91da8d863c556a27018e6b667bfcfbf536df3cebcaf
     HEAD_REF master
     PATCHES
         fix_dependency.patch
@@ -34,4 +34,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILSE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/caf/portfile.cmake
+++ b/ports/caf/portfile.cmake
@@ -34,4 +34,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-vcpkg_install_copyright(FILSE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/caf/vcpkg.json
+++ b/ports/caf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "caf",
-  "version": "0.19.3",
+  "version": "0.19.6",
   "description": "an open source implementation of the actor model for C++ featuring lightweight & fast actor implementations, pattern matching for messages, network transparent messaging, and more.",
   "homepage": "https://github.com/actor-framework/actor-framework",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1453,7 +1453,7 @@
       "port-version": 0
     },
     "caf": {
-      "baseline": "0.19.3",
+      "baseline": "0.19.6",
       "port-version": 0
     },
     "caffe2": {

--- a/versions/c-/caf.json
+++ b/versions/c-/caf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9193b5fa861c2d817ee9ee367739f190ea10e58d",
+      "version": "0.19.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "2b744b08352077e2bf620c383d9924f4a008cbca",
       "version": "0.19.3",
       "port-version": 0

--- a/versions/c-/caf.json
+++ b/versions/c-/caf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9193b5fa861c2d817ee9ee367739f190ea10e58d",
+      "git-tree": "e71a51cfec683161a30d2dcca04fe5fc7f063ea7",
       "version": "0.19.6",
       "port-version": 0
     },


### PR DESCRIPTION
Update `caf` to 0.19.6.

No feature needs to be tested, the usage test passed on `x64-windows` (header files found):
```
caf provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(CAF CONFIG REQUIRED)
  # note: 1 additional targets are not displayed.
  target_link_libraries(main PRIVATE CAF::io CAF::net CAF::core CAF::openssl)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
