### PR TITLE
[level-zero] added new port

### DIFF
--- a/ports/level-zero/001-patch-install-rules.patch
+++ b/ports/level-zero/001-patch-install-rules.patch
@@ -1,0 +1,116 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 5ef252c..c9d05dd 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -49,21 +49,10 @@ endif()
+ target_link_libraries(${TARGET_LOADER_NAME} utils)
+ 
+ install(TARGETS ze_loader
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+-    LIBRARY
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        COMPONENT level-zero
+-        NAMELINK_SKIP
+-)
+-
+-install(TARGETS ze_loader
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+-    LIBRARY
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        COMPONENT level-zero-devel
+-        NAMELINK_ONLY
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero-devel
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT level-zero
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero
++    NAMELINK_COMPONENT level-zero-devel
+ )
+ 
+ if(UNIX)
+diff --git a/source/drivers/null/CMakeLists.txt b/source/drivers/null/CMakeLists.txt
+index b384434..0cb8801 100644
+--- a/source/drivers/null/CMakeLists.txt
++++ b/source/drivers/null/CMakeLists.txt
+@@ -21,18 +21,10 @@ target_include_directories(${TARGET_NAME}
+ 
+ if(INSTALL_NULL_DRIVER)
+     install(TARGETS ze_null
+-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        LIBRARY
+-            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-            COMPONENT level-zero
+-            NAMELINK_SKIP
+-    )
+-    install(TARGETS ze_null
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    LIBRARY
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        COMPONENT level-zero-devel
+-        NAMELINK_ONLY
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero-devel
++        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT level-zero
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero
++        NAMELINK_COMPONENT level-zero-devel
+     )
+ endif()
+ 
+diff --git a/source/layers/tracing/CMakeLists.txt b/source/layers/tracing/CMakeLists.txt
+index 1dde028..63e0b20 100644
+--- a/source/layers/tracing/CMakeLists.txt
++++ b/source/layers/tracing/CMakeLists.txt
+@@ -49,20 +49,8 @@ set_target_properties(${TARGET_NAME} PROPERTIES
+ )
+ 
+ install(TARGETS ze_tracing_layer
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    LIBRARY
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        COMPONENT level-zero
+-        NAMELINK_SKIP
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero-devel
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT level-zero
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero
++    NAMELINK_COMPONENT level-zero-devel
+ )
+-
+-install(TARGETS ze_tracing_layer
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    LIBRARY
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        COMPONENT level-zero-devel
+-        NAMELINK_ONLY
+-)
+-
+diff --git a/source/layers/validation/CMakeLists.txt b/source/layers/validation/CMakeLists.txt
+index 3a4162c..ced5f21 100644
+--- a/source/layers/validation/CMakeLists.txt
++++ b/source/layers/validation/CMakeLists.txt
+@@ -37,21 +37,10 @@ set_target_properties(${TARGET_NAME} PROPERTIES
+ )
+ 
+ install(TARGETS ze_validation_layer
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    LIBRARY
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        COMPONENT level-zero
+-        NAMELINK_SKIP
+-)
+-
+-install(TARGETS ze_validation_layer
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    LIBRARY
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        COMPONENT level-zero-devel
+-        NAMELINK_ONLY
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero-devel
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT level-zero
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero
++    NAMELINK_COMPONENT level-zero-devel
+ )
+ 
+ add_subdirectory(handle_lifetime_tracking)

--- a/ports/level-zero/portfile.cmake
+++ b/ports/level-zero/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO oneapi-src/level-zero
+    REF "v${VERSION}"
+    SHA512 0498ec279ab73a61ccd4a2c27a8c3837090004e0730c01e92ef6e91f32000ca9e91167b87fbec66668674d86b5dede51470ce4c77dafb58f8b4d982db8b6e490
+    HEAD_REF master
+    PATCHES
+        001-patch-install-rules.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSYSTEM_SPDLOG=ON
+)
+
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/level-zero/vcpkg.json
+++ b/ports/level-zero/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "level-zero",
+  "version": "1.17.28",
+  "description": "oneAPI Level Zero Specification Headers and Loader.",
+  "homepage": "https://github.com/oneapi-src/level-zero",
+  "license": "MIT",
+  "supports": "x64 & !static & (linux | (windows & !uwp))",
+  "dependencies": [
+    "spdlog",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4184,6 +4184,10 @@
       "baseline": "1.35.1",
       "port-version": 3
     },
+    "level-zero": {
+      "baseline": "1.17.28",
+      "port-version": 0
+    },
     "leveldb": {
       "baseline": "1.23",
       "port-version": 0

--- a/versions/l-/level-zero.json
+++ b/versions/l-/level-zero.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ce4627310deb48fe8c5e30d69862c69039c31a98",
+      "version": "1.17.28",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.