### PR TITLE
[folly] Update to 2024.08.12.00

### DIFF
--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/folly
     REF "v${VERSION}"
-    SHA512 994723334f1d5e38f9563a97c39377f73149b3ac2e4dd2659d0d275a749431857968c673bfb7be8f63ba3564a5fd62d070c67609e1773d173bd98e1325c3d736
+    SHA512 32633ffdc8f200e4c36c7583b53102400104ac036a0c1c5ab2d6effa19a3cdf2559bb8aac3fecbd816bc4061e9c2572625b4dedfe59225b4395196790230bee2
     HEAD_REF main
     PATCHES
         disable-non-underscore-posix-names.patch

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "folly",
-  "version-string": "2024.08.05.00",
+  "version-string": "2024.08.12.00",
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2817,7 +2817,7 @@
       "port-version": 0
     },
     "folly": {
-      "baseline": "2024.08.05.00",
+      "baseline": "2024.08.12.00",
       "port-version": 0
     },
     "font-chef": {

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c7154490b97a5dd38fdd977ee601bae786a37c6e",
+      "version-string": "2024.08.12.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "e88e067a6f7efebd9599bcfd8ec9b8b2f7b23fba",
       "version-string": "2024.08.05.00",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40490

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplets:

```
x64-windows
x64-linux
```
Usage test pass with following triplet:

```
x64-windows
```