### PR TITLE
[CLI11] Force C++17 pre-compilation so that C++17 std::filesystem is available

### DIFF
--- a/ports/cli11/portfile.cmake
+++ b/ports/cli11/portfile.cmake
@@ -15,7 +15,6 @@ vcpkg_cmake_configure(
         -DCLI11_BUILD_DOCS=OFF
         -DCLI11_BUILD_TESTS=OFF
         -DCLI11_PRECOMPILED=ON
-    CMAKE_OPTIONS
         -DCMAKE_CXX_STANDARD=17
 )
 

--- a/ports/cli11/portfile.cmake
+++ b/ports/cli11/portfile.cmake
@@ -15,6 +15,8 @@ vcpkg_cmake_configure(
         -DCLI11_BUILD_DOCS=OFF
         -DCLI11_BUILD_TESTS=OFF
         -DCLI11_PRECOMPILED=ON
+	CMAKE_OPTIONS
+        -DCMAKE_CXX_STANDARD=17
 )
 
 vcpkg_cmake_install()

--- a/ports/cli11/portfile.cmake
+++ b/ports/cli11/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_cmake_configure(
         -DCLI11_BUILD_DOCS=OFF
         -DCLI11_BUILD_TESTS=OFF
         -DCLI11_PRECOMPILED=ON
-	CMAKE_OPTIONS
+    CMAKE_OPTIONS
         -DCMAKE_CXX_STANDARD=17
 )
 

--- a/ports/cli11/vcpkg.json
+++ b/ports/cli11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cli11",
-  "version": "2.4.2.0",
+  "version": "2.4.2.1",
   "description": "CLI11 is a command line parser for C++11 and beyond that provides a rich feature set with a simple and intuitive interface.",
   "homepage": "https://github.com/CLIUtils/CLI11",
   "license": "BSD-3-Clause",

--- a/ports/cli11/vcpkg.json
+++ b/ports/cli11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cli11",
-  "version": "2.4.2",
+  "version": "2.4.2.0",
   "description": "CLI11 is a command line parser for C++11 and beyond that provides a rich feature set with a simple and intuitive interface.",
   "homepage": "https://github.com/CLIUtils/CLI11",
   "license": "BSD-3-Clause",

--- a/ports/cli11/vcpkg.json
+++ b/ports/cli11/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cli11",
-  "version": "2.4.2.1",
+  "version": "2.4.2",
+  "port-version": 1,
   "description": "CLI11 is a command line parser for C++11 and beyond that provides a rich feature set with a simple and intuitive interface.",
   "homepage": "https://github.com/CLIUtils/CLI11",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1685,8 +1685,8 @@
       "port-version": 0
     },
     "cli11": {
-      "baseline": "2.4.2.1",
-      "port-version": 0
+      "baseline": "2.4.2",
+      "port-version": 1
     },
     "clickhouse-cpp": {
       "baseline": "2.5.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1685,7 +1685,7 @@
       "port-version": 0
     },
     "cli11": {
-      "baseline": "2.4.2.0",
+      "baseline": "2.4.2.1",
       "port-version": 0
     },
     "clickhouse-cpp": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1685,7 +1685,7 @@
       "port-version": 0
     },
     "cli11": {
-      "baseline": "2.4.2",
+      "baseline": "2.4.2.0",
       "port-version": 0
     },
     "clickhouse-cpp": {

--- a/versions/c-/cli11.json
+++ b/versions/c-/cli11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "15bf63080e577aa23457de19cb74e7803b2ce6cc",
+      "version": "2.4.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "06ac9dc66d709da4eabe20f952b83b4bb7ae7dda",
       "version": "2.4.2",
       "port-version": 0

--- a/versions/c-/cli11.json
+++ b/versions/c-/cli11.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "2255edf3106cfadbec9a4f570599fc9137aff88d",
-      "version": "2.4.2.1",
-      "port-version": 0
+      "git-tree": "30b823dd320787b99fe0d745bda9952c9b6d4589",
+      "version": "2.4.2",
+      "port-version": 1
     },
     {
       "git-tree": "06ac9dc66d709da4eabe20f952b83b4bb7ae7dda",

--- a/versions/c-/cli11.json
+++ b/versions/c-/cli11.json
@@ -5,6 +5,11 @@
       "version": "2.4.2",
       "port-version": 1
     },
+	{
+      "git-tree": "06ac9dc66d709da4eabe20f952b83b4bb7ae7dda",
+      "version": "2.4.2",
+      "port-version": 0
+    },
     {
       "git-tree": "05a104e144c6cfa16b0a896502ef96f3ccbbdddc",
       "version": "2.4.1",

--- a/versions/c-/cli11.json
+++ b/versions/c-/cli11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2255edf3106cfadbec9a4f570599fc9137aff88d",
+      "version": "2.4.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "15bf63080e577aa23457de19cb74e7803b2ce6cc",
       "version": "2.4.2.0",
       "port-version": 0

--- a/versions/c-/cli11.json
+++ b/versions/c-/cli11.json
@@ -1,14 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "30b823dd320787b99fe0d745bda9952c9b6d4589",
+      "git-tree": "e10d0e0ad642aa55ee6dcf00fac99493f866234a",
       "version": "2.4.2",
       "port-version": 1
-    },
-    {
-      "git-tree": "06ac9dc66d709da4eabe20f952b83b4bb7ae7dda",
-      "version": "2.4.2",
-      "port-version": 0
     },
     {
       "git-tree": "05a104e144c6cfa16b0a896502ef96f3ccbbdddc",

--- a/versions/c-/cli11.json
+++ b/versions/c-/cli11.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e10d0e0ad642aa55ee6dcf00fac99493f866234a",
+      "git-tree": "7d62ebd97719d822cd957182d68c9079256144e1",
       "version": "2.4.2",
       "port-version": 1
     },

--- a/versions/c-/cli11.json
+++ b/versions/c-/cli11.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "15bf63080e577aa23457de19cb74e7803b2ce6cc",
-      "version": "2.4.2.0",
-      "port-version": 0
-    },
-    {
       "git-tree": "06ac9dc66d709da4eabe20f952b83b4bb7ae7dda",
       "version": "2.4.2",
       "port-version": 0

--- a/versions/c-/cli11.json
+++ b/versions/c-/cli11.json
@@ -5,7 +5,7 @@
       "version": "2.4.2",
       "port-version": 1
     },
-	{
+    {
       "git-tree": "06ac9dc66d709da4eabe20f952b83b4bb7ae7dda",
       "version": "2.4.2",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/CLIUtils/CLI11/issues/1065

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.