### PR TITLE
[mlpack] Update to 4.4.0

### DIFF
--- a/ports/mlpack/portfile.cmake
+++ b/ports/mlpack/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mlpack/mlpack
     REF "${VERSION}"
-    SHA512 6b7c16190fa5106dde76cbedddc42ed0a4a97fcc606dc0b962744fdc812ac81f59a21b6cf071e3a8661c58cb9de2654a4eabd03c4f44d6091f99175887735c41
+    SHA512 2ae159a4aa8340be4763944c1b1e460f4d8fe838c79325cffdcacfbac340cca4cec3031493caec7e9b4dcf6fc921cbd93c1384d7e1954492fe410c83d3e615f8
     HEAD_REF master
 )
 

--- a/ports/mlpack/vcpkg.json
+++ b/ports/mlpack/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mlpack",
-  "version": "4.3.0",
-  "port-version": 1,
+  "version": "4.4.0",
   "description": "mlpack is an intuitive, fast, and flexible header-only C++ machine learning library with bindings to other languages.",
   "homepage": "https://github.com/mlpack/mlpack",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5877,8 +5877,8 @@
       "port-version": 0
     },
     "mlpack": {
-      "baseline": "4.3.0",
-      "port-version": 1
+      "baseline": "4.4.0",
+      "port-version": 0
     },
     "mman": {
       "baseline": "git-f5ff813",

--- a/versions/m-/mlpack.json
+++ b/versions/m-/mlpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "855456d472a81eca48e1c5de4918d5b94023d7ed",
+      "version": "4.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f3c84cbe875f9fb8e012180e81ef11b5d3c012b2",
       "version": "4.3.0",
       "port-version": 1


### PR DESCRIPTION
Fix #40201

Update to 4.4.0

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port usage tests pass with the following triplets:

* x64-windows