### PR TITLE
[glib] update to <2.80.3>

### DIFF
--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -2,7 +2,7 @@ string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIB_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(GLIB_ARCHIVE
     URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${VERSION}.tar.xz"
     FILENAME "glib-${VERSION}.tar.xz"
-    SHA512 6f3a06e10e7373a2dbf0688512de4126472fb73cbec488b7983b5ffecff09c64d7e1ca462f892e8f215d3d277d103ca802bad7ef0bd0f91edf26fc6ce67187b6
+    SHA512 b9c40e912c386192538ebe91b8aefca0ef00c9536b83604826ec9d3f1b963837e3330edd25ab6e11b8d8e3a475b2ea0938753a6ea8f657c8fcc93c3288b600c5
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH
@@ -39,6 +39,8 @@ if(VCPKG_HOST_IS_WINDOWS)
     vcpkg_list(APPEND ADDITIONAL_BINARIES "sh = ['${CMAKE_COMMAND}', '-E', 'false']")
 endif()
 
+x_vcpkg_get_python_packages(PYTHON_VERSION "3" PACKAGES packaging)
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     LANGUAGES C CXX OBJC OBJCXX
@@ -72,6 +74,9 @@ endforeach()
 set(GLIB_TOOLS
     gapplication
     gdbus
+    gi-compile-repository
+    gi-decompile-typelib
+    gi-inspect-typelib
     gio
     gio-querymodules
     glib-compile-resources

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "glib",
-  "version": "2.78.4",
-  "port-version": 3,
+  "version": "2.80.3",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",
@@ -12,6 +11,10 @@
     "libffi",
     "libiconv",
     "pcre2",
+    {
+      "name": "vcpkg-get-python-packages",
+      "host": true
+    },
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3081,8 +3081,8 @@
       "port-version": 2
     },
     "glib": {
-      "baseline": "2.78.4",
-      "port-version": 3
+      "baseline": "2.80.3",
+      "port-version": 0
     },
     "glib-networking": {
       "baseline": "2.78.0",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8c6e6ac15d1343c8ed85b2bfa056a66b97353a3",
+      "version": "2.80.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "ca77eedd8dca92c9e6c021316e81b9c7f648b58a",
       "version": "2.78.4",
       "port-version": 3


### PR DESCRIPTION
Fixes #39531

1. Update glib to the latest version 2.80.3
2. Add python package packaging module required in meson.build
3. Add tools of `gi-compile-repository`, `gi-decompile-typelib` and `gi-inspect-typeli` 

All features are tested successfully in the `x64-linux` triplet.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
