### PR TITLE
[cairomm] Update to 1.18.0

### DIFF
--- a/ports/cairomm/portfile.cmake
+++ b/ports/cairomm/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.cairographics.org/releases/cairomm-${VERSION}.tar.xz"
     FILENAME "cairomm-${VERSION}.tar.xz"
-    SHA512 5484ccefc255b2e8886722c483cde011043c98b8e7ae17ce642f1b67effa236a8499c332771104fa7e547a9066c168fcfbbff6249caa73df3860823b355567d9
+    SHA512 d358a765136e244773b4a0fdcb2d9c81dd0b76f7a27c7108f94df9765f2d790f5f50b5645c09c292efce3e012528f85114d51916450c5fe6fa87d09f5a405d4c
 )
 
 vcpkg_extract_source_archive(

--- a/ports/cairomm/vcpkg.json
+++ b/ports/cairomm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cairomm",
-  "version": "1.17.1",
-  "port-version": 1,
+  "version": "1.18.0",
   "description": "A C++ wrapper for the cairo graphics library",
   "homepage": "https://www.cairographics.org",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1469,8 +1469,8 @@
       "port-version": 1
     },
     "cairomm": {
-      "baseline": "1.17.1",
-      "port-version": 1
+      "baseline": "1.18.0",
+      "port-version": 0
     },
     "calceph": {
       "baseline": "4.0.0",
@@ -2128,10 +2128,6 @@
       "baseline": "30.475.1",
       "port-version": 0
     },
-    "cyrus-sasl": {
-      "baseline": "2.1.28",
-      "port-version": 0
-    },
     "cxxgraph": {
       "baseline": "4.1.0",
       "port-version": 0
@@ -2146,6 +2142,10 @@
     },
     "cyclonedds-cxx": {
       "baseline": "0.10.4",
+      "port-version": 0
+    },
+    "cyrus-sasl": {
+      "baseline": "2.1.28",
       "port-version": 0
     },
     "czmq": {

--- a/versions/c-/cairomm.json
+++ b/versions/c-/cairomm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd3f26958cdfb6aec8b42ca67dad1d7567461dcf",
+      "version": "1.18.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f6f54756edc3cdf81b1fbac86522410f64bda856",
       "version": "1.17.1",
       "port-version": 1


### PR DESCRIPTION
Fix #37503

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux