### PR TITLE
[yoga] update to 3.1.0

### DIFF
--- a/ports/yoga/portfile.cmake
+++ b/ports/yoga/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/yoga
     REF "v${VERSION}"
-    SHA512 3831e467428a54d256b75aa9fa86830b9ceb124eb6e16d817affa72b6093c768c7763e1d13bcdc3b332e4354df4367f88289ecd533790d89ccd90cef206563f8
+    SHA512 04fdb398a402c499cc876ccb36a3edfd741ee4013f0ac6b5b33ce495add1d3b76c09d7672b3e3842e5e50c0d7f42a97b19fd7e8085c6fa964c063a161d9a0fe2
     HEAD_REF master
     PATCHES
         disable_tests.patch

--- a/ports/yoga/vcpkg.json
+++ b/ports/yoga/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yoga",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Yoga is a cross-platform layout engine which implements Flexbox",
   "homepage": "https://github.com/facebook/yoga",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9657,7 +9657,7 @@
       "port-version": 0
     },
     "yoga": {
-      "baseline": "3.0.2",
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "yomm2": {

--- a/versions/y-/yoga.json
+++ b/versions/y-/yoga.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f4a1466ab3c27e5dd7ade997a96e98e3d46b3ad",
+      "version": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "be1192567872f981e847d21819c5ec44edc2b43f",
       "version": "3.0.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
