### PR TITLE
[libjpeg-turbo] Update to 3.0.3

### DIFF
--- a/ports/libjpeg-turbo/add-options-for-exes-docs-headers.patch
+++ b/ports/libjpeg-turbo/add-options-for-exes-docs-headers.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index adb0ca45..e66928bf 100644
+index ff9c9c27..d3fbad30 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -222,6 +222,12 @@ option(ENABLE_SHARED "Build shared libraries" TRUE)
+@@ -217,6 +217,12 @@ option(ENABLE_SHARED "Build shared libraries" TRUE)
  boolean_number(ENABLE_SHARED)
  option(ENABLE_STATIC "Build static libraries" TRUE)
  boolean_number(ENABLE_STATIC)
@@ -12,10 +12,10 @@ index adb0ca45..e66928bf 100644
 +boolean_number(INSTALL_DOCS)
 +option(INSTALL_HEADERS "Install header files" TRUE)
 +boolean_number(INSTALL_HEADERS)
- option(REQUIRE_SIMD "Generate a fatal error if SIMD extensions are not available for this platform (default is to fall back to a non-SIMD build)" FALSE)
- boolean_number(REQUIRE_SIMD)
- option(WITH_ARITH_DEC "Include arithmetic decoding support when emulating the libjpeg v6b API/ABI" TRUE)
-@@ -699,6 +705,7 @@ if(WITH_TURBOJPEG)
+ option(REQUIRE_SIMD
+   "Generate a fatal error if SIMD extensions are not available for this platform (default is to fall back to a non-SIMD build)"
+   FALSE)
+@@ -721,6 +727,7 @@ if(WITH_TURBOJPEG)
          LINK_FLAGS "${TJMAPFLAG}${TJMAPFILE}")
      endif()
  
@@ -23,7 +23,7 @@ index adb0ca45..e66928bf 100644
      add_executable(tjunittest tjunittest.c tjutil.c md5/md5.c md5/md5hl.c)
      target_link_libraries(tjunittest turbojpeg)
  
-@@ -710,9 +717,11 @@ if(WITH_TURBOJPEG)
+@@ -732,9 +739,11 @@ if(WITH_TURBOJPEG)
  
      add_executable(tjexample tjexample.c)
      target_link_libraries(tjexample turbojpeg)
@@ -36,7 +36,7 @@ index adb0ca45..e66928bf 100644
    endif()
  
    if(ENABLE_STATIC)
-@@ -733,6 +742,7 @@ if(WITH_TURBOJPEG)
+@@ -755,6 +764,7 @@ if(WITH_TURBOJPEG)
        set_target_properties(turbojpeg-static PROPERTIES OUTPUT_NAME turbojpeg)
      endif()
  
@@ -44,7 +44,7 @@ index adb0ca45..e66928bf 100644
      add_executable(tjunittest-static tjunittest.c tjutil.c md5/md5.c
        md5/md5hl.c)
      target_link_libraries(tjunittest-static turbojpeg-static)
-@@ -742,6 +752,7 @@ if(WITH_TURBOJPEG)
+@@ -764,6 +774,7 @@ if(WITH_TURBOJPEG)
      if(UNIX)
        target_link_libraries(tjbench-static m)
      endif()
@@ -52,7 +52,7 @@ index adb0ca45..e66928bf 100644
    endif()
  endif()
  
-@@ -760,13 +771,15 @@ if(ENABLE_STATIC)
+@@ -782,13 +793,15 @@ if(ENABLE_STATIC)
    add_library(cjpeg16-static OBJECT rdgif.c rdppm.c)
    set_property(TARGET cjpeg16-static PROPERTY COMPILE_FLAGS
      "-DBITS_IN_JSAMPLE=16 -DGIF_SUPPORTED -DPPM_SUPPORTED")
@@ -69,7 +69,7 @@ index adb0ca45..e66928bf 100644
    # Compile a separate version of these source files with 12-bit and 16-bit
    # data precision.
    add_library(djpeg12-static OBJECT rdcolmap.c wrgif.c wrppm.c)
-@@ -775,6 +788,7 @@ if(ENABLE_STATIC)
+@@ -797,6 +810,7 @@ if(ENABLE_STATIC)
    add_library(djpeg16-static OBJECT wrppm.c)
    set_property(TARGET djpeg16-static PROPERTY COMPILE_FLAGS
      "-DBITS_IN_JSAMPLE=16 -DPPM_SUPPORTED")
@@ -77,7 +77,7 @@ index adb0ca45..e66928bf 100644
    add_executable(djpeg-static djpeg.c cdjpeg.c rdcolmap.c rdswitch.c wrbmp.c
      wrgif.c wrppm.c wrtarga.c $<TARGET_OBJECTS:djpeg12-static>
      $<TARGET_OBJECTS:djpeg16-static>)
