### PR TITLE
[proj] fix gcc version<8 compile

### DIFF
--- a/ports/proj/fix-gcc-version-less-8.patch
+++ b/ports/proj/fix-gcc-version-less-8.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 36afe1156..14287744d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -63,9 +63,13 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+   set(PROJ_C_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
+     -Wmissing-prototypes
+   )
++  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8)
++	  set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
++		-Wextra-semi
++	  )
++  endif()
+   set(PROJ_CXX_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
+     -Weffc++
+-    -Wextra-semi
+     # -Wold-style-cast
+     -Woverloaded-virtual
+     -Wzero-as-null-pointer-constant

--- a/ports/proj/portfile.cmake
+++ b/ports/proj/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         fix-win-output-name.patch
         fix-proj4-targets-cmake.patch
         remove_toolset_restriction.patch
+        fix-gcc-version-less-8.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/proj/vcpkg.json
+++ b/ports/proj/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "proj",
   "version": "9.4.1",
+  "port-version": 1,
   "description": "PROJ library for cartographic projections",
   "homepage": "https://proj.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7026,7 +7026,7 @@
     },
     "proj": {
       "baseline": "9.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "projectm-eval": {
       "baseline": "1.0.0",

--- a/versions/p-/proj.json
+++ b/versions/p-/proj.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14287744dbfdfe9171b1949d032ecbbb62dcdd49",
+      "version": "9.4.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "dafa38417689eb52c17a425ace8e1f3ecfb74045",
       "version": "9.4.1",
       "port-version": 0

--- a/versions/p-/proj.json
+++ b/versions/p-/proj.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "14287744dbfdfe9171b1949d032ecbbb62dcdd49",
+      "git-tree": "3ea3cfc72b4b1d43a359755953f4792daadef34a",
       "version": "9.4.1",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
