### PR TITLE
[wxwidgets] Add feature secretstore

### DIFF
--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_check_features(
     FEATURES
         fonts   wxUSE_PRIVATE_FONTS
         media   wxUSE_MEDIACTRL
+        secretstore wxUSE_SECRETSTORE
         sound   wxUSE_SOUND
         webview wxUSE_WEBVIEW
         webview wxUSE_WEBVIEW_EDGE
@@ -68,7 +69,6 @@ vcpkg_cmake_configure(
         -DwxUSE_NANOSVG=sys
         -DwxUSE_GLCANVAS=ON
         -DwxUSE_LIBGNOMEVFS=OFF
-        -DwxUSE_LIBNOTIFY=OFF
         -DwxUSE_SECRETSTORE=OFF
         -DwxUSE_STL=${WXWIDGETS_USE_STL}
         -DwxUSE_STD_CONTAINERS=${WXWIDGETS_USE_STD_CONTAINERS}

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wxwidgets",
   "version": "3.2.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",
@@ -85,6 +85,9 @@
           "platform": "!windows & !osx & !ios"
         }
       ]
+    },
+    "secretstore": {
+      "description": "Use wxSecretStore class"
     },
     "sound": {
       "description": "Build wxSound support",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9486,7 +9486,7 @@
     },
     "wxwidgets": {
       "baseline": "3.2.5",
-      "port-version": 1
+      "port-version": 2
     },
     "wyhash": {
       "baseline": "2023-12-03",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f1a838731947da96400efcfb971565c8ef32da1",
+      "version": "3.2.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "bde0f4d4900b197bce1a65b91f837d883acecda3",
       "version": "3.2.5",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39588

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

This features passed with following triplets:

```
x64-windows
x64-windows-static
```