### PR TITLE
[mbedtls] update to 2.28.8

### DIFF
--- a/ports/mbedtls/enable-pthread.patch
+++ b/ports/mbedtls/enable-pthread.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b001bb7..b9fb566 100644
+index 844491778..aa81d01f5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -44,6 +44,7 @@ set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+@@ -46,6 +46,7 @@ set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
  
  option(USE_PKCS11_HELPER_LIBRARY "Build Mbed TLS with the pkcs11-helper library." OFF)
  option(ENABLE_ZLIB_SUPPORT "Build Mbed TLS with zlib library." OFF)
@@ -10,8 +10,8 @@ index b001bb7..b9fb566 100644
  
  option(ENABLE_PROGRAMS "Build Mbed TLS programs." ON)
  
-@@ -263,6 +264,8 @@ else()
-     set(LIB_INSTALL_DIR lib)
+@@ -264,6 +265,8 @@ if(LIB_INSTALL_DIR)
+     set(CMAKE_INSTALL_LIBDIR "${LIB_INSTALL_DIR}")
  endif()
  
 +include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/)
@@ -19,7 +19,7 @@ index b001bb7..b9fb566 100644
  if(ENABLE_ZLIB_SUPPORT)
      find_package(ZLIB)
  
-@@ -271,6 +274,17 @@ if(ENABLE_ZLIB_SUPPORT)
+@@ -272,6 +275,17 @@ if(ENABLE_ZLIB_SUPPORT)
      endif(ZLIB_FOUND)
  endif(ENABLE_ZLIB_SUPPORT)
  
@@ -38,7 +38,7 @@ index b001bb7..b9fb566 100644
  
  add_subdirectory(3rdparty)
 diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
-index 11b417b..5ca44c3 100644
+index 11b417bd3..5ca44c341 100644
 --- a/include/CMakeLists.txt
 +++ b/include/CMakeLists.txt
 @@ -1,10 +1,14 @@
@@ -58,7 +58,7 @@ index 11b417b..5ca44c3 100644
          DESTINATION include/mbedtls
          PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 diff --git a/include/mbedtls/config.h b/include/mbedtls/config.h
-index ac2146e..4cd831a 100644
+index 4842fd494..fbce34128 100644
 --- a/include/mbedtls/config.h
 +++ b/include/mbedtls/config.h
 @@ -12,6 +12,8 @@
@@ -84,7 +84,7 @@ index 0000000..9d5d42e
 +#endif
 \ No newline at end of file
 diff --git a/library/CMakeLists.txt b/library/CMakeLists.txt
-index 1b2980d..8c495fe 100644
+index 48e51a158..4e752f777 100644
 --- a/library/CMakeLists.txt
 +++ b/library/CMakeLists.txt
 @@ -149,7 +149,11 @@ if(ENABLE_ZLIB_SUPPORT)

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ARMmbed/mbedtls
     REF "v${VERSION}"
-    SHA512 b61dd319606c88c834b3a8e8f9f85e68a22b6b21ca177b340a972dfabe9efee984b8a9f6ed5d3b1829f229c689394e9f393b94efb38d82bda3a1e53d1e7a2861
+    SHA512 72a25a6b2a132545d32c7a6819bde569a315f2e83049467653af6347c918e4781462dceca21c64c76a4af7d19cedaf968f48b3f0309a6b0289466c087e49dd38
     HEAD_REF mbedtls-2.28
     PATCHES
         enable-pthread.patch
@@ -36,3 +36,4 @@ if (VCPKG_TARGET_IS_WINDOWS AND pthreads IN_LIST FEATURES)
 endif ()
 
 vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()

--- a/ports/mbedtls/vcpkg.json
+++ b/ports/mbedtls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mbedtls",
-  "version": "2.28.7",
+  "version": "2.28.8",
   "description": "An open source, portable, easy to use, readable and flexible SSL library",
   "homepage": "https://github.com/ARMmbed/mbedtls",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5701,7 +5701,7 @@
       "port-version": 2
     },
     "mbedtls": {
-      "baseline": "2.28.7",
+      "baseline": "2.28.8",
       "port-version": 0
     },
     "mchehab-zbar": {

--- a/versions/m-/mbedtls.json
+++ b/versions/m-/mbedtls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e5355b5449b7ca3e1de902bd6c264e27e8eae6d",
+      "version": "2.28.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "b8ca11fc0285875347dc1203913af7f84f9c7cad",
       "version": "2.28.7",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
