### PR TITLE
[realm-core] update to 14.10.4

### DIFF
--- a/ports/realm-core/portfile.cmake
+++ b/ports/realm-core/portfile.cmake
@@ -1,20 +1,12 @@
-vcpkg_download_distfile(
-    android-alooper-patch
-    URLS https://github.com/realm/realm-core/commit/50a9895544a195afab0450d0c87730e8a31cf667.diff?full_index=1
-    FILENAME realm-core-android-alooper-50a989.diff
-    SHA512 7c10f166ab61f4ea7a46473aa04eb1b5f440edd81c2997cc10b84b9890eb6dfe7b77d51364fe2d4c537c7809ce03dd8b269309d7da2eede72be8dec3b71c2485
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO realm/realm-core
-    REF "${VERSION}"
-    SHA512 474f5c6d62e42b221f7b934ca2d8070f83e92eeeeb1271594b7d750fc6f4d186889e04722e0f26ca725cf4f3130c5e1851e82e4ab944a05e25465f3115ffe8ce
+    REF "v${VERSION}"
+    SHA512 41ccf3e53bb1ff6e16a2baf90203984424d3b754973374af4d3767f67227f1223b314921954826ab62d45965a78540b93fc92a0ababd464f19dbaec368175022
     HEAD_REF master
     PATCHES 
         UWP_index_set.patch
         fix-zlib.patch
-        ${android-alooper-patch}
 )
 
 vcpkg_list(SET REALMCORE_CMAKE_OPTIONS)

--- a/ports/realm-core/vcpkg.json
+++ b/ports/realm-core/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-core",
-  "version": "14.8.0",
+  "version": "14.10.4",
   "description": "Realm is a mobile database that runs directly inside phones, tablets or wearables.",
   "homepage": "https://github.com/realm/realm-core",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7705,7 +7705,7 @@
       "port-version": 4
     },
     "realm-core": {
-      "baseline": "14.8.0",
+      "baseline": "14.10.4",
       "port-version": 0
     },
     "realsense2": {

--- a/versions/r-/realm-core.json
+++ b/versions/r-/realm-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b7b1feb241e6c92f5b300f0446f37d12aab3466",
+      "version": "14.10.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "c64fef7ec55844040ed78d90996fdb063556477a",
       "version": "14.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.