### PR TITLE
[x265] Fix x265 android build

### DIFF
--- a/ports/x265/fix-android-build.diff
+++ b/ports/x265/fix-android-build.diff
@@ -1,0 +1,18 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 11512ff..9ac8057 100755
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -85,7 +85,12 @@
+ endif()
+ 
+ if(UNIX)
+-    list(APPEND PLATFORM_LIBS pthread)
++    if (ANDROID)
++        set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
++        set(THREADS_PREFER_PTHREAD_FLAG TRUE)
++    else()
++        list(APPEND PLATFORM_LIBS pthread)
++    endif()
+     find_library(LIBRT rt)
+     if(LIBRT)
+         list(APPEND PLATFORM_LIBS rt)

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_bitbucket(
         version.patch
         linkage.diff
         pkgconfig.diff
+        fix-android-build.diff
 )
 
 set(ASSEMBLY_OPTIONS "-DENABLE_ASSEMBLY=OFF")

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "x265",
   "version": "3.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.",
   "homepage": "https://github.com/videolan/x265",
   "license": "GPL-2.0-or-later",

--- a/ports/zlmediakit/fix-dependency.patch
+++ b/ports/zlmediakit/fix-dependency.patch
@@ -54,3 +54,4 @@ index 44e03587..723befe8 100644
  elseif(NOT ANDROID OR IOS)
    update_cached_list(MK_LINK_LIBRARIES pthread)
  endif()
+

--- a/ports/zlmediakit/fix-dependency.patch
+++ b/ports/zlmediakit/fix-dependency.patch
@@ -35,8 +35,22 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 @@ -479,6 +479,7 @@
  # for assert.h
  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdpart)
- 
+
 +find_package(jsoncpp CONFIG REQUIRED)
  add_subdirectory(3rdpart)
- 
+
  add_subdirectory(src)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 44e03587..723befe8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -448,6 +448,8 @@ endif()
+
+ if(WIN32)
+   update_cached_list(MK_LINK_LIBRARIES WS2_32 Iphlpapi shlwapi)
++elseif(ANDROID)
++  update_cached_list(MK_LINK_LIBRARIES log)
+ elseif(NOT ANDROID OR IOS)
+   update_cached_list(MK_LINK_LIBRARIES pthread)
+ endif()

--- a/ports/zlmediakit/vcpkg.json
+++ b/ports/zlmediakit/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "A high-performance carrier-grade streaming media service framework based on C++11.",
   "homepage": "https://github.com/ZLMediaKit/ZLMediaKit",
   "license": "MIT",
-  "supports": "!uwp & !android",
+  "supports": "!uwp",
   "dependencies": [
     "jsoncpp",
     {

--- a/ports/zlmediakit/vcpkg.json
+++ b/ports/zlmediakit/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zlmediakit",
   "version-date": "2024-03-30",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A high-performance carrier-grade streaming media service framework based on C++11.",
   "homepage": "https://github.com/ZLMediaKit/ZLMediaKit",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9694,7 +9694,7 @@
     },
     "zlmediakit": {
       "baseline": "2024-03-30",
-      "port-version": 1
+      "port-version": 2
     },
     "zoe": {
       "baseline": "3.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9462,7 +9462,7 @@
     },
     "x265": {
       "baseline": "3.5",
-      "port-version": 1
+      "port-version": 2
     },
     "x86-simd-sort": {
       "baseline": "4.0",

--- a/versions/z-/zlmediakit.json
+++ b/versions/z-/zlmediakit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3d44ff997661e8449934e52293f5cf995940ea58",
+      "version-date": "2024-03-30",
+      "port-version": 2
+    },
+    {
       "git-tree": "f84ad2056d32e9ea7bdc07160784c2458c12e15d",
       "version-date": "2024-03-30",
       "port-version": 1


### PR DESCRIPTION

- [ √] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ √] SHA512s are updated for each updated download.
- [ √] The "supports" clause reflects platforms that may be fixed by this new version.
- [ √] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [√ ] Any patches that are no longer applied are deleted from the port's directory.
- [√ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ √] Only one version is added to each modified port's versions file.

