### PR TITLE
[re2] update to 2024.06.01

### DIFF
--- a/ports/re2/portfile.cmake
+++ b/ports/re2/portfile.cmake
@@ -1,17 +1,9 @@
-vcpkg_download_distfile(PATCH_488
-    URLS https://github.com/google/re2/commit/9ebe4a22cad8a025b68a9594bdff3c047a111333.patch?full_index=1
-    SHA512 83c1a4cc4ddd6e1443f5201f7f00cf6a0729d0a0fb8fc5068c3d80766238d72f019f1fddaeffebcc2d4322a07daf2203214121cdda039b10a5f39214b9fa8647
-    FILENAME 9ebe4a22cad8a025b68a9594bdff3c047a111333.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/re2
     REF "${VERSION}"
-    SHA512 1511d163ee90c724705cc16d2995e777a7d894ff8133bd3457a26d8c6a9dcb8ccdd2e77b73681e623317a1edbbd3c928569358af91e72ce8612f7b7b61108283
+    SHA512 c6a75cd77450b0859944497c197b69678a718d4b5234f0a5adc5524d0e113c1260b150b3fe99a7bfb87e96008eaedc7880dd851ddcf6ce9a4eee1409536c0482
     HEAD_REF master
-    PATCHES
-        "${PATCH_488}"
 )
 
 vcpkg_cmake_configure(

--- a/ports/re2/vcpkg.json
+++ b/ports/re2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "re2",
-  "version-date": "2024-04-01",
-  "port-version": 2,
+  "version-date": "2024-06-01",
   "description": "RE2 is a fast, safe, thread-friendly alternative to backtracking regular expression engines like those used in PCRE, Perl, and Python. It is a C++ library.",
   "homepage": "https://github.com/google/re2",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7633,8 +7633,8 @@
       "port-version": 2
     },
     "re2": {
-      "baseline": "2024-04-01",
-      "port-version": 2
+      "baseline": "2024-06-01",
+      "port-version": 0
     },
     "reactiveplusplus": {
       "baseline": "2.1.1",

--- a/versions/r-/re2.json
+++ b/versions/r-/re2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f583b8b9d194d943c7409dce77b31e9d2fd17c4d",
+      "version-date": "2024-06-01",
+      "port-version": 0
+    },
+    {
       "git-tree": "c0f4eacf4c6b1c048bb3fc11fd0abf9e4981aa64",
       "version-date": "2024-04-01",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.