### PR TITLE
[yara] Fix linking error with math libary

### DIFF
--- a/ports/yara/CMakeLists.txt
+++ b/ports/yara/CMakeLists.txt
@@ -3,6 +3,8 @@ project(yara C)
 
 if(MSVC)
   add_compile_options(/W3 /wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS)
+else()
+  find_library(HAVE_LIBM NAMES m)
 endif()
 
 
@@ -113,7 +115,7 @@ set(
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
 list(APPEND libyara_dependencies Crypt32.lib Ws2_32.lib)
 endif()
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+if(HAVE_LIBM)
   list(APPEND libyara_dependencies m)
 endif()
 

--- a/ports/yara/vcpkg.json
+++ b/ports/yara/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "yara",
   "version": "4.5.1",
+  "port-version": 1,
   "description": "The pattern matching swiss knife",
   "homepage": "https://github.com/VirusTotal/yara",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9654,7 +9654,7 @@
     },
     "yara": {
       "baseline": "4.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "yas": {
       "baseline": "7.1.0",

--- a/versions/y-/yara.json
+++ b/versions/y-/yara.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7c3d81fe565750da91a74c6a9474e447d7763e8",
+      "version": "4.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "812967f72f45b8689953677a3969d1146945543a",
       "version": "4.5.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #39598. Fix linking error with `math` libary when building with clang.

Error example(missing `-lm` when building with clang):
```
[58/60] : && /usr/bin/clang-18 -fPIC -g  CMakeFiles/yarac.dir/cli/args.c.o CMakeFiles/yarac.dir/cli/common.c.o CMakeFiles/yarac.dir/cli/yarac.c.o -o yarac  liblibyara.a  /home/velo/redacted/vcpkg_installed/x64-linux/debug/lib/libssl.a  /home/velo/redacted/vcpkg_installed/x64-linux/debug/lib/libcrypto.a  -ldl && :
FAILED: yarac 
: && /usr/bin/clang-18 -fPIC -g  CMakeFiles/yarac.dir/cli/args.c.o CMakeFiles/yarac.dir/cli/common.c.o CMakeFiles/yarac.dir/cli/yarac.c.o -o yarac  liblibyara.a  /home/velo/redacted/vcpkg_installed/x64-linux/debug/lib/libssl.a  /home/velo/redacted/vcpkg_installed/x64-linux/debug/lib/libcrypto.a  -ldl && :
/usr/bin/ld: liblibyara.a(math.c.o): in function `string_entropy':
/home/velo/redacted/deps/vcpkg/buildtrees/yara/src/v4.5.1-ca2aa74811.clean/libyara/modules/math/math.c:192:(.text+0x56e): undefined reference to `log2'
/usr/bin/ld: liblibyara.a(math.c.o): in function `data_entropy':
/home/velo/redacted/deps/vcpkg/buildtrees/yara/src/v4.5.1-ca2aa74811.clean/libyara/modules/math/math.c:228:(.text+0x846): undefined reference to `log2'
/usr/bin/ld: liblibyara.a(math.c.o): in function `data_monte_carlo_pi':
/home/velo/redacted/deps/vcpkg/buildtrees/yara/src/v4.5.1-ca2aa74811.clean/libyara/modules/math/math.c:451:(.text+0x1c7d): undefined reference to `pow'
/usr/bin/ld: /home/velo/redacted/deps/vcpkg/buildtrees/yara/src/v4.5.1-ca2aa74811.clean/libyara/modules/math/math.c:451:(.text+0x1c96): undefined reference to `pow'
/usr/bin/ld: liblibyara.a(math.c.o): in function `string_monte_carlo_pi':
/home/velo/redacted/deps/vcpkg/buildtrees/yara/src/v4.5.1-ca2aa74811.clean/libyara/modules/math/math.c:538:(.text+0x24e3): undefined reference to `pow'
/usr/bin/ld: /home/velo/redacted/deps/vcpkg/buildtrees/yara/src/v4.5.1-ca2aa74811.clean/libyara/modules/math/math.c:538:(.text+0x24fc): undefined reference to `pow'
clang-18: error: linker command failed with exit code 1 (use -v to see invocation)
```

Correct example(building with GCC):
```
[58/60] : && /usr/bin/cc -fPIC -g  CMakeFiles/yara.dir/cli/args.c.o CMakeFiles/yara.dir/cli/common.c.o CMakeFiles/yara.dir/cli/threading.c.o CMakeFiles/yara.dir/cli/yara.c.o -o yara  liblibyara.a  /mnt/vcpkg/installed/x64-linux/debug/lib/libssl.a  /mnt/vcpkg/installed/x64-linux/debug/lib/libcrypto.a  -lm  -ldl && :
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.