### PR TITLE
[tiff] Fix error when looking for lzma

### DIFF
--- a/ports/tiff/fix-lzma.patch
+++ b/ports/tiff/fix-lzma.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/LZMACodec.cmake b/cmake/LZMACodec.cmake
+index c51afe8..fcbca8d 100644
+--- a/cmake/LZMACodec.cmake
++++ b/cmake/LZMACodec.cmake
+@@ -26,7 +26,7 @@
+ 
+ # liblzma2
+ set(LZMA_SUPPORT FALSE)
+-find_package(liblzma)
++find_package(liblzma CONFIG REQUIRED)
+ 
+ option(lzma "use liblzma (required for LZMA2 compression)" ${LIBLZMA_FOUND})
+ if (lzma AND LIBLZMA_FOUND)

--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_gitlab(
     PATCHES
         FindCMath.patch
         requires-lerc.patch
+        fix-lzma.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/tiff/vcpkg.json
+++ b/ports/tiff/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tiff",
   "version": "4.6.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A library that supports the manipulation of TIFF image files",
   "homepage": "https://libtiff.gitlab.io/libtiff/",
   "license": "libtiff",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8790,7 +8790,7 @@
     },
     "tiff": {
       "baseline": "4.6.0",
-      "port-version": 4
+      "port-version": 5
     },
     "tinkerforge": {
       "baseline": "2.1.25",

--- a/versions/t-/tiff.json
+++ b/versions/t-/tiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34dfc4801b8ba3065546fa0c27e7f64bc72000fe",
+      "version": "4.6.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "9aa03ccc8de52590c49943ca462d6f833d0a9118",
       "version": "4.6.0",
       "port-version": 4


### PR DESCRIPTION
To fix an issue in [32398](https://github.com/microsoft/vcpkg/issues/32398).
An error occurred while modifying the link lzma, causing the downstream to be unable to call the lzma function.
When I use the command to install  dcmtk[core,iconv,icu,openssl,png,tiff,tools,xml2,zlib], the following error occurs.
```
/usr/bin/ld: /mnt/openldap/installed/x64-linux/lib/libtiff.a(tif_lzma.c.o): in function `LZMADecode':
tif_lzma.c:(.text+0x8d6): undefined reference to `lzma_code'
/usr/bin/ld: tif_lzma.c:(.text+0x8ec): undefined reference to `lzma_memusage'
/usr/bin/ld: tif_lzma.c:(.text+0x8f9): undefined reference to `lzma_stream_decoder'
/usr/bin/ld: /mnt/openldap/installed/x64-linux/lib/libtiff.a(tif_lzma.c.o): in function `TIFFInitLZMA':
tif_lzma.c:(.text+0xcb9): undefined reference to `lzma_lzma_preset'
collect2: error: ld returned 1 exit status
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplets:

```
x64-windows
x64-linux
```
Usage test pass with following triplet:

```
x64-windows
```