### PR TITLE
[vcpkg baseline][kddockwidgets] Disable undeclared dependencies and update to 2.1.0

### DIFF
--- a/ports/kddockwidgets/portfile.cmake
+++ b/ports/kddockwidgets/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDAB/KDDockWidgets
     REF "v${VERSION}" 
-    SHA512 4dccf24e901ab58d645478bc62ff9e72224dc11c3f39c53f5be5b188ece1bf8c682d50a42ece7a38400adfeb6147336795fcb86e903fd0957949c83f852c9b53 
+    SHA512 7b88f354e2aca4ac4c0f59874b6a7d6baaf77f5b54dd57b981ec7831e40acc0e2f6d3c6300af3d93c594bf34c7072c6a8a19a50c65039ccae22a9e47b90499d8
     HEAD_REF master
 )
 
@@ -21,9 +21,14 @@ vcpkg_cmake_configure(
     OPTIONS
         ${_qarg_OPTIONS}
         -DKDDockWidgets_QT6=ON
+        "-DKDDockWidgets_FRONTENDS=qtwidgets"
         -DKDDockWidgets_STATIC=${KD_STATIC}
         -DKDDockWidgets_PYTHON_BINDINGS=OFF
+        -DKDDockWidgets_TESTS=OFF
         -DKDDockWidgets_EXAMPLES=OFF
+        # https://github.com/KDAB/KDDockWidgets/blob/v2.1.0/CMakeLists.txt#L301
+        -DCMAKE_DISABLE_FIND_PACKAGE_spdlog=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_fmt=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/kddockwidgets/vcpkg.json
+++ b/ports/kddockwidgets/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kddockwidgets",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "KDAB's Dock Widget Framework for Qt",
   "homepage": "https://www.kdab.com/development-resources/qt-tools/kddockwidgets/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3885,7 +3885,7 @@
       "port-version": 0
     },
     "kddockwidgets": {
-      "baseline": "2.0.0",
+      "baseline": "2.1.0",
       "port-version": 0
     },
     "kdsoap": {

--- a/versions/k-/kddockwidgets.json
+++ b/versions/k-/kddockwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9644c9741f94c097fba186a4111f1dfcd68063e",
+      "version": "2.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5dcce3389ff415798302c843980052dd03314ddc",
       "version": "2.0.0",
       "port-version": 0


### PR DESCRIPTION
In [Pipelines - Run 20240802.25 (azure.com)](https://dev.azure.com/vcpkg/public/_build/results?buildId=105657&view=logs&jobId=6183daa0-a320-589b-0cd5-a753e5fec46f&j=6183daa0-a320-589b-0cd5-a753e5fec46f&t=a6fc56d5-8474-539e-4d4f-c23a54a40e2b), `kddockwidgets` failed with `fmt` format.

* Prevent dynamic search dependencies
  + Explicitly specify `FRONTENDS` as `qtwidgets`
    - Fix #38509
    - Alternative to #38611
  + Disable undeclared optional dependencies `spdlog` and `fmt`, see [KDAB/KDDockWidgets - CMakeLists.txt#L301](https://github.com/KDAB/KDDockWidgets/blob/v2.1.0/CMakeLists.txt#L301)
    - Support #40229
* Update to `v2.1.0`
  + Alternative to #38649

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets whether or not installed of `spdlog` and `fmt`:

* x64-linux