### PR TITLE
[vtk] Reduce dependencies by adding new features

### DIFF
--- a/ports/seacas/portfile.cmake
+++ b/ports/seacas/portfile.cmake
@@ -23,6 +23,7 @@ endif()
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         mpi     TPL_ENABLE_MPI
+        matio   TPL_ENABLE_Matio
         # mpi     TPL_ENABLE_Pnetcdf # missing Pnetcdf port
         ${PARMETIS_FEATURES}
 )
@@ -33,7 +34,7 @@ endif()
 
 set(tpl_disable_list GTest DataWarp Pamgen X11 CUDA Kokkos Faodel Pnetcdf ADIOS2 Catalyst2)
 
-set(tpl_enable_list Zlib HDF5 Netcdf CGNS Matio fmt Cereal)
+set(tpl_enable_list Zlib HDF5 Netcdf CGNS fmt Cereal)
 
 if(VCPKG_TARGET_IS_OSX)
     list(APPEND tpl_disable_list METIS)

--- a/ports/seacas/vcpkg.json
+++ b/ports/seacas/vcpkg.json
@@ -19,13 +19,6 @@
       "name": "hdf5",
       "default-features": false
     },
-    {
-      "name": "matio",
-      "default-features": false,
-      "features": [
-        "hdf5"
-      ]
-    },
     "metis",
     {
       "name": "netcdf-c",
@@ -44,7 +37,22 @@
     },
     "zlib"
   ],
+  "default-features": [
+    "matio"
+  ],
   "features": {
+    "matio": {
+      "description": "Enable Matio support",
+      "dependencies": [
+        {
+          "name": "matio",
+          "default-features": false,
+          "features": [
+            "hdf5"
+          ]
+        }
+      ]
+    },
     "mpi": {
       "description": "Enable MPI support",
       "dependencies": [

--- a/ports/seacas/vcpkg.json
+++ b/ports/seacas/vcpkg.json
@@ -1,13 +1,19 @@
 {
   "name": "seacas",
   "version-date": "2022-11-22",
-  "port-version": 5,
+  "port-version": 6,
   "description": "The Sandia Engineering Analysis Code Access System (SEACAS) is a suite of preprocessing, postprocessing, translation, and utility applications supporting finite element analysis software using the Exodus database file format.",
   "homepage": "https://github.com/sandialabs/seacas",
   "license": null,
   "dependencies": [
     "cereal",
-    "cgns",
+    {
+      "name": "cgns",
+      "default-features": false,
+      "features": [
+        "hdf5"
+      ]
+    },
     "fmt",
     {
       "name": "hdf5",

--- a/ports/seacas/vcpkg.json
+++ b/ports/seacas/vcpkg.json
@@ -37,9 +37,6 @@
     },
     "zlib"
   ],
-  "default-features": [
-    "matio"
-  ],
   "features": {
     "matio": {
       "description": "Enable Matio support",

--- a/ports/vtk/usage
+++ b/ports/vtk/usage
@@ -1,5 +1,4 @@
 The package vtk provides CMake targets:
 
     find_package(VTK REQUIRED)
-    include("${VTK_USE_FILE}")
     target_link_libraries(main PRIVATE ${VTK_LIBRARIES})

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -22,7 +22,10 @@
     "glew",
     {
       "name": "hdf5",
-      "default-features": false
+      "default-features": false,
+      "features": [
+        "zlib"
+      ]
     },
     "jsoncpp",
     {

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -45,7 +45,13 @@
       ]
     },
     "lz4",
-    "netcdf-c",
+    {
+      "name": "netcdf-c",
+      "default-features": false,
+      "features": [
+        "hdf5"
+      ]
+    },
     "pegtl",
     {
       "name": "proj",

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -238,8 +238,7 @@
             "widgets"
           ]
         },
-        "qtdeclarative",
-        "qtimageformats"
+        "qtdeclarative"
       ]
     },
     "utf8": {

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -12,7 +12,13 @@
     "exprtk",
     "fast-float",
     "fmt",
-    "freetype",
+    {
+      "name": "freetype",
+      "default-features": false,
+      "features": [
+        "zlib"
+      ]
+    },
     "glew",
     {
       "name": "hdf5",

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -34,7 +34,13 @@
     "libogg",
     "libpng",
     "libtheora",
-    "libxml2",
+    {
+      "name": "libxml2",
+      "default-features": false,
+      "features": [
+        "zlib"
+      ]
+    },
     "lz4",
     "netcdf-c",
     "pegtl",

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.3.0-pv5.12.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": "BSD-3-Clause",
@@ -213,15 +213,12 @@
           "features": [
             "gui",
             "opengl",
+            "sql-sqlite",
             "widgets"
           ]
         },
         "qtdeclarative",
-        "qtimageformats",
-        {
-          "name": "qttools",
-          "default-features": false
-        }
+        "qtimageformats"
       ]
     },
     "utf8": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8070,7 +8070,7 @@
     },
     "seacas": {
       "baseline": "2022-11-22",
-      "port-version": 5
+      "port-version": 6
     },
     "seal": {
       "baseline": "4.1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9310,7 +9310,7 @@
     },
     "vtk": {
       "baseline": "9.3.0-pv5.12.1",
-      "port-version": 1
+      "port-version": 2
     },
     "vtk-dicom": {
       "baseline": "0.8.14",

--- a/versions/s-/seacas.json
+++ b/versions/s-/seacas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "29eca3888f7e54ca7c8ef9b359efca3e0f77ff73",
+      "git-tree": "965ee0f753402c101ee5b8788cc919105402c89d",
       "version-date": "2022-11-22",
       "port-version": 6
     },

