### PR TITLE
[conjure-enum] new port

### DIFF
--- a/ports/conjure-enum/portfile.cmake
+++ b/ports/conjure-enum/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fix8mt/conjure_enum
-    REF "v1.0.0" # TODO: Change to "v${VERSION}" when upstream tag is fixed.
+    REF "v${VERSION}"
     SHA512 65fc1bc0364c6129b3b463b18c03ab38793c9632d0ece5b5e696a661e5ddad859c6b6ff2c5d8a1da98c7de2248e80f246e0a039d9e7be5fb507a4b61c71f69e8
     HEAD_REF master
 )

--- a/ports/conjure-enum/portfile.cmake
+++ b/ports/conjure-enum/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO fix8mt/conjure_enum
+    REF "v1.0.0" # TODO: Change to "v${VERSION}" when upstream tag is fixed.
+    SHA512 65fc1bc0364c6129b3b463b18c03ab38793c9632d0ece5b5e696a661e5ddad859c6b6ff2c5d8a1da98c7de2248e80f246e0a039d9e7be5fb507a4b61c71f69e8
+    HEAD_REF master
+)
+
+file(INSTALL ${SOURCE_PATH}/include/fix8/conjure_enum.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/conjure-enum/portfile.cmake
+++ b/ports/conjure-enum/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fix8mt/conjure_enum
     REF "v${VERSION}"
-    SHA512 65fc1bc0364c6129b3b463b18c03ab38793c9632d0ece5b5e696a661e5ddad859c6b6ff2c5d8a1da98c7de2248e80f246e0a039d9e7be5fb507a4b61c71f69e8
+    SHA512 b9054a62ba10dd7b27b0fa6d2fd6a0c03eaea0f39fc0ba954e12351face02969fccd393278a9e29fa3f8af52b285b16e5ca6d0bc00a05a6ad08d7482bc1c587c
     HEAD_REF master
 )
 

--- a/ports/conjure-enum/vcpkg.json
+++ b/ports/conjure-enum/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "conjure-enum",
+  "version": "1.0.1",
+  "description": "Lightweight header-only C++20 enum and typename reflection.",
+  "homepage": "https://github.com/fix8mt/conjure_enum",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1820,6 +1820,10 @@
       "baseline": "4.0.3",
       "port-version": 0
     },
+    "conjure-enum": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "console-bridge": {
       "baseline": "1.0.2",
       "port-version": 0

--- a/versions/c-/conjure-enum.json
+++ b/versions/c-/conjure-enum.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e00c24d3a30d461456162812374422247f402290",
+      "version": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/conjure-enum.json
+++ b/versions/c-/conjure-enum.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6c59daa2e4d7547928b1b9f053d14c96fff856d8",
+      "git-tree": "78574a0113c4bcf9bad05d2fcef406d0bc1d0891",
       "version": "1.0.1",
       "port-version": 0
     }

--- a/versions/c-/conjure-enum.json
+++ b/versions/c-/conjure-enum.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e00c24d3a30d461456162812374422247f402290",
+      "git-tree": "6c59daa2e4d7547928b1b9f053d14c96fff856d8",
       "version": "1.0.1",
       "port-version": 0
     }


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] ~~Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).~~
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
