### PR TITLE
[openscap] Update to 1.4.0

### DIFF
--- a/ports/openscap/fix-build.patch
+++ b/ports/openscap/fix-build.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 72d9aec..8938931 100644
+index e4076b7..dff0a45 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -164,12 +164,19 @@ if (WIN32 AND NOT MINGW)
+@@ -163,13 +163,19 @@ if (WIN32 AND NOT MINGW)
  else()
  	find_package(Threads REQUIRED)
  endif()
@@ -22,13 +22,13 @@ index 72d9aec..8938931 100644
 +else()
 +    find_package(Threads REQUIRED)
 +endif()
-+
+ 
 +# OpenSSL
 +link_libraries(OpenSSL::SSL OpenSSL::Crypto)
- 
  # WITH_CRYPTO
- set(WITH_CRYPTO "gcrypt" CACHE STRING "gcrypt|nss3")
-@@ -475,19 +482,9 @@ message(STATUS "asciidoc: ${ASCIIDOC_EXECUTABLE}")
+ set(WITH_CRYPTO "gcrypt" CACHE STRING "gcrypt|nss")
+ if(${WITH_CRYPTO} STREQUAL "nss")
+@@ -482,19 +488,9 @@ message(STATUS "asciidoc: ${ASCIIDOC_EXECUTABLE}")
  
  # ---------- PATHS
  
@@ -52,10 +52,10 @@ index 72d9aec..8938931 100644
  
  
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index e9339c6..9347087 100644
+index 5d59bf3..d6919d0 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -134,4 +134,8 @@ else()
+@@ -125,4 +125,8 @@ else()
  	set(OPENSCAP_INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR})
  endif()
  
@@ -66,7 +66,7 @@ index e9339c6..9347087 100644
 +  ARCHIVE DESTINATION lib
 +)
 diff --git a/utils/CMakeLists.txt b/utils/CMakeLists.txt
-index 93ce1f2..f500e1d 100644
+index 9347c29..0e16a8d 100644
 --- a/utils/CMakeLists.txt
 +++ b/utils/CMakeLists.txt
 @@ -29,22 +29,15 @@ if(ENABLE_OSCAP_UTIL)
@@ -82,7 +82,7 @@ index 93ce1f2..f500e1d 100644
 -		")
  	else()
 -		set(OSCAP_UTIL_DESTINATION ${CMAKE_INSTALL_BINDIR})
-+		set(OSCAP_UTIL_DESTINATION tools)
++		set(OSCAP_UTIL_DESTINATION bin)
  		# Install the 'oscap' utility
  		install(TARGETS "oscap"
  			DESTINATION ${OSCAP_UTIL_DESTINATION}

--- a/ports/openscap/fix-buildflag-and-install.patch
+++ b/ports/openscap/fix-buildflag-and-install.patch
@@ -1,26 +1,27 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8938931..d111896 100644
+index dff0a45..494512e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -148,9 +148,7 @@ if (APPLE)
+@@ -147,9 +147,7 @@ if (APPLE)
  endif()
  find_package(OpenSSL REQUIRED)
  add_definitions(${XMLSEC_DEFINITIONS})
 -if (WIN32)
- 	add_compile_definitions("XMLSEC_CRYPTO_OPENSSL")
+-       add_compile_definitions("XMLSEC_CRYPTO_OPENSSL")
 -endif()
++add_compile_definitions("XMLSEC_CRYPTO_OPENSSL")
  find_package(BZip2)
- 
+
  # PThread
-@@ -610,11 +608,6 @@ if(NOT WIN32)
- 	if(WITH_SYSTEMD)
- 		if(ENABLE_OSCAP_REMEDIATE_SERVICE)
- 			# systemd service for offline (boot-time) remediation
--			configure_file("oscap-remediate.service.in" "oscap-remediate.service" @ONLY)
--			install(FILES
--				${CMAKE_CURRENT_BINARY_DIR}/oscap-remediate.service
--				DESTINATION ${SYSTEMD_UNITDIR}
--			)
- 		endif()
- 	endif()
+@@ -614,11 +612,6 @@ if(NOT WIN32)
+        if(WITH_SYSTEMD)
+                if(ENABLE_OSCAP_REMEDIATE_SERVICE)
+                        # systemd service for offline (boot-time) remediation
+-                       configure_file("oscap-remediate.service.in" "oscap-remediate.service" @ONLY)
+-                       install(FILES
+-                               ${CMAKE_CURRENT_BINARY_DIR}/oscap-remediate.service
+-                               DESTINATION ${CMAKE_INSTALL_PREFIX}/${SYSTEMD_UNITDIR}
+-                       )
+                endif()
+        endif()
  endif()

--- a/ports/openscap/fix-utils.patch
+++ b/ports/openscap/fix-utils.patch
@@ -1,5 +1,5 @@
 diff --git a/utils/CMakeLists.txt b/utils/CMakeLists.txt
-index f500e1d..ebddcbf 100644
+index 0e16a8d..e2af57e 100644
 --- a/utils/CMakeLists.txt
 +++ b/utils/CMakeLists.txt
 @@ -1,5 +1,5 @@
@@ -9,18 +9,11 @@ index f500e1d..ebddcbf 100644
  )
  
  if(ENABLE_OSCAP_UTIL)
