### PR TITLE
[glm] fix clang compile

### DIFF
--- a/ports/glm/fix-clang.patch
+++ b/ports/glm/fix-clang.patch
@@ -1,0 +1,17 @@
+diff --git a/glm/detail/setup.hpp b/glm/detail/setup.hpp
+index 315eb346..21ccebf4 100644
+--- a/glm/detail/setup.hpp
++++ b/glm/detail/setup.hpp
+@@ -595,7 +595,11 @@
+ #	define GLM_DEPRECATED __declspec(deprecated)
+ #	define GLM_ALIGNED_TYPEDEF(type, name, alignment) typedef __declspec(align(alignment)) type name
+ #elif GLM_COMPILER & (GLM_COMPILER_GCC | GLM_COMPILER_CLANG | GLM_COMPILER_INTEL)
+-#	define GLM_DEPRECATED __attribute__((__deprecated__))
++#	if GLM_LANG & GLM_LANG_CXX14_FLAG
++#		define GLM_DEPRECATED [[deprecated]]
++#	else
++#		define GLM_DEPRECATED __attribute__((__deprecated__))
++#	endif
+ #	define GLM_ALIGNED_TYPEDEF(type, name, alignment) typedef type name __attribute__((aligned(alignment)))
+ #elif (GLM_COMPILER & GLM_COMPILER_CUDA) || (GLM_COMPILER & GLM_COMPILER_HIP)
+ #	define GLM_DEPRECATED

--- a/ports/glm/portfile.cmake
+++ b/ports/glm/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 c6c6fa1ea7a7e97820e36ee042a78be248ae828c99c1b1111080d9bf334a5160c9993a70312351c92a867cd49907c95f9f357c8dfe2bc29946da6e83e27ba20c
     HEAD_REF master
+    PATCHES
+        fix-clang.patch # Backport https://github.com/g-truc/glm/pull/1286. Remove with next update.
 )
 
 vcpkg_cmake_configure(

--- a/ports/glm/vcpkg.json
+++ b/ports/glm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glm",
   "version": "1.0.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "OpenGL Mathematics (GLM)",
   "homepage": "https://glm.g-truc.net",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3090,7 +3090,7 @@
     },
     "glm": {
       "baseline": "1.0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "globjects": {
       "baseline": "1.1.0",

--- a/versions/g-/glm.json
+++ b/versions/g-/glm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f8b09027afe97c717e95bd81d1d4f37c057d1c78",
+      "version": "1.0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "9f323014ca30e742823ae0d6e1a47243000774c1",
       "version": "1.0.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Current glm release has compiling issues with clang, see upstream issue: https://github.com/g-truc/glm/issues/1269
This backports the already merged upstream solution to the latest release version: https://github.com/g-truc/glm/pull/1286