### PR TITLE
[libmidi2] Update to v0.11

### DIFF
--- a/ports/libmidi2/portfile.cmake
+++ b/ports/libmidi2/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO midi2-dev/AM_MIDI2.0Lib
     REF "v${VERSION}"
-    SHA512 ff925aff38adfbeff4bae6c211d18e6a59e97f11d11af7616f3386208d1a0d30e64b60ba74f604d75c8da50f57f320f86a4f09bf292bb587be837bdda91f7110
+    SHA512 bcff7e1360d18f1e5cf5c89eda3cd8c3ff33605063bd12def1ddd6ecede950e8653ff8279f05f4f29a8a8f13c24cf31d3199c09b14db5cf37febb49c4b14ea67
     HEAD_REF main
 )
 

--- a/ports/libmidi2/vcpkg.json
+++ b/ports/libmidi2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmidi2",
-  "version": "0.10",
+  "version": "0.11",
   "description": "General purpose Midi 2 library for bytestream conversions and midi-ci",
   "homepage": "https://github.com/midi2-dev/AM_MIDI2.0Lib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4717,7 +4717,7 @@
       "port-version": 1
     },
     "libmidi2": {
-      "baseline": "0.10",
+      "baseline": "0.11",
       "port-version": 0
     },
     "libmikmod": {

--- a/versions/l-/libmidi2.json
+++ b/versions/l-/libmidi2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d219bec0af1a8ba6c018a3d27c12060001b8246",
+      "version": "0.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "3a8e774a8ec628d02f193004a97f2b6b3b331825",
       "version": "0.10",
       "port-version": 0


### PR DESCRIPTION
- **Updated libmidi2 to v0.11**
- **Updated libmidi2 to v0.11 - part 2**

- [*] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [*] SHA512s are updated for each updated download.
- [*] The "supports" clause reflects platforms that may be fixed by this new version.
- [*] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [*] Any patches that are no longer applied are deleted from the port's directory.
- [*] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [*] Only one version is added to each modified port's versions file.

