### PR TITLE
[google-cloud-cpp] fix bigquerycontrol feature

### DIFF
--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "2.28.0",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -256,6 +257,19 @@
           "default-features": false,
           "features": [
             "grpc-common"
+          ]
+        }
+      ]
+    },
+    "bigquerycontrol": {
+      "description": "Cloud BigQuery Control API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common",
+            "rest-common"
           ]
         }
       ]
@@ -705,19 +719,6 @@
           "default-features": false,
           "features": [
             "grpc-common"
-          ]
-        }
-      ]
-    },
-    "experimental-bigquerycontrol": {
-      "description": "Cloud BigQuery Control API C++ Client Library",
-      "dependencies": [
-        {
-          "name": "google-cloud-cpp",
-          "default-features": false,
-          "features": [
-            "grpc-common",
-            "rest-common"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3166,7 +3166,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "2.28.0",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b77ae60bffb897a84f15bcf11923eb3d1ef2f04",
+      "version": "2.28.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b6a996f7fdaeca872d6c37ecbd0a2cfe2aa0ee16",
       "version": "2.28.0",
       "port-version": 0


### PR DESCRIPTION
Fix the name of this feature. I do not consider this a breaking change because the `experimental-bigquerycontrol` feature did not install anything to begin with.

Tested on x64 linux with:

```sh
$ ./vcpkg install "google-cloud-cpp[core,bigquerycontrol]"

  find_package(google_cloud_cpp_bigquerycontrol CONFIG REQUIRED)
  target_link_libraries(main PRIVATE google-cloud-cpp::bigquery_v2_protos google-cloud-cpp::experimental-bigquerycontrol)
```

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.