### PR TITLE
[pugixml] Add feature wchart to enable wchar_t mode

### DIFF
--- a/ports/pugixml/portfile.cmake
+++ b/ports/pugixml/portfile.cmake
@@ -6,10 +6,16 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS options
+    FEATURES
+        wchart    PUGIXML_WCHAR_MODE
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DPUGIXML_BUILD_TESTS=OFF
+        ${options}
 )
 
 vcpkg_cmake_install()

--- a/ports/pugixml/vcpkg.json
+++ b/ports/pugixml/vcpkg.json
@@ -13,5 +13,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "wchart": {
+      "description": "Enable wchar_t mode"
+    }
+  }
 }

--- a/ports/pugixml/vcpkg.json
+++ b/ports/pugixml/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pugixml",
   "version": "1.14",
+  "port-version": 1,
   "description": "Light-weight, simple and fast XML parser for C++ with XPath support",
   "homepage": "https://github.com/zeux/pugixml",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7142,7 +7142,7 @@
     },
     "pugixml": {
       "baseline": "1.14",
-      "port-version": 0
+      "port-version": 1
     },
     "pulsar-client-cpp": {
       "baseline": "3.5.1",

--- a/versions/p-/pugixml.json
+++ b/versions/p-/pugixml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "37a767d9d233567679d160e26c47d40ab304f474",
+      "version": "1.14",
+      "port-version": 1
+    },
+    {
       "git-tree": "6e38344aea6e7529afde3895e0885ed5cb0c0542",
       "version": "1.14",
       "port-version": 0


### PR DESCRIPTION
Fixes #40108. Add feature `wchart` to enable `wchar_t mode`:  [225-additional-configuration-options](https://github.com/zeux/pugixml/blob/v1.14/docs/manual.adoc#225-additional-configuration-options).

`PUGIXML_WCHAR_MODE` define toggles between UTF-8 style interface (the in-memory text encoding is assumed to be UTF-8, most functions use `char` as character type) and UTF-16/32 style interface (the in-memory text encoding is assumed to be UTF-16/32, depending on `wchar_t` size, most functions use `wchar_t` as character type).

All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.