### PR TITLE
[cmake] WIP

### DIFF
--- a/scripts/test_ports/cmake/portfile.cmake
+++ b/scripts/test_ports/cmake/portfile.cmake
@@ -44,7 +44,7 @@ vcpkg_cmake_configure(
         -DCMake_QT_MAJOR_VERSION:STRING=6
         --trace-expand
 )
-file(COPY_FILE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/cmake_install.cmake" "${CURRENT_BUILDTREES_DIR}//cmake_install.cmake-${TARGET_TRIPLET}-dbg.log")
+file(COPY_FILE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/cmake_install.cmake" "${CURRENT_BUILDTREES_DIR}/cmake_install.cmake-${TARGET_TRIPLET}-dbg.log")
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/scripts/test_ports/cmake/portfile.cmake
+++ b/scripts/test_ports/cmake/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_gitlab(
     HEAD_REF master
     PATCHES
         curl.diff
+        rhash.diff
         fix-dependency-libuv.patch
 )
 set(OPTIONS)
@@ -38,22 +39,14 @@ vcpkg_cmake_configure(
     OPTIONS
         ${OPTIONS}
         -DBUILD_TESTING=OFF
-        #-DCMAKE_USE_SYSTEM_LIBRARIES=ON
-        -DCMAKE_USE_SYSTEM_LIBARCHIVE=ON
-        -DCMAKE_USE_SYSTEM_CURL=ON
-        -DCMAKE_USE_SYSTEM_EXPAT=ON
-        -DCMAKE_USE_SYSTEM_ZLIB=ON
-        -DCMAKE_USE_SYSTEM_BZIP2=ON
-        -DCMAKE_USE_SYSTEM_ZSTD=ON
-        -DCMAKE_USE_SYSTEM_FORM=ON
-        -DCMAKE_USE_SYSTEM_JSONCPP=ON
-        -DCMAKE_USE_SYSTEM_LIBRHASH=OFF # not yet in VCPKG
-        -DCMAKE_USE_SYSTEM_LIBUV=ON
+        -DCMAKE_USE_SYSTEM_LIBRARIES=ON
         -DBUILD_QtDialog=ON # Just to test Qt with CMake
         -DCMake_QT_MAJOR_VERSION:STRING=6
+        --trace-expand
 )
+file(COPY_FILE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/cmake_install.cmake" "${CURRENT_BUILDTREES_DIR}//cmake_install.cmake-${TARGET_TRIPLET}-dbg.log")
 
-vcpkg_cmake_install(ADD_BIN_TO_PATH)
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 if(NOT VCPKG_TARGET_IS_OSX)

--- a/scripts/test_ports/cmake/rhash.diff
+++ b/scripts/test_ports/cmake/rhash.diff
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a5d69b41..9789ffb6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -435,7 +435,8 @@ macro (CMAKE_BUILD_UTILITIES)
+   endif()
+ 
+   if(CMAKE_USE_SYSTEM_LIBRHASH)
+-    find_package(LibRHash)
++    find_package(LibRHash NAMES unofficial-rhash REQUIRED)
++    add_library(LibRHash::LibRHash ALIAS unofficial::rhash::rhash)
+     if(NOT LibRHash_FOUND)
+       message(FATAL_ERROR
+         "CMAKE_USE_SYSTEM_LIBRHASH is ON but LibRHash is not found!")

--- a/scripts/test_ports/cmake/vcpkg.json
+++ b/scripts/test_ports/cmake/vcpkg.json
@@ -6,24 +6,29 @@
   "homepage": "https://cmake.org/",
   "license": "BSD-3-Clause",
   "dependencies": [
-    "bzip2",
-    "curl",
+    {
+      "name": "curl",
+      "default-features": false
+    },
     "expat",
     "jsoncpp",
-    "libarchive",
-    "liblzma",
+    {
+      "name": "libarchive",
+      "default-features": false
+    },
     "libuv",
     {
       "name": "ncurses",
       "platform": "!(windows | uwp)"
     },
-    "nghttp2",
-    "qtbase",
+    "rhash",
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    "zlib",
-    "zstd"
+    }
   ]
 }

--- a/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
@@ -14,7 +14,6 @@
     {
       "name": "curl",
       "features": [
-        "c-ares",
         "http2",
         "zstd"
       ]
@@ -30,7 +29,6 @@
     {
       "name": "curl",
       "features": [
-        "gsasl",
         "psl"
       ],
       "platform": "!uwp"
@@ -49,13 +47,6 @@
         "tool"
       ],
       "platform": "!android & !uwp"
-    },
-    {
-      "name": "curl",
-      "features": [
-        "gnutls"
-      ],
-      "platform": "!arm & !xbox"
     }
   ]
 }


