### PR TITLE
[CI][GTK] Fix vulkan_enabled bug in GTK

### DIFF
--- a/ports/gtk/fix_vulkan_enabled.patch
+++ b/ports/gtk/fix_vulkan_enabled.patch
@@ -1,13 +1,12 @@
 diff --git a/meson.build b/meson.build
-index 5ade7c2..927ce79 100644
+index 5ade7c2..9f48161 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -123,7 +123,7 @@ os_unix = not os_win32
+@@ -123,7 +123,6 @@ os_unix = not os_win32
  
  if os_darwin
    wayland_enabled = false
 -  vulkan_enabled = false
-+  vulkan_enabled = vulkan_enabled.disable_if(true)
  else
    macos_enabled = false
  endif

--- a/ports/gtk/fix_vulkan_enabled.patch
+++ b/ports/gtk/fix_vulkan_enabled.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 5ade7c2..927ce79 100644
+--- a/meson.build
++++ b/meson.build
+@@ -123,7 +123,7 @@ os_unix = not os_win32
+ 
+ if os_darwin
+   wayland_enabled = false
+-  vulkan_enabled = false
++  vulkan_enabled = vulkan_enabled.disable_if(true)
+ else
+   macos_enabled = false
+ endif

--- a/ports/gtk/portfile.cmake
+++ b/ports/gtk/portfile.cmake
@@ -60,7 +60,6 @@ vcpkg_configure_meson(
         -Dman-pages=false
         -Dmedia-gstreamer=disabled  # Build the gstreamer media backend
         -Dprint-cups=disabled       # Build the cups print backend
-        -Dvulkan=disabled           # Enable support for the Vulkan graphics API
         -Dcloudproviders=disabled   # Enable the cloudproviders support
         -Dsysprof=disabled          # include tracing support for sysprof
         -Dtracker=disabled          # Enable Tracker3 filechooser search

--- a/ports/gtk/portfile.cmake
+++ b/ports/gtk/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_gitlab(
     HEAD_REF master # branch name
     PATCHES
         0001-build.patch
+        fix_vulkan_enabled.patch
 )
 
 vcpkg_find_acquire_program(PKGCONFIG)
@@ -60,6 +61,7 @@ vcpkg_configure_meson(
         -Dman-pages=false
         -Dmedia-gstreamer=disabled  # Build the gstreamer media backend
         -Dprint-cups=disabled       # Build the cups print backend
+        -Dvulkan=disabled           # Enable support for the Vulkan graphics API
         -Dcloudproviders=disabled   # Enable the cloudproviders support
         -Dsysprof=disabled          # include tracing support for sysprof
         -Dtracker=disabled          # Enable Tracker3 filechooser search

--- a/ports/gtk/vcpkg.json
+++ b/ports/gtk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gtk",
   "version": "4.14.0",
+  "port-version": 1,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3254,7 +3254,7 @@
     },
     "gtk": {
       "baseline": "4.14.0",
-      "port-version": 0
+      "port-version": 1
     },
     "gtk3": {
       "baseline": "3.24.38",

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3bf31e38dfdb8e00caded9dd921cb5090666bdbb",
+      "git-tree": "4a2c53b5715720e68051e3d26bfa56a83b6c8de0",
       "version": "4.14.0",
       "port-version": 1
     },

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "17da7ea2df735058995ffddbf62b962b1b28add7",
+      "git-tree": "3bf31e38dfdb8e00caded9dd921cb5090666bdbb",
       "version": "4.14.0",
       "port-version": 1
     },

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17da7ea2df735058995ffddbf62b962b1b28add7",
+      "version": "4.14.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d5ba4a94cd8433f563ba1519395f202d29bd8790",
       "version": "4.14.0",
       "port-version": 0


### PR DESCRIPTION
gtk:x64-osx is failing in [CI](https://dev.azure.com/vcpkg/public/_build/results?buildId=104733&view=results).

The error message indicates that the Meson build system cannot find the `glslc` shader compiler, but that is provided by Vulkan which is not on macOS. Looks like `vulkan_enabled` is being [overwritten](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/meson.build?ref_type=heads#L131) to false turning `glslc` into an optional dependency.