### PR TITLE
[libpng] Remove -DPNG_PREFIX=a option when apng feature enabled

### DIFF
--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -1,6 +1,5 @@
 # Download the apng patch
 set(LIBPNG_APNG_PATCH_PATH "")
-set(LIBPNG_APNG_OPTION "")
 if ("apng" IN_LIST FEATURES)
     if(VCPKG_HOST_IS_WINDOWS)
         # Get (g)awk and gzip installed
@@ -25,7 +24,6 @@ if ("apng" IN_LIST FEATURES)
             LOGNAME extract-patch.log
         )
     endif()
-    set(LIBPNG_APNG_OPTION "-DPNG_PREFIX=a")
 endif()
 
 vcpkg_from_github(
@@ -73,7 +71,6 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        ${LIBPNG_APNG_OPTION}
         ${LIBPNG_HARDWARE_OPTIMIZATIONS_OPTION}
         ${LD_VERSION_SCRIPT_OPTION}
         -DPNG_STATIC=${PNG_STATIC}

--- a/ports/libpng/vcpkg.json
+++ b/ports/libpng/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libpng",
   "version": "1.6.43",
-  "port-version": 2,
+  "port-version": 3,
   "description": "libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files",
   "homepage": "https://github.com/glennrp/libpng",
   "license": "libpng-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4882,7 +4882,7 @@
     },
     "libpng": {
       "baseline": "1.6.43",
-      "port-version": 2
+      "port-version": 3
     },
     "libpopt": {
       "baseline": "1.16",

--- a/versions/l-/libpng.json
+++ b/versions/l-/libpng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9c7fd06f1cdd1dfc08b35ca9d6b0ba470cdd2470",
+      "version": "1.6.43",
+      "port-version": 3
+    },
+    {
       "git-tree": "915cc8e8e0adbfb2708a310635217811a849d709",
       "version": "1.6.43",
       "port-version": 2


### PR DESCRIPTION
This option has the effect of manipulating the ELF version and symbol scripts applied to the shared library to define symbols like "apng_read_end@@PNG_16_0". When using a fully shared setup and linking other system libraries (for example, Qt6) in an application, this causes system libraries that were linked against the system libpng.so to fail to find libpng symbols. Because they have a prefix of "a".

This should have been removed in the merge from two separate ports into one port with a feature in
ff6a725392fcffa647880293e4c0a1352f0d3473

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


An example of the failure when using VCPKG_LIBRARY_LINKAGE of 'dynamic' is like so:

```
/home/andrew/ladybird-org/ladybird-browser/Build/ladybird/libexec/RequestServer: symbol lookup error: /lib/x86_64-linux-gnu/libcairo.so.2: undefined symbol: png_read_end, version PNG16_0
```

Because the lib as created by vcpkg does not export that symbol (png_read_end@@PNG16_0) but instead a host of versioned symbols with the name "apng_*"