### PR TITLE
[dpdk] Update to 24.07

### DIFF
--- a/ports/dpdk/enable-either-static-or-shared-build.patch
+++ b/ports/dpdk/enable-either-static-or-shared-build.patch
@@ -1,8 +1,8 @@
 diff --git a/config/meson.build b/config/meson.build
-index 7134e80..a77f533 100644
+index 9484987..722e114 100644
 --- a/config/meson.build
 +++ b/config/meson.build
-@@ -57,7 +57,9 @@ eal_pmd_path = join_paths(get_option('prefix'), driver_install_path)
+@@ -94,7 +94,9 @@ eal_pmd_path = join_paths(get_option('prefix'), driver_install_path)
  # driver .so files often depend upon the bus drivers for their connect bus,
  # e.g. ixgbe depends on librte_bus_pci. This means that the bus drivers need
  # to be in the library path, so symlink the drivers from the main lib directory.
@@ -14,10 +14,10 @@ index 7134e80..a77f533 100644
              get_option('libdir'), pmd_subdir_opt)
  elif meson.version().version_compare('>=0.55.0')
 diff --git a/drivers/meson.build b/drivers/meson.build
-index 1d8123b..36ab3c0 100644
+index 66931d4..65ded2e 100644
 --- a/drivers/meson.build
 +++ b/drivers/meson.build
-@@ -180,7 +180,7 @@ foreach subpath:subdirs
+@@ -247,7 +247,7 @@ foreach subpath:subdirs
                  include_directories: includes,
                  dependencies: static_deps,
                  c_args: cflags,
@@ -26,15 +26,16 @@ index 1d8123b..36ab3c0 100644
  
          # now build the shared driver
          version_map = '@0@/@1@/version.map'.format(meson.current_source_dir(), drv_path)
-@@ -220,6 +220,7 @@ foreach subpath:subdirs
-             endif
+@@ -295,7 +295,7 @@ foreach subpath:subdirs
+         else
+             lk_args = ['-Wl,--version-script=' + version_map]
          endif
- 
+-
 +      if get_option('default_library') == 'shared'
          shared_lib = shared_library(lib_name, sources,
                  objects: objs,
                  include_directories: includes,
-@@ -237,9 +238,13 @@ foreach subpath:subdirs
+@@ -313,10 +313,13 @@ foreach subpath:subdirs
          shared_dep = declare_dependency(link_with: shared_lib,
                  include_directories: includes,
                  dependencies: shared_deps)
@@ -42,17 +43,18 @@ index 1d8123b..36ab3c0 100644
          static_dep = declare_dependency(
                  include_directories: includes,
                  dependencies: static_deps)
+-
 +      if get_option('default_library') == 'static'
 +        shared_dep = static_dep
 +      endif
- 
          dpdk_drivers += static_lib
  
+         set_variable('shared_@0@'.format(lib_name), shared_dep)
 diff --git a/lib/meson.build b/lib/meson.build
-index 24adbe4..eef6e93 100644
+index 1622877..8ca5780 100644
 --- a/lib/meson.build
 +++ b/lib/meson.build
-@@ -192,7 +192,7 @@ foreach l:libraries
+@@ -249,7 +249,7 @@ foreach l:libraries
              c_args: cflags,
              dependencies: static_deps,
              include_directories: includes,
@@ -61,7 +63,7 @@ index 24adbe4..eef6e93 100644
      static_dep = declare_dependency(
              include_directories: includes,
              dependencies: static_deps)
-@@ -246,6 +246,7 @@ foreach l:libraries
+@@ -311,6 +311,7 @@ foreach l:libraries
                  output: name + '.sym_chk')
      endif
  
@@ -69,7 +71,7 @@ index 24adbe4..eef6e93 100644
      shared_lib = shared_library(libname,
              sources,
              objects: objs,
-@@ -262,6 +263,9 @@ foreach l:libraries
+@@ -327,6 +328,9 @@ foreach l:libraries
              dependencies: shared_deps)
  
      dpdk_libraries = [shared_lib] + dpdk_libraries

--- a/ports/dpdk/fix-dependencies.patch
+++ b/ports/dpdk/fix-dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/config/meson.build b/config/meson.build
-index 0dde249..64f7d1c 100644
+index 722e114..0eb717b 100644
 --- a/config/meson.build
 +++ b/config/meson.build
-@@ -181,12 +181,10 @@ if meson.is_cross_build() and not meson.get_cross_property('numa', true)
+@@ -234,12 +234,10 @@ if meson.is_cross_build() and not meson.get_cross_property('numa', true)
      find_libnuma = false
  endif
  if find_libnuma
@@ -11,54 +11,31 @@ index 0dde249..64f7d1c 100644
 +    numa_dep = dependency('numa', method: 'pkg-config')
 +    if numa_dep.found()
          dpdk_conf.set10('RTE_HAS_LIBNUMA', true)
-         has_libnuma = 1
+         has_libnuma = true
 -        add_project_link_arguments('-lnuma', language: 'c')
 -        dpdk_extra_ldflags += '-lnuma'
      endif
  endif
  
-@@ -211,8 +209,6 @@ if libarchive.found()
-     # Push libarchive link dependency at the project level to support
-     # statically linking dpdk apps. Details at:
-     # https://inbox.dpdk.org/dev/20210605004024.660267a1@sovereign/
--    add_project_link_arguments('-larchive', language: 'c')
--    dpdk_extra_ldflags += '-larchive'
- endif
- 
- # check for libbsd
 diff --git a/lib/eal/linux/meson.build b/lib/eal/linux/meson.build
-index 65f2ac6..3e023f8 100644
+index e99ebed..672c705 100644
 --- a/lib/eal/linux/meson.build
 +++ b/lib/eal/linux/meson.build
