### PR TITLE
[mnn] Fix feature opencl compilation error under Linux

### DIFF
--- a/ports/mnn/fix-linux.patch
+++ b/ports/mnn/fix-linux.patch
@@ -1,0 +1,44 @@
+diff --git a/source/backend/cpu/CPUFixedPoint.hpp b/source/backend/cpu/CPUFixedPoint.hpp
+index a5c44f9..fd2e979 100644
+--- a/source/backend/cpu/CPUFixedPoint.hpp
++++ b/source/backend/cpu/CPUFixedPoint.hpp
+@@ -17,7 +17,7 @@ limitations under the License.
+ #define CPUFixedPoint_HPP
+ 
+ #include <math.h>
+-#include <stdint.h>
++#include <cstdint>
+ #include <limits>
+ #include <stdexcept>
+ #include <algorithm>
+diff --git a/source/backend/opencl/schema/current/CLCache_generated.h b/source/backend/opencl/schema/current/CLCache_generated.h
+index 434a666..fc972b5 100644
+--- a/source/backend/opencl/schema/current/CLCache_generated.h
++++ b/source/backend/opencl/schema/current/CLCache_generated.h
+@@ -403,7 +403,7 @@ inline const flatbuffers::TypeTable *ShaderTypeTable() {
+     "buildInfo"
+   };
+   static const flatbuffers::TypeTable tt = {
+-    flatbuffers::ST_TABLE, 3, type_codes, nullptr, nullptr, names
++    flatbuffers::ST_TABLE, 3, type_codes, nullptr, nullptr, nullptr, names
+   };
+   return &tt;
+ }
+@@ -420,7 +420,7 @@ inline const flatbuffers::TypeTable *AutotuningTypeTable() {
+     "localSize"
+   };
+   static const flatbuffers::TypeTable tt = {
+-    flatbuffers::ST_TABLE, 3, type_codes, nullptr, nullptr, names
++    flatbuffers::ST_TABLE, 3, type_codes, nullptr, nullptr, nullptr, names
+   };
+   return &tt;
+ }
+@@ -439,7 +439,7 @@ inline const flatbuffers::TypeTable *CacheTypeTable() {
+     "tunings"
+   };
+   static const flatbuffers::TypeTable tt = {
+-    flatbuffers::ST_TABLE, 2, type_codes, type_refs, nullptr, names
++    flatbuffers::ST_TABLE, 2, type_codes, type_refs, nullptr, nullptr, names
+   };
+   return &tt;
+ }

--- a/ports/mnn/portfile.cmake
+++ b/ports/mnn/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         use-package-and-install.patch
+        fix-linux.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/mnn/vcpkg.json
+++ b/ports/mnn/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mnn",
   "version": "1.1.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "MNN is a blazing fast, lightweight deep learning framework, battle-tested by business-critical use cases in Alibaba",
   "homepage": "https://www.mnn.zone/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5866,7 +5866,7 @@
     },
     "mnn": {
       "baseline": "1.1.0",
-      "port-version": 5
+      "port-version": 6
     },
     "modern-cpp-kafka": {
       "baseline": "2023.03.07",

--- a/versions/m-/mnn.json
+++ b/versions/m-/mnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af18b8b69d85424bc490584793f69b7abb368947",
+      "version": "1.1.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "4f755e0b91f277b483ce9b157d7e10fb99b49878",
       "version": "1.1.0",
       "port-version": 5


### PR DESCRIPTION
Fix one of the issues in issue [32398](https://github.com/microsoft/vcpkg/issues/32398).

1. Use upstream PR [2645](https://github.com/alibaba/MNN/pull/2645) to fixes the following issue.
`error: ‘int32_t’ is not a member of ‘std’ `
2. The following problem is caused by the change in the definition of the [TypeTable](https://github.com/google/flatbuffers/blob/master/include/flatbuffers/flatbuffers.h) structure. Adding the initialization of the variables added to the structure fixes the problem. The same [issue](https://github.com/alibaba/MNN/issues/1832) existed upstream but was not fixed, so a patch was done locally.
```
/mnt/vcpkg/buildtrees/mnn/src/1.1.0-9f04ab166e/source/backend/opencl/schema/current/CLCache_generated.h:406:61: error: cannot convert ‘const char* const*’ to ‘const int64_t*’ {aka ‘const long int*’} in initialization
  406 |     flatbuffers::ST_TABLE, 3, type_codes, nullptr, nullptr, names
      |                                                             ^~~~~
      |                                                             |
      |                                                             const char* const*
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

The feature test pass with following triplets:

```
x64-windows
x64-linux
```