### PR TITLE
[bgfx] Update to 1.128.8777-475

### DIFF
--- a/ports/bgfx/portfile.cmake
+++ b/ports/bgfx/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_download_distfile(
   ARCHIVE_FILE
   URLS https://github.com/bkaradzic/bgfx.cmake/releases/download/v${VERSION}/bgfx.cmake.v${VERSION}.tar.gz
   FILENAME bgfx.cmake.v${VERSION}.tar.gz
-  SHA512 8aea4f3e548f8a79e8899c9d47ec3ca78dae48f77ae039d6f5df325ba73a8ddb70c9b7c1f0cb4129ac488b445e8a8523f36a964e509133bb4a449e073ebf6112
+  SHA512 889ccc4657415e55cc891ad04ba2b42acaf46e664fd9ed8c6bedebb0f43ba7f2b75a9ad54387d02cf88a6accc7221f7cd5cc74a7dc8248b668ecf14f525f53c8
 )
 
 vcpkg_extract_source_archive(

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,12 +1,11 @@
 {
   "name": "bgfx",
-  "version": "1.127.8725-469",
-  "port-version": 1,
+  "version": "1.128.8777-475",
   "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
   "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
   "homepage": "https://bkaradzic.github.io/bgfx/overview.html",
   "documentation": "https://bkaradzic.github.io/bgfx",
-  "license": null,
+  "license": "BSD-2-Clause AND CC0-1.0",
   "dependencies": [
     "libsquish",
     "miniz",

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "410ddaf19cbcc811e4757d3e6ecb236c7dc15838",
+      "version": "1.128.8777-475",
+      "port-version": 0
+    },
+    {
       "git-tree": "7b9ba6d3df9abc4bacc14ca3fcaf2095b7faf548",
       "version": "1.127.8725-469",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -625,8 +625,8 @@
       "port-version": 0
     },
     "bgfx": {
-      "baseline": "1.127.8725-469",
-      "port-version": 1
+      "baseline": "1.128.8777-475",
+      "port-version": 0
     },
     "bigint": {
       "baseline": "2010.04.30",


### PR DESCRIPTION
Removal of d3d9 support.
Linux wayland support.
VisionOS support

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
