### PR TITLE
[raylib] Add the option to explicitly build with AddressSanitizers

### DIFF
--- a/ports/raylib/portfile.cmake
+++ b/ports/raylib/portfile.cmake
@@ -42,8 +42,6 @@ if(VCPKG_TARGET_IS_MINGW)
     set(USE_SANITIZERS OFF)
 endif()
 
-message(${USE_SANITIZERS})
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/raylib/portfile.cmake
+++ b/ports/raylib/portfile.cmake
@@ -35,13 +35,14 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         hidpi SUPPORT_HIGH_DPI
         use-audio USE_AUDIO
+        use-sanitizers USE_SANITIZERS
 )
 
 if(VCPKG_TARGET_IS_MINGW)
-    set(DEBUG_ENABLE_SANITIZERS OFF)
-else()
-    set(DEBUG_ENABLE_SANITIZERS ON)
+    set(USE_SANITIZERS OFF)
 endif()
+
+message(${USE_SANITIZERS})
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -53,8 +54,8 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         ${ADDITIONAL_OPTIONS}
     OPTIONS_DEBUG
-        -DENABLE_ASAN=${DEBUG_ENABLE_SANITIZERS}
-        -DENABLE_UBSAN=${DEBUG_ENABLE_SANITIZERS}
+        -DENABLE_ASAN=${USE_SANITIZERS}
+        -DENABLE_UBSAN=${USE_SANITIZERS}
         -DENABLE_MSAN=OFF
     OPTIONS_RELEASE
         -DENABLE_ASAN=OFF

--- a/ports/raylib/vcpkg.json
+++ b/ports/raylib/vcpkg.json
@@ -28,6 +28,9 @@
     },
     "use-audio": {
       "description": "Build raylib with audio module"
+    },
+    "use-sanitizers": {
+      "description": "Build raylib with Sanitizers in Debug Mode"
     }
   }
 }

--- a/versions/r-/raylib.json
+++ b/versions/r-/raylib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7cf5ce249c066d11ea5afe9ed15972663992c0f2",
+      "git-tree": "0604c91aa6fe25461fa92518a57e596e48f919b9",
       "version": "5.0",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #39996
Moves the ASAN and UBSAN options into port features instead of enabling them automatically for every debug build. This causes linking errors and forces the user to enable Sanitizers for their project. I tested both use cases locally.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions