### PR TITLE
[stdexec] Use fixed versions for rapids-cmake and execution.bs

### DIFF
--- a/ports/stdexec/portfile.cmake
+++ b/ports/stdexec/portfile.cmake
@@ -12,22 +12,22 @@ vcpkg_from_github(
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH_RAPIDS
     REPO rapidsai/rapids-cmake
-    REF c7a28304639a2ed460181b4753f3280c7833c718
-    SHA512 9a87fdef490199337778b8c9b4df31ca37d65df23803d058f13b406dcfda4d96d992b2780b0b878b61b027c0dc848351496a0f32e779f95298f259bab040b49b
+    REF v24.02.01
+    SHA512 bb8f2b1177f6451d61f2de26f39fd6d31c2f0fb80b4cd1409edc3e6e4f726e80716ec177d510d0f31b8f39169cd8b58290861f0f217daedbd299e8e426d25891
     HEAD_REF main
 )
 
 vcpkg_download_distfile(RAPIDS_cmake
-    URLS "https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.02/RAPIDS.cmake"
+    URLS "https://raw.githubusercontent.com/rapidsai/rapids-cmake/v24.02.01/RAPIDS.cmake"
     FILENAME "RAPIDS.cmake"
     SHA512 e7830364222a9ea46fe7756859dc8d36e401c720f6a49880a2945a9ebc5bd9aa7e40a8bd382e1cae3af4235d5c9a7998f38331e23b676af7c5c72e7f00e61f0c
 )
 file(COPY "${RAPIDS_cmake}" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/")
 
 vcpkg_download_distfile(execution_bs
-    URLS "https://raw.githubusercontent.com/cplusplus/sender-receiver/main/execution.bs"
+    URLS "https://raw.githubusercontent.com/cplusplus/sender-receiver/a1790ddda5dcdf70f0658d0b50794649caa6c96f/execution.bs"
     FILENAME "execution.bs"
-    SHA512 90bb992356f22e4091ed35ca922f6a0143abd748499985553c0660eaf49f88d031a8f900addb6b4cf9a39ac8d1ab7c858b79677e2459136a640b2c52afe3dd23
+    SHA512 091c327eb1d161c46d77e7e0265c16d3de0c7fe7e1714c6891fbc6914d7147aed83ea28ba5a1f79703c9b00c84e7c2351fcf9106dacec46f634b0795692bc086
 )
 file(COPY "${execution_bs}" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/")
 

--- a/ports/stdexec/vcpkg.json
+++ b/ports/stdexec/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "stdexec",
   "version-date": "2024-06-16",
-  "port-version": 1,
+  "port-version": 2,
   "description": "stdexec is an experimental reference implementation of the Senders model of asynchronous programming proposed by P2300 - std::execution for adoption into the C++ Standard.",
   "homepage": "https://github.com/NVIDIA/stdexec",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8530,7 +8530,7 @@
     },
     "stdexec": {
       "baseline": "2024-06-16",
-      "port-version": 1
+      "port-version": 2
     },
     "stduuid": {
       "baseline": "1.2.3",

--- a/versions/s-/stdexec.json
+++ b/versions/s-/stdexec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54f7ff852dbec60f519f3b82d59e3dd0c621b6b0",
+      "version-date": "2024-06-16",
+      "port-version": 2
+    },
+    {
       "git-tree": "1bc8de1856cd06c3b1c1a04c580ef085b3f766ab",
       "version-date": "2024-06-16",
       "port-version": 1


### PR DESCRIPTION
This port started breaking recently trying to download `https://raw.githubusercontent.com/cplusplus/sender-receiver/main/execution.bs` with the wrong SHA512. Fixed the versions now, see here why 24.02 appears to be the correct version for rapids-cmake: https://github.com/NVIDIA/stdexec/blob/089c4613385f808c3b39c4f4915f658157013a36/CMakeLists.txt#L15

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
