### PR TITLE
[vlfeat] fix incorrect header install path, expose OpenMP as a feature

### DIFF
--- a/ports/openmvg/build_fixes.patch
+++ b/ports/openmvg/build_fixes.patch
@@ -392,7 +392,7 @@ index cd800b0..20e9c8e 100644
 -extern "C" {
 -#include "nonFree/sift/vl/sift.h"
 -}
-+#include <sift.h>
++#include <vl/sift.h>
  
  namespace openMVG {
  namespace features {

--- a/ports/openmvg/vcpkg.json
+++ b/ports/openmvg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openmvg",
   "version": "2.0",
-  "port-version": 10,
+  "port-version": 11,
   "description": "open Multiple View Geometry library. Basis for 3D computer vision and Structure from Motion.",
   "license": "MPL-2.0-no-copyleft-exception",
   "supports": "(x86 | x64 | arm64) & !xbox",

--- a/ports/vlfeat/CMakeLists.txt
+++ b/ports/vlfeat/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.10)
-project (vlfeat)
+project(vlfeat LANGUAGES C)
 
 set(INSTALL_BIN_DIR      "bin"                      CACHE PATH "Path where exe and dll will be installed")
 set(INSTALL_LIB_DIR      "lib"                      CACHE PATH "Path where lib will be installed")
@@ -16,35 +16,24 @@ foreach(p LIB BIN INCLUDE CMAKE)
 endforeach()
 
 # make sure that the default is a RELEASE
-set(default_build_type "Release")
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
-  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
-      STRING "Choose the type of build." FORCE)
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
-endif()
-
-if(ENABLE_OPENMP)
-  find_package(OpenMP REQUIRED)
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
 endif()
 
 if(MSVC)
   add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
   add_definitions(-D__LITTLE_ENDIAN__)
-  add_definitions(/Zp8)
-  add_definitions(/wd4146)
+  add_compile_options(/Zp8)
+  add_compile_options(/wd4146)
   if(CMAKE_C_FLAGS MATCHES "/W[0-4]")
     string(REGEX REPLACE "/W[0-4]" "/W1" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
   endif()
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)
-  add_definitions(-std=c99)
-  add_definitions(-Wno-unused-function)
-  add_definitions(-Wno-long-long)
-  add_definitions(-Wno-variadic-macros)
+  add_compile_options(-Wno-unused-function)
+  add_compile_options(-Wno-long-long)
+  add_compile_options(-Wno-variadic-macros)
 endif()
 
 if(USE_SSE)
