### PR TITLE
[qtbase] dnslookup feature flag and support for QDnsLookup on !Windows

### DIFF
--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -137,11 +137,14 @@ list(APPEND FEATURE_CORE_OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_WrapBacktrace:BOOL
     "openssl"             FEATURE_openssl
     "brotli"              FEATURE_brotli
     "securetransport"     FEATURE_securetransport
+    "dnslookup"           FEATURE_dnslookup
+    "dnslookup"           FEATURE_libresolv
     #"brotli"              CMAKE_REQUIRE_FIND_PACKAGE_WrapBrotli
     #"openssl"             CMAKE_REQUIRE_FIND_PACKAGE_WrapOpenSSL
  INVERTED_FEATURES
     "brotli"              CMAKE_DISABLE_FIND_PACKAGE_WrapBrotli
     "openssl"             CMAKE_DISABLE_FIND_PACKAGE_WrapOpenSSL
+    "dnslookup"           CMAKE_DISABLE_FIND_PACKAGE_WrapResolve
     )
 
 if("openssl" IN_LIST FEATURES)
@@ -152,7 +155,6 @@ endif()
 
 list(APPEND FEATURE_NET_OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_Libproxy:BOOL=ON)
 list(APPEND FEATURE_NET_OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_GSSAPI:BOOL=ON)
-list(APPEND FEATURE_NET_OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_WrapResolv:BOOL=ON)
 
 # Gui features:
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_GUI_OPTIONS

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.7.2",
+  "port-version": 1,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -65,6 +66,7 @@
       "platform": "!(static & windows)"
     },
     "default-features",
+    "dnslookup",
     "doubleconversion",
     "freetype",
     "gui",
@@ -182,6 +184,18 @@
             "gles2"
           ],
           "platform": "android"
+        }
+      ]
+    },
+    "dnslookup": {
+      "description": "Enable DNS lookup support",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "network"
+          ]
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7406,7 +7406,7 @@
     },
     "qtbase": {
       "baseline": "6.7.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtcharts": {
       "baseline": "6.7.2",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8c493a18ed293e1418f464515c9f9ddf3dc1bfe",
+      "version": "6.7.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "f8600119a4cecb137dd044bf72ab5a3c8b67ae02",
       "version": "6.7.2",
       "port-version": 0


### PR DESCRIPTION
Fixes QDnsLookup on !Windows.
Previously FEATURE_dnslookup was enabled but finding WrapResolv was disabled. That builds Qt with a dummy resolver that always errors.
    
FEATURE_dnslookup was implicitly active before and is therefore a default feature.
On !WINDOWS that will now require libresolv which is part of glibc. With the dnslookup feature disabled, including QDnsLookup header will now cause an error instead of always returning an error on actual lookups.

Fixes #39997 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
