### PR TITLE
[shiftmedia-libgnutls] update to 3.8.3

### DIFF
--- a/ports/shiftmedia-libgnutls/external-libtasn1.patch
+++ b/ports/shiftmedia-libgnutls/external-libtasn1.patch
@@ -1,8 +1,8 @@
 diff --git a/SMP/libgnutls.vcxproj.filters b/SMP/libgnutls.vcxproj.filters
-index 5c4d1070d..df4aa2b9f 100644
+index 0e810b202..5a69f12ec 100644
 --- a/SMP/libgnutls.vcxproj.filters
 +++ b/SMP/libgnutls.vcxproj.filters
-@@ -1514,30 +1514,6 @@
+@@ -1520,30 +1520,6 @@
      <ClCompile Include="..\lib\nettle\sysrng-bcrypt.c">
        <Filter>Source Files\lib\nettle</Filter>
      </ClCompile>
@@ -34,10 +34,10 @@ index 5c4d1070d..df4aa2b9f 100644
        <Filter>Source Files\lib\nettle\gost</Filter>
      </ClCompile>
 diff --git a/SMP/libgnutls_files.props b/SMP/libgnutls_files.props
-index 8bc3e2406..10e113e93 100644
+index 7fe1f88d5..cbc2d45c1 100644
 --- a/SMP/libgnutls_files.props
 +++ b/SMP/libgnutls_files.props
-@@ -170,16 +170,6 @@
+@@ -172,16 +172,6 @@
    <ItemGroup>
      <ClCompile Include="lib\gnutls_asn1_tab.c" />
      <ClCompile Include="lib\pkix_asn1_tab.c" />
@@ -53,12 +53,12 @@ index 8bc3e2406..10e113e93 100644
 -    <ClCompile Include="..\devel\libtasn1\lib\version.c" />
      <ClCompile Include="..\gnulib\lib\c-strcasecmp.c" />
      <ClCompile Include="..\gnulib\lib\c-strncasecmp.c" />
-     <ClCompile Include="..\gnulib\lib\hash-pjw-bare.c" />
+     <ClCompile Include="..\gnulib\lib\gl_linkedhash_list.c" />
 diff --git a/SMP/libgnutls_winrt.vcxproj.filters b/SMP/libgnutls_winrt.vcxproj.filters
-index 49778942d..804248636 100644
+index 761877440..cd40b5bb7 100644
 --- a/SMP/libgnutls_winrt.vcxproj.filters
 +++ b/SMP/libgnutls_winrt.vcxproj.filters
-@@ -1514,30 +1514,6 @@
+@@ -1520,30 +1520,6 @@
      <ClCompile Include="..\lib\nettle\sysrng-bcrypt.c">
        <Filter>Source Files\lib\nettle</Filter>
      </ClCompile>

--- a/ports/shiftmedia-libgnutls/portfile.cmake
+++ b/ports/shiftmedia-libgnutls/portfile.cmake
@@ -1,15 +1,10 @@
-set(PACKAGE_VERSION_MAJOR 3)
-set(PACKAGE_VERSION_MINOR 7)
-set(PACKAGE_VERSION_PATCH 6)
-set(PACKAGE_VERSION ${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}.${PACKAGE_VERSION_PATCH})
-
-set(GNULIB_REF "fb64a781")
+set(GNULIB_REF "3639c57")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ShiftMediaProject/gnutls
-    REF ${PACKAGE_VERSION}
-    SHA512 8a3ff480e065cf517468fac9d8d4474cfa6ed354fa83ae60de224580f359f8dcfbfed6cf640d33783779174ade0bca0fbe1c529097ee103af2b02546fc2acaec
+    REF ${VERSION}
+    SHA512 4be02eac5fd52ba02a69f3fb70dc1100d930e7e5f50f0106cb7e266e9fb3c6e12c14741317c097de85b5dc924f993a1ad6f220d33ae187c24fe5f670380b0c96
     HEAD_REF master
     PATCHES
         external-libtasn1.patch
@@ -22,7 +17,7 @@ vcpkg_download_distfile(
     GNULIB_SNAPSHOT
     URLS "https://git.savannah.gnu.org/gitweb/?p=gnulib.git;a=snapshot;h=${GNULIB_REF};sf=tgz"
     FILENAME "gnulib-${GNULIB_REF}.tar.gz"
-    SHA512 6e534b3a623efa5f473977deeed4d24669ef0e0e3ac5fcadc88c5cf2d6ad0852a07c68cd70ac748d7f9a3793704ce1a54a7d17114458a8c1f2e42d410681c340
+    SHA512 bc99be736d2907049d498f44d8f24db4beb2b3645459451b595087b9406ac1eebe4cbb4f2ef65df9e65823e01db4b4800b75eb9537236797fe1edcc65418c520
 )
 
 vcpkg_extract_source_archive(
@@ -157,7 +152,6 @@ if(VCPKG_TARGET_IS_UWP)
 endif()
 file(INSTALL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/${SOURCE_PATH_SUFFIX}/msvc/${WINRT_SUBFOLDER}/include" DESTINATION "${CURRENT_PACKAGES_DIR}")
 
-set(VERSION ${PACKAGE_VERSION})
 set(GNUTLS_REQUIRES_PRIVATE "Requires.private: gmp, nettle, hogweed, libtasn1")
 set(GNUTLS_LIBS_PRIVATE "-lcrypt32 -lws2_32 -lkernel32 -lncrypt")
 

--- a/ports/shiftmedia-libgnutls/vcpkg.json
+++ b/ports/shiftmedia-libgnutls/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "shiftmedia-libgnutls",
-  "version": "3.7.6",
-  "port-version": 4,
+  "version": "3.8.3",
   "description": "Unofficial GnuTLS fork with added custom native Visual Studio project build tools. ",
   "homepage": "https://github.com/ShiftMediaProject/gnutls",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8161,8 +8161,8 @@
       "port-version": 1
     },
     "shiftmedia-libgnutls": {
-      "baseline": "3.7.6",
-      "port-version": 4
+      "baseline": "3.8.3",
+      "port-version": 0
     },
     "shiftmedia-libgpg-error": {
       "baseline": "1.45",

--- a/versions/s-/shiftmedia-libgnutls.json
+++ b/versions/s-/shiftmedia-libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04072be735bed05abbc73b97eda60200be28bcce",
+      "version": "3.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ce284543d4e020e054350eedce9982b83695cfa",
       "version": "3.7.6",
       "port-version": 4


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
