### PR TITLE
[bext-sml2] Change to new repo

### DIFF
--- a/ports/bext-sml2/portfile.cmake
+++ b/ports/bext-sml2/portfile.cmake
@@ -1,9 +1,9 @@
 # Header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO boost-ext/sml2
-    REF df727871ec119343e68881d47a24ce69f9bbd841
-    SHA512 5a1ce9a6a6afb9504049a3e681d920c8b32394c5ffb6d635763488b8916dbcaf3390063ff0bae671729216f4eaea0f799bba7037aa922a1fc77ca9b0b1ac3a5b 
+    REPO qlibs/sml
+    REF "v${VERSION}"
+    SHA512 8c2406f1d35145b4f5896c41c8d1a616444cb151cc468f670daefc1b7dc4bd8aa6c9acc3c2c733158c0e6a21b4077cac4b519eea2b0fd3bc549dae726d0a23d7 
     HEAD_REF master
 )
 
@@ -12,4 +12,4 @@ file(INSTALL "${SOURCE_PATH}/sml2"
 )
 
 # Handle copyright
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/README.md")

--- a/ports/bext-sml2/vcpkg.json
+++ b/ports/bext-sml2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "bext-sml2",
-  "version-date": "2024-02-02",
+  "version": "2.0.0",
   "description": "Your scalable C++20 one header only State Machine Library with no dependencies",
-  "homepage": "https://github.com/boost-ext/sml2",
+  "homepage": "https://github.com/qlibs/sml",
   "license": "BSL-1.0"
 }

--- a/versions/b-/bext-sml2.json
+++ b/versions/b-/bext-sml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a044e08c33fb1465d65b751bd0d23e7b32b85f5",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "588ef9edb0c8c55acb5807d67ddbea854b563606",
       "version-date": "2024-02-02",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -609,7 +609,7 @@
       "port-version": 0
     },
     "bext-sml2": {
-      "baseline": "2024-02-02",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "bext-ut": {
@@ -2128,10 +2128,6 @@
       "baseline": "30.475.1",
       "port-version": 0
     },
-    "cyrus-sasl": {
-      "baseline": "2.1.28",
-      "port-version": 0
-    },
     "cxxgraph": {
       "baseline": "4.1.0",
       "port-version": 0
@@ -2146,6 +2142,10 @@
     },
     "cyclonedds-cxx": {
       "baseline": "0.10.4",
+      "port-version": 0
+    },
+    "cyrus-sasl": {
+      "baseline": "2.1.28",
       "port-version": 0
     },
     "czmq": {


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/40092

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.