### PR TITLE
[abseil] Fix missing #include <random> for std::uniform_int_distribution

### DIFF
--- a/ports/abseil/0002-Fix-missing-include-random-for-std-uniform_int_distr.patch
+++ b/ports/abseil/0002-Fix-missing-include-random-for-std-uniform_int_distr.patch
@@ -1,0 +1,29 @@
+From c025a934b199d069510bb68ee552ae58a4394916 Mon Sep 17 00:00:00 2001
+From: Derek Mauro <dmauro@google.com>
+Date: Tue, 21 May 2024 09:57:36 -0700
+Subject: [PATCH] Fix missing #include <random> for
+ std::uniform_int_distribution
+
+Fixes #1676
+
+PiperOrigin-RevId: 635840902
+Change-Id: Ifc4099175f1c5f040f55a9f5a47fe0c996af79d1
+---
+ absl/algorithm/container.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/absl/algorithm/container.h b/absl/algorithm/container.h
+index c7bafae1..a2d126b7 100644
+--- a/absl/algorithm/container.h
++++ b/absl/algorithm/container.h
+@@ -44,6 +44,7 @@
+ #include <cassert>
+ #include <iterator>
+ #include <numeric>
++#include <random>
+ #include <type_traits>
+ #include <unordered_map>
+ #include <unordered_set>
+-- 
+2.44.0.windows.1
+

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         0001-revert-integer-to-string-conversion-optimizations.patch # Fix openvino MSVC compile error
+		0002-Fix-missing-include-random-for-std-uniform_int_distr.patch # Fix missing include for std::uniform_int_distribution
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "abseil",
   "version": "20240116.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
     "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26ec106886be2fb2bc0f35b0bda9a1d3d5f01717",
+      "version": "20240116.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "de728ac31037e511da4996c815903e6ac71e8fb9",
       "version": "20240116.2",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
     },
     "abseil": {
       "baseline": "20240116.2",
-      "port-version": 1
+      "port-version": 2
     },
     "absent": {
       "baseline": "0.3.1",


### PR DESCRIPTION
Please forgive me, but this is my first PR for vcpkg.

What I'm trying to do, is create a patch for a very simple known and fixed bug for `abseil`.
This issue has already been fixed by this commit in the `abseil` repo:
https://github.com/abseil/abseil-cpp/commit/c025a934b199d069510bb68ee552ae58a4394916

I experienced the issue when compiling a Protobuf (protoc) generated `.pb.cc` file (on VS2022), there is an error:
"\absl\algorithm\container.h(797,14): error C2039: 'uniform_int_distribution': is not a member of 'std'"

The issue is not actually in Protobuf, but in the `abseil` dependancy, and is resolved simply by including a missing file: `#include <random>`

I've tried my best to create a port and patch for `vcpkg`, I tried to follow every instruction, but I can't get past `error: no version database entry for abseil at 20240116.2#2`. Even though I believe I've created the `versions` file enty correctly. Maybe it's just my local setup.

Thanks for your time.


- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