-@@ -788,11 +802,14 @@ if(ENABLE_STATIC)
+@@ -810,11 +824,14 @@ if(ENABLE_STATIC)
  
    add_executable(example-static example.c)
    target_link_libraries(example-static jpeg-static)
@@ -92,60 +92,61 @@ index adb0ca45..e66928bf 100644
  
  
  ###############################################################################
-@@ -1721,8 +1738,10 @@ if(WITH_TURBOJPEG)
-       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+@@ -1730,8 +1747,10 @@ if(WITH_TURBOJPEG)
+       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib
+       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib
+       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin)
 +    if(ENABLE_EXECUTABLES)
      install(TARGETS tjbench
-       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin)
 +    endif()
      if(NOT CMAKE_VERSION VERSION_LESS "3.1" AND MSVC AND
        CMAKE_C_LINKER_SUPPORTS_PDB)
        install(FILES "$<TARGET_PDB_FILE:turbojpeg>"
-@@ -1733,7 +1752,7 @@ if(WITH_TURBOJPEG)
+@@ -1742,7 +1761,7 @@ if(WITH_TURBOJPEG)
      install(TARGETS turbojpeg-static EXPORT ${CMAKE_PROJECT_NAME}Targets
        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib)
 -    if(NOT ENABLE_SHARED)
 +    if(NOT ENABLE_SHARED AND ENABLE_EXECUTABLES)
        if(GENERATOR_IS_MULTI_CONFIG)
          set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
        else()
-@@ -1743,15 +1762,17 @@ if(WITH_TURBOJPEG)
-         DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME tjbench${EXE})
+@@ -1752,15 +1771,17 @@ if(WITH_TURBOJPEG)
+         DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin RENAME tjbench${EXE})
      endif()
    endif()
 +  if(INSTALL_HEADERS)
    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/turbojpeg.h
-     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT include)
 +  endif()
  endif()
  
  if(ENABLE_STATIC)
    install(TARGETS jpeg-static EXPORT ${CMAKE_PROJECT_NAME}Targets
      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib)
 -  if(NOT ENABLE_SHARED)
 +  if(NOT ENABLE_SHARED AND ENABLE_EXECUTABLES)
      if(GENERATOR_IS_MULTI_CONFIG)
        set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
      else()
-@@ -1766,8 +1787,11 @@ if(ENABLE_STATIC)
+@@ -1775,9 +1796,12 @@ if(ENABLE_STATIC)
    endif()
  endif()
  
 +if(ENABLE_EXECUTABLES)
- install(TARGETS rdjpgcom wrjpgcom RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+ install(TARGETS rdjpgcom wrjpgcom
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin)
 +endif()
  
 +if(INSTALL_DOCS)
  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.ijg
    ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_SOURCE_DIR}/example.c
    ${CMAKE_CURRENT_SOURCE_DIR}/tjexample.c
-@@ -1779,8 +1803,9 @@ if(WITH_JAVA)
+@@ -1790,8 +1814,9 @@ if(WITH_JAVA)
    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/java/TJExample.java
-     DESTINATION ${CMAKE_INSTALL_DOCDIR})
+     DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT doc)
  endif()
 +endif()
  
@@ -154,25 +155,25 @@ index adb0ca45..e66928bf 100644
    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cjpeg.1
      ${CMAKE_CURRENT_SOURCE_DIR}/djpeg.1 ${CMAKE_CURRENT_SOURCE_DIR}/jpegtran.1
      ${CMAKE_CURRENT_SOURCE_DIR}/rdjpgcom.1
-@@ -1801,11 +1826,12 @@ install(EXPORT ${CMAKE_PROJECT_NAME}Targets
-   NAMESPACE ${CMAKE_PROJECT_NAME}::
-   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME})
+@@ -1814,11 +1839,12 @@ install(EXPORT ${CMAKE_PROJECT_NAME}Targets
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
+   COMPONENT lib)
  
 +if(INSTALL_HEADERS)
  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/jconfig.h
    ${CMAKE_CURRENT_SOURCE_DIR}/jerror.h ${CMAKE_CURRENT_SOURCE_DIR}/jmorecfg.h
    ${CMAKE_CURRENT_SOURCE_DIR}/jpeglib.h
-   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT include)
 -
 +endif()
  include(cmakescripts/BuildPackages.cmake)
  
  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmakescripts/cmake_uninstall.cmake.in"
 diff --git a/sharedlib/CMakeLists.txt b/sharedlib/CMakeLists.txt
-index 8e942569..6f3454a9 100644
+index eaed9e95..74d53696 100644
 --- a/sharedlib/CMakeLists.txt
 +++ b/sharedlib/CMakeLists.txt
