### PR TITLE
[FAudio] update to 24.06

### DIFF
--- a/ports/faudio/portfile.cmake
+++ b/ports/faudio/portfile.cmake
@@ -1,10 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FNA-XNA/faudio
-    REF cfdc4db21a9c7d21a9132da5b213248a823fbe05 # This is 24.03 with 3 patches to fix minor build failures by @rkitover and @dg0yt
-    SHA512 9f7ee882e9aa7cf80d976e2c016aa085222d21da2b0fac0e59f5a713e3a3dd41deb2dfc1a4698a3eff0b46bb122eca874fbd5b2747c243c53118bae3c5af9ef9
+    REF "${VERSION}"
+    SHA512 275b5da657d3999b7b3d0915971eae3e1498135791c22df0e2337e0f060aa618517ffbfe1e2f004cb071cbb75c82a2376c120fdd4287260145c82084a619bb23
     HEAD_REF master
-    PATCHES
 )
 
 set(options "")

--- a/ports/faudio/vcpkg.json
+++ b/ports/faudio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "faudio",
-  "version-string": "24.03",
+  "version-string": "24.06",
   "description": "FAudio - accuracy-focused XAudio reimplementation for open platforms",
   "homepage": "https://fna-xna.github.io/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2657,7 +2657,7 @@
       "port-version": 0
     },
     "faudio": {
-      "baseline": "24.03",
+      "baseline": "24.06",
       "port-version": 0
     },
     "fawdlstty-libfv": {

--- a/versions/f-/faudio.json
+++ b/versions/f-/faudio.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "214eea54c0348aa357a862b591d0872575e2ff0e",
-      "version-string": "24.03",
+      "git-tree": "14744a8defc0b6b7b781a6e3cb7e9c488c9285e5",
+      "version-string": "24.06",
       "port-version": 0
     }
   ]

--- a/versions/f-/faudio.json
+++ b/versions/f-/faudio.json
@@ -4,6 +4,11 @@
       "git-tree": "14744a8defc0b6b7b781a6e3cb7e9c488c9285e5",
       "version-string": "24.06",
       "port-version": 0
+    },
+    {
+      "git-tree": "214eea54c0348aa357a862b591d0872575e2ff0e",
+      "version-string": "24.03",
+      "port-version": 0
     }
   ]
 }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.