### PR TITLE
[jinja2cpp] New port

### DIFF
--- a/ports/jinja2cpp/build_fixes.patch
+++ b/ports/jinja2cpp/build_fixes.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9c42efc..909c2f1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -312,7 +312,7 @@ if(JINJA2CPP_INSTALL)
+             InstallTargets
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/static
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         FILE_SET HEADERS
+     )
+ 
+diff --git a/cmake/public/FindJinja2Cpp.cmake b/cmake/public/FindJinja2Cpp.cmake
+index d7c0a60..8a0bc5e 100644
+--- a/cmake/public/FindJinja2Cpp.cmake
++++ b/cmake/public/FindJinja2Cpp.cmake
+@@ -4,7 +4,7 @@ function (_Jinja2Cpp_Find_Library varName)
+         HINTS
+             ENV JINJA2CPP_ROOT
+             ${JINJA2CPP_INSTALL_DIR}
+-        PATH_SUFFIXES lib/static lib64/static
++        PATH_SUFFIXES lib lib64
+     )
+     mark_as_advanced(${varName})
+ endfunction ()

--- a/ports/jinja2cpp/portfile.cmake
+++ b/ports/jinja2cpp/portfile.cmake
@@ -1,0 +1,51 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Cheaterdev/Jinja2Cpp
+    REF "${VERSION}"
+    SHA512 345800e8b361186325b1f479154fdf0fa234029fb9bfcbce4540f1ea5a9a3ab8f098db4969f73a2c5996703e3ad12be4b29e51fde49cf4a5bc6fcbd8f88dc976
+    HEAD_REF master
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" JINJA2CPP_BUILD_SHARED)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH ${SOURCE_PATH}
+  OPTIONS
+    -DJINJA2CPP_BUILD_TESTS=OFF
+    -DJINJA2CPP_STRICT_WARNINGS=OFF
+    -DJINJA2CPP_BUILD_SHARED=${JINJA2CPP_BUILD_SHARED}
+	-DCMAKE_DISABLE_FIND_PACKAGE_expected-lite=ON
+	-DCMAKE_DISABLE_FIND_PACKAGE_variant-lite=ON
+	-DCMAKE_DISABLE_FIND_PACKAGE_optional-lite=ON
+	-DCMAKE_DISABLE_FIND_PACKAGE_string-view-lite=ON
+	-DJINJA2CPP_DEPS_MODE=external
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/${PORT}")
+
+find_library(JINJA2CPP_REL NAMES jinja2cpp PATHS "${CURRENT_PACKAGES_DIR}/lib/" NO_DEFAULT_PATH) 
+find_library(JINJA2CPP_DBG NAMES jinja2cpp PATHS "${CURRENT_PACKAGES_DIR}/debug/lib/" NO_DEFAULT_PATH) 
+
+if(JINJA2CPP_REL)
+    file(RENAME "${JINJA2CPP_REL}" "${CURRENT_PACKAGES_DIR}/lib/jinja2cpp.lib")
+endif()
+
+if(JINJA2CPP_DBG)
+    file(RENAME "${JINJA2CPP_DBG}" "${CURRENT_PACKAGES_DIR}/debug/lib/jinja2cpp.lib")
+endif()
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/jinja2cpp.pc" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/jinja2cpp.pc")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/jinja2cpp.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/jinja2cpp.pc")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/static" "${CURRENT_PACKAGES_DIR}/lib/static")
+
+file(INSTALL
+    ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright
+)

--- a/ports/jinja2cpp/portfile.cmake
+++ b/ports/jinja2cpp/portfile.cmake
@@ -25,8 +25,19 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/${PORT}")
 
-file(RENAME "${CURRENT_PACKAGES_DIR}/lib/static/jinja2cpp.lib" "${CURRENT_PACKAGES_DIR}/lib/jinja2cpp.lib")
-file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/static/jinja2cpp.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/jinja2cpp.lib")
+
+find_library(JINJA2CPP_REL NAMES jinja2cpp ${REL_NAMES} PATHS "${CURRENT_PACKAGES_DIR}/lib/static" NO_DEFAULT_PATH)
+find_library(JINJA2CPP_DBG NAMES jinja2cpp ${DBG_NAMES} PATHS "${CURRENT_PACKAGES_DIR}/debug/lib/static" NO_DEFAULT_PATH)
+
+if(JINJA2CPP_REL)
+ get_filename_component(JINJA2CPP_REL_EXT "${JINJA2CPP_REL}" EXT)
+ file(RENAME "${JINJA2CPP_REL}" "${CURRENT_PACKAGES_DIR}/lib/jinja2cpp.${JINJA2CPP_REL_EXT}")
+endif()
+
+if(JINJA2CPP_DBG)
+ get_filename_component(JINJA2CPP_DBG_EXT "${JINJA2CPP_DBG}" EXT)
+ file(RENAME "${JINJA2CPP_DBG}" "${CURRENT_PACKAGES_DIR}/debug/lib/jinja2cpp.${JINJA2CPP_DBG_EXT}")
+endif()
 
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/jinja2cpp.pc" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/jinja2cpp.pc")

