### PR TITLE
[quill] Update to 4.5.0

### DIFF
--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
     REF v${VERSION}
-    SHA512 f41c0eea126cea4eda675e2380e59f1a6262a6bb3a32f7aeba53733f82ce4cbf3c169d3e7b0b5acd0fb9f95b8edc1854c64730271bbc24ec27fc05a66ebaf6d5
+    SHA512 bf1708107342f8a300f60889ec266e26c2dc5037e85aa488b28fc02ada7c02ecd0f0f9b73d95cf6336a11f6e8bd2cdc149d2b3648d0971b4e17c8c9c870cc919
     HEAD_REF master
 )
 

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "description": "Asynchronous Low Latency C++ Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7557,7 +7557,7 @@
       "port-version": 9
     },
     "quill": {
-      "baseline": "4.4.1",
+      "baseline": "4.5.0",
       "port-version": 0
     },
     "quirc": {

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eee411380f028040f3ef96cf66d32f2692db29a8",
+      "version": "4.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "bd3a32da571b34118598f0d412b6de3ec8cf0644",
       "version": "4.4.1",
       "port-version": 0


### PR DESCRIPTION
Update quill port from 4.4.1 to 4.5.0: https://github.com/odygrd/quill/releases/tag/v4.5.0

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.