### PR TITLE
[microsoft-signalr] Disable WERROR for warning STL4043

### DIFF
--- a/ports/microsoft-signalr/portfile.cmake
+++ b/ports/microsoft-signalr/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_cmake_configure(
         -DBUILD_TESTING=OFF
         ${FEATURE_OPTIONS}
         -DWALL=OFF
+        -DWERROR=OFF
         "-DJSONCPP_LIB=JsonCpp::JsonCpp"
 )
 

--- a/ports/microsoft-signalr/vcpkg.json
+++ b/ports/microsoft-signalr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "microsoft-signalr",
   "version": "0.1.0-alpha4",
-  "port-version": 9,
+  "port-version": 10,
   "description": "C++ Client for ASP.NET Core SignalR.",
   "homepage": "https://github.com/aspnet/SignalR-Client-Cpp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5802,7 +5802,7 @@
     },
     "microsoft-signalr": {
       "baseline": "0.1.0-alpha4",
-      "port-version": 9
+      "port-version": 10
     },
     "mikktspace": {
       "baseline": "2020-10-06",

--- a/versions/m-/microsoft-signalr.json
+++ b/versions/m-/microsoft-signalr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dbcb170bce41778a732fcc2655b82d4d3cb7b06c",
+      "version": "0.1.0-alpha4",
+      "port-version": 10
+    },
+    {
       "git-tree": "25d06a130b123e7bd4dd76bdf2ddcf3af250b86d",
       "version": "0.1.0-alpha4",
       "port-version": 9


### PR DESCRIPTION
Fix #40492, `microsoft-signalr` failed with VS `17.11`:

```log
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\xutility(1281): error C2220: the following warning is treated as an error
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\xutility(1281): warning C4996: 'stdext::checked_array_iterator<char *>': warning STL4043: stdext::checked_array_iterator, stdext::unchecked_array_iterator, and related factory functions are non-Standard extensions and will be removed in the future. std::span (since C++20) and gsl::span can be used instead. You can define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING or _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.
```

Disable CMake option `WERROR` to suppress it.

See:

* https://github.com/microsoft/STL/pull/3818
* https://developercommunity.visualstudio.com/t/Warning-C4996-reference-STL4043-is-causi/10629789

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-windows