### PR TITLE
[ngtcp2] Change the dependencies of gnutls feature

### DIFF
--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ngtcp2",
   "version": "1.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "ngtcp2 project is an effort to implement RFC9000 QUIC protocol.",
   "homepage": "https://github.com/ngtcp2/ngtcp2",
   "license": "MIT",
@@ -19,7 +19,14 @@
     "gnutls": {
       "description": "Compile with gnutls",
       "dependencies": [
-        "libgnutls"
+        {
+          "name": "libgnutls",
+          "platform": "!windows | mingw"
+        },
+        {
+          "name": "shiftmedia-libgnutls",
+          "platform": "windows & !mingw"
+        }
       ]
     },
     "wolfssl": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6218,7 +6218,7 @@
     },
     "ngtcp2": {
       "baseline": "1.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "nifly": {
       "baseline": "1.0.0",

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ddfa61f547e616e5d2ae460b5f759a702e8c067d",
+      "version": "1.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "227654175c4fb36c68d385ee7414e057b534f644",
       "version": "1.6.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.