### PR TITLE
[librdkafka] Fix code download URL

### DIFF
--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO edenhill/librdkafka
+    REPO confluentinc/librdkafka
     REF "v${VERSION}"
     SHA512 a68b7382ec5a9afc0eb8513e97d8563c599021d774f7790a61af80565600678a497e4957dcdd823f8b9a426a19b9c5392cacd42d02d70493d993319f3343fe96
     HEAD_REF master

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "librdkafka",
   "version": "2.3.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Apache Kafka C/C++ library",
-  "homepage": "https://github.com/edenhill/librdkafka",
+  "homepage": "https://github.com/confluentinc/librdkafka",
   "license": null,
   "supports": "!uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4918,7 +4918,7 @@
     },
     "librdkafka": {
       "baseline": "2.3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libredwg": {
       "baseline": "0.13.3",

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6aa42a9dc181a15946be77986a9eaa45e0534f3c",
+      "version": "2.3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "420acc8b75e00d2fec12c4b991f63d909b69e022",
       "version": "2.3.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39828

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplets:

```
x64-windows
x64-windows-static
```