### PR TITLE
[ableton-link] use right variables

### DIFF
--- a/ports/ableton-link/portfile.cmake
+++ b/ports/ableton-link/portfile.cmake
@@ -39,7 +39,7 @@ endif()
 
 set(NEED_ASIOSDK OFF)
 if ("hut" IN_LIST FEATURES)
-  if(WIN32)
+  if(VCPKG_TARGET_IS_WINDOWS)
     # Need Steinberg ASIO audio driver SDK (only this low-latency audio driver makes the developer tool 'hut' useful on Windows)
     set(NEED_ASIOSDK ON)
   endif()

--- a/ports/ableton-link/vcpkg.json
+++ b/ports/ableton-link/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ableton-link",
   "version": "3.1.1",
+  "port-version": 1,
   "description": "Ableton Link, a technology that synchronizes musical beat, tempo, and phase across multiple applications running on one or more devices.",
   "homepage": "https://www.ableton.com/en/link/",
   "documentation": "http://ableton.github.io/link/",

--- a/versions/a-/ableton-link.json
+++ b/versions/a-/ableton-link.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8eccb8fd47b4f50d9963694746c4dd53a8c6ac22",
+      "version": "3.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "1e486a5e643aafc9810b1e4c2d9c3da1d3e2d156",
       "version": "3.1.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -14,7 +14,7 @@
     },
     "ableton-link": {
       "baseline": "3.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "abseil": {
       "baseline": "20240116.2",


### PR DESCRIPTION
Fixes 
```
CMake Error at scripts/ports.cmake:167 (message):
  Unexpected UNKNOWN_READ_ACCESS on variable WIN32 in script mode.

  This variable name insufficiently expresses whether it refers to the target
  system or to the host system.  Use a prefixed variable instead.

  - Variables providing information about the host:

    CMAKE_HOST_<SYSTEM>
    VCPKG_HOST_IS_<SYSTEM>

  - Variables providing information about the target:

    VCPKG_TARGET_IS_<SYSTEM>
    VCPKG_DETECTED_<VARIABLE> (using vcpkg_cmake_get_vars)

Call Stack (most recent call first):
  ports/ableton-link/portfile.cmake:9223372036854775807 (z_vcpkg_warn_ambiguous_system_variables)
  ports/ableton-link/portfile.cmake:42 (if)
  scripts/ports.cmake:191 (include)
```