-@@ -24,13 +24,13 @@ if(ENABLE_OSCAP_UTIL)
+@@ -24,7 +24,7 @@ if(ENABLE_OSCAP_UTIL)
  			target_link_libraries(oscap ${GETOPT_LIBRARY})
  		endif()
  		
 -		set(OSCAP_UTIL_DESTINATION ".")
-+		set(OSCAP_UTIL_DESTINATION bin)
- 		# Install the 'oscap' utility
- 		install(TARGETS "oscap"
- 			DESTINATION ${OSCAP_UTIL_DESTINATION}
- 		)
- 	else()
--		set(OSCAP_UTIL_DESTINATION tools)
 +		set(OSCAP_UTIL_DESTINATION bin)
  		# Install the 'oscap' utility
  		install(TARGETS "oscap"

--- a/ports/openscap/portfile.cmake
+++ b/ports/openscap/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenSCAP/openscap
     REF ${VERSION}
-    SHA512 88d095f350cb1b27f30222c809835ad9f182589a4410ea66f6389d9140804a45767b70176bcd52a0ad6b248ccf63153f09e44f93e70b3002d45cc445642a458f 
+    SHA512 10f28593a6776d28020c26fc3ad3f3aa095fdc48fa6261c0b9677c559d3c822a23eb61c02e09a3c11654dc20d8374b5fcc3154bb9d2d34da5985fc737d252a9b
     HEAD_REF dev
     PATCHES
         fix-build.patch
@@ -20,6 +20,13 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         util    ENABLE_OSCAP_UTIL
         python  ENABLE_PYTHON3
 )
+
+if(VCPKG_TARGET_IS_LINUX AND ENABLE_OSCAP_UTIL)
+     message("openscap with util feature requires the following packages via the system package manager:
+  libgcrypt20-dev
+On Ubuntu derivatives:
+  sudo apt install libgcrypt20-dev")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/openscap/vcpkg.json
+++ b/ports/openscap/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openscap",
-  "version": "1.3.7",
-  "port-version": 3,
+  "version": "1.4.0",
   "description": "The oscap program is a command line tool that allows users to load, scan, validate, edit, and export SCAP documents.",
   "homepage": "https://github.com/OpenSCAP/openscap",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6609,8 +6609,8 @@
       "port-version": 15
     },
     "openscap": {
-      "baseline": "1.3.7",
-      "port-version": 3
+      "baseline": "1.4.0",
+      "port-version": 0
     },
     "openslide": {
       "baseline": "3.4.1",

--- a/versions/o-/openscap.json
+++ b/versions/o-/openscap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "854ccfd3c08afae1dbf963c9c18b5cea7c5f4ae5",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "82c5fa2487fc5377950c5ad49bf9a3902cea36fd",
       "version": "1.3.7",
       "port-version": 3


### PR DESCRIPTION
Fix one of the https://github.com/microsoft/vcpkg/issues/32398 issues.
1. Update version to 1.4.0.
2. Fix util feature compilation error.
`/usr/bin/ld: src/libopenscap.so.33.0.0: undefined reference to `crapi_init'`

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplets:

```
x64-windows
x64-linux
```