### PR TITLE
[magma] Update to 2.8.0

### DIFF
--- a/ports/magma/portfile.cmake
+++ b/ports/magma/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_download_distfile(
     dist_file
     URLS https://icl.utk.edu/projectsfiles/magma/downloads/magma-${VERSION}.tar.gz
     FILENAME magma-${VERSION}.tar.gz
-    SHA512 7ab52ad09f452f7b997da573f74465d5bc8c83392f724747b131a7015b1445c457defdb59ae7a2fd4930e2cdc5bce3c7b99a069f04db1752a5df36ddc6e84987
+    SHA512 4c2d7c472a69f3b0d491410900db1622478476673e4896dcec26060b839918cdf3cfdfb2680ecbb2042335e8bcc11c44244a82d11e15ba93c489ae5c66d7385a
 )
 
 vcpkg_extract_source_archive(

--- a/ports/magma/vcpkg.json
+++ b/ports/magma/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "magma",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "Matrix Algebra on GPU and Multi-core Architectures (MAGMA) is a collection of next-generation linear algebra libraries for heterogeneous computing",
   "homepage": "https://icl.utk.edu/magma/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5613,7 +5613,7 @@
       "port-version": 3
     },
     "magma": {
-      "baseline": "2.7.2",
+      "baseline": "2.8.0",
       "port-version": 0
     },
     "magnum": {

--- a/versions/m-/magma.json
+++ b/versions/m-/magma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "07a55182c9e5bace6cbaff6e08c77a54fdcdcdbc",
+      "version": "2.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "44b519ef789c70ffb247ac2fc1686038b0616515",
       "version": "2.7.2",
       "port-version": 0


### PR DESCRIPTION
Update `magma` to 2.8.0. No feature needs to be tested. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
