### PR TITLE
[sdl2pp] Clean dependencies

### DIFF
--- a/ports/sdl2pp/vcpkg.json
+++ b/ports/sdl2pp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2pp",
   "version": "0.16.1",
-  "port-version": 9,
+  "port-version": 10,
   "description": "C++11 bindings/wrapper for SDL2",
   "homepage": "https://sdl2pp.amdmi3.ru",
   "license": "Zlib",
@@ -10,9 +10,6 @@
       "name": "sdl2",
       "default-features": false
     },
-    "sdl2-image",
-    "sdl2-mixer",
-    "sdl2-ttf",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8098,7 +8098,7 @@
     },
     "sdl2pp": {
       "baseline": "0.16.1",
-      "port-version": 9
+      "port-version": 10
     },
     "seacas": {
       "baseline": "2022-11-22",

--- a/versions/s-/sdl2pp.json
+++ b/versions/s-/sdl2pp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9c13583635bc0fc65f50cf02ff22c06ccb6ccaed",
+      "version": "0.16.1",
+      "port-version": 10
+    },
+    {
       "git-tree": "16f7b3b1b4e13c6a5d9320dae876c1119a9b10c6",
       "version": "0.16.1",
       "port-version": 9


### PR DESCRIPTION
Depend on https://github.com/microsoft/vcpkg/pull/40195

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
