### PR TITLE
[vtk] Fix vtk[mpi]

### DIFF
--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.3.0-pv5.12.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": "BSD-3-Clause",
@@ -184,6 +184,7 @@
           "name": "vtk",
           "default-features": false,
           "features": [
+            "seacas",
             "vtkm"
           ]
         },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9346,7 +9346,7 @@
     },
     "vtk": {
       "baseline": "9.3.0-pv5.12.1",
-      "port-version": 4
+      "port-version": 5
     },
     "vtk-dicom": {
       "baseline": "0.8.14",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99581eb538d39550007d25865540db2a368e3edb",
+      "version-semver": "9.3.0-pv5.12.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "f66a99e8c041f8e084d2871c3cc1d48146ca90f0",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 4


### PR DESCRIPTION
Fixes #40523 

During #40279 I overlooked `vtk[mpi]` and its dependency on seacas. Without this patch VTK was looking for netCDF which is disabled unless `vtk[netcdf]` is selected. 

Issue was resolved by adding a dependency to `vtk[seacas]` due to the feature (`vtk[mpi]`) already requiring `seacas[mpi]`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
