### PR TITLE
[abseil] Fix port bugs

### DIFF
--- a/ports/abseil/779a356-test-allocator.diff
+++ b/ports/abseil/779a356-test-allocator.diff
@@ -1,0 +1,12 @@
+diff --git a/absl/container/CMakeLists.txt b/absl/container/CMakeLists.txt
+index 449a2cad17e..ee9ca9c3c4a 100644
+--- a/absl/container/CMakeLists.txt
++++ b/absl/container/CMakeLists.txt
+@@ -213,6 +213,7 @@ absl_cc_library(
+   DEPS
+     absl::config
+     GTest::gmock
++  TESTONLY
+ )
+ 
+ absl_cc_test(

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -14,16 +14,12 @@ vcpkg_from_github(
         779a356-test-allocator.diff
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        cxx17 ABSL_USE_CXX17
-)
-
 # With ABSL_PROPAGATE_CXX_STD=ON abseil automatically detect if it is being
 # compiled with C++14 or C++17, and modifies the installed `absl/base/options.h`
 # header accordingly. This works even if CMAKE_CXX_STANDARD is not set. Abseil
 # uses the compiler default behavior to update `absl/base/options.h` as needed.
-if (ABSL_USE_CXX17)
+set(ABSL_USE_CXX17_OPTION "")
+if ("cxx17" IN_LIST FEATURES)
     set(ABSL_USE_CXX17_OPTION "-DCMAKE_CXX_STANDARD=17")
 endif ()
 

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -47,16 +47,9 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
                     "${CURRENT_PACKAGES_DIR}/include/absl/time/internal/cctz/testdata"
 )
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    file(GLOB_RECURSE headers "${CURRENT_PACKAGES_DIR}/include/absl/*.h")
-    foreach(header IN LISTS ${headers})
-        vcpkg_replace_string("${header}"
-            "!defined(ABSL_CONSUME_DLL)" "0"
-        )
-        vcpkg_replace_string("${header}"
-            "defined(ABSL_CONSUME_DLL)" "1"
-        )
-    endforeach()
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/absl/base/config.h" "defined(ABSL_CONSUME_DLL)" "1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/absl/base/internal/thread_identity.h" "defined(ABSL_CONSUME_DLL)" "1")
 endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     PATCHES
         0001-revert-integer-to-string-conversion-optimizations.patch # Fix openvino MSVC compile error
 		0002-Fix-missing-include-random-for-std-uniform_int_distr.patch # Fix missing include for std::uniform_int_distribution
+        779a356-test-allocator.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "abseil",
   "version": "20240116.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
     "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dcd1d7ce3c896f86473b155e608bb9cfdaae2d94",
+      "version": "20240116.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "26ec106886be2fb2bc0f35b0bda9a1d3d5f01717",
       "version": "20240116.2",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
     },
     "abseil": {
       "baseline": "20240116.2",
-      "port-version": 2
+      "port-version": 3
     },
     "absent": {
       "baseline": "0.3.1",


### PR DESCRIPTION
Fix unneeded gmock dependency.
Resolves  https://github.com/microsoft/vcpkg/issues/39452.
Resolves  https://github.com/microsoft/vcpkg/issues/39551.
Resolves  https://github.com/microsoft/vcpkg/issues/39661.

Fix dllimport fixup. 
Resolves  https://github.com/microsoft/vcpkg/issues/39584.
