### PR TITLE
[nettle, shiftmedia-libgnutls] nettle update to 3.10, shiftmedia-libgnutls update to 3.8.4

### DIFF
--- a/ports/nettle/ccas.patch
+++ b/ports/nettle/ccas.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile.in b/Makefile.in
-index 964ba18..3194735 100644
+index 2bf7f1e8..c9607468 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -302,7 +302,7 @@ libhogweed.a: $(hogweed_OBJS)
+@@ -303,7 +303,7 @@ libhogweed.a: $(hogweed_OBJS)
  
  %.$(OBJEXT): %.asm $(srcdir)/m4-utils.m4 $(srcdir)/asm.m4 config.m4 machine.m4
  	$(M4) $(srcdir)/m4-utils.m4 $(srcdir)/asm.m4 config.m4 machine.m4 $< >$*.s
@@ -12,20 +12,20 @@ index 964ba18..3194735 100644
  %.$(OBJEXT): %.c
  	$(COMPILE) -c $< \
 diff --git a/aclocal.m4 b/aclocal.m4
-index 0d97388..98f6916 100644
+index 629db8a7..04ff4d31 100644
 --- a/aclocal.m4
 +++ b/aclocal.m4
-@@ -302,7 +302,7 @@ AC_DEFUN([GMP_TRY_ASSEMBLE],
+@@ -268,7 +268,7 @@ AC_DEFUN([GMP_TRY_ASSEMBLE],
  [cat >conftest.s <<EOF
  [$1]
  EOF
 -gmp_assemble="$CC $CFLAGS $CPPFLAGS $ASM_FLAGS -c conftest.s >conftest.out 2>&1"
 +gmp_assemble="$CCAS $CPPFLAGS $ASM_FLAGS -c conftest.s >conftest.out 2>&1"
  if AC_TRY_EVAL(gmp_assemble); then
-   cat conftest.out >&AC_FD_CC
+   cat conftest.out >&AS_MESSAGE_LOG_FD
    ifelse([$2],,:,[$2])
 diff --git a/config.make.in b/config.make.in
-index 6aec7c7..8bc5599 100644
+index 6aec7c73..8bc5599f 100644
 --- a/config.make.in
 +++ b/config.make.in
 @@ -74,6 +74,8 @@ TEST_SHLIB_DIR = ${abs_top_builddir}/.lib
@@ -38,7 +38,7 @@ index 6aec7c7..8bc5599 100644
  LINK = $(CC) $(CFLAGS) $(PRE_LDFLAGS) $(LDFLAGS)
  LINK_CXX = $(CXX) $(CXXFLAGS) $(PRE_LDFLAGS) $(LDFLAGS)
 diff --git a/configure.ac b/configure.ac
-index dad15f6..7a17853 100644
+index 4f27e663..324e4706 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -148,6 +148,9 @@ LSH_RPATH_INIT([`echo $with_lib_path | sed 's/:/ /g'` \
@@ -51,21 +51,21 @@ index dad15f6..7a17853 100644
  
  NETTLE_CHECK_IFUNC
  
-@@ -335,7 +338,7 @@ W64_ABI=no   # For x86_64 windows
+@@ -318,7 +321,7 @@ W64_ABI=no   # For x86_64 windows
  case "$host_cpu" in
    [x86_64 | amd64])
-     AC_TRY_COMPILE([
+     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 -#if defined(__x86_64__) || defined(__arch64__)
 +#if defined(__x86_64__) || defined(__arch64__) || defined(_M_AMD64)
  #error 64-bit x86
  #endif
-     ], [], [
-@@ -388,7 +391,7 @@ case "$host_cpu" in
+     ]], [[]])], [
+@@ -371,7 +374,7 @@ case "$host_cpu" in
      ;;
    aarch64*)
-     AC_TRY_COMPILE([
+     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 -#if defined(__aarch64__)
 +#if defined(__aarch64__) || defined(_M_ARM64)
  #error 64-bit arm
  #endif
-     ], [], [
+     ]], [[]])], [

--- a/ports/nettle/hogweed-arm.def
+++ b/ports/nettle/hogweed-arm.def
@@ -51,8 +51,6 @@ EXPORTS
      nettle_ecc_point_get
      nettle_ecc_scalar_random
      _nettle_ecc_mod_random
-     _nettle_ecc_hash
-     _nettle_gost_hash
      _nettle_ecc_mul_a
      _nettle_ecc_mul_g
      _nettle_ecc_mul_m
@@ -280,3 +278,13 @@ EXPORTS
      nettle_sexp_iterator_check_type
      nettle_sexp_iterator_check_types
      nettle_sexp_iterator_assoc
+     _nettle_rsa_oaep_decrypt
+     _nettle_rsa_oaep_encrypt
+     nettle_rsa_oaep_sha256_decrypt
+     nettle_rsa_oaep_sha384_decrypt
+     nettle_rsa_oaep_sha512_decrypt     
+     nettle_rsa_oaep_sha256_encrypt
+     nettle_rsa_oaep_sha384_encrypt
+     nettle_rsa_oaep_sha512_encrypt
+     _nettle_oaep_decode_mgf1
+     _nettle_oaep_encode_mgf1

--- a/ports/nettle/hogweed-arm64.def
+++ b/ports/nettle/hogweed-arm64.def
@@ -51,8 +51,6 @@ EXPORTS
      nettle_ecc_point_get
      nettle_ecc_scalar_random
      _nettle_ecc_mod_random
-     _nettle_ecc_hash
-     _nettle_gost_hash
      _nettle_ecc_mul_a
      _nettle_ecc_mul_g
      _nettle_ecc_mul_m
@@ -280,3 +278,13 @@ EXPORTS
      nettle_sexp_iterator_check_type
      nettle_sexp_iterator_check_types
      nettle_sexp_iterator_assoc
+     _nettle_rsa_oaep_decrypt
+     _nettle_rsa_oaep_encrypt
+     nettle_rsa_oaep_sha256_decrypt
+     nettle_rsa_oaep_sha384_decrypt
+     nettle_rsa_oaep_sha512_decrypt     
+     nettle_rsa_oaep_sha256_encrypt
+     nettle_rsa_oaep_sha384_encrypt
+     nettle_rsa_oaep_sha512_encrypt
+     _nettle_oaep_decode_mgf1
+     _nettle_oaep_encode_mgf1

--- a/ports/nettle/hogweed-x64.def
+++ b/ports/nettle/hogweed-x64.def
@@ -58,8 +58,6 @@ EXPORTS
      nettle_ecc_point_get
      nettle_ecc_scalar_random
      _nettle_ecc_mod_random
-     _nettle_ecc_hash
-     _nettle_gost_hash
      _nettle_ecc_mul_a
      _nettle_ecc_mul_g
      _nettle_ecc_mul_m
@@ -287,3 +285,13 @@ EXPORTS
      nettle_sexp_iterator_check_type
      nettle_sexp_iterator_check_types
      nettle_sexp_iterator_assoc
+     _nettle_rsa_oaep_decrypt
+     _nettle_rsa_oaep_encrypt
+     nettle_rsa_oaep_sha256_decrypt
+     nettle_rsa_oaep_sha384_decrypt
+     nettle_rsa_oaep_sha512_decrypt     
+     nettle_rsa_oaep_sha256_encrypt
+     nettle_rsa_oaep_sha384_encrypt
+     nettle_rsa_oaep_sha512_encrypt
+     _nettle_oaep_decode_mgf1
+     _nettle_oaep_encode_mgf1

--- a/ports/nettle/hogweed-x86.def
+++ b/ports/nettle/hogweed-x86.def
@@ -51,8 +51,6 @@ EXPORTS
      nettle_ecc_point_get
      nettle_ecc_scalar_random
      _nettle_ecc_mod_random
-     _nettle_ecc_hash
-     _nettle_gost_hash
      _nettle_ecc_mul_a
      _nettle_ecc_mul_g
      _nettle_ecc_mul_m
@@ -280,3 +278,13 @@ EXPORTS
      nettle_sexp_iterator_check_type
      nettle_sexp_iterator_check_types
      nettle_sexp_iterator_assoc
+     _nettle_rsa_oaep_decrypt
+     _nettle_rsa_oaep_encrypt
+     nettle_rsa_oaep_sha256_decrypt
+     nettle_rsa_oaep_sha384_decrypt
+     nettle_rsa_oaep_sha512_decrypt     
+     nettle_rsa_oaep_sha256_encrypt
+     nettle_rsa_oaep_sha384_encrypt
+     nettle_rsa_oaep_sha512_encrypt
+     _nettle_oaep_decode_mgf1
+     _nettle_oaep_encode_mgf1

--- a/ports/nettle/host-tools.patch
+++ b/ports/nettle/host-tools.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile.in b/Makefile.in
-index 3a12fb4..d00b565 100644
+index 2bf7f1e8..4b80c8df 100644
 --- a/Makefile.in
 +++ b/Makefile.in
 @@ -1,3 +1,6 @@
@@ -9,7 +9,7 @@ index 3a12fb4..d00b565 100644
  # Nettle Makefile
  
  @SET_MAKE@
-@@ -335,11 +338,11 @@ des_headers = rotors.h keymap.h
+@@ -347,11 +350,11 @@ des_headers = rotors.h keymap.h
  # Generate DES headers.
  $(des_headers): desdata.stamp
  	f="$(srcdir)/`basename $@`"; \
@@ -24,7 +24,7 @@ index 3a12fb4..d00b565 100644
  	echo stamp > desdata.stamp
  
  des.$(OBJEXT): des.c des.h $(des_headers)
-@@ -352,7 +355,7 @@ des.$(OBJEXT): des.c des.h $(des_headers)
+@@ -364,7 +367,7 @@ des.$(OBJEXT): des.c des.h $(des_headers)
  # k = 11, c =  6, S = 192, T =  44 ( 33 A + 11 D)  9 KB
  # k = 16, c =  6, S = 128, T =  48 ( 32 A + 16 D)  6 KB
  ecc-secp192r1.h: eccdata.stamp
@@ -33,7 +33,7 @@ index 3a12fb4..d00b565 100644
  
  # Some reasonable choices for 224:
  # k = 16, c =  7, S = 256, T =  48 ( 32 A + 16 D) ~16 KB
-@@ -360,7 +363,7 @@ ecc-secp192r1.h: eccdata.stamp
+@@ -372,7 +375,7 @@ ecc-secp192r1.h: eccdata.stamp
  # k = 13, c =  6, S = 192, T =  52 ( 39 A + 13 D) ~12 KB
  # k =  9, c =  5, S = 160, T =  54 ( 45 A +  9 D) ~10 KB
  ecc-secp224r1.h: eccdata.stamp
@@ -42,7 +42,7 @@ index 3a12fb4..d00b565 100644
  
  # Some reasonable choices for 256:
  # k =  9, c =  6, S = 320, T =  54 ( 45 A +  9 D) 20 KB
-@@ -368,7 +371,7 @@ ecc-secp224r1.h: eccdata.stamp
+@@ -380,7 +383,7 @@ ecc-secp224r1.h: eccdata.stamp
  # k = 19, c =  7, S = 256, T =  57 ( 38 A + 19 D) 16 KB
  # k = 15, c =  6, S = 192, T =  60 ( 45 A + 15 D) 12 KB
  ecc-secp256r1.h: eccdata.stamp
@@ -51,7 +51,7 @@ index 3a12fb4..d00b565 100644
  
  # Some reasonable choices for 384:
  # k = 16, c =  6, S = 256, T =  80 ( 64 A + 16 D) 24 KB
-@@ -379,7 +382,7 @@ ecc-secp256r1.h: eccdata.stamp
+@@ -391,7 +394,7 @@ ecc-secp256r1.h: eccdata.stamp
  # k = 16, c =  5, S = 160, T =  96 ( 80 A + 16 D) 15 KB
  # k = 32, c =  6, S = 128, T =  96 ( 64 A + 32 D) 12 KB
  ecc-secp384r1.h: eccdata.stamp
@@ -60,7 +60,7 @@ index 3a12fb4..d00b565 100644
  
  # Some reasonable choices for 521:
  # k = 29, c =  6, S = 192, T = 116 ( 87 A + 29 D) ~27 KB
-@@ -387,14 +390,14 @@ ecc-secp384r1.h: eccdata.stamp
+@@ -399,14 +402,14 @@ ecc-secp384r1.h: eccdata.stamp
  # k = 44, c =  6, S = 128, T = 132 ( 88 A + 44 D) ~18 KB
  # k = 35, c =  5, S =  96, T = 140 (105 A + 35 D) ~14 KB
  ecc-secp521r1.h: eccdata.stamp
@@ -78,7 +78,7 @@ index 3a12fb4..d00b565 100644
  
  # Some reasonable choices for 256:
  # k =  9, c =  6, S = 320, T =  54 ( 45 A +  9 D) 20 KB
-@@ -402,7 +405,7 @@ ecc-curve448.h: eccdata.stamp
+@@ -414,7 +417,7 @@ ecc-curve448.h: eccdata.stamp
  # k = 19, c =  7, S = 256, T =  57 ( 38 A + 19 D) 16 KB
  # k = 15, c =  6, S = 192, T =  60 ( 45 A + 15 D) 12 KB
  ecc-gost-gc256b.h: eccdata.stamp
@@ -87,7 +87,7 @@ index 3a12fb4..d00b565 100644
  
  # Some reasonable choices for 512:
  # k = 22, c =  6, S = 256, T = 110 ( 88 A + 22 D) 32 KB
-@@ -411,10 +414,10 @@ ecc-gost-gc256b.h: eccdata.stamp
+@@ -423,10 +426,10 @@ ecc-gost-gc256b.h: eccdata.stamp
  # k = 43, c =  6, S = 128, T = 129 ( 86 A + 43 D) 16 KB
  # k = 35, c =  5, S =  96, T = 140 (105 A + 35 D) 12 KB
  ecc-gost-gc512a.h: eccdata.stamp
@@ -102,11 +102,11 @@ index 3a12fb4..d00b565 100644
  
  ecc-curve25519.$(OBJEXT): ecc-curve25519.h
 diff --git a/aclocal.m4 b/aclocal.m4
-index 8822c18..1d218a0 100644
+index 629db8a7..0cf32544 100644
 --- a/aclocal.m4
 +++ b/aclocal.m4
-@@ -378,6 +378,7 @@ if AC_TRY_EVAL(gmp_compile); then
-   if (./a.out || ./b.out || ./a.exe || ./a_out.exe || ./conftest) >&AC_FD_CC 2>&1; then
+@@ -345,6 +345,7 @@ if AC_TRY_EVAL(gmp_compile); then
+   if (./a.out || ./b.out || ./a.exe || ./a_out.exe || ./conftest) >&AS_MESSAGE_LOG_FD 2>&1; then
      cc_for_build_works=yes
    fi
 +  cc_for_build_works=yes # forced

--- a/ports/nettle/portfile.cmake
+++ b/ports/nettle/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://git.lysator.liu.se/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nettle/nettle
-    REF nettle_3.9.1_release_20230601
-    SHA512 4938d31d9183fd143c6d43a43bda8372bd8899c51c18dfb8640065bffd4c5928006481d16679b1ad057404697f7af06bf1630de4b8072592c38cbb7113d16b21
+    REF nettle_3.10_release_20240616
+    SHA512 8767e4f0c34ce76ead5d66f06f97e6b184d439fa94f848ee440196fafde3da2ea7cfc54f9bd8f9ab6a99929b0d14b3d5a28857e05d954551e94b619598c17659
     HEAD_REF master
     PATCHES 
         subdirs.patch

--- a/ports/nettle/subdirs.patch
+++ b/ports/nettle/subdirs.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile.in b/Makefile.in
-index c7dd33f..6d4387e 100644
+index 2bf7f1e8..3e0ba565 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -22,7 +22,7 @@ OPT_NETTLE_SOURCES = @OPT_NETTLE_SOURCES@
+@@ -19,7 +19,7 @@ OPT_NETTLE_SOURCES = @OPT_NETTLE_SOURCES@
  
  FAT_TEST_LIST = @FAT_TEST_LIST@
  
@@ -12,7 +12,7 @@ index c7dd33f..6d4387e 100644
  include config.make
  
 diff --git a/configure.ac b/configure.ac
-index b629e39..2464514 100644
+index 4f27e663..a72b732b 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -24,6 +24,14 @@ AC_SUBST([MINOR_VERSION])
@@ -29,4 +29,4 @@ index b629e39..2464514 100644
 +
  # Command line options
  AC_ARG_WITH(include-path,
-   AC_HELP_STRING([--with-include-path], [A colon-separated list of directories to search for include files]),,
+   AS_HELP_STRING([--with-include-path], [A colon-separated list of directories to search for include files]),,

--- a/ports/nettle/vcpkg.json
+++ b/ports/nettle/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nettle",
-  "version": "3.9.1",
+  "version": "3.10",
   "description": "Nettle is a low-level cryptographic library that is designed to fit easily in more or less any context: In crypto toolkits for object-oriented languages (C++, Python, Pike, ...), in applications like LSH or GNUPG, or even in kernel space.",
   "homepage": "https://git.lysator.liu.se/nettle/nettle",
   "license": null,

--- a/ports/shiftmedia-libgnutls/portfile.cmake
+++ b/ports/shiftmedia-libgnutls/portfile.cmake
@@ -4,11 +4,12 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ShiftMediaProject/gnutls
     REF ${VERSION}
-    SHA512 4be02eac5fd52ba02a69f3fb70dc1100d930e7e5f50f0106cb7e266e9fb3c6e12c14741317c097de85b5dc924f993a1ad6f220d33ae187c24fe5f670380b0c96
+    SHA512 5bd515da85f9e87b98f09a29472f788e869ccc3355f9583fbb4215d954cc5f97239e017120a0b358d259e58d0bd8e538fd00ea102fdbc1b29363cd92f06d0299
     HEAD_REF master
     PATCHES
         external-libtasn1.patch
         pkgconfig.patch
+        ssize_t_already_define.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/devel/perlasm")

--- a/ports/shiftmedia-libgnutls/ssize_t_already_define.patch
+++ b/ports/shiftmedia-libgnutls/ssize_t_already_define.patch
@@ -1,0 +1,14 @@
+diff --git a/SMP/gnutls/gnutls.h b/SMP/gnutls/gnutls.h
+index af1c296a69..796d838064 100644
+--- a/SMP/gnutls/gnutls.h
++++ b/SMP/gnutls/gnutls.h
+@@ -39,7 +39,9 @@
+ /* Get ssize_t. */
+ #ifdef _MSC_VER
+ #  include <BaseTsd.h>
++#  ifndef ssize_t
+ typedef SSIZE_T ssize_t;
++#  endif
+ #  include <sys/types.h>
+ #else
+ #  include <sys/types.h>

--- a/ports/shiftmedia-libgnutls/vcpkg.json
+++ b/ports/shiftmedia-libgnutls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "shiftmedia-libgnutls",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "description": "Unofficial GnuTLS fork with added custom native Visual Studio project build tools. ",
   "homepage": "https://github.com/ShiftMediaProject/gnutls",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6185,7 +6185,7 @@
       "port-version": 0
     },
     "nettle": {
-      "baseline": "3.9.1",
+      "baseline": "3.10",
       "port-version": 0
     },
     "networkdirect-sdk": {
@@ -8169,7 +8169,7 @@
       "port-version": 1
     },
     "shiftmedia-libgnutls": {
-      "baseline": "3.8.3",
+      "baseline": "3.8.4",
       "port-version": 0
     },
     "shiftmedia-libgpg-error": {

--- a/versions/n-/nettle.json
+++ b/versions/n-/nettle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9326fbe0ac4d6a3e70d622443d40b29d9538a9ff",
+      "version": "3.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "1b3f0bbb2ea2c2fb1bbb016d80d7c5e867b0f1a7",
       "version": "3.9.1",
       "port-version": 0

--- a/versions/s-/shiftmedia-libgnutls.json
+++ b/versions/s-/shiftmedia-libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2138ba71b3282796cf9ee0318ec585fc0482281",
+      "version": "3.8.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "04072be735bed05abbc73b97eda60200be28bcce",
       "version": "3.8.3",
       "port-version": 0


### PR DESCRIPTION
update nettle to 3.10
update shiftmedia-libgnutls to 3.8.4

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.