### PR TITLE
[quantlib] update to v1.35

### DIFF
--- a/ports/quantlib/portfile.cmake
+++ b/ports/quantlib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lballabio/QuantLib
     REF "v${VERSION}"
-    SHA512 b99051ec5b621e9bfd91851487d3dd2153618785b458fbe039b7ab58de8f6da0a36eb0240182a11696ab8ab67788069fc2c4e7efa347ddf3bb77fafe5b190a05
+    SHA512 5017548669fec649a9324298d828e11e44b9fb12924f5bfebbe90d2893bd02c627c38f7e8516416d894ab82f3fa3c77cba2a2ba09a25c19dc0efa130a3dba72c
     HEAD_REF master
 )
 
@@ -14,7 +14,6 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DQL_BUILD_BENCHMARK=OFF
         -DQL_BUILD_EXAMPLES=OFF
         -DQL_BUILD_TEST_SUITE=OFF
 )

--- a/ports/quantlib/vcpkg.json
+++ b/ports/quantlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quantlib",
-  "version": "1.34",
+  "version": "1.35",
   "description": "The QuantLib C++ library",
   "homepage": "https://www.quantlib.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7585,7 +7585,7 @@
       "port-version": 0
     },
     "quantlib": {
-      "baseline": "1.34",
+      "baseline": "1.35",
       "port-version": 0
     },
     "quaternions": {

--- a/versions/q-/quantlib.json
+++ b/versions/q-/quantlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0dfe33379e9412c9ef411bdd5505d76728b8a61",
+      "version": "1.35",
+      "port-version": 0
+    },
+    {
       "git-tree": "fba242bf1761f859aaa2d0768f555b71f06fe587",
       "version": "1.34",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The `QL_BUILD_BENCHMARK` option is no longer supported for this package, so I have removed it.