### PR TITLE
[virtualgl] New port

### DIFF
--- a/ports/virtualgl/fix-dependencies.patch
+++ b/ports/virtualgl/fix-dependencies.patch
@@ -1,0 +1,108 @@
+From 52acb2f9493eca631f95a39833dc26405fc59b54 Mon Sep 17 00:00:00 2001
+From: aristotelos <arisvd@gmail.com>
+Date: Mon, 22 Jul 2024 11:16:36 +0200
+Subject: [PATCH] Fix dependencies
+
+Switch from including `Find...` modules and `find_path` to
+`find_package` and `find_library`, which support finding VCPKG
+dependencies.
+---
+ CMakeLists.txt                   |  4 ++--
+ cmakescripts/FindTurboJPEG.cmake | 36 +-------------------------------
+ server/CMakeLists.txt            |  2 +-
+ wgldemos/CMakeLists.txt          |  2 +-
+ 4 files changed, 5 insertions(+), 39 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index be0a02b1..534fefcb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -298,11 +298,11 @@ else()
+ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+     set(CMAKE_LIBRARY_PATH /usr/lib/${CPU_TYPE}-linux-gnu;/usr/lib${BITS};/usr/lib)
+ endif()
+-include(FindX11)
++find_package(X11 REQUIRED)
+ # Clarify that we need to link with the legacy OpenGL library (libGL) rather
+ # than the GLVND OpenGL library.  This shuts up CMake 3.11 and later.
+ set(OpenGL_GL_PREFERENCE LEGACY)
+-include(FindOpenGL)
++find_package(OpenGL REQUIRED)
+
+ # Ensure that we build and link against the X11 version of OpenGL on OS X/macOS
+ if(APPLE)
+diff --git a/cmakescripts/FindTurboJPEG.cmake b/cmakescripts/FindTurboJPEG.cmake
+index 47983a37..382d8efd 100644
+--- a/cmakescripts/FindTurboJPEG.cmake
++++ b/cmakescripts/FindTurboJPEG.cmake
+@@ -1,5 +1,3 @@
+-include(CheckCSourceCompiles)
+-
+ set(DEFAULT_TJPEG_INCLUDE_DIR /opt/libjpeg-turbo/include)
+ if(NOT TJPEG_INCLUDE_DIR)
+     set(TJPEG_INCLUDE_DIR_HINTS ${DEFAULT_TJPEG_INCLUDE_DIR})
+@@ -19,38 +17,6 @@ else()
+ endif()
+ include_directories(${TJPEG_INCLUDE_DIR})
+
+-set(DEFAULT_TJPEG_LIBRARY /opt/libjpeg-turbo/lib${BITS}/libturbojpeg.a)
+-
+-set(TJPEG_LIBRARY_OVERRIDE 0)
+-if(TJPEG_LIBRARY)
+-	set(TJPEG_LIBRARY_OVERRIDE 1)
+-endif()
+-
+-set(TJPEG_LIBRARY ${DEFAULT_TJPEG_LIBRARY} CACHE STRING
+-	"Path to TurboJPEG library or flags necessary to link with it (default: ${DEFAULT_TJPEG_LIBRARY})")
+-
+-set(CMAKE_REQUIRED_INCLUDES ${TJPEG_INCLUDE_DIR})
+-set(CMAKE_REQUIRED_LIBRARIES ${TJPEG_LIBRARY})
+-check_c_source_compiles("#include <turbojpeg.h>\nint main(void) { tjhandle h = tjInitCompress();  return h != 0 ? 0 : 1; }" TURBOJPEG_WORKS)
+-if(NOT TURBOJPEG_WORKS AND NOT TJPEG_LIBRARY_OVERRIDE AND UNIX)
+-	message(STATUS "Could not link with official TurboJPEG library ${TJPEG_LIBRARY}.  Checking whether the operating system supplies it ...")
+-	set(CMAKE_REQUIRED_LIBRARIES turbojpeg)
+-	check_c_source_compiles("#include <turbojpeg.h>\nint main(void) { tjhandle h = tjInitCompress();  return h != 0 ? 0 : 1; }" SYSTEM_TURBOJPEG_WORKS)
+-	if(SYSTEM_TURBOJPEG_WORKS)
+-		set(TJPEG_LIBRARY turbojpeg CACHE STRING
+-			"Path to TurboJPEG library or flags necessary to link with it (default: ${DEFAULT_TJPEG_LIBRARY})"
+-			FORCE)
+-	endif()
+-endif()
+-set(CMAKE_REQUIRED_DEFINITIONS)
+-set(CMAKE_REQUIRED_INCLUDES)
+-set(CMAKE_REQUIRED_LIBRARIES)
+-if(NOT TURBOJPEG_WORKS AND NOT SYSTEM_TURBOJPEG_WORKS)
+-	unset(TURBOJPEG_WORKS)
+-	unset(TURBOJPEG_WORKS CACHE)
+-	unset(SYSTEM_TURBOJPEG_WORKS)
+-	unset(SYSTEM_TURBOJPEG_WORKS CACHE)
+-	message(FATAL_ERROR "Could not link with TurboJPEG library ${TJPEG_LIBRARY}.  If it is installed in a different place, then set TJPEG_LIBRARY accordingly.")
+-endif()
++find_library(TJPEG_LIBRARY NAMES turbojpeg REQUIRED HINTS /opt/libjpeg-turbo/lib${BITS})
+
+ message(STATUS "TJPEG_LIBRARY = ${TJPEG_LIBRARY}")
+diff --git a/server/CMakeLists.txt b/server/CMakeLists.txt
+index 7047a0ed..32694d73 100644
+--- a/server/CMakeLists.txt
++++ b/server/CMakeLists.txt
+@@ -45,7 +45,7 @@ boolean_number(VGL_FAKEOPENCL)
+ boolean_number(VGL_FAKEOPENCL PARENT_SCOPE)
+ report_option(VGL_FAKEOPENCL "OpenCL interposer")
+ if(VGL_FAKEOPENCL)
+-	include(FindOpenCL)
++	find_package(OpenCL REQUIRED)
+ endif()
+
+ get_directory_property(DEFS_PROP COMPILE_DEFINITIONS)
+diff --git a/wgldemos/CMakeLists.txt b/wgldemos/CMakeLists.txt
+index e73bbea5..bf80cc53 100644
+--- a/wgldemos/CMakeLists.txt
++++ b/wgldemos/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-include(FindOpenGL)
++find_package(OpenGL REQUIRED)
+
+ include_directories(${OPENGL_INCLUDE_DIR})
+
+--
+2.43.0

