### PR TITLE
[lightgbm] Add Threadless Feature

### DIFF
--- a/ports/lightgbm/portfile.cmake
+++ b/ports/lightgbm/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         gpu USE_GPU
-        threadless USE_OPENMP_OFF
+        openmp USE_OPENMP
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -20,7 +20,7 @@ else()
 endif()
 
 set(OPENMP_OPTION "-DUSE_OPENMP=ON")
-if("x${USE_OPENMP_OFF}" STREQUAL "xON")
+if("x${USE_OPENMP}" STREQUAL "xOFF")
     set(OPENMP_OPTION "-DUSE_OPENMP=OFF")
 endif()
 

--- a/ports/lightgbm/portfile.cmake
+++ b/ports/lightgbm/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         gpu USE_GPU
+        threadless USE_OPENMP_OFF
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -18,12 +19,18 @@ else()
     set(BUILD_STATIC_LIB "ON")
 endif()
 
+# Set CMake option based on feature
+set(OPENMP_OPTION "-DUSE_OPENMP=ON")
+if("x${USE_OPENMP_OFF}" STREQUAL "xON")
+    set(OPENMP_OPTION "-DUSE_OPENMP=OFF")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DBUILD_STATIC_LIB=${BUILD_STATIC_LIB}
         ${FEATURE_OPTIONS}
+        ${OPENMP_OPTION}
 )
 
 vcpkg_cmake_install()

--- a/ports/lightgbm/portfile.cmake
+++ b/ports/lightgbm/portfile.cmake
@@ -19,17 +19,11 @@ else()
     set(BUILD_STATIC_LIB "ON")
 endif()
 
-set(OPENMP_OPTION "-DUSE_OPENMP=ON")
-if("x${USE_OPENMP}" STREQUAL "xOFF")
-    set(OPENMP_OPTION "-DUSE_OPENMP=OFF")
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DBUILD_STATIC_LIB=${BUILD_STATIC_LIB}
         ${FEATURE_OPTIONS}
-        ${OPENMP_OPTION}
 )
 
 vcpkg_cmake_install()

--- a/ports/lightgbm/portfile.cmake
+++ b/ports/lightgbm/portfile.cmake
@@ -19,7 +19,6 @@ else()
     set(BUILD_STATIC_LIB "ON")
 endif()
 
-# Set CMake option based on feature
 set(OPENMP_OPTION "-DUSE_OPENMP=ON")
 if("x${USE_OPENMP_OFF}" STREQUAL "xON")
     set(OPENMP_OPTION "-DUSE_OPENMP=OFF")

--- a/ports/lightgbm/vcpkg.json
+++ b/ports/lightgbm/vcpkg.json
@@ -18,6 +18,9 @@
       "host": true
     }
   ],
+  "default-features": [
+    "openmp"
+  ],
   "features": {
     "gpu": {
       "description": "GPU support using Boost.Compute",
@@ -26,8 +29,8 @@
         "opencl"
       ]
     },
-    "threadless": {
-      "description": "Build without OpenMP support for threadless operation"
+    "openmp": {
+      "description": "Support for multi-threading using OpenMP"
     }
   }
 }

--- a/ports/lightgbm/vcpkg.json
+++ b/ports/lightgbm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "lightgbm",
   "version": "4.4.0",
+  "port-version": 1,
   "description": [
     "A fast, distributed, high performance gradient boosting (GBT, GBDT, GBRT, GBM or MART) framework based on decision tree algorithms.",
     "Designed to be distributed and efficient and comes with faster training speeds, higher efficiency, lower memory usage and support of parallel, distributed, and GPU learning."
@@ -24,6 +25,9 @@
         "boost-compute",
         "opencl"
       ]
+    },
+    "threadless": {
+      "description": "Build without OpenMP support for threadless operation"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5414,7 +5414,7 @@
     },
     "lightgbm": {
       "baseline": "4.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "lightningscanner": {
       "baseline": "1.0.1",

--- a/versions/l-/lightgbm.json
+++ b/versions/l-/lightgbm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "01b12f92167da57de6b1012d53ad9bfc433ca84c",
+      "git-tree": "a28e05a3ffd7cd7b8384476fc6a28e23c96580cf",
       "version": "4.4.0",
       "port-version": 1
     },

--- a/versions/l-/lightgbm.json
+++ b/versions/l-/lightgbm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3d9b0129407b892fce33eb7ae8b1bebc17e8b3b8",
+      "git-tree": "01b12f92167da57de6b1012d53ad9bfc433ca84c",
       "version": "4.4.0",
       "port-version": 1
     },

--- a/versions/l-/lightgbm.json
+++ b/versions/l-/lightgbm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "398542746d3a4842f45cd80d72943e5f4d4cb76b",
+      "git-tree": "3d9b0129407b892fce33eb7ae8b1bebc17e8b3b8",
       "version": "4.4.0",
       "port-version": 1
     },

--- a/versions/l-/lightgbm.json
+++ b/versions/l-/lightgbm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "398542746d3a4842f45cd80d72943e5f4d4cb76b",
+      "version": "4.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e8a4ff8e712c8794cc650c722dfd9d65581c68bb",
       "version": "4.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Adding the threadless option/feature listed here:
https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#build-threadless-version-not-recommended

To increase compatibility with projects which do not use OpenMP.