### PR TITLE
[Rapidcsv] update to 8.82

### DIFF
--- a/ports/rapidcsv/portfile.cmake
+++ b/ports/rapidcsv/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO d99kris/rapidcsv
     REF "v${VERSION}"
-    SHA512 cf1d8b9b23c03702496e63aedbc97cc1cbb64ca25bfd5a47a5fde5db80f5b1072a658b0b629a2e1c334e6d12c4511401f3e0aaef14843b1bce71a27c138ddba4
+    SHA512 721e82306315481dbec88a1c150568d038ab57f50dd2d8fd13bfe66cc55f62bedcca1392610ff678ef06fa7908a876a6d38a8fb7afd5c17f2b3d1b3a57661d26
     HEAD_REF master
 )
 

--- a/ports/rapidcsv/vcpkg.json
+++ b/ports/rapidcsv/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rapidcsv",
-  "version": "8.80",
+  "version": "8.82",
   "description": "Rapidcsv is a C++ header-only library for CSV parsing.",
   "homepage": "https://github.com/d99kris/rapidcsv/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7593,7 +7593,7 @@
       "port-version": 0
     },
     "rapidcsv": {
-      "baseline": "8.80",
+      "baseline": "8.82",
       "port-version": 0
     },
     "rapidfuzz": {

--- a/versions/r-/rapidcsv.json
+++ b/versions/r-/rapidcsv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "970f398017a383c61f6c8e46116443235f001d6d",
+      "version": "8.82",
+      "port-version": 0
+    },
+    {
       "git-tree": "4b8c616fc3d8226d7c5f69e2bb24543483a1dac0",
       "version": "8.80",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
