### PR TITLE
[harfbuzz] Update to 9.0.0

### DIFF
--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
     REF ${VERSION}
-    SHA512 e3f72335d574d34556149c688cead7c040c1d49e639c40dcaeda3b00c9c31441ff391c3ced65b89c1d082d26bbf46b9a3cac3a92ecd08c356ba92b41726d4ae5
+    SHA512 2f59759d29b735ff869407598afb5fd298db4709d8c7b932389ec60d42c1ec43d07dc6672ac0c14341c1bae1b839eb3bd2cb7ef1985fb02b5a48c8e5b02f4e7c
     HEAD_REF master
     PATCHES
         fix-win32-build.patch

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "harfbuzz",
-  "version": "8.5.0",
-  "port-version": 1,
+  "version": "9.0.0",
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3369,8 +3369,8 @@
       "port-version": 0
     },
     "harfbuzz": {
-      "baseline": "8.5.0",
-      "port-version": 1
+      "baseline": "9.0.0",
+      "port-version": 0
     },
     "hash-library": {
       "baseline": "8",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c46893f9942b1516524920b9f82d8f7fcaa06cc9",
+      "version": "9.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "14cae658d3e86c06b7c572997e729376ef93c90f",
       "version": "8.5.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
