### PR TITLE
[zlmediakit] Fix zlmediakit android

### DIFF
--- a/ports/zlmediakit/fix-android-build.patch
+++ b/ports/zlmediakit/fix-android-build.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 72a4544e..8f34f1c7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -445,6 +445,8 @@ endif()
+ 
+ if(WIN32)
+   update_cached_list(MK_LINK_LIBRARIES WS2_32 Iphlpapi shlwapi)
++elseif(ANDROID)
++  update_cached_list(MK_LINK_LIBRARIES log)
+ elseif(NOT ANDROID OR IOS)
+   update_cached_list(MK_LINK_LIBRARIES pthread)
+ endif()

--- a/ports/zlmediakit/fix-dependency.patch
+++ b/ports/zlmediakit/fix-dependency.patch
@@ -35,22 +35,8 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 @@ -479,6 +479,7 @@
  # for assert.h
  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdpart)
-
+ 
 +find_package(jsoncpp CONFIG REQUIRED)
  add_subdirectory(3rdpart)
-
+ 
  add_subdirectory(src)
-
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 44e03587..723befe8 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -448,6 +448,8 @@ endif()
-
- if(WIN32)
-   update_cached_list(MK_LINK_LIBRARIES WS2_32 Iphlpapi shlwapi)
-+elseif(ANDROID)
-+  update_cached_list(MK_LINK_LIBRARIES log)
- elseif(NOT ANDROID OR IOS)
-   update_cached_list(MK_LINK_LIBRARIES pthread)
- endif()

--- a/ports/zlmediakit/fix-dependency.patch
+++ b/ports/zlmediakit/fix-dependency.patch
@@ -35,8 +35,22 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 @@ -479,6 +479,7 @@
  # for assert.h
  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdpart)
- 
+
 +find_package(jsoncpp CONFIG REQUIRED)
  add_subdirectory(3rdpart)
- 
+
  add_subdirectory(src)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 44e03587..723befe8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -448,6 +448,8 @@ endif()
+
+ if(WIN32)
+   update_cached_list(MK_LINK_LIBRARIES WS2_32 Iphlpapi shlwapi)
++elseif(ANDROID)
++  update_cached_list(MK_LINK_LIBRARIES log)
+ elseif(NOT ANDROID OR IOS)
+   update_cached_list(MK_LINK_LIBRARIES pthread)
+ endif()

--- a/ports/zlmediakit/portfile.cmake
+++ b/ports/zlmediakit/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF af3ef996b0ae265e000344e7faf753577f9abf4e
     SHA512 e45572a579d4644b4e48e70c999796d032947d64f074d7f143bd760238523d46ae061f079d9fe539a21542032f3c94ff7465fe2ba6c9fb39dbeac245dffd188b
     HEAD_REF master
-    PATCHES fix-dependency.patch
+    PATCHES 
+        fix-dependency.patch
+        fix-android-build.patch
 )
 
 vcpkg_from_github(

--- a/ports/zlmediakit/vcpkg.json
+++ b/ports/zlmediakit/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "zlmediakit",
   "version-date": "2024-03-30",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A high-performance carrier-grade streaming media service framework based on C++11.",
   "homepage": "https://github.com/ZLMediaKit/ZLMediaKit",
   "license": "MIT",
-  "supports": "!uwp & !android",
+  "supports": "!uwp",
   "dependencies": [
     "jsoncpp",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9702,7 +9702,7 @@
     },
     "zlmediakit": {
       "baseline": "2024-03-30",
-      "port-version": 1
+      "port-version": 2
     },
     "zoe": {
       "baseline": "3.0",

--- a/versions/z-/zlmediakit.json
+++ b/versions/z-/zlmediakit.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a616c3035bb31c893260826c33f56efc3086f8b",
+      "git-tree": "6e9961ba37fd6444cafde78116cb797229f116d3",
       "version-date": "2024-03-30",
       "port-version": 2
     },

--- a/versions/z-/zlmediakit.json
+++ b/versions/z-/zlmediakit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a616c3035bb31c893260826c33f56efc3086f8b",
+      "version-date": "2024-03-30",
+      "port-version": 2
+    },
+    {
       "git-tree": "f84ad2056d32e9ea7bdc07160784c2458c12e15d",
       "version-date": "2024-03-30",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [x] Only one version is added to each modified port's versions file.

@microsoft-github-policy-service agree

