### PR TITLE
[stdexec] Move all downloads to portfile, use stable refs

### DIFF
--- a/ports/stdexec/portfile.cmake
+++ b/ports/stdexec/portfile.cmake
@@ -1,3 +1,4 @@
+set(VCPKG_BUILD_TYPE release) # header-only
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -30,8 +31,6 @@ vcpkg_download_distfile(execution_bs
     SHA512 90bb992356f22e4091ed35ca922f6a0143abd748499985553c0660eaf49f88d031a8f900addb6b4cf9a39ac8d1ab7c858b79677e2459136a640b2c52afe3dd23
 )
 file(COPY "${execution_bs}" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/")
-
-set(VCPKG_BUILD_TYPE release)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/stdexec/portfile.cmake
+++ b/ports/stdexec/portfile.cmake
@@ -55,6 +55,8 @@ vcpkg_from_github(
         "${SOURCE_PATH}/cmake/cpm/patches/icm/regex-build-error.diff"
 )
 
+vcpkg_find_acquire_program(GIT)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -63,6 +65,7 @@ vcpkg_cmake_configure(
         "-DFETCHCONTENT_SOURCE_DIR_RAPIDS-CMAKE=${SOURCE_PATH_RAPIDS}"
         "-DCPM_SOURCE_CACHE=${CURRENT_BUILDTREES_DIR}/cpm"
         "-DCPM_icm_SOURCE=${SOURCE_PATH_ICM}"
+        "-DGIT_EXECUTABLE=${GIT}"
 )
 
 vcpkg_cmake_install()

--- a/ports/stdexec/portfile.cmake
+++ b/ports/stdexec/portfile.cmake
@@ -13,8 +13,8 @@ vcpkg_from_github(
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH_RAPIDS
     REPO rapidsai/rapids-cmake
-    REF c7a28304639a2ed460181b4753f3280c7833c718
-    SHA512 9a87fdef490199337778b8c9b4df31ca37d65df23803d058f13b406dcfda4d96d992b2780b0b878b61b027c0dc848351496a0f32e779f95298f259bab040b49b
+    REF v24.02.01 # stable tag (stdexec wants branch-24.02)
+    SHA512 bb8f2b1177f6451d61f2de26f39fd6d31c2f0fb80b4cd1409edc3e6e4f726e80716ec177d510d0f31b8f39169cd8b58290861f0f217daedbd299e8e426d25891
     HEAD_REF main
 )
 vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt" 

--- a/ports/stdexec/portfile.cmake
+++ b/ports/stdexec/portfile.cmake
@@ -23,7 +23,7 @@ vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt"
 )
 
 vcpkg_download_distfile(execution_bs
-    URLS "https://raw.githubusercontent.com/cplusplus/sender-receiver/main/execution.bs"
+    URLS "https://raw.githubusercontent.com/cplusplus/sender-receiver/12fde4af201017e49efd39178126f661a04dbb94/execution.bs"
     FILENAME "execution.bs"
     SHA512 90bb992356f22e4091ed35ca922f6a0143abd748499985553c0660eaf49f88d031a8f900addb6b4cf9a39ac8d1ab7c858b79677e2459136a640b2c52afe3dd23
 )

--- a/ports/stdexec/portfile.cmake
+++ b/ports/stdexec/portfile.cmake
@@ -17,27 +17,27 @@ vcpkg_from_github(
     SHA512 9a87fdef490199337778b8c9b4df31ca37d65df23803d058f13b406dcfda4d96d992b2780b0b878b61b027c0dc848351496a0f32e779f95298f259bab040b49b
     HEAD_REF main
 )
-
-vcpkg_download_distfile(RAPIDS_cmake
-    URLS "https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.02/RAPIDS.cmake"
-    FILENAME "RAPIDS.cmake"
-    SHA512 e7830364222a9ea46fe7756859dc8d36e401c720f6a49880a2945a9ebc5bd9aa7e40a8bd382e1cae3af4235d5c9a7998f38331e23b676af7c5c72e7f00e61f0c
+vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt" 
+    [[file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-24.02/RAPIDS.cmake]]
+    "file(COPY_FILE \"${SOURCE_PATH_RAPIDS}/RAPIDS.cmake\""
 )
-file(COPY "${RAPIDS_cmake}" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/")
 
 vcpkg_download_distfile(execution_bs
     URLS "https://raw.githubusercontent.com/cplusplus/sender-receiver/main/execution.bs"
     FILENAME "execution.bs"
     SHA512 90bb992356f22e4091ed35ca922f6a0143abd748499985553c0660eaf49f88d031a8f900addb6b4cf9a39ac8d1ab7c858b79677e2459136a640b2c52afe3dd23
 )
-file(COPY "${execution_bs}" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/")
+vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt" 
+    [[file(DOWNLOAD "https://raw.githubusercontent.com/cplusplus/sender-receiver/main/execution.bs"]]
+    "file(COPY_FILE \"${execution_bs}\""
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSTDEXEC_BUILD_TESTS=OFF
         -DSTDEXEC_BUILD_EXAMPLES=OFF
-        -DFETCHCONTENT_SOURCE_DIR_RAPIDS-CMAKE="${SOURCE_PATH_RAPIDS}"
+        "-DFETCHCONTENT_SOURCE_DIR_RAPIDS-CMAKE=${SOURCE_PATH_RAPIDS}"
 )
 
 vcpkg_cmake_install()

--- a/ports/stdexec/vcpkg.json
+++ b/ports/stdexec/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "stdexec",
   "version-date": "2024-06-16",
-  "port-version": 1,
+  "port-version": 2,
   "description": "stdexec is an experimental reference implementation of the Senders model of asynchronous programming proposed by P2300 - std::execution for adoption into the C++ Standard.",
   "homepage": "https://github.com/NVIDIA/stdexec",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8526,7 +8526,7 @@
     },
     "stdexec": {
       "baseline": "2024-06-16",
-      "port-version": 1
+      "port-version": 2
     },
     "stduuid": {
       "baseline": "1.2.3",

--- a/versions/s-/stdexec.json
+++ b/versions/s-/stdexec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fc0ad57a43ae985ba4836f1a18953eddfde39e69",
+      "version-date": "2024-06-16",
+      "port-version": 2
+    },
+    {
       "git-tree": "1bc8de1856cd06c3b1c1a04c580ef085b3f766ab",
       "version-date": "2024-06-16",
       "port-version": 1

--- a/versions/s-/stdexec.json
+++ b/versions/s-/stdexec.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fc0ad57a43ae985ba4836f1a18953eddfde39e69",
+      "git-tree": "06777edff8fc92c3716e6a800ae44c8c80cf8af3",
       "version-date": "2024-06-16",
       "port-version": 2
     },


### PR DESCRIPTION
The changes which should have been part of https://github.com/microsoft/vcpkg/pull/39756:

 - Move ALL downloads to the portfile.
   Fixes offline builds and asset caching.
   Admittedly, a hard case with rapids-cmake *and* cpm.
 - Use STABLE git refs for downloads, not git branches.
   Fixes foreseeable - and now observed - baseline regression.
 - Update rapids-cmake.

