### PR TITLE
[half] New port

### DIFF
--- a/ports/half/portfile.cmake
+++ b/ports/half/portfile.cmake
@@ -1,0 +1,14 @@
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO half/half
+    REF ${VERSION}
+    FILENAME "half-${VERSION}.zip"
+    NO_REMOVE_ONE_LEVEL
+    SHA512 299db9ab12d8135ae2eb1bb6229e11fec72c1ccc4d0db04d1c912c1e5cdadbddec738097b03c3bbf9b7993e589c32abcd509bfe0c20daf1996da65f633a94574
+)
+
+file(GLOB HEADER_FILES "${SOURCE_PATH}/include/*.hpp")
+file(COPY ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/half/usage
+++ b/ports/half/usage
@@ -1,0 +1,4 @@
+half is header-only and can be used from CMake via:
+
+  find_path(HALF_INCLUDE_DIRS "half.hpp")
+  target_include_directories(main PRIVATE ${HALF_INCLUDE_DIRS})

--- a/ports/half/vcpkg.json
+++ b/ports/half/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "half",
+  "version": "2.2.0",
+  "description": "C++ library for half precision floating point arithmetics.",
+  "homepage": "https://sourceforge.net/projects/half/",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3344,6 +3344,10 @@
       "baseline": "2022-05-24",
       "port-version": 0
     },
+    "half": {
+      "baseline": "2.2.0",
+      "port-version": 0
+    },
     "halide": {
       "baseline": "17.0.1",
       "port-version": 1

--- a/versions/h-/half.json
+++ b/versions/h-/half.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e3a5c15b1a3e75ee363b297822da89dcb6b3588b",
+      "version": "2.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
