### PR TITLE
[small-gicp] New port

### DIFF
--- a/ports/small-gicp/disable_openmp_osx.patch
+++ b/ports/small-gicp/disable_openmp_osx.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ec14eea..f83d678 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -55,11 +55,15 @@ if(NOT Eigen3_FOUND)
+   )
+ endif()
+ 
+-if(BUILD_WITH_OPENMP STREQUAL "auto")
+-  find_package(OpenMP)
+-  set(BUILD_WITH_OPENMP ${OpenMP_FOUND})
+-elseif(BUILD_WITH_OPENMP)
+-  find_package(OpenMP REQUIRED)
++if(APPLE)
++  set(BUILD_WITH_OPENMP FALSE)
++else()
++  if(BUILD_WITH_OPENMP STREQUAL "auto")
++    find_package(OpenMP)
++    set(BUILD_WITH_OPENMP ${OpenMP_FOUND})
++  elseif(BUILD_WITH_OPENMP)
++    find_package(OpenMP REQUIRED)
++  endif()
+ endif()
+ 
+ if (BUILD_WITH_TBB)

--- a/ports/small-gicp/portfile.cmake
+++ b/ports/small-gicp/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO koide3/small_gicp
+    REF v0.1.0
+    SHA512 bdd0d1e39d25877e58b2753addbad082f2fdf3962809fe646cab8ba63438eff05e2276afb2803aaed0a3905e0251208e2faaf8c1c416b551ffbdd54b9743ddb6
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME small_gicp
+    CONFIG_PATH lib/cmake/small_gicp
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/small-gicp/portfile.cmake
+++ b/ports/small-gicp/portfile.cmake
@@ -12,11 +12,17 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         tbb   BUILD_WITH_TBB
 )
 
+if(VCPKG_TARGET_IS_OSX)
+    set(BUILD_WITH_OPENMP OFF)
+else()
+    set(BUILD_WITH_OPENMP "auto")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        -DBUILD_WITH_OPENMP=${BUILD_WITH_OPENMP}
 )
 
 vcpkg_cmake_install()

--- a/ports/small-gicp/portfile.cmake
+++ b/ports/small-gicp/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO koide3/small_gicp
-    REF v0.1.0
+    REF "v${VERSION}"
     SHA512 bdd0d1e39d25877e58b2753addbad082f2fdf3962809fe646cab8ba63438eff05e2276afb2803aaed0a3905e0251208e2faaf8c1c416b551ffbdd54b9743ddb6
     HEAD_REF master
     PATCHES disable_openmp_osx.patch

--- a/ports/small-gicp/portfile.cmake
+++ b/ports/small-gicp/portfile.cmake
@@ -6,7 +6,19 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        pcl   BUILD_WITH_PCL
+        tbb   BUILD_WITH_TBB
+)
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME small_gicp

--- a/ports/small-gicp/portfile.cmake
+++ b/ports/small-gicp/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF v0.1.0
     SHA512 bdd0d1e39d25877e58b2753addbad082f2fdf3962809fe646cab8ba63438eff05e2276afb2803aaed0a3905e0251208e2faaf8c1c416b551ffbdd54b9743ddb6
     HEAD_REF master
+    PATCHES disable_openmp_osx.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -12,17 +13,10 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         tbb   BUILD_WITH_TBB
 )
 
-if(VCPKG_TARGET_IS_OSX)
-    set(BUILD_WITH_OPENMP OFF)
-else()
-    set(BUILD_WITH_OPENMP "auto")
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
-        -DBUILD_WITH_OPENMP=${BUILD_WITH_OPENMP}
 )
 
 vcpkg_cmake_install()

--- a/ports/small-gicp/usage
+++ b/ports/small-gicp/usage
@@ -1,0 +1,4 @@
+small-gicp provides CMake targets:
+
+  find_package(small_gicp REQUIRED)
+  target_link_libraries(main PRIVATE small_gicp::small_gicp)

--- a/ports/small-gicp/vcpkg.json
+++ b/ports/small-gicp/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Efficient and parallelized algorithms for point cloud registration",
   "homepage": "https://github.com/koide3/small_gicp",
   "license": "MIT",
+  "supports": "!(x86|arm32)",
   "dependencies": [
     "eigen3",
     {

--- a/ports/small-gicp/vcpkg.json
+++ b/ports/small-gicp/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Efficient and parallelized algorithms for point cloud registration",
   "homepage": "https://github.com/koide3/small_gicp",
   "license": "MIT",
-  "supports": "!(x86|arm32)",
+  "supports": "!(x86 | arm32)",
   "dependencies": [
     "eigen3",
     {

--- a/ports/small-gicp/vcpkg.json
+++ b/ports/small-gicp/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "small-gicp",
+  "version": "0.1.0",
+  "description": "Efficient and parallelized algorithms for point cloud registration",
+  "homepage": "https://github.com/koide3/small_gicp",
+  "license": "MIT",
+  "dependencies": [
+    "eigen3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "pcl": {
+      "description": "Enable interfacing with PointCloud Library.",
+      "dependencies": [
+        "pcl"
+      ]
+    },
+    "tbb": {
+      "description": "Enable Intel TBB based parallelism.",
+      "dependencies": [
+        "tbb"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8220,6 +8220,10 @@
       "baseline": "2.4.0",
       "port-version": 3
     },
+    "small-gicp": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "smf": {
       "baseline": "0.1.1",
       "port-version": 0

--- a/versions/s-/small-gicp.json
+++ b/versions/s-/small-gicp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b3b8e3ab27c4cd7b986ae5f02c3ccaa0f9dfc58d",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/small-gicp.json
+++ b/versions/s-/small-gicp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b3b8e3ab27c4cd7b986ae5f02c3ccaa0f9dfc58d",
+      "git-tree": "dfa0416785bdea36ca6f5893d25d7c7af608bf9b",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/s-/small-gicp.json
+++ b/versions/s-/small-gicp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9100c3029150c44f0c3b2c7cc6ea1a861de90587",
+      "git-tree": "580a9b893d2996aceb7ed24d6fcb0bc2111f0553",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/s-/small-gicp.json
+++ b/versions/s-/small-gicp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dfa0416785bdea36ca6f5893d25d7c7af608bf9b",
+      "git-tree": "9100c3029150c44f0c3b2c7cc6ea1a861de90587",
       "version": "0.1.0",
       "port-version": 0
     }


### PR DESCRIPTION

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
