### PR TITLE
[thorvg] Revert _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR

### DIFF
--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 428a9e09f9e0d1dffd06862331a892c79b233c022403b4b97418a769e5b0c849146f6920c3ee8733894a73c6641175daf3f92a71b61e2fad99996d1729e0f5a2
     HEAD_REF master
+    PATCHES
+      revert-mutex.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/thorvg/revert-mutex.patch
+++ b/ports/thorvg/revert-mutex.patch
@@ -1,0 +1,26 @@
+diff --git a/src/common/tvgLock.h b/src/common/tvgLock.h
+index 59f68d0..d3a4e41 100644
+--- a/src/common/tvgLock.h
++++ b/src/common/tvgLock.h
+@@ -25,8 +25,6 @@
+ 
+ #ifdef THORVG_THREAD_SUPPORT
+ 
+-#define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
+-
+ #include <mutex>
+ #include "tvgTaskScheduler.h"
+ 
+diff --git a/src/renderer/tvgTaskScheduler.h b/src/renderer/tvgTaskScheduler.h
+index 5e43457..fb9de21 100644
+--- a/src/renderer/tvgTaskScheduler.h
++++ b/src/renderer/tvgTaskScheduler.h
+@@ -23,8 +23,6 @@
+ #ifndef _TVG_TASK_SCHEDULER_H_
+ #define _TVG_TASK_SCHEDULER_H_
+ 
+-#define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
+-
+ #include <mutex>
+ #include <condition_variable>
+ 

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "thorvg",
   "version": "0.14.3",
+  "port-version": 1,
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8770,7 +8770,7 @@
     },
     "thorvg": {
       "baseline": "0.14.3",
-      "port-version": 0
+      "port-version": 1
     },
     "threadpool": {
       "baseline": "0.2.5",

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ec8150fa5be495b1134bd23b93674697c16adec",
+      "version": "0.14.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "c58ad01d02306e3e84517f9d042ef2e839dd0719",
       "version": "0.14.3",
       "port-version": 0


### PR DESCRIPTION
Restore the contents of the PR https://github.com/thorvg/thorvg/pull/2385 to prevent header macros from being broken

Related PRs: 
https://github.com/thorvg/thorvg/pull/2385 
https://github.com/thorvg/thorvg/pull/2611

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.`~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
