### PR TITLE
[gdk-pixbuf] Enable other loaders, which are weakly maintained (ani, bmp, icns, ico, pnm, qtif, tga, xbm, xpm)

### DIFF
--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -37,6 +37,12 @@ else()
     list(APPEND OPTIONS -Djpeg=disabled)
 endif()
 
+if("others" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dothers=enabled)
+else()
+    list(APPEND OPTIONS -Dothers=disabled)
+endif()
+
 if(CMAKE_HOST_WIN32 AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     set(GIR_TOOL_DIR ${CURRENT_INSTALLED_DIR})
 else()

--- a/ports/gdk-pixbuf/vcpkg.json
+++ b/ports/gdk-pixbuf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdk-pixbuf",
   "version": "2.42.12",
+  "port-version": 1,
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-or-later",
@@ -41,6 +42,9 @@
       "dependencies": [
         "libjpeg-turbo"
       ]
+    },
+    "others": {
+      "description": "Enable other loaders, which are weakly maintained (ani, bmp, icns, ico, pnm, qtif, tga, xbm, xpm)"
     },
     "png": {
       "description": "Enable PNG loader (requires libpng)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2986,7 +2986,7 @@
     },
     "gdk-pixbuf": {
       "baseline": "2.42.12",
-      "port-version": 0
+      "port-version": 1
     },
     "gemmlowp": {
       "baseline": "2021-09-28",

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3dd13dfa169e843726c8ac404a85d60aebdb981",
+      "version": "2.42.12",
+      "port-version": 1
+    },
+    {
       "git-tree": "bbf12c7f576f4ecae98d0b4d8cdc0f5fc07f24fb",
       "version": "2.42.12",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
