### PR TITLE
[vcpkg baseline][xaudio2redist] Fix XAUDIO_ARCH for x86

### DIFF
--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_extract_source_archive(
     NO_REMOVE_ONE_LEVEL
 )
 
-if(XAUDIO_ARCH STREQUAL "x86")
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     set(XAUDIO_ARCH x86)
 else()
     set(XAUDIO_ARCH x64)

--- a/ports/xaudio2redist/vcpkg.json
+++ b/ports/xaudio2redist/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "xaudio2redist",
   "version": "1.2.11",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Redistributable version of XAudio 2.9 for Windows 7 SP1 or later",
   "homepage": "https://aka.ms/XAudio2Redist",
   "documentation": "https://aka.ms/XAudio2Redist",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9570,7 +9570,7 @@
     },
     "xaudio2redist": {
       "baseline": "1.2.11",
-      "port-version": 3
+      "port-version": 4
     },
     "xbitmaps": {
       "baseline": "1.1.2",

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a92fe4e38d46aa663e8ce588def6df3ce53cbdd5",
+      "version": "1.2.11",
+      "port-version": 4
+    },
+    {
       "git-tree": "aa6ba77559dd683ed82dc24204784c5d3c280dae",
       "version": "1.2.11",
       "port-version": 3


### PR DESCRIPTION
Fix [Pipelines - Run 20240730.3 (azure.com)](https://dev.azure.com/vcpkg/public/_build/results?buildId=105480&view=logs&j=878666d5-db33-5b27-9e7d-b0c7ee352005&t=69176ca8-c93b-5311-0f74-6cb12a2b3f92&l=8095), which should check `VCPKG_TARGET_ARCHITECTURE` rather than `XAUDIO_ARCH`.

Affected by issue mentioned in #40124, regression from #40161.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x86-windows