### PR TITLE
[x265] Update to 3.6, fix pthread flags, add feature "tools"

### DIFF
--- a/ports/x265/compiler-target.diff
+++ b/ports/x265/compiler-target.diff
@@ -1,0 +1,14 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index ab5ddfe..e99c4d8 100755
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -570,6 +570,9 @@ if((MSVC_IDE OR XCODE OR GCC) AND ENABLE_ASSEMBLY)
+         set(SUFFIX o)
+     endif()
+ 
++    if(CMAKE_CXX_COMPILER_TARGET)
++        list(PREPEND ARM_ARGS "--target=${CMAKE_CXX_COMPILER_TARGET}")
++    endif()
+     if(ARM OR CROSS_COMPILE_ARM)
+     # compile ARM arch asm files here
+         enable_language(ASM)

--- a/ports/x265/neon.diff
+++ b/ports/x265/neon.diff
@@ -1,0 +1,18 @@
+diff --git a/source/cmake/FindNeon.cmake b/source/cmake/FindNeon.cmake
+index cb02180..6a939b8 100644
+--- a/source/cmake/FindNeon.cmake
++++ b/source/cmake/FindNeon.cmake
+@@ -16,6 +16,13 @@ else()
+                     OUTPUT_STRIP_TRAILING_WHITESPACE)
+ endif()
+ 
++if(CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
++    set(neon_version 1)
++elseif(CMAKE_ANDROID_ARCH_ABI STREQUAL "armeabi-v7a")
++    set(neon_version "${CMAKE_ANDROID_ARM_NEON}")
++elseif(CMAKE_CROSSCOMPILING AND CMAKE_SIZEOF_VOID_P LESS "8")
++    set(neon_version 0)
++endif()
+ if(neon_version)
+     set(CPU_HAS_NEON 1)
+ endif()

--- a/ports/x265/pkgconfig.diff
+++ b/ports/x265/pkgconfig.diff
@@ -35,15 +35,6 @@ index a407271..a575642 100755
          if(IS_ABSOLUTE ${LIB} AND EXISTS ${LIB})
              list(APPEND PLIBLIST "${LIB}")
          else()
-@@ -702,7 +711,7 @@ if(X265_LATEST_TAG)
-     endforeach()
-     if(PLIBLIST)
-         # blacklist of libraries that should not be in Libs.private
--        list(REMOVE_ITEM PLIBLIST "-lc" "-lpthread" "-lmingwex" "-lmingwthrd"
-+        list(REMOVE_ITEM PLIBLIST "-lc"             "-lmingwex" "-lmingwthrd"
-             "-lmingw32" "-lmoldname" "-lmsvcrt" "-ladvapi32" "-lshell32"
-             "-luser32" "-lkernel32")
-         string(REPLACE ";" " " PRIVATE_LIBS "${PLIBLIST}")
 diff --git a/source/x265.pc.in b/source/x265.pc.in
 index 0bf99e9..fe76d20 100644
 --- a/source/x265.pc.in

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -17,11 +17,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
         tool   ENABLE_CLI
 )
 
-set(ASSEMBLY_OPTIONS "-DENABLE_ASSEMBLY=OFF")
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_find_acquire_program(NASM)
-    set(ASSEMBLY_OPTIONS "-DENABLE_ASSEMBLY=ON" "-DNASM_EXECUTABLE=${NASM}")
-endif()
+vcpkg_find_acquire_program(NASM)
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED)
 
@@ -29,9 +25,9 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/source"
     OPTIONS
         ${OPTIONS}
-        ${ASSEMBLY_OPTIONS}
         -DENABLE_SHARED=${ENABLE_SHARED}
         -DENABLE_LIBNUMA=OFF
