### PR TITLE
[vcpkg baseline][pocketpy] Don't install include/pybind11/*

### DIFF
--- a/ports/pocketpy/fix-conflict.patch
+++ b/ports/pocketpy/fix-conflict.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ed02678..9297b20 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -86,7 +86,8 @@ if (PK_INSTALL)
+         DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ 
+         DESTINATION include 
+         FILES_MATCHING PATTERN "*.h"
+-        PATTERN "typings" EXCLUDE
++        PATTERN "typings"
++        PATTERN "pybind11" EXCLUDE
+     )
+     
+     # generate config.cmake

--- a/ports/pocketpy/fix-conflict.patch
+++ b/ports/pocketpy/fix-conflict.patch
@@ -7,7 +7,7 @@ index ed02678..9297b20 100644
          DESTINATION include 
          FILES_MATCHING PATTERN "*.h"
 -        PATTERN "typings" EXCLUDE
-+        PATTERN "typings"
++        PATTERN "typings" EXCLUDE
 +        PATTERN "pybind11" EXCLUDE
      )
      

--- a/ports/pocketpy/portfile.cmake
+++ b/ports/pocketpy/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 6c9872c4a402bc702e577067c05d593034f45f150ebbf033ef204b4c7deff6cd2da0f9db44e0bb37aefdeb7a4d99e5a9c4a93ece57316f561c5bf4cd33cd12e3
     HEAD_REF master
+    PATCHES
+        fix-conflict.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)

--- a/ports/pocketpy/vcpkg.json
+++ b/ports/pocketpy/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pocketpy",
   "version": "1.4.6",
+  "port-version": 1,
   "description": "pkpy is a lightweight(~15K LOC) Python interpreter for game scripting, built on C++17 with STL.",
   "homepage": "https://github.com/pocketpy/pocketpy",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6922,7 +6922,7 @@
     },
     "pocketpy": {
       "baseline": "1.4.6",
-      "port-version": 0
+      "port-version": 1
     },
     "poco": {
       "baseline": "1.13.3",

--- a/versions/p-/pocketpy.json
+++ b/versions/p-/pocketpy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89423f6f26d2b39a2798dcb9269ba58e69ba52c8",
+      "version": "1.4.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "ddb905f0cbb265ebd49458d25e24c666f911fe22",
       "version": "1.4.6",
       "port-version": 0

--- a/versions/p-/pocketpy.json
+++ b/versions/p-/pocketpy.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "89423f6f26d2b39a2798dcb9269ba58e69ba52c8",
+      "git-tree": "822ad9d667f6fbfd6b8db0ce4995f1228cfdb53f",
       "version": "1.4.6",
       "port-version": 1
     },


### PR DESCRIPTION
Detected by https://dev.azure.com/vcpkg/public/_build/results?buildId=104413&view=results

```
error: The following files are already installed in /mnt/vcpkg-ci/installed/x64-linux and are in conflict with pocketpy:x64-linux
Installed by pybind11:x64-linux  
include/pybind11/embed.h
    include/pybind11/functional.h
    include/pybind11/operators.h
    include/pybind11/pybind11.h
    include/pybind11/stl.h
```

Broken by https://github.com/microsoft/vcpkg/pull/39510, in which pybind11 support was added.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Tested usage successfully by `pocketpy:x64-windows`:
````
pocketpy provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(pocketpy CONFIG REQUIRED)
  target_link_libraries(main PRIVATE pocketpy)
````