### PR TITLE
[ompl] Fix compilation errors on linux and osx

### DIFF
--- a/ports/ompl/0002_Fix_config.patch
+++ b/ports/ompl/0002_Fix_config.patch
@@ -1,13 +1,16 @@
-﻿diff --git a/omplConfig.cmake.in b/omplConfig.cmake.in
-index 465de25d..d1e91929 100644
+diff --git a/omplConfig.cmake.in b/omplConfig.cmake.in
+index 2d88251..a01e1c4 100644
 --- a/omplConfig.cmake.in
 +++ b/omplConfig.cmake.in
-@@ -18,8 +18,11 @@ set(OMPL_MAJOR_VERSION @PROJECT_VERSION_MAJOR@)
+@@ -18,8 +18,14 @@ set(OMPL_MAJOR_VERSION @PROJECT_VERSION_MAJOR@)
  set(OMPL_MINOR_VERSION @PROJECT_VERSION_MINOR@)
  set(OMPL_PATCH_VERSION @PROJECT_VERSION_PATCH@)
  
 +include(CMakeFindDependencyMacro)
-+find_dependency(Boost 1.58 COMPONENTS serialization filesystem system program_options)
++find_dependency(boost_serialization CONFIG)
++find_dependency(boost_filesystem CONFIG) 
++find_dependency(boost_system CONFIG)
++find_dependency(boost_program_options CONFIG)
 +find_dependency(Eigen3)
  set_and_check(OMPL_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
 -set(OMPL_INCLUDE_DIRS "${OMPL_INCLUDE_DIR};@Boost_INCLUDE_DIR@;@EIGEN3_INCLUDE_DIR@")
@@ -15,7 +18,7 @@ index 465de25d..d1e91929 100644
  foreach(_dir @FLANN_INCLUDE_DIRS@;@ODE_INCLUDE_DIRS@;@SPOT_INCLUDE_DIRS@;@TRIANGLE_INCLUDE_DIR@;@FCL_INCLUDE_DIRS@;@PQP_INCLUDE_DIR@;@ASSIMP_INCLUDE_DIRS@;@OPENGL_INCLUDE_DIR@)
      if(_dir)
          list(APPEND OMPL_INCLUDE_DIRS "${_dir}")
-@@ -29,7 +32,7 @@ list(REMOVE_DUPLICATES OMPL_INCLUDE_DIRS)
+@@ -29,7 +35,7 @@ list(REMOVE_DUPLICATES OMPL_INCLUDE_DIRS)
  set(OMPL_INCLUDE_DIRS "${OMPL_INCLUDE_DIRS}" CACHE STRING "Include path for OMPL and its dependencies")
  
  set_and_check(OMPL_LIBRARY_DIR @PACKAGE_LIB_INSTALL_DIR@)
@@ -24,7 +27,7 @@ index 465de25d..d1e91929 100644
  foreach(_dir @FLANN_LIBRARY_DIRS@;@ODE_LIBRARY_DIRS@;@SPOT_LIBRARY_DIRS@;@FCL_LIBRARY_DIRS@;@ASSIMP_LIBRARY_DIRS@)
      if(_dir)
          list(APPEND OMPL_LIBRARY_DIRS "${_dir}")
-@@ -40,7 +43,7 @@ set(OMPL_LIBRARY_DIRS "${OMPL_LIBRARY_DIRS}" CACHE STRING "Library path for OMPL
+@@ -40,7 +46,7 @@ set(OMPL_LIBRARY_DIRS "${OMPL_LIBRARY_DIRS}" CACHE STRING "Library path for OMPL
  
  find_library(OMPL_LIBRARIES NAMES ompl.${OMPL_VERSION} ompl
      PATHS ${OMPL_LIBRARY_DIR} NO_DEFAULT_PATH)
@@ -33,8 +36,20 @@ index 465de25d..d1e91929 100644
      if(_lib)
          list(APPEND OMPL_LIBRARIES "${_lib}")
      endif()
-@@ -61,3 +64,4 @@ endif()
+@@ -61,3 +67,4 @@ endif()
  
  include(FindPackageHandleStandardArgs)
  find_package_handle_standard_args(ompl DEFAULT_MSG OMPL_INCLUDE_DIRS OMPL_LIBRARY_DIRS OMPL_LIBRARIES)
 +include(${CMAKE_CURRENT_LIST_DIR}/ompl-targets.cmake)
+diff --git a/src/ompl/CMakeLists.txt b/src/ompl/CMakeLists.txt
+index 7057838..405fa78 100644
+--- a/src/ompl/CMakeLists.txt
++++ b/src/ompl/CMakeLists.txt
+@@ -61,6 +61,7 @@ target_link_libraries(ompl
+     ${Boost_SYSTEM_LIBRARY}
+     ${CMAKE_THREAD_LIBS_INIT})
+ 
++target_include_directories(ompl PUBLIC $<INSTALL_INTERFACE:include>)
+ if (OMPL_EXTENSION_ODE)
+     if (NOT CMAKE_VERSION VERSION_LESS 3.13)
+         target_link_directories(ompl PUBLIC ${ODE_LIBRARY_DIRS})

--- a/ports/ompl/0002_Fix_config.patch
+++ b/ports/ompl/0002_Fix_config.patch
@@ -1,16 +1,13 @@
-diff --git a/omplConfig.cmake.in b/omplConfig.cmake.in
-index 2d88251..a01e1c4 100644
+﻿diff --git a/omplConfig.cmake.in b/omplConfig.cmake.in
+index 465de25d..d1e91929 100644
 --- a/omplConfig.cmake.in
 +++ b/omplConfig.cmake.in
-@@ -18,8 +18,14 @@ set(OMPL_MAJOR_VERSION @PROJECT_VERSION_MAJOR@)
+@@ -18,8 +18,11 @@ set(OMPL_MAJOR_VERSION @PROJECT_VERSION_MAJOR@)
  set(OMPL_MINOR_VERSION @PROJECT_VERSION_MINOR@)
  set(OMPL_PATCH_VERSION @PROJECT_VERSION_PATCH@)
  
 +include(CMakeFindDependencyMacro)
-+find_dependency(boost_serialization CONFIG)
-+find_dependency(boost_filesystem CONFIG) 
-+find_dependency(boost_system CONFIG)
-+find_dependency(boost_program_options CONFIG)
++find_dependency(Boost 1.58 COMPONENTS serialization filesystem system program_options)
 +find_dependency(Eigen3)
  set_and_check(OMPL_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
 -set(OMPL_INCLUDE_DIRS "${OMPL_INCLUDE_DIR};@Boost_INCLUDE_DIR@;@EIGEN3_INCLUDE_DIR@")
@@ -18,7 +15,7 @@ index 2d88251..a01e1c4 100644
  foreach(_dir @FLANN_INCLUDE_DIRS@;@ODE_INCLUDE_DIRS@;@SPOT_INCLUDE_DIRS@;@TRIANGLE_INCLUDE_DIR@;@FCL_INCLUDE_DIRS@;@PQP_INCLUDE_DIR@;@ASSIMP_INCLUDE_DIRS@;@OPENGL_INCLUDE_DIR@)
      if(_dir)
          list(APPEND OMPL_INCLUDE_DIRS "${_dir}")
-@@ -29,7 +35,7 @@ list(REMOVE_DUPLICATES OMPL_INCLUDE_DIRS)
+@@ -29,7 +32,7 @@ list(REMOVE_DUPLICATES OMPL_INCLUDE_DIRS)
  set(OMPL_INCLUDE_DIRS "${OMPL_INCLUDE_DIRS}" CACHE STRING "Include path for OMPL and its dependencies")
  
  set_and_check(OMPL_LIBRARY_DIR @PACKAGE_LIB_INSTALL_DIR@)
@@ -27,7 +24,7 @@ index 2d88251..a01e1c4 100644
  foreach(_dir @FLANN_LIBRARY_DIRS@;@ODE_LIBRARY_DIRS@;@SPOT_LIBRARY_DIRS@;@FCL_LIBRARY_DIRS@;@ASSIMP_LIBRARY_DIRS@)
      if(_dir)
          list(APPEND OMPL_LIBRARY_DIRS "${_dir}")
-@@ -40,7 +46,7 @@ set(OMPL_LIBRARY_DIRS "${OMPL_LIBRARY_DIRS}" CACHE STRING "Library path for OMPL
+@@ -40,7 +43,7 @@ set(OMPL_LIBRARY_DIRS "${OMPL_LIBRARY_DIRS}" CACHE STRING "Library path for OMPL
  
  find_library(OMPL_LIBRARIES NAMES ompl.${OMPL_VERSION} ompl
      PATHS ${OMPL_LIBRARY_DIR} NO_DEFAULT_PATH)
@@ -36,20 +33,8 @@ index 2d88251..a01e1c4 100644
      if(_lib)
          list(APPEND OMPL_LIBRARIES "${_lib}")
      endif()
-@@ -61,3 +67,4 @@ endif()
+@@ -61,3 +64,4 @@ endif()
  
  include(FindPackageHandleStandardArgs)
  find_package_handle_standard_args(ompl DEFAULT_MSG OMPL_INCLUDE_DIRS OMPL_LIBRARY_DIRS OMPL_LIBRARIES)
 +include(${CMAKE_CURRENT_LIST_DIR}/ompl-targets.cmake)
-diff --git a/src/ompl/CMakeLists.txt b/src/ompl/CMakeLists.txt
-index 7057838..405fa78 100644
---- a/src/ompl/CMakeLists.txt
-+++ b/src/ompl/CMakeLists.txt
-@@ -61,6 +61,7 @@ target_link_libraries(ompl
-     ${Boost_SYSTEM_LIBRARY}
-     ${CMAKE_THREAD_LIBS_INIT})
- 
-+target_include_directories(ompl PUBLIC $<INSTALL_INTERFACE:include>)
- if (OMPL_EXTENSION_ODE)
-     if (NOT CMAKE_VERSION VERSION_LESS 3.13)
-         target_link_directories(ompl PUBLIC ${ODE_LIBRARY_DIRS})

--- a/ports/ompl/0003_fix_dep.patch
+++ b/ports/ompl/0003_fix_dep.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cc81419..03f57d9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -49,8 +49,10 @@ set_package_properties(Boost PROPERTIES
+     PURPOSE "Used throughout OMPL for data serialization, graphs, etc.")
+ set(Boost_USE_MULTITHREADED ON)
+ set(Boost_NO_BOOST_CMAKE ON)
+-find_package(Boost 1.58 QUIET REQUIRED COMPONENTS serialization filesystem system program_options)
+-include_directories(SYSTEM ${Boost_INCLUDE_DIR})
++find_package(boost_serialization CONFIG REQUIRED)
++find_package(boost_filesystem CONFIG REQUIRED)
++find_package(boost_system CONFIG REQUIRED)
++find_package(boost_program_options CONFIG REQUIRED)
+ 
+ # Add support in Boost::Python for std::shared_ptr
+ # This is a hack that replaces boost::shared_ptr related code with std::shared_ptr.
+@@ -183,7 +185,7 @@ add_subdirectory(demos)
+ add_subdirectory(scripts)
+ add_subdirectory(doc)
+ 
+-if(NOT MSVC)
++if(0)
+     target_link_flags(ompl)
+     set(PKG_NAME "ompl")
+     set(PKG_DESC "The Open Motion Planning Library")

--- a/ports/ompl/0003_fix_dep.patch
+++ b/ports/ompl/0003_fix_dep.patch
@@ -1,21 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index cc81419..03f57d9 100644
+index cc81419..88046b3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -49,8 +49,10 @@ set_package_properties(Boost PROPERTIES
-     PURPOSE "Used throughout OMPL for data serialization, graphs, etc.")
- set(Boost_USE_MULTITHREADED ON)
- set(Boost_NO_BOOST_CMAKE ON)
--find_package(Boost 1.58 QUIET REQUIRED COMPONENTS serialization filesystem system program_options)
--include_directories(SYSTEM ${Boost_INCLUDE_DIR})
-+find_package(boost_serialization CONFIG REQUIRED)
-+find_package(boost_filesystem CONFIG REQUIRED)
-+find_package(boost_system CONFIG REQUIRED)
-+find_package(boost_program_options CONFIG REQUIRED)
- 
- # Add support in Boost::Python for std::shared_ptr
- # This is a hack that replaces boost::shared_ptr related code with std::shared_ptr.
-@@ -183,7 +185,7 @@ add_subdirectory(demos)
+@@ -183,7 +183,7 @@ add_subdirectory(demos)
  add_subdirectory(scripts)
  add_subdirectory(doc)
  
@@ -24,3 +11,15 @@ index cc81419..03f57d9 100644
      target_link_flags(ompl)
      set(PKG_NAME "ompl")
      set(PKG_DESC "The Open Motion Planning Library")
+diff --git a/src/ompl/CMakeLists.txt b/src/ompl/CMakeLists.txt
+index 7057838..405fa78 100644
+--- a/src/ompl/CMakeLists.txt
++++ b/src/ompl/CMakeLists.txt
+@@ -61,6 +61,7 @@ target_link_libraries(ompl
+     ${Boost_SYSTEM_LIBRARY}
+     ${CMAKE_THREAD_LIBS_INIT})
+ 
++target_include_directories(ompl PUBLIC $<INSTALL_INTERFACE:include>)
+ if (OMPL_EXTENSION_ODE)
+     if (NOT CMAKE_VERSION VERSION_LESS 3.13)
+         target_link_directories(ompl PUBLIC ${ODE_LIBRARY_DIRS})

--- a/ports/ompl/portfile.cmake
+++ b/ports/ompl/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
     PATCHES
         0001_Export_targets.patch
         0002_Fix_config.patch
+        0003_fix_dep.patch
 )
 
 # Based on selected features different files get downloaded, so use the following command instead of patch.
@@ -37,7 +38,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH share/ompl/cmake)
-vcpkg_fixup_pkgconfig()
 
 # Remove debug distribution and other, move ompl_benchmark to tools/ dir
 file(REMOVE_RECURSE

--- a/ports/ompl/vcpkg.json
+++ b/ports/ompl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ompl",
   "version": "1.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Open Motion Planning Library, consists of many state-of-the-art sampling-based motion planning algorithms",
   "homepage": "https://ompl.kavrakilab.org/",
   "dependencies": [

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -818,6 +818,18 @@ offscale-libetcd-cpp:arm64-uwp=fail
 offscale-libetcd-cpp:x64-uwp=fail
 ogdf:arm64-android=fail
 ois:x64-android=fail
+# ompl is vulnerable to some form of race in its dependent ports, and adding 'ode' as a dependency
+# does not resolve the issue
+# src/ompl/CMakeFiles/ompl.dir/extensions/ode/src/OpenDEStateValidityChecker.cpp.o
+# -L/mnt/vcpkg-ci/packages/flann_x64-linux/debug/lib   -L/mnt/vcpkg-ci/packages/ode_x64-linux/debug/lib
+# -Wl,-rpath,/mnt/vcpkg-ci/packages/flann_x64-linux/debug/lib:/mnt/vcpkg-ci/packages/ode_x64-linux/debug/lib::::::::::::::::::::::::::::::::::::::::::::::::
+# -lode  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libboost_serialization.a
+# /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libboost_filesystem.a
+# /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libboost_system.a  -lpthread && :
+# /usr/bin/ld: cannot find -lode
+ompl:arm-neon-android=fail
+ompl:arm64-android=fail
+ompl:x64-android=fail
 # opencc/deps/rapidjson-1.1.0/rapidjson.h: Unknown machine endianess detected
 onednn:x64-android=fail
 # opencc/deps/marisa-0.2.5/lib/marisa/grimoire/io/mapper.cc currently doesn't support UWP.

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -827,12 +827,6 @@ ois:x64-android=fail
 # /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libboost_filesystem.a
 # /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libboost_system.a  -lpthread && :
 # /usr/bin/ld: cannot find -lode
-ompl:arm-neon-android=fail
-ompl:arm64-android=fail
-ompl:x64-android=fail
-ompl:x64-osx=fail
-ompl:arm64-osx=fail
-ompl:x64-linux=fail
 # opencc/deps/rapidjson-1.1.0/rapidjson.h: Unknown machine endianess detected
 onednn:x64-android=fail
 # opencc/deps/marisa-0.2.5/lib/marisa/grimoire/io/mapper.cc currently doesn't support UWP.

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -818,15 +818,6 @@ offscale-libetcd-cpp:arm64-uwp=fail
 offscale-libetcd-cpp:x64-uwp=fail
 ogdf:arm64-android=fail
 ois:x64-android=fail
-# ompl is vulnerable to some form of race in its dependent ports, and adding 'ode' as a dependency
-# does not resolve the issue
-# src/ompl/CMakeFiles/ompl.dir/extensions/ode/src/OpenDEStateValidityChecker.cpp.o
-# -L/mnt/vcpkg-ci/packages/flann_x64-linux/debug/lib   -L/mnt/vcpkg-ci/packages/ode_x64-linux/debug/lib
-# -Wl,-rpath,/mnt/vcpkg-ci/packages/flann_x64-linux/debug/lib:/mnt/vcpkg-ci/packages/ode_x64-linux/debug/lib::::::::::::::::::::::::::::::::::::::::::::::::
-# -lode  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libboost_serialization.a
-# /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libboost_filesystem.a
-# /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libboost_system.a  -lpthread && :
-# /usr/bin/ld: cannot find -lode
 # opencc/deps/rapidjson-1.1.0/rapidjson.h: Unknown machine endianess detected
 onednn:x64-android=fail
 # opencc/deps/marisa-0.2.5/lib/marisa/grimoire/io/mapper.cc currently doesn't support UWP.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6430,7 +6430,7 @@
     },
     "ompl": {
       "baseline": "1.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "omplapp": {
       "baseline": "1.5.1",

--- a/versions/o-/ompl.json
+++ b/versions/o-/ompl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6553fd6c4b42923ba3f8349ad84af9a5f27dd2be",
+      "version": "1.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "052eff04bde8b7a8eee0d49d4e017679a2d1aff2",
       "version": "1.6.0",
       "port-version": 1

--- a/versions/o-/ompl.json
+++ b/versions/o-/ompl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6553fd6c4b42923ba3f8349ad84af9a5f27dd2be",
+      "git-tree": "af59be72a074fcdfbfaf6500afca3442e0a2648b",
       "version": "1.6.0",
       "port-version": 2
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39863

1. Fix the issue of pc files not linking on linux and osx. The ompl.pc file generated on non-Windows systems requires boost::serialization and boost::system, but there are no corresponding pc files in Boost, causing the call to fail. Therefore, remove the process of generating the ompl.pc file.
```
CMake Error at scripts/cmake/vcpkg_fixup_pkgconfig.cmake:134 (message):
  /opt/homebrew/bin/pkg-config --exists ompl failed with error code: 1
      ENV{PKG_CONFIG_PATH}: "/Users/vcpkg/jim/vcpkg/packages/ompl_arm64-osx/lib/pkgconfig:/Users/vcpkg/jim/vcpkg/packages/ompl_arm64-osx/share/pkgconfig:/Users/vcpkg/jim/vcpkg/installed/arm64-osx/lib/pkgconfig:/Users/vcpkg/jim/vcpkg/installed/arm64-osx/share/pkgconfig"
      output: Package Boost::serialization was not found in the pkg-config search path.
  Perhaps you should add the directory containing `Boost::serialization.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'Boost::serialization', required by 'ompl', not found
```

2. Fix the issue of header files not being callable after installation.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
```
Compile test pass with following triplets:
```
x64-linux
x64-windows
arm64-osx
```