### PR TITLE
Revert "Add VCPKG_(PRE|POST)_PORTFILE_INCLUDES for code injection before/after the portfile"

### DIFF
--- a/scripts/ports.cmake
+++ b/scripts/ports.cmake
@@ -189,18 +189,7 @@ target system or to the host system. Use a prefixed variable instead.
     set(Z_VCPKG_ERROR_LOG_COLLECTION_FILE "${CURRENT_BUILDTREES_DIR}/error-logs-${TARGET_TRIPLET}.txt")
     file(REMOVE "${Z_VCPKG_ERROR_LOG_COLLECTION_FILE}")
 
-    foreach(z_pre_portfile_include IN LISTS VCPKG_PRE_PORTFILE_INCLUDES)
-        include("${z_pre_portfile_include}")
-    endforeach()
-    unset(z_pre_portfile_include)
-
     include("${CURRENT_PORT_DIR}/portfile.cmake")
-
-    foreach(z_post_portfile_include IN LISTS VCPKG_POST_PORTFILE_INCLUDES)
-        include("${z_post_portfile_include}")
-    endforeach()
-    unset(z_post_portfile_include)
-
     if(DEFINED PORT)
         # Always fixup RPATH on linux and osx unless explicitly disabled.
         if(VCPKG_FIXUP_ELF_RPATH OR (VCPKG_TARGET_IS_LINUX AND NOT DEFINED VCPKG_FIXUP_ELF_RPATH))


### PR DESCRIPTION
Reverts microsoft/vcpkg#25847

@BillyONeal The PR wasn't adjusted to the changes in the tool.