### PR TITLE
[proj] Disable hardcoded definition PROJ_DATA

### DIFF
--- a/ports/proj/portfile.cmake
+++ b/ports/proj/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(PATCH_ADD_OPTION_EMBED_PROJ_DATA_PATH
+    URLS https://github.com/OSGeo/PROJ/commit/bddac146b2aa9db78cd491153aaad260eb307b11.patch?full_index=1
+    SHA512 06511fe82f85498813e1b99a419359e9877689f7c763db392a66ae0202027ee12f9a4015a5bb9c13a357d0ba22d002b021e5c0dc9c31d33293c48fc71e766a69
+    FILENAME OSGeo-PROJ-bddac146b2aa9db78cd491153aaad260eb307b11.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/PROJ
@@ -9,6 +15,7 @@ vcpkg_from_github(
         fix-proj4-targets-cmake.patch
         remove_toolset_restriction.patch
         fix-gcc-version-less-8.patch
+        "${PATCH_ADD_OPTION_EMBED_PROJ_DATA_PATH}"
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -33,7 +40,10 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         -DNLOHMANN_JSON=external
         -DBUILD_TESTING=OFF
+        -DBUILD_EXAMPLES=OFF
         "-DEXE_SQLITE3=${EXE_SQLITE3}"
+        -DPROJ_DATA_ENV_VAR_TRIED_LAST=ON
+        -DEMBED_PROJ_DATA_PATH=OFF
     OPTIONS_DEBUG
         -DBUILD_APPS=OFF
 )
@@ -70,4 +80,4 @@ if(NOT DEFINED VCPKG_BUILD_TYPE AND VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET
 endif()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/proj/vcpkg.json
+++ b/ports/proj/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "proj",
   "version": "9.4.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "PROJ library for cartographic projections",
   "homepage": "https://proj.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7078,7 +7078,7 @@
     },
     "proj": {
       "baseline": "9.4.1",
-      "port-version": 1
+      "port-version": 2
     },
     "projectm-eval": {
       "baseline": "1.0.0",

--- a/versions/p-/proj.json
+++ b/versions/p-/proj.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50f38dc99103f1c718d8fe295888d1f675548e87",
+      "version": "9.4.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "3ea3cfc72b4b1d43a359755953f4792daadef34a",
       "version": "9.4.1",
       "port-version": 1


### PR DESCRIPTION
Fix #40055, backport https://github.com/OSGeo/PROJ/commit/bddac146b2aa9db78cd491153aaad260eb307b11

Turn off option `EMBED_PROJ_DATA_PATH`

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test
The port usage tests pass with the following triplets:
* x64-windows