### PR TITLE
[mbedtls] update to v3.6.0

### DIFF
--- a/ports/mbedtls/enable-pthread.patch
+++ b/ports/mbedtls/enable-pthread.patch
@@ -1,28 +1,20 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 844491778..aa81d01f5 100644
+index 2eba16da5..5e7e242de 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -46,6 +46,7 @@ set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+@@ -58,6 +58,7 @@ endif()
+ # Set the project root directory.
+ set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
  
- option(USE_PKCS11_HELPER_LIBRARY "Build Mbed TLS with the pkcs11-helper library." OFF)
- option(ENABLE_ZLIB_SUPPORT "Build Mbed TLS with zlib library." OFF)
 +option(ENABLE_PTHREAD "Build Mbed TLS with pthread" OFF)
- 
  option(ENABLE_PROGRAMS "Build Mbed TLS programs." ON)
  
-@@ -264,6 +265,8 @@ if(LIB_INSTALL_DIR)
-     set(CMAKE_INSTALL_LIBDIR "${LIB_INSTALL_DIR}")
+ option(UNSAFE_BUILD "Allow unsafe builds. These builds ARE NOT SECURE." OFF)
+@@ -288,6 +289,18 @@ if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/framework/CMakeLists.txt")
  endif()
+ add_subdirectory(framework)
  
 +include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/)
-+
- if(ENABLE_ZLIB_SUPPORT)
-     find_package(ZLIB)
- 
-@@ -272,6 +275,17 @@ if(ENABLE_ZLIB_SUPPORT)
-     endif(ZLIB_FOUND)
- endif(ENABLE_ZLIB_SUPPORT)
- 
 +if(ENABLE_PTHREAD)
 +    if(WIN32)
 +        find_package(pthreads_windows REQUIRED)
@@ -38,7 +30,7 @@ index 844491778..aa81d01f5 100644
  
  add_subdirectory(3rdparty)
 diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
-index 11b417bd3..5ca44c341 100644
+index e11e2715a..897c79785 100644
 --- a/include/CMakeLists.txt
 +++ b/include/CMakeLists.txt
 @@ -1,10 +1,14 @@
@@ -57,22 +49,9 @@ index 11b417bd3..5ca44c341 100644
      install(FILES ${headers}
          DESTINATION include/mbedtls
          PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
-diff --git a/include/mbedtls/config.h b/include/mbedtls/config.h
-index 4842fd494..fbce34128 100644
---- a/include/mbedtls/config.h
-+++ b/include/mbedtls/config.h
-@@ -12,6 +12,8 @@
-  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
-  */
- 
-+#include "mbedtls/config_threading.h"
-+
- #ifndef MBEDTLS_CONFIG_H
- #define MBEDTLS_CONFIG_H
- 
 diff --git a/include/mbedtls/config_threading.h.in b/include/mbedtls/config_threading.h.in
 new file mode 100644
-index 0000000..9d5d42e
+index 000000000..9d5d42ead
 --- /dev/null
 +++ b/include/mbedtls/config_threading.h.in
 @@ -0,0 +1,6 @@
@@ -83,19 +62,31 @@ index 0000000..9d5d42e
 +#define MBEDTLS_THREADING_PTHREAD
 +#endif
 \ No newline at end of file
+diff --git a/include/mbedtls/mbedtls_config.h b/include/mbedtls/mbedtls_config.h
+index 35921412c..3cefab75d 100644
+--- a/include/mbedtls/mbedtls_config.h
++++ b/include/mbedtls/mbedtls_config.h
+@@ -20,6 +20,7 @@
+  * introduced the config format we want to be compatible with.
+  */
+ //#define MBEDTLS_CONFIG_VERSION 0x03000000
++#include "mbedtls/config_threading.h"
+ 
+ /**
+  * \name SECTION: System support
 diff --git a/library/CMakeLists.txt b/library/CMakeLists.txt
-index 48e51a158..4e752f777 100644
+index e6705de55..09ce3bf1b 100644
 --- a/library/CMakeLists.txt
 +++ b/library/CMakeLists.txt
-@@ -149,7 +149,11 @@ if(ENABLE_ZLIB_SUPPORT)
- endif(ENABLE_ZLIB_SUPPORT)
+@@ -232,7 +232,11 @@ if(HAIKU)
+ endif(HAIKU)
  
  if(LINK_WITH_PTHREAD)
--    set(libs ${libs} pthread)
+-    set(libs ${libs} ${CMAKE_THREAD_LIBS_INIT})
 +    if(WIN32)
 +        set(libs ${libs} ${PThreads4W_LIBRARY})
 +    else()
-+        set(libs ${libs} pthread)
++        set(libs ${libs}  ${CMAKE_THREAD_LIBS_INIT})
 +    endif()
  endif()
  

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -4,11 +4,21 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ARMmbed/mbedtls
     REF "v${VERSION}"
-    SHA512 72a25a6b2a132545d32c7a6819bde569a315f2e83049467653af6347c918e4781462dceca21c64c76a4af7d19cedaf968f48b3f0309a6b0289466c087e49dd38
-    HEAD_REF mbedtls-2.28
+    SHA512 7e50cf2bb2c9abeb56f18a25bc126b96ac5e3329702cf5b2e266df6b649b9544ab5f2ac00bd57e06091e10cdcf907e600c14eb415942d028000d7b6f1c0cfa42
     PATCHES
         enable-pthread.patch
 )
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH FRAMEWORK_SOURCE_PATH
+    REPO Mbed-TLS/mbedtls-framework
+    REF 750634d3a51eb9d61b59fd5d801546927c946588
+    SHA512 b22687ba164502a12bb39f46cde9bc012cd0e1e4493de815f8f43c835d3385b4bb43f423f2991ba8062191b40ce3ea14955e1a6601a9688819cead5861715267
+    HEAD_REF main
+)
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/framework")
+file(RENAME "${FRAMEWORK_SOURCE_PATH}" "${SOURCE_PATH}/framework")
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -36,4 +46,6 @@ if (VCPKG_TARGET_IS_WINDOWS AND pthreads IN_LIST FEATURES)
 endif ()
 
 vcpkg_copy_pdbs()
+
 vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -48,4 +48,4 @@ endif ()
 vcpkg_copy_pdbs()
 
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/MbedTLS")

--- a/ports/mbedtls/vcpkg.json
+++ b/ports/mbedtls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mbedtls",
-  "version": "2.28.8",
+  "version": "3.6.0",
   "description": "An open source, portable, easy to use, readable and flexible SSL library",
   "homepage": "https://github.com/ARMmbed/mbedtls",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5709,7 +5709,7 @@
       "port-version": 2
     },
     "mbedtls": {
-      "baseline": "2.28.8",
+      "baseline": "3.6.0",
       "port-version": 0
     },
     "mchehab-zbar": {

--- a/versions/m-/mbedtls.json
+++ b/versions/m-/mbedtls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a27d78d5747222eebd8051f75c9f3c3387aeb15",
+      "version": "3.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1e5355b5449b7ca3e1de902bd6c264e27e8eae6d",
       "version": "2.28.8",
       "port-version": 0

--- a/versions/m-/mbedtls.json
+++ b/versions/m-/mbedtls.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2a27d78d5747222eebd8051f75c9f3c3387aeb15",
+      "git-tree": "2a5578b499d7d6fb2c26cffdf487ef6acf69d889",
       "version": "3.6.0",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
