### PR TITLE
[gettext-libintl] Handle atypical Linux installations

### DIFF
--- a/ports/gettext-libintl/detect/CMakeLists.txt
+++ b/ports/gettext-libintl/detect/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.20)
+project(find-libintl C)
+
+set(OUTFILE "${CMAKE_CURRENT_BINARY_DIR}/detected_intl.cmake" CACHE FILEPATH "Where to store results")
+
+find_package(Intl)
+find_file(LIBINTL_H NAMES libintl.h PATHS ${Intl_INCLUDE_DIRS})
+
+string(CONFIGURE [[
+set(VCPKG_DETECTED_Intl_FOUND "@Intl_FOUND@")
+set(VCPKG_DETECTED_Intl_IS_BUILT_IN "@Intl_IS_BUILT_IN@")
+set(VCPKG_DETECTED_Intl_INCLUDE_DIRS "@Intl_INCLUDE_DIRS@")
+set(VCPKG_DETECTED_LIBINTL_H "@LIBINTL_H@")
+]] detected_intl @ONLY ESCAPE_QUOTES)
+
+file(WRITE "${OUTFILE}" "${detected_intl}")

--- a/ports/gettext-libintl/portfile.cmake
+++ b/ports/gettext-libintl/portfile.cmake
@@ -5,7 +5,7 @@ if(VCPKG_TARGET_IS_LINUX)
             "When targeting Linux, `libintl.h` is expected to come from the C Runtime Library (glibc). "
             "Please use the following commands or the equivalent to install development files. \n"
             "On Debian and Ubuntu derivatives: \"sudo apt-get install libc-dev\"\n"
-            "On Alpine: \"apk add autoconf gettext-dev\"\n"
+            "On Alpine: \"apk add gettext-dev\"\n"
         )
     endif()
     file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/gettext-libintl/portfile.cmake
+++ b/ports/gettext-libintl/portfile.cmake
@@ -1,4 +1,4 @@
-if(VCPKG_TARGET_IS_LINUX)
+if(VCPKG_TARGET_IS_LINUX AND NOT X_VCPKG_FORCE_VCPKG_GETTEXT_LIBINTL)
     set(detection_results "${CURRENT_BUILDTREES_DIR}/detected-intl-${TARGET_TRIPLET}.cmake.log")
     file(REMOVE "${detection_results}")
     block(SCOPE_FOR VARIABLES)

--- a/ports/gettext-libintl/portfile.cmake
+++ b/ports/gettext-libintl/portfile.cmake
@@ -3,7 +3,9 @@ if(VCPKG_TARGET_IS_LINUX)
     if(NOT EXISTS "/usr/include/libintl.h")
         message(FATAL_ERROR
             "When targeting Linux, `libintl.h` is expected to come from the C Runtime Library (glibc). "
-            "Please use \"sudo apt-get install libc-dev\" or the equivalent to install development files."
+            "Please use the following commands or the equivalent to install development files. \n"
+            "On Debian and Ubuntu derivatives: \"sudo apt-get install libc-dev\"\n"
+            "On Alpine: \"apk add autoconf gettext-dev\"\n"
         )
     endif()
     file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/gettext-libintl/portfile.cmake
+++ b/ports/gettext-libintl/portfile.cmake
@@ -1,13 +1,22 @@
 if(VCPKG_TARGET_IS_LINUX)
-    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-    if(NOT EXISTS "/usr/include/libintl.h")
+    set(detection_results "${CURRENT_BUILDTREES_DIR}/detected-intl-${TARGET_TRIPLET}.cmake.log")
+    file(REMOVE "${detection_results}")
+    block(SCOPE_FOR VARIABLES)
+        set(VCPKG_BUILD_TYPE release)
+        vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/detect" OPTIONS "-DOUTFILE=${detection_results}")
+    endblock()
+    include("${detection_results}")
+    message(STATUS "libintl header: ${VCPKG_DETECTED_LIBINTL_H}")
+    if(NOT VCPKG_DETECTED_LIBINTL_H)
         message(FATAL_ERROR
-            "When targeting Linux, `libintl.h` is expected to come from the C Runtime Library (glibc). "
-            "Please use the following commands or the equivalent to install development files. \n"
+            "When targeting Linux, `libintl.h` is expected to come from a system package. "
+            "Please use the following commands or the equivalent to install development files.\n"
             "On Debian and Ubuntu derivatives: \"sudo apt-get install libc-dev\"\n"
             "On Alpine: \"apk add gettext-dev\"\n"
         )
     endif()
+
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
     file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
     return()
 endif()

--- a/ports/gettext-libintl/vcpkg.json
+++ b/ports/gettext-libintl/vcpkg.json
@@ -10,6 +10,11 @@
     {
       "name": "libiconv",
       "platform": "!linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true,
+      "platform": "linux"
     }
   ]
 }

--- a/ports/gettext-libintl/vcpkg.json
+++ b/ports/gettext-libintl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gettext-libintl",
   "version": "0.22.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The libintl C library from GNU gettext-runtime.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3018,7 +3018,7 @@
     },
     "gettext-libintl": {
       "baseline": "0.22.5",
-      "port-version": 1
+      "port-version": 2
     },
     "gettimeofday": {
       "baseline": "2017-10-14",

--- a/versions/g-/gettext-libintl.json
+++ b/versions/g-/gettext-libintl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5fd108863fbac23a7f375f58ef70b30b5530cd4b",
+      "version": "0.22.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "ac89519d5ec11430978a4e45619befb7a1c4a062",
       "version": "0.22.5",
       "port-version": 1

--- a/versions/g-/gettext-libintl.json
+++ b/versions/g-/gettext-libintl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5fd108863fbac23a7f375f58ef70b30b5530cd4b",
+      "git-tree": "f41e983c85004eb6ee8d290ecb2465832fce8c00",
       "version": "0.22.5",
       "port-version": 2
     },


### PR DESCRIPTION
Fix `libintl.h` detection on atypical Linux systems such as NixOS. Resolves #39641.
Adjust messages to cover musl libc systems. Resolves #39617. (Based on #39659.)
Add triplet variable to force build on linux. Useful for musl libc systems.
Report detected header location. Useful to discover inconsistencies. (My linux cross builds still detect the host header. The error message is unaware of cross builds.)