### PR TITLE
[msh3] New port

### DIFF
--- a/ports/msh3/dependencies_fix.patch
+++ b/ports/msh3/dependencies_fix.patch
@@ -1,0 +1,64 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4bd7155..b7adecc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -72,7 +72,7 @@ target_include_directories(msh3_headers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+ option(LSQPACK_TESTS "Build tests" OFF)
+ option(LSQPACK_BIN "Build binaries" OFF)
+-add_subdirectory(ls-qpack)
++find_package(unofficial-ls-qpack CONFIG REQUIRED)
+ 
+ # Configure and build msquic dependency.
+ if (WIN32)
+@@ -83,8 +83,9 @@ endif()
+ set(QUIC_BUILD_SHARED ON CACHE BOOL "Builds MsQuic as a dynamic library")
+ set(QUIC_ENABLE_LOGGING ON CACHE BOOL "Enable MsQuic logging")
+ set(CMAKE_BUILD_TYPE "Release")
+-add_subdirectory(msquic)
+-target_compile_features(inc INTERFACE cxx_std_20)
++find_package(msquic CONFIG REQUIRED)
++
++target_compile_features(msh3_headers INTERFACE cxx_std_20)
+ 
+ # Build msh3 library (and cmd line tool).
+ add_subdirectory(lib)
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index ab7fc24..c488486 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -7,10 +7,7 @@ else()
+     set(SOURCES msh3.cpp)
+ endif()
+ add_library(msh3 SHARED ${SOURCES})
+-target_link_libraries(msh3 PRIVATE inc warnings msquic ls-qpack msh3_headers)
+-if (NOT BUILD_SHARED_LIBS)
+-    target_link_libraries(msh3 PRIVATE base_link)
+-endif()
++target_link_libraries(msh3 PRIVATE msquic unofficial::ls-qpack::ls-qpack msh3_headers)
+ if (MSH3_SERVER_SUPPORT)
+     target_link_libraries(msh3 PRIVATE platform) # For selfsign APIs
+ endif()
+@@ -26,7 +23,11 @@ elseif (CX_PLATFORM STREQUAL "darwin")
+         PROPERTIES LINK_FLAGS "-exported_symbols_list \"${CMAKE_CURRENT_SOURCE_DIR}/darwin/exports.txt\"")
+ endif()
+ 
+-install(TARGETS msh3 EXPORT msh3 DESTINATION lib)
++install(TARGETS msh3 EXPORT msh3
++    RUNTIME DESTINATION bin
++    ARCHIVE DESTINATION lib
++    LIBRARY DESTINATION lib
++)
+ install(FILES ../msh3.h DESTINATION include)
+ configure_file(msh3-config.cmake.in ${CMAKE_BINARY_DIR}/msh3-config.cmake)
+ install(FILES ${CMAKE_BINARY_DIR}/msh3-config.cmake DESTINATION share/msh3)
+diff --git a/lib/msh3-config.cmake.in b/lib/msh3-config.cmake.in
+index b4a54bf..a6a0fd2 100644
+--- a/lib/msh3-config.cmake.in
++++ b/lib/msh3-config.cmake.in
+@@ -1,4 +1,4 @@
+ include(CMakeFindDependencyMacro)
+ @FILENAME_DEP_REPLACE@
+ 
+-include(${SELF_DIR}/msh3.cmake)
++include(${CMAKE_INSTALL_PREFIX}/share/msh3/msh3.cmake)

--- a/ports/msh3/portfile.cmake
+++ b/ports/msh3/portfile.cmake
@@ -1,0 +1,27 @@
+set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nibanks/msh3
+    REF v${VERSION}
+    SHA512 e6ba4e8f4ce5cd3f586d61739148bf75dfddbe70f399b2e498e7d416c8d730a5f8c2c38f0eabe687049bb7525df44f5f511515ec578bc3832989f73961cdda72
+    HEAD_REF main
+    PATCHES
+        dependencies_fix.patch
+)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/msh3/vcpkg.json
+++ b/ports/msh3/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "msh3",
+  "version": "0.6.0",
+  "description": "Minimal HTTP/3 library",
+  "homepage": "https://github.com/nibanks/msh3",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    "ls-qpack",
+    "msquic",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/msquic/all_headers.patch
+++ b/ports/msquic/all_headers.patch
@@ -1,0 +1,13 @@
+diff --git a/src/bin/CMakeLists.txt b/src/bin/CMakeLists.txt
+index d0592a320..07df9daf7 100644
+--- a/src/bin/CMakeLists.txt
++++ b/src/bin/CMakeLists.txt
+@@ -269,6 +269,8 @@ set(PUBLIC_HEADERS
+     ../inc/msquic_posix.h
+     ../inc/quic_sal_stub.h)
+ 
++file(GLOB PUBLIC_HEADERS "../inc/*.h" "../inc/*.hpp")
++
+ install(TARGETS msquic EXPORT msquic
+     RUNTIME DESTINATION bin
+     ARCHIVE DESTINATION lib

--- a/ports/msquic/portfile.cmake
+++ b/ports/msquic/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         fix-install.patch # Adjust install path of build outputs
         fix-uwp-crt.patch # https://github.com/microsoft/msquic/pull/4373
         fix-comparing-system-processor-with-win32.patch # https://github.com/microsoft/msquic/pull/4374
+        all_headers.patch
 )
 
 # This avoids a link error on x86-windows:

--- a/ports/msquic/vcpkg.json
+++ b/ports/msquic/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "msquic",
   "version": "2.3.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Cross-platform, C implementation of the IETF QUIC protocol",
   "homepage": "https://github.com/microsoft/msquic",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6040,6 +6040,10 @@
       "baseline": "0.0.10",
       "port-version": 4
     },
+    "msh3": {
+      "baseline": "0.6.0",
+      "port-version": 0
+    },
     "msinttypes": {
       "baseline": "2018-02-25",
       "port-version": 2
@@ -6054,7 +6058,7 @@
     },
     "msquic": {
       "baseline": "2.3.5",
-      "port-version": 1
+      "port-version": 2
     },
     "mstch": {
       "baseline": "1.0.2",

--- a/versions/m-/msh3.json
+++ b/versions/m-/msh3.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1621424c690e4de0daaac921e92fc0c06ace9677",
+      "version": "0.6.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/m-/msquic.json
+++ b/versions/m-/msquic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "637f7184ab6b84691b2ac5ff61186b53b13a9660",
+      "version": "2.3.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "85ab1ddebbe0f051950212c6dc07ea3ad96cb271",
       "version": "2.3.5",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

