### PR TITLE
[dbus] Enable default DBUS_SESSION_SOCKET_DIR when cross-compiling

### DIFF
--- a/ports/dbus/0006-cmake.tempdir.patch
+++ b/ports/dbus/0006-cmake.tempdir.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6d23230..9572c7d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -567,8 +567,8 @@ if(MSVC_IDE)
+ endif()
+
+ #### Find socket directories
+-set(DBUS_SESSION_SOCKET_DIR "" CACHE STRING "Default directory for session socket")
+-if(UNIX)
++set(DBUS_SESSION_SOCKET_DIR "${DBUS_SESSION_SOCKET_DIR}" CACHE STRING "Default directory for session socket")
++if(0)
+     if (CMAKE_CROSSCOMPILING)
+         if (NOT DBUS_SESSION_SOCKET_DIR)
+             message(FATAL_ERROR "cannot autodetect session socket directory "

--- a/ports/dbus/portfile.cmake
+++ b/ports/dbus/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_gitlab(
         pkgconfig.patch
         getpeereid.patch # missing check from configure.ac
         libsystemd.patch
+        0006-cmake.tempdir.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS options
@@ -37,6 +38,7 @@ vcpkg_cmake_configure(
         "-DCMAKE_INSTALL_SYSCONFDIR=${CURRENT_PACKAGES_DIR}/etc/${PORT}"
         "-DWITH_SYSTEMD_SYSTEMUNITDIR=lib/systemd/system"
         "-DWITH_SYSTEMD_USERUNITDIR=lib/systemd/user"
+        "-DDBUS_SESSION_SOCKET_DIR=/tmp"
         ${options}
     OPTIONS_RELEASE
         -DDBUS_DISABLE_ASSERT=OFF
@@ -88,4 +90,4 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
 endif()
 vcpkg_copy_tools(TOOL_NAMES ${TOOLS} AUTO_CLEAN)
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/dbus/vcpkg.json
+++ b/ports/dbus/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dbus",
   "version": "1.15.8",
-  "port-version": 5,
+  "port-version": 6,
   "description": "D-Bus specification and reference implementation, including libdbus and dbus-daemon",
   "homepage": "https://gitlab.freedesktop.org/dbus/dbus",
   "license": "AFL-2.1 OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2242,7 +2242,7 @@
     },
     "dbus": {
       "baseline": "1.15.8",
-      "port-version": 5
+      "port-version": 6
     },
     "dcmtk": {
       "baseline": "3.6.8",

--- a/versions/d-/dbus.json
+++ b/versions/d-/dbus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "900ad2fe5930486f211c9de29eb0ebb3b77dea37",
+      "version": "1.15.8",
+      "port-version": 6
+    },
+    {
       "git-tree": "ce28359a2d828a06b421d8a7b3841f83d98f0ed4",
       "version": "1.15.8",
       "port-version": 5


### PR DESCRIPTION
Fix #40031.

Allow setting default `DBUS_SESSION_SOCKET_DIR`, default `/tmp`.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port cross-compile installation tests pass with the following triplets:
* x64-osx (on arm64-osx)