### PR TITLE
[flecs] Add documentation link to manifest

### DIFF
--- a/ports/flecs/vcpkg.json
+++ b/ports/flecs/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "flecs",
   "version": "4.0.0",
+  "port-version": 1,
   "description": "A fast entity component system (ECS) for C & C++",
   "homepage": "https://github.com/SanderMertens/flecs",
+  "documentation": "https://www.flecs.dev/flecs/",
   "license": "MIT",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2766,7 +2766,7 @@
     },
     "flecs": {
       "baseline": "4.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "flint": {
       "baseline": "2.9.0",

--- a/versions/f-/flecs.json
+++ b/versions/f-/flecs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b5803a6b34ec2413e7b1fe48aa63a3f4f06331e",
+      "version": "4.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "24af229b956345525447a09037658c5c29a29a22",
       "version": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
