### PR TITLE
[gdk-pixbuf] Add support of libsrvg to gdk-pixbuf when built statically on linux

### DIFF
--- a/ports/gdk-pixbuf/add_optional_svg_support.patch
+++ b/ports/gdk-pixbuf/add_optional_svg_support.patch
@@ -1,0 +1,75 @@
+diff --git a/gdk-pixbuf/gdk-pixbuf-io.c b/gdk-pixbuf/gdk-pixbuf-io.c
+index e1df5900f..d7018da6e 100644
+--- a/gdk-pixbuf/gdk-pixbuf-io.c
++++ b/gdk-pixbuf/gdk-pixbuf-io.c
+@@ -592,7 +592,10 @@ gdk_pixbuf_init_modules (const char  *path,
+ 	g_free (filename);
+ 	return ret;
+ }
+-
++#ifdef INCLUDE_svg
++extern void _gdk_pixbuf__svg_fill_info   (GdkPixbufFormat *info) __attribute__((weak));
++extern void _gdk_pixbuf__svg_fill_vtable (GdkPixbufModule *module) __attribute__((weak));
++#endif
+ static void
+ gdk_pixbuf_io_init_builtin (void)
+ {
+@@ -659,6 +662,10 @@ gdk_pixbuf_io_init_builtin (void)
+         /* Except the gdip-png loader which normally isn't built at all even */
+         load_one_builtin_module (png);
+ #endif
++#ifdef INCLUDE_svg
++        if (_gdk_pixbuf__svg_fill_info && _gdk_pixbuf__svg_fill_vtable)
++                load_one_builtin_module (svg);
++#endif
+ 
+ #undef load_one_builtin_module
+ }
+@@ -777,6 +784,15 @@ gdk_pixbuf_load_module_unlocked (GdkPixbufModule *image_module,
+ #ifdef INCLUDE_qtif
+         try_module (qtif,qtif);
+ #endif
++#ifdef INCLUDE_svg
++if (fill_info == NULL &&
++           strcmp (image_module->module_name, "svg") == 0) {
++               if (_gdk_pixbuf__svg_fill_info && _gdk_pixbuf__svg_fill_vtable) {
++                        fill_info = _gdk_pixbuf__svg_fill_info;
++                        fill_vtable = _gdk_pixbuf__svg_fill_vtable;
++               }
++       }
++#endif
+ 
+ #undef try_module
+         
+diff --git a/meson.build b/meson.build
+index 3eb3fcc15..b11331239 100644
+--- a/meson.build
++++ b/meson.build
+@@ -280,6 +280,12 @@ if not gif_opt.disabled()
+   enabled_loaders += 'gif'
+ endif
+ 
++svg_opt = get_option('svg')
++if not svg_opt.disabled()
++  enabled_loaders += 'svg'
++  add_project_arguments([ '-DINCLUDE_svg' ], language: 'c')
++endif
++
+ others_opt = get_option('others')
+ if not others_opt.disabled()
+   # Keep sorted alphabetically
+diff --git a/meson_options.txt b/meson_options.txt
+index 74830154a..6961c9530 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -18,6 +18,10 @@ option('others',
+        description: 'Enable other loaders, which are weakly maintained',
+        type: 'feature',
+        value: 'disabled')
++option('svg',
++       description: 'Enable SVG loader (requires manual librsvg linking)',
++       type: 'feature',
++       value: 'disabled')
+ option('builtin_loaders',
+        description: 'Comma-separated list of loaders to build into gdk-pixbuf',
+        type: 'array',

--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_gitlab(
         loaders-cache.patch
         use-libtiff-4-pkgconfig.patch
         fix-static-deps.patch
+        add_optional_svg_support.patch
 )
 
 if("introspection" IN_LIST FEATURES)
@@ -35,6 +36,12 @@ if("jpeg" IN_LIST FEATURES)
     list(APPEND OPTIONS -Djpeg=enabled)
 else()
     list(APPEND OPTIONS -Djpeg=disabled)
+endif()
+
+if("svg" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dsvg=enabled)
+else()
+    list(APPEND OPTIONS -Dsvg=disabled)
 endif()
 
 if(CMAKE_HOST_WIN32 AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")

--- a/ports/gdk-pixbuf/vcpkg.json
+++ b/ports/gdk-pixbuf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdk-pixbuf",
   "version": "2.42.12",
+  "port-version": 1,
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-or-later",
@@ -47,6 +48,10 @@
       "dependencies": [
         "libpng"
       ]
+    },
+    "svg": {
+      "description": "Enable SVG loader (requires librsvg to be added manually: https://github.com/microsoft/vcpkg/pull/39988)",
+      "supports": "!windows"
     },
     "tiff": {
       "description": "Enable TIFF loader (requires libtiff)",

--- a/ports/librsvg/CMakeLists.txt
+++ b/ports/librsvg/CMakeLists.txt
@@ -117,8 +117,8 @@ add_library(${LIBRSVG_TARGET} ${LIBRSVG_SOURCES})
 target_compile_definitions(${LIBRSVG_TARGET} PRIVATE
     -DRSVG_COMPILATION
     -D_CRT_SECURE_NO_WARNINGS
-    -DSRCDIR="${CMAKE_CURRENT_SOURCE_DIR}" 
-    -DGDK_PIXBUF_ENABLE_BACKEND 
+    -DSRCDIR="${CMAKE_CURRENT_SOURCE_DIR}"
+    -DGDK_PIXBUF_ENABLE_BACKEND
     -DG_LOG_DOMAIN="libpixbufloader-svg"
     -DSRCDIR=""
     $<$<BOOL:${MINGW}>:HAVE_STRTOK_R>
@@ -168,7 +168,11 @@ set(PIXBUFLOADERSVG_SOURCES
     gdk-pixbuf-loader/io-svg.c
 )
 
-add_library(pixbufloader-svg MODULE ${PIXBUFLOADERSVG_SOURCES})
+if (BUILD_SHARED_LIBS)
+    add_library(pixbufloader-svg MODULE ${PIXBUFLOADERSVG_SOURCES})
+else()
+    add_library(pixbufloader-svg ${PIXBUFLOADERSVG_SOURCES})
+endif()
 target_include_directories(pixbufloader-svg
     PRIVATE
         "${CMAKE_CURRENT_BINARY_DIR}"
@@ -186,14 +190,25 @@ target_link_libraries(pixbufloader-svg
         ${LIBRSVG_TARGET}
         PkgConfig::GDK_PIXBUF
 )
-install(TARGETS pixbufloader-svg
-    RUNTIME DESTINATION "${GDK_PIXBUF_MODULEDIR}"
-    LIBRARY DESTINATION "${GDK_PIXBUF_MODULEDIR}"
-)
+if (BUILD_SHARED_LIBS)
+    install(TARGETS pixbufloader-svg
+        RUNTIME DESTINATION "${GDK_PIXBUF_MODULEDIR}"
+        LIBRARY DESTINATION "${GDK_PIXBUF_MODULEDIR}"
+    )
+else()
+    install(TARGETS pixbufloader-svg
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+    )
+endif()
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/librsvg.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" @ONLY)
 file(READ "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" librsvg_pc)
 list(JOIN librsvg_pc_requires_private " " requires_private)
 string(REPLACE "Requires.private:" "Requires.private: ${requires_private}" librsvg_pc "${librsvg_pc}")
+if (NOT BUILD_SHARED_LIBS)
+    string(REPLACE "-lm" "-lpixbufloader-svg -lm" librsvg_pc "${librsvg_pc}")
+endif()
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" "${librsvg_pc}")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" RENAME "librsvg-${RSVG_API_VERSION}.pc")

--- a/ports/librsvg/fix_io_svg_for_static_build.patch
+++ b/ports/librsvg/fix_io_svg_for_static_build.patch
@@ -1,0 +1,40 @@
+diff --git a/gdk-pixbuf-loader/io-svg.c b/gdk-pixbuf-loader/io-svg.c
+index bcdfd0bb..1d2fd7d1 100644
+--- a/gdk-pixbuf-loader/io-svg.c
++++ b/gdk-pixbuf-loader/io-svg.c
+@@ -43,8 +43,8 @@ typedef struct {
+         gpointer                    user_data;
+ } SvgContext;
+ 
+-G_MODULE_EXPORT void fill_vtable (GdkPixbufModule *module);
+-G_MODULE_EXPORT void fill_info (GdkPixbufFormat *info);
++// G_MODULE_EXPORT void fill_vtable (GdkPixbufModule *module);
++// G_MODULE_EXPORT void fill_info (GdkPixbufFormat *info);
+ 
+ enum {
+         ERROR_WRITING = 1,
+@@ -173,16 +173,20 @@ gdk_pixbuf__svg_image_stop_load (gpointer data, GError **error)
+         return result;
+ }
+ 
+-void
+-fill_vtable (GdkPixbufModule *module)
++#ifdef BUILD_SHARED_LIBS
++#define MODULE_ENTRY(function) G_MODULE_EXPORT void function
++#else
++#define MODULE_ENTRY(function) void _gdk_pixbuf__svg_ ## function
++#endif
++
++MODULE_ENTRY (fill_vtable) (GdkPixbufModule *module)
+ {
+         module->begin_load     = gdk_pixbuf__svg_image_begin_load;
+         module->stop_load      = gdk_pixbuf__svg_image_stop_load;
+         module->load_increment = gdk_pixbuf__svg_image_load_increment;
+ }
+ 
+-void
+-fill_info (GdkPixbufFormat *info)
++MODULE_ENTRY (fill_info) (GdkPixbufFormat *info)
+ {
+         static const GdkPixbufModulePattern signature[] = {
+                 {  " <svg",  "*    ", 100 },

--- a/ports/librsvg/portfile.cmake
+++ b/ports/librsvg/portfile.cmake
@@ -11,6 +11,8 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+    PATCHES
+        fix_io_svg_for_static_build.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" "${CMAKE_CURRENT_LIST_DIR}/config.h.linux" DESTINATION "${SOURCE_PATH}")

--- a/ports/librsvg/vcpkg.json
+++ b/ports/librsvg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "librsvg",
   "version": "2.40.20",
-  "port-version": 11,
+  "port-version": 12,
   "description": "A small library to render Scalable Vector Graphics (SVG)",
   "homepage": "https://gitlab.gnome.org/GNOME/librsvg",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2982,7 +2982,7 @@
     },
     "gdk-pixbuf": {
       "baseline": "2.42.12",
-      "port-version": 0
+      "port-version": 1
     },
     "gemmlowp": {
       "baseline": "2021-09-28",
@@ -4934,7 +4934,7 @@
     },
     "librsvg": {
       "baseline": "2.40.20",
-      "port-version": 11
+      "port-version": 12
     },
     "librsync": {
       "baseline": "2.3.4",

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88fd857069afceb50b98dd5cbe0debab232ab13b",
+      "version": "2.42.12",
+      "port-version": 1
+    },
+    {
       "git-tree": "bbf12c7f576f4ecae98d0b4d8cdc0f5fc07f24fb",
       "version": "2.42.12",
       "port-version": 0

--- a/versions/l-/librsvg.json
+++ b/versions/l-/librsvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0f9c7df272962b1147b531fb77696bab86124797",
+      "version": "2.40.20",
+      "port-version": 12
+    },
+    {
       "git-tree": "c1f96a053c524889c293f4db10c0e43ec0951ca8",
       "version": "2.40.20",
       "port-version": 11


### PR DESCRIPTION
By default, gdk-pixbuf has no support of SVG images. When it's built (outside of vcpkg) dynamically, it supports plugins, that extend the list of supported image formats. Hovewer, when built statically, there is no way to load dynamic plugins. Looks like SVG is widely used on Linux OSs with KDE window manager (at least I see this on Kubuntu 22.04).

In this patch we try to force gdk-pixbuf to use libsrvg when the latter is built statically with the resulting application. We can't add support of librsvg directly, because it required gdk-pixbuf to be built first, thus making a circular dependency. In order to overcome this, we are using weak symbols during linking.

To make everything work, the user should do the next:
1. In the vcpkg.json mention both librsvg and gdk-pixbuf in the dependencies section:
```json
"dependencies": [
    "librsvg",
    {
        "name": "gdk-pixbuf",
        "features": ["jpeg", "png", "svg", "tiff"],
        "default-features": false
    }
]
```
2. Add the next lines to the CMakeLists.txt of the application:
```cmake
find_package(PkgConfig REQUIRED)
pkg_check_modules(LIBRSVG_LINK_PUBLIC librsvg-2.0 IMPORTED_TARGET REQUIRED)
target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::LIBRSVG_LINK_PUBLIC)
```
3. In the main.cpp (or whatever the main file is) add the next lines:
```cpp
extern "C" void _gdk_pixbuf__svg_fill_info (void *module);
extern "C" void _gdk_pixbuf__svg_fill_vtable (void *module);
extern "C" unsigned int rsvg_error_quark (void);
extern "C" void rsvg_handle_pixbuf (void *handle);

typedef void (*GdkPixbufFillInfo) (void *module);
typedef void (*GdkPixbufFillVtable) (void *module);
typedef unsigned int (*RsvgErrorQuark) (void);
typedef void (*RsvgHandlePixbuf) (void *handle);

int main (void) {
    GdkPixbufFillInfo fill_info = _gdk_pixbuf__svg_fill_info;
    GdkPixbufFillVtable fill_vtable = _gdk_pixbuf__svg_fill_vtable;
    RsvgErrorQuark error_quark = rsvg_error_quark;
    RsvgHandlePixbuf handle_pixbuf = rsvg_handle_pixbuf;
    return 0;
}
```

This fixes #38012.