### PR TITLE
[vcpkg baseline][arrayfire] Disable parallel configure

### DIFF
--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -84,10 +84,6 @@ vcpkg_cmake_configure(
   OPTIONS
     ${AF_DEFAULT_VCPKG_CMAKE_FLAGS}
     ${AF_BACKEND_FEATURE_OPTIONS}
-  OPTIONS_DEBUG
-    -DAF_INSTALL_CMAKE_DIR="${CURRENT_PACKAGES_DIR}/debug/share/${PORT}" # for CMake configs/targets
-  OPTIONS_RELEASE
-    -DAF_INSTALL_CMAKE_DIR="${CURRENT_PACKAGES_DIR}/share/${PORT}" # for CMake configs/targets
   MAYBE_UNUSED_VARIABLES
     AF_CPU_THREAD_PATH
 )
@@ -95,12 +91,12 @@ vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-vcpkg_cmake_config_fixup()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" 
     "${CURRENT_PACKAGES_DIR}/debug/examples" 
-    "${CURRENT_PACKAGES_DIR}/examples" 
-    "${CURRENT_PACKAGES_DIR}/debug/share" 
+    "${CURRENT_PACKAGES_DIR}/examples"
+    "${CURRENT_PACKAGES_DIR}/LICENSES"
     "${CURRENT_PACKAGES_DIR}/debug/LICENSES")
 
 # Copyright and license

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -80,6 +80,7 @@ vcpkg_check_features(
 # Build and install
 vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
   OPTIONS
     ${AF_DEFAULT_VCPKG_CMAKE_FLAGS}
     ${AF_BACKEND_FEATURE_OPTIONS}

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -91,10 +91,15 @@ vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+if(VCPKG_TARGET_IS_OSX)
+    vcpkg_cmake_config_fixup(CONFIG_PATH share/ArrayFire/cmake)
+else()
+    vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" 
-    "${CURRENT_PACKAGES_DIR}/debug/examples" 
+    "${CURRENT_PACKAGES_DIR}/debug/examples"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
     "${CURRENT_PACKAGES_DIR}/examples"
     "${CURRENT_PACKAGES_DIR}/LICENSES"
     "${CURRENT_PACKAGES_DIR}/debug/LICENSES")

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrayfire",
   "version-semver": "3.8.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "ArrayFire is a general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.",
   "homepage": "https://github.com/arrayfire/arrayfire",
   "license": "BSD-3-Clause",

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "944640cc76b8a17d04f8426203cca9191ef01ce5",
+      "version-semver": "3.8.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "4e9b4b24be953b97638224c3563759c7d8a86602",
       "version-semver": "3.8.0",
       "port-version": 5

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "944640cc76b8a17d04f8426203cca9191ef01ce5",
+      "git-tree": "e52c7c7651567f91a3447c05e3760b2b277308c6",
       "version-semver": "3.8.0",
       "port-version": 6
     },

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e52c7c7651567f91a3447c05e3760b2b277308c6",
+      "git-tree": "45bae5e28a1c092e6024e21dcc4bab12c4e03440",
       "version-semver": "3.8.0",
       "port-version": 6
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -238,7 +238,7 @@
     },
     "arrayfire": {
       "baseline": "3.8.0",
-      "port-version": 5
+      "port-version": 6
     },
     "arrow": {
       "baseline": "16.1.0",


### PR DESCRIPTION
Failed on: https://dev.azure.com/vcpkg/public/_build/results?buildId=105005&view=results
```
CMake Error at CMakeModules/AFconfigure_forge_submodule.cmake:47 (configure_file):
  No such file or directory
Call Stack (most recent call first):
  CMakeLists.txt:115 (include)
```
Add option `DISABLE_PARALLEL_CONFIGURE` to fix this error.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.