### PR TITLE
[commsdsl] Update to 6.3.3 and fix usage error

### DIFF
--- a/ports/commsdsl/portfile.cmake
+++ b/ports/commsdsl/portfile.cmake
@@ -1,15 +1,14 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO commschamp/commsdsl
-    REF v4.0
-    SHA512 420fd0dd30aa5530692f40e15e3a640d1ef766c642e91edc07ed182e2125043c6ade1d245ef4d549a606c372c8c5f53fea7faa14b230ff485cf24d4f13ecfbee
+    REF "v${VERSION}"
+    SHA512 21a1fd4a3a66f2c9389c19ab8ad0aadf09bc97db39492921385534de6d819b1cd5a1e65798abc71de8f8f6c436191fd199e8e77dc8b5c979b07d313a2b825fde
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DCOMMSDSL_BUILD_APPS=ON
         -DCOMMSDSL_INSTALL_APPS=ON
         -DCOMMSDSL_INSTALL_LIBRARY=ON
         -DCOMMSDSL_INSTALL_LIBRARY_HEADERS=ON
@@ -21,11 +20,18 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_copy_tools(
-    TOOL_NAMES commsdsl2comms commsdsl2test commsdsl2tools_qt
+    TOOL_NAMES commsdsl2comms
     AUTO_CLEAN
 )
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME LibCommsdsl CONFIG_PATH lib/LibCommsdsl/cmake)
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/LibCommsdsl/LibCommsdslConfig.cmake"
+"if (TARGET cc::commsdsl)"
+[[include(CMakeFindDependencyMacro)
+find_dependency(LibXml2)
+if (TARGET cc::commsdsl)]])
+
 # after fixing the following dirs are empty
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/LibCommsdsl")
@@ -35,4 +41,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/commsdsl/vcpkg.json
+++ b/ports/commsdsl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "commsdsl",
-  "version-semver": "4.0.0",
+  "version-semver": "6.3.3",
   "description": "DSL schemas parser and code generator for CommsChampion Ecosystem",
   "homepage": "https://commschamp.github.io/",
   "documentation": "https://github.com/commschamp/commsdsl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1801,7 +1801,7 @@
       "port-version": 0
     },
     "commsdsl": {
-      "baseline": "4.0.0",
+      "baseline": "6.3.3",
       "port-version": 0
     },
     "compoundfilereader": {

--- a/versions/c-/commsdsl.json
+++ b/versions/c-/commsdsl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a9abbda77e304e8b2e7304052d672211b66e87d",
+      "version-semver": "6.3.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "a363dfeed76ba38fa1d1b3007b06223c347e0063",
       "version-semver": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Usage passed on `x64-windows` and `x64-linux`.