### PR TITLE
[openimageio] update to 2.5.14.0

### DIFF
--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/OpenImageIO
     REF "v${VERSION}"
-    SHA512 c6e53b5484702c66f01490d23f272e597e016b984d54f81e400605bf2a2e1dd7843ce25a7ef51ffbc7ee7089b42e8d73a91699b93cb655b5ca9ef869c9a950f4
+    SHA512 2d9423e16613a9daa6faa53e2f52ad6af749f07f73251f44720eba468635b70aec97b5aeaac2f67a8b260158808458e5408ced75908b00379eb6640b1413f463
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openimageio",
-  "version": "2.5.12.0",
-  "port-version": 2,
+  "version": "2.5.14.0",
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6569,8 +6569,8 @@
       "port-version": 4
     },
     "openimageio": {
-      "baseline": "2.5.12.0",
-      "port-version": 2
+      "baseline": "2.5.14.0",
+      "port-version": 0
     },
     "openjpeg": {
       "baseline": "2.5.2",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ffa8987ec86923ad9e385a26b22730ad020f79d",
+      "version": "2.5.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e0caa7c7cee2cc24b441cc7dba90b8b183a757b0",
       "version": "2.5.12.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.