### PR TITLE
[presentmon] Update to 2.1.1

### DIFF
--- a/ports/presentmon/CMakeLists.txt
+++ b/ports/presentmon/CMakeLists.txt
@@ -7,19 +7,17 @@ option(BUILD_TOOLS "Build tool PresentMon" OFF)
 set(PRESENTDATA_SRCS
     PresentData/Debug.cpp
     PresentData/GpuTrace.cpp
-    PresentData/MixedRealityTraceConsumer.cpp
     PresentData/PresentMonTraceConsumer.cpp
+    PresentData/PresentMonTraceSession.cpp
     PresentData/TraceConsumer.cpp
-    PresentData/TraceSession.cpp
 )
 
 set(PRESENTDATA_HDRS
     PresentData/Debug.hpp
     PresentData/GpuTrace.hpp
-    PresentData/MixedRealityTraceConsumer.hpp
     PresentData/PresentMonTraceConsumer.hpp
+    PresentData/PresentMonTraceSession.hpp
     PresentData/TraceConsumer.hpp
-    PresentData/TraceSession.hpp
     ${CMAKE_BINARY_DIR}/generated/version.h
 )
 
@@ -49,11 +47,10 @@ if (BUILD_TOOLS)
         PresentMon/Console.cpp
         PresentMon/ConsumerThread.cpp
         PresentMon/CsvOutput.cpp
-        PresentMon/LateStageReprojectionData.cpp
         PresentMon/MainThread.cpp
         PresentMon/OutputThread.cpp
         PresentMon/Privilege.cpp
-        PresentMon/TraceSession.cpp
+        PresentMon/PresentMon.hpp
     )
     
     add_executable(PresentMon ${PresentMon_SRCS})

--- a/ports/presentmon/portfile.cmake
+++ b/ports/presentmon/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GameTechDev/PresentMon
     REF "v${VERSION}"
-    SHA512 d593a4066e3087abd02df5bd049bb1cbe1a91ac07a4efb53bae7a44bcb98dc67f7e2f2688dd339292eeaf9b96f35d5790a86d355faacad5cf61dafa0fa584edc
+    SHA512 30945e61ba09e23ebc05e3f8a0e96a298349dad6a83043a37df9e1af0c892bee1704214e8f6ddc8cdaa9f527deb16f27b3653c855eab6bbc2f9ce509da4ded00
     HEAD_REF main
 )
 

--- a/ports/presentmon/vcpkg.json
+++ b/ports/presentmon/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "presentmon",
-  "version-semver": "1.10.0",
-  "port-version": 1,
+  "version-semver": "2.1.1",
   "description": "PresentMon is a tool to capture and analyze ETW events related to swap chain presentation on Windows.",
   "supports": "windows & !uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7069,8 +7069,8 @@
       "port-version": 0
     },
     "presentmon": {
-      "baseline": "1.10.0",
-      "port-version": 1
+      "baseline": "2.1.1",
+      "port-version": 0
     },
     "proj": {
       "baseline": "9.4.1",

--- a/versions/p-/presentmon.json
+++ b/versions/p-/presentmon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "320eb831b4a4a59b6ed3825c1caefcf9a860bd8a",
+      "version-semver": "2.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b00ceac5f8c1c2abf8f819f27b1582ea9427cb70",
       "version-semver": "1.10.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40302
Modify the cmakelists.txt file, delete the non-existent compiled source code files, and add new source code files.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplets:

```
x64-windows
x64-windows-static
```