### PR TITLE
[nanopb] use right var

### DIFF
--- a/ports/nanopb/portfile.cmake
+++ b/ports/nanopb/portfile.cmake
@@ -43,7 +43,7 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 if(nanopb_BUILD_GENERATOR)
     file(INSTALL "${CURRENT_PACKAGES_DIR}/bin/generator/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
-    if(WIN32)
+    if(VCPKG_TARGET_IS_WINDOWS)
         file(INSTALL "${CURRENT_PACKAGES_DIR}/bin/nanopb_generator.bat" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
         file(INSTALL "${CURRENT_PACKAGES_DIR}/bin/protoc-gen-nanopb.bat" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
     else()

--- a/ports/nanopb/vcpkg.json
+++ b/ports/nanopb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nanopb",
   "version-semver": "0.4.8",
+  "port-version": 1,
   "description": "A small code-size Protocol Buffers implementation in ANSI C.",
   "homepage": "https://jpa.kapsi.fi/nanopb/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6098,7 +6098,7 @@
     },
     "nanopb": {
       "baseline": "0.4.8",
-      "port-version": 0
+      "port-version": 1
     },
     "nanoprintf": {
       "baseline": "0.3.4",

--- a/versions/n-/nanopb.json
+++ b/versions/n-/nanopb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08dcb204cd192ab2022b8d2f1f84cf480db0fb44",
+      "version-semver": "0.4.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "4081435b822c87880779d5b6e9a763ee0389aa79",
       "version-semver": "0.4.8",
       "port-version": 0


### PR DESCRIPTION
Fixes
```
CMake Error at scripts/ports.cmake:167 (message):
  Unexpected UNKNOWN_READ_ACCESS on variable WIN32 in script mode.

  This variable name insufficiently expresses whether it refers to the target
  system or to the host system.  Use a prefixed variable instead.

  - Variables providing information about the host:

    CMAKE_HOST_<SYSTEM>
    VCPKG_HOST_IS_<SYSTEM>

  - Variables providing information about the target:

    VCPKG_TARGET_IS_<SYSTEM>
    VCPKG_DETECTED_<VARIABLE> (using vcpkg_cmake_get_vars)

Call Stack (most recent call first):
  ports/nanopb/portfile.cmake:9223372036854775807 (z_vcpkg_warn_ambiguous_system_variables)
  ports/nanopb/portfile.cmake:46 (if)
  scripts/ports.cmake:191 (include)
```