### PR TITLE
[vcpkgTools.xml] Add 7zip binary

### DIFF
--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -144,6 +144,19 @@
         <sha512>6b88a761f7cc8b8affc074b24750bcdc65cc3ab18d127c8bfdd1eca953d43e21558eb1137c4b934689990564d7d24cf14e249a773dc1e5ddb7316b10d73682f8</sha512>
         <archiveName>7z2406-extra.7z</archiveName>
      </tool>
+         <tool name="7zr" os="windows">
+        <version>24.07</version>
+        <exeRelativePath>7zr.exe</exeRelativePath>
+        <url>https://github.com/ip7z/7zip/releases/download/24.08/7zr.exe</url>
+        <sha512>424196f2acf5b89807f4038683acc50e7604223fc630245af6bab0e0df923f8b1c49cb09ac709086568c214c3f53dcb7d6c32e8a54af222a3ff78cfab9c51670</sha512>
+    </tool>
+        <tool name="7za" os="windows">
+        <version>24.08</version>
+        <exeRelativePath>7za.exe</exeRelativePath>
+        <url>https://github.com/ip7z/7zip/releases/download/24.08/7z2408-extra.7z</url>
+        <sha512>35f55236fccfb576ca014e29d0c35f4a213e53f06683bd2e82f869ed02506e230c8dd623c01d0207244d6a997031f737903456b7ad4a44db1717f0a17a78602e</sha512>
+        <archiveName>7z2408-extra.7z</archiveName>
+    </tool>
     <tool name="aria2" os="windows">
         <version>1.37.0</version>
         <exeRelativePath>aria2-1.37.0-win-64bit-build1\aria2c.exe</exeRelativePath>

--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -144,18 +144,11 @@
         <sha512>6b88a761f7cc8b8affc074b24750bcdc65cc3ab18d127c8bfdd1eca953d43e21558eb1137c4b934689990564d7d24cf14e249a773dc1e5ddb7316b10d73682f8</sha512>
         <archiveName>7z2406-extra.7z</archiveName>
      </tool>
-         <tool name="7zr" os="windows">
-        <version>24.07</version>
+    <tool name="7zr" os="windows">
+        <version>24.08</version>
         <exeRelativePath>7zr.exe</exeRelativePath>
         <url>https://github.com/ip7z/7zip/releases/download/24.08/7zr.exe</url>
         <sha512>424196f2acf5b89807f4038683acc50e7604223fc630245af6bab0e0df923f8b1c49cb09ac709086568c214c3f53dcb7d6c32e8a54af222a3ff78cfab9c51670</sha512>
-    </tool>
-        <tool name="7za" os="windows">
-        <version>24.08</version>
-        <exeRelativePath>7za.exe</exeRelativePath>
-        <url>https://github.com/ip7z/7zip/releases/download/24.08/7z2408-extra.7z</url>
-        <sha512>35f55236fccfb576ca014e29d0c35f4a213e53f06683bd2e82f869ed02506e230c8dd623c01d0207244d6a997031f737903456b7ad4a44db1717f0a17a78602e</sha512>
-        <archiveName>7z2408-extra.7z</archiveName>
     </tool>
     <tool name="aria2" os="windows">
         <version>1.37.0</version>


### PR DESCRIPTION
This just adds the 7zip binaries to vckpgTools in preparation to use 7zip for all extraction on windows. 