### PR TITLE
[bullet3]: Fix config error on android ndk r27

### DIFF
--- a/ports/bullet3/portfile.cmake
+++ b/ports/bullet3/portfile.cmake
@@ -32,6 +32,7 @@ vcpkg_cmake_configure(
         -DBUILD_GIMPACTUTILS_EXTRA=OFF        
         -DBUILD_UNIT_TESTS=OFF        
         -DINSTALL_LIBS=ON
+        -DCMAKE_POLICY_DEFAULT_CMP0057=NEW
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/bullet3/vcpkg.json
+++ b/ports/bullet3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "bullet3",
   "version": "3.25",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Bullet Physics is a professional collision detection, rigid body, and soft body dynamics library",
   "homepage": "https://github.com/bulletphysics/bullet3",
   "license": "Zlib",

--- a/versions/b-/bullet3.json
+++ b/versions/b-/bullet3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ee7660a10459f4d3d11054ab88177126d2131ca",
+      "version": "3.25",
+      "port-version": 2
+    },
+    {
       "git-tree": "9ecadb6b6e0651347e89555207f28c4ee5b1b51c",
       "version": "3.25",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1410,7 +1410,7 @@
     },
     "bullet3": {
       "baseline": "3.25",
-      "port-version": 1
+      "port-version": 2
     },
     "bustache": {
       "baseline": "1.1.0",


### PR DESCRIPTION
Fixes #40264 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
