### PR TITLE
[vcpkg baseline] Move cyrus-sasl to correct location in baseline.json

### DIFF
--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2128,10 +2128,6 @@
       "baseline": "30.475.1",
       "port-version": 0
     },
-    "cyrus-sasl": {
-      "baseline": "2.1.28",
-      "port-version": 0
-    },
     "cxxgraph": {
       "baseline": "4.1.0",
       "port-version": 0
@@ -2146,6 +2142,10 @@
     },
     "cyclonedds-cxx": {
       "baseline": "0.10.4",
+      "port-version": 0
+    },
+    "cyrus-sasl": {
+      "baseline": "2.1.28",
       "port-version": 0
     },
     "czmq": {


### PR DESCRIPTION
#39892 resulted in the `cyrus-sasl` dependency being inserted out-of-order in `versions/baseline.json`. This is making the move appear in other changes anytime someone runs `vcpkg x-add-version`. Split the fix out into its own PR to minimize conflicts.