### PR TITLE
[sese] fix fmt error

### DIFF
--- a/ports/sese/001-fix-fmt-error.patch
+++ b/ports/sese/001-fix-fmt-error.patch
@@ -1,0 +1,138 @@
+diff --git a/alpine-x64.dockerfile b/alpine-x64.dockerfile
+index d24c0d661..1e84ea96e 100644
+--- a/alpine-x64.dockerfile
++++ b/alpine-x64.dockerfile
+@@ -1,27 +1,11 @@
+ FROM amd64/alpine:3.20.1
+ 
+-RUN apk add \
+-    samurai \
+-    ninja-build \
+-    autoconf \
+-    automake \
+-    gcc \
+-    g++ \
+-    cmake \
+-    git \
+-    libtool \
+-    libunwind-dev \
+-    gtest-dev \
+-    benchmark-dev \
+-    sqlite-dev \
+-    libpq-dev \
+-    mariadb-connector-c-dev \
+-    asio-dev \
+-    openssl-dev \
+-    libarchive-dev \
+-    python3 \
+-    py3-pip \
+-    doxygen
++RUN apk add samurai ninja-build autoconf automake gcc g++ cmake
++
++RUN apk add libtool libunwind-dev gtest-dev benchmark-dev sqlite-dev libpq-dev mariadb-connector-c-dev \
++    asio-dev openssl-dev libarchive-dev python3 py3-pip
++
++RUN apk add doxygen mariadb-client postgresql-client
+ 
+ COPY ./requirements.txt /tmp/requirements.txt
+ 
+diff --git a/sese/internal/db/impl/sqlite/SqlitePreparedStatementImpl.cpp b/sese/internal/db/impl/sqlite/SqlitePreparedStatementImpl.cpp
+index 6d085d8eb..64d18fdb3 100644
+--- a/sese/internal/db/impl/sqlite/SqlitePreparedStatementImpl.cpp
++++ b/sese/internal/db/impl/sqlite/SqlitePreparedStatementImpl.cpp
+@@ -92,6 +92,7 @@ int64_t impl::SqlitePreparedStatementImpl::executeUpdate() noexcept {
+ }
+ 
+ bool impl::SqlitePreparedStatementImpl::setDouble(uint32_t index, const double &value) noexcept {
++    if (index == 0 || index > count) return false;
+     if (this->stmtStatus) sqlite3_reset(stmt);
+     if (this->isManual[index - 1]) {
+         free(this->buffer[index - 1]);
+@@ -102,6 +103,7 @@ bool impl::SqlitePreparedStatementImpl::setDouble(uint32_t index, const double &
+ }
+ 
+ bool impl::SqlitePreparedStatementImpl::setFloat(uint32_t index, const float &value) noexcept {
++    if (index == 0 || index > count) return false;
+     if (this->stmtStatus) sqlite3_reset(stmt);
+     if (this->isManual[index - 1]) {
+         free(this->buffer[index - 1]);
+@@ -112,6 +114,7 @@ bool impl::SqlitePreparedStatementImpl::setFloat(uint32_t index, const float &va
+ }
+ 
+ bool impl::SqlitePreparedStatementImpl::setLong(uint32_t index, const int64_t &value) noexcept {
++    if (index == 0 || index > count) return false;
+     if (this->stmtStatus) sqlite3_reset(stmt);
+     if (this->isManual[index - 1]) {
+         free(this->buffer[index - 1]);
+@@ -122,6 +125,7 @@ bool impl::SqlitePreparedStatementImpl::setLong(uint32_t index, const int64_t &v
+ }
+ 
+ bool impl::SqlitePreparedStatementImpl::setInteger(uint32_t index, const int32_t &value) noexcept {
++    if (index == 0 || index > count) return false;
+     if (this->stmtStatus) sqlite3_reset(stmt);
+     if (this->isManual[index - 1]) {
+         free(this->buffer[index - 1]);
+@@ -132,6 +136,7 @@ bool impl::SqlitePreparedStatementImpl::setInteger(uint32_t index, const int32_t
+ }
+ 
+ bool impl::SqlitePreparedStatementImpl::setText(uint32_t index, const char *value) noexcept {
++    if (index == 0 || index > count) return false;
+     if (this->stmtStatus) sqlite3_reset(stmt);
+     if (this->isManual[index - 1]) {
+         free(this->buffer[index - 1]);
+@@ -148,6 +153,7 @@ bool impl::SqlitePreparedStatementImpl::setText(uint32_t index, const char *valu
+ }
+ 
+ bool impl::SqlitePreparedStatementImpl::setNull(uint32_t index) noexcept {
++    if (index == 0 || index > count) return false;
+     if (this->stmtStatus) sqlite3_reset(stmt);
+     if (this->isManual[index - 1]) {
+         free(this->buffer[index - 1]);
+@@ -158,6 +164,7 @@ bool impl::SqlitePreparedStatementImpl::setNull(uint32_t index) noexcept {
+ }
+ 
+ bool impl::SqlitePreparedStatementImpl::setDateTime(uint32_t index, const sese::DateTime &value) noexcept {
++    if (index == 0 || index > count) return false;
+     if (this->stmtStatus) sqlite3_reset(stmt);
+     this->stmtStatus = false;
+ 
+diff --git a/sese/test/TestFormat.cpp b/sese/test/TestFormat.cpp
+index 515551380..7a6130bfa 100644
+--- a/sese/test/TestFormat.cpp
++++ b/sese/test/TestFormat.cpp
+@@ -123,16 +123,17 @@ TEST(TestFormat, Number) {
+ }
+ 
+ TEST(TestFormat, Formatter) {
+-    Point point{1, 2};
+-    SESE_INFO(R"(\{{\}123\}ABC\}})", point);
+-    auto datetime = sese::DateTime::now();
+-    SESE_INFO("{} | {HH:mm:ss}", datetime, datetime);
+-    SESE_INFO("{A}", "Hello");
++    // Point point{1, 2};
++    // SESE_INFO(R"(\{{\}123\}ABC\}})", point);
++    // auto datetime = sese::DateTime::now();
++    // SESE_INFO("{} | {HH:mm:ss}", datetime, datetime);
++    // SESE_INFO("{A}", "Hello");
++    SESE_INFO("free buffer[{}] = 0x{:x}", 1, 123456);
+ }
+ 
+ TEST(TestFormat, MismatchParam) {
+     SESE_INFO("{}");
+-    SESE_INFO("{}",1, 2);
++    SESE_INFO("{}", 1, 2);
+ }
+ 
+ TEST(TestFormat, Constexpr) {
+diff --git a/sese/text/Format.cpp b/sese/text/Format.cpp
+index 3aa635c2f..a519e246f 100644
+--- a/sese/text/Format.cpp
++++ b/sese/text/Format.cpp
+@@ -57,6 +57,7 @@ bool sese::text::FmtCtx::parsing(std::string &args) {
+ 
+         // 无参数直接返回
+         if (*pre_m == '}') {
++            pos = pre_m + 1;
+             return true;
+         }
+ 

--- a/ports/sese/portfile.cmake
+++ b/ports/sese/portfile.cmake
@@ -18,6 +18,8 @@ vcpkg_from_github(
         REPO libsese/sese
         REF "${VERSION}"
         SHA512 6a87cabe6cbd69ab41de85be27ff397c1ae49f95c11151a27e8b9329afe4ff3b580084be53c129e883be50e13fadccb3b6cc1eed833c44ce4f8457dedc71b758
+        PATCHES
+            001-fix-fmt-error.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/sese/vcpkg.json
+++ b/ports/sese/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sese",
   "version": "2.2.0",
+  "port-version": 1,
   "description": "A cross-platform framework for basic components.",
   "homepage": "https://github.com/libsese/sese",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8114,7 +8114,7 @@
     },
     "sese": {
       "baseline": "2.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sf2cute": {
       "baseline": "0.2.0",

--- a/versions/s-/sese.json
+++ b/versions/s-/sese.json
@@ -6,8 +6,8 @@
       "port-version": 0
     },
     {
-      "git-tree" :"2c2f1991af3f16a82ee1cace6d83e9dc9ab917ff",
-      "version" : "2.2.0",
+      "git-tree": "ac627dbb07263cec40760f87fb1b21d776d324a9",
+      "version": "2.2.0",
       "port-version": 1
     }
   ]

--- a/versions/s-/sese.json
+++ b/versions/s-/sese.json
@@ -4,6 +4,11 @@
       "git-tree": "2c0343b399dfd14e5d1c07c3773ea4ce10dde345",
       "version": "2.2.0",
       "port-version": 0
+    },
+    {
+      "git-tree" :"2c2f1991af3f16a82ee1cace6d83e9dc9ab917ff",
+      "version" : "2.2.0",
+      "port-version": 1
     }
   ]
 }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.