### PR TITLE
[Jsonifier] Update to v0.9.96

### DIFF
--- a/ports/jsonifier/portfile.cmake
+++ b/ports/jsonifier/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO realtimechris/jsonifier
     REF "v${VERSION}"    
-    SHA512 50f8c244c87bc038251ef13574ae86ce20ca1df9ef1c8fc8de5ebade038a60bb8b98528ce6c978ffe4e0f24b12959a650e8ef5d3c53bcdbd1f187b6cae18493a
+    SHA512 7f86c6634a599fafaba012d30c586340074cbed9d9ac6eadc270da253b725ce9ae9f920d1bf1e60530579b6e4fb4cd5c0eda8c491c0c704da471e4ac05c29c7b
     HEAD_REF main
 )
 

--- a/ports/jsonifier/vcpkg.json
+++ b/ports/jsonifier/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonifier",
-  "version": "0.9.95",
+  "version": "0.9.96",
   "description": "A few classes for parsing and serializing json - very rapidly.",
   "homepage": "https://github.com/realtimechris/jsonifier",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3821,7 +3821,7 @@
       "port-version": 4
     },
     "jsonifier": {
-      "baseline": "0.9.95",
+      "baseline": "0.9.96",
       "port-version": 0
     },
     "jsonnet": {

--- a/versions/j-/jsonifier.json
+++ b/versions/j-/jsonifier.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f2f2b25b98924de736300a7cefc6ff2f3e07449",
+      "version": "0.9.96",
+      "port-version": 0
+    },
+    {
       "git-tree": "23448e65953949d76b27798096a9b13d0d185e25",
       "version": "0.9.95",
       "port-version": 0


### PR DESCRIPTION
Jsonifier 0.9.96 Changes:
----
* Added support for directly prettifying the Json data as it's written.
* Fixed a string parsing issue with sizes.
* Added the ARM-NEON implementation for various string operations.
* Added new simd-based hashmap implementation to improve key find-performance.
* Added a new minimal-char-based hashmap implementation to improve key find-performance.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
