### PR TITLE
[cairo] Fixed build error on arm64-linux

### DIFF
--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_gitlab(
         ${PATCHES}
         fix-alloca-undefine.patch # Upstream PR: https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/520
         cairo_add_lzo_feature_option.patch
+        skip_run_check_on_cross_build.patch
 )
 
 if("fontconfig" IN_LIST FEATURES)
@@ -29,11 +30,15 @@ else()
     list(APPEND OPTIONS -Dfreetype=disabled)
 endif()
 
-if ("x11" IN_LIST FEATURES)
-    message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxft-dev libxext-dev\n")
-    list(APPEND OPTIONS -Dxlib=enabled)
-else()
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
     list(APPEND OPTIONS -Dxlib=disabled)
+else()
+    if ("x11" IN_LIST FEATURES)
+        message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxft-dev libxext-dev\n")
+        list(APPEND OPTIONS -Dxlib=enabled)
+    else()
+        list(APPEND OPTIONS -Dxlib=disabled)
+    endif()
 endif()
 list(APPEND OPTIONS -Dxcb=disabled)
 list(APPEND OPTIONS -Dxlib-xcb=disabled)

--- a/ports/cairo/skip_run_check_on_cross_build.patch
+++ b/ports/cairo/skip_run_check_on_cross_build.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index a1ae2f8..3f86dc9 100644
+--- a/meson.build
++++ b/meson.build
+@@ -376,7 +376,7 @@ if x11_dep.found() and xext_dep.found()
+ 
+   # Can skip the run check by providing the result in a cross file or
+   # native file as bool property value.
+-  prop = meson.get_external_property('ipc_rmid_deferred_release', 'auto')
++  prop = meson.get_external_property('ipc_rmid_deferred_release', meson.is_cross_build() ? 'false' : 'auto')
+   # We don't know the type of prop (bool, string) but need to differentiate
+   # between a set value (bool) or the fallback value (string), so convert to
+   # a string and check the string value.

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cairo",
   "version": "1.18.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "LGPL-2.1-only OR MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1462,7 +1462,7 @@
     },
     "cairo": {
       "baseline": "1.18.0",
-      "port-version": 1
+      "port-version": 2
     },
     "cairomm": {
       "baseline": "1.17.1",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5075d610780fe93fdcebfa346480dfdb88cbc7e",
+      "version": "1.18.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "0fda02793cfc3911468cd200b0a889c65035db1d",
       "version": "1.18.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixed #39583
Fixed #39666

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
