### PR TITLE
[openvino] disble apiValidator search

### DIFF
--- a/ports/openvino/002-api-validator.patch
+++ b/ports/openvino/002-api-validator.patch
@@ -1,0 +1,53 @@
+diff --git a/cmake/developer_package/api_validator/api_validator.cmake b/cmake/developer_package/api_validator/api_validator.cmake
+index 0fd1f2c03a..68e6d1fccb 100644
+--- a/cmake/developer_package/api_validator/api_validator.cmake
++++ b/cmake/developer_package/api_validator/api_validator.cmake
+@@ -2,7 +2,11 @@
+ # SPDX-License-Identifier: Apache-2.0
+ #
+ 
+-if(WIN32)
++function(ov_search_api_validator)
++    if(NOT ENABLE_API_VALIDATOR)
++        return()
++    endif()
++
+     # CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION is only set when
+     # Visual Studio generators are used, but we need it
+     # when we use Ninja as well
+@@ -11,8 +15,10 @@ if(WIN32)
+             string(REPLACE "\\" "" WINDOWS_SDK_VERSION $ENV{WindowsSDKVersion})
+             set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION ${WINDOWS_SDK_VERSION})
+             message(STATUS "Use ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} Windows SDK version")
++            # set to parent scope as well for later usage in '_ov_add_api_validator_post_build_step'
++            set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION ${WINDOWS_SDK_VERSION} PARENT_SCOPE)
+         else()
+-          message(FATAL_ERROR "WindowsSDKVersion environment variable is not set,\
++            message(FATAL_ERROR "WindowsSDKVersion environment variable is not set,\
+ can't find Windows SDK version. Try to use vcvarsall.bat script")
+         endif()
+     endif()
+@@ -41,7 +47,9 @@ can't find Windows SDK version. Try to use vcvarsall.bat script")
+             message(STATUS "Found apivalidator: ${ONECORE_API_VALIDATOR}")
+         endif()
+     endif()
+-endif()
++endfunction()
++
++ov_search_api_validator()
+ 
+ function(_ov_add_api_validator_post_build_step_recursive)
+     cmake_parse_arguments(API_VALIDATOR "" "TARGET" "" ${ARGN})
+diff --git a/cmake/features.cmake b/cmake/features.cmake
+index bfa3a05481..7b0c9249dc 100644
+--- a/cmake/features.cmake
++++ b/cmake/features.cmake
+@@ -192,6 +192,8 @@ ov_dependent_option(ENABLE_JS "Enables JS API building" ON "NOT ANDROID;NOT EMSC
+ 
+ ov_option(ENABLE_OPENVINO_DEBUG "Enable output for OPENVINO_DEBUG statements" OFF)
+ 
++ov_dependent_option (ENABLE_API_VALIDATOR "Enables API Validator usage" ON "WIN32" OFF)
++
+ if(NOT BUILD_SHARED_LIBS AND ENABLE_OV_TF_FRONTEND)
+     set(FORCE_FRONTENDS_USE_PROTOBUF ON)
+ else()

--- a/ports/openvino/portfile.cmake
+++ b/ports/openvino/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     PATCHES
         # vcpkg specific patch, because OV creates a file in source tree, which is prohibited
         001-disable-tools.patch
+        # https://github.com/openvinotoolkit/openvino/pull/25069: disable apiValidator
+        002-api-validator.patch
     HEAD_REF master)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -117,6 +119,10 @@ endif()
 
 if(ENABLE_OV_TF_LITE_FRONTEND)
     list(APPEND FEATURE_OPTIONS "-DENABLE_SYSTEM_FLATBUFFERS=ON")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    list(APPEND FEATURE_OPTIONS "-DENABLE_API_VALIDATOR=OFF")
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/openvino/vcpkg.json
+++ b/ports/openvino/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openvino",
   "version": "2024.2.0",
+  "port-version": 1,
   "maintainers": "OpenVINO Developers <openvino@intel.com>",
   "summary": "This is a port for Open Visual Inference And Optimization toolkit for AI inference",
   "description": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6594,7 +6594,7 @@
     },
     "openvino": {
       "baseline": "2024.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openvpn3": {
       "baseline": "3.7.0",

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b102766e5924f3b8699f6c17d8594330d486bf24",
+      "version": "2024.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "45d124d7a01390f13b5f50d4f7aa573fc181f27c",
       "version": "2024.2.0",
       "port-version": 0


### PR DESCRIPTION
Closes https://github.com/microsoft/vcpkg/issues/38221

Ports https://github.com/openvinotoolkit/openvino/pull/25069

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.