### PR TITLE
[hffix] Update to 1.4.1

### DIFF
--- a/ports/hffix/portfile.cmake
+++ b/ports/hffix/portfile.cmake
@@ -1,10 +1,10 @@
-# header only library
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jamesdbrock/hffix
     REF "v${VERSION}"
-    SHA512 a04a22360074f383997756d36ddf520a565e5d200e32e8439ef92f33bcb30ab29e962fc4d85142c1da323ddf9fef2d8b6a023dcbeedf1a5c269889adfcd70fb8
+    SHA512 155c0e0bd57d952523343e94b0160baf3b20d366ff8260340d96c2ec4e638c94d192c08b7204303b0fa8610beb5c71046f62fa8b0212b477aaab88e49974cac1
     HEAD_REF master
 )
 
@@ -16,7 +16,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/hffix")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/hffix/vcpkg.json
+++ b/ports/hffix/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hffix",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "description": "Financial Information Exchange Protocol C++ Library",
   "homepage": "https://jamesdbrock.github.io/hffix",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3429,7 +3429,7 @@
       "port-version": 0
     },
     "hffix": {
-      "baseline": "1.3.0",
+      "baseline": "1.4.1",
       "port-version": 0
     },
     "hfsm2": {

--- a/versions/h-/hffix.json
+++ b/versions/h-/hffix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e5b00d20790e99706cd80550e290b61db9984e67",
+      "version": "1.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3aab9fe5c85f6055d5df986ca8c6a8e67cd7014c",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
Update `hffix` to 1.4.1.

No feature needs to be tested, the usage test passed on `x64-windows`(header files found):
```
hffix provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(hffix CONFIG REQUIRED)
  target_link_libraries(main PRIVATE hffix::hffix)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.