### PR TITLE
[cpp-httplib] update to 0.16.0 

### DIFF
--- a/ports/cpp-httplib/fix-find-brotli.patch
+++ b/ports/cpp-httplib/fix-find-brotli.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 73de511..940b6ab 100644
+index e27481b..51bfdf1 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -141,10 +141,10 @@ endif()
+@@ -146,10 +146,10 @@ endif()
  # This is so we can use our custom FindBrotli.cmake
  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
  if(HTTPLIB_REQUIRE_BROTLI)
@@ -15,7 +15,7 @@ index 73de511..940b6ab 100644
  	set(HTTPLIB_IS_USING_BROTLI ${Brotli_FOUND})
  endif()
  
-@@ -217,9 +217,9 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
+@@ -223,9 +223,9 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
  		# Needed for API from MacOS Security framework
  		"$<$<AND:$<PLATFORM_ID:Darwin>,$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>,$<BOOL:${HTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN}>>:-framework CoreFoundation -framework Security>"
  		# Can't put multiple targets in a single generator expression or it bugs out.
@@ -28,7 +28,7 @@ index 73de511..940b6ab 100644
  		$<$<BOOL:${HTTPLIB_IS_USING_ZLIB}>:ZLIB::ZLIB>
  		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::SSL>
  		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::Crypto>
-@@ -275,9 +275,6 @@ if(HTTPLIB_INSTALL)
+@@ -281,9 +281,6 @@ if(HTTPLIB_INSTALL)
  	install(FILES
  		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
  		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
@@ -38,10 +38,10 @@ index 73de511..940b6ab 100644
  		DESTINATION ${_TARGET_INSTALL_CMAKEDIR}
  	)
  
-diff --git a/httplibConfig.cmake.in b/httplibConfig.cmake.in
+diff --git a/cmake/httplibConfig.cmake.in b/cmake/httplibConfig.cmake.in
 index 93dff32..8c6bc11 100644
---- a/httplibConfig.cmake.in
-+++ b/httplibConfig.cmake.in
+--- a/cmake/httplibConfig.cmake.in
++++ b/cmake/httplibConfig.cmake.in
 @@ -32,7 +32,7 @@ if(@HTTPLIB_IS_USING_BROTLI@)
  	# Note that the FindBrotli.cmake file is installed in the same dir as this file.
  	list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yhirose/cpp-httplib
     REF "v${VERSION}"
-    SHA512 f7fc9c9eb71f091b82958e023a7b417b30d2590fd5d1a920d1c98361f34bcaca796dbeda7f9fdb8b2c722a8968977b77463c6cbb252cba9823a79c22471fa439
+    SHA512 63dc5a50f425e7be909d60db138caa1b9d7260c5d4db26603011a329f0d6a645d56f436c79466fbe662f24a94bc0f72926062b3ed49cb658eb91a6bdb2ddf25b
     HEAD_REF master
     PATCHES
         fix-find-brotli.patch

--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-httplib",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1865,7 +1865,7 @@
       "port-version": 0
     },
     "cpp-httplib": {
-      "baseline": "0.15.3",
+      "baseline": "0.16.0",
       "port-version": 0
     },
     "cpp-ipc": {

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "caa3be04dad9a8bb2fd223fcd97ab8b1a1597484",
+      "version": "0.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8378b4e8bb46f2879c44465e1084a8eef0dd4318",
       "version": "0.15.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #39371

Update cpp-httplib to the latest version 0.16.0 


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static

Tested usage successfully by cpp-httplib:x64-windows:
````
cpp-httplib provides CMake targets:

    find_package(httplib CONFIG REQUIRED)
    target_link_libraries(main PRIVATE httplib::httplib)
````