### PR TITLE
[ngtcp2,wolfssl] Add features

### DIFF
--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -11,9 +11,16 @@ vcpkg_from_github(
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC_LIB)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED_LIB)
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        wolfssl     ENABLE_WOLFSSL
+        gnutls      ENABLE_GNUTLS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         "-DENABLE_STATIC_LIB=${ENABLE_STATIC_LIB}"
         "-DENABLE_SHARED_LIB=${ENABLE_SHARED_LIB}"
         -DBUILD_TESTING=OFF

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -13,5 +13,19 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "wolfssl": {
+      "description": "Compile with wolfssl",
+      "dependencies": [
+        "wolfssl"
+      ]      
+    },
+    "gnutls": {
+      "description": "Compile with gnutls",
+      "dependencies": [
+        "libgnutls"
+      ]
+    }
+  }
 }

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ngtcp2",
   "version": "1.6.0",
+  "port-version": 1,
   "description": "ngtcp2 project is an effort to implement RFC9000 QUIC protocol.",
   "homepage": "https://github.com/ngtcp2/ngtcp2",
   "license": "MIT",
@@ -15,16 +16,21 @@
     }
   ],
   "features": {
-    "wolfssl": {
-      "description": "Compile with wolfssl",
-      "dependencies": [
-        "wolfssl"
-      ]      
-    },
     "gnutls": {
       "description": "Compile with gnutls",
       "dependencies": [
         "libgnutls"
+      ]
+    },
+    "wolfssl": {
+      "description": "Compile with wolfssl",
+      "dependencies": [
+        {
+          "name": "wolfssl",
+          "features": [
+            "quic"
+          ]
+        }
       ]
     }
   }

--- a/ports/wolfssl/portfile.cmake
+++ b/ports/wolfssl/portfile.cmake
@@ -13,6 +13,12 @@ else()
     set(ENABLE_DTLS no)
 endif()
 
+if ("quic" IN_LIST FEATURES)
+    set(ENABLE_QUIC yes)
+else()
+    set(ENABLE_QUIC no)
+endif()
+
 vcpkg_cmake_get_vars(cmake_vars_file)
 include("${cmake_vars_file}")
 
@@ -40,6 +46,8 @@ vcpkg_cmake_configure(
       -DWOLFSSL_DTLS=${ENABLE_DTLS}
       -DWOLFSSL_DTLS13=${ENABLE_DTLS}
       -DWOLFSSL_DTLS_CID=${ENABLE_DTLS}
+      -DWOLFSSL_QUIC=${ENABLE_QUIC}
+      -DWOLFSSL_SESSION_TICKET=${ENABLE_QUIC}
     OPTIONS_RELEASE
       -DCMAKE_C_FLAGS=${VCPKG_COMBINED_C_FLAGS_RELEASE}
     OPTIONS_DEBUG

--- a/ports/wolfssl/vcpkg.json
+++ b/ports/wolfssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "wolfssl",
   "version": "5.7.2",
+  "port-version": 1,
   "description": "TLS and Cryptographic library for many platforms",
   "homepage": "https://wolfssl.com",
   "license": "GPL-2.0-or-later",
@@ -22,6 +23,9 @@
   "features": {
     "dtls": {
       "description": "DTLS support"
+    },
+    "quic": {
+      "description": "Enable quic support"
     },
     "secret-callback": {
       "description": "Enables callback to provide TLS keys for debugging"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6202,7 +6202,7 @@
     },
     "ngtcp2": {
       "baseline": "1.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nifly": {
       "baseline": "1.0.0",
@@ -9478,7 +9478,7 @@
     },
     "wolfssl": {
       "baseline": "5.7.2",
-      "port-version": 0
+      "port-version": 1
     },
     "wolftpm": {
       "baseline": "3.2.0",

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "227654175c4fb36c68d385ee7414e057b534f644",
+      "version": "1.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f7c18d82e3bac5d715689349cf8c28fa0596c6e2",
       "version": "1.6.0",
       "port-version": 0

--- a/versions/w-/wolfssl.json
+++ b/versions/w-/wolfssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3145f691d33b3e979a5466f29a3a46c887a0c510",
+      "version": "5.7.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "eb293c6d9a0ff4ce3a4d4353172a9b79aac32027",
       "version": "5.7.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


wolfssl:
- quic feature

ngtcp2:
- wolfssl feature
- gnutls feature

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
