### PR TITLE
[libjuice] Update to 1.5.2

### DIFF
--- a/ports/libjuice/fix-for-vcpkg.patch
+++ b/ports/libjuice/fix-for-vcpkg.patch
@@ -1,8 +1,19 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3e2a2dc..011a4ca 100644
+index 5712462..66d63cf 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -66,7 +66,7 @@ set(TESTS_SOURCES
+@@ -30,6 +30,10 @@ if(WIN32)
+ 	endif()
+ endif()
+ 
++if(DEFINED JUICE_STATIC)
++    add_definitions(-DJUICE_STATIC)
++endif()
++
+ if(CLANG_TIDY)
+ 	set(CMAKE_C_CLANG_TIDY clang-tidy)
+ endif()
+@@ -89,7 +93,7 @@ source_group("Fuzzer Files" FILES "${FUZZER_SOURCES}")
  set(THREADS_PREFER_PTHREAD_FLAG ON)
  find_package(Threads REQUIRED)
  
@@ -11,16 +22,16 @@ index 3e2a2dc..011a4ca 100644
  set_target_properties(juice PROPERTIES VERSION ${PROJECT_VERSION})
  target_include_directories(juice PUBLIC
      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-@@ -96,11 +96,15 @@ if(WIN32)
+@@ -120,11 +124,15 @@ if(WIN32)
  endif()
  
  if (USE_NETTLE)
 -	find_package(Nettle REQUIRED)
-+	find_path(NETTLE_INCLUDE_PATH "nettle/hmac.h" REQUIRED)
++    find_path(NETTLE_INCLUDE_PATH "nettle/hmac.h" REQUIRED)
 +    find_library(NETTLE_LIBRARY_PATH NAMES nettle libnettle REQUIRED) 
 +    target_include_directories(juice PRIVATE ${NETTLE_INCLUDE_PATH})
 +    target_include_directories(juice-static PRIVATE ${NETTLE_INCLUDE_PATH})
-+    
++
      target_compile_definitions(juice PRIVATE USE_NETTLE=1)
 -    target_link_libraries(juice PRIVATE Nettle::Nettle)
 +    target_link_libraries(juice PRIVATE ${NETTLE_LIBRARY_PATH})

--- a/ports/libjuice/portfile.cmake
+++ b/ports/libjuice/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO paullouisageneau/libjuice
     REF "v${VERSION}"
-    SHA512 5696ada382b70e5e8edc123c021cc1bf48a091253e20c705d1a23de3e5a9a240c138090228d02c5937a2418202e10216fafce4579195d5c2c92e7f7be107e622
+    SHA512 8a7e26daf05219ee2e490052b36be732bad35d570b66e9c08c36e4364ba183a511ea01e4444a8bf94dffd764a3f45f38900f7f4e26a531568b6c3adbd2bd7b53
     HEAD_REF master
     PATCHES
         fix-for-vcpkg.patch
@@ -13,10 +13,15 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         nettle USE_NETTLE
 )
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    list(APPEND arg_OPTIONS "-DJUICE_STATIC=ON")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        ${arg_OPTIONS}
         -DNO_TESTS=ON
 )
 

--- a/ports/libjuice/vcpkg.json
+++ b/ports/libjuice/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libjuice",
-  "version": "1.4.2",
+  "version": "1.5.2",
   "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libjuice",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4625,7 +4625,7 @@
       "port-version": 0
     },
     "libjuice": {
-      "baseline": "1.4.2",
+      "baseline": "1.5.2",
       "port-version": 0
     },
     "libjxl": {

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "115892ea71ab4fd1ba3c977752a7bac2dec321a4",
+      "version": "1.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ac2cd791b2bea7ccbe226e924b3c3e9493c784b5",
       "version": "1.4.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #39812. Update `libjuice` to 1.5.2, and make a simple fix in portfile.cmake to remove the need to define `JUICE_STATIC`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.