### PR TITLE
[librdkafka] Fix feature curl compilation error under arm64-osx triplet

### DIFF
--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -19,7 +19,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         zstd    WITH_ZSTD
         snappy  WITH_SNAPPY
         curl    WITH_CURL
-        curl    WITH_OAUTHBEARER_OIDC
 )
 
 vcpkg_cmake_configure(
@@ -69,7 +68,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 # Handle copyright
-configure_file("${SOURCE_PATH}/LICENSES.txt" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSES.txt" )
 
 # Install usage
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "librdkafka",
   "version": "2.3.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The Apache Kafka C/C++ library",
   "homepage": "https://github.com/confluentinc/librdkafka",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4918,7 +4918,7 @@
     },
     "librdkafka": {
       "baseline": "2.3.0",
-      "port-version": 2
+      "port-version": 3
     },
     "libredwg": {
       "baseline": "0.13.3",

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43fbb6abd2228252734e70f03890aba159c4d45c",
+      "version": "2.3.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "6aa42a9dc181a15946be77986a9eaa45e0534f3c",
       "version": "2.3.0",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39885
According to the [upstream code](https://github.com/confluentinc/librdkafka/blob/6eaf89fb124c421b66b43b195879d458a3a31f86/CMakeLists.txt#L164-L166), WITH_OAUTHBEARER_OIDC is not a compilation option for feature curl. Enabling WITH_OAUTHBEARER_OIDC requires starting both curl and ssl features. Therefore, the curl feature to enable WITH_OAUTHBEARER_OIDC option is deleted.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

The feature test passes the following triplets:

```
x64-windows
arm64-osx
```
