### PR TITLE
[libtracepoint] Update to 1.4.0, add "tools" features

### DIFF
--- a/ports/libeventheader-decode/portfile.cmake
+++ b/ports/libeventheader-decode/portfile.cmake
@@ -4,18 +4,30 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 b296ad3ee102d45cd8bccb2e3ed478f3d7adff8b3650251926189fd6efbca38728db61208af1627c08c16641b349e31e9366c6bc1965795063f39a167181f067
+    SHA512 baf27c967b2fa1fb8e8684951fd8e12e40fe9c23f5052a2d77c63eceab6ddfc112537422b97c37cfb0e479361fa8aedea6d8d7edfae91810f1ed696060fcb822
     HEAD_REF main)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools  BUILD_TOOLS
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/libeventheader-decode-cpp"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBUILD_SAMPLES=OFF
-        -DBUILD_TOOLS=OFF)
+)
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+if (BUILD_TOOLS)
+    vcpkg_copy_tools(
+        TOOL_NAMES perf-decode
+        AUTO_CLEAN)
+endif()
 
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME eventheader-decode

--- a/ports/libeventheader-decode/vcpkg.json
+++ b/ports/libeventheader-decode/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libeventheader-decode",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "C++ classes for decoding EventHeader-encoded Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
@@ -8,11 +8,11 @@
   "dependencies": [
     {
       "name": "libeventheader-tracepoint",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "libtracepoint-decode",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "vcpkg-cmake",
@@ -22,5 +22,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build user tools: perf-decode"
+    }
+  }
 }

--- a/ports/libeventheader-tracepoint/portfile.cmake
+++ b/ports/libeventheader-tracepoint/portfile.cmake
@@ -6,14 +6,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 b296ad3ee102d45cd8bccb2e3ed478f3d7adff8b3650251926189fd6efbca38728db61208af1627c08c16641b349e31e9366c6bc1965795063f39a167181f067
+    SHA512 baf27c967b2fa1fb8e8684951fd8e12e40fe9c23f5052a2d77c63eceab6ddfc112537422b97c37cfb0e479361fa8aedea6d8d7edfae91810f1ed696060fcb822
     HEAD_REF main)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/libeventheader-tracepoint"
     OPTIONS
         -DBUILD_SAMPLES=OFF
-        -DBUILD_TOOLS=OFF)
+)
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/libeventheader-tracepoint/vcpkg.json
+++ b/ports/libeventheader-tracepoint/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libeventheader-tracepoint",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "C/C++ interface for generating EventHeader-encoded Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "libtracepoint",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/libtracepoint-control/portfile.cmake
+++ b/ports/libtracepoint-control/portfile.cmake
@@ -4,19 +4,29 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 b296ad3ee102d45cd8bccb2e3ed478f3d7adff8b3650251926189fd6efbca38728db61208af1627c08c16641b349e31e9366c6bc1965795063f39a167181f067
+    SHA512 baf27c967b2fa1fb8e8684951fd8e12e40fe9c23f5052a2d77c63eceab6ddfc112537422b97c37cfb0e479361fa8aedea6d8d7edfae91810f1ed696060fcb822
     HEAD_REF main)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools  BUILD_TOOLS
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/libtracepoint-control-cpp"
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
         -DBUILD_SAMPLES=OFF
-        -DBUILD_TESTS=OFF
-        -DBUILD_TOOLS=OFF)
+)
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+if (BUILD_TOOLS)
+    vcpkg_copy_tools(
+        TOOL_NAMES perf-collect
+        AUTO_CLEAN)
+endif()
 
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME tracepoint-control

--- a/ports/libtracepoint-control/vcpkg.json
+++ b/ports/libtracepoint-control/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libtracepoint-control",
-  "version": "1.3.3",
-  "port-version": 1,
+  "version": "1.4.0",
   "description": "C++ classes for collecting Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
@@ -9,7 +8,7 @@
   "dependencies": [
     {
       "name": "libtracepoint-decode",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "vcpkg-cmake",
@@ -19,5 +18,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build user tools: perf-collect",
+      "supports": "linux"
+    }
+  }
 }

