### PR TITLE
[shiftmedia-libgnutls] Fix warnings when compile with curl

### DIFF
--- a/ports/shiftmedia-libgnutls/fix-warnings.patch
+++ b/ports/shiftmedia-libgnutls/fix-warnings.patch
@@ -1,0 +1,32 @@
+diff --git a/lib/includes/gnutls/ocsp.h b/lib/includes/gnutls/ocsp.h
+index 9e271476cf..80d8ccc8f5 100644
+--- a/lib/includes/gnutls/ocsp.h
++++ b/lib/includes/gnutls/ocsp.h
+@@ -224,9 +224,9 @@ int gnutls_ocsp_resp_get_single(gnutls_ocsp_resp_const_t resp, unsigned indx,
+ 				gnutls_datum_t *issuer_name_hash,
+ 				gnutls_datum_t *issuer_key_hash,
+ 				gnutls_datum_t *serial_number,
+-				unsigned int *cert_status, time_t *this_update,
++				gnutls_ocsp_cert_status_t *cert_status, time_t *this_update,
+ 				time_t *next_update, time_t *revocation_time,
+-				unsigned int *revocation_reason);
++				gnutls_x509_crl_reason_t *revocation_reason);
+ int gnutls_ocsp_resp_get_extension(gnutls_ocsp_resp_const_t resp, unsigned indx,
+ 				   gnutls_datum_t *oid, unsigned int *critical,
+ 				   gnutls_datum_t *data);
+diff --git a/lib/x509/ocsp.c b/lib/x509/ocsp.c
+index 0120129d50..3a46f2d174 100644
+--- a/lib/x509/ocsp.c
++++ b/lib/x509/ocsp.c
+@@ -1433,9 +1433,9 @@ int gnutls_ocsp_resp_get_single(gnutls_ocsp_resp_const_t resp, unsigned indx,
+ 				gnutls_datum_t *issuer_name_hash,
+ 				gnutls_datum_t *issuer_key_hash,
+ 				gnutls_datum_t *serial_number,
+-				unsigned int *cert_status, time_t *this_update,
++				gnutls_ocsp_cert_status_t *cert_status, time_t *this_update,
+ 				time_t *next_update, time_t *revocation_time,
+-				unsigned int *revocation_reason)
++				gnutls_x509_crl_reason_t *revocation_reason)
+ {
+ 	char name[MAX_NAME_SIZE];
+ 	int ret, result;

--- a/ports/shiftmedia-libgnutls/portfile.cmake
+++ b/ports/shiftmedia-libgnutls/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         external-libtasn1.patch
         pkgconfig.patch
         ssize_t_already_define.patch
+        fix-warnings.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/devel/perlasm")

--- a/ports/shiftmedia-libgnutls/vcpkg.json
+++ b/ports/shiftmedia-libgnutls/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "shiftmedia-libgnutls",
   "version": "3.8.4",
+  "port-version": 1,
   "description": "Unofficial GnuTLS fork with added custom native Visual Studio project build tools. ",
   "homepage": "https://github.com/ShiftMediaProject/gnutls",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8178,7 +8178,7 @@
     },
     "shiftmedia-libgnutls": {
       "baseline": "3.8.4",
-      "port-version": 0
+      "port-version": 1
     },
     "shiftmedia-libgpg-error": {
       "baseline": "1.45",

--- a/versions/s-/shiftmedia-libgnutls.json
+++ b/versions/s-/shiftmedia-libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a784f9e85e153f86f04458fed9d158e76b861eda",
+      "version": "3.8.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "f2138ba71b3282796cf9ee0318ec585fc0482281",
       "version": "3.8.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

When compile shifmedia-gnutls with curl, it give a warning on gnutls_ocsp_resp_get_single that it not use the correct types.
Curl usually compile their code without warning, then these warning transfer to errors.

https://github.com/curl/curl/blob/master/lib/vtls/gtls.c#L1344

```
D:\a\curl\curl\lib\vtls\gtls.c(1345,41): error C2220: the following warning is treated as an error [D:\a\curl\curl\bld\lib\libcurl_object.vcxproj]
D:\a\curl\curl\lib\vtls\gtls.c(1345,41): warning C4133: 'function': incompatible types - from 'gnutls_ocsp_cert_status_t *' to 'unsigned int *' [D:\a\curl\curl\bld\lib\libcurl_object.vcxproj]
D:\a\curl\curl\lib\vtls\gtls.c(1345,68): warning C4133: 'function': incompatible types - from 'gnutls_x509_crl_reason_t *' to 'unsigned int *' [D:\a\curl\curl\bld\lib\libcurl_object.vcxproj]
```