### PR TITLE
[directx12-agility] update port to 1.614.1

### DIFF
--- a/ports/directx12-agility/portfile.cmake
+++ b/ports/directx12-agility/portfile.cmake
@@ -6,7 +6,7 @@ set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/${VERSION}"
     FILENAME "Microsoft.Direct3D.D3D12.${VERSION}.zip"
-    SHA512 aab78de3a9db35b1b11b2c2498d2dd19e66a71cdcd1cb426f0469d551fcd6917f4d80734be8b6d0c0b20f7f6ae4b5b9936b0b0aedb229ea49265932b36aee11e
+    SHA512 05baa55231684ab10a3e905c9b85ce78f04ade9360f7de84a06bbae3bfc3123bcccaa563647a25e151cc759106bc19e37740ef78563592d28e3a723fd744b42f
 )
 
 vcpkg_extract_source_archive(
@@ -15,10 +15,12 @@ vcpkg_extract_source_archive(
     NO_REMOVE_ONE_LEVEL
 )
 
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(REDIST_ARCH arm64)
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     set(REDIST_ARCH win32)
 else()
-    set(REDIST_ARCH ${VCPKG_TARGET_ARCHITECTURE})
+    set(REDIST_ARCH x64)
 endif()
 
 file(COPY "${PACKAGE_PATH}/build/native/bin/${REDIST_ARCH}/D3D12Core.dll" "${PACKAGE_PATH}/build/native/bin/${REDIST_ARCH}/D3D12Core.pdb"

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx12-agility",
-  "version": "1.614.0",
+  "version": "1.614.1",
   "description": "DirectX 12 Agility SDK",
   "homepage": "https://aka.ms/directx12agility",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -5,7 +5,7 @@
   "homepage": "https://aka.ms/directx12agility",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",
   "license": null,
-  "supports": "windows & !uwp & !xbox",
+  "supports": "windows & !uwp & !xbox & !arm32",
   "dependencies": [
     "directx-headers",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2261,7 +2261,7 @@
       "port-version": 0
     },
     "directx12-agility": {
-      "baseline": "1.614.0",
+      "baseline": "1.614.1",
       "port-version": 0
     },
     "directxmath": {

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b24c33b59464bd18f81242a3a43011f5c344d16",
+      "version": "1.614.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a435eb1c37fae2f189768a78bf22315940da5657",
       "version": "1.614.0",
       "port-version": 0

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7b24c33b59464bd18f81242a3a43011f5c344d16",
+      "git-tree": "640cc319351249fe3d6eb031c72abc87655b6d58",
       "version": "1.614.1",
       "port-version": 0
     },


### PR DESCRIPTION
Update port for servicing release on NuGet.

ARM 32-bit support was in 1.611 by removed as of 1.613 per the deprecation plan. The supports expression needed updating.

Also made the port work for the `arm64ec-windows` community triplet.