### PR TITLE
[vcpkg baseline][omplapp] Skip due to conflict with ompl

### DIFF
--- a/ports/omplapp/portfile.cmake
+++ b/ports/omplapp/portfile.cmake
@@ -1,10 +1,8 @@
 vcpkg_buildpath_length_warning(37)
 
-set(OMPL_VERSION 1.5.1)
-
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/ompl/omplapp/releases/download/1.5.1/omplapp-1.5.1-Source.tar.gz"
-    FILENAME "omplapp-${OMPL_VERSION}.tar.gz"
+    URLS "https://github.com/ompl/omplapp/releases/download/${VERSION}/omplapp-${VERSION}-Source.tar.gz"
+    FILENAME "omplapp-${VERSION}-Source.tar.gz"
     SHA512 83b1b09d6be776f7e15a748402f0c2f072459921de61a92731daf5171bd1f91a829fbeb6e10a489b92fba0297f6272e7bb6b8f07830c387bb29ccdbc7b3731f3
 )
 
@@ -15,7 +13,7 @@ endif()
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE ${ARCHIVE}
-    SOURCE_BASE ${OMPL_VERSION}
+    SOURCE_BASE ${VERSION}
     PATCHES
         fix_dependency.patch
         ${STATIC_PATCH}
@@ -59,15 +57,8 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/ompl/cmake)
 # Remove debug distribution and other, move ompl_benchmark to tools/ dir
 vcpkg_copy_tools(TOOL_NAMES ompl_benchmark AUTO_CLEAN)
 file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/include/ompl"
-    "${CURRENT_PACKAGES_DIR}/bin"
     "${CURRENT_PACKAGES_DIR}/include/omplapp/CMakeFiles"
-    "${CURRENT_PACKAGES_DIR}/lib/ompl.lib"
-    "${CURRENT_PACKAGES_DIR}/share/ompl"
-    "${CURRENT_PACKAGES_DIR}/share/man"
-    "${CURRENT_PACKAGES_DIR}/debug/bin"
     "${CURRENT_PACKAGES_DIR}/debug/include"
-    "${CURRENT_PACKAGES_DIR}/debug/lib/ompl.lib"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 
@@ -79,5 +70,4 @@ endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/omplapp/vcpkg.json
+++ b/ports/omplapp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "omplapp",
   "version": "1.5.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Use OMPL for reading meshes and performing collision checking",
   "homepage": "https://ompl.kavrakilab.org/",
   "license": null,

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -831,6 +831,8 @@ ois:x64-android=fail
 ompl:arm-neon-android=fail
 ompl:arm64-android=fail
 ompl:x64-android=fail
+omplapp:arm64-osx               = skip  # conflicts with ompl
+omplapp:x64-osx                 = skip
 # opencc/deps/rapidjson-1.1.0/rapidjson.h: Unknown machine endianess detected
 onednn:x64-android=fail
 # opencc/deps/marisa-0.2.5/lib/marisa/grimoire/io/mapper.cc currently doesn't support UWP.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6438,7 +6438,7 @@
     },
     "omplapp": {
       "baseline": "1.5.1",
-      "port-version": 5
+      "port-version": 6
     },
     "onednn": {
       "baseline": "3.4",

--- a/versions/o-/omplapp.json
+++ b/versions/o-/omplapp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "58824bda7d341c623d9250d53741ab6741bfbf58",
+      "version": "1.5.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "8c7e3d29552841ecf363e9f222c6bc554be4b91e",
       "version": "1.5.1",
       "port-version": 5


### PR DESCRIPTION
Fix https://dev.azure.com/vcpkg/public/_build/results?buildId=105429&view=logs&j=ac0731cb-f2f9-5764-2e0a-a6fa8ebb4a08

```log
error: The following files are already installed in /Users/vcpkg/Data/installed/arm64-osx and are in conflict with omplapp:arm64-osx
Installed by ompl:arm64-osx  
debug/lib/libompl.dylib
    lib/libompl.dylib
```

Since `omplapp` coupled with `ompl`, and `ompl` has been fixed and enabled CI test in #40080:

* Mark `omplapp` as `skip`
* Remove command of "delete conflicts ompl files".

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux