### PR TITLE
[c-ares] Update to 1.33.0, fix uwp

### DIFF
--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO c-ares/c-ares
     REF "v${VERSION}"
-    SHA512 87ca8ceda8b4afbc3e68014c6c8604550f17e6b343330801c396aae393f1c98747e65d3459db7b9626abc73f1216422e794a0d0f044dd1fda3efda4005b0ef1f
+    SHA512 5924d706341e35ad467bf48c88a8f53617d5fb94546b1d9dd24a7091cc84763e52f9bbdfa39abdf1aa55099d4b87116af56bf584b99a5c8f5e554ecf9d7bc8a8
     HEAD_REF main
     PATCHES
         avoid-docs.patch

--- a/ports/c-ares/usage
+++ b/ports/c-ares/usage
@@ -1,4 +1,4 @@
-The package c-ares provides CMake targets:
+c-ares provides CMake targets:
 
-    find_package(c-ares CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE c-ares::cares)
+  find_package(c-ares CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE c-ares::cares)

--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,11 +1,9 @@
 {
   "name": "c-ares",
-  "version-semver": "1.31.0",
-  "port-version": 1,
+  "version-semver": "1.33.0",
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "license": "MIT-CMU",
-  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1433,8 +1433,8 @@
       "port-version": 5
     },
     "c-ares": {
-      "baseline": "1.31.0",
-      "port-version": 1
+      "baseline": "1.33.0",
+      "port-version": 0
     },
     "c-dbg-macro": {
       "baseline": "2020-02-29",

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "81de8007de0b4b64a0f76fd0a415a9df9e42517a",
+      "version-semver": "1.33.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6c07bb206a33f3005265a3e2db4c697a3097f8f3",
       "version-semver": "1.31.0",
       "port-version": 1


### PR DESCRIPTION
The uwp fix from upstream needed a small edit.
Originally https://github.com/c-ares/c-ares/pull/845
Upstream reacted super-fast when noticed. It is a pity that it wasn't immediately reported with #40213.