### PR TITLE
[miniz]: Fix config error on android ndk r27

### DIFF
--- a/ports/miniz/portfile.cmake
+++ b/ports/miniz/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DBUILD_EXAMPLES=OFF
         -DINSTALL_PROJECT=ON
+        -DCMAKE_POLICY_DEFAULT_CMP0057=NEW
 )
 
 vcpkg_cmake_install()

--- a/ports/miniz/vcpkg.json
+++ b/ports/miniz/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "miniz",
   "version": "3.0.2",
+  "port-version": 1,
   "description": "Single C source file zlib-replacement library",
   "homepage": "https://github.com/richgel999/miniz",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5862,7 +5862,7 @@
     },
     "miniz": {
       "baseline": "3.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "minizip": {
       "baseline": "1.3.1",

--- a/versions/m-/miniz.json
+++ b/versions/m-/miniz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "91b28cb3c5b2606dc0706969eeacbf6966e9b50c",
+      "version": "3.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "3bc5e6266f184934f9701339f472db510bb7a1e4",
       "version": "3.0.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #40260

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
