### PR TITLE
[abseil] fix test-allocator

### DIFF
--- a/ports/abseil/0004-test-allocator-testonly.patch
+++ b/ports/abseil/0004-test-allocator-testonly.patch
@@ -1,0 +1,10 @@
+--- a/absl/container/CMakeLists.txt
++++ b/absl/container/CMakeLists.txt
+@@ -213,6 +213,7 @@ absl_cc_library(
+   DEPS
+     absl::config
+     GTest::gmock
++  TESTONLY
+ )
+ 
+ absl_cc_test(

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         0001-revert-integer-to-string-conversion-optimizations.patch # Fix openvino MSVC compile error
 		0002-Fix-missing-include-random-for-std-uniform_int_distr.patch # Fix missing include for std::uniform_int_distribution
         779a356-test-allocator.diff
+        0004-test-allocator-testonly.patch # Do not build test_allocator target when tests are disabled
 )
 
 # With ABSL_PROPAGATE_CXX_STD=ON abseil automatically detect if it is being

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "abseil",
   "version": "20240116.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
     "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",


### PR DESCRIPTION
This fixes building librsvg with Cairo on windows for the 20240116.2#2 version, maybe 20240116.2#3 don't needs this already, but probably it needs.

This patch just adds `TESTONLY` word there:
```cmake
# Internal-only target, do not depend on directly.
absl_cc_library(
  NAME
    test_allocator
  HDRS
    "internal/test_allocator.h"
  COPTS
    ${ABSL_DEFAULT_COPTS}
  DEPS
    absl::config
    GTest::gmock
  TESTONLY
)
```

The patch is by [SpaceIm](https://github.com/SpaceIm) and it's taken from there:
https://github.com/conan-io/conan-center-index/blob/832ff6dd9098928c6dd5d222bd780b1240dfed2e/recipes/abseil/all/patches/0004-test-allocator-testonly.patch#L4
with related commit on Conan.io:
https://github.com/conan-io/conan-center-index/commit/a7f4e358c6c183d73f85a6841a473364cba1737c

abseil PR - closed and not merged probably because of Contributor License Agreement (CLA):
https://github.com/abseil/abseil-cpp/pull/1536

Related file:
https://github.com/abseil/abseil-cpp/blob/lts_2024_01_16/absl/container/CMakeLists.txt

Package page:
https://vcpkg.io/en/package/abseil