--- a/ports/libtracepoint-decode/portfile.cmake
+++ b/ports/libtracepoint-decode/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 b296ad3ee102d45cd8bccb2e3ed478f3d7adff8b3650251926189fd6efbca38728db61208af1627c08c16641b349e31e9366c6bc1965795063f39a167181f067
+    SHA512 baf27c967b2fa1fb8e8684951fd8e12e40fe9c23f5052a2d77c63eceab6ddfc112537422b97c37cfb0e479361fa8aedea6d8d7edfae91810f1ed696060fcb822
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/libtracepoint-decode/vcpkg.json
+++ b/ports/libtracepoint-decode/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtracepoint-decode",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "C++ classes for decoding Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",

--- a/ports/libtracepoint/portfile.cmake
+++ b/ports/libtracepoint/portfile.cmake
@@ -6,19 +6,29 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "microsoft/LinuxTracepoints"
     REF "v${VERSION}"
-    SHA512 b296ad3ee102d45cd8bccb2e3ed478f3d7adff8b3650251926189fd6efbca38728db61208af1627c08c16641b349e31e9366c6bc1965795063f39a167181f067
+    SHA512 baf27c967b2fa1fb8e8684951fd8e12e40fe9c23f5052a2d77c63eceab6ddfc112537422b97c37cfb0e479361fa8aedea6d8d7edfae91810f1ed696060fcb822
     HEAD_REF main)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools  BUILD_TOOLS)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/libtracepoint"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBUILD_SAMPLES=OFF
-        -DBUILD_TOOLS=OFF
         -DBUILD_TESTS=OFF)
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+if (BUILD_TOOLS)
+    vcpkg_copy_tools(
+        TOOL_NAMES tracepoint-register
+        AUTO_CLEAN)
+endif()
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     vcpkg_cmake_config_fixup(

--- a/ports/libtracepoint/vcpkg.json
+++ b/ports/libtracepoint/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libtracepoint",
-  "version": "1.3.3",
-  "port-version": 1,
+  "version": "1.4.0",
   "description": "C/C++ interface for generating Linux Tracepoints",
   "homepage": "https://github.com/microsoft/LinuxTracepoints/",
   "license": "MIT",
@@ -15,5 +14,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build user tools: tracepoint-register",
+      "supports": "linux"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4377,11 +4377,11 @@
       "port-version": 1
     },
     "libeventheader-decode": {
-      "baseline": "1.3.3",
+      "baseline": "1.4.0",
       "port-version": 0
     },
     "libeventheader-tracepoint": {
-      "baseline": "1.3.3",
+      "baseline": "1.4.0",
       "port-version": 0
     },
     "libevhtp": {
@@ -5085,15 +5085,15 @@
       "port-version": 0
     },
     "libtracepoint": {
-      "baseline": "1.3.3",
-      "port-version": 1
+      "baseline": "1.4.0",
+      "port-version": 0
     },
     "libtracepoint-control": {
-      "baseline": "1.3.3",
-      "port-version": 1
+      "baseline": "1.4.0",
+      "port-version": 0
     },
     "libtracepoint-decode": {
-      "baseline": "1.3.3",
+      "baseline": "1.4.0",
       "port-version": 0
     },
     "libu2f-server": {

--- a/versions/l-/libeventheader-decode.json
+++ b/versions/l-/libeventheader-decode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c09584c798815084e1889cb8d74627d4fc3d6e34",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "30514fb5dce7aa046e1b71f658cc3cc10a0366ec",
       "version": "1.3.3",
       "port-version": 0

--- a/versions/l-/libeventheader-tracepoint.json
+++ b/versions/l-/libeventheader-tracepoint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "573c10d322f63b1eca14f7f176b1f129b0375d0c",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d6fd027094b3930216990f5572f1de34531d4b05",
       "version": "1.3.3",
       "port-version": 0

--- a/versions/l-/libtracepoint-control.json
+++ b/versions/l-/libtracepoint-control.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77d1f20773ba8b6d4cb0bd56c508a11521bb6577",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b43d20ba774f4d86540350bd84f420e1bcaa386b",
       "version": "1.3.3",
       "port-version": 1

--- a/versions/l-/libtracepoint-decode.json
+++ b/versions/l-/libtracepoint-decode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27e3b141818c89cc05ff4d66ee23f0b945ef8e2f",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1e04ce7805f13762e06cd0bb01069e1b27f283f2",
       "version": "1.3.3",
       "port-version": 0

--- a/versions/l-/libtracepoint.json
+++ b/versions/l-/libtracepoint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "914ce95e52f114854f76063fda0789ba1590f897",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4f06adb290d6c05a65c1c62c8e37edc43f33eeac",
       "version": "1.3.3",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.