### PR TITLE
[str-view] Add new port str-view

### DIFF
--- a/ports/str-view/portfile.cmake
+++ b/ports/str-view/portfile.cmake
@@ -1,7 +1,6 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_download_distfile(
-    archive
+vcpkg_download_distfile(ARCHIVE
     URLS https://github.com/agl-alexglopez/str_view/releases/download/v${VERSION}/str_view-v${VERSION}.zip
     FILENAME str_view-v${VERSION}.zip
     SHA512 46343734382ba4f17286069b42dbb3d94a69b74c5836f09bf552a287d902c2f07f79829220029bff74e190d73aa2ff3b3000fc2487e862f74249331dce778cbb

--- a/ports/str-view/portfile.cmake
+++ b/ports/str-view/portfile.cmake
@@ -1,6 +1,7 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_download_distfile(ARCHIVE
+vcpkg_download_distfile(
+    ARCHIVE
     URLS https://github.com/agl-alexglopez/str_view/releases/download/v${VERSION}/str_view-v${VERSION}.zip
     FILENAME str_view-v${VERSION}.zip
     SHA512 46343734382ba4f17286069b42dbb3d94a69b74c5836f09bf552a287d902c2f07f79829220029bff74e190d73aa2ff3b3000fc2487e862f74249331dce778cbb
@@ -8,7 +9,7 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
-    ARCHIVE ${archive}
+    ARCHIVE ${ARCHIVE}
     NO_REMOVE_ONE_LEVEL
 )
 
@@ -24,5 +25,5 @@ vcpkg_cmake_config_fixup(
 )
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_install_copyright(FILE_LIST "${src}/LICENSE")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/str-view/portfile.cmake
+++ b/ports/str-view/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_download_distfile(ARCHIVE
 )
 
 vcpkg_extract_source_archive(
-    src
+    SOURCE_PATH
     ARCHIVE ${archive}
     NO_REMOVE_ONE_LEVEL
 )

--- a/ports/str-view/portfile.cmake
+++ b/ports/str-view/portfile.cmake
@@ -1,16 +1,11 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_download_distfile(
-    ARCHIVE
-    URLS https://github.com/agl-alexglopez/str_view/releases/download/v${VERSION}/str_view-v${VERSION}.zip
-    FILENAME str_view-v${VERSION}.zip
-    SHA512 46343734382ba4f17286069b42dbb3d94a69b74c5836f09bf552a287d902c2f07f79829220029bff74e190d73aa2ff3b3000fc2487e862f74249331dce778cbb
-)
-
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    NO_REMOVE_ONE_LEVEL
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO agl-alexglopez/str_view
+    REF "v${VERSION}"
+    SHA512 4dde3d91197ad78bbd808cc88058e6e1588c3ec3b6fbce198538b5ea390b1f3cc8429c76169794dec5d0576862e071feadb280128605ac30c2f12d25d66b9f34
+    HEAD_REF release
 )
 
 vcpkg_cmake_configure(

--- a/ports/str-view/portfile.cmake
+++ b/ports/str-view/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_extract_source_archive(
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${src}"
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
 vcpkg_cmake_install()

--- a/ports/str-view/portfile.cmake
+++ b/ports/str-view/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_download_distfile(
+    archive
+    URLS https://github.com/agl-alexglopez/str_view/releases/download/v${VERSION}/str_view-v${VERSION}.zip
+    FILENAME str_view-v${VERSION}.zip
+    SHA512 46343734382ba4f17286069b42dbb3d94a69b74c5836f09bf552a287d902c2f07f79829220029bff74e190d73aa2ff3b3000fc2487e862f74249331dce778cbb
+)
+
+vcpkg_extract_source_archive(
+    src
+    ARCHIVE ${archive}
+    NO_REMOVE_ONE_LEVEL
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${src}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "str_view"
+    CONFIG_PATH "lib/cmake/str_view"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${src}/LICENSE")
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/str-view/portfile.cmake
+++ b/ports/str-view/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REPO agl-alexglopez/str_view
     REF "v${VERSION}"
     SHA512 4dde3d91197ad78bbd808cc88058e6e1588c3ec3b6fbce198538b5ea390b1f3cc8429c76169794dec5d0576862e071feadb280128605ac30c2f12d25d66b9f34
-    HEAD_REF release
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/str-view/usage
+++ b/ports/str-view/usage
@@ -1,0 +1,4 @@
+str_view provides CMake targets:
+
+find_package(str_view CONFIG REQUIRED)
+target_link_libraries(main PRIVATE str_view::str_view)

--- a/ports/str-view/usage
+++ b/ports/str-view/usage
@@ -1,4 +1,4 @@
 str_view provides CMake targets:
 
-find_package(str_view CONFIG REQUIRED)
-target_link_libraries(main PRIVATE str_view::str_view)
+  find_package(str_view CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE str_view::str_view)

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "str-view",
-  "version": "0.1.20",
+  "version": "0.2.0",
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "str-view",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "str-view",
-  "version": "0.2.4",
+  "version": "0.3.4",
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",
+  "supports": "!windows",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "str-view",
-  "version": "0.3.9",
+  "version": "0.3.11",
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "str-view",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,17 +1,17 @@
 {
-    "name": "str-view",
-    "version": "0.1.18",
-    "homepage": "https://github.com/agl-alexglopez/str_view",
-    "description": "A simple, robust, and convenient library for read-only string handling in C.",
-    "license": "MIT",
-    "dependencies": [
-        {
-            "name" : "vcpkg-cmake",
-            "host" : true
-        },
-        {
-            "name" : "vcpkg-cmake-config",
-            "host" : true
-        }
-    ]
+  "name": "str-view",
+  "version": "0.1.18",
+  "description": "A simple, robust, and convenient library for read-only string handling in C.",
+  "homepage": "https://github.com/agl-alexglopez/str_view",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,0 +1,17 @@
+{
+    "name": "str-view",
+    "version": "0.1.18",
+    "homepage": "https://github.com/agl-alexglopez/str_view",
+    "description": "A simple, robust, and convenient library for read-only string handling in C.",
+    "license": "MIT",
+    "dependencies": [
+        {
+            "name" : "vcpkg-cmake",
+            "host" : true
+        },
+        {
+            "name" : "vcpkg-cmake-config",
+            "host" : true
+        }
+    ]
+}

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "str-view",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",
-  "supports": "!windows",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "str-view",
-  "version": "0.3.7",
+  "version": "0.3.9",
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "str-view",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "str-view",
-  "version": "0.3.4",
+  "version": "0.3.7",
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "str-view",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",

--- a/ports/str-view/vcpkg.json
+++ b/ports/str-view/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "str-view",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A simple, robust, and convenient library for read-only string handling in C.",
   "homepage": "https://github.com/agl-alexglopez/str_view",
   "license": "MIT",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1110,6 +1110,14 @@ spscqueue:arm64-android=fail
 spscqueue:x64-android=fail
 stormlib:arm64-uwp=fail
 stormlib:x64-uwp=fail
+# upstream issue https://github.com/agl-alexglopez/str_view/issues/9
+str-view:arm64-uwp=fail
+str-view:arm64-windows=fail
+str-view:x64-uwp=fail
+str-view:x64-windows=fail
+str-view:x64-windows-static=fail
+str-view:x64-windows-static-md=fail
+str-view:x86-windows=fail
 stxxl:arm-neon-android=fail
 # upstream issue https://github.com/stxxl/stxxl/issues/99
 stxxl:x86-windows=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8549,7 +8549,7 @@
       "port-version": 0
     },
     "str-view": {
-      "baseline": "0.2.1",
+      "baseline": "0.2.2",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8549,7 +8549,7 @@
       "port-version": 0
     },
     "str-view": {
-      "baseline": "0.2.3",
+      "baseline": "0.2.4",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8549,7 +8549,7 @@
       "port-version": 0
     },
     "str-view": {
-      "baseline": "0.3.9",
+      "baseline": "0.3.11",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8549,7 +8549,7 @@
       "port-version": 0
     },
     "str-view": {
-      "baseline": "0.2.2",
+      "baseline": "0.2.3",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8549,7 +8549,7 @@
       "port-version": 0
     },
     "str-view": {
-      "baseline": "0.3.4",
+      "baseline": "0.3.7",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8548,6 +8548,10 @@
       "baseline": "9.26",
       "port-version": 0
     },
+    "str-view": {
+      "baseline": "0.1.18",
+      "port-version": 0
+    },
     "strict-variant": {
       "baseline": "0.5",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8549,7 +8549,7 @@
       "port-version": 0
     },
     "str-view": {
-      "baseline": "0.1.19",
+      "baseline": "0.1.20",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8549,7 +8549,7 @@
       "port-version": 0
     },
     "str-view": {
-      "baseline": "0.1.20",
+      "baseline": "0.2.0",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8549,7 +8549,7 @@
       "port-version": 0
     },
     "str-view": {
-      "baseline": "0.1.18",
+      "baseline": "0.1.19",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8549,7 +8549,7 @@
       "port-version": 0
     },
     "str-view": {
-      "baseline": "0.2.4",
+      "baseline": "0.3.4",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8549,7 +8549,7 @@
       "port-version": 0
     },
     "str-view": {
-      "baseline": "0.3.7",
+      "baseline": "0.3.9",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8549,7 +8549,7 @@
       "port-version": 0
     },
     "str-view": {
-      "baseline": "0.2.0",
+      "baseline": "0.2.1",
       "port-version": 0
     },
     "strict-variant": {

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b6a3b240b0c24a725484b1c813ce4f3dd1c9d182",
+      "version": "0.1.19",
+      "port-version": 0
+    },
+    {
       "git-tree": "6a0e83aebbf96d07c580e2c3f987aa1302e24a63",
       "version": "0.1.18",
       "port-version": 0

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae2ea5ff486a84e4d9f6d9ac7b849a9f9c93c85d",
+      "version": "0.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d74d92b9a6ba544ecda14779317665ecb4277d6a",
       "version": "0.1.20",
       "port-version": 0

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "370a95554534b71c065cdcab3a42f790d1f37133",
+      "version": "0.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae2ea5ff486a84e4d9f6d9ac7b849a9f9c93c85d",
       "version": "0.2.0",
       "port-version": 0

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "76b80abf5f95750f5817c5bfa025982582cfb212",
+      "git-tree": "ee4cf410be527c1c4a363a9fab710430841241ca",
       "version": "0.3.9",
       "port-version": 0
     }

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d74d92b9a6ba544ecda14779317665ecb4277d6a",
+      "version": "0.1.20",
+      "port-version": 0
+    },
+    {
       "git-tree": "b6a3b240b0c24a725484b1c813ce4f3dd1c9d182",
       "version": "0.1.19",
       "port-version": 0

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "ee4cf410be527c1c4a363a9fab710430841241ca",
-      "version": "0.3.9",
+      "git-tree": "a0451e418c42ac6d27391a264603dd9a7d25ef1c",
+      "version": "0.3.11",
       "port-version": 0
     }
   ]

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -4,56 +4,6 @@
       "git-tree": "76b80abf5f95750f5817c5bfa025982582cfb212",
       "version": "0.3.9",
       "port-version": 0
-    },
-    {
-      "git-tree": "72d7459d4bef6d98b0e4eea232a4ea6b7f954afa",
-      "version": "0.3.7",
-      "port-version": 0
-    },
-    {
-      "git-tree": "dba234a6cd1892c90fc4c5893bb424f19754639a",
-      "version": "0.3.4",
-      "port-version": 0
-    },
-    {
-      "git-tree": "3c2508e21af652f06cd8baa4adcadbecc0fa0d66",
-      "version": "0.2.4",
-      "port-version": 0
-    },
-    {
-      "git-tree": "c706f74f10f880883687663174b3a40a7ecdaab7",
-      "version": "0.2.3",
-      "port-version": 0
-    },
-    {
-      "git-tree": "be171a797caa82995a378374d28345fae3f13fca",
-      "version": "0.2.2",
-      "port-version": 0
-    },
-    {
-      "git-tree": "370a95554534b71c065cdcab3a42f790d1f37133",
-      "version": "0.2.1",
-      "port-version": 0
-    },
-    {
-      "git-tree": "ae2ea5ff486a84e4d9f6d9ac7b849a9f9c93c85d",
-      "version": "0.2.0",
-      "port-version": 0
-    },
-    {
-      "git-tree": "d74d92b9a6ba544ecda14779317665ecb4277d6a",
-      "version": "0.1.20",
-      "port-version": 0
-    },
-    {
-      "git-tree": "b6a3b240b0c24a725484b1c813ce4f3dd1c9d182",
-      "version": "0.1.19",
-      "port-version": 0
-    },
-    {
-      "git-tree": "6a0e83aebbf96d07c580e2c3f987aa1302e24a63",
-      "version": "0.1.18",
-      "port-version": 0
     }
   ]
 }

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c706f74f10f880883687663174b3a40a7ecdaab7",
+      "version": "0.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "be171a797caa82995a378374d28345fae3f13fca",
       "version": "0.2.2",
       "port-version": 0

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "72d7459d4bef6d98b0e4eea232a4ea6b7f954afa",
+      "version": "0.3.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "dba234a6cd1892c90fc4c5893bb424f19754639a",
       "version": "0.3.4",
       "port-version": 0

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dba234a6cd1892c90fc4c5893bb424f19754639a",
+      "version": "0.3.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "3c2508e21af652f06cd8baa4adcadbecc0fa0d66",
       "version": "0.2.4",
       "port-version": 0

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76b80abf5f95750f5817c5bfa025982582cfb212",
+      "version": "0.3.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "72d7459d4bef6d98b0e4eea232a4ea6b7f954afa",
       "version": "0.3.7",
       "port-version": 0

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be171a797caa82995a378374d28345fae3f13fca",
+      "version": "0.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "370a95554534b71c065cdcab3a42f790d1f37133",
       "version": "0.2.1",
       "port-version": 0

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5fc2d027c15587641fb31cb778d3d47b92b045bf",
+      "version": "0.1.18",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5fc2d027c15587641fb31cb778d3d47b92b045bf",
+      "git-tree": "6a0e83aebbf96d07c580e2c3f987aa1302e24a63",
       "version": "0.1.18",
       "port-version": 0
     }

--- a/versions/s-/str-view.json
+++ b/versions/s-/str-view.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c2508e21af652f06cd8baa4adcadbecc0fa0d66",
+      "version": "0.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "c706f74f10f880883687663174b3a40a7ecdaab7",
       "version": "0.2.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

