### PR TITLE
[ls-qpack] Add new port port

### DIFF
--- a/ports/ls-qpack/portfile.cmake
+++ b/ports/ls-qpack/portfile.cmake
@@ -29,3 +29,5 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/ls-qpack/portfile.cmake
+++ b/ports/ls-qpack/portfile.cmake
@@ -1,0 +1,31 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO litespeedtech/ls-qpack
+    REF "v${VERSION}"
+    SHA512 7677f673b4b23a68ad5e899706f17536777b30d7e91c63d3ea97504a6a2885cf7f431c191ac0581631723151050f914ec31bcb84e2b6e3fcdf4140cde0a18063
+    HEAD_REF master
+    PATCHES
+        xxhash.patch
+)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+        -DLSQPACK_TESTS=OFF
+        -DLSQPACK_BIN=OFF
+        -DLSQPACK_XXH=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ls-qpack/usage
+++ b/ports/ls-qpack/usage
@@ -1,0 +1,7 @@
+The package ls-qpack can be used via CMake:
+
+    find_path(LSQPACK_INCLUDE_DIRS "lsqpack.h")
+    find_library(LSQPACK_LIBRARY ls-qpack REQUIRED)
+
+    target_include_directories(main PRIVATE ${LSQPACK_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE ${LSQPACK_LIBRARY})

--- a/ports/ls-qpack/vcpkg.json
+++ b/ports/ls-qpack/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "ls-qpack",
+  "version": "2.5.4",
+  "description": "QPACK compression library for use with HTTP/3",
+  "homepage": "https://github.com/litespeedtech/ls-qpack",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    "xxhash"
+  ]
+}

--- a/ports/ls-qpack/xxhash.patch
+++ b/ports/ls-qpack/xxhash.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1a1f8e9..949d7f1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,9 +20,14 @@ add_library(ls-qpack "")
+ target_include_directories(ls-qpack PUBLIC .)
+ target_sources(ls-qpack PRIVATE lsqpack.c)
+ 
+-target_include_directories(ls-qpack PRIVATE deps/xxhash/)
++# target_include_directories(ls-qpack PRIVATE deps/xxhash/)
+ if(LSQPACK_XXH)
+     target_sources(ls-qpack PRIVATE deps/xxhash/xxhash.c)
++else()
++    find_package(PkgConfig REQUIRED)
++    pkg_check_modules(XXH REQUIRED IMPORTED_TARGET libxxhash)
++    target_link_libraries(ls-qpack PUBLIC PkgConfig::XXH)
++    set(LSQPACK_DEPENDS "libxxhash")
+ endif()
+ 
+ if(WIN32)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5500,6 +5500,10 @@
       "baseline": "1.1.0",
       "port-version": 1
     },
+    "ls-qpack": {
+      "baseline": "2.5.4",
+      "port-version": 0
+    },
     "ltla-aarand": {
       "baseline": "2023-03-19",
       "port-version": 0

--- a/versions/l-/ls-qpack.json
+++ b/versions/l-/ls-qpack.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fbe06fc07f0636585f225b298d91842aeae568ac",
+      "git-tree": "6b05f64e6b3116005c25b7b9b585e8770abcdae7",
       "version": "2.5.4",
       "port-version": 0
     }

--- a/versions/l-/ls-qpack.json
+++ b/versions/l-/ls-qpack.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fbe06fc07f0636585f225b298d91842aeae568ac",
+      "version": "2.5.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.