### PR TITLE
[librtmp] Refactor librtmp

### DIFF
--- a/ports/librtmp/0006-typedef-off_t.diff
+++ b/ports/librtmp/0006-typedef-off_t.diff
@@ -1,0 +1,12 @@
+diff --git a/librtmp/rtmp_sys.h b/librtmp/rtmp_sys.h
+index 5b3eb54e86767a45a91f941014113ca9e62b5b74..5b4c1e98a12b2b2dc3009fee007ac140fd2745f8 100644
+--- a/librtmp/rtmp_sys.h
++++ b/librtmp/rtmp_sys.h
+@@ -43,6 +43,7 @@
+ #define sleep(n)	Sleep(n*1000)
+ #define msleep(n)	Sleep(n)
+ #define SET_RCVTIMEO(tv,s)	int tv = s*1000
++#include <sys/types.h>
+ #else /* !_WIN32 */
+ #include <sys/types.h>
+ #include <sys/socket.h>

--- a/ports/librtmp/CMakeLists.txt
+++ b/ports/librtmp/CMakeLists.txt
@@ -1,57 +1,133 @@
-cmake_minimum_required(VERSION 3.8)
+# Unofficial librtmp CMakeLists.txt from Makefile of https://git.ffmpeg.org/gitweb/rtmpdump.git/blob/6f6bb1353fc84f4cc37138baa99f586750028a01:/librtmp/Makefile
+cmake_minimum_required(VERSION 3.29)
 
-project(librtmp C)
+project(librtmp
+    VERSION ${VERSION}
+    DESCRIPTION "RTMP implementation"
+    HOMEPAGE_URL "http://rtmpdump.mplayerhq.hu"
+    LANGUAGES C
+)
+set(LIBRTMP_SO_VERSION ${LIBRTMP_SO_VERSION})
 
+# options switch `LIBRTMP_CRYPTO` and string `LIBRTMP_SSL` of "NOSSL;POLARSSL;OPENSSL;GNUTLS"
+option(LIBRTMP_CRYPTO "" ON)
+if(LIBRTMP_CRYPTO)
+    set(LIBRTMP_SSL "OPENSSL" CACHE STRING "")
+    set(LIBRTMP_SSL_ITEMS "NOSSL" "POLARSSL" "OPENSSL" "GNUTLS")
+    set_property(CACHE LIBRTMP_SSL PROPERTY STRINGS ${LIBRTMP_SSL_ITEMS})
+    if(NOT LIBRTMP_SSL IN_LIST LIBRTMP_SSL_ITEMS)
+        message(FATAL_ERROR "String option LIBRTMP_SSL must be one of ${LIBRTMP_SSL_ITEMS}")
+    endif()
+endif()
+
+# target librtmp
+set(librtmp_target "librtmp")
+add_library(${librtmp_target})
+set_target_properties(${librtmp_target} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${LIBRTMP_SO_VERSION})
+if(WIN32)
+    target_sources(${librtmp_target} PRIVATE "librtmp.def")
+endif()
+
+# target librtmp_public
+set(librtmp_public "librtmp_public")
+add_library(${librtmp_public} INTERFACE)
+target_compile_definitions(${librtmp_public} INTERFACE "RTMPDUMP_VERSION=\"${PROJECT_VERSION}\"")
+
+# target librtmp_local
+set(librtmp_local "librtmp_local")
+add_library(${librtmp_local} INTERFACE)
+target_compile_definitions(${librtmp_local} INTERFACE "LIBRTMP_ONLY")
+
+# target librtmp_transitive
+set(librtmp_transitive "librtmp_transitive")
+add_library(${librtmp_transitive} INTERFACE)
+
+# dependency zlib
 find_package(ZLIB REQUIRED)
-find_package(OpenSSL REQUIRED)
+target_link_libraries(${librtmp_transitive} INTERFACE ZLIB::ZLIB)
 
-include_directories(${ZLIB_INCLUDE_DIRS})
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
-set(CMAKE_DEBUG_POSTFIX "d")
-
-if(MSVC)
-    add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
-    add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
-    add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
+# dependency crypto
+if(NOT LIBRTMP_CRYPTO)
+    target_compile_definitions(${librtmp_public} INTERFACE "NO_CRYPTO")
+else()
+    if(LIBRTMP_SSL STREQUAL "OPENSSL")
+        target_compile_definitions(${librtmp_public} INTERFACE "USE_OPENSSL")
+        find_package(OpenSSL CONFIG REQUIRED)
+        target_link_libraries(${librtmp_transitive} INTERFACE OpenSSL::SSL OpenSSL::Crypto)
+    else()
+        message(FATAL_ERROR "Unsupported LIBRTMP_SSL: ${LIBRTMP_SSL}")
+    endif()
 endif()
 
