### PR TITLE
[wolfssl] add patch to increase default max alt name limit

### DIFF
--- a/ports/wolfssl/increase-max-alt-names.patch
+++ b/ports/wolfssl/increase-max-alt-names.patch
@@ -1,0 +1,13 @@
+diff --git a/wolfssl/wolfcrypt/asn.h b/wolfssl/wolfcrypt/asn.h
+index 693aaff60c..ad1e84656a 100644
+--- a/wolfssl/wolfcrypt/asn.h
++++ b/wolfssl/wolfcrypt/asn.h
+@@ -799,7 +799,7 @@ extern const WOLFSSL_ObjectInfo wolfssl_object_info[];
+  * Any certificate containing more than this number of subject
+  * alternative names will cause an error when attempting to parse. */
+ #ifndef WOLFSSL_MAX_ALT_NAMES
+-#define WOLFSSL_MAX_ALT_NAMES 128
++#define WOLFSSL_MAX_ALT_NAMES 1024
+ #endif
+ 
+ /* Maximum number of allowed name constraints in a certificate.

--- a/ports/wolfssl/vcpkg.json
+++ b/ports/wolfssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wolfssl",
   "version": "5.7.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "TLS and Cryptographic library for many platforms",
   "homepage": "https://wolfssl.com",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9498,7 +9498,7 @@
     },
     "wolfssl": {
       "baseline": "5.7.2",
-      "port-version": 1
+      "port-version": 2
     },
     "wolftpm": {
       "baseline": "3.2.0",

--- a/versions/w-/wolfssl.json
+++ b/versions/w-/wolfssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e1315afd8abfaee90ea4b173ac95594208eff46",
+      "version": "5.7.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "3145f691d33b3e979a5466f29a3a46c887a0c510",
       "version": "5.7.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.