### PR TITLE
[spglib] Add a new port

### DIFF
--- a/ports/spglib/portfile.cmake
+++ b/ports/spglib/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO spglib/spglib
+    REF "v${VERSION}"
+    SHA512 15c0ced6168a436468d1f9db28bb93f3ff130467cd1f0b966cb9731d36be3d9877b3452561dbace3242351b7c9b41d41930a76ca2278f00c1b45620c06ee93e0
+    HEAD_REF develop
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SPGLIB_SHARED_LIBS)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+    -DSPGLIB_WITH_TESTS=OFF
+    -DSPGLIB_SHARED_LIBS=${SPGLIB_SHARED_LIBS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Spglib)
+vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+# handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/spglib/usage
+++ b/ports/spglib/usage
@@ -1,0 +1,9 @@
+spglib provides CMake targets:
+
+    find_package(Spglib CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Spglib::symspg)
+
+spglib provides pkg-config modules:
+
+    # The spglib library
+    spglib

--- a/ports/spglib/vcpkg.json
+++ b/ports/spglib/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "spglib",
+  "version-semver": "2.4.0",
+  "description": "C library for finding and handling crystal symmetries",
+  "homepage": "https://spglib.readthedocs.io/en/latest/",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8396,6 +8396,10 @@
       "baseline": "1.2.1",
       "port-version": 1
     },
+    "spglib": {
+      "baseline": "2.4.0",
+      "port-version": 0
+    },
     "spine-runtimes": {
       "baseline": "4.1.0",
       "port-version": 0

--- a/versions/s-/spglib.json
+++ b/versions/s-/spglib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "72a361224c8e7cc3dd14810ae402a410aad4c0bb",
+      "version-semver": "2.4.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

---

This is the first time researching vcpkg packaging, I would appreciate any feedback and suggestions that would need to be upstreamed. I do not have a vcpkg setup so I am relying a bit on the CI system. If there is some setup for packagers either for CI/CD in upstream or containerfiles setup, it would help immensely.