### PR TITLE
[vtk]: Convert dependencies into default features

### DIFF
--- a/ports/opencv3/vcpkg.json
+++ b/ports/opencv3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv3",
   "version": "3.4.18",
-  "port-version": 15,
+  "port-version": 16,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "BSD-3-Clause",
@@ -300,7 +300,10 @@
             "contrib"
           ]
         },
-        "vtk"
+        {
+          "name": "vtk",
+          "default-features": false
+        }
       ]
     },
     "webp": {

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.8.0",
-  "port-version": 21,
+  "port-version": 22,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",
@@ -372,7 +372,10 @@
             "contrib"
           ]
         },
-        "vtk"
+        {
+          "name": "vtk",
+          "default-features": false
+        }
       ]
     },
     "vulkan": {

--- a/ports/pcl/vcpkg.json
+++ b/ports/pcl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pcl",
   "version": "1.14.1",
+  "port-version": 1,
   "description": "Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.",
   "homepage": "https://github.com/PointCloudLibrary/pcl",
   "license": "BSD-3-Clause",
@@ -55,8 +56,7 @@
       "description": "CUDA support for PCL",
       "supports": "x64",
       "dependencies": [
-        "cuda",
-        "vtk"
+        "cuda"
       ]
     },
     "examples": {
@@ -115,6 +115,7 @@
       "dependencies": [
         {
           "name": "vtk",
+          "default-features": false,
           "features": [
             "qt"
           ]
@@ -152,6 +153,7 @@
       "dependencies": [
         {
           "name": "vtk",
+          "default-features": false,
           "features": [
             "opengl"
           ]

--- a/ports/vtk/no-libharu-for-ioexport.patch
+++ b/ports/vtk/no-libharu-for-ioexport.patch
@@ -1,0 +1,12 @@
+diff --git a/IO/Export/vtk.module b/IO/Export/vtk.module
+index 01b18a48..dcac24c0 100644
+--- a/IO/Export/vtk.module
++++ b/IO/Export/vtk.module
+@@ -36,7 +36,6 @@ PRIVATE_DEPENDS
+   VTK::IOGeometry
+   VTK::ImagingCore
+   VTK::nlohmannjson
+-  VTK::libharu
+   VTK::utf8
+ TEST_DEPENDS
+   VTK::ChartsCore

--- a/ports/vtk/no-libproj-for-netcdf.patch
+++ b/ports/vtk/no-libproj-for-netcdf.patch
@@ -1,0 +1,24 @@
+diff --git a/IO/NetCDF/vtk.module b/IO/NetCDF/vtk.module
+index a0cc0741..07f3606b 100644
+--- a/IO/NetCDF/vtk.module
++++ b/IO/NetCDF/vtk.module
+@@ -26,7 +26,6 @@ PRIVATE_DEPENDS
+   VTK::CommonDataModel
+   VTK::netcdf
+   VTK::vtksys
+-  VTK::libproj
+ TEST_DEPENDS
+   VTK::CommonExecutionModel
+   VTK::FiltersGeometry
+diff --git a/IO/NetCDF/vtkNetCDFCFWriter.cxx b/IO/NetCDF/vtkNetCDFCFWriter.cxx
+index 756ff87..d71de89 100644
+--- a/IO/NetCDF/vtkNetCDFCFWriter.cxx
++++ b/IO/NetCDF/vtkNetCDFCFWriter.cxx
+@@ -33,7 +33,6 @@
+ #include <sstream>
+ #include <vector>
+ 
+-#include "vtk_libproj.h"
+ #include "vtk_netcdf.h"
+ 
+ VTK_ABI_NAMESPACE_BEGIN

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -37,6 +37,8 @@ vcpkg_from_github(
         remove-prefix-changes.patch
         hdf5helper.patch
         opencascade-7.8.0.patch
+        no-libharu-for-ioexport.patch
+        no-libproj-for-netcdf.patch
 )
 
 # =============================================================================
@@ -120,6 +122,38 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS VTK_FEATURE_OPTIONS
         "gdal"        VTK_MODULE_ENABLE_VTK_IOGDAL
         "geojson"     VTK_MODULE_ENABLE_VTK_IOGeoJSON
         "ioocct"      VTK_MODULE_ENABLE_VTK_IOOCCT
+        "libtheora"   VTK_MODULE_ENABLE_VTK_IOOggTheora
+        "libharu"     VTK_MODULE_ENABLE_VTK_IOExportPDF
+        "cgns"        VTK_MODULE_ENABLE_VTK_IOCGNSReader
+        "seacas"      VTK_MODULE_ENABLE_VTK_IOIOSS
+        "seacas"      VTK_MODULE_ENABLE_VTK_IOExodus
+        "sql"         VTK_MODULE_ENABLE_VTK_IOSQL
+        "proj"        VTK_MODULE_ENABLE_VTK_IOCesium3DTiles
+        "proj"        VTK_MODULE_ENABLE_VTK_GeovisCore
+        "netcdf"      VTK_MODULE_ENABLE_VTK_IONetCDF
+        "netcdf"      VTK_MODULE_ENABLE_VTK_IOMINC
+)
+
+# Require port features to prevent accidental finding of transitive dependencies
+vcpkg_check_features(OUT_FEATURE_OPTIONS PACKAGE_FEATURE_OPTIONS
+  FEATURES
+    "libtheora" CMAKE_REQUIRE_FIND_PACKAGE_THEORA
+    "libharu" CMAKE_REQUIRE_FIND_PACKAGE_LibHaru
+    "cgns" CMAKE_REQUIRE_FIND_PACKAGE_CGNS
+    "seacas" CMAKE_REQUIRE_FIND_PACKAGE_SEACASIoss
+    "seacas" CMAKE_REQUIRE_FIND_PACKAGE_SEACASExodus
+    "sql" CMAKE_REQUIRE_FIND_PACKAGE_SQLite3
+    "proj" CMAKE_REQUIRE_FIND_PACKAGE_PROJ
+    "netcdf" CMAKE_REQUIRE_FIND_PACKAGE_NetCDF
+  INVERTED_FEATURES
+    "libtheora" CMAKE_DISABLE_FIND_PACKAGE_THEORA
+    "libharu" CMAKE_DISABLE_FIND_PACKAGE_LibHaru
+    "cgns" CMAKE_DISABLE_FIND_PACKAGE_CGNS
+    "seacas" CMAKE_DISABLE_FIND_PACKAGE_SEACASIoss
+    "seacas" CMAKE_DISABLE_FIND_PACKAGE_SEACASExodus
+    "sql" CMAKE_DISABLE_FIND_PACKAGE_SQLite3
+    "proj" CMAKE_DISABLE_FIND_PACKAGE_PROJ
+    "netcdf" CMAKE_DISABLE_FIND_PACKAGE_NetCDF
 )
 
 # Replace common value to vtk value
@@ -227,6 +261,7 @@ vcpkg_cmake_configure(
     OPTIONS
         ${FEATURE_OPTIONS}
         ${VTK_FEATURE_OPTIONS}
+        ${PACKAGE_FEATURE_OPTIONS}
         -DBUILD_TESTING=OFF
         -DVTK_BUILD_TESTING=OFF
         -DVTK_BUILD_EXAMPLES=OFF
@@ -254,6 +289,24 @@ vcpkg_cmake_configure(
         VTK_MODULE_ENABLE_VTK_GUISupportMFC # only windows
         VTK_QT_VERSION # Only with Qt
         CMAKE_INSTALL_QMLDIR
+        # When working properly these should be unused
+        CMAKE_DISABLE_FIND_PACKAGE_CGNS
+        CMAKE_DISABLE_FIND_PACKAGE_LibHaru
+        CMAKE_DISABLE_FIND_PACKAGE_NetCDF
+        CMAKE_DISABLE_FIND_PACKAGE_PROJ
+        CMAKE_DISABLE_FIND_PACKAGE_SEACASExodus
+        CMAKE_DISABLE_FIND_PACKAGE_SEACASIoss
+        CMAKE_DISABLE_FIND_PACKAGE_SQLite3
+        CMAKE_DISABLE_FIND_PACKAGE_THEORA
+        CMAKE_REQUIRE_FIND_PACKAGE_CGNS
+        CMAKE_REQUIRE_FIND_PACKAGE_LibHaru
+        CMAKE_REQUIRE_FIND_PACKAGE_NetCDF
+        CMAKE_REQUIRE_FIND_PACKAGE_PROJ
+        CMAKE_REQUIRE_FIND_PACKAGE_SEACASExodus
+        CMAKE_REQUIRE_FIND_PACKAGE_SEACASIoss
+        CMAKE_REQUIRE_FIND_PACKAGE_SQLite3
+        CMAKE_REQUIRE_FIND_PACKAGE_THEORA
+
 )
 
 vcpkg_cmake_install()

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.3.0-pv5.12.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": "BSD-3-Clause",
@@ -28,15 +28,9 @@
       ]
     },
     "jsoncpp",
-    {
-      "name": "libharu",
-      "version>=": "2.4.3"
-    },
     "libjpeg-turbo",
     "liblzma",
-    "libogg",
     "libpng",
-    "libtheora",
     {
       "name": "libxml2",
       "default-features": false,
@@ -45,28 +39,9 @@
       ]
     },
     "lz4",
-    {
-      "name": "netcdf-c",
-      "default-features": false,
-      "features": [
-        "hdf5"
-      ]
-    },
+    "nlohmann-json",
     "pegtl",
-    {
-      "name": "proj",
-      "default-features": false
-    },
     "pugixml",
-    {
-      "name": "seacas",
-      "default-features": false
-    },
-    "sqlite3",
-    {
-      "name": "sqlite3",
-      "host": true
-    },
     {
       "name": "tiff",
       "default-features": false
@@ -83,6 +58,15 @@
     "verdict",
     "zlib"
   ],
+  "default-features": [
+    "cgns",
+    "libharu",
+    "libtheora",
+    "netcdf",
+    "proj",
+    "seacas",
+    "sql"
+  ],
   "features": {
     "all": {
       "description": "Build all vtk modules",
@@ -93,11 +77,18 @@
           "name": "vtk",
           "default-features": false,
           "features": [
+            "cgns",
             "gdal",
             "geojson",
+            "libharu",
+            "libtheora",
             "mpi",
+            "netcdf",
+            "proj",
             "python",
-            "qt"
+            "qt",
+            "seacas",
+            "sql"
           ]
         },
         {
@@ -117,6 +108,15 @@
         {
           "name": "atlmfc",
           "platform": "windows"
+        }
+      ]
+    },
+    "cgns": {
+      "description": "CGNS functionality for VTK",
+      "dependencies": [
+        {
+          "name": "cgns",
+          "default-features": false
         }
       ]
     },
@@ -145,6 +145,21 @@
           "name": "opencascade",
           "default-features": false
         }
+      ]
+    },
+    "libharu": {
+      "description": "PDF functionality for VTK",
+      "dependencies": [
+        {
+          "name": "libharu",
+          "version>=": "2.4.3"
+        }
+      ]
+    },
+    "libtheora": {
+      "description": "Compressed ogg functionality for VTK",
+      "dependencies": [
+        "libtheora"
       ]
     },
     "mpi": {
@@ -181,6 +196,18 @@
         }
       ]
     },
