### PR TITLE
[libxml2] Update to 2.11.8 [CVE]

### DIFF
--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/libxml2
     REF "v${VERSION}"
-    SHA512 289d8e30a894a3efde78e06d1cedadc1491f4abdc2c0b653bb5410be48338aacec29e0ca23e1f1cac2725fd4e2114a8d20dcdaa80cf7f5b34302342d6f5efe10
+    SHA512 21f6c0340fab0dc16bfe516493aa7ce96b26abf1719b69862829eaa682d87b7b5ece1d540b7f8c30127becd0691facc278fe1cb50cd2c87320cb6d73b077caf3
     HEAD_REF master
     PATCHES
         disable-docs.patch

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxml2",
-  "version": "2.11.7",
+  "version": "2.11.8",
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5285,7 +5285,7 @@
       "port-version": 2
     },
     "libxml2": {
-      "baseline": "2.11.7",
+      "baseline": "2.11.8",
       "port-version": 0
     },
     "libxmlmm": {

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "acdc173889c739d439e9ded5ee2111cdac6af270",
+      "version": "2.11.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "caa5f663ba4c26ac2402c6aaa56781bd262fc05e",
       "version": "2.11.7",
       "port-version": 0


### PR DESCRIPTION
Fixes CVE-2024-34459.
Without the hassle of API changes which make #39478 a complex change.
Related: #39444.