### PR TITLE
[bgfx] Update to v1.128.8786-480

### DIFF
--- a/ports/bgfx/portfile.cmake
+++ b/ports/bgfx/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_download_distfile(
   ARCHIVE_FILE
   URLS https://github.com/bkaradzic/bgfx.cmake/releases/download/v${VERSION}/bgfx.cmake.v${VERSION}.tar.gz
   FILENAME bgfx.cmake.v${VERSION}.tar.gz
-  SHA512 889ccc4657415e55cc891ad04ba2b42acaf46e664fd9ed8c6bedebb0f43ba7f2b75a9ad54387d02cf88a6accc7221f7cd5cc74a7dc8248b668ecf14f525f53c8
+  SHA512 23e334deed4ca6429c474b3b12b250ee1c660b524a05c6c9699c353509e51adcf8cbee9974313ae8c8e1a36891404f50c5be7673de4194a31fe37093548b4652
 )
 
 vcpkg_extract_source_archive(

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bgfx",
-  "version": "1.128.8777-475",
+  "version": "1.128.8786-480",
   "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
   "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
   "homepage": "https://bkaradzic.github.io/bgfx/overview.html",

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce8b9fb8c5bb63ede2168612877dd02b9187942f",
+      "version": "1.128.8786-480",
+      "port-version": 0
+    },
+    {
       "git-tree": "410ddaf19cbcc811e4757d3e6ecb236c7dc15838",
       "version": "1.128.8777-475",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -625,7 +625,7 @@
       "port-version": 0
     },
     "bgfx": {
-      "baseline": "1.128.8777-475",
+      "baseline": "1.128.8786-480",
       "port-version": 0
     },
     "bigint": {


### PR DESCRIPTION
Fix for visionOS compilation with XCode version 15.0 and 15.1.
Fix compilation error on Android NDK r27.
CMake shader compilation macro is now more generic for header and binary generation.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
