### PR TITLE
[libuv] add # ifndef ssize_t

### DIFF
--- a/ports/libuv/portfile.cmake
+++ b/ports/libuv/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 81a9580bc51c22385de4dab748968477b5e552aa25f901c376e3ffac624e0e05362b48239222e826cad900329f9a7cbdb080794fb4ada9ca14196efc2969cc57
     HEAD_REF v1.x
-    PATCHES fix-build-type.patch
+    PATCHES 
+        fix-build-type.patch
+        ssize_t.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LIBUV_BUILD_SHARED)

--- a/ports/libuv/ssize_t.patch
+++ b/ports/libuv/ssize_t.patch
@@ -1,0 +1,14 @@
+diff --git a/include/uv/win.h b/include/uv/win.h
+index 12ac53b4..6e1abd5b 100644
+--- a/include/uv/win.h
++++ b/include/uv/win.h
+@@ -24,7 +24,9 @@
+ #endif
+ 
+ #if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
++# ifndef ssize_t
+ typedef intptr_t ssize_t;
++# endif
+ # define SSIZE_MAX INTPTR_MAX
+ # define _SSIZE_T_
+ # define _SSIZE_T_DEFINED

--- a/ports/libuv/vcpkg.json
+++ b/ports/libuv/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libuv",
   "version-semver": "1.48.0",
+  "port-version": 1,
   "description": "libuv is a multi-platform support library with a focus on asynchronous I/O.",
   "homepage": "https://github.com/libuv/libuv",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5202,7 +5202,7 @@
     },
     "libuv": {
       "baseline": "1.48.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libuvc": {
       "baseline": "0.0.7",

--- a/versions/l-/libuv.json
+++ b/versions/l-/libuv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9acba527010351e148700213675f5ed81fd2300e",
+      "version-semver": "1.48.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "eb297582074da541775cf29ad02a7dfe8a5a57e1",
       "version-semver": "1.48.0",
       "port-version": 0


### PR DESCRIPTION
When compile curl with libuv (for their tests) in vcpkg, I get this error:
```
C:\vcpkg\installed\x64-windows\include\uv\win.h(27,18): error C2628: 'intptr_t' followed by '__int64' is illegal (did you forget a ';'?) [D:\a\curl\curl\bld\src\curl.vcxproj]
Error: Process completed with exit code 1.
```

I am not sure if vcpkg or curl add the definition of ssize_t.

I create a PR on upstream: 
https://github.com/libuv/libuv/pull/4493

upstream want to implement it different way, but I am not sure the source of the problem. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