--- a/ports/jinja2cpp/portfile.cmake
+++ b/ports/jinja2cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO Cheaterdev/Jinja2Cpp
+    REPO jinja2cpp/Jinja2Cpp
     REF "${VERSION}"
-    SHA512 345800e8b361186325b1f479154fdf0fa234029fb9bfcbce4540f1ea5a9a3ab8f098db4969f73a2c5996703e3ad12be4b29e51fde49cf4a5bc6fcbd8f88dc976
+    SHA512 10fa5b6d8d64b33f078611f25ce4c1be325f98ce81cb03cf3af5cbbd2c3d5b29867245d68bf5bdb3edf9c8ef79577bb6eaa1c5b681dc314a81f6caeaca89b1f3
     HEAD_REF master
 )
 
@@ -14,11 +14,11 @@ vcpkg_cmake_configure(
     -DJINJA2CPP_BUILD_TESTS=OFF
     -DJINJA2CPP_STRICT_WARNINGS=OFF
     -DJINJA2CPP_BUILD_SHARED=${JINJA2CPP_BUILD_SHARED}
-	-DCMAKE_DISABLE_FIND_PACKAGE_expected-lite=ON
-	-DCMAKE_DISABLE_FIND_PACKAGE_variant-lite=ON
-	-DCMAKE_DISABLE_FIND_PACKAGE_optional-lite=ON
-	-DCMAKE_DISABLE_FIND_PACKAGE_string-view-lite=ON
-	-DJINJA2CPP_DEPS_MODE=external
+    -DCMAKE_DISABLE_FIND_PACKAGE_expected-lite=ON
+    -DCMAKE_DISABLE_FIND_PACKAGE_variant-lite=ON
+    -DCMAKE_DISABLE_FIND_PACKAGE_optional-lite=ON
+    -DCMAKE_DISABLE_FIND_PACKAGE_string-view-lite=ON
+    -DJINJA2CPP_DEPS_MODE=external
 )
 
 vcpkg_cmake_install()
@@ -31,6 +31,7 @@ file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/static/jinja2cpp.lib" "${CURRENT_
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/jinja2cpp.pc" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/jinja2cpp.pc")
 file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/jinja2cpp.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/jinja2cpp.pc")
+
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/jinja2cpp/portfile.cmake
+++ b/ports/jinja2cpp/portfile.cmake
@@ -25,16 +25,8 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/${PORT}")
 
-find_library(JINJA2CPP_REL NAMES jinja2cpp PATHS "${CURRENT_PACKAGES_DIR}/lib/" NO_DEFAULT_PATH) 
-find_library(JINJA2CPP_DBG NAMES jinja2cpp PATHS "${CURRENT_PACKAGES_DIR}/debug/lib/" NO_DEFAULT_PATH) 
-
-if(JINJA2CPP_REL)
-    file(RENAME "${JINJA2CPP_REL}" "${CURRENT_PACKAGES_DIR}/lib/jinja2cpp.lib")
-endif()
-
-if(JINJA2CPP_DBG)
-    file(RENAME "${JINJA2CPP_DBG}" "${CURRENT_PACKAGES_DIR}/debug/lib/jinja2cpp.lib")
-endif()
+file(RENAME "${CURRENT_PACKAGES_DIR}/lib/static/jinja2cpp.lib" "${CURRENT_PACKAGES_DIR}/lib/jinja2cpp.lib")
+file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/static/jinja2cpp.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/jinja2cpp.lib")
 
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/jinja2cpp.pc" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/jinja2cpp.pc")

--- a/ports/jinja2cpp/portfile.cmake
+++ b/ports/jinja2cpp/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 10fa5b6d8d64b33f078611f25ce4c1be325f98ce81cb03cf3af5cbbd2c3d5b29867245d68bf5bdb3edf9c8ef79577bb6eaa1c5b681dc314a81f6caeaca89b1f3
     HEAD_REF master
