### PR TITLE
 [fftw3] Fix the wrong package version

### DIFF
--- a/ports/fftw3/fix-wrong-version.patch
+++ b/ports/fftw3/fix-wrong-version.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bc150c6..39a49fb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -283,7 +283,7 @@ if (HAVE_AVX2)
+   list (APPEND SOURCEFILES ${fftw_dft_simd_avx2_SOURCE} ${fftw_rdft_simd_avx2_SOURCE})
+ endif ()
+ 
+-set (FFTW_VERSION 3.3.9)
++set (FFTW_VERSION 3.3.10)
+ 
+ set (PREC_SUFFIX)
+ if (ENABLE_FLOAT)

--- a/ports/fftw3/portfile.cmake
+++ b/ports/fftw3/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_extract_source_archive(
         bigobj.patch
         fix-openmp.patch
         install-subtargets.patch
+        fix-wrong-version.patch # https://github.com/FFTW/fftw3/commit/0842f00ae6b6e1f3aade155bc0edd17a7313fa6a
 )
 
 vcpkg_check_features(

--- a/ports/fftw3/vcpkg.json
+++ b/ports/fftw3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fftw3",
   "version": "3.3.10",
-  "port-version": 8,
+  "port-version": 9,
   "description": "FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data (as well as of even/odd data, i.e. the discrete cosine/sine transforms or DCT/DST).",
   "homepage": "https://www.fftw.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2698,7 +2698,7 @@
     },
     "fftw3": {
       "baseline": "3.3.10",
-      "port-version": 8
+      "port-version": 9
     },
     "fftwpp": {
       "baseline": "2019-12-19",

--- a/versions/f-/fftw3.json
+++ b/versions/f-/fftw3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d64246f2b42f53756787bd4f886488846a789030",
+      "version": "3.3.10",
+      "port-version": 9
+    },
+    {
       "git-tree": "824a4cda47df1a63c0b13f2a603e7d0fb0dac900",
       "version": "3.3.10",
       "port-version": 8


### PR DESCRIPTION
Fixes #39717

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
