### PR TITLE
[openblas] adds gcc14 support patch

### DIFF
--- a/ports/openblas/gcc14.patch
+++ b/ports/openblas/gcc14.patch
@@ -1,0 +1,19 @@
+Index: cmake/system.cmake
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cmake/system.cmake b/cmake/system.cmake
+--- a/cmake/system.cmake	(revision ce3f668c992cb3cc80849d5c30ed637f5adbd5b2)
++++ b/cmake/system.cmake	(date 1718638483744)
+@@ -160,6 +160,10 @@
+   endif ()
+ endif ()
+ 
++if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU")
++  set(CCOMMON_OPT "${CCOMMON_OPT} -Wno-error=incompatible-pointer-types")
++endif ()
++
+ include("${PROJECT_SOURCE_DIR}/cmake/prebuild.cmake")
+ if (DEFINED TARGET)
+   if (${TARGET} STREQUAL COOPERLAKE AND NOT NO_AVX512)

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         uwp.patch
         fix-redefinition-function.patch
         install-tools.patch
+        gcc14.patch
 )
 
 find_program(GIT NAMES git git.cmd)

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openblas",
   "version": "0.3.27",
+  "port-version": 1,
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/OpenMathLib/OpenBLAS",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6418,7 +6418,7 @@
     },
     "openblas": {
       "baseline": "0.3.27",
-      "port-version": 0
+      "port-version": 1
     },
     "opencascade": {
       "baseline": "7.8.1",

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a11cdf69c9d9071c73f8d88458aa8b09c597d695",
+      "version": "0.3.27",
+      "port-version": 1
+    },
+    {
       "git-tree": "653ab9ede4c3c8b556b5d1b8b7d98d6abab8ef9d",
       "version": "0.3.27",
       "port-version": 0


### PR DESCRIPTION
Fixes #38739

Upstream Issue: https://github.com/OpenMathLib/OpenBLAS/issues/4668

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