@@ -143,6 +132,13 @@ set_property(TARGET vl PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(vl PRIVATE -DVL_BUILD_DLL)
 target_include_directories(vl PUBLIC $<INSTALL_INTERFACE:${RELATIVE_INSTALL_INCLUDE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vl>)
 set_target_properties(vl PROPERTIES PUBLIC_HEADER "${H_SOURCES}")
+target_compile_features(vl PRIVATE c_std_99)
+
+if(ENABLE_OPENMP)
+  find_package(OpenMP REQUIRED)
+  # PRIVATE because '#pragma omp' is only used in .c files
+  target_link_libraries(vl PRIVATE OpenMP::OpenMP_C)
+endif()
 
 install(TARGETS vl EXPORT vlfeatTargets
   RUNTIME DESTINATION "${INSTALL_BIN_DIR}"

--- a/ports/vlfeat/CMakeLists.txt
+++ b/ports/vlfeat/CMakeLists.txt
@@ -1,21 +1,6 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required(VERSION 3.10)
 project(vlfeat LANGUAGES C)
 
-set(INSTALL_BIN_DIR      "bin"                      CACHE PATH "Path where exe and dll will be installed")
-set(INSTALL_LIB_DIR      "lib"                      CACHE PATH "Path where lib will be installed")
-set(INSTALL_INCLUDE_DIR  "include/vl"               CACHE PATH "Path where headers will be installed")
-set(INSTALL_CMAKE_DIR    "share/vlfeat"             CACHE PATH "Path where cmake configs will be installed")
-
-# Make relative paths absolute (needed later on)
-set(RELATIVE_INSTALL_INCLUDE_DIR ${INSTALL_INCLUDE_DIR})
-foreach(p LIB BIN INCLUDE CMAKE)
-  set(var INSTALL_${p}_DIR)
-  if(NOT IS_ABSOLUTE "${${var}}")
-    set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
-  endif()
-endforeach()
-
-# make sure that the default is a RELEASE
 if(NOT DEFINED CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
@@ -127,11 +112,12 @@ set (H_SOURCES
   vl/vlad.h
 )
 
+include(GNUInstallDirs)
+
 add_library(vl ${C_SOURCES} ${H_SOURCES})
 set_property(TARGET vl PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(vl PRIVATE -DVL_BUILD_DLL)
-target_include_directories(vl PUBLIC $<INSTALL_INTERFACE:${RELATIVE_INSTALL_INCLUDE_DIR}>)
-set_target_properties(vl PROPERTIES PUBLIC_HEADER "${H_SOURCES}")
+target_include_directories(vl PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_compile_features(vl PRIVATE c_std_99)
 
 if(ENABLE_OPENMP)
@@ -140,16 +126,16 @@ if(ENABLE_OPENMP)
   target_link_libraries(vl PRIVATE OpenMP::OpenMP_C)
 endif()
 
-install(TARGETS vl EXPORT vlfeatTargets
-  RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
-  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
-  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
-  PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}"
-  COMPONENT dev
+install(TARGETS vl
+    EXPORT vlfeatTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+install(FILES ${H_SOURCES} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/vl")
 
 install(EXPORT vlfeatTargets
   FILE vlfeatConfig.cmake
   NAMESPACE unofficial::vlfeat::
-  DESTINATION "${INSTALL_CMAKE_DIR}"
+  DESTINATION "share/vlfeat"
 )

--- a/ports/vlfeat/CMakeLists.txt
+++ b/ports/vlfeat/CMakeLists.txt
@@ -3,7 +3,7 @@ project(vlfeat LANGUAGES C)
 
 set(INSTALL_BIN_DIR      "bin"                      CACHE PATH "Path where exe and dll will be installed")
 set(INSTALL_LIB_DIR      "lib"                      CACHE PATH "Path where lib will be installed")
-set(INSTALL_INCLUDE_DIR  "include/vlfeat"           CACHE PATH "Path where headers will be installed")
+set(INSTALL_INCLUDE_DIR  "include/vl"               CACHE PATH "Path where headers will be installed")
 set(INSTALL_CMAKE_DIR    "share/vlfeat"             CACHE PATH "Path where cmake configs will be installed")
 
 # Make relative paths absolute (needed later on)

--- a/ports/vlfeat/CMakeLists.txt
+++ b/ports/vlfeat/CMakeLists.txt
@@ -130,7 +130,7 @@ set (H_SOURCES
 add_library(vl ${C_SOURCES} ${H_SOURCES})
 set_property(TARGET vl PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(vl PRIVATE -DVL_BUILD_DLL)
-target_include_directories(vl PUBLIC $<INSTALL_INTERFACE:${RELATIVE_INSTALL_INCLUDE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vl>)
+target_include_directories(vl PUBLIC $<INSTALL_INTERFACE:${RELATIVE_INSTALL_INCLUDE_DIR}>)
 set_target_properties(vl PROPERTIES PUBLIC_HEADER "${H_SOURCES}")
 target_compile_features(vl PRIVATE c_std_99)
 

--- a/ports/vlfeat/fix-openmp-build.patch
+++ b/ports/vlfeat/fix-openmp-build.patch
@@ -1,31 +1,11 @@
-Based on https://salsa.debian.org/science-team/vlfeat/-/blob/master/debian/patches/0018-Fixed-build-on-gcc-9.patch
-
-From: Dima Kogan <dkogan@debian.org>
-Date: Thu, 12 Dec 2019 22:27:51 -0800
-Subject: Fixed build on gcc-9
-
-The openmp release used in GCC-9 treats const data in an incompatible way, and
-kmeans.c was not building as a result. Here I explicitly mark a const varible as
-shared on gcc-9 to make vlfeat build on that platform.
-
-See the "OpenMP data sharing" section of
-https://gcc.gnu.org/gcc-9/porting_to.html
----
- vl/kmeans.c | 8 ++++++--
- 1 file changed, 6 insertions(+), 2 deletions(-)
-
-diff --git a/vl/kmeans.c b/vl/kmeans.c
-index c250ca8..f0a67c9 100644
 --- a/vl/kmeans.c
 +++ b/vl/kmeans.c
-@@ -669,9 +669,8 @@ VL_XCAT(_vl_kmeans_quantize_, SFX)
- #endif
+@@ -669,7 +669,7 @@ VL_XCAT(_vl_kmeans_quantize_, SFX)
  
  #ifdef _OPENMP
  #pragma omp parallel default(none) \
 -            shared(self, distances, assignments, numData, distFn, data) \
--            num_threads(vl_get_max_threads())
-+    shared(self, distances, assignments, numData, distFn, data, vl_infinity_d) num_threads(vl_get_max_threads())
++            shared(self, distances, assignments, numData, distFn, data, vl_infinity_d) \
+             num_threads(vl_get_max_threads())
  #endif
    {
-     /* vl_malloc cannot be used here if mapped to MATLAB malloc */

--- a/ports/vlfeat/fix-openmp-build.patch
+++ b/ports/vlfeat/fix-openmp-build.patch
@@ -1,0 +1,31 @@
+Based on https://salsa.debian.org/science-team/vlfeat/-/blob/master/debian/patches/0018-Fixed-build-on-gcc-9.patch
+
+From: Dima Kogan <dkogan@debian.org>
+Date: Thu, 12 Dec 2019 22:27:51 -0800
+Subject: Fixed build on gcc-9
+
+The openmp release used in GCC-9 treats const data in an incompatible way, and
+kmeans.c was not building as a result. Here I explicitly mark a const varible as
+shared on gcc-9 to make vlfeat build on that platform.
+
+See the "OpenMP data sharing" section of
+https://gcc.gnu.org/gcc-9/porting_to.html
+---
+ vl/kmeans.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/vl/kmeans.c b/vl/kmeans.c
+index c250ca8..f0a67c9 100644
+--- a/vl/kmeans.c
++++ b/vl/kmeans.c
+@@ -669,9 +669,8 @@ VL_XCAT(_vl_kmeans_quantize_, SFX)
+ #endif
+ 
+ #ifdef _OPENMP
+ #pragma omp parallel default(none) \
+-            shared(self, distances, assignments, numData, distFn, data) \
+-            num_threads(vl_get_max_threads())
++    shared(self, distances, assignments, numData, distFn, data, vl_infinity_d) num_threads(vl_get_max_threads())
+ #endif
+   {
+     /* vl_malloc cannot be used here if mapped to MATLAB malloc */

--- a/ports/vlfeat/portfile.cmake
+++ b/ports/vlfeat/portfile.cmake
@@ -36,4 +36,4 @@ vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/vlfeat/portfile.cmake
+++ b/ports/vlfeat/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 6d317a1a9496ccac80244553d555fe060b150ccc7ee397a353b64f3a8451f24d1f03d8c00ed04cd9fc2dc066a5c5089b03695c614cb43ffa09be363660278255
     PATCHES
         expose_missing_symbols.patch
+        fix-openmp-build.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/vlfeat/portfile.cmake
+++ b/ports/vlfeat/portfile.cmake
@@ -7,6 +7,11 @@ vcpkg_from_github(
         expose_missing_symbols.patch
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    openmp    ENABLE_OPENMP
+)
+
 set(USE_SSE ON)
 set(USE_AVX OFF)  # feature is broken, so it's always off anyway
 
@@ -22,6 +27,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DUSE_SSE=${USE_SSE}
         -DUSE_AVX=${USE_AVX}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/vlfeat/vcpkg.json
+++ b/ports/vlfeat/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vlfeat",
   "version-date": "2020-07-10",
-  "port-version": 3,
+  "port-version": 4,
   "description": "An open library of computer vision algorithms",
   "homepage": "https://www.vlfeat.org",
   "dependencies": [
@@ -13,5 +13,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "openmp": {
+      "description": "Enable OpenMP support"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9218,7 +9218,7 @@
     },
     "vlfeat": {
       "baseline": "2020-07-10",
-      "port-version": 3
+      "port-version": 4
     },
     "vlpp": {
       "baseline": "1.1.0.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6526,7 +6526,7 @@
     },
     "openmvg": {
       "baseline": "2.0",
-      "port-version": 10
+      "port-version": 11
     },
     "openmvs": {
       "baseline": "2.1.0",

--- a/versions/o-/openmvg.json
+++ b/versions/o-/openmvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e08aec4337f9a281817b2c84d04fee5a079551d8",
+      "version": "2.0",
+      "port-version": 11
+    },
+    {
       "git-tree": "55f106dfa39d38867f5cf8ce976cc2079ab65454",
       "version": "2.0",
       "port-version": 10

--- a/versions/v-/vlfeat.json
+++ b/versions/v-/vlfeat.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0a6fa9315ccefd9dfa1c85967c217dc40ea28329",
+      "git-tree": "2fda6a26ab41016975d961c980833dbc193431fd",
       "version-date": "2020-07-10",
       "port-version": 4
     },

--- a/versions/v-/vlfeat.json
+++ b/versions/v-/vlfeat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a6fa9315ccefd9dfa1c85967c217dc40ea28329",
+      "version-date": "2020-07-10",
+      "port-version": 4
+    },
+    {
       "git-tree": "d8ae9112b64ac005ccb493693bf4f5f9f8753355",
       "version-date": "2020-07-10",
       "port-version": 3

--- a/versions/v-/vlfeat.json
+++ b/versions/v-/vlfeat.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2fda6a26ab41016975d961c980833dbc193431fd",
+      "git-tree": "00b7794f5db916989104858cce0f09b7bc6b65a2",
       "version-date": "2020-07-10",
       "port-version": 4
     },


### PR DESCRIPTION
Fixes the headers being installed under `vlfeat/` instead of `vl/` by the custom CMakeLists.txt.

The project docs use `#include <vl/...>` (https://www.vlfeat.org/api/kmeans.html) and so does the Debian package (https://packages.debian.org/sid/amd64/libvlfeat-dev/filelist), for example.

I also included a patch from Debian to fix OpenMP support and exposed OpenMP as an optional feature.

Related to #39354.

----
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