+        "-DNASM_EXECUTABLE=${NASM}"
         "-DVERSION=${VERSION}"
     OPTIONS_DEBUG
         -DENABLE_CLI=OFF

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -22,6 +22,12 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     vcpkg_find_acquire_program(NASM)
     list(APPEND OPTIONS "-DNASM_EXECUTABLE=${NASM}")
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" AND NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_OSX)
+        # x265 doesn't create sufficient PIC for asm, breaking usage
+        # in shared libs, e.g. the libheif gdk pixbuf plugin.
+        # Users can override this in custom triplets.
+        list(APPEND OPTIONS "-DENABLE_ASSEMBLY=OFF")
+    endif()
 elseif(VCPKG_TARGET_IS_WINDOWS)
     list(APPEND OPTIONS "-DENABLE_ASSEMBLY=OFF")
 endif()

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_from_bitbucket(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
     FEATURES
-        tools   ENABLE_CLI
+        tool   ENABLE_CLI
 )
 
 set(ASSEMBLY_OPTIONS "-DENABLE_ASSEMBLY=OFF")
@@ -43,7 +43,7 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-if("tools" IN_LIST FEATURES)
+if("tool" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES x265 AUTO_CLEAN)
 endif()
 

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -12,6 +12,11 @@ vcpkg_from_bitbucket(
         pthread.diff
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
+    FEATURES
+        tools   ENABLE_CLI
+)
+
 set(ASSEMBLY_OPTIONS "-DENABLE_ASSEMBLY=OFF")
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_find_acquire_program(NASM)
@@ -23,6 +28,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/source"
     OPTIONS
+        ${OPTIONS}
         ${ASSEMBLY_OPTIONS}
         -DENABLE_SHARED=${ENABLE_SHARED}
         -DENABLE_LIBNUMA=OFF
@@ -37,7 +43,9 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-vcpkg_copy_tools(TOOL_NAMES x265 AUTO_CLEAN)
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES x265 AUTO_CLEAN)
+endif()
 
 if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/x265.h" "#ifdef X265_API_IMPORTS" "#if 1")

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_bitbucket(
         version.patch
         linkage.diff
         pkgconfig.diff
+        pthread.diff
 )
 
 set(ASSEMBLY_OPTIONS "-DENABLE_ASSEMBLY=OFF")

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_bitbucket(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO multicoreware/x265_git
     REF "${VERSION}"
-    SHA512 e95e454b438114cf90e32818847afa65b54caf69442a4a39dc92f125a7ec6f99c83ec509549ced3395cd5a77305abef0ecdad38b4a359f82fb17fce6c4c7cc7a
+    SHA512 cfc3fdd7ce10a6cadf4515707d8f338fe58329cbbbcac11a85f00376e29156baccfb19a514ac2bc816432d15a2a4eb1bb7e16e3a870b6b9f9bc28e1a44270091
     HEAD_REF master
     PATCHES
         disable-install-pdb.patch

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -10,6 +10,8 @@ vcpkg_from_bitbucket(
         linkage.diff
         pkgconfig.diff
         pthread.diff
+        compiler-target.diff
+        neon.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
@@ -17,7 +19,12 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
         tool   ENABLE_CLI
 )
 
-vcpkg_find_acquire_program(NASM)
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    vcpkg_find_acquire_program(NASM)
+    list(APPEND OPTIONS "-DNASM_EXECUTABLE=${NASM}")
+elseif(VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND OPTIONS "-DENABLE_ASSEMBLY=OFF")
+endif()
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED)
 
