### PR TITLE
[via-httplib] add new port

### DIFF
--- a/ports/via-httplib/portfile.cmake
+++ b/ports/via-httplib/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kenba/via-httplib
+    REF b1baffa347b5a5a0b02e687ccc6273f26e1f7515 # v1.9.0
+    SHA512 a756c8869f5d17df3bdf8a83995f211b7a23cef6aacf916c9f4fbff365b8a6f4d2499154fc6de2db97de65b2dccbcc4a953aed37da68d8478cf1a9e38ac03d9a
+    HEAD_REF master    
+)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}" )
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ViaHttpLib)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib" 
+                    "${CURRENT_PACKAGES_DIR}/lib"
+                    "${CURRENT_PACKAGES_DIR}/debug"
+                    )
+
+file(INSTALL "${SOURCE_PATH}/LICENSE_1_0.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/via-httplib" RENAME copyright)

--- a/ports/via-httplib/portfile.cmake
+++ b/ports/via-httplib/portfile.cmake
@@ -17,9 +17,6 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/ViaHttpLib/ViaHttpLibConfig.
 "find_dependency(Boost 1.51)"
 [[find_dependency(Boost 1.51 COMPONENTS system)]])
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib" 
-                    "${CURRENT_PACKAGES_DIR}/lib"
-                    "${CURRENT_PACKAGES_DIR}/debug"
-                    )
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE_1_0.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/via-httplib" RENAME copyright)

--- a/ports/via-httplib/portfile.cmake
+++ b/ports/via-httplib/portfile.cmake
@@ -1,3 +1,4 @@
+set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kenba/via-httplib

--- a/ports/via-httplib/portfile.cmake
+++ b/ports/via-httplib/portfile.cmake
@@ -11,7 +11,11 @@ vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ViaHttpLib)
+vcpkg_cmake_config_fixup(PACKAGE_NAME ViaHttpLib CONFIG_PATH lib/cmake/ViaHttpLib)
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/ViaHttpLib/ViaHttpLibConfig.cmake"
+"find_dependency(Boost 1.51)"
+[[find_dependency(Boost 1.51 COMPONENTS system)]])
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib" 
                     "${CURRENT_PACKAGES_DIR}/lib"

--- a/ports/via-httplib/portfile.cmake
+++ b/ports/via-httplib/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     HEAD_REF master    
 )
 
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}" )
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
 

--- a/ports/via-httplib/portfile.cmake
+++ b/ports/via-httplib/portfile.cmake
@@ -19,4 +19,4 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/ViaHttpLib/ViaHttpLibConfig.
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE_1_0.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/via-httplib" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE_1_0.txt")

--- a/ports/via-httplib/portfile.cmake
+++ b/ports/via-httplib/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME ViaHttpLib CONFIG_PATH lib/cmake/ViaHttpLi
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/ViaHttpLib/ViaHttpLibConfig.cmake"
 "find_dependency(Boost 1.51)"
-[[find_dependency(Boost 1.51 COMPONENTS system)]])
+[[find_dependency(Boost COMPONENTS system)]])
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 

--- a/ports/via-httplib/portfile.cmake
+++ b/ports/via-httplib/portfile.cmake
@@ -2,8 +2,8 @@ set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kenba/via-httplib
-    REF b1baffa347b5a5a0b02e687ccc6273f26e1f7515 # v1.9.0
-    SHA512 a756c8869f5d17df3bdf8a83995f211b7a23cef6aacf916c9f4fbff365b8a6f4d2499154fc6de2db97de65b2dccbcc4a953aed37da68d8478cf1a9e38ac03d9a
+    REF ${VERSION}
+    SHA512 3a36d251b6dfe9ad40d798761169a70877c6d12a94ea2799670d701a4449e2fe15558bc9f50fa46e17e3f2a53b91eb233254efd5000eeece07890e1a804f301d
     HEAD_REF master    
 )
 

--- a/ports/via-httplib/vcpkg.json
+++ b/ports/via-httplib/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "via-httplib",
+  "version": "1.9.0",
+  "description": "C++ HTTP Library",
+  "homepage": "https://github.com/kenba/via-httplib",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    "boost-asio",
+    "json-spirit",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9288,6 +9288,10 @@
       "baseline": "1.4.0",
       "port-version": 0
     },
+    "via-httplib": {
+      "baseline": "1.9.0",
+      "port-version": 0
+    },
     "vili": {
       "baseline": "1.0.0+20221123",
       "port-version": 1

--- a/versions/v-/via-httplib.json
+++ b/versions/v-/via-httplib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7f479ac7e5bc81e08f4ba794deb1782ffcfaa7d4",
+      "version": "1.9.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/v-/via-httplib.json
+++ b/versions/v-/via-httplib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ed7a5ed7fd3443c2e83c89a4aef18b51fa6379da",
+      "git-tree": "b8d9653408119df7140ccacc79ac7f75caddeea2",
       "version": "1.9.0",
       "port-version": 0
     }

--- a/versions/v-/via-httplib.json
+++ b/versions/v-/via-httplib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7f479ac7e5bc81e08f4ba794deb1782ffcfaa7d4",
+      "git-tree": "ed7a5ed7fd3443c2e83c89a4aef18b51fa6379da",
       "version": "1.9.0",
       "port-version": 0
     }


### PR DESCRIPTION

- [ x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x ] The license declaration in `vcpkg.json` matches what upstream says.
- [x ] The installed as the "copyright" file matches what upstream says.
- [x ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Only one version is in the new port's versions file.
- [ x] Only one version is added to each modified port's versions file.
