### PR TITLE
[mfx-dispatch] Fix linux build 

### DIFF
--- a/ports/mfx-dispatch/fix-linux.patch
+++ b/ports/mfx-dispatch/fix-linux.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a8a3288..4315b44 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,23 +5,21 @@ project( libmfx )
+ # FIXME Adds support for using system/other install of intel media sdk
+ set(INTELMEDIASDK_PATH "${CMAKE_CURRENT_LIST_DIR}")
+ 
+-set(SOURCES
+-  src/main.cpp
+-  src/mfx_dispatcher.cpp
+-  src/mfx_dispatcher_log.cpp
+-  src/mfx_function_table.cpp
+-)
+-
+ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+   add_definitions(-fPIC)
+   list(APPEND SOURCES
+-    src/mfx_library_iterator_linux.cpp
+-    src/mfx_load_dll_linux.cpp
+-    src/mfx_critical_section_linux.cpp
++    src/mfxloader.cpp
++    src/mfxparser.cpp
+   )
+ endif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+ 
+ if (CMAKE_SYSTEM_NAME MATCHES "Windows")
++  set(SOURCES
++    src/main.cpp
++    src/mfx_dispatcher.cpp
++    src/mfx_dispatcher_log.cpp
++    src/mfx_function_table.cpp
++  )
+   add_definitions(-DWIN32)
+   list(APPEND SOURCES
+     src/mfx_critical_section.cpp

--- a/ports/mfx-dispatch/fix-linux.patch
+++ b/ports/mfx-dispatch/fix-linux.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a8a3288..4315b44 100644
+index a8a3288..aff7320 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -5,23 +5,21 @@ project( libmfx )
+@@ -5,20 +5,28 @@ project( libmfx )
  # FIXME Adds support for using system/other install of intel media sdk
  set(INTELMEDIASDK_PATH "${CMAKE_CURRENT_LIST_DIR}")
  
@@ -11,10 +11,22 @@ index a8a3288..4315b44 100644
 -  src/mfx_dispatcher.cpp
 -  src/mfx_dispatcher_log.cpp
 -  src/mfx_function_table.cpp
--)
--
- if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-   add_definitions(-fPIC)
++add_definitions(
++    -DMINGW_HAS_SECURE_API=1
++    -DMFX_MODULES_DIR=\".\"
++    -DMFX_PLUGINS_CONF_DIR=\".\"
+ )
+ 
+-if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+-  add_definitions(-fPIC)
++if (CMAKE_SYSTEM_NAME MATCHES "Windows")
++  set(SOURCES
++    src/main.cpp
++    src/mfx_dispatcher.cpp
++    src/mfx_dispatcher_log.cpp
++    src/mfx_function_table.cpp
++  )
++else()
    list(APPEND SOURCES
 -    src/mfx_library_iterator_linux.cpp
 -    src/mfx_load_dll_linux.cpp
@@ -22,15 +34,10 @@ index a8a3288..4315b44 100644
 +    src/mfxloader.cpp
 +    src/mfxparser.cpp
    )
++endif()
++
++if (CMAKE_SYSTEM_NAME MATCHES "Linux")
++  add_definitions(-fPIC)
  endif (CMAKE_SYSTEM_NAME MATCHES "Linux")
  
  if (CMAKE_SYSTEM_NAME MATCHES "Windows")
-+  set(SOURCES
-+    src/main.cpp
-+    src/mfx_dispatcher.cpp
-+    src/mfx_dispatcher_log.cpp
-+    src/mfx_function_table.cpp
-+  )
-   add_definitions(-DWIN32)
-   list(APPEND SOURCES
-     src/mfx_critical_section.cpp

--- a/ports/mfx-dispatch/portfile.cmake
+++ b/ports/mfx-dispatch/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
         PATCHES
             fix-unresolved-symbol.patch
             fix-pkgconf.patch
+            fix-linux.patch
 )
 
 set(LIBRARY_TYPE ${VCPKG_LIBRARY_LINKAGE})

--- a/ports/mfx-dispatch/vcpkg.json
+++ b/ports/mfx-dispatch/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "Open source Intel media sdk dispatcher",
   "homepage": "https://github.com/lu-zero/mfx_dispatch",
   "license": "BSD-3-Clause",
-  "supports": "!linux & !uwp & !osx",
+  "supports": "!uwp & !osx",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/mfx-dispatch/vcpkg.json
+++ b/ports/mfx-dispatch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mfx-dispatch",
   "version": "1.35.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Open source Intel media sdk dispatcher",
   "homepage": "https://github.com/lu-zero/mfx_dispatch",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5786,7 +5786,7 @@
     },
     "mfx-dispatch": {
       "baseline": "1.35.1",
-      "port-version": 3
+      "port-version": 4
     },
     "mgnlibs": {
       "baseline": "2019-09-29",

--- a/versions/m-/mfx-dispatch.json
+++ b/versions/m-/mfx-dispatch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8e7b240f08e1d57a4af61fa086345b3532a6df1e",
+      "git-tree": "4723fd61ef9b3c654fe3cc115246d3b6a473bbe6",
       "version": "1.35.1",
       "port-version": 4
     },

--- a/versions/m-/mfx-dispatch.json
+++ b/versions/m-/mfx-dispatch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4723fd61ef9b3c654fe3cc115246d3b6a473bbe6",
+      "git-tree": "ce65c0d9cfa30a1be0d9d6ed9381d754baad2bee",
       "version": "1.35.1",
       "port-version": 4
     },

--- a/versions/m-/mfx-dispatch.json
+++ b/versions/m-/mfx-dispatch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce65c0d9cfa30a1be0d9d6ed9381d754baad2bee",
+      "git-tree": "d5c5af3dc8b932e454e0ba1be81ee83cf860ac00",
       "version": "1.35.1",
       "port-version": 4
     },

--- a/versions/m-/mfx-dispatch.json
+++ b/versions/m-/mfx-dispatch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e7b240f08e1d57a4af61fa086345b3532a6df1e",
+      "version": "1.35.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "4372c27465a70b6b113adc8fb69ea86da3c21a3f",
       "version": "1.35.1",
       "port-version": 3


### PR DESCRIPTION
Fixes #36004. Upstream supports [Linux build](https://github.com/lu-zero/mfx_dispatch?tab=readme-ov-file#linux), but there is a problem with the provided `CMakeLists.txt`, reported issue: https://github.com/lu-zero/mfx_dispatch/issues/101, trying to fix it now.

No feature needs to be tested, the header file is found through the `libmfx.pc` file on `x64-linux`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
