### PR TITLE
[libpqxx] Fix building libpqxx 7.9.0 with cmake 3.30

### DIFF
--- a/ports/libpqxx/fix_build_cmake_3.30.patch
+++ b/ports/libpqxx/fix_build_cmake_3.30.patch
@@ -1,0 +1,42 @@
+From d5bf7cf83d0c86c502b6b30d5f0c8dc3b3049a38 Mon Sep 17 00:00:00 2001
+From: Jeroen Vermeulen <jtvjtv@gmail.com>
+Date: Sun, 23 Jun 2024 21:03:24 +0200
+Subject: [PATCH] Fixes https://github.com/jtv/libpqxx/issues/851
+
+Thanks @tt4g.
+---
+ cmake/config.cmake | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/config.cmake b/cmake/config.cmake
+index ef2ebf5fc..4d9f7e935 100644
+--- a/cmake/config.cmake
++++ b/cmake/config.cmake
+@@ -8,10 +8,18 @@ function(detect_code_compiled code macro msg)
+     endif()
+ endfunction(detect_code_compiled)
+ 
++if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0)
++    include(CMakeDetermineCompilerSupport)
++    cmake_determine_compiler_support(CXX)
++else()
++    # This function changed names in CMake 3.30.  :-(
++    include(CMakeDetermineCompileFeatures)
++    cmake_determine_compile_features(CXX)
++endif()
++
+ include(CheckIncludeFileCXX)
+ include(CheckFunctionExists)
+ include(CheckSymbolExists)
+-include(CMakeDetermineCompileFeatures)
+ include(CheckCXXSourceCompiles)
+ include(CMakeFindDependencyMacro)
+ 
+@@ -39,7 +47,6 @@ check_function_exists("poll" PQXX_HAVE_POLL)
+ 
+ set(CMAKE_REQUIRED_LIBRARIES pq)
+ 
+-cmake_determine_compile_features(CXX)
+ cmake_policy(SET CMP0057 NEW)
+ 
+ # check_cxx_source_compiles requires CMAKE_REQUIRED_DEFINITIONS to specify

--- a/ports/libpqxx/portfile.cmake
+++ b/ports/libpqxx/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix_build_with_vs2017.patch
+        fix_build_cmake_3.30.patch      # remove with > 7.9.1, upstream fix: https://github.com/jtv/libpqxx/commit/d5bf7cf83d0c86c502b6b30d5f0c8dc3b3049a38
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/config-public-compiler.h.in" DESTINATION "${SOURCE_PATH}")

--- a/ports/libpqxx/vcpkg.json
+++ b/ports/libpqxx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libpqxx",
   "version": "7.9.0",
+  "port-version": 1,
   "description": "The official C++ client API for PostgreSQL",
   "homepage": "https://www.postgresql.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4874,7 +4874,7 @@
     },
     "libpqxx": {
       "baseline": "7.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libprotobuf-mutator": {
       "baseline": "1.3",

--- a/versions/l-/libpqxx.json
+++ b/versions/l-/libpqxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "36fb80efda7137194f2bf679b9e685e9dab60bb5",
+      "version": "7.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c8078815fcddf1da8e7d8fba66100befaa779ec0",
       "version": "7.9.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #39694

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

Upstream issue: https://github.com/jtv/libpqxx/issues/851
