### PR TITLE
[libsquish]: Fix config error on android ndk r27

### DIFF
--- a/ports/libsquish/cmake-version.patch
+++ b/ports/libsquish/cmake-version.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a36e574..6f137d5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,9 +9,9 @@
+ #   Unix and VS: SSE2 support is enabled by default
+ #    use BUILD_SQUISH_WITH_SSE2 and BUILD_SQUISH_WITH_ALTIVEC to override
+
+-PROJECT(squish)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.3)
++PROJECT(squish)
+
+ OPTION(BUILD_SQUISH_WITH_OPENMP "Build with OpenMP." ON)
+ 

--- a/ports/libsquish/portfile.cmake
+++ b/ports/libsquish/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_sourceforge(
     PATCHES
         fix-export-symbols.patch
         export-target.patch
+        cmake-version.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libsquish/vcpkg.json
+++ b/ports/libsquish/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsquish",
   "version": "1.15",
-  "port-version": 13,
+  "port-version": 14,
   "description": "Open source DXT compression library.",
   "homepage": "https://sourceforge.net/projects/libsquish",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5062,7 +5062,7 @@
     },
     "libsquish": {
       "baseline": "1.15",
-      "port-version": 13
+      "port-version": 14
     },
     "libsrt": {
       "baseline": "1.5.3",

--- a/versions/l-/libsquish.json
+++ b/versions/l-/libsquish.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb13fe850ce51bd142d19b0662ba0d990efb5d77",
+      "version": "1.15",
+      "port-version": 14
+    },
+    {
       "git-tree": "b6a8a3e697c1cfcd378bfe725d5994ac9e9dc6d3",
       "version": "1.15",
       "port-version": 13


### PR DESCRIPTION
Fixes #40262 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
