### PR TITLE
[godot-cpp] Update to 4.2.2

### DIFF
--- a/ports/godot-cpp/hotreloadable.patch
+++ b/ports/godot-cpp/hotreloadable.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 248756e..a024e44 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -149,6 +149,13 @@ add_library(${PROJECT_NAME} STATIC
+ )
+ add_library(godot::cpp ALIAS ${PROJECT_NAME})
+ 
++if(GODOT_ENABLE_HOT_RELOAD)
++	target_compile_definitions(${PROJECT_NAME} PUBLIC "$<$<CONFIG:Debug>:HOT_RELOAD_ENABLED>")
++	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
++		target_compile_options(${PROJECT_NAME} PUBLIC "$<$<CONFIG:Debug>:-fno-gnu-unique>")
++	endif()
++endif()
++
+ include(GodotCompilerWarnings)
+ 
+ target_compile_features(${PROJECT_NAME}

--- a/ports/godot-cpp/packagable.patch
+++ b/ports/godot-cpp/packagable.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e715102..b000066 100644
+index 7884a06..248756e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -37,7 +37,7 @@
  # Todo
  # Test build for Windows, Mac and mingw.
  
--cmake_minimum_required(VERSION 3.12)
+-cmake_minimum_required(VERSION 3.13)
 +cmake_minimum_required(VERSION 3.19)
  project(godot-cpp LANGUAGES CXX)
  

--- a/ports/godot-cpp/portfile.cmake
+++ b/ports/godot-cpp/portfile.cmake
@@ -5,17 +5,25 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "godotengine/godot-cpp"
     REF "godot-${VERSION}-stable"
-    SHA512 "820e07ffb0545324f01598898bb342d7e143dcc8b83818824e7e1bc22937d3e8016b435f1ec085ebaae8b26e6f6dfb5500f120089316fc0f0c4153c340226941"
+    SHA512 "aa7fbdc398eda9abbfbbe4d0cfed2ce4651cc5ca4d8d246d739dc3814e766011ff8bb221ad4033830bfb7926adbb69f6f26dc7356c9a7cb3f1e8d39f4db053fc"
     HEAD_REF "master"
     PATCHES
+        "hotreloadable.patch"
         "packagable.patch"
 )
 
 vcpkg_find_acquire_program(PYTHON3)
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "hotreload"    "GODOT_ENABLE_HOT_RELOAD"
+)
+
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         "-DPython3_EXECUTABLE=${PYTHON3}"
 )
 

--- a/ports/godot-cpp/vcpkg.json
+++ b/ports/godot-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-cpp",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "C++ bindings for the Godot script API",
   "homepage": "https://github.com/godotengine/godot-cpp",
   "license": "MIT",
@@ -13,5 +13,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "hotreload"
+  ],
+  "features": {
+    "hotreload": {
+      "description": "Enable support for hot reloading"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3161,7 +3161,7 @@
       "port-version": 8
     },
     "godot-cpp": {
-      "baseline": "4.2.1",
+      "baseline": "4.2.2",
       "port-version": 0
     },
     "google-cloud-cpp": {

--- a/versions/g-/godot-cpp.json
+++ b/versions/g-/godot-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f160abb0a7b4aea1cf0d1d261539d823e036d172",
+      "version": "4.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "3125afbc0a8a200f3a3213b8a4be710ad3190890",
       "version": "4.2.1",
       "port-version": 0


### PR DESCRIPTION
Updates the godot-cpp port to use version 4.2.2 and add support for hot reloading.


- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

