### PR TITLE
[ableton-link] Update port to version 3.1.2

### DIFF
--- a/ports/ableton-link/portfile.cmake
+++ b/ports/ableton-link/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Ableton/link
     REF "Link-${VERSION}"
-    SHA512 d82529d08897833c3fd6f19eca1689dfbfeac945daa4f1cb5a5719248ba1428875084155761d4de9521d486552e82ea47c71009fa8ef868ed4dca86a561f5c3e
+    SHA512 889aa8cf56df19631a15cc4e245f3b7165a1d08aa199446de3b209c5be58904c11776899e9202900e73cc90ea63d366c6c3b2628657dac96db5a16a5217b3df7
     HEAD_REF master
     PATCHES
         replace_local_asiostandalone_by_vcpkg_asio.patch

--- a/ports/ableton-link/vcpkg.json
+++ b/ports/ableton-link/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ableton-link",
-  "version": "3.1.1",
-  "port-version": 1,
+  "version": "3.1.2",
   "description": "Ableton Link, a technology that synchronizes musical beat, tempo, and phase across multiple applications running on one or more devices.",
   "homepage": "https://www.ableton.com/en/link/",
   "documentation": "http://ableton.github.io/link/",

--- a/versions/a-/ableton-link.json
+++ b/versions/a-/ableton-link.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6b47180236436bf9d91f8f42f011480011283298",
+      "version": "3.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "8eccb8fd47b4f50d9963694746c4dd53a8c6ac22",
       "version": "3.1.1",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -13,8 +13,8 @@
       "port-version": 2
     },
     "ableton-link": {
-      "baseline": "3.1.1",
-      "port-version": 1
+      "baseline": "3.1.2",
+      "port-version": 0
     },
     "abseil": {
       "baseline": "20240722.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

