### PR TITLE
[brpc] Update to 1.10.0

### DIFF
--- a/ports/brpc/fix-compilation-error.patch
+++ b/ports/brpc/fix-compilation-error.patch
@@ -1,5 +1,5 @@
 diff --git a/src/brpc/serialized_response.h b/src/brpc/serialized_response.h
-index 4e7d86e..564e4eb 100644
+index 4e7d86e..3b33cb2 100644
 --- a/src/brpc/serialized_response.h
 +++ b/src/brpc/serialized_response.h
 @@ -53,7 +53,7 @@ public:
@@ -7,7 +7,7 @@ index 4e7d86e..564e4eb 100644
      bool IsInitialized() const override;
      int ByteSize() const;
 -    int GetCachedSize() const override { return (int)_serialized.size(); }
-+    int GetCachedSize() const { return (int)_serialized.size(); }
++    int GetCachedSize() const PB_422_OVERRIDE { return (int)_serialized.size(); }
      butil::IOBuf& serialized_data() { return _serialized; }
      const butil::IOBuf& serialized_data() const { return _serialized; }
  
@@ -16,7 +16,7 @@ index 4e7d86e..564e4eb 100644
      void SharedCtor();
      void SharedDtor();
 -    void SetCachedSize(int size) const override;
-+    void SetCachedSize(int size) const;
++    void SetCachedSize(int size) const PB_422_OVERRIDE;
    
  private:
      butil::IOBuf _serialized;

--- a/ports/brpc/portfile.cmake
+++ b/ports/brpc/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
         fix-build.patch
         fix-warnings.patch
         protobuf.patch
-        remove-override.patch
+        fix-compilation-error.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/brpc/portfile.cmake
+++ b/ports/brpc/portfile.cmake
@@ -2,12 +2,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/brpc
     REF "${VERSION}"
-    SHA512 a908c3cf63224d6fb98f1855aca75c3adf528c40da5180c6e298cc52ee9ccbef08809a81078333bdd6ac1a4af54448edac8dd4e0333e72e9dec2790454355e7a
+    SHA512 cc1a373d94752c43376a731b4f08dc559bffcd67bdad7e22268a2a20a1034b40d658d591d946d4c1aa94287060146eb041626e0354188ee7dc41554512d72490
     HEAD_REF master
     PATCHES
         fix-build.patch
         fix-warnings.patch
         protobuf.patch
+        remove-override.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/brpc/remove-override.patch
+++ b/ports/brpc/remove-override.patch
@@ -1,0 +1,22 @@
+diff --git a/src/brpc/serialized_response.h b/src/brpc/serialized_response.h
+index 4e7d86e..564e4eb 100644
+--- a/src/brpc/serialized_response.h
++++ b/src/brpc/serialized_response.h
+@@ -53,7 +53,7 @@ public:
+     void Clear() override;
+     bool IsInitialized() const override;
+     int ByteSize() const;
+-    int GetCachedSize() const override { return (int)_serialized.size(); }
++    int GetCachedSize() const { return (int)_serialized.size(); }
+     butil::IOBuf& serialized_data() { return _serialized; }
+     const butil::IOBuf& serialized_data() const { return _serialized; }
+ 
+@@ -71,7 +71,7 @@ private:
+     void MergeFrom(const SerializedResponse& from);
+     void SharedCtor();
+     void SharedDtor();
+-    void SetCachedSize(int size) const override;
++    void SetCachedSize(int size) const;
+   
+ private:
+     butil::IOBuf _serialized;

--- a/ports/brpc/vcpkg.json
+++ b/ports/brpc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "brpc",
-  "version": "1.9.0",
-  "port-version": 1,
+  "version": "1.10.0",
   "description": "Industrial-grade RPC framework used throughout Baidu, with 1,000,000+ instances and thousands kinds of services, called \"baidu-rpc\" inside Baidu.",
   "homepage": "https://github.com/apache/brpc",
   "license": "Apache-2.0",

--- a/versions/b-/brpc.json
+++ b/versions/b-/brpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e1dd257b26dd27f5e57c137ab8d6229d5d1a179",
+      "version": "1.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e3c927bb9bf156c75d26d06f1c0c250afd50df69",
       "version": "1.9.0",
       "port-version": 1

--- a/versions/b-/brpc.json
+++ b/versions/b-/brpc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7e1dd257b26dd27f5e57c137ab8d6229d5d1a179",
+      "git-tree": "0da3bb20bb9b3dd1b8ef66a4f812f16496be422c",
       "version": "1.10.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1377,8 +1377,8 @@
       "port-version": 1
     },
     "brpc": {
-      "baseline": "1.9.0",
-      "port-version": 1
+      "baseline": "1.10.0",
+      "port-version": 0
     },
     "brunocodutra-metal": {
       "baseline": "2.1.4",


### PR DESCRIPTION
Update `brpc` to the latest version 1.10.0.

Modified the `override` keyword to fix the following errors because there is no corresponding virtual function in the base class (the current version of `protobuf` in vcpkg does not have it).
```
vcpkg/buildtrees/brpc/src/1.10.0-6977522ae8.clean/src/brpc/serialized_response.h:56:9: error: ‘int brpc::SerializedResponse::GetCachedSize() const’ marked ‘override’, but does not override
   56 |     int GetCachedSize() const override { return (int)_serialized.size(); }
      |         ^~~~~~~~~~~~~
vcpkg/buildtrees/brpc/src/1.10.0-6977522ae8.clean/src/brpc/serialized_response.h:74:10: error: ‘void brpc::SerializedResponse::SetCachedSize(int) const’ marked ‘override’, but does not override
   74 |     void SetCachedSize(int size) const override;
      |          ^~~~~~~~~~~~~
```
This modifications from upstream's PR https://github.com/apache/brpc/pull/2722.

No feature needs to be tested.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
