### PR TITLE
[acl] Update to 2.3.2

### DIFF
--- a/ports/acl/portfile.cmake
+++ b/ports/acl/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_download_distfile(ARCHIVE
          "https://www.mirrorservice.org/sites/download.savannah.gnu.org/releases/acl/acl-${VERSION}.tar.xz"
          
     FILENAME "acl-${VERSION}.tar.xz"
-    SHA512 7d02f05d17305f8587ab485395b00c7fdb8e44c1906d0d04b70a43a3020803e8b2b8c707abb6147f794867dfa87bd51769c2d3e11a3db55ecbd2006a6e6231dc
+    SHA512 c2d061dbfd28c00cecbc1ae614d67f3138202bf4d39b383f2df4c6a8b10b830f33acec620fb211f268478737dde4037d338a5823af445253cb088c48a135099b
 )
 
 vcpkg_extract_source_archive(

--- a/ports/acl/vcpkg.json
+++ b/ports/acl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "acl",
-  "version-semver": "2.3.1",
-  "port-version": 2,
+  "version-semver": "2.3.2",
   "description": "Commands for Manipulating POSIX Access Control Lists",
   "homepage": "https://savannah.nongnu.org/projects/acl",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/acl.json
+++ b/versions/a-/acl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb604826193ba4179f82e2279639c996321551df",
+      "version-semver": "2.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2d8c536397cb3a1f7c8979db3df870ae53a439cf",
       "version-semver": "2.3.1",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -29,8 +29,8 @@
       "port-version": 0
     },
     "acl": {
-      "baseline": "2.3.1",
-      "port-version": 2
+      "baseline": "2.3.2",
+      "port-version": 0
     },
     "activemq-cpp": {
       "baseline": "3.9.5",


### PR DESCRIPTION
Update `acl` to 2.3.2.

All features are tested successfully in the following triplet:
```
x64-linux
```

Header files can be found through `.pc` files.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
