### PR TITLE
[tevclient] Add tevclient port

### DIFF
--- a/ports/tevclient/portfile.cmake
+++ b/ports/tevclient/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO westlicht/tevclient
+    REF aae4d33472bcf23a5b66af27dcea7ca299b61976
+    SHA512 e452b6b6cfbe7fc56e0f4794c8a4ecdd5695da2a8ae006ea02fed0a4c5a13a411042e66f6996a7e49b789a5ff86cdfb771cb55ba0a30465649ed1c4f5f7062c4
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+ )
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/tevclient)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tevclient/portfile.cmake
+++ b/ports/tevclient/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO westlicht/tevclient

--- a/ports/tevclient/vcpkg.json
+++ b/ports/tevclient/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "tevclient",
+  "version-date": "2024-08-19",
+  "description": "C++ client library for communicating to the tev image viewer",
+  "homepage": "https://github.com/westlicht/tevclient",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/tevclient/vcpkg.json
+++ b/ports/tevclient/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "tevclient",
-  "version-date": "2024-08-19",
+  "version-date": "2023-12-04",
   "description": "C++ client library for communicating to the tev image viewer",
   "homepage": "https://github.com/westlicht/tevclient",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8736,6 +8736,10 @@
       "baseline": "5.4.1",
       "port-version": 0
     },
+    "tevclient": {
+      "baseline": "2024-08-19",
+      "port-version": 0
+    },
     "tfhe": {
       "baseline": "1.0.1",
       "port-version": 5

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8737,7 +8737,7 @@
       "port-version": 0
     },
     "tevclient": {
-      "baseline": "2024-08-19",
+      "baseline": "2023-12-04",
       "port-version": 0
     },
     "tfhe": {

--- a/versions/t-/tevclient.json
+++ b/versions/t-/tevclient.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d9c21f426c68176962c8c7a04e98ca07437587b1",
+      "version-date": "2024-08-19",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/t-/tevclient.json
+++ b/versions/t-/tevclient.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "d9c21f426c68176962c8c7a04e98ca07437587b1",
-      "version-date": "2024-08-19",
+      "git-tree": "32031dafc991a94d4b1bca9b0ed22649785fa977",
+      "version-date": "2023-12-04",
       "port-version": 0
     }
   ]


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
