### PR TITLE
[upb] Fixed NAN/INFINITY definitions to work on Windows 11 SDK

### DIFF
--- a/ports/upb/fix-NAN-on-Win11.patch
+++ b/ports/upb/fix-NAN-on-Win11.patch
@@ -1,0 +1,17 @@
+diff --git a/upb/message/message.c b/upb/message/message.c
+index 265d30d..afc6e51 100644
+--- a/upb/message/message.c
++++ b/upb/message/message.c
+@@ -15,9 +15,9 @@
+ // Must be last.
+ #include "upb/port/def.inc"
+ 
+-const float kUpb_FltInfinity = INFINITY;
+-const double kUpb_Infinity = INFINITY;
+-const double kUpb_NaN = NAN;
++const float kUpb_FltInfinity = (float)(1.0 / 0.0);
++const double kUpb_Infinity = 1.0 / 0.0;
++const double kUpb_NaN = 0.0 / 0.0;
+ 
+ static const size_t overhead = sizeof(upb_Message_InternalData);
+ 

--- a/ports/upb/portfile.cmake
+++ b/ports/upb/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         fix-cmake.patch
+        fix-NAN-on-Win11.patch
 )
 
 vcpkg_check_features(

--- a/ports/upb/vcpkg.json
+++ b/ports/upb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "upb",
   "version": "4.25.1",
+  "port-version": 1,
   "description": "μpb (often written 'upb') is a small protobuf implementation written in C.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9054,7 +9054,7 @@
     },
     "upb": {
       "baseline": "4.25.1",
-      "port-version": 0
+      "port-version": 1
     },
     "urdfdom": {
       "baseline": "3.1.1",

--- a/versions/u-/upb.json
+++ b/versions/u-/upb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47d5e848e2c7213cc67e4dfa6c7797fa973f2c12",
+      "version": "4.25.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "3edd5c1f37803c69faaf1b0884791e8c1d8ff48f",
       "version": "4.25.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40034
Fixes https://github.com/microsoft/vcpkg/issues/39868
Fixes https://github.com/microsoft/vcpkg/issues/39626

This solution came from upstream: https://github.com/protocolbuffers/protobuf/pull/17471

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