--- a/versions/s-/seacas.json
+++ b/versions/s-/seacas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29eca3888f7e54ca7c8ef9b359efca3e0f77ff73",
+      "version-date": "2022-11-22",
+      "port-version": 6
+    },
+    {
       "git-tree": "0107d3359b2fa880981554b822946ccb2109baea",
       "version-date": "2022-11-22",
       "port-version": 5

--- a/versions/s-/seacas.json
+++ b/versions/s-/seacas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "965ee0f753402c101ee5b8788cc919105402c89d",
+      "git-tree": "bebbef6d1a82c6848bbb8d619a5e379f9b29b3f9",
       "version-date": "2022-11-22",
       "port-version": 6
     },

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "91a008c8c2e70ff4fe47a30c485fccef610e9f8a",
+      "git-tree": "b1cd891175ff37d3aa4ad5e05e792185f3932515",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 2
     },

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b3714c3b4ff6292945aeda34e43f4bdfecc75355",
+      "git-tree": "91a008c8c2e70ff4fe47a30c485fccef610e9f8a",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 2
     },

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b1cd891175ff37d3aa4ad5e05e792185f3932515",
+      "git-tree": "75ff1160df1785eaaf6ae614abd5ce48771f838e",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 2
     },

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a06086009d89e2110d9e04c19847880ba6a87fe",
+      "git-tree": "b3714c3b4ff6292945aeda34e43f4bdfecc75355",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 2
     },

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b47305babe848e39f6df38135489590cff3531f0",
+      "version-semver": "9.3.0-pv5.12.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "a29da0e8cb31a173e6d7aacf0f1fdfc0f7178744",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 1

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "75ff1160df1785eaaf6ae614abd5ce48771f838e",
+      "git-tree": "0c230cc0e6003a34330671080a7c00f3618c23e4",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 2
     },

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b47305babe848e39f6df38135489590cff3531f0",
+      "git-tree": "4a06086009d89e2110d9e04c19847880ba6a87fe",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 2
     },


### PR DESCRIPTION
Fixes #39491.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

The CI check all dependencies at once. I want to reduce dependencies of vtk. I will check that the following package can be installed one by one on my computer for triplet x64-windows, x64-windows-static-md, x64-linux, x64-linux-dynamic:

 - [x] itk[core,vtk] : x64-linux, ~~x64-linux-dynamic~~
 - [x] opencascade[core,vtk] : x64-linux
 - [x] opencv[core,vtk] : x64-linux
 - [x] opencv3[core,vtk] : x64-linux
 - [x] opencv4[core,vtk] : x64-linux
 - [x] paraview[core,vtkm] : x64-linux
 - [x] pcl[core,vtk] : x64-linux
 - [x] rtabmap[core,gui] : x64-linux
 - [x] vtk-dicom[core] : x64-linux

The previous tick must be checked before leaving Draft.