### PR TITLE
[foonathan-memory] Allow dynamic builds

### DIFF
--- a/ports/foonathan-memory/portfile.cmake
+++ b/ports/foonathan-memory/portfile.cmake
@@ -111,4 +111,4 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/nodesize_dbg${EXECUTABLE_SUFFIX}")
 endif()
 
 # Handle copyright
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/foonathan-memory/portfile.cmake
+++ b/ports/foonathan-memory/portfile.cmake
@@ -1,7 +1,3 @@
-# WINDOWS_EXPORT_ALL_SYMBOLS doesn't work.
-# unresolved external symbol "public: static unsigned int const foonathan::memory::detail::memory_block_stack::implementation_offset
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_download_distfile(
     REMOVE_TOOL_STATIC_LINKING_CROSS_COMPILATION_PATCH
     URLS https://github.com/foonathan/memory/commit/abb0bff7a232572b1fce304dd2e2a2d5c0a6806c.patch?full_index=1

--- a/ports/foonathan-memory/vcpkg.json
+++ b/ports/foonathan-memory/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "foonathan-memory",
   "version": "0.7.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "STL compatible C++ memory allocator library",
   "homepage": "https://foonathan.net/doc/memory/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2818,7 +2818,7 @@
     },
     "foonathan-memory": {
       "baseline": "0.7.3",
-      "port-version": 1
+      "port-version": 2
     },
     "forge": {
       "baseline": "1.0.8",

--- a/versions/f-/foonathan-memory.json
+++ b/versions/f-/foonathan-memory.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "62a9fbf293e4ef285b97f9bc5f39294ed2893a4c",
+      "version": "0.7.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "3b259607933426427c0e9cac415275c1738a6f34",
       "version": "0.7.3",
       "port-version": 1


### PR DESCRIPTION
Fixes #39373. Allow dynamic builds.

All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```

The usage test passed on `x64-windows` (header files found):
```
foonathan-memory provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(foonathan_memory CONFIG REQUIRED)
  target_link_libraries(main PRIVATE foonathan_memory)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.