+    PATCHES build_fixes.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" JINJA2CPP_BUILD_SHARED)
@@ -25,31 +26,14 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/${PORT}")
 
-
-find_library(JINJA2CPP_REL NAMES jinja2cpp ${REL_NAMES} PATHS "${CURRENT_PACKAGES_DIR}/lib/static" NO_DEFAULT_PATH)
-find_library(JINJA2CPP_DBG NAMES jinja2cpp ${DBG_NAMES} PATHS "${CURRENT_PACKAGES_DIR}/debug/lib/static" NO_DEFAULT_PATH)
-
-if(JINJA2CPP_REL)
- get_filename_component(JINJA2CPP_REL_EXT "${JINJA2CPP_REL}" EXT)
- file(RENAME "${JINJA2CPP_REL}" "${CURRENT_PACKAGES_DIR}/lib/jinja2cpp.${JINJA2CPP_REL_EXT}")
-endif()
-
-if(JINJA2CPP_DBG)
- get_filename_component(JINJA2CPP_DBG_EXT "${JINJA2CPP_DBG}" EXT)
- file(RENAME "${JINJA2CPP_DBG}" "${CURRENT_PACKAGES_DIR}/debug/lib/jinja2cpp.${JINJA2CPP_DBG_EXT}")
-endif()
-
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/jinja2cpp.pc" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/jinja2cpp.pc")
 file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/jinja2cpp.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/jinja2cpp.pc")
 
-vcpkg_fixup_pkgconfig()
-
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/static" "${CURRENT_PACKAGES_DIR}/lib/static")
 
-file(INSTALL
-    ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright
-)
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/jinja2cpp/vcpkg.json
+++ b/ports/jinja2cpp/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "jinja2cpp",
-  "version": "1.0.1",
-  "description": "A sample C++ library designed to serve as a foundational example for a tutorial on packaging libraries with vcpkg.",
+  "version": "1.3.2",
+  "description": "C++ implementation of the Jinja2 Python template engine. This library brings support of powerful Jinja2 template features into the C++ world, reports dynamic HTML pages and source code generation.",
   "homepage": "https://github.com/jinja2cpp/Jinja2Cpp",
-  "license": "MIT",
+  "license": "MPL-2.0",
   "dependencies": [
     "boost-algorithm",
     "boost-filesystem",

--- a/ports/jinja2cpp/vcpkg.json
+++ b/ports/jinja2cpp/vcpkg.json
@@ -1,0 +1,31 @@
+{
+  "name": "jinja2cpp",
+  "version": "1.0.1",
+  "description": "A sample C++ library designed to serve as a foundational example for a tutorial on packaging libraries with vcpkg.",
+  "homepage": "https://github.com/jinja2cpp/Jinja2Cpp",
+  "license": "MIT",
+  "dependencies": [
+    "boost-algorithm",
+    "boost-filesystem",
+    "boost-json",
+    "boost-lexical-cast",
+    "boost-numeric-conversion",
+    "boost-optional",
+    "boost-regex",
+    "boost-variant",
+    "expected-lite",
+    "fmt",
+    "optional-lite",
+    "rapidjson",
+    "string-view-lite",
+    "variant-lite",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3744,6 +3744,10 @@
       "baseline": "2023-12-27",
       "port-version": 0
     },
+    "jinja2cpp": {
+      "baseline": "1.3.2",
+      "port-version": 0
+    },
     "jinja2cpplight": {
       "baseline": "2018-05-08",
       "port-version": 3

--- a/versions/j-/jinja2cpp.json
+++ b/versions/j-/jinja2cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8339a1e44c7bbc8b3ccd4e6d726ae3d0973176f8",
+      "version": "1.3.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/j-/jinja2cpp.json
+++ b/versions/j-/jinja2cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8339a1e44c7bbc8b3ccd4e6d726ae3d0973176f8",
+      "git-tree": "de1b5c3ac185b4db7fb37d9e4d341f3495c0a845",
       "version": "1.3.2",
       "port-version": 0
     }

--- a/versions/j-/jinja2cpp.json
+++ b/versions/j-/jinja2cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "de1b5c3ac185b4db7fb37d9e4d341f3495c0a845",
+      "git-tree": "71b76a859255c496fc0b04e342c7ab9f52e03dc3",
       "version": "1.3.2",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

