### PR TITLE
[libyuv] Fix install tools

### DIFF
--- a/ports/libyuv/fix-cmakelists.patch
+++ b/ports/libyuv/fix-cmakelists.patch
@@ -80,7 +80,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 -INSTALL ( TARGETS ${ly_lib_static}						DESTINATION lib )
 -INSTALL ( TARGETS ${ly_lib_shared} LIBRARY				DESTINATION lib RUNTIME DESTINATION bin )
 -INSTALL ( DIRECTORY ${PROJECT_SOURCE_DIR}/include/		DESTINATION include )
-+INSTALL ( TARGETS yuvconvert DESTINATION tools )
++INSTALL ( TARGETS yuvconvert DESTINATION bin )
 +INSTALL ( FILES ${ly_include_files} DESTINATION include/libyuv )
 +INSTALL ( TARGETS ${ly_lib_static} EXPORT libyuv-targets DESTINATION lib INCLUDES DESTINATION include PUBLIC_HEADER DESTINATION include )
 +INSTALL( EXPORT libyuv-targets DESTINATION share/cmake/libyuv/ EXPORT_LINK_INTERFACE_LIBRARIES )

--- a/ports/libyuv/portfile.cmake
+++ b/ports/libyuv/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/libyuv)
+vcpkg_copy_tools(TOOL_NAMES yuvconvert AUTO_CLEAN)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/ports/libyuv/vcpkg.json
+++ b/ports/libyuv/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libyuv",
   "version": "1857",
+  "port-version": 1,
   "description": "libyuv is an open source project that includes YUV scaling and conversion functionality",
   "homepage": "https://chromium.googlesource.com/libyuv/libyuv",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5354,7 +5354,7 @@
     },
     "libyuv": {
       "baseline": "1857",
-      "port-version": 0
+      "port-version": 1
     },
     "libzen": {
       "baseline": "0.4.41",

--- a/versions/l-/libyuv.json
+++ b/versions/l-/libyuv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a814249d5f2638de96bece573dfddddadec7527c",
+      "version": "1857",
+      "port-version": 1
+    },
+    {
       "git-tree": "ee4cbd8592c2d5f3fd77c1478b679bc00671b316",
       "version": "1857",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
