### PR TITLE
[glaze] Update to 2.9.0

### DIFF
--- a/ports/glaze/portfile.cmake
+++ b/ports/glaze/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stephenberry/glaze
     REF "v${VERSION}"
-    SHA512 d9bcd4e6dc9bd44d87ef392c0820e9eb8adc3d5b70b0639e02dcf81b05bcb853a0418b23aef496cd86f036d30591210cccdaf80436741b1a5083c53ee4d4195c 
+    SHA512 547c16e4ab3c1f7b424ae15cfa737280b1760f79a93c41a80872e76fa3e30187778489eab194a10c87124bc6a3ad3bc63372c26ba11686dd2c3c7ad012540df6
 )
 
 vcpkg_cmake_configure(

--- a/ports/glaze/vcpkg.json
+++ b/ports/glaze/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glaze",
-  "version": "2.6.9",
+  "version": "2.9.0",
   "description": "One of the fastest JSON libraries in the world. Glaze reads and writes from C++ memory, simplifying interfaces and offering incredible performance.",
   "homepage": "https://github.com/stephenberry/glaze",
   "license": "MIT",

--- a/ports/saucer/patch-return-type.diff
+++ b/ports/saucer/patch-return-type.diff
@@ -1,5 +1,5 @@
 diff --git a/src/serializer.glaze.cpp b/src/serializer.glaze.cpp
-index 38e891c..2bafd36 100644
+index 45ca691..a77336e 100644
 --- a/src/serializer.glaze.cpp
 +++ b/src/serializer.glaze.cpp
 @@ -38,7 +38,7 @@ namespace saucer::serializers
@@ -9,5 +9,5 @@ index 38e891c..2bafd36 100644
 -    tl::expected<T, glz::parse_error> parse_as(const std::string &buffer)
 +    auto parse_as(const std::string &buffer)
      {
-         static constexpr auto opts = glz::opts{.error_on_missing_keys = true, .raw_string = false};
+         static constexpr auto opts = glz::opts{.error_on_missing_keys = true};
  

--- a/ports/saucer/patch-return-type.diff
+++ b/ports/saucer/patch-return-type.diff
@@ -1,0 +1,13 @@
+diff --git a/src/serializer.glaze.cpp b/src/serializer.glaze.cpp
+index 38e891c..2bafd36 100644
+--- a/src/serializer.glaze.cpp
++++ b/src/serializer.glaze.cpp
+@@ -38,7 +38,7 @@ namespace saucer::serializers
+     }
+ 
+     template <typename T>
+-    tl::expected<T, glz::parse_error> parse_as(const std::string &buffer)
++    auto parse_as(const std::string &buffer)
+     {
+         static constexpr auto opts = glz::opts{.error_on_missing_keys = true, .raw_string = false};
+ 

--- a/ports/saucer/patch-return-type.diff
+++ b/ports/saucer/patch-return-type.diff
@@ -1,8 +1,8 @@
 diff --git a/src/serializer.glaze.cpp b/src/serializer.glaze.cpp
-index 45ca691..a77336e 100644
+index 45ca691..71ea6cc 100644
 --- a/src/serializer.glaze.cpp
 +++ b/src/serializer.glaze.cpp
-@@ -38,7 +38,7 @@ namespace saucer::serializers
+@@ -38,19 +38,20 @@ namespace saucer::serializers
      }
  
      template <typename T>
@@ -11,3 +11,18 @@ index 45ca691..a77336e 100644
      {
          static constexpr auto opts = glz::opts{.error_on_missing_keys = true};
  
+         T value;
+         auto error = glz::read<opts>(value, buffer);
++        using return_t = tl::expected<T, std::decay_t<decltype(glz::read<{}>(value, buffer))>>;
+ 
+         if (error)
+         {
+-            return tl::make_unexpected(error);
++            return return_t(tl::make_unexpected(error));
+         }
+ 
+-        return value;
++        return return_t(value);
+     }
+ 
+     std::unique_ptr<message_data> glaze::parse(const std::string &data) const

--- a/ports/saucer/patch-return-type.diff
+++ b/ports/saucer/patch-return-type.diff
@@ -1,5 +1,5 @@
 diff --git a/src/serializer.glaze.cpp b/src/serializer.glaze.cpp
-index 45ca691..71ea6cc 100644
+index 45ca691..36ff3da 100644
 --- a/src/serializer.glaze.cpp
 +++ b/src/serializer.glaze.cpp
 @@ -38,19 +38,20 @@ namespace saucer::serializers
@@ -13,7 +13,7 @@ index 45ca691..71ea6cc 100644
  
          T value;
          auto error = glz::read<opts>(value, buffer);
-+        using return_t = tl::expected<T, std::decay_t<decltype(glz::read<{}>(value, buffer))>>;
++        using return_t = tl::expected<T, std::decay_t<decltype(glz::read<opts>(value, buffer))>>;
  
          if (error)
          {

--- a/ports/saucer/portfile.cmake
+++ b/ports/saucer/portfile.cmake
@@ -8,10 +8,11 @@ vcpkg_from_github(
     HEAD_REF dev
     PATCHES
         fix_findpkg.patch
+        patch-return-type.diff
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH} 
+    SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         ${BACKEND_OPTION}
         -Dsaucer_prefer_remote=OFF

--- a/ports/saucer/vcpkg.json
+++ b/ports/saucer/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "saucer",
   "version": "2.1.0",
+  "port-version": 1,
   "description": "Next-gen desktop apps with web-frontend in C++",
   "homepage": "https://saucer.github.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3061,7 +3061,7 @@
       "port-version": 0
     },
     "glaze": {
-      "baseline": "2.6.9",
+      "baseline": "2.9.0",
       "port-version": 0
     },
     "glbinding": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7926,7 +7926,7 @@
     },
     "saucer": {
       "baseline": "2.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sbp": {
       "baseline": "3.4.10",

--- a/versions/g-/glaze.json
+++ b/versions/g-/glaze.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb7ed72b6af260c531e1e16222b24b520515be0f",
+      "version": "2.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e4c7bcd9cc4ef7d76f13f2406500af8e13bb25e2",
       "version": "2.6.9",
       "port-version": 0

--- a/versions/s-/saucer.json
+++ b/versions/s-/saucer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "22aba539f934aa40bab4fdaadd0515f499f3b876",
+      "git-tree": "49e315df09479611c91d79de412b3f35b4dbf8fb",
       "version": "2.1.0",
       "port-version": 1
     },

--- a/versions/s-/saucer.json
+++ b/versions/s-/saucer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a2a3d8f66665bef47b3da01ce66ead5ce201fda",
+      "version": "2.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0ad0dc8844c60450afe70ba393b6d31a517b553d",
       "version": "2.1.0",
       "port-version": 0

--- a/versions/s-/saucer.json
+++ b/versions/s-/saucer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "49e315df09479611c91d79de412b3f35b4dbf8fb",
+      "git-tree": "39f87fe0fec8334d74d65c778d1073f7ab525c69",
       "version": "2.1.0",
       "port-version": 1
     },

--- a/versions/s-/saucer.json
+++ b/versions/s-/saucer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a2a3d8f66665bef47b3da01ce66ead5ce201fda",
+      "git-tree": "22aba539f934aa40bab4fdaadd0515f499f3b876",
       "version": "2.1.0",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
