### PR TITLE
[dav1d] Skip host nasm dependency when targeting non-x86

### DIFF
--- a/ports/dav1d/portfile.cmake
+++ b/ports/dav1d/portfile.cmake
@@ -6,18 +6,16 @@ vcpkg_from_gitlab(
     SHA512 7f02c1e65fb79352a159cc60346e02d5844c01d1228f860f802c553799ae0213e76ccc81ff427913e89bd3cfcf0185ea063cf3b6f7c4242faa76962ebd661e5e
 )
 
-vcpkg_find_acquire_program(NASM)
-get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
-vcpkg_add_to_path(${NASM_EXE_PATH})
-
-if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
-    if(VCPKG_TARGET_IS_WINDOWS)
-        vcpkg_find_acquire_program(GASPREPROCESSOR)
-        foreach(GAS_PATH ${GASPREPROCESSOR})
-            get_filename_component(GAS_ITEM_PATH ${GAS_PATH} DIRECTORY)
-            set(ENV{PATH} "$ENV{PATH}${VCPKG_HOST_PATH_SEPARATOR}${GAS_ITEM_PATH}")
-        endforeach(GAS_PATH)
-    endif()
+if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    vcpkg_find_acquire_program(NASM)
+    get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
+    vcpkg_add_to_path(${NASM_EXE_PATH})
+elseif (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_find_acquire_program(GASPREPROCESSOR)
+    foreach(GAS_PATH ${GASPREPROCESSOR})
+        get_filename_component(GAS_ITEM_PATH ${GAS_PATH} DIRECTORY)
+        vcpkg_add_to_path(${GAS_ITEM_PATH})
+    endforeach(GAS_PATH)
 endif()
 
 set(LIBRARY_TYPE ${VCPKG_LIBRARY_LINKAGE})

--- a/ports/dav1d/vcpkg.json
+++ b/ports/dav1d/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dav1d",
   "version": "1.4.0",
+  "port-version": 1,
   "description": "dav1d is a new open-source AV1 decoder developed by the VideoLAN and FFmpeg communities and sponsored by the Alliance for Open Media.",
   "homepage": "https://code.videolan.org/videolan/dav1d",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2178,7 +2178,7 @@
     },
     "dav1d": {
       "baseline": "1.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "daw-header-libraries": {
       "baseline": "2.106.0",

--- a/versions/d-/dav1d.json
+++ b/versions/d-/dav1d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c92b5d1be96a53ccc47eddb738e08111b537513f",
+      "version": "1.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0349d1196602b2983b1171647b30b5a9379920c6",
       "version": "1.4.0",
       "port-version": 0


### PR DESCRIPTION
`nasm` is only required when targeting x86(_64).

Fixes #39920

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.