### PR TITLE
[dataframe] Hossein/data frame 3.2.0

### DIFF
--- a/ports/dataframe/portfile.cmake
+++ b/ports/dataframe/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hosseinmoein/DataFrame
     REF "${VERSION}"
-    SHA512 f202ff3890cf9afd2140cf90d04c4915a9a1fdb13ed82c5d5f8459de62ea015be653a9e196945f06f146865fdfbaf0d6514bf26210fe627d91e5839f1e1f2b96
+    SHA512 94c95d9fe89ddf00c7e8097eb993c35de11f97749cb7b319642064a8aa7fbdb2d1286b29e138752c47a4bc5cdd0519e4fe7a1a0df33b2990438e3fc194d9e0e0
     HEAD_REF master
 )
 vcpkg_cmake_configure(

--- a/ports/dataframe/vcpkg.json
+++ b/ports/dataframe/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dataframe",
-  "version": "3.1.0",
-  "description": "This is a C++ statistical library that provides an interface similar to Pandas package in Python",
+  "version": "3.2.0",
+    "description": "C++ DataFrame for statistical, Financial, and ML analysis -- in modern C++ using native types and contiguous memory storage",
   "homepage": "https://github.com/hosseinmoein/DataFrame",
   "license": "BSD-3-Clause",
   "supports": "!uwp",

--- a/ports/dataframe/vcpkg.json
+++ b/ports/dataframe/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dataframe",
   "version": "3.2.0",
-    "description": "C++ DataFrame for statistical, Financial, and ML analysis -- in modern C++ using native types and contiguous memory storage",
+  "description": "C++ DataFrame for statistical, Financial, and ML analysis -- in modern C++ using native types and contiguous memory storage",
   "homepage": "https://github.com/hosseinmoein/DataFrame",
   "license": "BSD-3-Clause",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2165,7 +2165,7 @@
       "port-version": 3
     },
     "dataframe": {
-      "baseline": "3.1.0",
+      "baseline": "3.2.0",
       "port-version": 0
     },
     "date": {

--- a/versions/d-/dataframe.json
+++ b/versions/d-/dataframe.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b32bd7958333bd9dc3aa3183204128fec80702e1",
+	"git-tree": "1fcfb92efe87c15eaa2f1f94e0ea7e93d48cc07b",
       "version": "3.2.0",
       "port-version": 0
     },

--- a/versions/d-/dataframe.json
+++ b/versions/d-/dataframe.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "git-tree": "40857d32d0402b8dd0a5defd76581aa7ac54b9a8",
+      "version": "3.2.0",
+      "port-version": 0
+    },
+    {
+      "git-tree": "40857d32d0402b8dd0a5defd76581aa7ac54b9a8",
       "version": "3.1.0",
       "port-version": 0
     },

--- a/versions/d-/dataframe.json
+++ b/versions/d-/dataframe.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "40857d32d0402b8dd0a5defd76581aa7ac54b9a8",
+      "git-tree": "b32bd7958333bd9dc3aa3183204128fec80702e1",
       "version": "3.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [ x ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ x ] SHA512s are updated for each updated download.
- [ x ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ x ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ x ] Any patches that are no longer applied are deleted from the port's directory.
- [ x ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x ] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
