### PR TITLE
[async-mqtt] update port to 8.0.0

### DIFF
--- a/ports/async-mqtt/portfile.cmake
+++ b/ports/async-mqtt/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO redboltz/async_mqtt
     REF "${VERSION}"
-    SHA512 1e4c1ecb10de7f7554fbbf9c05be4d6d8399d40e52f54203f8ce246606b146ff26e5a5fd9dedb4b2c9067ff44f891e55897a27da7b6bd34db308c30aaf6c1f7b
+    SHA512 47982ce823c62ca49d91a693a21eadeeb2c62da13392f8b8ff99ff164140ad721629d7b96782fbc4cc436c8d3c26bbf16837e984a6cce6528d425bc2dc931770
     HEAD_REF main
 )
 

--- a/ports/async-mqtt/vcpkg.json
+++ b/ports/async-mqtt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "async-mqtt",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Header-only Asynchronous MQTT communication library for C++17 based on Boost.Asio.",
   "homepage": "https://github.com/redboltz/async_mqtt",
   "license": "BSL-1.0",
@@ -11,10 +11,15 @@
     "boost-beast",
     "boost-container",
     "boost-container-hash",
+    "boost-date-time",
     "boost-endian",
+    "boost-filesystem",
+    "boost-hana",
+    "boost-lexical-cast",
     "boost-log",
     "boost-multi-index",
     "boost-numeric-conversion",
+    "boost-preprocessor",
     "boost-system",
     {
       "name": "vcpkg-cmake",

--- a/versions/a-/async-mqtt.json
+++ b/versions/a-/async-mqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a46b733b06a4305733c5e81235a270e6d22db445",
+      "version": "8.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "286bc76359a1cd98053b0a9a8ff81047ebf663ad",
       "version": "7.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -285,7 +285,7 @@
       "port-version": 0
     },
     "async-mqtt": {
-      "baseline": "7.0.0",
+      "baseline": "8.0.0",
       "port-version": 0
     },
     "async-simple": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
