### PR TITLE
[dbus] does not build on android and ios

### DIFF
--- a/ports/dbus/vcpkg.json
+++ b/ports/dbus/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "dbus",
   "version": "1.15.8",
-  "port-version": 4,
+  "port-version": 5,
   "description": "D-Bus specification and reference implementation, including libdbus and dbus-daemon",
   "homepage": "https://gitlab.freedesktop.org/dbus/dbus",
   "license": "AFL-2.1 OR GPL-2.0-or-later",
-  "supports": "!uwp & !staticcrt",
+  "supports": "!uwp & !staticcrt & !android & !ios",
   "dependencies": [
     "expat",
     {

--- a/ports/qtconnectivity/vcpkg.json
+++ b/ports/qtconnectivity/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtconnectivity",
   "version": "6.7.2",
+  "port-version": 1,
   "description": "The Qt Connectivity module provides access to Bluetooth and NFC hardware.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -19,7 +20,7 @@
       "features": [
         "dbus"
       ],
-      "platform": "!(windows & static)"
+      "platform": "!(windows & static) & !android & !ios"
     }
   ]
 }

--- a/ports/qtsensors/vcpkg.json
+++ b/ports/qtsensors/vcpkg.json
@@ -1,17 +1,22 @@
 {
   "name": "qtsensors",
   "version": "6.7.2",
+  "port-version": 1,
   "description": "The Qt Sensors API provides access to sensor hardware via QML and C++ interfaces. The Qt Sensors API also provides a motion gesture recognition API for devices.",
   "homepage": "https://www.qt.io/",
   "license": null,
   "dependencies": [
     {
       "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "qtbase",
       "default-features": false,
       "features": [
         "dbus"
       ],
-      "platform": "!(windows & static)"
+      "platform": "!(windows & static) & !android & !ios"
     },
     {
       "name": "qtconnectivity",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2206,7 +2206,7 @@
     },
     "dbus": {
       "baseline": "1.15.8",
-      "port-version": 4
+      "port-version": 5
     },
     "dcmtk": {
       "baseline": "3.6.8",
@@ -7382,7 +7382,7 @@
     },
     "qtconnectivity": {
       "baseline": "6.7.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtdatavis3d": {
       "baseline": "6.7.2",
@@ -7490,7 +7490,7 @@
     },
     "qtsensors": {
       "baseline": "6.7.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtserialbus": {
       "baseline": "6.7.2",

--- a/versions/d-/dbus.json
+++ b/versions/d-/dbus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce28359a2d828a06b421d8a7b3841f83d98f0ed4",
+      "version": "1.15.8",
+      "port-version": 5
+    },
+    {
       "git-tree": "0d922ac71a87fc0b7ca31eb4820639b887cc2450",
       "version": "1.15.8",
       "port-version": 4

--- a/versions/q-/qtconnectivity.json
+++ b/versions/q-/qtconnectivity.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e29a9fda18148ad48a6da12bf66416045cc59704",
+      "version": "6.7.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "821b00228f3a81b83def29d6247cfed22af846a1",
       "version": "6.7.2",
       "port-version": 0

--- a/versions/q-/qtsensors.json
+++ b/versions/q-/qtsensors.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0fe4dfe56c75438cb1b385d63ab6ca197b7c1482",
+      "version": "6.7.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "1d1dbeb9ae710c360b48b8f0de16fc84fbe4279e",
       "version": "6.7.2",
       "port-version": 0


### PR DESCRIPTION
`dbus` fails to build on android and ios.
This recovers `qtconnectivity` and `qtsensors` by building them without this dependency.