@@ -26,8 +33,8 @@ vcpkg_cmake_configure(
     OPTIONS
         ${OPTIONS}
         -DENABLE_SHARED=${ENABLE_SHARED}
+        -DENABLE_PIC=ON
         -DENABLE_LIBNUMA=OFF
-        "-DNASM_EXECUTABLE=${NASM}"
         "-DVERSION=${VERSION}"
     OPTIONS_DEBUG
         -DENABLE_CLI=OFF

--- a/ports/x265/pthread.diff
+++ b/ports/x265/pthread.diff
@@ -1,0 +1,24 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index a407271..f147d37 100755
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -85,6 +85,9 @@ else()
+ endif()
+ 
+ if(UNIX)
++    set(THREADS_PREFER_PTHREAD_FLAG 1)
++    find_package(Threads)
++    add_library(pthread ALIAS Threads::Threads)
+     list(APPEND PLATFORM_LIBS pthread)
+     find_library(LIBRT rt)
+     if(LIBRT)
+@@ -705,6 +708,9 @@ if(X265_LATEST_TAG)
+         list(REMOVE_ITEM PLIBLIST "-lc" "-lpthread" "-lmingwex" "-lmingwthrd"
+             "-lmingw32" "-lmoldname" "-lmsvcrt" "-ladvapi32" "-lshell32"
+             "-luser32" "-lkernel32")
++        if(UNIX)
++            list(APPEND PLIBLIST ${CMAKE_THREAD_LIBS_INIT})
++        endif()
+         string(REPLACE ";" " " PRIVATE_LIBS "${PLIBLIST}")
+     else()
+         set(PRIVATE_LIBS "")

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -10,5 +10,10 @@
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build command line tool"
+    }
+  }
 }

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -12,8 +12,8 @@
     }
   ],
   "features": {
-    "tools": {
-      "description": "Build command line tool"
+    "tool": {
+      "description": "Build the command line tool"
     }
   }
 }

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.",
   "homepage": "https://bitbucket.org/multicoreware/x265_git/",
   "license": "GPL-2.0-or-later",
-  "supports": "!xbox",
+  "supports": "!uwp & !xbox",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.",
   "homepage": "https://bitbucket.org/multicoreware/x265_git/",
   "license": "GPL-2.0-or-later",
-  "supports": "!uwp & !(arm & windows) & !xbox",
+  "supports": "!xbox",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -13,7 +13,8 @@
   ],
   "features": {
     "tool": {
-      "description": "Build the command line tool"
+      "description": "Build the command line tool",
+      "supports": "!uwp"
     }
   }
 }

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "x265",
-  "version": "3.5",
-  "port-version": 1,
+  "version": "3.6",
   "description": "x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.",
-  "homepage": "https://github.com/videolan/x265",
+  "homepage": "https://bitbucket.org/multicoreware/x265_git/",
   "license": "GPL-2.0-or-later",
   "supports": "!uwp & !(arm & windows) & !xbox",
   "dependencies": [

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1243,9 +1243,6 @@ wpilib:arm64-android=fail # requires full c++20 support
 wpilib:x64-android=fail # requires full c++20 support
 x264:arm-neon-android=fail
 x264:arm64-android=fail
-x265:arm-neon-android=fail
-x265:arm64-android=fail
-x265:x64-android=fail
 # No xorg-macros available on osx
 xbitmaps:arm-neon-android=fail
 xbitmaps:arm64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9481,8 +9481,8 @@
       "port-version": 1
     },
     "x265": {
-      "baseline": "3.5",
-      "port-version": 1
+      "baseline": "3.6",
+      "port-version": 0
     },
     "x86-simd-sort": {
       "baseline": "4.0",

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "12dc2e8caa2705c4bc8c936e310f2d1be7bc1f4a",
+      "git-tree": "89429aa82874053b23e7094d6e57bda7cfe6ab3e",
       "version": "3.6",
       "port-version": 0
     },

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "894ed23aca43dda9911269a2e8a130feee2991d6",
+      "git-tree": "12dc2e8caa2705c4bc8c936e310f2d1be7bc1f4a",
       "version": "3.6",
       "port-version": 0
     },

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "402214424fa79316671ce2378742b8819d021693",
+      "version": "3.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "93b9b05210a7eeeb11abdf3f09ad3f949047ed20",
       "version": "3.5",
       "port-version": 1

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "402214424fa79316671ce2378742b8819d021693",
+      "git-tree": "894ed23aca43dda9911269a2e8a130feee2991d6",
       "version": "3.6",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes build errors on android due to wrong pthread flags and 32 bit API level requirements (`ftello`).

Alternative to #39314.