### PR TITLE
[libsvm] use right var

### DIFF
--- a/ports/libsvm/portfile.cmake
+++ b/ports/libsvm/portfile.cmake
@@ -29,7 +29,7 @@ vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(PACKAGE_NAME "unofficial-${PORT}" CONFIG_PATH "share/unofficial-${PORT}")
 
 if("tools" IN_LIST FEATURES)
-    if(WIN32)
+    if(VCPKG_TARGET_IS_WINDOWS)
         vcpkg_copy_tools(TOOL_NAMES svm-predict svm-scale svm-toy svm-train AUTO_CLEAN)
     else()
         vcpkg_copy_tools(TOOL_NAMES svm-predict svm-scale svm-train AUTO_CLEAN)

--- a/ports/libsvm/vcpkg.json
+++ b/ports/libsvm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libsvm",
   "version": "3.32",
+  "port-version": 1,
   "description": "A library for Support Vector Machines.",
   "homepage": "https://www.csie.ntu.edu.tw/~cjlin/libsvm/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5066,7 +5066,7 @@
     },
     "libsvm": {
       "baseline": "3.32",
-      "port-version": 0
+      "port-version": 1
     },
     "libsystemd": {
       "baseline": "256.2",

--- a/versions/l-/libsvm.json
+++ b/versions/l-/libsvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d4da9c9b61dde9237ef3eed114e812e46a923e1a",
+      "version": "3.32",
+      "port-version": 1
+    },
+    {
       "git-tree": "322988838e09b1a1ce9766a803eab0e9867e0e1d",
       "version": "3.32",
       "port-version": 0


### PR DESCRIPTION
Fixes
```
CMake Error at scripts/ports.cmake:167 (message):
  Unexpected UNKNOWN_READ_ACCESS on variable WIN32 in script mode.

  This variable name insufficiently expresses whether it refers to the target
  system or to the host system.  Use a prefixed variable instead.

  - Variables providing information about the host:

    CMAKE_HOST_<SYSTEM>
    VCPKG_HOST_IS_<SYSTEM>

  - Variables providing information about the target:

    VCPKG_TARGET_IS_<SYSTEM>
    VCPKG_DETECTED_<VARIABLE> (using vcpkg_cmake_get_vars)

Call Stack (most recent call first):
  ports/libsvm/portfile.cmake:9223372036854775807 (z_vcpkg_warn_ambiguous_system_variables)
  ports/libsvm/portfile.cmake:32 (if)
  scripts/ports.cmake:191 (include)
```