### PR TITLE
[nvidia-cutlass] New port with v3.3.0

### DIFF
--- a/ports/libtorch/fix-aten-cutlass.patch
+++ b/ports/libtorch/fix-aten-cutlass.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 80bbfc6b..eead313d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -560,6 +560,8 @@ if(MSVC)
+ 
+   string(APPEND CMAKE_CXX_FLAGS " /FS")
+   string(APPEND CMAKE_CUDA_FLAGS " -Xcompiler /FS")
++  # CUTLASS_CONSTEXPR_IF_CXX17 must be constexpr. Correct the __cplusplus value
++  string(APPEND CMAKE_CUDA_FLAGS " -Xcompiler /Zc:__cplusplus")
+ endif(MSVC)
+ 
+ string(APPEND CMAKE_CUDA_FLAGS " -Xfatbin -compress-all")
+diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
+index 93021a74..0755c890 100644
+--- a/aten/src/ATen/CMakeLists.txt
++++ b/aten/src/ATen/CMakeLists.txt
+@@ -437,7 +437,13 @@ if(NOT MSVC AND NOT EMSCRIPTEN AND NOT INTERN_BUILD_MOBILE)
+ endif()
+ 
+ if(USE_CUDA AND NOT USE_ROCM)
+-  list(APPEND ATen_CUDA_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/cutlass/include)
++  find_package(NvidiaCutlass CONFIG REQUIRED)
++  get_target_property(CUTLASS_INCLUDE_DIRS nvidia::cutlass::cutlass INTERFACE_INCLUDE_DIRECTORIES)
++  list(APPEND ATen_CUDA_INCLUDE ${CUTLASS_INCLUDE_DIRS})
++  if(MSVC)
++    # CUTLASS_CONSTEXPR_IF_CXX17 must be constexpr. Correct the __cplusplus value with MSVC
++    add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:"-Xcompiler /Zc:__cplusplus">)
++  endif()
+   if($ENV{ATEN_STATIC_CUDA})
+     list(APPEND ATen_CUDA_DEPENDENCY_LIBS
+       ${CUDA_LIBRARIES}

--- a/ports/libtorch/portfile.cmake
+++ b/ports/libtorch/portfile.cmake
@@ -36,6 +36,7 @@ vcpkg_from_github(
         fix-msvc-ICE.patch
         fix-calculate-minloglevel.patch
         force-cuda-include.patch
+        # fix-aten-cutlass.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/caffe2/core/macros.h") # We must use generated header files
@@ -60,15 +61,6 @@ vcpkg_from_github(
 )
 file(COPY "${src_cudnn}/" DESTINATION "${SOURCE_PATH}/third_party/cudnn_frontend")
 
-
-vcpkg_from_github(
-    OUT_SOURCE_PATH src_cutlass
-    REPO NVIDIA/cutlass # new port ?
-    REF 6f47420213f757831fae65c686aa471749fa8d60
-    SHA512 f3b3c43fbd7942f96407669405385c9a99274290e99f86cab5bb8657664bf1951e4da27f3069500a4825c427adeec883e05e81302b58390df3a3adb8c08e31ed
-    HEAD_REF main
-)
-file(COPY "${src_cutlass}/" DESTINATION "${SOURCE_PATH}/third_party/cutlass")
 
 file(REMOVE
   "${SOURCE_PATH}/cmake/Modules/FindBLAS.cmake"

--- a/ports/libtorch/portfile.cmake
+++ b/ports/libtorch/portfile.cmake
@@ -36,7 +36,7 @@ vcpkg_from_github(
         fix-msvc-ICE.patch
         fix-calculate-minloglevel.patch
         force-cuda-include.patch
-        # fix-aten-cutlass.patch
+        fix-aten-cutlass.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/caffe2/core/macros.h") # We must use generated header files

--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtorch",
   "version": "2.1.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
   "homepage": "https://pytorch.org/",
   "license": null,
@@ -65,7 +65,8 @@
       "dependencies": [
         "cuda",
         "cudnn",
-        "magma"
+        "magma",
+        "nvidia-cutlass"
       ]
     },
     "dist": {

--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NVIDIA/cutlass
     REF "v${VERSION}"
-    SHA512 989b62323f81708fd41a16aab10b7fc179dc9a66704446ab5d8f97160d9acf2958646dac58ac3aa2b04fff294a5c126192d2e88a7bea9f902130c8c051dc196f
+    SHA512 c950ab718e67ffc972911b81890eae767a27d32dfc13f72b91e21e7c6b98eadfb3a5eebb9683091e61aed61709481451cfcd95d660e723686bf79a155e9f0b17
     HEAD_REF main
 )
 
@@ -13,16 +13,26 @@ vcpkg_add_to_path(PREPEND "${PYTHON_PATH}")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DCMAKE_SUPPRESS_REGENERATION=ON # for some reason it keeps regenerating in Windows
         "-DCUTLASS_REVISION:STRING=v${VERSION}"
         -DCUTLASS_ENABLE_HEADERS_ONLY=ON
+        -DCUTLASS_ENABLE_TOOLS=OFF
+        -DCUTLASS_ENABLE_LIBRARY=OFF
+        -DCUTLASS_ENABLE_PROFILER=OFF
         -DCUTLASS_ENABLE_PERFORMANCE=OFF
+        -DCUTLASS_ENABLE_TESTS=OFF
+        -DCUTLASS_ENABLE_GTEST_UNIT_TESTS=OFF
         -DCUTLASS_ENABLE_CUBLAS=ON
         -DCUTLASS_ENABLE_CUDNN=ON
-        -DCUTLASS_ENABLE_PROFILER=OFF
         "-DPython3_EXECUTABLE:FILEPATH=${PYTHON3}"
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/NvidiaCutlass" PACKAGE_NAME "NvidiaCutlass")
+
+# note CUTLASS_ENABLE_LIBRARY=OFF
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/NvidiaCutlass/NvidiaCutlassConfig.cmake"
+    "add_library" "# add_library" # comment out the command
+)
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug"

--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -6,6 +6,10 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON_PATH "${PYTHON3}" PATH)
+vcpkg_add_to_path(PREPEND "${PYTHON_PATH}")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -15,6 +19,7 @@ vcpkg_cmake_configure(
         -DCUTLASS_ENABLE_CUBLAS=ON
         -DCUTLASS_ENABLE_CUDNN=ON
         -DCUTLASS_ENABLE_PROFILER=OFF
+        "-DPython3_EXECUTABLE:FILEPATH=${PYTHON3}"
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/NvidiaCutlass" PACKAGE_NAME "NvidiaCutlass")

--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -15,7 +15,6 @@ vcpkg_cmake_configure(
     OPTIONS
         -DCMAKE_SUPPRESS_REGENERATION=ON # for some reason it keeps regenerating in Windows
         "-DCUTLASS_REVISION:STRING=v${VERSION}"
-        -DCUTLASS_NATIVE_CUDA=OFF
         -DCUTLASS_ENABLE_HEADERS_ONLY=ON
         -DCUTLASS_ENABLE_TOOLS=OFF
         -DCUTLASS_ENABLE_LIBRARY=OFF

--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DCMAKE_SUPPRESS_REGENERATION=ON # for some reason it keeps regenerating in Windows
         "-DCUTLASS_REVISION:STRING=v${VERSION}"
+        -DCUTLASS_NATIVE_CUDA=OFF
         -DCUTLASS_ENABLE_HEADERS_ONLY=ON
         -DCUTLASS_ENABLE_TOOLS=OFF
         -DCUTLASS_ENABLE_LIBRARY=OFF

--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIA/cutlass
+    REF "v${VERSION}"
+    SHA512 989b62323f81708fd41a16aab10b7fc179dc9a66704446ab5d8f97160d9acf2958646dac58ac3aa2b04fff294a5c126192d2e88a7bea9f902130c8c051dc196f
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DCUTLASS_REVISION:STRING=v${VERSION}"
+        -DCUTLASS_ENABLE_HEADERS_ONLY=ON
+        -DCUTLASS_ENABLE_PERFORMANCE=OFF
+        -DCUTLASS_ENABLE_CUBLAS=ON
+        -DCUTLASS_ENABLE_CUDNN=ON
+        -DCUTLASS_ENABLE_PROFILER=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/NvidiaCutlass" PACKAGE_NAME "NvidiaCutlass")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/test"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/nvidia-cutlass/vcpkg.json
+++ b/ports/nvidia-cutlass/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "nvidia-cutlass",
+  "version-semver": "3.5.0",
+  "description": "CUDA Templates for Linear Algebra Subroutines",
+  "homepage": "https://github.com/NVIDIA/cutlass",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "cuda",
+    "cudnn",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/nvidia-cutlass/vcpkg.json
+++ b/ports/nvidia-cutlass/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nvidia-cutlass",
-  "version": "3.5.0",
+  "version": "3.3.0",
   "description": "CUDA Templates for Linear Algebra Subroutines",
   "homepage": "https://github.com/NVIDIA/cutlass",
   "license": "BSD-3-Clause",

--- a/ports/nvidia-cutlass/vcpkg.json
+++ b/ports/nvidia-cutlass/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nvidia-cutlass",
-  "version-semver": "3.5.0",
+  "version": "3.5.0",
   "description": "CUDA Templates for Linear Algebra Subroutines",
   "homepage": "https://github.com/NVIDIA/cutlass",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6304,6 +6304,10 @@
       "baseline": "5.1.4",
       "port-version": 0
     },
+    "nvidia-cutlass": {
+      "baseline": "3.5.0",
+      "port-version": 0
+    },
     "nvtt": {
       "baseline": "2.1.2",
       "port-version": 8

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6305,7 +6305,7 @@
       "port-version": 0
     },
     "nvidia-cutlass": {
-      "baseline": "3.5.0",
+      "baseline": "3.3.0",
       "port-version": 0
     },
     "nvtt": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5106,7 +5106,7 @@
     },
     "libtorch": {
       "baseline": "2.1.2",
-      "port-version": 3
+      "port-version": 4
     },
     "libtorrent": {
       "baseline": "2.0.10",

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "669a1f2317ab243ad046d2a48b96ed72e82976d8",
+      "version": "2.1.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "cfd452fa297b8737790b9dae9db4bd027e47955e",
       "version": "2.1.2",
       "port-version": 3

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5dd9b44cf96a071236a7570201ba9a4dee3095ad",
+      "version-semver": "3.5.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ae044a5068324091eafcb099d278668c3d3653c9",
+      "git-tree": "ac3d1ad74c2fa682b35453ca19ee1b3b639ec7b3",
       "version": "3.5.0",
       "port-version": 0
     }

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "5dd9b44cf96a071236a7570201ba9a4dee3095ad",
-      "version-semver": "3.5.0",
+      "git-tree": "ae044a5068324091eafcb099d278668c3d3653c9",
+      "version": "3.5.0",
       "port-version": 0
     }
   ]

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "ac3d1ad74c2fa682b35453ca19ee1b3b639ec7b3",
-      "version": "3.5.0",
+      "git-tree": "aeffbd51f66f7a547f37270be0745dbfa18bfaaf",
+      "version": "3.3.0",
       "port-version": 0
     }
   ]

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b84f2cac28c9a5f421b287af682f6a101146f3a8",
+      "git-tree": "aeffbd51f66f7a547f37270be0745dbfa18bfaaf",
       "version": "3.3.0",
       "port-version": 0
     }

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "aeffbd51f66f7a547f37270be0745dbfa18bfaaf",
+      "git-tree": "b84f2cac28c9a5f421b287af682f6a101146f3a8",
       "version": "3.3.0",
       "port-version": 0
     }


### PR DESCRIPTION
New port with https://github.com/NVIDIA/cutlass/releases/tag/v3.5.0  

* Resolve #32648

Maybe we can name it with `cutlass`, like the repository name.  
Here, I brought changes of the following PR

* https://github.com/luncliff/vcpkg-registry/pull/191

The port can help CUDA GPU support of other ports

* #36850


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
