### PR TITLE
[Type lite] update to 0.2.0

### DIFF
--- a/ports/type-lite/portfile.cmake
+++ b/ports/type-lite/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martinmoene/type-lite
-    REF v0.2.0
+    REF "v${VERSION}"
     SHA512 f193f6c2afd89151b59d393e22da2c0d7c271c759f4e8a71f9f31eae1b547c5ce9d803b3d1688aa7ecb18bd37c18867f28d5686c6d48b4cd18e29ef16cfd96c6
     HEAD_REF master
 )

--- a/ports/type-lite/portfile.cmake
+++ b/ports/type-lite/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martinmoene/type-lite
-    REF v0.1.0
-    SHA512  5a5ea623890af9c88c7f82869278af743e08b3dbda3c48c4523737244a7da76d2509501b4502efc2226aaef5df72b6ff69cd6b5b36c8cfc282b8c8406525016b
+    REF v0.2.0
+    SHA512 f193f6c2afd89151b59d393e22da2c0d7c271c759f4e8a71f9f31eae1b547c5ce9d803b3d1688aa7ecb18bd37c18867f28d5686c6d48b4cd18e29ef16cfd96c6
     HEAD_REF master
 )
 

--- a/ports/type-lite/vcpkg.json
+++ b/ports/type-lite/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "type-lite",
-  "version": "0.1.0",
-  "port-version": 3,
+  "version": "0.2.0",
   "description": "Strong types for C++98, C++11 and later in a single-file header-only library.",
   "homepage": "https://github.com/martinmoene/type-lite",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8929,8 +8929,8 @@
       "port-version": 1
     },
     "type-lite": {
-      "baseline": "0.1.0",
-      "port-version": 3
+      "baseline": "0.2.0",
+      "port-version": 0
     },
     "type-safe": {
       "baseline": "0.2.4",

--- a/versions/t-/type-lite.json
+++ b/versions/t-/type-lite.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "89f45174a983f02ee46712bba6549216586d53c5",
+      "git-tree": "7ebc5db10421a042126a6ca788752a332402be10",
       "version": "0.2.0",
       "port-version": 0
     },

--- a/versions/t-/type-lite.json
+++ b/versions/t-/type-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89f45174a983f02ee46712bba6549216586d53c5",
+      "version": "0.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "87b4ca306e885d75327f894c485304ca3ead022c",
       "version": "0.1.0",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
