### PR TITLE
[scintilla] Update version to 5.5.1

### DIFF
--- a/ports/scintilla/portfile.cmake
+++ b/ports/scintilla/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-  URLS "https://www.scintilla.org/scintilla550.zip"
-  FILENAME "scintilla550.zip"
-  SHA512 6e6dac00a6be902e64abdb6687887ef3c956cbeaf0ea5e05ce99af6876b5b57898c3633b38b9f975e6b06d3d4e17c6e6b6d4c51b0982b5e3375422af046830d1
+  URLS "https://www.scintilla.org/scintilla551.zip"
+  FILENAME "scintilla551.zip"
+  SHA512 00a230cbdd6e41925eec71566143f4a0fc8e4a87eddb459e3b547835e0cc1a8773e450112468acddacebbf0d4252c9b7edc9d813804a144d6f090f96441b7e1b
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/scintilla/vcpkg.json
+++ b/ports/scintilla/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "scintilla",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "A free source code editing component for Win32, GTK+, and OS X",
   "homepage": "https://www.scintilla.org/",
   "supports": "!(uwp | linux | osx)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8005,7 +8005,7 @@
       "port-version": 1
     },
     "scintilla": {
-      "baseline": "5.5.0",
+      "baseline": "5.5.1",
       "port-version": 0
     },
     "sciplot": {

--- a/versions/s-/scintilla.json
+++ b/versions/s-/scintilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9879865509d99cf64894e8573f8dcbc4e4dde77d",
+      "version": "5.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9d311c9adf5b021fbc6b5e3b3bcf99e036472f44",
       "version": "5.5.0",
       "port-version": 0


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/40466

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.