### PR TITLE
[dingo] new port

### DIFF
--- a/ports/dingo/portfile.cmake
+++ b/ports/dingo/portfile.cmake
@@ -1,0 +1,13 @@
+set(VCPKG_BUILD_TYPE release) # header-only
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO romanpauk/dingo
+    REF "v${VERSION}"
+    HEAD_REF master
+    SHA512 a302e8e504a9f0a863c729432a479134ade96198af48219064d8f3f1e18ef78541e93048811865cd8cb878e5a0837ed98425e7481fd08726806e6b72aa57f908 
+)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+

--- a/ports/dingo/vcpkg.json
+++ b/ports/dingo/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "dingo",
+  "version": "0.1.0",
+  "description": "Dependency Injection Container for C++",
+  "homepage": "https://github.com/romanpauk/dingo",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2252,6 +2252,10 @@
       "baseline": "7.2.0",
       "port-version": 0
     },
+    "dingo": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "directx-dxc": {
       "baseline": "2024-05-28",
       "port-version": 0

--- a/versions/d-/dingo.json
+++ b/versions/d-/dingo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8b08446fbafe0d88dca748b6d26be7e2e1f7cacc",
+      "git-tree": "07c18ec5a00213c565eb07a4a7e80b3f6750d713",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/d-/dingo.json
+++ b/versions/d-/dingo.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8b08446fbafe0d88dca748b6d26be7e2e1f7cacc",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.