### PR TITLE
[vcpkg baseline][cachelib] Passing remove form fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -159,8 +159,6 @@ boringssl:x64-windows-static-md=skip
 boringssl:x86-windows=skip
 brpc:x64-android=fail
 buck-yeh-bux:x64-android=fail
-# Missing system libraries on linux: libaio1 & libaio-dev
-cachelib:x64-linux=fail
 caf:arm-neon-android=fail
 caf:arm64-uwp=fail
 caf:arm64-android=fail


### PR DESCRIPTION
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=104488&view=results.
```
PASSING, REMOVE FROM FAIL LIST: cachelib:x64-linux
```

Added `cachelib` to `ci.baseline.txt` by #38279 due to missing system libraries `libaio1` and `libaio-dev` on Linux. This issue is now fixed by #39376, which adds the new port `libaio`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.