### PR TITLE
[parsi] new port

### DIFF
--- a/ports/parsi/portfile.cmake
+++ b/ports/parsi/portfile.cmake
@@ -1,0 +1,17 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO cthulhu-irl/parsi
+    REF "v${VERSION}"
+    SHA512 193927b3b2e50d358752c6b58798d4050101d634d5231bf3e5c354edaca846a4e05f8b862c8fc461116f8ddecda0b0ebac7ee936579868a816e6404cedf964ec
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}" OPTIONS -DPARSI_MAIN_PROJECT=OFF -DPARSI_INSTALL=ON)
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/parsi/usage
+++ b/ports/parsi/usage
@@ -1,0 +1,4 @@
+parsi provides CMake targets:
+
+  find_package(parsi CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE parsi::parsi)

--- a/ports/parsi/vcpkg.json
+++ b/ports/parsi/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "parsi",
+  "version": "0.1.0",
+  "description": "A declarative parser combinator library.",
+  "homepage": "https://github.com/cthulhu-irl/parsi",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6704,6 +6704,10 @@
       "baseline": "0",
       "port-version": 2
     },
+    "parsi": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "parson": {
       "baseline": "2022-11-13",
       "port-version": 0

--- a/versions/p-/parsi.json
+++ b/versions/p-/parsi.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a9a39be660329c96c3a59d7b87a62323d2dee934",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
