### PR TITLE
[libsodium] Add comment about tag usage

### DIFF
--- a/ports/libsodium/portfile.cmake
+++ b/ports/libsodium/portfile.cmake
@@ -1,3 +1,8 @@
+# libsodium has a special branching/tagging scheme, where regular version tags can actually be moved
+# as new patches are applied to that version. This means that we may get unexpected hash mismatches
+# when the upstream tag points to a new commit. To avoid this, we must make sure that we always
+# use a '-RELEASE' tag, since those seem to be fixed to a single commit.
+# See https://github.com/jedisct1/libsodium/issues/1373#issuecomment-2135172301 for more info.
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jedisct1/libsodium
@@ -50,11 +55,11 @@ else()
     if(NOT VCPKG_TARGET_IS_MINGW)
         list(APPEND OPTIONS --disable-pie)
     endif()
-    
+
     vcpkg_configure_make(
         AUTOCONFIG
         SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS ${OPTIONS}        
+        OPTIONS ${OPTIONS}
     )
     vcpkg_install_make()
 

--- a/ports/libsodium/vcpkg.json
+++ b/ports/libsodium/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsodium",
   "version": "1.0.20",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A modern and easy-to-use crypto library",
   "homepage": "https://libsodium.org/",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4978,7 +4978,7 @@
     },
     "libsodium": {
       "baseline": "1.0.20",
-      "port-version": 2
+      "port-version": 3
     },
     "libsonic": {
       "baseline": "0.2.0",

--- a/versions/l-/libsodium.json
+++ b/versions/l-/libsodium.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6dcb750702485c4dafac0b605b910b81e2c48831",
+      "version": "1.0.20",
+      "port-version": 3
+    },
+    {
       "git-tree": "1b7b00b7cccd397e07fa2b1b3ce3725d3ebead29",
       "version": "1.0.20",
       "port-version": 2


### PR DESCRIPTION
The libsodium port is special in that we must make sure to always use '-RELEASE' tags instead of regular ones, since the latter can actually be moved. This commit adds a comment documenting this behavior.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
