### PR TITLE
[toml11] update to 4.2.0

### DIFF
--- a/ports/toml11/portfile.cmake
+++ b/ports/toml11/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ToruNiina/toml11
     REF "v${VERSION}"
-    SHA512 1d7d38c32af178e15b007f5c7a69f4789ba8b0c1ee1e2dc6b853fd38d5794944305baff86e97c9b49b28dbeadec6165273a7de16b94c06be9fc5a46d27cbec3e
+    SHA512 acb29d37150e5752526cf0a38ae7f207fcfd142d3c78d280e706ad404b2d32f5bae6d44d6ce13cc0bdfd3b0fa4a0a94cf732d70b1fd2a01c3c517fee8a4ef05b
     HEAD_REF master
 )
 

--- a/ports/toml11/vcpkg.json
+++ b/ports/toml11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "toml11",
-  "version": "4.0.0",
+  "version": "4.2.0",
   "description": "A C++11 header-only toml parser/encoder depending only on C++ standard library.",
   "homepage": "https://github.com/ToruNiina/toml11",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8929,7 +8929,7 @@
       "port-version": 1
     },
     "toml11": {
-      "baseline": "4.0.0",
+      "baseline": "4.2.0",
       "port-version": 0
     },
     "tomlplusplus": {

--- a/versions/t-/toml11.json
+++ b/versions/t-/toml11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d42cf90d8c98a2a3da2c0d3cd94f038b9093eb60",
+      "version": "4.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6d0661e8bc2ab6bc227b81d44fc3323986f271dc",
       "version": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
