### PR TITLE
[curl] ngtcp2 http3 curl features

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -53,6 +53,28 @@ endif()
 
 set(OPTIONS "")
 
+if(FEATURES MATCHES "http3-(gnutls|wolfssl)")
+    if("http3-gnutls" IN_LIST FEATURES AND "http3-wolfssl" IN_LIST FEATURES)
+        message(FATAL_ERROR "Cannot have both features of http3 (http3-gnutls and http3-wolfssl). Choose one.")
+    endif()
+    if("http2" IN_LIST FEATURES)
+        message(FATAL_ERROR "Currently http2 depend on ssl. Add http2 cause multissl feature in curl that will cause build failure.")
+    endif()
+
+    set(NUM_TLS 0)
+    set(TLS_BACKEND_LIST "wolfssl" "openssl" "mbedtls" "schannel" "sectransp" "gnutls")
+    foreach(tls_backend IN LISTS TLS_BACKEND_LIST)
+        if(${tls_backend} IN_LIST FEATURES)
+            MATH(EXPR NUM_TLS "${NUM_TLS}+1")
+        endif()
+    endforeach()
+
+    if(NUM_TLS GREATER 1)
+        message(FATAL_ERROR "Cannot compile with more than one tls feature with http3. Make sure you choose only one that match your http3.")
+    endif()
+    list(APPEND OPTIONS -DUSE_NGTCP2=ON -DHAVE_SSL_CTX_SET_QUIC_METHOD=ON)
+endif()
+
 if("sectransp" IN_LIST FEATURES)
     list(APPEND OPTIONS -DCURL_CA_PATH=none -DCURL_CA_BUNDLE=none)
 endif()

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "curl",
   "version": "8.10.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",
@@ -70,6 +70,44 @@
           ]
         },
         "nghttp2"
+      ]
+    },
+    "http3-gnutls": {
+      "description": "Enable http3 with gnutls backend",
+      "dependencies": [
+        {
+          "name": "curl",
+          "default-features": false,
+          "features": [
+            "gnutls"
+          ]
+        },
+        "nghttp3",
+        {
+          "name": "ngtcp2",
+          "features": [
+            "gnutls"
+          ]
+        }
+      ]
+    },
+    "http3-wolfssl": {
+      "description": "Enable http3 with wolfssl backend",
+      "dependencies": [
+        {
+          "name": "curl",
+          "default-features": false,
+          "features": [
+            "wolfssl"
+          ]
+        },
+        "nghttp3",
+        {
+          "name": "ngtcp2",
+          "features": [
+            "wolfssl"
+          ]
+        }
       ]
     },
     "idn": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2130,7 +2130,7 @@
     },
     "curl": {
       "baseline": "8.10.1",
-      "port-version": 1
+      "port-version": 2
     },
     "curlcpp": {
       "baseline": "3.1",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66dbf89187b3392f30ade954a01ec44719141113",
+      "version": "8.10.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "31d4981751582248fd2983bcadc540584a906a9a",
       "version": "8.10.1",
       "port-version": 1


### PR DESCRIPTION
Add ngtcp2 http3 curl features

These features is not experimental in http3 curl:
https://curl.se/docs/http3.html

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->


- [x] Depends on https://github.com/microsoft/vcpkg/pull/40224

