### PR TITLE
[opencc] allow to build on arm

### DIFF
--- a/ports/opencc/vcpkg.json
+++ b/ports/opencc/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "opencc",
   "version": "1.1.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A project for conversions between Traditional Chinese, Simplified Chinese and Japanese Kanji (Shinjitai)",
   "homepage": "https://github.com/BYVoid/OpenCC",
   "license": "Apache-2.0",
-  "supports": "!(arm | uwp)",
+  "supports": "!(uwp | android)",
   "dependencies": [
     "darts-clone",
     "marisa-trie",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6426,7 +6426,7 @@
     },
     "opencc": {
       "baseline": "1.1.6",
-      "port-version": 1
+      "port-version": 2
     },
     "opencensus-cpp": {
       "baseline": "2021-08-26",

--- a/versions/o-/opencc.json
+++ b/versions/o-/opencc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b7cbf369d028252699de8cd0b307aec3b563c68",
+      "version": "1.1.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "85a9b30209f5cd7460d2be2c8e1cc206fab66aaa",
       "version": "1.1.6",
       "port-version": 1


### PR DESCRIPTION
This package can be built on ARM (I tested on macOS) today.

Homebrew has been providing ARM build of this package for a very long time https://formulae.brew.sh/formula/opencc

Their CI also has Arm build since 3 years ago https://github.com/BYVoid/OpenCC/blame/e5d6c5f1b78e28a5797e7ad3ede3513314e544b7/.travis.yml#L16-L18