### PR TITLE
[curlcpp] Add curlcpp port

### DIFF
--- a/ports/curlcpp/fix-cmake.patch
+++ b/ports/curlcpp/fix-cmake.patch
@@ -1,66 +1,13 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index f3c6d78..4cd17e9 100644
+index f3c6d78..a457717 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -23,44 +23,23 @@ set(CURLCPP_HEADER_LIST
-   ../include/curl_utility.h
- )
- 
--
--if(NOT BUILD_SHARED_LIBS)
--    add_library(curlcpp
--        curl_easy.cpp
--        curl_header.cpp
--        curl_global.cpp
--        curl_form.cpp
--        curl_multi.cpp
--        curl_share.cpp
--        curl_info.cpp
--        curl_cookie.cpp
--        curl_exception.cpp
--        cookie.cpp
--        cookie_date.cpp
--        cookie_time.cpp
--        cookie_datetime.cpp
--        
--        ${CURLCPP_HEADER_LIST}
--    )
--else()
+@@ -43,7 +43,7 @@ if(NOT BUILD_SHARED_LIBS)
+         ${CURLCPP_HEADER_LIST}
+     )
+ else()
 -    add_library(curlcpp ${BUILD_SHARED_LIBS}
--        curl_easy.cpp
--        curl_header.cpp
--        curl_global.cpp
--        curl_form.cpp
--        curl_multi.cpp
--        curl_share.cpp
--        curl_info.cpp
--        curl_cookie.cpp
--        curl_exception.cpp
--        cookie.cpp
--        cookie_date.cpp
--        cookie_time.cpp
--        cookie_datetime.cpp
--        
--        ${CURLCPP_HEADER_LIST}
--    )
--endif()
-+add_library(curlcpp
-+    curl_easy.cpp
-+    curl_header.cpp
-+    curl_global.cpp
-+    curl_form.cpp
-+    curl_multi.cpp
-+    curl_share.cpp
-+    curl_info.cpp
-+    curl_cookie.cpp
-+    curl_exception.cpp
-+    cookie.cpp
-+    cookie_date.cpp
-+    cookie_time.cpp
-+    cookie_datetime.cpp
-+    
-+    ${CURLCPP_HEADER_LIST}
-+)
- 
- add_library(curlcpp::curlcpp ALIAS curlcpp)
- 
++    add_library(curlcpp SHARED
+         curl_easy.cpp
+         curl_header.cpp
+         curl_global.cpp

--- a/ports/curlcpp/fix-cmake.patch
+++ b/ports/curlcpp/fix-cmake.patch
@@ -1,0 +1,66 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index f3c6d78..4cd17e9 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -23,44 +23,23 @@ set(CURLCPP_HEADER_LIST
+   ../include/curl_utility.h
+ )
+ 
+-
+-if(NOT BUILD_SHARED_LIBS)
+-    add_library(curlcpp
+-        curl_easy.cpp
+-        curl_header.cpp
+-        curl_global.cpp
+-        curl_form.cpp
+-        curl_multi.cpp
+-        curl_share.cpp
+-        curl_info.cpp
+-        curl_cookie.cpp
+-        curl_exception.cpp
+-        cookie.cpp
+-        cookie_date.cpp
+-        cookie_time.cpp
+-        cookie_datetime.cpp
+-        
+-        ${CURLCPP_HEADER_LIST}
+-    )
+-else()
+-    add_library(curlcpp ${BUILD_SHARED_LIBS}
+-        curl_easy.cpp
+-        curl_header.cpp
+-        curl_global.cpp
+-        curl_form.cpp
+-        curl_multi.cpp
+-        curl_share.cpp
+-        curl_info.cpp
+-        curl_cookie.cpp
+-        curl_exception.cpp
+-        cookie.cpp
+-        cookie_date.cpp
+-        cookie_time.cpp
+-        cookie_datetime.cpp
+-        
+-        ${CURLCPP_HEADER_LIST}
+-    )
+-endif()
++add_library(curlcpp
++    curl_easy.cpp
++    curl_header.cpp
++    curl_global.cpp
++    curl_form.cpp
++    curl_multi.cpp
++    curl_share.cpp
++    curl_info.cpp
++    curl_cookie.cpp
++    curl_exception.cpp
++    cookie.cpp
++    cookie_date.cpp
++    cookie_time.cpp
++    cookie_datetime.cpp
++    
++    ${CURLCPP_HEADER_LIST}
++)
+ 
+ add_library(curlcpp::curlcpp ALIAS curlcpp)
+ 

--- a/ports/curlcpp/portfile.cmake
+++ b/ports/curlcpp/portfile.cmake
@@ -1,0 +1,27 @@
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO JosephP91/curlcpp
+    REF "${VERSION}"
+    SHA512 9c84dff893ac4f7a02b6b360d72f9cf65a69ca33bed6c35ceef21cef2f20c1eb36664fdb3e2918a39a88f88bd4104d9d09f5d40168847a3be83135958bd41046
+    HEAD_REF master
+    PATCHES
+        fix-cmake.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT} PACKAGE_NAME "curlcpp")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/curlcpp/vcpkg.json
+++ b/ports/curlcpp/vcpkg.json
@@ -1,18 +1,18 @@
 {
-    "name": "curlcpp",
-    "version": "3.1",
-    "homepage": "https://josephp91.github.io/curlcpp/",
-    "description": "An object oriented C++ wrapper for CURL (libcurl)",
-    "license": "MIT",
-    "dependencies": [
-      {
-        "name" : "vcpkg-cmake",
-        "host" : true
-      },
-      {
-        "name" : "vcpkg-cmake-config",
-        "host" : true
-      },
-      "curl"
-    ]
-  }
+  "name": "curlcpp",
+  "version": "3.1",
+  "description": "An object oriented C++ wrapper for CURL (libcurl)",
+  "homepage": "https://josephp91.github.io/curlcpp/",
+  "license": "MIT",
+  "dependencies": [
+    "curl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/curlcpp/vcpkg.json
+++ b/ports/curlcpp/vcpkg.json
@@ -1,0 +1,18 @@
+{
+    "name": "curlcpp",
+    "version": "3.1",
+    "homepage": "https://josephp91.github.io/curlcpp/",
+    "description": "An object oriented C++ wrapper for CURL (libcurl)",
+    "license": "MIT",
+    "dependencies": [
+      {
+        "name" : "vcpkg-cmake",
+        "host" : true
+      },
+      {
+        "name" : "vcpkg-cmake-config",
+        "host" : true
+      },
+      "curl"
+    ]
+  }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2108,6 +2108,10 @@
       "baseline": "8.9.1",
       "port-version": 1
     },
+    "curlcpp": {
+      "baseline": "3.1",
+      "port-version": 0
+    },
     "curlpp": {
       "baseline": "2018-06-15",
       "port-version": 9

--- a/versions/c-/curlcpp.json
+++ b/versions/c-/curlcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "aa91fce05f4660ecffb6d34b8b8364fa6b876f85",
+      "git-tree": "67b833806d04afb8e34bc6da72c7ba29a11243ac",
       "version": "3.1",
       "port-version": 0
     }

--- a/versions/c-/curlcpp.json
+++ b/versions/c-/curlcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "67b833806d04afb8e34bc6da72c7ba29a11243ac",
+      "git-tree": "c5fc6feed65a45463099e6a395bbd977f07cf15a",
       "version": "3.1",
       "port-version": 0
     }

--- a/versions/c-/curlcpp.json
+++ b/versions/c-/curlcpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "aa91fce05f4660ecffb6d34b8b8364fa6b876f85",
+      "version": "3.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