-add_definitions(-DLIBRTMP_ONLY)
-
-# List the header files
-set(HEADERS librtmp/amf.h
-            librtmp/bytes.h
-            librtmp/dh.h
-            librtmp/dhgroups.h
-            librtmp/handshake.h
-            librtmp/http.h
-            librtmp/log.h
-            librtmp/rtmp.h
-            librtmp/rtmp_sys.h
-)
-
-# List the source files
-set(SRCS librtmp/amf.c
-         librtmp/hashswf.c
-         librtmp/log.c
-         librtmp/parseurl.c
-         librtmp/rtmp.c
-)
-
-if(MSVC)
-    set(SRCS_MSVC "librtmp/librtmp.def")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4996")
+# dependency system
+if(WIN32)
+    target_link_libraries(${librtmp_transitive} INTERFACE ws2_32 winmm)
 endif()
 
-add_library(librtmp ${SRCS} ${HEADERS} ${SRCS_MSVC})
+# target objects
+set(librtmp_obj_list "log" "rtmp" "amf" "hashswf" "parseurl")
+add_library(log OBJECT)
+target_sources(log PRIVATE "log.c" PUBLIC FILE_SET HEADERS FILES "log.h")
+add_library(rtmp OBJECT)
+target_sources(rtmp PRIVATE "rtmp.c" PUBLIC FILE_SET HEADERS FILES "rtmp.h" "rtmp_sys.h" "handshake.h" "dh.h" "log.h" "amf.h")
+add_library(amf OBJECT)
+target_sources(amf PRIVATE "amf.c" PUBLIC FILE_SET HEADERS FILES "amf.h" "bytes.h" "log.h")
+add_library(hashswf OBJECT)
+target_sources(hashswf PRIVATE "hashswf.c" PUBLIC FILE_SET HEADERS FILES "http.h" "rtmp.h" "rtmp_sys.h")
+add_library(parseurl OBJECT)
+target_sources(parseurl PRIVATE "parseurl.c" PUBLIC FILE_SET HEADERS FILES "rtmp.h" "rtmp_sys.h" "log.h")
 
-target_include_directories(librtmp PRIVATE ./librtmp)
-target_link_libraries(librtmp PRIVATE ${ZLIB_LIBRARIES} ${OPENSSL_LIBRARIES})
-target_link_libraries(librtmp PRIVATE Ws2_32.lib Winmm.lib)
+# link
+foreach(obj IN LISTS librtmp_obj_list)
+    target_link_libraries(${obj} PUBLIC ${librtmp_public} PRIVATE ${librtmp_transitive} $<BUILD_LOCAL_INTERFACE:${librtmp_local}>)
+endforeach()
+target_link_libraries(${librtmp_target} PUBLIC ${librtmp_obj_list})
 
