### PR TITLE
[gettext-libintl] WIP

### DIFF
--- a/ports/gettext-libintl/portfile.cmake
+++ b/ports/gettext-libintl/portfile.cmake
@@ -4,8 +4,11 @@ if(VCPKG_TARGET_IS_LINUX)
         message(FATAL_ERROR
             "When targeting Linux, `libintl.h` is expected to come from the C Runtime Library (glibc). "
             "Please use the following commands or the equivalent to install development files. \n"
-            "On Debian and Ubuntu derivatives: \"sudo apt-get install libc-dev\"\n"
-            "On Alpine: \"apk add autoconf gettext-dev\"\n"
+            "On Debian and Ubuntu derivatives: \"sudo apt-get install libc6-dev\"\n"
+            "On Alpine: \"apk add gettext-dev\"\n"
+            "On CentOS and recent Red Hat: \"sudo yum install gettext-devel\"\n"
+            "On Fedora: \"sudo dnf install gettext-devel\"\n"
+            "On Arch Linux: \"sudo pacman -S gettext\"\n"
         )
     endif()
     file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/gettext-libintl/portfile.cmake
+++ b/ports/gettext-libintl/portfile.cmake
@@ -3,7 +3,9 @@ if(VCPKG_TARGET_IS_LINUX)
     if(NOT EXISTS "/usr/include/libintl.h")
         message(FATAL_ERROR
             "When targeting Linux, `libintl.h` is expected to come from the C Runtime Library (glibc). "
-            "Please use \"sudo apt-get install libc-dev\" or the equivalent to install development files."
+            "Please use the following commands or the equivalent to install development files. \n"
+            "On Debian and Ubuntu derivatives: \"sudo apt-get install libc-dev\"\n"
+            "On Alpine: \"apk add autoconf gettext-dev\"\n"
         )
     endif()
     file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/gettext-libintl/vcpkg.json
+++ b/ports/gettext-libintl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gettext-libintl",
   "version": "0.22.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The libintl C library from GNU gettext-runtime.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3018,7 +3018,7 @@
     },
     "gettext-libintl": {
       "baseline": "0.22.5",
-      "port-version": 1
+      "port-version": 2
     },
     "gettimeofday": {
       "baseline": "2017-10-14",

--- a/versions/g-/gettext-libintl.json
+++ b/versions/g-/gettext-libintl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5fd108863fbac23a7f375f58ef70b30b5530cd4b",
+      "git-tree": "6b90ab403e647e43fccf21836c469a296eee5a44",
       "version": "0.22.5",
       "port-version": 2
     },

--- a/versions/g-/gettext-libintl.json
+++ b/versions/g-/gettext-libintl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5fd108863fbac23a7f375f58ef70b30b5530cd4b",
+      "version": "0.22.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "ac89519d5ec11430978a4e45619befb7a1c4a062",
       "version": "0.22.5",
       "port-version": 1


### PR DESCRIPTION
Related issue: https://github.com/microsoft/vcpkg/issues/39617
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