-@@ -23,5 +23,6 @@ sources += files(
+@@ -21,5 +21,6 @@ sources += files(
  
  deps += ['kvargs', 'telemetry']
- if has_libnuma == 1
+ if has_libnuma
 +    ext_deps += numa_dep
      dpdk_conf.set10('RTE_EAL_NUMA_AWARE_HUGEPAGES', true)
  endif
-diff --git a/lib/eal/meson.build b/lib/eal/meson.build
-index 056beb9..04bd3fe 100644
---- a/lib/eal/meson.build
-+++ b/lib/eal/meson.build
-@@ -29,6 +29,9 @@ endif
- if dpdk_conf.has('RTE_USE_LIBBSD')
-     ext_deps += libbsd
- endif
-+if dpdk_conf.has('RTE_HAS_LIBARCHIVE')
-+    ext_deps += libarchive
-+endif
- if cc.has_function('getentropy', prefix : '#include <unistd.h>')
-     cflags += '-DRTE_LIBEAL_USE_GETENTROPY'
- endif
 diff --git a/lib/vhost/meson.build b/lib/vhost/meson.build
-index bc72720..83970c7 100644
+index 41b622a..afff033 100644
 --- a/lib/vhost/meson.build
 +++ b/lib/vhost/meson.build
 @@ -6,6 +6,7 @@ if not is_linux
      reason = 'only supported on Linux'
  endif
- if has_libnuma == 1
+ if has_libnuma
 +    ext_deps += numa_dep
      dpdk_conf.set10('RTE_LIBRTE_VHOST_NUMA', true)
  endif

--- a/ports/dpdk/portfile.cmake
+++ b/ports/dpdk/portfile.cmake
@@ -24,12 +24,11 @@ if(VCPKG_TARGET_IS_LINUX)
   endif()
 endif()
 
-set(PORT_VERSION 22.07)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO DPDK/dpdk
-  REF v${PORT_VERSION}
-  SHA512 86892f5f61ee8f7ccd61c47767515603683d0e7a217389490a9a5d4ac87b42557572113f4cd56425fef212eff5715095a34ed3c03a3ce6351ffdcacb850b0851
+  REF "v${VERSION}"
+  SHA512 1599ae78228307f612776e43160e8002c71024940813bc655b3e2631bfe3de9a93b09f2d5caae48d3d83e07c48e953838ba45f4965d2eb21d1e7955edbaa7d0d
   HEAD_REF main
   PATCHES
       enable-either-static-or-shared-build.patch
@@ -72,9 +71,6 @@ vcpkg_configure_meson(SOURCE_PATH "${SOURCE_PATH}"
 vcpkg_install_meson()
 
 set(tools dpdk-devbind.py dpdk-pmdinfo.py dpdk-telemetry.py dpdk-hugepages.py)
-if("tests" IN_LIST FEATURES)
-  list(APPEND tools dpdk-test)
-endif()
 vcpkg_copy_tools(TOOL_NAMES ${tools} AUTO_CLEAN)
 
 vcpkg_fixup_pkgconfig()

--- a/ports/dpdk/portfile.cmake
+++ b/ports/dpdk/portfile.cmake
@@ -83,4 +83,4 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/share/doc")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/license/README" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license/README")

--- a/ports/dpdk/remove-examples-src-from-datadir.patch
+++ b/ports/dpdk/remove-examples-src-from-datadir.patch
@@ -1,17 +1,15 @@
 diff --git a/meson.build b/meson.build
-index 0541e7f145..00f6e67550 100644
+index 8b248d4..c546c62 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -79,9 +79,9 @@ subdir('doc')
+@@ -90,10 +90,6 @@ subdir('doc')
+
  # build any examples explicitly requested - useful for developers - and
  # install any example code into the appropriate install path
- subdir('examples')
+-subdir('examples')
 -install_subdir('examples',
 -        install_dir: get_option('datadir') + '/dpdk',
 -        exclude_files: ex_file_excludes)
-+# install_subdir('examples',
-+#         install_dir: get_option('datadir') + '/dpdk',
-+#         exclude_files: ex_file_excludes)
 
- # build kernel modules if enabled
- if get_option('enable_kmods')
+ # build kernel modules
+ subdir('kernel')

--- a/ports/dpdk/stop-building-apps.patch
+++ b/ports/dpdk/stop-building-apps.patch
@@ -1,13 +1,13 @@
 diff --git a/app/meson.build b/app/meson.build
-index 93d8c15032..389dc13b99 100644
+index 5b2c80c..d3ec534 100644
 --- a/app/meson.build
 +++ b/app/meson.build
-@@ -27,7 +27,7 @@ if get_option('default_library') == 'static' and not is_windows
- endif
+@@ -52,7 +52,7 @@ endif
 
  foreach app:apps
+     name = app
 -    build = true
 +    build = false
-     name = app
+     reason = '<unknown reason>' # set if build == false to explain
      sources = []
      includes = []

--- a/ports/dpdk/vcpkg.json
+++ b/ports/dpdk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dpdk",
-  "version-string": "22.07",
-  "port-version": 1,
+  "version-string": "24.07",
   "description": "A set of libraries and drivers for fast packet processing",
   "homepage": "https://www.dpdk.org/",
   "documentation": "https://doc.dpdk.org/guides/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2353,8 +2353,8 @@
       "port-version": 1
     },
     "dpdk": {
-      "baseline": "22.07",
-      "port-version": 1
+      "baseline": "24.07",
+      "port-version": 0
     },
     "dpp": {
       "baseline": "10.0.30",

--- a/versions/d-/dpdk.json
+++ b/versions/d-/dpdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a4d23173aedf2ba7b16305a9bb0b110bd8b05026",
+      "version-string": "24.07",
+      "port-version": 0
+    },
+    {
       "git-tree": "7a813d878c38c9649c599c5b9d35572399655fbf",
       "version-string": "22.07",
       "port-version": 1


### PR DESCRIPTION
Fix one of the [32398](https://github.com/microsoft/vcpkg/issues/32398) issues.

Upstream has set the installation of dpdk-test to false, so remove dpdk-test from the copy list of vcpkg_copy_tools.
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplet:

```
x64-linux
```