### PR TITLE
[expat] Fix compiler error

### DIFF
--- a/ports/expat/fix-compiler.patch
+++ b/ports/expat/fix-compiler.patch
@@ -7,7 +7,7 @@ index 8829f77..8a3278e 100644
  #endif
  
 -#define XMLPARSEAPI(type) XMLIMPORT type XMLCALL
-+##define XMLPARSEAPI(type) __declspec(dllimport) type XMLCALL
++#define XMLPARSEAPI(type) __declspec(dllimport) type XMLCALL
  
  #ifdef __cplusplus
  extern "C" {

--- a/ports/expat/fix-compiler.patch
+++ b/ports/expat/fix-compiler.patch
@@ -1,0 +1,13 @@
+diff --git a/expat/lib/expat_external.h b/expat/lib/expat_external.h
+index 8829f77..8a3278e 100644
+--- a/expat/lib/expat_external.h
++++ b/expat/lib/expat_external.h
+@@ -122,7 +122,7 @@
+ #  define XML_ATTR_ALLOC_SIZE(x)
+ #endif
+ 
+-#define XMLPARSEAPI(type) XMLIMPORT type XMLCALL
++##define XMLPARSEAPI(type) __declspec(dllimport) type XMLCALL
+ 
+ #ifdef __cplusplus
+ extern "C" {

--- a/ports/expat/portfile.cmake
+++ b/ports/expat/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF "${REF}"
     SHA512 49b6be12bd6284106920abc61d86d441cba126615fc4019744fc56dc5e7c5efc72b02c09e5c7b491882a633c1c45dc4a03e92a96372ab62bcd70755f6878c6b6
     HEAD_REF master
+    PATCHES
+        fix-compiler.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" EXPAT_LINKAGE)

--- a/ports/expat/vcpkg.json
+++ b/ports/expat/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "expat",
   "version": "2.6.2",
+  "port-version": 1,
   "description": "XML parser library written in C",
   "homepage": "https://github.com/libexpat/libexpat",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2566,7 +2566,7 @@
     },
     "expat": {
       "baseline": "2.6.2",
-      "port-version": 0
+      "port-version": 1
     },
     "expected-lite": {
       "baseline": "0.8.0",

--- a/versions/e-/expat.json
+++ b/versions/e-/expat.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc8e5f1ffcc7f5fcc9ba9b810feca000319e2c42",
+      "git-tree": "181727d15f0e060f5292832425769920855bff6f",
       "version": "2.6.2",
       "port-version": 1
     },

--- a/versions/e-/expat.json
+++ b/versions/e-/expat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc8e5f1ffcc7f5fcc9ba9b810feca000319e2c42",
+      "version": "2.6.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "e75ed0e0697a3049343ccfb52fd11eea6cebc30a",
       "version": "2.6.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #35878

Follow https://github.com/microsoft/vcpkg/issues/35878#issuecomment-2034823675, fix error:
````
CMake Error at C:/Users/Danylo/airtouch/third_party/windows/vcpkg/downloads/tools/cmake-3.27.1-windows/cmake-3.27.1-windows-i386/share/cmake-3.27/Modules/CMakeTestCCompiler.cmake:67 (message):
  The C compiler

    "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe"

  is not able to compile a simple test program.

  It fails with the following output:
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.