### PR TITLE
[libi2c] Add libi2c port to vcpkg

### DIFF
--- a/ports/libi2c/portfile.cmake
+++ b/ports/libi2c/portfile.cmake
@@ -1,0 +1,52 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO busytester/libi2c
+    REF bbd8c785b2729681a8b8e81af904a80da3e5aa9b
+    SHA512 d3dcd7a1f0d3d3a33263901e98a614984a8e2ddbc0df37db12dc6d94cadd7434ca103be9a93cb68233361097daf1c7ac4912da6b26ec21ebdf92a706ee684492
+)
+
+vcpkg_execute_required_process(
+    COMMAND make libi2cio.so
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME build-${TARGET_TRIPLET}
+)
+
+message(STATUS "Contents of ${SOURCE_PATH}:")
+file(GLOB SOURCE_FILES "${SOURCE_PATH}/*")
+foreach(FILE ${SOURCE_FILES})
+    message(STATUS "${FILE}")
+endforeach()
+
+message(STATUS "Contents of ${SOURCE_PATH}/Makefile:")
+file(READ "${SOURCE_PATH}/Makefile" MAKEFILE_CONTENTS)
+message(STATUS "${MAKEFILE_CONTENTS}")
+
+# Debug: Print contents of BUILD_DIR after build
+message(STATUS "Contents of ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel:")
+file(GLOB_RECURSE BUILD_FILES "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/*")
+foreach(FILE ${BUILD_FILES})
+    message(STATUS "${FILE}")
+endforeach()
+
+# Debug: Print contents of BUILD_DIR after build
+message(STATUS "Contents of ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel after build:")
+file(GLOB_RECURSE BUILD_FILES "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/*")
+foreach(FILE ${BUILD_FILES})
+    message(STATUS "${FILE}")
+endforeach()
+
+# Install
+if(EXISTS "${SOURCE_PATH}/libi2cio.so")
+    file(INSTALL "${SOURCE_PATH}/libi2cio.so" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(INSTALL "${SOURCE_PATH}/libi2cio.so" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+else()
+    message(FATAL_ERROR "libi2cio.so not found in ${SOURCE_PATH}")
+endif()
+
+if(EXISTS "${SOURCE_PATH}/i2c-io.h")
+    file(INSTALL "${SOURCE_PATH}/i2c-io.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+else()
+    message(FATAL_ERROR "i2c-io.h not found in ${SOURCE_PATH}")
+endif()
+
+vcpkg_copy_pdbs()

--- a/ports/libi2c/vcpkg.json
+++ b/ports/libi2c/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libi2c",
+  "version": "2023-06-13",
+  "description": "A library for I2C communication",
+  "homepage": "https://github.com/busytester/libi2c",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
