### PR TITLE
[shader-slang] Update to v2024.1.33

### DIFF
--- a/ports/shader-slang/portfile.cmake
+++ b/ports/shader-slang/portfile.cmake
@@ -8,49 +8,44 @@ elseif(VCPKG_TARGET_IS_OSX)
 elseif(VCPKG_TARGET_IS_LINUX)
 	set(key "linux-${VCPKG_TARGET_ARCHITECTURE}")
 endif()
-string(REPLACE "arm64" "aarch64" key "${key}")
 
 set(ARCHIVE NOTFOUND)
 # For convenient updates, use 
 # vcpkg install shader-slang --cmake-args=-DVCPKG_SHADER_SLANG_UPDATE=1
-if(key STREQUAL "windows-x86" OR VCPKG_SHADER_SLANG_UPDATE)
-	vcpkg_download_distfile(
-		ARCHIVE
-		URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-win32.zip"
-		FILENAME "slang-${VERSION}-win32.zip"
-		SHA512 e5c2b1062822577fa0fbf0e9d1d9b020bf5b3e079247546b14d460f2ef5cf453e32b5da80d1b5c94b648761d5e5cdd64bcc15e259b52a1e55c2e54fe41dcf74a
-	)
-endif()
 if(key STREQUAL "windows-x64" OR VCPKG_SHADER_SLANG_UPDATE)
 	vcpkg_download_distfile(
 		ARCHIVE
-		URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-win64.zip"
-		FILENAME "slang-${VERSION}-win64.zip"
-		SHA512 4bdb6917f8689036f7619a07f575b86a2bf10deb258d037399a434bc35e80c8a014f59914f5883a5cd55d5d3717b1ff54d583a63527e5f1cfed06864a15638bb
+		URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-windows-x86_64.zip"
+		FILENAME "slang-${VERSION}-windows-x86_64.zip"
+		SHA512 6f19e8a59462a70d6615bb27768090df4da837c79e67ed130d15fb684ceb4341e3fe31411b814acc1b1540305fdfad22004ad4c3b697e8236e77cacba27816f5
 	)
 endif()
-if(key STREQUAL "windows-aarch64" OR VCPKG_SHADER_SLANG_UPDATE)
+if(key STREQUAL "windows-arm64" OR VCPKG_SHADER_SLANG_UPDATE)
 	vcpkg_download_distfile(
 		ARCHIVE
-		URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-win-arm64.zip"
-		FILENAME "slang-${VERSION}-win-arm64.zip"
-		SHA512 7d4371270af96a6d3072411c37e83804108e6dfbd6dcc58b4c750165c67a0df7094f9f9b61d9a32f2a7740484c9393b7ed03866d6e37407b126dc2fb441c3bf9
+		URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-windows-aarch64.zip"
+		FILENAME "slang-${VERSION}-windows-aarch64.zip"
+		SHA512 07f48beb5ec676de71bb0d8774fae6984e720ce4fcc47cbb684c87bc9763a8e4a6440175e801425a1a17aa2fd9292aa6dc18da6a085b0524cfe2e80d701389df
 	)
 endif()
 if(key STREQUAL "macosx-x64" OR VCPKG_SHADER_SLANG_UPDATE)
+	set(unavailable_for_x64 "${VERSION}")
+	string(REPLACE "2024.1.33" "2024.1.32" VERSION "${VERSION}")
+	message(WARNING "${unavailable} is not available. Using ${VERSION} instead.")
 	vcpkg_download_distfile(
 		ARCHIVE
-		URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-macos-x64.zip"
-		FILENAME "slang-${VERSION}-macos-x64.zip"
-		SHA512 069fade467bfa0c58d25d4366070cb7e17f64f96e8a3c873e69435f52b688660b4f4da51c99266fc6ca1765f1e3fde8e3bb719cccd9c6a2407bfa8468dc6c724
+		URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-macos-x86_64.zip"
+		FILENAME "slang-${VERSION}-macos-x86_64.zip"
+		SHA512 50a710f4432ab1b9cf08e3b490b9e663e7f7a20ed8b8f19fd0d9650cef53e637f66f53a87c1df11b521faaf85fd2e61434f457487cc646debdb240607eaf952f
 	)
+	set(VERSION "${unavailable_for_x64}")
 endif()
-if(key STREQUAL "macosx-aarch64" OR VCPKG_SHADER_SLANG_UPDATE)
+if(key STREQUAL "macosx-arm64" OR VCPKG_SHADER_SLANG_UPDATE)
 	vcpkg_download_distfile(
 		ARCHIVE
 		URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-macos-aarch64.zip"
 		FILENAME "slang-${VERSION}-macos-aarch64.zip"
-		SHA512 d4f2ef7f0c90297eb97e772860cb2cc4cb8beb81ea36aa0d488364bb4e78cd5c98c455168daa5cf03fa7b295f212b0d49a66a7de3ae385fe5c22ddb471d282ae
+		SHA512 166950d26df51818eb2206a1d3659d7061b1853b562dce43fa436971ff8fe946cd4d7a96afa7aa20016b3ae2a2617759220eb424b7caa2494d10ff53222da057
 	)
 endif()
 if(key STREQUAL "linux-x64" OR VCPKG_SHADER_SLANG_UPDATE)
@@ -58,15 +53,15 @@ if(key STREQUAL "linux-x64" OR VCPKG_SHADER_SLANG_UPDATE)
 		ARCHIVE
 		URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-linux-x86_64.zip"
 		FILENAME "slang-${VERSION}-linux-x86_64.zip"
