### PR TITLE
[tvision] update to 2024-05-22

### DIFF
--- a/ports/tvision/portfile.cmake
+++ b/ports/tvision/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO magiblot/tvision
-    REF d1fa783e0fa8685c199563a466cdc221e8d9b85c
+    REF 966226d643cd638fb516b621ac90a31f3ec8d1f6
     HEAD_REF master
-    SHA512 84c7c4f47274fa4976004b2d542e47446f4bb3eca54b4426f19a2de5e381eb78e42d87f12ab00d7d6ceb05d3d32462da2c02dc3e4a7ef06e3f6fcbbe87c30ac1
+    SHA512 b18a466cad2edebff62f6db6d5ab6b6b4d000fbc0fcc682f169efd9c0cc7efe5f0535ffa019f9dcb3d6e7931f77c476ec5d11aa7b39ed7ce0417ceec270f2d36
 )
 
 vcpkg_cmake_configure(

--- a/ports/tvision/vcpkg.json
+++ b/ports/tvision/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tvision",
-  "version-date": "2024-02-28",
+  "version-date": "2024-05-22",
   "description": "A modern port of Turbo Vision 2.0, the classical framework for text-based user interfaces.",
   "homepage": "https://github.com/magiblot/tvision",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9013,7 +9013,7 @@
       "port-version": 3
     },
     "tvision": {
-      "baseline": "2024-02-28",
+      "baseline": "2024-05-22",
       "port-version": 0
     },
     "tweeny": {

--- a/versions/t-/tvision.json
+++ b/versions/t-/tvision.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8cee900fb22152eb04edacae88909ae9e75d8e9e",
+      "version-date": "2024-05-22",
+      "port-version": 0
+    },
+    {
       "git-tree": "da8928e7b75f6ad89f6a86a5ed09077fbc4edb1d",
       "version-date": "2024-02-28",
       "port-version": 0


### PR DESCRIPTION
Update `tvision` to the latest commit 2024-05-22.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
