### PR TITLE
[x265] fix android library build

### DIFF
--- a/ports/x265/fix-android-build.diff
+++ b/ports/x265/fix-android-build.diff
@@ -1,0 +1,18 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 11512ff..9ac8057 100755
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -85,7 +85,12 @@
+ endif()
+ 
+ if(UNIX)
+-    list(APPEND PLATFORM_LIBS pthread)
++    if (ANDROID)
++        set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
++        set(THREADS_PREFER_PTHREAD_FLAG TRUE)
++    else()
++        list(APPEND PLATFORM_LIBS pthread)
++    endif()
+     find_library(LIBRT rt)
+     if(LIBRT)
+         list(APPEND PLATFORM_LIBS rt)

--- a/ports/x265/fix-android-build.diff
+++ b/ports/x265/fix-android-build.diff
@@ -1,16 +1,13 @@
 diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
-index 11512ff..9ac8057 100755
+index a407271b4..8e1716e68 100755
 --- a/source/CMakeLists.txt
 +++ b/source/CMakeLists.txt
-@@ -85,7 +85,12 @@
+@@ -85,7 +85,9 @@ else()
  endif()
  
  if(UNIX)
 -    list(APPEND PLATFORM_LIBS pthread)
-+    if (ANDROID)
-+        set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-+        set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-+    else()
++    if(NOT ANDROID)
 +        list(APPEND PLATFORM_LIBS pthread)
 +    endif()
      find_library(LIBRT rt)

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_bitbucket(
         version.patch
         linkage.diff
         pkgconfig.diff
+        fix-android-build.diff
 )
 
 set(ASSEMBLY_OPTIONS "-DENABLE_ASSEMBLY=OFF")

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "3.5",
   "port-version": 2,
   "description": "x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.",
-  "homepage": "https://github.com/videolan/x265",
+  "homepage": "https://bitbucket.org/multicoreware/x265_git/",
   "license": "GPL-2.0-or-later",
   "supports": "!uwp & !(arm & windows) & !xbox",
   "dependencies": [

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "x265",
   "version": "3.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.",
   "homepage": "https://github.com/videolan/x265",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9462,7 +9462,7 @@
     },
     "x265": {
       "baseline": "3.5",
-      "port-version": 1
+      "port-version": 2
     },
     "x86-simd-sort": {
       "baseline": "4.0",

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5651b3041f1dd53984046d39f06f58994dbbce4e",
+      "version": "3.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "93b9b05210a7eeeb11abdf3f09ad3f949047ed20",
       "version": "3.5",
       "port-version": 1


### PR DESCRIPTION
[ √] Changes comply with the maintainer guide.
[ √] SHA512s are updated for each updated download.
[ √] The "supports" clause reflects platforms that may be fixed by this new version.
[ √] Any fixed CI baseline entries are removed from that file.
[√ ] Any patches that are no longer applied are deleted from the port's directory.
[√ ] The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
[ √] Only one version is added to each modified port's versions file.