### PR TITLE
[pybind11] update to 2.13.1

### DIFF
--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pybind/pybind11
     REF "v${VERSION}"
-    SHA512 6b7a1125b2374622af5e486dcaa3a5cc2b8fbd970e818233ce44daa15e18877a8118d47ccd2f34b8e1ed9a2175545aead517e39c8b7baad3cf64b6e5ab09997a
+    SHA512 97d7a2892af67adad16b6ff0fb3e6324c88d1dd931dfa0d34cf6d181baec05ed791f0980abf2174db22aabaa382fd5b5f00cb287cf6477a4786c999f29719717
     HEAD_REF master
 )
 

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pybind11",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7109,7 +7109,7 @@
       "port-version": 0
     },
     "pybind11": {
-      "baseline": "2.13.0",
+      "baseline": "2.13.1",
       "port-version": 0
     },
     "pystring": {

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9363778fdebae781bbd12e1cc09e4bca0b72fcfa",
+      "version": "2.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "852607347e3b98677dab358767c5ca70758f9143",
       "version": "2.13.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.