### PR TITLE
[botan] Update version to 3.5.0

### DIFF
--- a/ports/botan/libcxx-winpthread-fixes.patch
+++ b/ports/botan/libcxx-winpthread-fixes.patch
@@ -1,3 +1,18 @@
+diff --git a/src/lib/utils/os_utils.cpp b/src/lib/utils/os_utils.cpp
+index 45bea5d..307ae08 100644
+--- a/src/lib/utils/os_utils.cpp
++++ b/src/lib/utils/os_utils.cpp
+@@ -662,6 +662,8 @@ void OS::set_thread_name(std::thread& thread, const std::string& name) {
+    static_cast<void>(pthread_setname_np(thread.native_handle(), "%s", const_cast<char*>(name.c_str())));
+    #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(_LIBCPP_HAS_THREAD_API_PTHREAD)
+    static_cast<void>(pthread_setname_np(thread.native_handle(), name.c_str()));
++   #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(_LIBCPP_HAS_THREAD_API_PTHREAD)
++   static_cast<void>(pthread_setname_np(thread.native_handle(), name.c_str()));
+    #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(BOTAN_BUILD_COMPILER_IS_MSVC)
+    typedef HRESULT(WINAPI * std_proc)(HANDLE, PCWSTR);
+    HMODULE kern = GetModuleHandleA("KernelBase.dll");
+diff --git a/src/tests/tests.h b/src/tests/tests.h
+index d198376..253158b 100644
 --- a/src/tests/tests.h
 +++ b/src/tests/tests.h
 @@ -17,6 +17,9 @@
@@ -7,17 +22,6 @@
 +#ifndef __ANDROID__
 +#include <ranges>
 +#endif
+ #include <ranges>
  #include <set>
  #include <sstream>
- #include <string>
---- a/src/lib/utils/os_utils.cpp
-+++ b/src/lib/utils/os_utils.cpp
-@@ -627,6 +627,8 @@
-    static_cast<void>(pthread_set_name_np(thread.native_handle(), name.c_str()));
-    #elif defined(BOTAN_TARGET_OS_IS_NETBSD)
-    static_cast<void>(pthread_setname_np(thread.native_handle(), "%s", const_cast<char*>(name.c_str())));
-+   #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(_LIBCPP_HAS_THREAD_API_PTHREAD)
-+   static_cast<void>(pthread_setname_np(thread.native_handle(), name.c_str()));
-    #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(BOTAN_BUILD_COMPILER_IS_MSVC)
-    typedef HRESULT(WINAPI * std_proc)(HANDLE, PCWSTR);
-    HMODULE kern = GetModuleHandleA("KernelBase.dll");

--- a/ports/botan/libcxx-winpthread-fixes.patch
+++ b/ports/botan/libcxx-winpthread-fixes.patch
@@ -1,16 +1,3 @@
-diff --git a/src/lib/utils/os_utils.cpp b/src/lib/utils/os_utils.cpp
-index 45bea5d..307ae08 100644
---- a/src/lib/utils/os_utils.cpp
-+++ b/src/lib/utils/os_utils.cpp
-@@ -662,6 +662,8 @@ void OS::set_thread_name(std::thread& thread, const std::string& name) {
-    static_cast<void>(pthread_setname_np(thread.native_handle(), "%s", const_cast<char*>(name.c_str())));
-    #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(_LIBCPP_HAS_THREAD_API_PTHREAD)
-    static_cast<void>(pthread_setname_np(thread.native_handle(), name.c_str()));
-+   #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(_LIBCPP_HAS_THREAD_API_PTHREAD)
-+   static_cast<void>(pthread_setname_np(thread.native_handle(), name.c_str()));
-    #elif defined(BOTAN_TARGET_OS_HAS_WIN32) && defined(BOTAN_BUILD_COMPILER_IS_MSVC)
-    typedef HRESULT(WINAPI * std_proc)(HANDLE, PCWSTR);
-    HMODULE kern = GetModuleHandleA("KernelBase.dll");
 diff --git a/src/tests/tests.h b/src/tests/tests.h
 index d198376..253158b 100644
 --- a/src/tests/tests.h

--- a/ports/botan/libcxx-winpthread-fixes.patch
+++ b/ports/botan/libcxx-winpthread-fixes.patch
@@ -1,14 +1,14 @@
 diff --git a/src/tests/tests.h b/src/tests/tests.h
-index d198376..253158b 100644
+index d198376..12f001a 100644
 --- a/src/tests/tests.h
 +++ b/src/tests/tests.h
-@@ -17,6 +17,9 @@
+@@ -17,7 +17,9 @@
  #include <map>
  #include <memory>
  #include <optional>
 +#ifndef __ANDROID__
-+#include <ranges>
-+#endif
  #include <ranges>
++#endif
  #include <set>
  #include <sstream>
+ #include <string>

--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO randombit/botan
     REF "${VERSION}"
-    SHA512 5b3e22ad14bf0c37d97835c8309d1a5797cfab67b14ebfad9fd69a999ee27fe97d42ecff5e57e598d21575d053c07c30995f8c2d5f3a23433fb59d6bab45e1e7
+    SHA512 5b5766d279d92659fd8e6d5d5aac8be7328a8eae7412085c96e7059ecc560f596bf55ff0a8df6d671de5169d2a80694a6bdd6561dbe9bbb4c3df56b687c50039
     HEAD_REF master
     PATCHES
         embed-debug-info.patch

--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -177,7 +177,7 @@ else()
     endif()
 endif()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Botan-3.3.0)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Botan-3.5.0)
 
 file(RENAME "${CURRENT_PACKAGES_DIR}/include/botan-3/botan" "${CURRENT_PACKAGES_DIR}/include/botan")
 

--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -177,7 +177,7 @@ else()
     endif()
 endif()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Botan-3.5.0)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/Botan-${VERSION}")
 
 file(RENAME "${CURRENT_PACKAGES_DIR}/include/botan-3/botan" "${CURRENT_PACKAGES_DIR}/include/botan")
 

--- a/ports/botan/vcpkg.json
+++ b/ports/botan/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "botan",
-  "version": "3.3.0",
-  "port-version": 2,
+  "version": "3.5.0",
   "description": "A cryptography library written in C++11",
   "homepage": "https://botan.randombit.net",
   "license": "BSD-2-Clause",

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c322b72159974a4ed022603117b00dd3144cd16b",
+      "git-tree": "e67014d9c3aa9cf32bcdda2de026245b01c2ee9a",
       "version": "3.5.0",
       "port-version": 0
     },

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e67014d9c3aa9cf32bcdda2de026245b01c2ee9a",
+      "git-tree": "9bb4ac83d6ed4e5e3184198d28f5dbe22416a0de",
       "version": "3.5.0",
       "port-version": 0
     },

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9bb4ac83d6ed4e5e3184198d28f5dbe22416a0de",
+      "git-tree": "3416aa602b64d0eff810540b4555dac28560ba3e",
       "version": "3.5.0",
       "port-version": 0
     },

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c322b72159974a4ed022603117b00dd3144cd16b",
+      "version": "3.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "24b20ce86f1fff75cd0c14c71e8ddcd7459b48c8",
       "version": "3.3.0",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1353,8 +1353,8 @@
       "port-version": 0
     },
     "botan": {
-      "baseline": "3.3.0",
-      "port-version": 2
+      "baseline": "3.5.0",
+      "port-version": 0
     },
     "box2d": {
       "baseline": "2.4.1",


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/40049

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.