### PR TITLE
[freetype] Get source from gitlab

### DIFF
--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -2,12 +2,15 @@ if("subpixel-rendering" IN_LIST FEATURES)
     set(SUBPIXEL_RENDERING_PATCH "subpixel-rendering.patch")
 endif()
 
-vcpkg_from_sourceforge(
+string(REPLACE "." "-" VERSION_HYPHEN "${VERSION}")
+
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.freedesktop.org/
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO freetype/freetype2
-    REF "${VERSION}"
-    FILENAME freetype-${VERSION}.tar.xz
-    SHA512 a5917edaa45cb9f75786f8a4f9d12fdf07529247e09dfdb6c0cf7feb08f7588bb24f7b5b11425fb47f8fd62fcb426e731c944658f6d5a59ce4458ad5b0a50194
+    REPO freetype/freetype
+    REF "VER-${VERSION_HYPHEN}"
+    SHA512  9d7600af7e981227e37585dca71fbd7bc78b367a54d7705fe03e0f5549ce49e420548fa09b21c6bb137830f779a0a0b965611f50b163297b79fdc5903b4dc11d
+    HEAD_REF master
     PATCHES
         0003-Fix-UWP.patch
         brotli-static.patch

--- a/ports/freetype/vcpkg.json
+++ b/ports/freetype/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "freetype",
   "version": "2.13.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library to render fonts.",
   "homepage": "https://www.freetype.org/",
   "license": "FTL OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2878,7 +2878,7 @@
     },
     "freetype": {
       "baseline": "2.13.2",
-      "port-version": 1
+      "port-version": 2
     },
     "freetype-gl": {
       "baseline": "2022-01-17",

--- a/versions/f-/freetype.json
+++ b/versions/f-/freetype.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54cf8ab9e35b7a17045ef0d39caca8836501dc60",
+      "version": "2.13.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "60a5a2596ec865db746a7ea741458322cf0cc2bc",
       "version": "2.13.2",
       "port-version": 1


### PR DESCRIPTION
Fix #40560

Download source code from the official git repositories.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-windows