### PR TITLE
[gmmlib] update to 22.3.20

### DIFF
--- a/ports/gmmlib/portfile.cmake
+++ b/ports/gmmlib/portfile.cmake
@@ -14,7 +14,6 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS -DARCH=64
 )
 
 vcpkg_cmake_install()

--- a/ports/gmmlib/portfile.cmake
+++ b/ports/gmmlib/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/gmmlib
     REF "intel-gmmlib-${VERSION}"
-    SHA512 073cb2e9ec025ae32e2f33f51547083cd8425b0c7297e361b037c71b55a8d2322cd36ac7cabbf8c7a325f80f1cc97947c0aa8aa833dc5fbae5abe28e9c04451a
+    SHA512 d5a6da43f4bdcb2a138c249e197b2e441d0999e89867aa66dfa68cbfc6982e631a7df29fd213a72a57b31cb29366f654343cb6b77a46f22e54bfa5432310e053
     HEAD_REF master
 )
 

--- a/ports/gmmlib/vcpkg.json
+++ b/ports/gmmlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gmmlib",
-  "version": "22.3.17",
+  "version": "22.3.20",
   "description": "Intel(R) Graphics Memory Management Library",
   "homepage": "https://github.com/intel/gmmlib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3125,7 +3125,7 @@
       "port-version": 6
     },
     "gmmlib": {
-      "baseline": "22.3.17",
+      "baseline": "22.3.20",
       "port-version": 0
     },
     "gmp": {

--- a/versions/g-/gmmlib.json
+++ b/versions/g-/gmmlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9fed467a77404a49cada7ca4c3435f6f2dba458e",
+      "version": "22.3.20",
+      "port-version": 0
+    },
+    {
       "git-tree": "7f7e953649b6c9b189ade0aa39fb4ac5689322c3",
       "version": "22.3.17",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