+    "netcdf": {
+      "description": "NetCDF functionality for VTK",
+      "dependencies": [
+        {
+          "name": "netcdf-c",
+          "default-features": false,
+          "features": [
+            "hdf5"
+          ]
+        }
+      ]
+    },
     "opengl": {
       "description": "All opengl related modules",
       "dependencies": [
@@ -213,9 +240,27 @@
           "name": "vtk",
           "default-features": false,
           "features": [
-            "atlmfc"
+            "atlmfc",
+            "libtheora",
+            "seacas"
           ],
           "platform": "windows"
+        }
+      ]
+    },
+    "proj": {
+      "description": "Geographic projection functionality for VTK",
+      "dependencies": [
+        {
+          "name": "proj",
+          "default-features": false
+        },
+        {
+          "name": "vtk",
+          "default-features": false,
+          "features": [
+            "sql"
+          ]
         }
       ]
     },
@@ -238,7 +283,37 @@
             "widgets"
           ]
         },
-        "qtdeclarative"
+        "qtdeclarative",
+        {
+          "name": "vtk",
+          "default-features": false,
+          "features": [
+            "sql"
+          ]
+        }
+      ]
+    },
+    "seacas": {
+      "description": "Exodus and IOSS functionality for VTK",
+      "dependencies": [
+        {
+          "name": "seacas",
+          "default-features": false
+        },
+        {
+          "name": "vtk",
+          "default-features": false,
+          "features": [
+            "cgns",
+            "netcdf"
+          ]
+        }
+      ]
+    },
+    "sql": {
+      "description": "SQL functionality for VTK",
+      "dependencies": [
+        "sqlite3"
       ]
     },
     "utf8": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6530,11 +6530,11 @@
     },
     "opencv3": {
       "baseline": "3.4.18",
-      "port-version": 15
+      "port-version": 16
     },
     "opencv4": {
       "baseline": "4.8.0",
-      "port-version": 21
+      "port-version": 22
     },
     "opendnp3": {
       "baseline": "3.1.1",
@@ -6802,7 +6802,7 @@
     },
     "pcl": {
       "baseline": "1.14.1",
-      "port-version": 0
+      "port-version": 1
     },
     "pcre": {
       "baseline": "8.45",
@@ -9346,7 +9346,7 @@
     },
     "vtk": {
       "baseline": "9.3.0-pv5.12.1",
-      "port-version": 3
+      "port-version": 4
     },
     "vtk-dicom": {
       "baseline": "0.8.14",

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77a77ff352a1fa7d9271ea206e706929bfd2faff",
+      "version": "3.4.18",
+      "port-version": 16
+    },
+    {
       "git-tree": "5d13125fc5a48e77592a3d66b8716012d79425ca",
       "version": "3.4.18",
       "port-version": 15

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1c14acfbb673af2479af39dd8424c8f151752ad",
+      "version": "4.8.0",
+      "port-version": 22
+    },
+    {
       "git-tree": "946d30019e6bcb9e6043c4b18a9dbe1b719694af",
       "version": "4.8.0",
       "port-version": 21

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e55506ffdfffe9bc2104eadddea53dde27686a8d",
+      "version": "1.14.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d21fc9ad60ee928ee8d65084b278b7254ea02cab",
       "version": "1.14.1",
       "port-version": 0

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f66a99e8c041f8e084d2871c3cc1d48146ca90f0",
+      "version-semver": "9.3.0-pv5.12.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "dbdb5ecd3e43e28d167883d384b471f65eb59012",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 3


### PR DESCRIPTION
Moves multiple previously mandatory dependencies to be default features instead. This was inspired by, and builds upon, @bansan85's work on #39511 to have `vtk[core]` pull in much less dependencies.

Everything is added as a default feature because the dependencies are required for things in the "Standalone" or "Rendering" VTK groups which the portfile has enabled (ie: `VTK_GROUP_ENABLE_StandAlone=YES`). So I take that as the "expected functionality".

This could be taken further but I was focused on value-for-effort and seacas was my main target for making non-strictly-required.

I've tested many configurations (if only on Windows) but if anything has problems it'll probably be from paraview or rtabmap; which I was not able to test properly because... they're huge.

Before (vtk[cgns,libharu,libtheora,netcdf,proj,seacas,sql]) -- 48 packages -- 3.67GB
```
vcpkg-cmake:
vcpkg-cmake-get-vars: vcpkg-cmake
vcpkg-cmake-config:
vcpkg-tool-meson: vcpkg-cmake-get-vars
szip: vcpkg-cmake, vcpkg-cmake-config
zlib: vcpkg-cmake
egl-registry:
pkgconf: vcpkg-tool-meson
libjpeg-turbo: vcpkg-cmake, vcpkg-cmake-config
liblzma: vcpkg-cmake, vcpkg-cmake-config
hdf5[szip, zlib, tools]: szip, vcpkg-cmake, vcpkg-cmake-config, zlib
curl[non-http, ssl, schannel, sspi]: vcpkg-cmake, vcpkg-cmake-config, zlib
gklib: vcpkg-cmake, vcpkg-cmake-config
opengl-registry: egl-registry
vcpkg-pkgconfig-get-modules: pkgconf
brotli: vcpkg-cmake, vcpkg-cmake-config
bzip2[tool]: vcpkg-cmake
cereal: vcpkg-cmake, vcpkg-cmake-config
cgns[hdf5, lfs, lfsselector]: hdf5, vcpkg-cmake, vcpkg-cmake-config
nlohmann-json: vcpkg-cmake, vcpkg-cmake-config
sqlite3[json1, tool]: vcpkg-cmake, vcpkg-cmake-config
fmt: vcpkg-cmake, vcpkg-cmake-config
libpng: vcpkg-cmake, vcpkg-cmake-config, zlib
opengl: opengl-registry
tiff[jpeg, lzma, zip]: libjpeg-turbo, liblzma, vcpkg-cmake, vcpkg-cmake-config, zlib
libiconv:
libogg: vcpkg-cmake, vcpkg-cmake-config
metis: gklib, vcpkg-cmake, vcpkg-cmake-config
netcdf-c[netcdf-4, dap, hdf5, nczarr]: curl, hdf5, vcpkg-cmake, vcpkg-cmake-config, vcpkg-pkgconfig-get-modules
double-conversion: vcpkg-cmake, vcpkg-cmake-config
eigen3: vcpkg-cmake, vcpkg-cmake-config
lz4: vcpkg-cmake, vcpkg-cmake-config
glew: opengl, vcpkg-cmake, vcpkg-cmake-config
freetype[brotli, bzip2, zlib, png]: brotli, bzip2, libpng, vcpkg-cmake, vcpkg-cmake-config, zlib
fast-float: vcpkg-cmake, vcpkg-cmake-config
exprtk:
expat: vcpkg-cmake, vcpkg-cmake-config
jsoncpp: vcpkg-cmake, vcpkg-cmake-config
libtheora: libogg, vcpkg-cmake, vcpkg-cmake-config
pegtl: vcpkg-cmake, vcpkg-cmake-config
libxml2[iconv, lzma, zlib]: libiconv, liblzma, vcpkg-cmake, vcpkg-cmake-config, zlib
libharu: libpng, vcpkg-cmake, vcpkg-cmake-config, zlib
proj[net, tiff]: curl, nlohmann-json, sqlite3, tiff, vcpkg-cmake, vcpkg-cmake-config
pugixml: vcpkg-cmake, vcpkg-cmake-config
seacas: cereal, cgns, fmt, hdf5, metis, netcdf-c, vcpkg-cmake, vcpkg-cmake-config, zlib
utfcpp: vcpkg-cmake, vcpkg-cmake-config
verdict: vcpkg-cmake, vcpkg-cmake-config
vtk[cgns, proj, libharu, seacas, libtheora, netcdf, sql]: cgns, double-conversion, eigen3, expat, exprtk, fast-float, fmt, freetype, glew, hdf5, jsoncpp, libharu, libjpeg-turbo, liblzma, libpng, libtheora, libxml2, lz4, netcdf-c, nlohmann-json, pegtl, proj, pugixml, seacas, sqlite3, tiff, utfcpp, vcpkg-cmake, vcpkg-cmake-config, verdict, zlib
```

After (vtk[core]) -- 32 packages -- 3.30GB
```
vcpkg-cmake:
egl-registry:
vcpkg-cmake-config:
zlib: vcpkg-cmake
opengl-registry: egl-registry
brotli: vcpkg-cmake, vcpkg-cmake-config
bzip2[tool]: vcpkg-cmake
libpng: vcpkg-cmake, vcpkg-cmake-config, zlib
opengl: opengl-registry
szip: vcpkg-cmake, vcpkg-cmake-config
libiconv:
libjpeg-turbo: vcpkg-cmake, vcpkg-cmake-config
liblzma: vcpkg-cmake, vcpkg-cmake-config
double-conversion: vcpkg-cmake, vcpkg-cmake-config
eigen3: vcpkg-cmake, vcpkg-cmake-config
expat: vcpkg-cmake, vcpkg-cmake-config
exprtk:
fast-float: vcpkg-cmake, vcpkg-cmake-config
fmt: vcpkg-cmake, vcpkg-cmake-config
freetype[brotli, bzip2, zlib, png]: brotli, bzip2, libpng, vcpkg-cmake, vcpkg-cmake-config, zlib
glew: opengl, vcpkg-cmake, vcpkg-cmake-config
hdf5[szip, zlib]: szip, vcpkg-cmake, vcpkg-cmake-config, zlib
jsoncpp: vcpkg-cmake, vcpkg-cmake-config
libxml2[iconv, lzma, zlib]: libiconv, liblzma, vcpkg-cmake, vcpkg-cmake-config, zlib
lz4: vcpkg-cmake, vcpkg-cmake-config
nlohmann-json: vcpkg-cmake, vcpkg-cmake-config
pegtl: vcpkg-cmake, vcpkg-cmake-config
pugixml: vcpkg-cmake, vcpkg-cmake-config
tiff[jpeg, lzma, zip]: libjpeg-turbo, liblzma, vcpkg-cmake, vcpkg-cmake-config, zlib
utfcpp: vcpkg-cmake, vcpkg-cmake-config
verdict: vcpkg-cmake, vcpkg-cmake-config
vtk: double-conversion, eigen3, expat, exprtk, fast-float, fmt, freetype, glew, hdf5, jsoncpp, libjpeg-turbo, liblzma, libpng, libxml2, lz4, nlohmann-json, pegtl, pugixml, tiff, utfcpp, vcpkg-cmake, vcpkg-cmake-config, verdict, zlib
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

