### PR TITLE
[snappy] Update to 1.2.1

### DIFF
--- a/ports/snappy/portfile.cmake
+++ b/ports/snappy/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/snappy
     REF ${VERSION}
-    SHA512 3578597f1d4ec09104ce0296b825b013590351230dfe56c635081fd282ce7a13a34caf2c283ac77bd24065e2d27af6db068d1f84b98cec2fd39a0e37a0d77070
+    SHA512 e7290d79ddd45605aafd02cba9eaa32309c94af04f137552a97a915c391f185dccab9b7b21a01b28f3f446be420232c3c22d91c06e0be6e1e2e32d645174798c
     HEAD_REF master
     PATCHES
         fix_clang-cl_build.patch

--- a/ports/snappy/vcpkg.json
+++ b/ports/snappy/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "snappy",
-  "version": "1.1.10",
-  "port-version": 1,
+  "version": "1.2.1",
   "description": "A fast compressor/decompressor.",
   "homepage": "https://github.com/google/snappy",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8229,8 +8229,8 @@
       "port-version": 2
     },
     "snappy": {
-      "baseline": "1.1.10",
-      "port-version": 1
+      "baseline": "1.2.1",
+      "port-version": 0
     },
     "sndfile": {
       "baseline": "0",

--- a/versions/s-/snappy.json
+++ b/versions/s-/snappy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9672ae749ed648326f88d504ae03872883a526e4",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "52d0b0f59c6f6e765c7f8df9e075ff7b90552c1e",
       "version": "1.1.10",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/22677
No feature needs to be tested.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.