### PR TITLE
[blpapi] update to 3.24.6

### DIFF
--- a/ports/blpapi/portfile.cmake
+++ b/ports/blpapi/portfile.cmake
@@ -3,15 +3,15 @@
 
 if (VCPKG_TARGET_IS_LINUX)
     vcpkg_download_distfile(ARCHIVE
-        URLS "https://bcms.bloomberg.com/BLPAPI-Generic/blpapi_cpp_3.20.2.1-linux.tar.gz"
-        FILENAME "blpapi_cpp_3.20.2.1-linux.tar.gz"
-        SHA512 4d4cf999d6cc2bf924dfb79fdabd2a30c2d1251e4e56fe856684c4f8e0be03dcd33f69d75f8706d381bb35ad4b1ad954a5cc88156a80e053f2601d8257815863
+        URLS "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_3.24.6.1-linux.tar.gz"
+        FILENAME "blpapi_cpp_3.24.6.1-linux.tar.gz"
+        SHA512 a70b43614a7c3414ca391b4b1a9499a545d6ec98779caafed4317b2bc5cdce3e493bcd600196b340c657ce23287ce6f85833ec270b5301e074884f4640cb19f4
     )
 elseif (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_download_distfile(ARCHIVE
-        URLS "https://bcms.bloomberg.com/BLPAPI-Generic/blpapi_cpp_3.20.2.2-windows.zip"
-        FILENAME "blpapi_cpp_3.20.2.2-windows.zip"
-        SHA512 f6e66d75a8f16c014737ae813c65304e38423e5ab955eb98fb7f487eecda06bcc9d84733b55957ac577f689da2af753fdeb132feb0eb02a9ec38e8f3868ad795
+        URLS "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_3.24.6.1-windows.zip"
+        FILENAME "blpapi_cpp_3.24.6.1-windows.zip"
+        SHA512 1e1dba172767c9fcd0d015f2e8eaa16ef25f643a241144bf4a38ed35c8d8cce9f7fa9f4275636abd8a7307c21def17e50cda0a28bdb3f233d1e7a5affd87d3a5
     )
 endif()
 

--- a/ports/blpapi/vcpkg.json
+++ b/ports/blpapi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "blpapi",
-  "version": "3.20.2",
+  "version": "3.24.6",
   "description": "Bloomberg API Library (BLPAPI)",
   "homepage": "https://www.bloomberg.com/professional/support/api-library/",
   "supports": "(linux | (windows & !uwp)) & !static & (x86 | x64)"

--- a/versions/b-/blpapi.json
+++ b/versions/b-/blpapi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f06f8feee872cd3a196d20113ed1f77c39554910",
+      "version": "3.24.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "78171a41201cdb236d95e50ed26f6b76675f97de",
       "version": "3.20.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -701,7 +701,7 @@
       "port-version": 0
     },
     "blpapi": {
-      "baseline": "3.20.2",
+      "baseline": "3.24.6",
       "port-version": 0
     },
     "boinc": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.