### PR TITLE
[botan] Fix error C2039: 'string': is not a member of 'std'

### DIFF
--- a/ports/botan/add-include-string.patch
+++ b/ports/botan/add-include-string.patch
@@ -1,0 +1,12 @@
+diff --git a/src/lib/math/pcurves/pcurves_id.h b/src/lib/math/pcurves/pcurves_id.h
+index 915dd95..3d39666 100644
+--- a/src/lib/math/pcurves/pcurves_id.h
++++ b/src/lib/math/pcurves/pcurves_id.h
+@@ -10,6 +10,7 @@
+ #include <botan/secmem.h>
+ #include <botan/types.h>
+ #include <optional>
++#include <string>
+ #include <string_view>
+ #include <vector>
+ 

--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         fix_android.patch
         libcxx-winpthread-fixes.patch
         fix-cmake-usage.patch
+        add-include-string.patch
 )
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/configure" DESTINATION "${SOURCE_PATH}")
 

--- a/ports/botan/vcpkg.json
+++ b/ports/botan/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "botan",
   "version": "3.5.0",
+  "port-version": 1,
   "description": "A cryptography library written in C++11",
   "homepage": "https://botan.randombit.net",
   "license": "BSD-2-Clause",

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "827a8fc1dd4c4f2b998824ba4c9dae41a47afa98",
+      "version": "3.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3416aa602b64d0eff810540b4555dac28560ba3e",
       "version": "3.5.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1354,7 +1354,7 @@
     },
     "botan": {
       "baseline": "3.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "box2d": {
       "baseline": "2.4.1",


### PR DESCRIPTION
In an internal version of Visual Studio, `botan` install failed with following error:
```
build\include\internal\botan/internal/pcurves_id.h(57): error C2039: 'string': is not a member of 'std'
```
This issue caused by the STL PR: https://github.com/microsoft/STL/pull/4633, and according to Stephan's suggestion, the affected files need to include the `Standard <string> header`.

I have submitted an issue on the qt upstream: https://github.com/randombit/botan/issues/4278

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