-install(TARGETS librtmp
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+# === Install ===
 
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/librtmp DESTINATION include FILES_MATCHING PATTERN "*.h")
+# install settings
+include(GNUInstallDirs)
+set(librtmp_package_name "unofficial-librtmp")
+set(librtmp_namespace "unofficial::librtmp::")
+set(librtmp_target_list "${librtmp_target};${librtmp_obj_list};${librtmp_public};${librtmp_transitive}")
+set(librtmp_export_targets "librtmp-targets")
+set(librtmp_install_include "${CMAKE_INSTALL_INCLUDEDIR}/librtmp")
+set(librtmp_install_share "${CMAKE_INSTALL_DATAROOTDIR}/${librtmp_package_name}")
+set(librtmp_config_filename "${librtmp_package_name}-config.cmake")
+set(librtmp_config_template_path "${CMAKE_CURRENT_BINARY_DIR}/Config.cmake.in")
+
+# install targets
+install(TARGETS ${librtmp_target_list}
+        EXPORT "${librtmp_export_targets}"
+        FILE_SET HEADERS DESTINATION "${librtmp_install_include}"
+)
+
+install(EXPORT "${librtmp_export_targets}"
+    NAMESPACE "${librtmp_namespace}"
+    DESTINATION "${librtmp_install_share}"
+)
+
+# generate configs
+file(WRITE "${librtmp_config_template_path}"
+[[@PACKAGE_INIT@
+set(LIBRTMP_CRYPTO @LIBRTMP_CRYPTO@)
+set(LIBRTMP_SSL @LIBRTMP_SSL@)
+include(CMakeFindDependencyMacro)
+find_dependency(ZLIB REQUIRED)
+if(LIBRTMP_CRYPTO AND LIBRTMP_SSL STREQUAL "OPENSSL")
+    find_dependency(OpenSSL CONFIG REQUIRED)
+endif()
+include("${CMAKE_CURRENT_LIST_DIR}/@librtmp_export_targets@.cmake")
+]]
+)
+include(CMakePackageConfigHelpers)
+configure_package_config_file("${librtmp_config_template_path}"
+  "${librtmp_config_filename}"
+  INSTALL_DESTINATION "${librtmp_install_share}"
+)
+
+# install configs
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${librtmp_config_filename}" DESTINATION "${librtmp_install_share}")
+
+# install man
+install(FILES "librtmp.3" "librtmp.3.html" DESTINATION "${CMAKE_INSTALL_MANDIR}/man3")

--- a/ports/librtmp/portfile.cmake
+++ b/ports/librtmp/portfile.cmake
@@ -9,21 +9,36 @@ vcpkg_from_github(
         hashswf.patch           #Openssl 1.1.1 patch
         fix_strncasecmp.patch
         hide_netstackdump.patch
+        0006-typedef-off_t.diff
 )
 
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/librtmp.def" DESTINATION "${SOURCE_PATH}/librtmp")
+file(COPY
+        "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt"
+        "${CMAKE_CURRENT_LIST_DIR}/librtmp.def"
+    DESTINATION "${SOURCE_PATH}/librtmp"
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        crypto LIBRTMP_CRYPTO
+)
+if(LIBRTMP_CRYPTO)
+    list(APPEND FEATURE_OPTIONS "-DLIBRTMP_SSL=OPENSSL")
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
+    SOURCE_PATH "${SOURCE_PATH}/librtmp"
+    OPTIONS
+        -DVERSION=2.3
+        -DLIBRTMP_SO_VERSION=1
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-# License and man
-file(INSTALL "${SOURCE_PATH}/librtmp/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-file(INSTALL "${SOURCE_PATH}/librtmp/librtmp.3.html" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
 vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "unofficial-librtmp")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/librtmp/COPYING")

--- a/ports/librtmp/usage
+++ b/ports/librtmp/usage
@@ -1,0 +1,4 @@
+@PORT@ provides CMake targets:
+
+    find_package(unofficial-librtmp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::librtmp::librtmp)

--- a/ports/librtmp/vcpkg.json
+++ b/ports/librtmp/vcpkg.json
@@ -1,15 +1,30 @@
 {
   "name": "librtmp",
   "version-date": "2019-11-11",
-  "port-version": 4,
+  "port-version": 5,
   "description": "RTMPDump Real-Time Messaging Protocol API",
   "homepage": "https://rtmpdump.mplayerhq.hu",
+  "license": "LGPL-2.1",
   "dependencies": [
-    "openssl",
     {
       "name": "vcpkg-cmake",
       "host": true
     },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib"
-  ]
+  ],
+  "default-features": [
+    "crypto"
+  ],
+  "features": {
+    "crypto": {
+      "description": "Build librtmp with CRYPTO and SSL support",
+      "dependencies": [
+        "openssl"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4906,7 +4906,7 @@
     },
     "librtmp": {
       "baseline": "2019-11-11",
-      "port-version": 4
+      "port-version": 5
     },
     "librttopo": {
       "baseline": "1.1.0",

--- a/versions/l-/librtmp.json
+++ b/versions/l-/librtmp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9550a9382a2e0badbab68c975bef91ac0094a9e9",
+      "version-date": "2019-11-11",
+      "port-version": 5
+    },
+    {
       "git-tree": "dffe604262f6902df5c0beeb5e67650804ae2479",
       "version-date": "2019-11-11",
       "port-version": 4


### PR DESCRIPTION
All the credits if for @WangWeiLin-MV 
All changes taken from here #38269

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.