### PR TITLE
[wabt] Add new port

### DIFF
--- a/ports/wabt/include_picosha2.cmake
+++ b/ports/wabt/include_picosha2.cmake
@@ -1,0 +1,2 @@
+find_path(PICOSHA2_INCLUDE_DIRECTORY picosha2.h REQUIRED)
+include_directories("${PICOSHA2_INCLUDE_DIRECTORY}")

--- a/ports/wabt/portfile.cmake
+++ b/ports/wabt/portfile.cmake
@@ -1,0 +1,57 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH source_path
+    REPO WebAssembly/wabt
+    REF "${VERSION}"
+    SHA512 5b8c2b9cc7b96c0964a8c33fd13a3f0fdeb665598d6a55f47264f285f52f646865613b6745c20ebecb50f3358c454aaef6737a895bc64009c4ef06ef6ce14a7e
+    HEAD_REF main
+)
+
+# wabt enables wasm-rt-impl iff setjmp.h is found by `check_include_file`.
+# It does not use this variable otherwise.
+vcpkg_check_features(OUT_FEATURE_OPTIONS feature_options
+                     FEATURES
+                     tools BUILD_TOOLS
+                     wasm-rt-impl HAVE_SETJMP_H)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${source_path}"
+    OPTIONS
+        ${feature_options}
+        -DBUILD_LIBWASM=OFF
+        -DBUILD_TESTS=OFF
+        "-DCMAKE_PROJECT_INCLUDE=${CMAKE_CURRENT_LIST_DIR}/include_picosha2.cmake"
+        -DUSE_INTERNAL_SHA256=ON
+        -DWABT_INSTALL_CMAKEDIR=share/wabt
+        -DWITH_EXCEPTIONS=ON
+    OPTIONS_DEBUG
+        -DBUILD_TOOLS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+if ("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(
+        TOOL_NAMES
+            spectest-interp
+            wasm-decompile
+            wasm-interp
+            wasm-objdump
+            wasm-stats
+            wasm-strip
+            wasm-validate
+            wasm2c
+            wasm2wat
+            wast2json
+            wat-desugar
+            wat2wasm
+        AUTO_CLEAN
+    )
+endif ()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${source_path}/LICENSE")

--- a/ports/wabt/vcpkg.json
+++ b/ports/wabt/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "wabt",
+  "version": "1.0.36",
+  "description": "The WebAssembly Binary Toolkit",
+  "homepage": "https://github.com/WebAssembly/wabt/",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "picosha2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tools": {
+      "description": "Build wabt commandline tools"
+    },
+    "wasm-rt-impl": {
+      "description": "Include the WABT C runtime implementation library"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9396,6 +9396,10 @@
       "baseline": "2.0.2",
       "port-version": 6
     },
+    "wabt": {
+      "baseline": "1.0.36",
+      "port-version": 0
+    },
     "wampcc": {
       "baseline": "2019-09-04",
       "port-version": 5

--- a/versions/w-/wabt.json
+++ b/versions/w-/wabt.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "65511e5727b5f54cb654fd7991080ff7a7f58fc1",
+      "version": "1.0.36",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
