### PR TITLE
[sese] update to 2.2.0

### DIFF
--- a/ports/sese/portfile.cmake
+++ b/ports/sese/portfile.cmake
@@ -16,7 +16,7 @@ set(SOURCE_PATH ${CURRENT_BUILDTRESS_DIR}/sese)
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO libsese/sese
-        REF ${VERSION}
+        REF "${VERSION}"
         SHA512 6a87cabe6cbd69ab41de85be27ff397c1ae49f95c11151a27e8b9329afe4ff3b580084be53c129e883be50e13fadccb3b6cc1eed833c44ce4f8457dedc71b758
 )
 

--- a/ports/sese/portfile.cmake
+++ b/ports/sese/portfile.cmake
@@ -16,18 +16,19 @@ set(SOURCE_PATH ${CURRENT_BUILDTRESS_DIR}/sese)
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO libsese/sese
-        REF "${VERSION}"
-        SHA512 e7c3e014ff2eaecf9968c4fa304ec98445b57458b87da1c4af17f41655565b3cc187e07189ee280104e07b1511f6e2c490a3c689d49d8982d054fc9a462fe136
+        REF ${VERSION}
+        SHA512 6a87cabe6cbd69ab41de85be27ff397c1ae49f95c11151a27e8b9329afe4ff3b580084be53c129e883be50e13fadccb3b6cc1eed833c44ce4f8457dedc71b758
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         FEATURES
-        tests        SESE_BUILD_TEST
-        mysql        SESE_DB_USE_MARIADB
-        sqlite3      SESE_DB_USE_SQLITE
-        psql         SESE_DB_USE_POSTGRES
-        async-logger SESE_USE_ASYNC_LOGGER
-        archive      SESE_USE_ARCHIVE
+        tests            SESE_BUILD_TEST
+        mysql            SESE_DB_USE_MARIADB
+        sqlite3          SESE_DB_USE_SQLITE
+        psql             SESE_DB_USE_POSTGRES
+        async-logger     SESE_USE_ASYNC_LOGGER
+        archive          SESE_USE_ARCHIVE
+        replace-execinfo SESE_REPLACE_EXECINFO
 )
 
 vcpkg_cmake_configure(
@@ -42,6 +43,8 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/sese")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 remove_empty_directories_recursive("${CURRENT_PACKAGES_DIR}/include/sese")
+
+vcpkg_copy_pdbs()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE" "${SOURCE_PATH}/NOTICE")
 

--- a/ports/sese/vcpkg.json
+++ b/ports/sese/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sese",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "A cross-platform framework for basic components.",
   "homepage": "https://github.com/libsese/sese",
   "license": "Apache-2.0",
@@ -48,6 +48,12 @@
         "libpq"
       ]
     },
+    "replace-execinfo": {
+      "description": "replace the system execinfo implementation",
+      "dependencies": [
+        "libunwind"
+      ]
+    },
     "sqlite3": {
       "description": "add sqlite3 support",
       "dependencies": [
@@ -57,6 +63,7 @@
     "tests": {
       "description": "build the unit test",
       "dependencies": [
+        "benchmark",
         "gtest"
       ]
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8109,7 +8109,7 @@
       "port-version": 0
     },
     "sese": {
-      "baseline": "2.1.2",
+      "baseline": "2.2.0",
       "port-version": 0
     },
     "sf2cute": {

--- a/versions/s-/sese.json
+++ b/versions/s-/sese.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "c68004d1e51579448d9f1a6ad2a5bcdf6bc9fe4b",
-      "version": "2.1.2",
+      "git-tree": "88a5c18ee7034225648425a15cc5c3840359f813",
+      "version": "2.2.0",
       "port-version": 0
     }
   ]

--- a/versions/s-/sese.json
+++ b/versions/s-/sese.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "88a5c18ee7034225648425a15cc5c3840359f813",
+      "git-tree": "2c0343b399dfd14e5d1c07c3773ea4ce10dde345",
       "version": "2.2.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.