### PR TITLE
[google-cloud-cpp] Skip building mock libraries.

### DIFF
--- a/ports/google-cloud-cpp/fix_mocks_dependent_option.patch
+++ b/ports/google-cloud-cpp/fix_mocks_dependent_option.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e1a1dc8..807f6e2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -173,7 +173,7 @@ provided mocks to test code involving the Cloud C++ clients may wish to turn
+ this flag off.]==]
+     ON
+     "NOT BUILD_TESTING"
+-    ON)
++    $<IF:$<BOOL:${BUILD_TESTING}>:OFF:ON>)
+ mark_as_advanced(GOOGLE_CLOUD_CPP_WITH_MOCKS)
+ 
+ # The examples use exception handling to simplify the code. Therefore they
+@@ -246,7 +246,7 @@ include(CTest)
+ # used in the depends condition of the next option.
+ include(EnableCxxExceptions)
+ 
+-if (BUILD_TESTING)
++if (BUILD_TESTING OR GOOGLE_CLOUD_CPP_WITH_MOCKS)
+     # Discover and add targets for the GTest::gtest and GTest::gmock libraries.
+     include(FindGMockWithTargets)
+ endif ()

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch
+        fix_mocks_dependent_option.patch
 )
 
 if ("grpc-common" IN_LIST FEATURES)

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -48,6 +48,7 @@ vcpkg_cmake_configure(
         -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF
         -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
         -DBUILD_TESTING=OFF
+        -DGOOGLE_CLOUD_CPP_WITH_MOCKS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "2.26.0",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3154,7 +3154,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "2.26.0",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "79809a3d4f368d9afe5eac6f10d892311b464e00",
+      "version": "2.26.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6f92046f144ea5804abafe724ea2fec115dad148",
       "version": "2.26.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

This PR adds the `-DGOOGLE_CLOUD_CPP_WITH_MOCKS=OFF` introduced in googleapis/google-cloud-cpp#13673, to fix errors in CMake 3.30 about target `GTest::gmock_main` not being found.

Validated locally. This is not a breaking change; the mock targets were already not installed because [they belong in `COMPONENT google_cloud_cpp_development`](https://github.com/googleapis/google-cloud-cpp/blob/d43e267e19db8e2d556d17ccb0f5649f3dd6beca/google/cloud/google_cloud_cpp_common.cmake#L309-L323).