--- a/ports/virtualgl/portfile.cmake
+++ b/ports/virtualgl/portfile.cmake
@@ -1,0 +1,53 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO VirtualGL/virtualgl
+    REF "${VERSION}"
+    SHA512 4668ebfbfe663d3cf66468b120ecf46da161cbce3b793dbeaea9ace50d19d8d3edcdc84ef31d87b27903c1c8a6648ae0419c796960928f1421a90171a5db7d43
+    HEAD_REF main
+    PATCHES
+        fix-dependencies.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "opencl"    VGL_FAKEOPENCL
+        "xcb"       VGL_FAKEXCB
+        "xv"        VGL_USEXV
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DTJPEG_INCLUDE_DIR=${_VCPKG_INSTALLED_DIR}/${TARGET_TRIPLET}/include"
+        ${FEATURE_OPTIONS}
+)
+
+
+vcpkg_cmake_install()
+
+vcpkg_copy_tools(TOOL_NAMES
+    cpustat
+    eglinfo
+    eglxinfo
+    eglxspheres64
+    glxinfo
+    glreadtest
+    glxspheres64
+    nettest
+    tcbench
+    vglclient
+    vglconfig
+    vglconnect
+    vglgenkey
+    vgllogin
+    vglrun
+    .vglrun.vars64
+    vglserver_config
+    AUTO_CLEAN)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/virtualgl/usage
+++ b/ports/virtualgl/usage
@@ -1,0 +1,1 @@
+virtualgl delivers the `vglrun` tool to run an application with VirtualGL.

--- a/ports/virtualgl/vcpkg.json
+++ b/ports/virtualgl/vcpkg.json
@@ -1,0 +1,44 @@
+{
+  "name": "virtualgl",
+  "version": "3.1.1",
+  "description": "VirtualGL is a toolkit that allows most Linux/Unix OpenGL applications to be remotely displayed with 3D hardware acceleration to thin clients, regardless of whether the clients have 3D rendering capabilities, and regardless of the size of the 3D data being rendered or the speed of the network.",
+  "homepage": "https://virtualgl.org/",
+  "license": "wxWindows",
+  "supports": "linux",
+  "dependencies": [
+    "libjpeg-turbo",
+    "libx11",
+    "libxext",
+    "libxtst",
+    "opengl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "opencl",
+      "platform": "!windows"
+    },
+    "xcb",
+    "xv"
+  ],
+  "features": {
+    "opencl": {
+      "description": "Interpose enough of the OpenCL API to make OpenCL/OpenGL interoperability work",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "xcb": {
+      "description": "Interpose enough of the XCB API to make Qt 5 work"
+    },
+    "xv": {
+      "description": "Enable X Video support",
+      "dependencies": [
+        "libxv"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9268,6 +9268,10 @@
       "baseline": "2.2.3",
       "port-version": 0
     },
+    "virtualgl": {
+      "baseline": "3.1.1",
+      "port-version": 0
+    },
     "visit-struct": {
       "baseline": "1.1.0",
       "port-version": 0

--- a/versions/v-/virtualgl.json
+++ b/versions/v-/virtualgl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "382add1254a80813975b679a8d9106c4913beca9",
+      "version": "3.1.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Create a vcpkg port for [VirtualGL](https://virtualgl.org).

Creating a suggested implementation of a VirtualGL port, as there was no response to #39936 yet.

VirtualGL will be mostly a runtime dependency, not a build-time dependency, so in a build system such as CMake there will not be linking of libraries but just copying of executables (such as vglrun) and libraries (such as libvglfaker.so) to the output directory bin and lib folder.

Closes #39936.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
