### PR TITLE
[mongo-c-driver/libbson] update to 1.27.4

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 2651f94980184755cd44d764dc6dea595cb1fcb47e167efb10ba35a5022a26d4a20db760c399620b6f9a449b44b07febb2f4237778b664a78cc596e2da89632a
+    SHA512 b22fd88084e0fead31faf47b505d7e38dff20e0b65c18f38c2d089807d2ed4a28f23d02fc429e80b0c3ef1bdd5f653b2399701389b3a29d305d96e99bebc3943
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "1.27.3",
+  "version": "1.27.4",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 2651f94980184755cd44d764dc6dea595cb1fcb47e167efb10ba35a5022a26d4a20db760c399620b6f9a449b44b07febb2f4237778b664a78cc596e2da89632a
+    SHA512 b22fd88084e0fead31faf47b505d7e38dff20e0b65c18f38c2d089807d2ed4a28f23d02fc429e80b0c3ef1bdd5f653b2399701389b3a29d305d96e99bebc3943
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.27.3",
+  "version": "1.27.4",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4245,7 +4245,7 @@
       "port-version": 4
     },
     "libbson": {
-      "baseline": "1.27.3",
+      "baseline": "1.27.4",
       "port-version": 0
     },
     "libcaer": {
@@ -5865,7 +5865,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.27.3",
+      "baseline": "1.27.4",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "327298df35164620f2b462f82d05dfda37a14998",
+      "version": "1.27.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "6cb66f69440c4d5780dff700c44c5de9fdea1f40",
       "version": "1.27.3",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f9e2f7d1753f1a119b6af302f8836b75e2eb420",
+      "version": "1.27.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "d46e1ebb4f01c99e5f6740c5d5745f6eb4a9cb3b",
       "version": "1.27.3",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39656

All features passed with following triplets:
x86-windows
x64-windows
x64-windows-static

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