### PR DESCRIPTION
Adressing baseline regression: The Windows DLL triplets fail to build downstream cmake.
~~~
[527/528] C:\Windows\system32\cmd.exe /C "cd . && D:\downloads\tools\cmake-3.29.2-windows\cmake-3.29.2-windows-i386\bin\cmake.exe -E vs_link_exe --intdir=Source\QtDialog\CMakeFiles\cmake-gui.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests D:\b\cmake\src\17503183d2-2d56d3dcb1.clean\Source\cmake.version.manifest -- C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1438~1.331\bin\Hostx64\x64\link.exe  Source\QtDialog\CMakeFiles\CMakeGUIQRCLib.dir\qrc_CMakeSetup.cpp.obj Source\CMakeFiles\CMakeVersion.dir\CMakeVersion.rc.res Source\QtDialog\CMakeFiles\cmake-gui.dir\CMakeGUIExec.cxx.obj Source\QtDialog\CMakeFiles\cmake-gui.dir\CMakeSetup.rc.res  /out:bin\cmake-gui.exe /implib:bin\cmake-gui.lib /pdb:bin\cmake-gui.pdb /version:0.0 /machine:x64 -stack:10000000 /nologo    /debug /INCREMENTAL /subsystem:windows  Source\QtDialog\CMakeGUIMainLib.lib  Source\QtDialog\CMakeGUILib.lib  Source\CMakeLib.lib  Source\kwsys\cmsys.lib  Utilities\std\cmstd.lib  D:\installed\x64-windows\debug\lib\libexpatd.lib  D:\installed\x64-windows\debug\lib\zlibd.lib  D:\installed\x64-windows\debug\lib\archive.lib  D:\installed\x64-windows\debug\lib\libcurl-d.lib  D:\installed\x64-windows\debug\lib\jsoncpp.lib  D:\installed\x64-windows\debug\lib\uv.lib  psapi.lib  user32.lib  advapi32.lib  iphlpapi.lib  ws2_32.lib  dbghelp.lib  ole32.lib  Utilities\cmlibrhash\cmlibrhash.lib  rpcrt4.lib  crypt32.lib  D:\installed\x64-windows\debug\lib\Qt6Widgetsd.lib  D:\installed\x64-windows\debug\lib\Qt6Guid.lib  D:\installed\x64-windows\debug\lib\Qt6Cored.lib  mpr.lib  userenv.lib  D:\installed\x64-windows\debug\lib\Qt6EntryPointd.lib  shell32.lib  d3d11.lib  dxgi.lib  dxguid.lib  d3d12.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
[527/528] C:\Windows\system32\cmd.exe /C "cd /D D:\b\cmake\x64-windows-dbg && D:\b\cmake\x64-windows-dbg\bin\cmake.exe -P cmake_install.cmake"
FAILED: CMakeFiles/install.util 
C:\Windows\system32\cmd.exe /C "cd /D D:\b\cmake\x64-windows-dbg && D:\b\cmake\x64-windows-dbg\bin\cmake.exe -P cmake_install.cmake"
~~~
The link command is executed via the installed cmake (`D:\downloads\tools\cmake-3.29.2-windows\cmake-3.29.2-windows-i386\bin\cmake.exe`),
but the failing install command is executed via the the freshly built cmake (`D:\b\cmake\x64-windows-dbg\bin\cmake.exe`). 

(From https://github.com/microsoft/vcpkg/pull/40224#issuecomment-2266412090

CMake wants it this way for native builds:
https://github.com/Kitware/CMake/blob/4aa42149d69c8e0fa542e18196463d671190710c/Source/cmGlobalGenerator.cxx#L3121-L3127

So there seems to be an issue with DLLs.
