### PR TITLE
[catch2] Add feature to disable posix signal/windows seh handling

### DIFF
--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -12,11 +12,17 @@ vcpkg_from_github(
         fix-install-path.patch
 )
 
+set (OPTIONS)
+if("disable-posix-signals-windows-seh-handling" IN_LIST FEATURES)
+    list(APPEND OPTIONS -DCATCH_CONFIG_NO_POSIX_SIGNALS=ON -DCATCH_CONFIG_NO_WINDOWS_SEH=ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DCATCH_INSTALL_DOCS=OFF
         -DCMAKE_CXX_STANDARD=17
+        ${OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "catch2",
   "version-semver": "3.6.0",
+  "port-version": 1,
   "description": "A modern, C++-native, test framework for unit-tests, TDD and BDD.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",
@@ -13,5 +14,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "disable-posix-signals-windows-seh-handling": {
+      "description": "Disable POSIX signals and Windows SEH handling"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1514,7 +1514,7 @@
     },
     "catch2": {
       "baseline": "3.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cblas": {
       "baseline": "2024-03-19",

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f005a06108cf9b41de92d72414d66be6804d3497",
+      "version-semver": "3.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f61acaeefdf6127fa878f7192fc109fa8e1a0135",
       "version-semver": "3.6.0",
       "port-version": 0


### PR DESCRIPTION
This is essential to making test crashes diagnosable. With Catch2 posix signal/windows seh handling enabled the developer will just get the name of test and signal, which is often not enough to diagnose the problem. With these handlers disabled the developer can instead get a core/dmp file with all the relevant information that can be analyzed in a debugger. See also
https://github.com/catchorg/Catch2/issues/2791.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
