### PR TITLE
[glslang] Fix `tools` feature installation

### DIFF
--- a/ports/glslang/0001-Fix-glslangValidator-installation.patch
+++ b/ports/glslang/0001-Fix-glslangValidator-installation.patch
@@ -1,0 +1,57 @@
+From 3992259996aee72a65b99a0731584b2d69fcf32e Mon Sep 17 00:00:00 2001
+From: friendlyanon <friendlyanon@users.noreply.github.com>
+Date: Tue, 2 Jul 2024 19:55:24 +0200
+Subject: [PATCH] Fix `glslangValidator` installation
+
+This caused the glslang[tools] vcpkg feature to not install properly,
+because the glslangValidator executable didn't exist for tool
+installation.
+---
+ StandAlone/CMakeLists.txt | 25 ++++++++++++++++---------
+ 1 file changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/StandAlone/CMakeLists.txt b/StandAlone/CMakeLists.txt
+index e0fdb487..9ecdcd23 100644
+--- a/StandAlone/CMakeLists.txt
++++ b/StandAlone/CMakeLists.txt
+@@ -90,21 +90,28 @@ endif()
+ # Create a symbolic link to glslang named glslangValidator for backwards compatibility
+ set(legacy_glslang_name "glslangValidator${CMAKE_EXECUTABLE_SUFFIX}")
+ set(link_method create_symlink)
+-if (WIN32 OR MINGW)
+-set(link_method copy_if_different)
++if(WIN32 OR MINGW)
++  set(link_method copy_if_different)
+ endif()
+-add_custom_command(TARGET glslang-standalone
+-	       POST_BUILD
+-	       COMMAND ${CMAKE_COMMAND} -E ${link_method} $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name}
+-	       WORKING_DIRECTORY $<TARGET_FILE_DIR:glslang-standalone>)
++
++add_custom_command(
++    TARGET glslang-standalone POST_BUILD
++    COMMAND "${CMAKE_COMMAND}" -E "${link_method}" "\$<TARGET_FILE_NAME:glslang-standalone>" "${legacy_glslang_name}"
++    WORKING_DIRECTORY "\$<TARGET_FILE_DIR:glslang-standalone>"
++    VERBATIM
++)
+ 
+ if(GLSLANG_ENABLE_INSTALL)
+     install(TARGETS glslang-standalone EXPORT glslang-targets)
+ 
+     # Create the same symlink at install time
+-    install(CODE "execute_process( \
+-                      COMMAND ${CMAKE_COMMAND} -E ${link_method} $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name} \
+-                      WORKING_DIRECTORY \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})")
++    install(CODE "\
++        message(STATUS \"Installing (${link_method}): \$<TARGET_FILE_NAME:glslang-standalone> -> \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\")
++        execute_process(
++            COMMAND \"\${CMAKE_COMMAND}\" -E ${link_method} [=[\$<TARGET_FILE_NAME:glslang-standalone>]=] [=[${legacy_glslang_name}]=]
++            WORKING_DIRECTORY \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\"
++        )
++    ")
+ 
+     if(ENABLE_SPVREMAPPER)
+         install(TARGETS spirv-remap EXPORT glslang-targets)
+-- 
+2.29.1.windows.1
+

--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 570d2ff15116f48e195c73d9be1517b05e7c37541af10f6c05779a001e2d0295725349c1f4dd0bcca6f0c7e7e48c5162a60726c3e76cf04619c8e14bd0636ab6
     HEAD_REF master
+    PATCHES
+        0001-Fix-glslangValidator-installation.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -16,11 +18,11 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         rtti ENABLE_RTTI
 )
 
-if (ENABLE_GLSLANG_BINARIES)
+if(ENABLE_GLSLANG_BINARIES)
     vcpkg_find_acquire_program(PYTHON3)
     get_filename_component(PYTHON_PATH ${PYTHON3} DIRECTORY)
     vcpkg_add_to_path("${PYTHON_PATH}")
-endif ()
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -45,9 +47,9 @@ endif()
 
 vcpkg_copy_pdbs()
 
-if (ENABLE_GLSLANG_BINARIES)
+if(ENABLE_GLSLANG_BINARIES)
     vcpkg_copy_tools(TOOL_NAMES glslang glslangValidator spirv-remap AUTO_CLEAN)
-endif ()
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/glslang/vcpkg.json
+++ b/ports/glslang/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "glslang",
   "version": "14.2.0",
+  "port-version": 1,
   "description": "Khronos-reference front end for GLSL/ESSL, partial front end for HLSL, and a SPIR-V generator.",
   "homepage": "https://github.com/KhronosGroup/glslang",
   "license": "Apache-2.0 AND BSD-3-Clause AND MIT AND GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3114,7 +3114,7 @@
     },
     "glslang": {
       "baseline": "14.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "glui": {
       "baseline": "2019-11-30",

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "30ffabc3f5451d8cdd54ca141f9c231d64bb36ae",
+      "version": "14.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0af162a02e91b107148e1462bde87b8c4a7f6863",
       "version": "14.2.0",
       "port-version": 0


### PR DESCRIPTION
Implement patch from https://github.com/KhronosGroup/glslang/pull/3642 to fix `glslangValidator` installation.

Fixes #39653

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
