### PR TITLE
[cxxgraph] Update to 4.1.0

### DIFF
--- a/ports/cxxgraph/portfile.cmake
+++ b/ports/cxxgraph/portfile.cmake
@@ -4,13 +4,12 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ZigRazor/CXXGraph
     REF "v${VERSION}"
-    SHA512 a4409c81132e6c7e34022c54d9a57b965970aa8e1fcd97b9f916334c1d480674a526e7d5ad727ab652e4842083249dea89de519b104c1f9f205423eabd3c2338
+    SHA512 81af9edbb3d768bf770a3626b411c753632763a1229fe87dbdca7c8d8f96554205abf527f0916bfe6dff47b5c19259345f2f9cad81bc84eb4d7972de75643af4
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 # cxxgraph provides no targets and is a header only lib designed to be copied to include dir
-file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/cxxgraph")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/cxxgraph" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-

--- a/ports/cxxgraph/usage
+++ b/ports/cxxgraph/usage
@@ -1,4 +1,4 @@
 To use CXXGraph header files:
-	
-	find_path(CXXGRAPH_INCLUDE_DIR cxxgraph/CXXGraph.hpp)
-	target_include_directories(main PRIVATE ${CXXGRAPH_INCLUDE_DIR})
+
+    find_path(CXXGRAPH_INCLUDE_DIR CXXGraph/CXXGraph.hpp)
+    target_include_directories(main PRIVATE ${CXXGRAPH_INCLUDE_DIR})

--- a/ports/cxxgraph/vcpkg.json
+++ b/ports/cxxgraph/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cxxgraph",
-  "version": "2.0.0",
+  "version": "4.1.0",
   "description": "CXXGraph is a header only comprehensive C++ graph library.",
   "homepage": "https://github.com/ZigRazor/CXXGraph",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2125,7 +2125,7 @@
       "port-version": 0
     },
     "cxxgraph": {
-      "baseline": "2.0.0",
+      "baseline": "4.1.0",
       "port-version": 0
     },
     "cxxopts": {

--- a/versions/c-/cxxgraph.json
+++ b/versions/c-/cxxgraph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "485a4ab0bee5661c3cffc9e288a9a431a9924c29",
+      "version": "4.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "84cc008947dc5a40193ec5bc5ce10d175b0cf893",
       "version": "2.0.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #39716, update `cxxgraph` to 4.1.0.

No feature needs to be tested, the usage test passed on `x64-windows`(header files found):
```
To use CXXGraph header files:

    find_path(CXXGRAPH_INCLUDE_DIR CXXGraph/CXXGraph.hpp)
    target_include_directories(main PRIVATE ${CXXGRAPH_INCLUDE_DIR})
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
