### PR TITLE
[libxml2] Update to 2.11.9

### DIFF
--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/libxml2
     REF "v${VERSION}"
-    SHA512 21f6c0340fab0dc16bfe516493aa7ce96b26abf1719b69862829eaa682d87b7b5ece1d540b7f8c30127becd0691facc278fe1cb50cd2c87320cb6d73b077caf3
+    SHA512 3f2de446657bf3c23c92358ce8946f59253b9fcc09577b59eecaffdbd97e051659855c79f4882ee9f8841dd194b6bd5de2a8017691473b505e905b9dde6a1bc9
     HEAD_REF master
     PATCHES
         disable-docs.patch

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxml2",
-  "version": "2.11.8",
+  "version": "2.11.9",
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5321,7 +5321,7 @@
       "port-version": 2
     },
     "libxml2": {
-      "baseline": "2.11.8",
+      "baseline": "2.11.9",
       "port-version": 0
     },
     "libxmlmm": {

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9adc435281d53b3906a7cc7394dfe340edeb1c51",
+      "version": "2.11.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "acdc173889c739d439e9ded5ee2111cdac6af270",
       "version": "2.11.8",
       "port-version": 0


### PR DESCRIPTION
Fixes [CVE-2024-40896](https://gitlab.gnome.org/GNOME/libxml2/-/issues/761).
Related: https://github.com/microsoft/vcpkg/issues/39444.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


All features passed with following triplets:

```
x64-windows
x64-windows-static
```