### PR TITLE
[mp-units] Version 2.2.0

### DIFF
--- a/ports/mp-units/config.patch
+++ b/ports/mp-units/config.patch
@@ -1,16 +1,20 @@
 diff --git a/src/mp-unitsConfig.cmake b/src/mp-unitsConfig.cmake
-index 519b180b..6005e9f8 100644
+index f5bee933d..5effb72bf 100644
 --- a/src/mp-unitsConfig.cmake
 +++ b/src/mp-unitsConfig.cmake
-@@ -23,9 +23,9 @@
+@@ -23,13 +23,9 @@
  include(CMakeFindDependencyMacro)
  
- if(MP_UNITS_USE_LIBFMT)
+ if(NOT MP_UNITS_API_FREESTANDING AND NOT MP_UNITS_API_STD_FORMAT)
 -    find_dependency(fmt)
-+  find_dependency(fmt CONFIG)
++    find_dependency(fmt CONFIG)
  endif()
  
--find_dependency(gsl-lite)
+-if(MP_UNITS_API_CONTRACTS STREQUAL "GSL-LITE")
+-    find_dependency(gsl-lite)
+-elseif(MP_UNITS_API_CONTRACTS STREQUAL "MS-GSL")
+-    find_dependency(Microsoft.GSL)
+-endif()
 +find_dependency(gsl-lite CONFIG)
  
  include("${CMAKE_CURRENT_LIST_DIR}/mp-unitsTargets.cmake")

--- a/ports/mp-units/portfile.cmake
+++ b/ports/mp-units/portfile.cmake
@@ -6,20 +6,20 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mpusz/units
     REF "v${VERSION}"
-    SHA512 5e01cc4ee6cbbaf81f02c9268dfa8f0ca348925a85f84704f06405874edb478437837900e6fbe882aba9e9040235310d82b6420fd81b39eb1cc8d38570e48613
+    SHA512 7968b215c6b27a7a988ce41235139a57be6bb849db6d6ea0df46b0a40d279d4be4c53646c5a4bf695fb9e70ff4967d3fd443fec8ee40c4ab7f0c90d8695632c3
     PATCHES
       config.patch
 )
 
-set(USE_LIBFMT OFF)
+set(USE_STD_FORMAT TRUE)
 if ("use-libfmt" IN_LIST FEATURES)
-    set(USE_LIBFMT ON)
+    set(USE_STD_FORMAT FALSE)
 endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/src"
     OPTIONS
-      -DMP_UNITS_USE_LIBFMT=${USE_LIBFMT}
+    -DMP_UNITS_API_STD_FORMAT=${USE_STD_FORMAT}
 )
 
 vcpkg_cmake_install()

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mp-units",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "mp-units - A Units Library for C++",
   "homepage": "https://github.com/mpusz/units",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5893,7 +5893,7 @@
       "port-version": 0
     },
     "mp-units": {
-      "baseline": "2.1.1",
+      "baseline": "2.2.0",
       "port-version": 0
     },
     "mp3lame": {

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32d38ebf2cf91ab717ba623e298ec889635ac4a6",
+      "version": "2.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cd01504fde793a9f37f3dcd16963ede0d1acae99",
       "version": "2.1.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.