### PR TITLE
[thrift] Update thrift 0.20.0 git reference

### DIFF
--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_find_acquire_program(BISON)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/thrift
-    REF "${VERSION}"
+    REF "v${VERSION}"
     SHA512 5e4ee9870b30fe5ba484d39781c435716f7f3903793dc8aae96594ca813b1a5a73363b84719038ca8fa3ab8ef0a419a28410d936ff7b3bbadf36fc085a6883ae
     HEAD_REF master
     PATCHES

--- a/ports/thrift/vcpkg.json
+++ b/ports/thrift/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "thrift",
   "version": "0.20.0",
+  "port-version": 1,
   "description": "Apache Thrift is a software project spanning a variety of programming languages and use cases. Our goal is to make reliable, performant communication and data serialization across languages as efficient and seamless as possible.",
   "homepage": "https://github.com/apache/thrift",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8730,7 +8730,7 @@
     },
     "thrift": {
       "baseline": "0.20.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tidy-html5": {
       "baseline": "5.8.0",

--- a/versions/t-/thrift.json
+++ b/versions/t-/thrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13757a6b05741cf3c9c39e3a1dcc5e5cd685e025",
+      "version": "0.20.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6855be1ce96497811d4eb0a9879baf6cf1b3610c",
       "version": "0.20.0",
       "port-version": 0


### PR DESCRIPTION
This is a candidate fix for the Thrift build failure identified in #39786. 

The PR updates the port to reference the `v0.20.0` tag instead of the `0.20.0` branch.

Fixes #39786.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
