### PR TITLE
[tinygltf] update to 2.9.3

### DIFF
--- a/ports/tinygltf/portfile.cmake
+++ b/ports/tinygltf/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO syoyo/tinygltf
     REF "v${VERSION}"
-    SHA512 daee181b4212c7ba96b3e791fc28aa77102555323a2fef167edaee24d6e13ba4c9a844d028a3f2734760a65440face0eb759d034daecd4c0e3b4c4b67dadfd72
+    SHA512 4f4d479a8ad8dd858340b0bfa5af4fdc9073279e59c4240918d5dfce94d2b50b87bc0acad0a2e7659d090dd4aa3b34b456550749fe57bb4f7b58ac2f2b6927aa
     HEAD_REF master
 )
 

--- a/ports/tinygltf/vcpkg.json
+++ b/ports/tinygltf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tinygltf",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "A header only C++11 glTF 2.0 library.",
   "homepage": "https://github.com/syoyo/tinygltf",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8845,7 +8845,7 @@
       "port-version": 0
     },
     "tinygltf": {
-      "baseline": "2.9.2",
+      "baseline": "2.9.3",
       "port-version": 0
     },
     "tinynpy": {

--- a/versions/t-/tinygltf.json
+++ b/versions/t-/tinygltf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "79294fe8043f1405ad2595c7e4847e597951e3b5",
+      "version": "2.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "9735efbd747cfc611ad41fd34e5985a03b61fa30",
       "version": "2.9.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.