### PR TITLE
[mongo-c-driver] Revise dependencies

### DIFF
--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -21,7 +21,6 @@ endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
     FEATURES
-        icu         ENABLE_ICU
         snappy      ENABLE_SNAPPY
         zstd        ENABLE_ZSTD
 )
@@ -40,27 +39,39 @@ if(VCPKG_TARGET_IS_ANDROID)
     vcpkg_list(APPEND OPTIONS -DENABLE_SRV=OFF)
 endif()
 
+vcpkg_find_acquire_program(PKGCONFIG)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         ${OPTIONS}
         "-DBUILD_VERSION=${VERSION}"
+        -DUSE_BUNDLED_UTF8PROC=OFF
         -DUSE_SYSTEM_LIBBSON=ON
+        -DENABLE_CLIENT_SIDE_ENCRYPTION=OFF
         -DENABLE_EXAMPLES=OFF
+        -DENABLE_SASL=OFF
         -DENABLE_SHM_COUNTERS=OFF
         -DENABLE_STATIC=${ENABLE_STATIC}
         -DENABLE_TESTS=OFF
         -DENABLE_UNINSTALL=OFF
         -DENABLE_ZLIB=SYSTEM
-        -DVCPKG_HOST_TRIPLET=${HOST_TRIPLET} # for host pkgconf in PATH
         -DCMAKE_DISABLE_FIND_PACKAGE_Python=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Python3=ON
-    MAYBE_UNUSED_VARIABLES
-        ENABLE_ICU 
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+
+if("snappy" IN_LIST FEATURES AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libmongoc-static-1.0.pc" " -lSnappy::snappy" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libmongoc-static-1.0.pc" "Requires: " "Requires: snappy ")
+    if(NOT VCPKG_BUILD_TYPE)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libmongoc-static-1.0.pc" " -lSnappy::snappy" "")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libmongoc-static-1.0.pc" "Requires: " "Requires: snappy ")
+    endif()
+endif()
 vcpkg_fixup_pkgconfig()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME mongoc-1.0 CONFIG_PATH "lib/cmake/mongoc-1.0" DO_NOT_DELETE_PARENT_CONFIG_PATH)

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mongo-c-driver",
   "version": "1.27.4",
+  "port-version": 1,
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": null,
@@ -14,6 +15,7 @@
       ],
       "platform": "!windows & !osx & !ios"
     },
+    "utf8proc",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -25,12 +27,6 @@
     "zlib"
   ],
   "features": {
-    "icu": {
-      "description": "Enable ICU support, necessary to use non-ASCII usernames or passwords",
-      "dependencies": [
-        "icu"
-      ]
-    },
     "openssl": {
       "description": "Use OpenSSL (even on Windows or Apple systems)",
       "dependencies": [
@@ -46,10 +42,6 @@
     "zstd": {
       "description": "Enables zstd compressor support",
       "dependencies": [
-        {
-          "name": "pkgconf",
-          "host": true
-        },
         "zstd"
       ]
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5898,7 +5898,7 @@
     },
     "mongo-c-driver": {
       "baseline": "1.27.4",
-      "port-version": 0
+      "port-version": 1
     },
     "mongo-cxx-driver": {
       "baseline": "3.10.2",

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e0d49789eb2474ec5c4a4bf3b1d54f16805e997d",
+      "version": "1.27.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "1f9e2f7d1753f1a119b6af302f8836b75e2eb420",
       "version": "1.27.4",
       "port-version": 0


### PR DESCRIPTION
Fix installation order problem with cyrus-sasl.
Remove unused icu dependency.
Devendor utf8proc.
Fix snappy in pc file.