### PR TITLE
[vcpkg] fix find_library suffix/prefix definitions for iOS

### DIFF
--- a/scripts/cmake/vcpkg_common_definitions.cmake
+++ b/scripts/cmake/vcpkg_common_definitions.cmake
@@ -95,7 +95,7 @@ elseif(VCPKG_TARGET_IS_WINDOWS)
     set(VCPKG_TARGET_IMPORT_LIBRARY_PREFIX "")
     set(VCPKG_FIND_LIBRARY_SUFFIXES ".lib" ".dll") #This is a slight modification to CMakes value which does not include ".dll".
     set(VCPKG_FIND_LIBRARY_PREFIXES "" "lib") #This is a slight modification to CMakes value which does not include "lib".
-elseif(VCPKG_TARGET_IS_OSX)
+elseif(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
     set(VCPKG_TARGET_STATIC_LIBRARY_SUFFIX ".a")
     set(VCPKG_TARGET_IMPORT_LIBRARY_SUFFIX "")
     set(VCPKG_TARGET_SHARED_LIBRARY_SUFFIX ".dylib")


### PR DESCRIPTION
For example, when building dynamic iOS libs for `mp3lame`, the generated `mp3lame-config.cmake` would be erroneously looking for `libmp3lame.a` instead of `libmp3lame.dylib`.
