### PR TITLE
[perfetto] update to 47.0

### DIFF
--- a/ports/perfetto/portfile.cmake
+++ b/ports/perfetto/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/perfetto
     REF "v${VERSION}"
-    SHA512 eabdf1991411a9323815b7c1f5bb29d7584d33e04f0219baadb11dd1118d3e34788d31ba0d9904a55fc02138b9103bfa0e50ab5994696749157b58669b2952d8
+    SHA512 4aa83f121fdc9c8f8d1bfdb22bfa78a8658352ccef58e0efbfa88dbda5e1bc6bca4a3d2cb45bdc6c91d6cfced0e7df7dce678a034935aa247e0f92bfb6adf2b2
     HEAD_REF main
 )
 

--- a/ports/perfetto/vcpkg.json
+++ b/ports/perfetto/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "perfetto",
-  "version": "46.0",
+  "version": "47.0",
   "description": "System profiling, app tracing and trace analysis",
   "homepage": "https://perfetto.dev",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6845,7 +6845,7 @@
       "port-version": 3
     },
     "perfetto": {
-      "baseline": "46.0",
+      "baseline": "47.0",
       "port-version": 0
     },
     "pffft": {

--- a/versions/p-/perfetto.json
+++ b/versions/p-/perfetto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a21f08b9f5fbf6b716698ed7a1499f61eadca1f3",
+      "version": "47.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "87c775f6546ba2a72c09d2c7b0e439ab5ca8dc33",
       "version": "46.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.