### PR TITLE
[libmysql] Fix the install path of pdb files

### DIFF
--- a/ports/libmysql/fix-pdb-install-path.patch
+++ b/ports/libmysql/fix-pdb-install-path.patch
@@ -1,0 +1,22 @@
+diff --git a/cmake/install_macros.cmake b/cmake/install_macros.cmake
+index c45fda7..b862597 100644
+--- a/cmake/install_macros.cmake
++++ b/cmake/install_macros.cmake
+@@ -46,7 +46,7 @@ MACRO(INSTALL_DEBUG_SYMBOLS target)
+     # No .pdb file for static libraries.
+     IF(NOT type MATCHES "STATIC_LIBRARY")
+       INSTALL(FILES $<TARGET_PDB_FILE:${target}>
+-        DESTINATION ${INSTALL_LOCATION} COMPONENT ${comp})
++        DESTINATION bin COMPONENT ${comp})
+     ENDIF()
+   ENDIF()
+ ENDMACRO()
+@@ -307,7 +307,7 @@ FUNCTION(INSTALL_DEBUG_TARGET target)
+     ENDIF()
+ 
+     INSTALL(FILES ${debug_pdb_target_location}
+-      DESTINATION ${ARG_DESTINATION}
++      DESTINATION bin
+       ${PDB_RENAME_PARAM}
+       CONFIGURATIONS Release RelWithDebInfo
+       COMPONENT ${ARG_COMPONENT}

--- a/ports/libmysql/install-exports.patch
+++ b/ports/libmysql/install-exports.patch
@@ -1,7 +1,16 @@
 diff --git a/cmake/install_macros.cmake b/cmake/install_macros.cmake
-index baf49cd5..c45fda71 100644
+index baf49cd..b862597 100644
 --- a/cmake/install_macros.cmake
 +++ b/cmake/install_macros.cmake
+@@ -46,7 +46,7 @@ MACRO(INSTALL_DEBUG_SYMBOLS target)
+     # No .pdb file for static libraries.
+     IF(NOT type MATCHES "STATIC_LIBRARY")
+       INSTALL(FILES $<TARGET_PDB_FILE:${target}>
+-        DESTINATION ${INSTALL_LOCATION} COMPONENT ${comp})
++        DESTINATION bin COMPONENT ${comp})
+     ENDIF()
+   ENDIF()
+ ENDMACRO()
 @@ -113,8 +113,30 @@ FUNCTION(MYSQL_INSTALL_TARGET target_arg)
    IF(ARG_NAMELINK_SKIP)
      SET(LIBRARY_INSTALL_ARGS NAMELINK_SKIP)
@@ -34,6 +43,15 @@ index baf49cd5..c45fda71 100644
      ARCHIVE DESTINATION ${ARG_DESTINATION} ${COMP}
      LIBRARY DESTINATION ${ARG_DESTINATION} ${COMP} ${LIBRARY_INSTALL_ARGS})
    SET(INSTALL_LOCATION ${ARG_DESTINATION} )
+@@ -285,7 +307,7 @@ FUNCTION(INSTALL_DEBUG_TARGET target)
+     ENDIF()
+ 
+     INSTALL(FILES ${debug_pdb_target_location}
+-      DESTINATION ${ARG_DESTINATION}
++      DESTINATION bin
+       ${PDB_RENAME_PARAM}
+       CONFIGURATIONS Release RelWithDebInfo
+       COMPONENT ${ARG_COMPONENT}
 diff --git a/cmake/libutils.cmake b/cmake/libutils.cmake
 index a5333987..c954bfb1 100644
 --- a/cmake/libutils.cmake

--- a/ports/libmysql/install-exports.patch
+++ b/ports/libmysql/install-exports.patch
@@ -1,16 +1,7 @@
 diff --git a/cmake/install_macros.cmake b/cmake/install_macros.cmake
-index baf49cd..b862597 100644
+index baf49cd5..c45fda71 100644
 --- a/cmake/install_macros.cmake
 +++ b/cmake/install_macros.cmake
-@@ -46,7 +46,7 @@ MACRO(INSTALL_DEBUG_SYMBOLS target)
-     # No .pdb file for static libraries.
-     IF(NOT type MATCHES "STATIC_LIBRARY")
-       INSTALL(FILES $<TARGET_PDB_FILE:${target}>
--        DESTINATION ${INSTALL_LOCATION} COMPONENT ${comp})
-+        DESTINATION bin COMPONENT ${comp})
-     ENDIF()
-   ENDIF()
- ENDMACRO()
 @@ -113,8 +113,30 @@ FUNCTION(MYSQL_INSTALL_TARGET target_arg)
    IF(ARG_NAMELINK_SKIP)
      SET(LIBRARY_INSTALL_ARGS NAMELINK_SKIP)
@@ -43,15 +34,6 @@ index baf49cd..b862597 100644
      ARCHIVE DESTINATION ${ARG_DESTINATION} ${COMP}
      LIBRARY DESTINATION ${ARG_DESTINATION} ${COMP} ${LIBRARY_INSTALL_ARGS})
    SET(INSTALL_LOCATION ${ARG_DESTINATION} )
-@@ -285,7 +307,7 @@ FUNCTION(INSTALL_DEBUG_TARGET target)
-     ENDIF()
- 
-     INSTALL(FILES ${debug_pdb_target_location}
--      DESTINATION ${ARG_DESTINATION}
-+      DESTINATION bin
-       ${PDB_RENAME_PARAM}
-       CONFIGURATIONS Release RelWithDebInfo
-       COMPONENT ${ARG_COMPONENT}
 diff --git a/cmake/libutils.cmake b/cmake/libutils.cmake
 index a5333987..c954bfb1 100644
 --- a/cmake/libutils.cmake

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         install-exports.patch
         fix_dup_symbols.patch
         cross-build.patch
+        fix-pdb-install-path.patch
 )
 
 file(GLOB third_party "${SOURCE_PATH}/extra/*" "${SOURCE_PATH}/include/boost_1_70_0")

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -91,6 +91,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install(ADD_BIN_TO_PATH)
+vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-libmysql)
 vcpkg_fixup_pkgconfig()
 

--- a/ports/libmysql/vcpkg.json
+++ b/ports/libmysql/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmysql",
   "version": "8.0.34",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A MySQL client library for C development",
   "homepage": "https://github.com/mysql/mysql-server",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4754,7 +4754,7 @@
     },
     "libmysql": {
       "baseline": "8.0.34",
-      "port-version": 1
+      "port-version": 2
     },
     "libnice": {
       "baseline": "0.1.21",

--- a/versions/l-/libmysql.json
+++ b/versions/l-/libmysql.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b0aa05b211fde52e4aaac27df5e82aad541f476d",
+      "git-tree": "d203c4fd8f6d845b6d0b744bade33dd78a83957f",
       "version": "8.0.34",
       "port-version": 2
     },

--- a/versions/l-/libmysql.json
+++ b/versions/l-/libmysql.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0aa05b211fde52e4aaac27df5e82aad541f476d",
+      "version": "8.0.34",
+      "port-version": 2
+    },
+    {
       "git-tree": "4fa6006119f50a9baff9cdf0966b065097113fd7",
       "version": "8.0.34",
       "port-version": 1


### PR DESCRIPTION
Fixes #40027
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.