### PR TITLE
[fastrtps] Fixes missing fast-discovery-serverd-1.0.1.exe

### DIFF
--- a/ports/fastrtps/portfile.cmake
+++ b/ports/fastrtps/portfile.cmake
@@ -36,7 +36,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
         file(INSTALL "${CURRENT_PACKAGES_DIR}/bin/${TOOL}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
         file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/${TOOL}")
     endforeach()
-   
+
     # copy tools from "debug/bin" to "tools/debug/bin" folder
     foreach(TOOL "fast-discovery-serverd-1.0.1.exe" "fast-discovery-server.bat" "fastdds.bat" "ros-discovery.bat")
         file(INSTALL "${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin")
@@ -47,7 +47,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fastrtps/fast-discovery-server-targets-debug.cmake" "tools/fastrtps" "tools/fastrtps/debug/bin")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/fastdds.bat" "%dir%\\..\\tools\\fastdds\\fastdds.py" "%dir%\\..\\fastdds\\fastdds.py")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/ros-discovery.bat" "%dir%\\..\\tools\\fastdds\\fastdds.py" "%dir%\\..\\fastdds\\fastdds.py")
-    
+
     vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
     vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin")
 elseif(VCPKG_TARGET_IS_LINUX)
@@ -56,7 +56,7 @@ elseif(VCPKG_TARGET_IS_LINUX)
         file(INSTALL "${CURRENT_PACKAGES_DIR}/bin/${TOOL}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
         file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/${TOOL}")
     endforeach()
-    
+
     # copy tools from "debug/bin" to "tools/debug/bin" folder
     foreach(TOOL "fast-discovery-serverd-1.0.1" "fast-discovery-server" "fastdds" "ros-discovery")
         file(INSTALL "${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin")

--- a/ports/fastrtps/portfile.cmake
+++ b/ports/fastrtps/portfile.cmake
@@ -36,36 +36,39 @@ if(VCPKG_TARGET_IS_WINDOWS)
         file(INSTALL "${CURRENT_PACKAGES_DIR}/bin/${TOOL}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
         file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/${TOOL}")
     endforeach()
-
-    # remove tools from debug builds
+   
+    # copy tools from "debug/bin" to "tools/debug/bin" folder
     foreach(TOOL "fast-discovery-serverd-1.0.1.exe" "fast-discovery-server.bat" "fastdds.bat" "ros-discovery.bat")
-        if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL}")
-            file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL}")
-        endif()
+        file(INSTALL "${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL}")
     endforeach()
 
     # adjust paths in batch files
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fastrtps/fast-discovery-server-targets-debug.cmake" "tools/fastrtps" "tools/fastrtps/debug/bin")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/fastdds.bat" "%dir%\\..\\tools\\fastdds\\fastdds.py" "%dir%\\..\\fastdds\\fastdds.py")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/ros-discovery.bat" "%dir%\\..\\tools\\fastdds\\fastdds.py" "%dir%\\..\\fastdds\\fastdds.py")
-
+    
     vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+    vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin")
 elseif(VCPKG_TARGET_IS_LINUX)
     # copy tools from "bin" to "tools" folder
     foreach(TOOL "fast-discovery-server-1.0.1" "fast-discovery-server" "fastdds" "ros-discovery")
         file(INSTALL "${CURRENT_PACKAGES_DIR}/bin/${TOOL}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
         file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/${TOOL}")
     endforeach()
+    
+    # copy tools from "debug/bin" to "tools/debug/bin" folder
+    foreach(TOOL "fast-discovery-serverd-1.0.1" "fast-discovery-server" "fastdds" "ros-discovery")
+        file(INSTALL "${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL}")
+    endforeach()
 
     # replace symlink by a copy because symlinks do not work well together with vcpkg binary caching
     file(REMOVE "${CURRENT_PACKAGES_DIR}/tools/${PORT}/fast-discovery-server")
     file(INSTALL "${CURRENT_PACKAGES_DIR}/tools/${PORT}/fast-discovery-server-1.0.1" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}" RENAME "fast-discovery-server")
 
-    # remove tools from debug builds
-    foreach(TOOL "fast-discovery-serverd-1.0.1" "fast-discovery-server" "fastdds" "ros-discovery")
-        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL}")
-    endforeach()
-
     # adjust paths in batch files
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fastrtps/fast-discovery-server-targets-debug.cmake" "tools/fastrtps" "tools/fastrtps/debug/bin")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/fastdds" "$dir/../tools/fastdds/fastdds.py" "$dir/../fastdds/fastdds.py")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/ros-discovery" "$dir/../tools/fastdds/fastdds.py" "$dir/../fastdds/fastdds.py")
 endif()

--- a/ports/fastrtps/vcpkg.json
+++ b/ports/fastrtps/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fastrtps",
   "version": "2.14.0",
+  "port-version": 1,
   "description": "eprosima Fast DDS (formerly Fast RTPS) is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.",
   "homepage": "https://www.eprosima.com/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2654,7 +2654,7 @@
     },
     "fastrtps": {
       "baseline": "2.14.0",
-      "port-version": 0
+      "port-version": 1
     },
     "faudio": {
       "baseline": "24.03",

--- a/versions/f-/fastrtps.json
+++ b/versions/f-/fastrtps.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a8e271f22a5e7eadd8064f5eb81f16d3d0f0f046",
+      "version": "2.14.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3ca79d1102948e72e1383c2aac8b5069932c790d",
       "version": "2.14.0",
       "port-version": 0

--- a/versions/f-/fastrtps.json
+++ b/versions/f-/fastrtps.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a8e271f22a5e7eadd8064f5eb81f16d3d0f0f046",
+      "git-tree": "57d060b23aea5b9c4de01413550810bdc79101ea",
       "version": "2.14.0",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39375

Usage test passed with x64-windows

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.