### PR TITLE
[glfw3] Fix build on wasm32-emscripten

### DIFF
--- a/ports/glfw3/glfw3Config.cmake
+++ b/ports/glfw3/glfw3Config.cmake
@@ -1,0 +1,6 @@
+if (NOT TARGET glfw)
+    add_library(glfw INTERFACE IMPORTED)
+    set_target_properties(glfw PROPERTIES
+        INTERFACE_LINK_OPTIONS "-sUSE_GLFW=3"
+    )
+endif()

--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -51,6 +51,8 @@ These can be installed via brew install libxinerama-dev libxcursor-dev xorg-dev 
             -DGLFW_BUILD_TESTS=OFF
             -DGLFW_BUILD_DOCS=OFF
             ${FEATURE_OPTIONS}
+        MAYBE_UNUSED_VARIABLES
+            GLFW_USE_WAYLAND
     )
 
     vcpkg_cmake_install()

--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -6,8 +6,15 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-if(VCPKG_TARGET_IS_LINUX)
-    message(
+if (VCPKG_TARGET_IS_EMSCRIPTEN)
+    # emscripten has built-in glfw3 library
+    set(VCPKG_BUILD_TYPE release)
+    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/glfw3Config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/glfw3")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+    if(VCPKG_TARGET_IS_LINUX)
+        message(
 "GLFW3 currently requires the following libraries from the system package manager:
     xinerama
     xcursor
@@ -20,8 +27,8 @@ These can be installed on Ubuntu systems via sudo apt install libxinerama-dev li
 Alternatively, when targeting the Wayland display server, use the packages listed in the GLFW documentation here:
 
 https://www.glfw.org/docs/3.3/compile.html#compile_deps_wayland")
-else(VCPKG_TARGET_IS_OSX)
-    message(
+    else(VCPKG_TARGET_IS_OSX)
+        message(
 "GLFW3 currently requires the following libraries from the system package manager:
     xinerama
     xcursor
@@ -30,30 +37,32 @@ else(VCPKG_TARGET_IS_OSX)
     pkg-config
 
 These can be installed via brew install libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev pkg-config")
+    endif()
+
+    vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+        FEATURES
+        wayland         GLFW_BUILD_WAYLAND
+    )
+
+    vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+            -DGLFW_BUILD_EXAMPLES=OFF
+            -DGLFW_BUILD_TESTS=OFF
+            -DGLFW_BUILD_DOCS=OFF
+            ${FEATURE_OPTIONS}
+    )
+
+    vcpkg_cmake_install()
+
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/glfw3)
+
+    vcpkg_fixup_pkgconfig()
+
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+    file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+    vcpkg_copy_pdbs()
+
 endif()
-
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-    wayland         GLFW_BUILD_WAYLAND
-)
-
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DGLFW_BUILD_EXAMPLES=OFF
-        -DGLFW_BUILD_TESTS=OFF
-        -DGLFW_BUILD_DOCS=OFF
-        ${FEATURE_OPTIONS}
-)
-
-vcpkg_cmake_install()
-
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/glfw3)
-
-vcpkg_fixup_pkgconfig()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_copy_pdbs()

--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -54,4 +54,4 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -1,3 +1,11 @@
+if (VCPKG_TARGET_IS_EMSCRIPTEN)
+    # emscripten has built-in glfw3 library
+    set(VCPKG_BUILD_TYPE release)
+    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/glfw3Config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/glfw3")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+    return()
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO glfw/glfw
@@ -6,15 +14,8 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-if (VCPKG_TARGET_IS_EMSCRIPTEN)
-    # emscripten has built-in glfw3 library
-    set(VCPKG_BUILD_TYPE release)
-    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/glfw3Config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/glfw3")
-    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
-
-    if(VCPKG_TARGET_IS_LINUX)
-        message(
+if(VCPKG_TARGET_IS_LINUX)
+    message(
 "GLFW3 currently requires the following libraries from the system package manager:
     xinerama
     xcursor
@@ -27,44 +28,30 @@ These can be installed on Ubuntu systems via sudo apt install libxinerama-dev li
 Alternatively, when targeting the Wayland display server, use the packages listed in the GLFW documentation here:
 
 https://www.glfw.org/docs/3.3/compile.html#compile_deps_wayland")
-    else(VCPKG_TARGET_IS_OSX)
-        message(
-"GLFW3 currently requires the following libraries from the system package manager:
-    xinerama
-    xcursor
-    xorg
-    libglu1-mesa
-    pkg-config
-
-These can be installed via brew install libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev pkg-config")
-    endif()
-
-    vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-        FEATURES
-        wayland         GLFW_BUILD_WAYLAND
-    )
-
-    vcpkg_cmake_configure(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
-            -DGLFW_BUILD_EXAMPLES=OFF
-            -DGLFW_BUILD_TESTS=OFF
-            -DGLFW_BUILD_DOCS=OFF
-            ${FEATURE_OPTIONS}
-        MAYBE_UNUSED_VARIABLES
-            GLFW_USE_WAYLAND
-    )
-
-    vcpkg_cmake_install()
-
-    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/glfw3)
-
-    vcpkg_fixup_pkgconfig()
-
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-    file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-    vcpkg_copy_pdbs()
-
 endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    wayland         GLFW_BUILD_WAYLAND
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DGLFW_BUILD_EXAMPLES=OFF
+        -DGLFW_BUILD_TESTS=OFF
+        -DGLFW_BUILD_DOCS=OFF
+        ${FEATURE_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        GLFW_USE_WAYLAND
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/glfw3)
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/glfw3/vcpkg.json
+++ b/ports/glfw3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "glfw3",
   "version": "3.4",
+  "port-version": 1,
   "description": "GLFW is a free, Open Source, multi-platform library for OpenGL, OpenGL ES and Vulkan application development. It provides a simple, platform-independent API for creating windows, contexts and surfaces, reading input, handling events, etc.",
   "homepage": "https://github.com/glfw/glfw",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3090,7 +3090,7 @@
     },
     "glfw3": {
       "baseline": "3.4",
-      "port-version": 0
+      "port-version": 1
     },
     "gli": {
       "baseline": "2021-07-06",

--- a/versions/g-/glfw3.json
+++ b/versions/g-/glfw3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "07287724626f6e3c75d6e80d409e8965262b3d41",
+      "git-tree": "d4bbd4f27c2ca619f57778985120cddcedadb1cc",
       "version": "3.4",
       "port-version": 1
     },

--- a/versions/g-/glfw3.json
+++ b/versions/g-/glfw3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "91cd870790297631b68758caa4c05672c21f0b89",
+      "git-tree": "f8363ac6b3d2e5b9c42964b894525e25c9eb45dd",
       "version": "3.4",
       "port-version": 1
     },

--- a/versions/g-/glfw3.json
+++ b/versions/g-/glfw3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "91cd870790297631b68758caa4c05672c21f0b89",
+      "version": "3.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "fcbaa3b4073da7a24e20e043164075512f027d2d",
       "version": "3.4",
       "port-version": 0

--- a/versions/g-/glfw3.json
+++ b/versions/g-/glfw3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f8363ac6b3d2e5b9c42964b894525e25c9eb45dd",
+      "git-tree": "07287724626f6e3c75d6e80d409e8965262b3d41",
       "version": "3.4",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

emscripten has built-in glfw3 library.
Fix #36529