### PR TITLE
[vcpkg baseline][mongo-cxx-driver] Fixes missing PKG_CONFIG_EXECUTABLE

### DIFF
--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -19,6 +19,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         boost   CMAKE_DISABLE_FIND_PACKAGE_Boost
 )
 
+vcpkg_find_acquire_program(PKGCONFIG)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -29,6 +31,7 @@ vcpkg_cmake_configure(
         -DENABLE_UNINSTALL=OFF
         -DMONGOCXX_HEADER_INSTALL_DIR=include
         -DNEED_DOWNLOAD_C_DRIVER=OFF
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
     MAYBE_UNUSED_VARIABLES
         CMAKE_DISABLE_FIND_PACKAGE_Boost
         BSONCXX_HEADER_INSTALL_DIR

--- a/ports/mongo-cxx-driver/vcpkg.json
+++ b/ports/mongo-cxx-driver/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mongo-cxx-driver",
   "version": "3.10.2",
+  "port-version": 1,
   "description": "MongoDB C++ Driver.",
   "homepage": "https://github.com/mongodb/mongo-cxx-driver",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5910,7 +5910,7 @@
     },
     "mongo-cxx-driver": {
       "baseline": "3.10.2",
-      "port-version": 0
+      "port-version": 1
     },
     "mongoose": {
       "baseline": "7.14",

--- a/versions/m-/mongo-cxx-driver.json
+++ b/versions/m-/mongo-cxx-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "202dd71355e92ddb5af61d81232242e0574d4aa9",
+      "version": "3.10.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "e246a2d1a2ff8883db714ee2ca91b0522f40d532",
       "version": "3.10.2",
       "port-version": 0


### PR DESCRIPTION
Fixes `mongo-cxx-driver` failures in CI baseline run https://dev.azure.com/vcpkg/public/_build/results?buildId=105489&view=results:
```
mongo-cxx-driver:arm64-windows
mongo-cxx-driver:x64-windows-static
mongo-cxx-driver:x64-windows-static-md
mongo-cxx-driver:x86-windows

CMake Error at D:/downloads/tools/cmake-3.29.2-windows/cmake-3.29.2-windows-i386/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
