### PR TITLE
[mlpack] Change the header file directory structure

### DIFF
--- a/ports/mlpack/portfile.cmake
+++ b/ports/mlpack/portfile.cmake
@@ -8,8 +8,10 @@ vcpkg_from_github(
 )
 
 # Copy the header files
-file(GLOB HEADERS "${SOURCE_PATH}/src/*.hpp"  "${SOURCE_PATH}/src/mlpack/*.hpp")
-file(COPY ${HEADERS} DESTINATION "${CURRENT_PACKAGES_DIR}/include/mlpack")
+file(GLOB HEADERS_SRC "${SOURCE_PATH}/src/*.hpp")
+file(GLOB HEADERS_MLPACK "${SOURCE_PATH}/src/mlpack/*.hpp")
+file(COPY ${HEADERS_SRC} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY ${HEADERS_MLPACK} DESTINATION "${CURRENT_PACKAGES_DIR}/include/mlpack")
 file(COPY "${SOURCE_PATH}/src/mlpack/methods/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/mlpack/methods")
 file(COPY "${SOURCE_PATH}/src/mlpack/core/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/mlpack/core")
 

--- a/ports/mlpack/usage
+++ b/ports/mlpack/usage
@@ -1,4 +1,4 @@
 The package mlpack is header only and can be used from CMake via:
   
-  find_path(MLPACK_INCLUDE_DIRS "mlpack/mlpack.hpp")
+  find_path(MLPACK_INCLUDE_DIRS "mlpack.hpp")
   target_include_directories(main PRIVATE ${MLPACK_INCLUDE_DIRS})

--- a/ports/mlpack/vcpkg.json
+++ b/ports/mlpack/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mlpack",
   "version": "4.3.0",
+  "port-version": 1,
   "description": "mlpack is an intuitive, fast, and flexible header-only C++ machine learning library with bindings to other languages.",
   "homepage": "https://github.com/mlpack/mlpack",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5870,7 +5870,7 @@
     },
     "mlpack": {
       "baseline": "4.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "mman": {
       "baseline": "git-f5ff813",

--- a/versions/m-/mlpack.json
+++ b/versions/m-/mlpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3c84cbe875f9fb8e012180e81ef11b5d3c012b2",
+      "version": "4.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7439b5dbdc37394f6bb291343d634642d919f9d1",
       "version": "4.3.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #40170. Modify the mlpack header file directory structure, because the current directory structure violates every document and tutorial provided by the upstream. For details, see the upstream instructions: https://github.com/microsoft/vcpkg/issues/40170#issuecomment-2262897189.

The usage test passed on `x64-windows` (header files found):
```
The package mlpack is header only and can be used from CMake via:

  find_path(MLPACK_INCLUDE_DIRS "mlpack.hpp")
  target_include_directories(main PRIVATE ${MLPACK_INCLUDE_DIRS})
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.