### PR TITLE
[vcglib] Update to 2023.12.

### DIFF
--- a/ports/vcglib/portfile.cmake
+++ b/ports/vcglib/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cnr-isti-vclab/vcglib
-    REF 2022.02
-    SHA512 1a4b04c53eb52d0d9864f4e942f0a06e6f4fe5f2b5686fa534b6c68b715941147d89ed6d83bce9dc8d0c7029460824ab1f73231ba6b7c32472becfe641e2a7cb
+    REF "${VERSION}"
+    SHA512 867a4e4e038f2c67000486a207c04a69ae7fa8dff5be73b4bae8a67ae1530faeb8d20915086c334da545b6e3511b4fe6b1135d732f41b632cf3256687882218e
     PATCHES
         consume-vcpkg-eigen3.patch
         fix-build.patch

--- a/ports/vcglib/vcpkg.json
+++ b/ports/vcglib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcglib",
-  "version-string": "2023.12",
+  "version": "2023.12",
   "description": "library for manipulation, processing, cleaning, simplifying triangle meshes.",
   "license": "GPL-3.0-only",
   "dependencies": [

--- a/ports/vcglib/vcpkg.json
+++ b/ports/vcglib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcglib",
-  "version-string": "2022.02",
+  "version-string": "2023.12",
   "description": "library for manipulation, processing, cleaning, simplifying triangle meshes.",
   "license": "GPL-3.0-only",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9085,7 +9085,7 @@
       "port-version": 0
     },
     "vcglib": {
-      "baseline": "2022.02",
+      "baseline": "2023.12",
       "port-version": 0
     },
     "vcpkg-boost": {

--- a/versions/v-/vcglib.json
+++ b/versions/v-/vcglib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "67e2bde19f60e3d61bbc65be91896142c665f2e0",
+      "version": "2023.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "1170b49b3d2980357ba10d68769b0bcfaeda42f7",
       "version-string": "2022.02",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.