### PR TITLE
[opentelemetry-cpp] Update opentelemetry-proto dependency version to 1.3.1

### DIFF
--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -29,11 +29,11 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 # opentelemetry-proto is a third party submodule and opentelemetry-cpp release did not pack it.
 if(WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
-    set(OTEL_PROTO_VERSION "1.1.0")
+    set(OTEL_PROTO_VERSION "1.3.1")
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/open-telemetry/opentelemetry-proto/archive/v${OTEL_PROTO_VERSION}.tar.gz"
         FILENAME "opentelemetry-proto-${OTEL_PROTO_VERSION}.tar.gz"
-        SHA512 cd20991efb2d7f1bc8650fd0e124be707922b0717e429b6212390cd2c0d0afdb403c9aece196f07ae81ebed948863f4ec75c08ffbb3968795a0010d5cb34dc1b
+        SHA512 8c75e4ff79c4b5b251e0ec8ece92ec901d70ec601644505ffdd137fb728daac91fd9203e1f448500124906737d91d80f10b694977688c655418b94f61c828d06
     )
 
     vcpkg_extract_source_archive(src ARCHIVE "${ARCHIVE}")

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.16.0",
+  "port-version": 1,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6602,7 +6602,7 @@
     },
     "opentelemetry-cpp": {
       "baseline": "1.16.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opentracing": {
       "baseline": "1.6.0",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "24f0a022ab07e290283011657cac26e32a6dd648",
+      "version-semver": "1.16.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "463e6bcd28686e4433ddd353b8f0cfd82e7c577b",
       "version-semver": "1.16.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #39830.

The last time when `opentelemetry-cpp` got updated to `1.16.0`, its corresponding dependency version, `opentelemetry-proto`, which gets downloaded via `portfile.cmake` did not get updated.

But if you look at the https://github.com/open-telemetry/opentelemetry-cpp/tree/v1.16.0/third_party, the git reference for `opentelemetry-proto` it has, is for `1.3.1`:
![image](https://github.com/microsoft/vcpkg/assets/41349689/38b999b5-da58-4044-896b-97636cd36243)
