### PR TITLE
[libavif] Skip host nasm dependency on non-x64 platforms

### DIFF
--- a/ports/libavif/portfile.cmake
+++ b/ports/libavif/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         disable-source-utf8.patch
         find-dependency.patch # from https://github.com/AOMediaCodec/libavif/pull/1339
+	skip-nasm-non-x64.patch # from https://github.com/AOMediaCodec/libavif/pull/2267
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libavif/skip-nasm-non-x64.patch
+++ b/ports/libavif/skip-nasm-non-x64.patch
@@ -1,0 +1,28 @@
+From b45c002ba6e021d5740cf8e25f83bdf8b392b78e Mon Sep 17 00:00:00 2001
+From: Andrew Kaster <akaster@serenityos.org>
+Date: Sat, 13 Jul 2024 16:28:24 -0600
+Subject: [PATCH] cmake: Only search for ASM_NASM language on x86_64 platforms
+
+The only use of the nasm assembler in the project is for the SVT-AV1
+dependency. SVT-AV1 only looks for ASM_NASM when it has detected that
+the target platform is x86_64/amd64[0].
+
+[0] https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/b13aec2a1a820efb8417e5c147240aa677ec8a74/CMakeLists.txt#L75-L98
+---
+ cmake/Modules/LocalSvt.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/Modules/LocalSvt.cmake b/cmake/Modules/LocalSvt.cmake
+index 7fd34f493..720613499 100644
+--- a/cmake/Modules/LocalSvt.cmake
++++ b/cmake/Modules/LocalSvt.cmake
+@@ -30,7 +30,7 @@ else()
+             enable_language(ASM)
+         endif()
+     endif()
+-    if(NOT CMAKE_ASM_NASM_COMPILER)
++    if(NOT CMAKE_ASM_NASM_COMPILER AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|AMD64|amd64)")
+         include(CheckLanguage)
+         check_language(ASM_NASM)
+         if(CMAKE_ASM_NASM_COMPILER)
+

--- a/ports/libavif/vcpkg.json
+++ b/ports/libavif/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libavif",
   "version-semver": "1.0.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Library for encoding and decoding AVIF files",
   "homepage": "https://github.com/AOMediaCodec/libavif",
   "license": "BSD-2-Clause AND Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4238,7 +4238,7 @@
     },
     "libavif": {
       "baseline": "1.0.4",
-      "port-version": 1
+      "port-version": 2
     },
     "libb2": {
       "baseline": "0.98.1",

--- a/versions/l-/libavif.json
+++ b/versions/l-/libavif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c93850ba438523241deff19a32467a61c38e9a5c",
+      "version-semver": "1.0.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "5464a231b3a83e3d8a076b339d93c5247d04b36b",
       "version-semver": "1.0.4",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This patch removes the unnecessary host dependency on nasm when targeting non-x86_64 platforms when using libavif.

Upstream PR: https://github.com/AOMediaCodec/libavif/pull/2267