### PR TITLE
[msdfgen] update to 1.12

### DIFF
--- a/ports/msdfgen/portfile.cmake
+++ b/ports/msdfgen/portfile.cmake
@@ -1,9 +1,8 @@
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Chlumsky/msdfgen
-    REF v1.11
-    SHA512 b5223bbdbd7245e7a891914158a25ea1d570bbe1066ca6c016d1ddd469d5156690f83f91c78630b2b2efcc890de0b7e1c9e8963a67f9eb8f83c6d45284d5b08a
+    REF "v${VERSION}"
+    SHA512 285bb81418de6c5ad0207e579c9cc3f3d81759008fd9c1c2b62b77e2b4258ca7a3a6ec69d6bed65e1d6408636c3c5473b9ee4f9d18fe5f63da23803ca949c903
     HEAD_REF master
 )
 
@@ -48,4 +47,4 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # license
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/msdfgen/vcpkg.json
+++ b/ports/msdfgen/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "msdfgen",
-  "version": "1.11.0",
+  "version": "1.12",
   "description": "Multi-channel signed distance field generator",
   "homepage": "https://github.com/Chlumsky/msdfgen",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5945,7 +5945,7 @@
       "port-version": 0
     },
     "msdfgen": {
-      "baseline": "1.11.0",
+      "baseline": "1.12",
       "port-version": 0
     },
     "msgpack": {

--- a/versions/m-/msdfgen.json
+++ b/versions/m-/msdfgen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6850c0a8ac8fd879ec675c1a667a87efb869759c",
+      "version": "1.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "eb66c5ad525b3152e1f73a029dfd0a2caa4a7f5c",
       "version": "1.11.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39305

All features passed with following triplets:
x86-windows 
x64-windows 
x64-windows-static 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.