### PR TITLE
[osqp] Add new port

### DIFF
--- a/ports/osqp/portfile.cmake
+++ b/ports/osqp/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO osqp/osqp
+    REF "v${VERSION}"
+    SHA512 d6c0efdc226c096fdfe76dd85522ee4cc9591fafde8de45f3c18453d37bd0509be80f6ba6841adff9216339a0fef1d49072fdc57323e1dd0eb1673f40d3b5d73
+    HEAD_REF master
+)
+vcpkg_from_github(
+    OUT_SOURCE_PATH MODULES_SOURCE_PATH
+    REPO osqp/qdldl
+    REF 7d16b70a10a152682204d745d814b6eb63dc5cd2
+    SHA512 9174269e6fb52a8184a12d8ff62c028f5e5065ebe688af92c02cd98b0cd87e015709b2a5a1a8c8a33719b2133e52261f9949fbb678f5a8bb98ae68bd0066c099
+    HEAD_REF master
+)
+file(REMOVE_RECURSE "${SOURCE_PATH}/lin_sys/direct/qdldl/qdldl_sources")
+file(RENAME "${MODULES_SOURCE_PATH}" "${SOURCE_PATH}/lin_sys/direct/qdldl/qdldl_sources")
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/osqp/vcpkg.json
+++ b/ports/osqp/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "osqp",
+  "version": "0.6.3",
+  "description": "The Operator Splitting QP Solver",
+  "homepage": "https://osqp.org",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6664,6 +6664,10 @@
       "baseline": "4.6.1",
       "port-version": 0
     },
+    "osqp": {
+      "baseline": "0.6.3",
+      "port-version": 0
+    },
     "otl": {
       "baseline": "4.0.476",
       "port-version": 0

--- a/versions/o-/osqp.json
+++ b/versions/o-/osqp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "29ff394737e5b48b99db4e5504ecc5b1bc0d44f5",
+      "version": "0.6.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
