### PR TITLE
[vcpkg baseline][c-ares] Add unsupported uwp platform

### DIFF
--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,9 +1,11 @@
 {
   "name": "c-ares",
   "version-semver": "1.31.0",
+  "port-version": 1,
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "license": "MIT-CMU",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1434,7 +1434,7 @@
     },
     "c-ares": {
       "baseline": "1.31.0",
-      "port-version": 0
+      "port-version": 1
     },
     "c-dbg-macro": {
       "baseline": "2020-02-29",

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6c07bb206a33f3005265a3e2db4c697a3097f8f3",
+      "version-semver": "1.31.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3fa7d03d9b026df7fa4cd6bdd8e2a5140cae4f5f",
       "version-semver": "1.31.0",
       "port-version": 0


### PR DESCRIPTION
Failed on: https://dev.azure.com/vcpkg/public/_build/results?buildId=105429&view=results

```
 error C4013: 'UnregisterWait' undefined; assuming extern returning int
 error C4013: 'NotifyIpInterfaceChange' undefined; assuming extern returning int
```
The UnregisterWait and NotifyIpInterfaceChange functions are Win32 system functions and are not defined under UWP. Therefore, adding them does not support the UWP platform.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
x64-windows-static
```