### PR TITLE
[ffmpeg] Update to 7.0.1

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ffmpeg/ffmpeg
     REF "n${VERSION}"
-    SHA512 ac147e52557b71cab0a38c0fee5f710a70d7e99107d1cb881e733c489a6b16f99d2c15e00e359ab48353bd710ead13399ee31840e6c5844a11d042eda71a0aa0
+    SHA512 1212ebcb78fdaa103b0304373d374e41bf1fe680e1fa4ce0f60624857491c26b4dda004c490c3ef32d4a0e10f42ae6b54546f9f318e2dcfbaa116117f687bc88
     HEAD_REF master
     PATCHES
         0001-create-lib-libraries.patch

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg",
-  "version": "7.0",
+  "version": "7.0.1",
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2705,7 +2705,7 @@
       "port-version": 7
     },
     "ffmpeg": {
-      "baseline": "7.0",
+      "baseline": "7.0.1",
       "port-version": 0
     },
     "ffnvcodec": {

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f846400323dc4c9fb34910e43a85f3c625bc4bf4",
+      "version": "7.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6c14224b4a8c90efabd3640a98f76eaee8607f98",
       "version": "7.0",
       "port-version": 0


### PR DESCRIPTION
- [*] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [*] SHA512s are updated for each updated download.
- [*] The "supports" clause reflects platforms that may be fixed by this new version.
- [*] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [*] Any patches that are no longer applied are deleted from the port's directory.
- [*] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [*] Only one version is added to each modified port's versions file.