### PR TITLE
[vcpkg baseline][lastools] Passing remove form fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -509,9 +509,6 @@ kfr:x64-android=fail
 kfr:x64-uwp=fail
 # needs android-24
 kubazip:arm-neon-android=fail
-lastools:arm-neon-android=fail
-lastools:arm64-android=fail
-lastools:x64-android=fail
 lcm:x64-windows-static=fail
 lcm:x64-windows-static-md=fail
 lcm:arm-neon-android=fail


### PR DESCRIPTION
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=106058&view=results
````
PASSING, REMOVE FROM FAIL LIST: lastools:arm-neon-android
PASSING, REMOVE FROM FAIL LIST: lastools:x64-android
PASSING, REMOVE FROM FAIL LIST: lastools:larm64-android
````
Fixed PR: https://github.com/microsoft/vcpkg/pull/40273

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [ ] ~~Only one version is added to each modified port's versions file.~~
