### PR TITLE
 [nvtt] Add support for arm64-linux

### DIFF
--- a/ports/nvtt/add-support-for-arm64-linux.patch
+++ b/ports/nvtt/add-support-for-arm64-linux.patch
@@ -1,0 +1,28 @@
+diff --git a/extern/CMP_Core/source/cmp_math_vec4.h b/extern/CMP_Core/source/cmp_math_vec4.h
+index 4467deb..461d5d2 100644
+--- a/extern/CMP_Core/source/cmp_math_vec4.h
++++ b/extern/CMP_Core/source/cmp_math_vec4.h
+@@ -27,6 +27,10 @@
+ // Vector Class definitions for CPU & Intrinsics
+ //====================================================
+ 
++#if defined linux || defined __linux__
++#  define _LINUX 1
++#endif
++
+ #if defined (_LINUX) || defined (_WIN32)
+ 
+ //============================================= VEC2 ==================================================
+diff --git a/src/nvcore/Debug.h b/src/nvcore/Debug.h
+index 4aca31b..0c08dc4 100644
+--- a/src/nvcore/Debug.h
++++ b/src/nvcore/Debug.h
+@@ -166,7 +166,7 @@ NVCORE_API void NV_CDECL nvDebugPrint( const char *msg, ... ) __attribute__((for
+ namespace nv
+ {
+     inline bool isValidPtr(const void * ptr) {
+-    #if NV_CPU_X86_64 || POSH_CPU_PPC64 || NV_CPU_AARCH64
++    #if NV_CPU_X86_64 || POSH_CPU_PPC64 || POSH_CPU_AARCH64
+         if (ptr == NULL) return true;
+         if (reinterpret_cast<uint64>(ptr) < 0x10000ULL) return false;
+         if (reinterpret_cast<uint64>(ptr) >= 0x000007FFFFFEFFFFULL) return false;

--- a/ports/nvtt/portfile.cmake
+++ b/ports/nvtt/portfile.cmake
@@ -16,7 +16,8 @@ vcpkg_from_github(
         skip-building-libsquish.patch
         fix-intrinsic-function.patch
         fix-release-flags.patch
-)
+        add-support-for-arm64-linux.patch
+	)
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/nvtt/vcpkg.json
+++ b/ports/nvtt/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "nvtt",
   "version": "2.1.2",
-  "port-version": 8,
+  "port-version": 9,
   "description": "Texture processing tools with support for Direct3D 10 and 11 formats.",
   "homepage": "https://github.com/castano/nvidia-texture-tools",
   "license": "MIT",
-  "supports": "!uwp & !arm",
+  "supports": "!uwp & !(arm & !(arm64 & linux))",
   "dependencies": [
     "libsquish",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6306,7 +6306,7 @@
     },
     "nvtt": {
       "baseline": "2.1.2",
-      "port-version": 8
+      "port-version": 9
     },
     "nyan-lang": {
       "baseline": "0.3",

--- a/versions/n-/nvtt.json
+++ b/versions/n-/nvtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f6fe7d91dcb1a613502c60df051b577b996fcacf",
+      "version": "2.1.2",
+      "port-version": 9
+    },
+    {
       "git-tree": "3da8e5721ec0b2c3a408e5708802209258ae8945",
       "version": "2.1.2",
       "port-version": 8


### PR DESCRIPTION
<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

