### PR TITLE
[cnats] Update to 3.8.2

### DIFF
--- a/ports/cnats/lowercase_ws2_32.patch
+++ b/ports/cnats/lowercase_ws2_32.patch
@@ -1,0 +1,19 @@
+Subject: [PATCH] Change "Ws2_32" to "ws2_32" for MinGW compatibility with no adverse effect for native Windows build.
+---
+Index: CMakeLists.txt
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	(revision 1cb8d8cacec14bb9760a50f712b5f62d16ddc91e)
++++ b/CMakeLists.txt	(revision c1d98cd1d3484e3d41b7236fbd272295e9ef72ce)
+@@ -196,7 +196,7 @@
+ elseif(WIN32)
+   set(NATS_LIBDIR "lib")
+   set(NATS_INCLUDE_DIR "include")
+-  set(NATS_EXTRA_LIB "Ws2_32")
++  set(NATS_EXTRA_LIB "ws2_32")
+   set(NATS_OS "_WIN32")
+   set(NATS_PLATFORM_INCLUDE "win")
+   if(sodium_USE_STATIC_LIBS)

--- a/ports/cnats/portfile.cmake
+++ b/ports/cnats/portfile.cmake
@@ -2,11 +2,12 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nats-io/nats.c
     REF "v${VERSION}"
-    SHA512 d32979a686420fe23af96b58efcf366ff9ff315531ca54962f2ae8ae7126174b5ca10a74152cc14f49be1143d0ad7dd5a68beeb31126410c76dbaa0468a45382
+    SHA512 4cc127a461a5074d8a49d8cee633577951152cd54f57b4118ff6e4a8c0da73e2f61e9e54546a34c9e79a4557165a80bedc7e9cf6ed0fde28134019eb59a241b9
     HEAD_REF main
     PATCHES
         fix-sodium-dep.patch
         fix_install_path.patch
+        lowercase_ws2_32.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/cnats/vcpkg.json
+++ b/ports/cnats/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cnats",
-  "version": "3.8.0",
+  "version": "3.8.2",
   "description": "A C client for the NATS messaging system",
   "homepage": "https://github.com/nats-io/nats.c",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1733,7 +1733,7 @@
       "port-version": 3
     },
     "cnats": {
-      "baseline": "3.8.0",
+      "baseline": "3.8.2",
       "port-version": 0
     },
     "cnl": {

--- a/versions/c-/cnats.json
+++ b/versions/c-/cnats.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a521d9641d065db79cce09b63daef612a0a34c41",
+      "version": "3.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "963d6b12fba8001c650cc6d56a21a1a5122cf845",
       "version": "3.8.0",
       "port-version": 0


### PR DESCRIPTION
Updates cnats to 3.8.2.
Supports MinGW builds with `lowercase_ws2_32.patch`. This issue will also be [fixed upstream](https://github.com/nats-io/nats.c/pull/763) in the next release.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.~~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
