### PR TITLE
[cpp-timsort] Update to 3.0.0

### DIFF
--- a/ports/cpp-timsort/portfile.cmake
+++ b/ports/cpp-timsort/portfile.cmake
@@ -1,8 +1,10 @@
+set(VCPKG_BUILD_TYPE release) # header-only
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO timsort/cpp-TimSort
-    REF v2.1.0
-    SHA512 57fe79d3174d9939a3212282cf64f4fdd90586eba806f57df65eb42c2b4783a68f39bd2b6709830b1688ae15f1a83f554468059b2ddf52b31805bfd23efc7db1
+    REF "v${VERSION}"
+    SHA512 4110017fa25055724a896367f572f1119f0635c7be787f600d68714e4438dd73d0d023f3d021c3c15a3b09a47b13c43a927a2674e5ca601ef5a202b9bc56b849
     HEAD_REF master
 )
 
@@ -16,7 +18,6 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/gfx PACKAGE_NAME gfx-timsort)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cpp-timsort/vcpkg.json
+++ b/ports/cpp-timsort/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "cpp-timsort",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A C++ implementation of timsort",
   "homepage": "https://github.com/timsort/cpp-TimSort",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1905,7 +1905,7 @@
       "port-version": 2
     },
     "cpp-timsort": {
-      "baseline": "2.1.0",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "cppad": {

--- a/versions/c-/cpp-timsort.json
+++ b/versions/c-/cpp-timsort.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f5a8b81f0e75aa7dfb3545271564bfd1ff8977c3",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f04e9f0c24e916697a6451b43cf16a2423019635",
       "version": "2.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Usage passed on `x64-windows`.