### PR TITLE
[mongo-cxx-driver] Update to 3.10.2

### DIFF
--- a/ports/mongo-cxx-driver/fix-dependencies.patch
+++ b/ports/mongo-cxx-driver/fix-dependencies.patch
@@ -1,15 +1,3 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a1b60bd..78c6907 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -100,7 +100,6 @@ if(NEED_DOWNLOAD_C_DRIVER)
-         set(BUILD_TESTING OFF)
-         string(REPLACE " -Werror" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-         string(REPLACE " -Werror" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
--        add_subdirectory(${mongo-c-driver_SOURCE_DIR} ${mongo-c-driver_BINARY_DIR})
-         set(CMAKE_CXX_FLAGS ${OLD_CMAKE_CXX_FLAGS})
-         set(CMAKE_C_FLAGS ${OLD_CMAKE_C_FLAGS})
-         set(ENABLE_TESTS ${OLD_ENABLE_TESTS})
 diff --git a/src/bsoncxx/CMakeLists.txt b/src/bsoncxx/CMakeLists.txt
 index 1e241f5..adf9a27 100644
 --- a/src/bsoncxx/CMakeLists.txt

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-cxx-driver
     REF "r${VERSION}"
-    SHA512 cc09ccbb926b1f00ebd9ead5afda150d0d8a8619c2439f8a9bc01a1f49ebfc0cee91ca2019d97a883a469a8594961b5b74fcc06525dce38461e2003a9f1894c4
+    SHA512 a2e303c503b3e79b30c994888a4a9a31178352a1bb4a9ae73a2e41787c113fdd28e3a0e806abbb9e14419fe1b9aea512bcfe3a54edc126b66f0b732f3df09595
     HEAD_REF master
     PATCHES
         fix-dependencies.patch
@@ -28,6 +28,7 @@ vcpkg_cmake_configure(
         -DENABLE_TESTS=OFF
         -DENABLE_UNINSTALL=OFF
         -DMONGOCXX_HEADER_INSTALL_DIR=include
+        -DNEED_DOWNLOAD_C_DRIVER=OFF
     MAYBE_UNUSED_VARIABLES
         CMAKE_DISABLE_FIND_PACKAGE_Boost
         BSONCXX_HEADER_INSTALL_DIR

--- a/ports/mongo-cxx-driver/vcpkg.json
+++ b/ports/mongo-cxx-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-cxx-driver",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "MongoDB C++ Driver.",
   "homepage": "https://github.com/mongodb/mongo-cxx-driver",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5869,7 +5869,7 @@
       "port-version": 0
     },
     "mongo-cxx-driver": {
-      "baseline": "3.10.1",
+      "baseline": "3.10.2",
       "port-version": 0
     },
     "mongoose": {

--- a/versions/m-/mongo-cxx-driver.json
+++ b/versions/m-/mongo-cxx-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e246a2d1a2ff8883db714ee2ca91b0522f40d532",
+      "version": "3.10.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1cb201479398cab55eb19e2010472c4f35b1fa50",
       "version": "3.10.1",
       "port-version": 0


### PR DESCRIPTION
Fix #39539

Update `ports/mongo-cxx-driver/fix-dependencies.patch`, disable dependency by `NEED_DOWNLOAD_C_DRIVER=OFF`

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The port usage tests pass with the following triplets:
* x64-windows