### PR TITLE
[cyrus-sasl] new port

### DIFF
--- a/ports/cyrus-sasl/portfile.cmake
+++ b/ports/cyrus-sasl/portfile.cmake
@@ -1,0 +1,52 @@
+# NOTE: We don't use vcpkg_from_github as it does not
+# include all the necessary source files
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-${VERSION}/cyrus-sasl-${VERSION}.tar.gz"
+    FILENAME "cyrus-sasl-${VERSION}.tar.gz"
+    SHA512 db15af9079758a9f385457a79390c8a7cd7ea666573dace8bf4fb01bb4b49037538d67285727d6a70ad799d2e2318f265c9372e2427de9371d626a1959dd6f78
+)
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    file(REMOVE "${SOURCE_PATH}/include/md5global.h")
+    file(COPY "${SOURCE_PATH}/win32/include/md5global.h" DESTINATION "${SOURCE_PATH}/include/md5global.h")
+    vcpkg_install_nmake(
+        SOURCE_PATH "${SOURCE_PATH}"
+        DETERMINE_BUILD_TRIPLET
+        PROJECT_NAME "NTMakefile"
+        OPTIONS
+            GSSAPI=MITKerberos
+            "DB_INCLUDE=${CURRENT_INSTALLED_DIR}/include"
+            "DB_LIB=libdb48.lib"
+        OPTIONS_RELEASE
+            CFG=Release
+            "prefix=${CURRENT_PACKAGES_DIR}"
+            "OPENSSL_LIBPATH=${CURRENT_INSTALLED_DIR}/lib"
+            "DB_LIBPATH=${CURRENT_INSTALLED_DIR}/lib"
+        OPTIONS_DEBUG
+            CFG=Debug
+            "prefix=${CURRENT_PACKAGES_DIR}/debug"
+            "OPENSSL_LIBPATH=${CURRENT_INSTALLED_DIR}/lib/debug"
+            "DB_LIBPATH=${CURRENT_INSTALLED_DIR}/lib/debug"
+    )
+else()
+    vcpkg_configure_make(
+        SOURCE_PATH "${SOURCE_PATH}"
+        DETERMINE_BUILD_TRIPLET
+        OPTIONS
+            "--with-gssapi"
+            "--disable-macos-framework"
+    )
+    vcpkg_install_make()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/cyrus-sasl/vcpkg.json
+++ b/ports/cyrus-sasl/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "cyrus-sasl",
+  "version": "2.1.28",
+  "description": "Cyrus SASL is an implementation of SASL that makes it easy for application developers to integrate authentication mechanisms into their application in a generic way.",
+  "homepage": "https://github.com/cyrusimap/cyrus-sasl",
+  "license": "BSD-3-Clause-Attribution",
+  "supports": "linux | osx | (x64 & windows & !static & !uwp)",
+  "dependencies": [
+    {
+      "name": "berkeleydb",
+      "platform": "windows"
+    },
+    "krb5",
+    "openssl"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2124,6 +2124,10 @@
       "baseline": "30.475.1",
       "port-version": 0
     },
+    "cyrus-sasl": {
+      "baseline": "2.1.28",
+      "port-version": 0
+    },
     "cxxgraph": {
       "baseline": "2.0.0",
       "port-version": 0

--- a/versions/c-/cyrus-sasl.json
+++ b/versions/c-/cyrus-sasl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1577585f5eff556f1f478ffb103713e066caf4dc",
+      "version": "2.1.28",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/5894
Leverages https://github.com/microsoft/vcpkg/pull/38402
Relates to https://github.com/microsoft/vcpkg/pull/37523
Goal: add `gssapi` support to `librdkafka`


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
