### PR TITLE
[fastcdr] Update to 2.2.1

### DIFF
--- a/ports/fastcdr/pdb-file.patch
+++ b/ports/fastcdr/pdb-file.patch
@@ -1,13 +1,13 @@
 diff --git a/src/cpp/CMakeLists.txt b/src/cpp/CMakeLists.txt
-index da35d03..343f038 100644
+index 7ac643b..a70750d 100644
 --- a/src/cpp/CMakeLists.txt
 +++ b/src/cpp/CMakeLists.txt
-@@ -195,7 +195,7 @@ elseif(NOT EPROSIMA_INSTALLER)
-         endif()
+@@ -158,7 +158,7 @@ if(MSVC OR MSVC_IDE)
+     endif()
  
-         # install symbols if any
--        if(PDB_FILE)
-+        if(PDB_FILE AND BUILD_SHARED_LIBS)
-             install(FILES ${PDB_FILE}
-                 DESTINATION ${LIB_INSTALL_DIR}${MSVCARCH_DIR_EXTENSION}
-                 COMPONENT symbols
+     # install symbols if any
+-    if(PDB_FILE)
++    if(PDB_FILE AND BUILD_SHARED_LIBS)
+         install(FILES ${PDB_FILE}
+             DESTINATION ${LIB_INSTALL_DIR}
+             COMPONENT symbols

--- a/ports/fastcdr/portfile.cmake
+++ b/ports/fastcdr/portfile.cmake
@@ -1,10 +1,8 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eProsima/Fast-CDR
-    REF v${VERSION}
-    SHA512 66040acb563d7c06efb67a1536eb178183776e71a6b54c7e02efbe50ff0926aa24d87fb7869273e985c5c0f2b5d1496d3b1a20f10358373c73171b51c71e7e6a
+    REF "v${VERSION}"
+    SHA512 4e3b39f371393e2be2b2a33cba1284f5eef9dea3e27ec8904db3f90b88b04aefbec2f095c078c7f4975bef4a7fb4a0dd53236636c4353a40378172559313f5c7
     HEAD_REF master
     PATCHES
         pdb-file.patch

--- a/ports/fastcdr/vcpkg.json
+++ b/ports/fastcdr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastcdr",
-  "version-semver": "1.1.0",
+  "version-semver": "2.2.1",
   "description": "eProsima FastCDR is a C++ library that provides two serialization mechanisms. One is the standard CDR serialization mechanism, while the other is a faster implementation that modifies the standard.",
   "homepage": "https://github.com/eProsima/Fast-CDR",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2621,7 +2621,7 @@
       "port-version": 0
     },
     "fastcdr": {
-      "baseline": "1.1.0",
+      "baseline": "2.2.1",
       "port-version": 0
     },
     "fastcgi": {

--- a/versions/f-/fastcdr.json
+++ b/versions/f-/fastcdr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3d1487d4af6d136031c30effdcabb6c9e0a1738a",
+      "version-semver": "2.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9f8b9c01af9c5166bc7666ca9aac688747ff7a03",
       "version-semver": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #39328. Update `fastcdr` to 2.2.1.

No feature needs to be tested, the usage test passed on `x64-windows` (header files found):
```
fastcdr provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(fastcdr CONFIG REQUIRED)
  target_link_libraries(main PRIVATE fastcdr)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
