### PR TITLE
[ilmbase] Delist

### DIFF
--- a/ports/ilmbase/portfile.cmake
+++ b/ports/ilmbase/portfile.cmake
@@ -1,1 +1,0 @@
-set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/ports/ilmbase/vcpkg.json
+++ b/ports/ilmbase/vcpkg.json
@@ -1,8 +1,0 @@
-{
-  "name": "ilmbase",
-  "version": "3",
-  "description": "Obsolete, use port imath instead",
-  "dependencies": [
-    "imath"
-  ]
-}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3624,10 +3624,6 @@
       "baseline": "9e",
       "port-version": 1
     },
-    "ilmbase": {
-      "baseline": "3",
-      "port-version": 0
-    },
     "im3d": {
       "baseline": "2022-10-11",
       "port-version": 0


### PR DESCRIPTION
Integrated into `openexr` in, i.e. empty since, 2019.
Split out from openexr into `imath` in 2022.
Appearing as vulnerable "openexr" 3 on https://repology.org/projects/o/?inrepo=vcpkg&vulnerable=True.