### PR TITLE
[numcpp] change boost dependencies to a feature

### DIFF
--- a/ports/numcpp/portfile.cmake
+++ b/ports/numcpp/portfile.cmake
@@ -7,8 +7,15 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+        boost NUMCPP_NO_USE_BOOST
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/numcpp/vcpkg.json
+++ b/ports/numcpp/vcpkg.json
@@ -1,21 +1,11 @@
 {
   "name": "numcpp",
   "version": "2.12.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++ implementation of the Python Numpy library",
   "homepage": "https://dpilger26.github.io/NumCpp",
   "license": "MIT",
   "dependencies": [
-    "boost-algorithm",
-    "boost-date-time",
-    "boost-endian",
-    "boost-integer",
-    "boost-log",
-    "boost-math",
-    "boost-predef",
-    "boost-python",
-    "boost-random",
-    "boost-type-traits",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -26,6 +16,21 @@
     }
   ],
   "features": {
+    "boost": {
+      "description": "Enable use boost",
+      "dependencies": [
+        "boost-algorithm",
+        "boost-date-time",
+        "boost-endian",
+        "boost-integer",
+        "boost-log",
+        "boost-math",
+        "boost-predef",
+        "boost-python",
+        "boost-random",
+        "boost-type-traits"
+      ]
+    },
     "python": {
       "description": "Interacting with Python with pybind11 interface",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6262,7 +6262,7 @@
     },
     "numcpp": {
       "baseline": "2.12.1",
-      "port-version": 1
+      "port-version": 2
     },
     "nuspell": {
       "baseline": "5.1.4",

--- a/versions/n-/numcpp.json
+++ b/versions/n-/numcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e82e792de63955399c5b96c8ceaef6e66eb6230a",
+      "version": "2.12.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "300dfe4a76995143213ee1c14076a13c597f3bea",
       "version": "2.12.1",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39363
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.