### PR TITLE
[vcpkg-ci-curl] Add openssl to curl tests

### DIFF
--- a/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
@@ -32,6 +32,7 @@
       "features": [
         "gsasl",
         "mbedtls",
+        "openssl",
         "psl"
       ],
       "platform": "!uwp"


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~