-@@ -76,12 +76,13 @@ set_property(TARGET cjpeg12 PROPERTY COMPILE_FLAGS
+@@ -88,12 +88,13 @@ set_property(TARGET cjpeg12 PROPERTY COMPILE_FLAGS
  add_library(cjpeg16 OBJECT ../rdgif.c ../rdppm.c)
  set_property(TARGET cjpeg16 PROPERTY COMPILE_FLAGS
    "-DBITS_IN_JSAMPLE=16 -DGIF_SUPPORTED -DPPM_SUPPORTED")
@@ -187,7 +188,7 @@ index 8e942569..6f3454a9 100644
  # Compile a separate version of these source files with 12-bit and 16-bit data
  # precision.
  add_library(djpeg12 OBJECT ../rdcolmap.c ../wrgif.c ../wrppm.c)
-@@ -90,6 +91,7 @@ set_property(TARGET djpeg12 PROPERTY COMPILE_FLAGS
+@@ -102,6 +103,7 @@ set_property(TARGET djpeg12 PROPERTY COMPILE_FLAGS
  add_library(djpeg16 OBJECT ../wrppm.c)
  set_property(TARGET djpeg16 PROPERTY COMPILE_FLAGS
    "-DBITS_IN_JSAMPLE=16 -DPPM_SUPPORTED")
@@ -195,7 +196,7 @@ index 8e942569..6f3454a9 100644
  add_executable(djpeg ../djpeg.c ../cdjpeg.c ../rdcolmap.c ../rdswitch.c
    ../wrbmp.c ../wrgif.c ../wrppm.c ../wrtarga.c $<TARGET_OBJECTS:djpeg12>
    $<TARGET_OBJECTS:djpeg16>)
-@@ -105,14 +107,16 @@ target_link_libraries(example jpeg)
+@@ -117,14 +119,16 @@ target_link_libraries(example jpeg)
  
  add_executable(jcstest ../jcstest.c)
  target_link_libraries(jcstest jpeg)
@@ -203,12 +204,12 @@ index 8e942569..6f3454a9 100644
 +endif()
  install(TARGETS jpeg EXPORT ${CMAKE_PROJECT_NAME}Targets
    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin)
 +if(ENABLE_EXECUTABLES)
  install(TARGETS cjpeg djpeg jpegtran
-   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin)
 +endif()
  if(NOT CMAKE_VERSION VERSION_LESS "3.1" AND MSVC AND
    CMAKE_C_LINKER_SUPPORTS_PDB)

--- a/ports/libjpeg-turbo/portfile.cmake
+++ b/ports/libjpeg-turbo/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libjpeg-turbo/libjpeg-turbo
     REF "${VERSION}"
-    SHA512 9dddc039d9fd43fe2e2ff6a8b14fab4344f778ff270ec6f38f6496846501701df10b5127e2fe8b778cc236cac38b73889b9cc5bf884f8a43c37c4736097abb25
+    SHA512 46c44be837654e201d11bbf8d9fbb35b775a7d4bf653e9e709279437b10d5c8b0825ece4c8ee33f66689c263234fa2b08240fb5f5ba80e76e03891da8f64eda8
     HEAD_REF master
     PATCHES
         add-options-for-exes-docs-headers.patch

--- a/ports/libjpeg-turbo/vcpkg.json
+++ b/ports/libjpeg-turbo/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libjpeg-turbo",
-  "version": "3.0.2",
-  "port-version": 1,
+  "version": "3.0.3",
   "description": "libjpeg-turbo is a JPEG image codec that uses SIMD instructions (MMX, SSE2, NEON, AltiVec) to accelerate baseline JPEG compression and decompression on x86, x86-64, ARM, and PowerPC systems.",
   "homepage": "https://github.com/libjpeg-turbo/libjpeg-turbo",
   "license": "BSD-3-Clause",

--- a/ports/libjpeg-turbo/workaround_cmake_system_processor.patch
+++ b/ports/libjpeg-turbo/workaround_cmake_system_processor.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3730326..0c2b87c 100644
+index d3fbad30..9cf01cf5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -66,7 +66,7 @@ include(cmakescripts/PackageInfo.cmake)
+@@ -89,7 +89,7 @@ include(cmakescripts/PackageInfo.cmake)
  
  # Detect CPU type and whether we're building 64-bit or 32-bit code
  math(EXPR BITS "${CMAKE_SIZEOF_VOID_P} * 8")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4589,8 +4589,8 @@
       "port-version": 2
     },
     "libjpeg-turbo": {
-      "baseline": "3.0.2",
-      "port-version": 1
+      "baseline": "3.0.3",
+      "port-version": 0
     },
     "libjuice": {
       "baseline": "1.4.2",

--- a/versions/l-/libjpeg-turbo.json
+++ b/versions/l-/libjpeg-turbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92dfeb0598eab9d20f4512111e795009a9bc7f00",
+      "version": "3.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "90819937ef59097a94e3a8dad79a2eb34b962827",
       "version": "3.0.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
