### PR TITLE
[curl] Add feature gsasl

### DIFF
--- a/ports/curl/dependencies.patch
+++ b/ports/curl/dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/CMake/curl-config.cmake.in b/CMake/curl-config.cmake.in
-index 9adb96e..9bf6900 100644
+index 9adb96e0a..9bf69004d 100644
 --- a/CMake/curl-config.cmake.in
 +++ b/CMake/curl-config.cmake.in
 @@ -31,6 +31,19 @@ if(@USE_ZLIB@)
@@ -23,7 +23,7 @@ index 9adb96e..9bf6900 100644
  check_required_components("@PROJECT_NAME@")
  
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c3525d3..aaeb237 100644
+index c3525d3fc..1927464e8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -164,7 +164,8 @@ set(CURL_LIBS "")
@@ -123,7 +123,20 @@ index c3525d3..aaeb237 100644
    if(LIBSSH2_FOUND)
      list(APPEND CURL_LIBS ${LIBSSH2_LIBRARY})
      list(APPEND CMAKE_REQUIRED_INCLUDES "${LIBSSH2_INCLUDE_DIR}")
-@@ -961,7 +983,11 @@ option(CURL_USE_GSSAPI "Use GSSAPI implementation (right now only Heimdal is sup
+@@ -957,11 +979,24 @@ if(NOT USE_LIBSSH2 AND CURL_USE_LIBSSH)
+   endif()
+ endif()
+ 
++option(CURL_USE_GSASL "Use GSASL implementation" OFF)
++mark_as_advanced(CURL_USE_GSASL)
++if(CURL_USE_GSASL)
++  find_package(PkgConfig REQUIRED)
++  pkg_check_modules(GSASL REQUIRED libgsasl)
++  list(APPEND CURL_LIBS ${GSASL_LINK_LIBRARIES})
++  set(USE_GSASL ON)
++endif()
++
+ option(CURL_USE_GSSAPI "Use GSSAPI implementation (right now only Heimdal is supported with CMake build)" OFF)
  mark_as_advanced(CURL_USE_GSSAPI)
  
  if(CURL_USE_GSSAPI)
@@ -136,7 +149,7 @@ index c3525d3..aaeb237 100644
  
    set(HAVE_GSSAPI ${GSS_FOUND})
    if(GSS_FOUND)
-@@ -973,6 +999,7 @@ if(CURL_USE_GSSAPI)
+@@ -973,6 +1008,7 @@ if(CURL_USE_GSSAPI)
      check_include_file_concat("gssapi/gssapi_generic.h" HAVE_GSSAPI_GSSAPI_GENERIC_H)
      check_include_file_concat("gssapi/gssapi_krb5.h" HAVE_GSSAPI_GSSAPI_KRB5_H)
  
@@ -144,3 +157,25 @@ index c3525d3..aaeb237 100644
      if(NOT GSS_FLAVOUR STREQUAL "Heimdal")
        # MIT
        set(_INCLUDE_LIST "")
+@@ -1618,6 +1654,7 @@ if(NOT CURL_DISABLE_INSTALL)
+   _add_if("UnixSockets"   USE_UNIX_SOCKETS)
+   _add_if("libz"          HAVE_LIBZ)
+   _add_if("brotli"        HAVE_BROTLI)
++  _add_if("gsasl"         USE_GSASL)
+   _add_if("zstd"          HAVE_ZSTD)
+   _add_if("AsynchDNS"     USE_ARES OR USE_THREADS_POSIX OR USE_THREADS_WIN32)
+   _add_if("IDN"           HAVE_LIBIDN2 OR USE_WIN32_IDN OR USE_APPLE_IDN)
+diff --git a/lib/curl_config.h.cmake b/lib/curl_config.h.cmake
+index 3a46c6490..7ce3facb6 100644
+--- a/lib/curl_config.h.cmake
++++ b/lib/curl_config.h.cmake
+@@ -713,6 +713,9 @@ ${SIZEOF_TIME_T_CODE}
+ /* if librtmp/rtmpdump is in use */
+ #cmakedefine USE_LIBRTMP 1
+ 
++/* if GSASL is in use */
++#cmakedefine USE_GSASL 1
++
+ /* Define to 1 if you don't want the OpenSSL configuration to be loaded
+    automatically */
+ #cmakedefine CURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG 1

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -35,6 +35,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         zstd        CURL_ZSTD
         psl         CURL_USE_LIBPSL
         gssapi      CURL_USE_GSSAPI
+        gsasl       CURL_USE_GSASL
     INVERTED_FEATURES
         ldap        CURL_DISABLE_LDAP
         ldap        CURL_DISABLE_LDAPS

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "curl",
   "version": "8.8.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",
@@ -31,6 +31,12 @@
       "description": "c-ares support",
       "dependencies": [
         "c-ares"
+      ]
+    },
+    "gsasl": {
+      "description": "GSASL support (libgsasl)",
+      "dependencies": [
+        "gsasl"
       ]
     },
     "gssapi": {

--- a/ports/openscap/portfile.cmake
+++ b/ports/openscap/portfile.cmake
@@ -37,6 +37,7 @@ vcpkg_cmake_configure(
         -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON
         -DENABLE_TESTS=OFF
         -DENABLE_DOCS=OFF
+        -DWANT_BASE64=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/openscap/vcpkg.json
+++ b/ports/openscap/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openscap",
   "version": "1.3.7",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The oscap program is a command line tool that allows users to load, scan, validate, edit, and export SCAP documents.",
   "homepage": "https://github.com/OpenSCAP/openscap",
   "license": "LGPL-2.1-or-later",

--- a/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
@@ -29,7 +29,8 @@
     {
       "name": "curl",
       "features": [
-        "psl"
+        "psl",
+        "gsasl"
       ],
       "platform": "!uwp"
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2094,7 +2094,7 @@
     },
     "curl": {
       "baseline": "8.8.0",
-      "port-version": 2
+      "port-version": 3
     },
     "curlpp": {
       "baseline": "2018-06-15",
@@ -6554,7 +6554,7 @@
     },
     "openscap": {
       "baseline": "1.3.7",
-      "port-version": 2
+      "port-version": 3
     },
     "openslide": {
       "baseline": "3.4.1",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2924ae75a54112be27209863ebe3d343da7541ba",
+      "version": "8.8.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "9b6ca5a9d3afa70bbfe734cbb4db575c24dcf304",
       "version": "8.8.0",
       "port-version": 2

--- a/versions/o-/openscap.json
+++ b/versions/o-/openscap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82c5fa2487fc5377950c5ad49bf9a3902cea36fd",
+      "version": "1.3.7",
+      "port-version": 3
+    },
+    {
       "git-tree": "5317006070f414abe07df69cea20ee7a7ebfc1d4",
       "version": "1.3.7",
       "port-version": 2


### PR DESCRIPTION
Merged upstream as https://github.com/curl/curl/pull/13948

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.