-		SHA512 d6b03a7c35218324d85ac478470e8ba5ffea49703f601202cd04e837c9ffddf5461ee954bde324f71fd3e400bcd2bb637d1dbbbefd2418b7e0f80013c0ff6bed
+		SHA512 2679732c9b27b97e347f6609414ad6953ffe1e165544d16aca48cffaaee6bfb63a2e4726fbe5ef533716788e98a1d47b0e20ecdd23158f9311f92161fcc25631
 	)
 endif()
-if(key STREQUAL "linux-aarch64" OR VCPKG_SHADER_SLANG_UPDATE)
+if(key STREQUAL "linux-arm64" OR VCPKG_SHADER_SLANG_UPDATE)
 	vcpkg_download_distfile(
 		ARCHIVE
 		URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-linux-aarch64.zip"
 		FILENAME "slang-${VERSION}-linux-aarch64.zip"
-		SHA512 68f7912aa0c8280f0ce872ecfdfbb509de66573bc4d0f9c50843f74d5070e62d58556044a7f1dbff57d06017b0b8886452af23671a597f712aa4bf913a100baa
+		SHA512 3ce15de5a7a770460108bee42706a3fa83ed2cfce24297b65cfd7e61b3568e37aaf4f38b8e4b2ea7352abfb932bdc43065b361858900fc02aca136730f22d4bb
 	)
 endif()
 if(NOT ARCHIVE)
@@ -79,37 +74,20 @@ vcpkg_extract_source_archive(
 	NO_REMOVE_ONE_LEVEL
 )
 
-# https://github.com/shader-slang/slang/issues/4117
-if(NOT EXISTS "${BINDIST_PATH}/LICENSE" OR VCPKG_SHADER_SLANG_UPDATE)
-	vcpkg_download_distfile(
-		LICENSE_ARCHIVE
-		URLS "https://github.com/shader-slang/slang/releases/download/v${VERSION}/slang-${VERSION}-source.zip"
-		FILENAME "slang-${VERSION}-source.zip"
-		SHA512 599924333c41c2ee0497d1bfc59b9daefe6f05d43aef96cfba64ec819c8da8fab89c8bfa15bc52ce7c014919c0b87997094489a3dfacee8ecbab1c7d8909f462
-	)
-	vcpkg_extract_source_archive(
-		SOURCE_PATH
-		ARCHIVE "${LICENSE_ARCHIVE}"
-		NO_REMOVE_ONE_LEVEL
-	)
-	file(COPY "${SOURCE_PATH}/LICENSE" DESTINATION "${BINDIST_PATH}")
-endif()
-
 if(VCPKG_SHADER_SLANG_UPDATE)
 	message(STATUS "All downloads are up-to-date.")
 	message(FATAL_ERROR "Stopping due to VCPKG_SHADER_SLANG_UPDATE being enabled.")
 endif()
 
-set(SLANG_BIN_PATH "bin/${key}/release")
 file(GLOB libs
-	"${BINDIST_PATH}/${SLANG_BIN_PATH}/*.lib"
-	"${BINDIST_PATH}/${SLANG_BIN_PATH}/*.dylib"
-	"${BINDIST_PATH}/${SLANG_BIN_PATH}/*.so"
+	"${BINDIST_PATH}/lib/*.lib"
+	"${BINDIST_PATH}/lib/*.dylib"
+	"${BINDIST_PATH}/lib/*.so"
 )
 file(INSTALL ${libs} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
 
 if(VCPKG_TARGET_IS_WINDOWS)
-	file(GLOB dlls "${BINDIST_PATH}/${SLANG_BIN_PATH}/*.dll")
+	file(GLOB dlls "${BINDIST_PATH}/bin/*.dll")
 	file(INSTALL ${dlls} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
 endif()
 
@@ -120,9 +98,9 @@ if(NOT VCPKG_BUILD_TYPE)
 	endif()
 endif()
 
-vcpkg_copy_tools(TOOL_NAMES slangc slangd SEARCH_DIR "${BINDIST_PATH}/${SLANG_BIN_PATH}")
+vcpkg_copy_tools(TOOL_NAMES slangc slangd SEARCH_DIR "${BINDIST_PATH}/bin")
 
-file(GLOB headers "${BINDIST_PATH}/*.h" "${BINDIST_PATH}/prelude")
+file(GLOB headers "${BINDIST_PATH}/include/*.h")
 file(INSTALL ${headers} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 vcpkg_install_copyright(

--- a/ports/shader-slang/vcpkg.json
+++ b/ports/shader-slang/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "shader-slang",
-  "version": "2024.1.25",
+  "version": "2024.1.33",
   "description": "Slang is a shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion, while also maintaining the highest possible performance on modern GPUs and graphics APIs. Slang is based on years of collaboration between researchers at NVIDIA, Carnegie Mellon University, and Stanford.",
   "homepage": "https://github.com/shader-slang/slang",
   "license": "MIT",
-  "supports": "((x86 & windows) | (x64 & (linux | osx | windows)) | (arm64 & (linux | osx | windows))) & !uwp"
+  "supports": "(arm64 | x64) & (linux | osx | windows) & !uwp"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8161,7 +8161,7 @@
       "port-version": 0
     },
     "shader-slang": {
-      "baseline": "2024.1.25",
+      "baseline": "2024.1.33",
       "port-version": 0
     },
     "shaderc": {

--- a/versions/s-/shader-slang.json
+++ b/versions/s-/shader-slang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23bdedb2bc7b9f55b87cf511967ca80db73d874a",
+      "version": "2024.1.33",
+      "port-version": 0
+    },
+    {
       "git-tree": "98ddbe50381d354e915f198a08478bdd9396d85d",
       "version": "2024.1.25",
       "port-version": 0


### PR DESCRIPTION
But v2024.1.32 for x64-arm because there is no binary package for the same version. ([Diff](https://github.com/shader-slang/slang/compare/v2024.1.32...v2024.1.33))

x86-windows hasn't been present in several releases.
