### PR TITLE
[curl,vcpkg-ci-curl] Update to curl 8.9.1, Add gnutls feature, Add test gnutls for curl

### DIFF
--- a/ports/curl/gnutls.patch
+++ b/ports/curl/gnutls.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 580cc4357..735a9e234 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -540,11 +540,12 @@ if(CURL_USE_WOLFSSL)
+ endif()
+ 
+ if(CURL_USE_GNUTLS)
+-  find_package(GnuTLS REQUIRED)
+-  find_package(nettle REQUIRED)
++  find_package(PkgConfig REQUIRED)
++  pkg_check_modules(GNUTLS "gnutls")
++  pkg_check_modules(NETTLE "nettle")
+   set(SSL_ENABLED ON)
+   set(USE_GNUTLS ON)
+-  list(APPEND CURL_LIBS ${GNUTLS_LIBRARIES} ${NETTLE_LIBRARIES})
++  list(APPEND CURL_LIBS ${GNUTLS_LINK_LIBRARIES} ${NETTLE_LINK_LIBRARIES})
+   list(APPEND LIBCURL_PC_REQUIRES_PRIVATE "gnutls" "nettle")
+   include_directories(${GNUTLS_INCLUDE_DIRS} ${NETTLE_INCLUDE_DIRS})
+ 

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO curl/curl
     REF "${curl_version}"
-    SHA512 9f7e92292bde501334ee415335404da7c40e033443c34464ed48af5bab7d1fd594859278eac695bec77ee6d58c0629162a7a9876a38a5abd404faa1c43f2b14e
+    SHA512 f5c425c3fbd7bfda13137e8e9bc969ed7dc94c5bfcf0681a2358ab7d3b5d10402781a93385255a80c402c9824aeb97d70213b412f2d208dee4abdba5bbed2ca4
     HEAD_REF master
     PATCHES
         0005_remove_imp_suffix.patch
@@ -13,6 +13,7 @@ vcpkg_from_github(
         export-components.patch
         dependencies.patch
         cmake-config.patch
+        gnutls.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -36,11 +37,20 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         psl         CURL_USE_LIBPSL
         gssapi      CURL_USE_GSSAPI
         gsasl       CURL_USE_GSASL
+        gnutls      CURL_USE_GNUTLS
     INVERTED_FEATURES
         ldap        CURL_DISABLE_LDAP
         ldap        CURL_DISABLE_LDAPS
         non-http    HTTP_ONLY
 )
+
+# Add warning on build failuer when using wolfssl and openssl features togther.
+if("openssl" IN_LIST FEATURES AND "wolfssl" IN_LIST FEATURES)
+    message(WARNING "Adding OpenSSL and WolfSSL simultaneously will result in a build failure. \
+                     Please remove one of these features from your build process.\
+                     If you are using OpenSSL version 1.1, you may disregard this warning."
+    )
+endif()
 
 set(OPTIONS "")
 

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "curl",
-  "version": "8.9.0",
+  "version": "8.9.1",
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",
@@ -30,6 +30,19 @@
       "description": "c-ares support",
       "dependencies": [
         "c-ares"
+      ]
+    },
+    "gnutls": {
+      "description": "SSL support (gnutls)",
+      "dependencies": [
+        {
+          "name": "libgnutls",
+          "platform": "!windows | mingw"
+        },
+        {
+          "name": "shiftmedia-libgnutls",
+          "platform": "windows & !mingw"
+        }
       ]
     },
     "gsasl": {

--- a/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
@@ -49,6 +49,13 @@
         "tool"
       ],
       "platform": "!android & !uwp"
+    },
+    {
+      "name": "curl",
+      "features": [
+        "gnutls"
+      ],
+      "platform": "!arm & !xbox"
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2105,7 +2105,7 @@
       "port-version": 8
     },
     "curl": {
-      "baseline": "8.9.0",
+      "baseline": "8.9.1",
       "port-version": 0
     },
     "curlpp": {

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f243fde8de72db4bb1d25a29e758d5b8973551e4",
+      "version": "8.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "58954b5f6ad96e9c390d6ae282b8a04c46a65ad3",
       "version": "8.9.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

curl:
- Update curl to 8.9.1
- Add gnutls feature (both for unix + windows)

vcpkg-ci-curl:
- Add test gnutls