### PR TITLE
[microsoft-signalr] Backport fix compilation with gcc 13

### DIFF
--- a/ports/microsoft-signalr/portfile.cmake
+++ b/ports/microsoft-signalr/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(PATCH_FIX_GCC_13_COMPILATION
+    URLS https://github.com/aspnet/SignalR-Client-Cpp/commit/66458704cf588eae28b490b73bbc8261bf04f31a.diff?full_index=1
+    SHA512 e8b6edbc84f9f6fd1fe5f0f63a1b66004d562c3926ab9130a2ce4fa7137e6b1d4d5c407b95f2867e452863578ffd03ca3be3326dac19d14baf77416c71e237c9
+    FILENAME aspnet-SignalR-Client-Cpp-pr-96.diff
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aspnet/SignalR-Client-Cpp
@@ -6,6 +12,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         find-msgpack.patch
+        "${PATCH_FIX_GCC_13_COMPILATION}"
 )
 
 vcpkg_check_features(

--- a/ports/microsoft-signalr/vcpkg.json
+++ b/ports/microsoft-signalr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "microsoft-signalr",
   "version": "0.1.0-alpha4",
-  "port-version": 8,
+  "port-version": 9,
   "description": "C++ Client for ASP.NET Core SignalR.",
   "homepage": "https://github.com/aspnet/SignalR-Client-Cpp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5806,7 +5806,7 @@
     },
     "microsoft-signalr": {
       "baseline": "0.1.0-alpha4",
-      "port-version": 8
+      "port-version": 9
     },
     "mikktspace": {
       "baseline": "2020-10-06",

--- a/versions/m-/microsoft-signalr.json
+++ b/versions/m-/microsoft-signalr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "25d06a130b123e7bd4dd76bdf2ddcf3af250b86d",
+      "version": "0.1.0-alpha4",
+      "port-version": 9
+    },
+    {
       "git-tree": "31b63c815c4f6877e688b163a083df208d8ca133",
       "version": "0.1.0-alpha4",
       "port-version": 8


### PR DESCRIPTION
Fix #40292, failed with "error: field ‘m_message’ has incomplete type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}"

Backports fix in https://github.com/aspnet/SignalR-Client-Cpp/pull/96

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux (GNU 14)