### PR TITLE
[small-gicp] Update to version 1.0.0

### DIFF
--- a/ports/small-gicp/portfile.cmake
+++ b/ports/small-gicp/portfile.cmake
@@ -2,14 +2,16 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO koide3/small_gicp
     REF "v${VERSION}"
-    SHA512 78fda568981cdbb37e62b5e6dddae028e515abbfd3cc8ae6f6d57f10b5166eac66a628de12fed124cebcc1243fb6d083cb9b0bf105655a422a6733747313114f
+    SHA512 b4d4b662d74b5492b7b89bcaf022e2d90262eecd3f1b6d3229edefbb00288a95910d486e66a9e884528f6f9c253a5e535ce7f96829fdc760f58ac001f6192790
     HEAD_REF master
+    PATCHES preprocessor_portability.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        pcl   BUILD_WITH_PCL
-        tbb   BUILD_WITH_TBB
+        pcl     BUILD_WITH_PCL
+        tbb     BUILD_WITH_TBB
+        openmp  BUILD_WITH_OPENMP
 )
 
 vcpkg_cmake_configure(

--- a/ports/small-gicp/preprocessor_portability.patch
+++ b/ports/small-gicp/preprocessor_portability.patch
@@ -1,0 +1,13 @@
+diff --git a/include/small_gicp/registration/reduction_omp.hpp b/include/small_gicp/registration/reduction_omp.hpp
+index 8c11267..7edf4a5 100644
+--- a/include/small_gicp/registration/reduction_omp.hpp
++++ b/include/small_gicp/registration/reduction_omp.hpp
+@@ -7,7 +7,7 @@
+ namespace small_gicp {
+ 
+ #ifndef _OPENMP
+-#warning "OpenMP is not available. Parallel reduction will be disabled."
++#pragma message ( "OpenMP is not available. Parallel reduction will be disabled." )
+ inline int omp_get_thread_num() {
+   return 0;
+ }

--- a/ports/small-gicp/vcpkg.json
+++ b/ports/small-gicp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "small-gicp",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "Efficient and parallelized algorithms for point cloud registration",
   "homepage": "https://github.com/koide3/small_gicp",
   "license": "MIT",
@@ -17,6 +17,9 @@
     }
   ],
   "features": {
+    "openmp": {
+      "description": "Enable OpenMP based parallelism."
+    },
     "pcl": {
       "description": "Enable interfacing with PointCloud Library.",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8297,7 +8297,7 @@
       "port-version": 3
     },
     "small-gicp": {
-      "baseline": "0.1.2",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "smf": {

--- a/versions/s-/small-gicp.json
+++ b/versions/s-/small-gicp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "be6468a401b4cf5b170ecb3c0afc71f5a44d3acc",
+      "git-tree": "476016c83550a280e02101c7bd4d5c215c0fba7b",
       "version": "1.0.0",
       "port-version": 0
     },

--- a/versions/s-/small-gicp.json
+++ b/versions/s-/small-gicp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be6468a401b4cf5b170ecb3c0afc71f5a44d3acc",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c7becadc73dd4c8b5a23a12521521ce4b636a4ea",
       "version": "0.1.2",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
