### PR TITLE
[restc-cpp] Add C++17 option to fix build error

### DIFF
--- a/ports/restc-cpp/portfile.cmake
+++ b/ports/restc-cpp/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jgaa/restc-cpp
-    REF v0.10.0
+    REF "v${VERSION}"
     SHA512 0f74d825d3958810c270748c2810953fe394d0bf1f147d81b9177803e29a86c702715d5995c5966c4fe671b7689f26d9a0fad4e82d111277bbd3ddce1a68f73a
     HEAD_REF master
     PATCHES
@@ -26,6 +26,7 @@ vcpkg_cmake_configure(
         -DRESTC_CPP_WITH_EXAMPLES=OFF
         -DRESTC_CPP_WITH_UNIT_TESTS=OFF
         -DRESTC_CPP_WITH_FUNCTIONALT_TESTS=OFF
+        -DRESTC_CPP_USE_CPP17=ON
         ${FEATURE_OPTIONS}
 )
 
@@ -37,4 +38,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
                     "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/restc-cpp/vcpkg.json
+++ b/ports/restc-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "restc-cpp",
   "version-semver": "0.10.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Modern C++ REST Client library",
   "homepage": "https://github.com/jgaa/restc-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7798,7 +7798,7 @@
     },
     "restc-cpp": {
       "baseline": "0.10.0",
-      "port-version": 2
+      "port-version": 3
     },
     "restclient-cpp": {
       "baseline": "2022-02-09",

--- a/versions/r-/restc-cpp.json
+++ b/versions/r-/restc-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d19c339247ae8eab33e5141cfe985b86c440dcde",
+      "version-semver": "0.10.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "2e57eacc4df802951e1ae319194becc2bc3e0fb4",
       "version-semver": "0.10.0",
       "port-version": 2


### PR DESCRIPTION
Fixes #40293
When use restc-cpp feature in linux will get this error:
````
./vcpkg install restc-cpp[boost-log] restc-cpp[openssl] restc-cpp[threaded-ctx] restc-cpp[zlib]
````
````
FAILED: CMakeFiles/restc-cpp.dir/src/ConnectionPoolImpl.cpp.o 
/usr/bin/c++ -DBOOST_ATOMIC_NO_LIB -DBOOST_ATOMIC_STATIC_LINK -DBOOST_CHRONO_NO_LIB -DBOOST_CHRONO_STATIC_LINK -DBOOST_CONTAINER_NO_LIB -DBOOST_CONTAINER_STATIC_LINK -DBOOST_CONTEXT_EXPORT="" -DBOOST_CONTEXT_NO_LIB="" -DBOOST_CONTEXT_STATIC_LINK="" -DBOOST_COROUTINE_NO_DEPRECATION_WARNING=1 -DBOOST_COROUTINE_NO_LIB -DBOOST_COROUTINE_STATIC_LINK -DBOOST_DATE_TIME_NO_LIB -DBOOST_DATE_TIME_STATIC_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_FILESYSTEM_STATIC_LINK=1 -DBOOST_LOG_NO_LIB -DBOOST_LOG_STATIC_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_PROGRAM_OPTIONS_STATIC_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_STATIC_LINK -DBOOST_THREAD_USE_LIB -I/home/sagarc/vcpkg/vcpkg/buildtrees/restc-cpp/src/v0.10.0-308bf516f0.clean/include -I/home/sagarc/vcpkg/vcpkg/buildtrees/restc-cpp/x64-linux-dbg/generated-include -I/home/sagarc/vcpkg/vcpkg/installed/x64-linux/share/rapidjson/../../include -I/home/sagarc/vcpkg/vcpkg/installed/x64-linux/include/build -I/home/sagarc/vcpkg/vcpkg/buildtrees/restc-cpp/x64-linux-dbg/include-exports -isystem /home/sagarc/vcpkg/vcpkg/installed/x64-linux/include -fPIC -g -std=gnu++14 -MD -MT CMakeFiles/restc-cpp.dir/src/ConnectionPoolImpl.cpp.o -MF CMakeFiles/restc-cpp.dir/src/ConnectionPoolImpl.cpp.o.d -o CMakeFiles/restc-cpp.dir/src/ConnectionPoolImpl.cpp.o -c /home/sagarc/vcpkg/vcpkg/buildtrees/restc-cpp/src/v0.10.0-308bf516f0.clean/src/ConnectionPoolImpl.cpp
/home/sagarc/vcpkg/vcpkg/buildtrees/restc-cpp/src/v0.10.0-308bf516f0.clean/src/ConnectionPoolImpl.cpp:98:66: error: use of deleted function ‘std::atomic<_Tp>::atomic(const std::atomic<_Tp>&) [with _Tp = std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >]’
   98 |         atomic<timestamp_t> last_used = chrono::steady_clock::now();
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~^~
````
Turn option `RESTC_CPP_USE_CPP17` to `ON` fix this error.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.