### PR TITLE
[libsrt] use right var

### DIFF
--- a/ports/libsrt/portfile.cmake
+++ b/ports/libsrt/portfile.cmake
@@ -34,7 +34,7 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
 if(ENABLE_APPS)
-    if(NOT MINGW)
+    if(NOT VCPKG_TARGET_IS_MINGW)
         vcpkg_copy_tools(TOOL_NAMES srt-tunnel AUTO_CLEAN)
     endif()
     vcpkg_copy_tools(TOOL_NAMES srt-file-transmit srt-live-transmit AUTO_CLEAN)

--- a/ports/libsrt/vcpkg.json
+++ b/ports/libsrt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsrt",
   "version": "1.5.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Secure Reliable Transport (SRT) is an open source transport technology that optimizes streaming performance across unpredictable networks, such as the Internet.",
   "homepage": "https://github.com/Haivision/srt",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5042,7 +5042,7 @@
     },
     "libsrt": {
       "baseline": "1.5.3",
-      "port-version": 1
+      "port-version": 2
     },
     "libsrtp": {
       "baseline": "2.5.0",

--- a/versions/l-/libsrt.json
+++ b/versions/l-/libsrt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "578c7b45771245ff525647973280f997fef43d9b",
+      "version": "1.5.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "0ef5c07af28fb2b9c3ea49b40716593f14c48b8b",
       "version": "1.5.3",
       "port-version": 1


### PR DESCRIPTION
Fixes
```
CMake Error at scripts/ports.cmake:167 (message):
  Unexpected UNKNOWN_READ_ACCESS on variable MINGW in script mode.

  This variable name insufficiently expresses whether it refers to the target
  system or to the host system.  Use a prefixed variable instead.

  - Variables providing information about the host:

    CMAKE_HOST_<SYSTEM>
    VCPKG_HOST_IS_<SYSTEM>

  - Variables providing information about the target:

    VCPKG_TARGET_IS_<SYSTEM>
    VCPKG_DETECTED_<VARIABLE> (using vcpkg_cmake_get_vars)

Call Stack (most recent call first):
  ports/libsrt/portfile.cmake:9223372036854775807 (z_vcpkg_warn_ambiguous_system_variables)
  ports/libsrt/portfile.cmake:37 (if)
  scripts/ports.cmake:191 (include)
```