### PR TITLE
[vulkan-*] Fix dependency versions

### DIFF
--- a/ports/lunarg-vulkantools/vcpkg.json
+++ b/ports/lunarg-vulkantools/vcpkg.json
@@ -1,14 +1,21 @@
 {
   "name": "lunarg-vulkantools",
   "version": "1.3.290.0",
+  "port-version": 1,
   "description": "Tools to aid in Vulkan development",
   "homepage": "https://github.com/LunarG/VulkanTools",
   "license": null,
   "supports": "!osx & !staticcrt",
   "dependencies": [
-    "jsoncpp",
+    {
+      "name": "jsoncpp",
+      "version>=": "1.9.5"
+    },
     "qt5-base",
-    "valijson",
+    {
+      "name": "valijson",
+      "version>=": "1.0.1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -21,7 +28,13 @@
       "name": "vcpkg-get-python-packages",
       "host": true
     },
-    "vulkan-loader",
-    "vulkan-utility-libraries"
+    {
+      "name": "vulkan-loader",
+      "version>=": "1.3.290.0#1"
+    },
+    {
+      "name": "vulkan-utility-libraries",
+      "version>=": "1.3.290.0#1"
+    }
   ]
 }

--- a/ports/spirv-cross/vcpkg.json
+++ b/ports/spirv-cross/vcpkg.json
@@ -1,10 +1,14 @@
 {
   "name": "spirv-cross",
   "version": "1.3.290.0",
+  "port-version": 1,
   "description": "SPIRV-Cross is a practical tool and library for performing reflection on SPIR-V and disassembling SPIR-V back to high level languages.",
   "homepage": "https://github.com/KhronosGroup/SPIRV-Cross",
   "dependencies": [
-    "spirv-headers",
+    {
+      "name": "spirv-headers",
+      "version>=": "1.3.290.0"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/spirv-tools/vcpkg.json
+++ b/ports/spirv-tools/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "spirv-tools",
   "version": "1.3.290.0",
+  "port-version": 1,
   "description": "API and commands for processing SPIR-V modules",
   "homepage": "https://github.com/KhronosGroup/SPIRV-Tools",
   "license": "Apache-2.0",
   "dependencies": [
-    "spirv-headers",
+    {
+      "name": "spirv-headers",
+      "version>=": "1.3.290.0"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/vulkan-loader/vcpkg.json
+++ b/ports/vulkan-loader/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vulkan-loader",
   "version": "1.3.290.0",
+  "port-version": 1,
   "description": "Vulkan Development Tools",
   "homepage": "https://github.com/KhronosGroup/Vulkan-Loader",
   "license": null,
@@ -14,6 +15,9 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "vulkan-headers"
+    {
+      "name": "vulkan-headers",
+      "version>=": "1.3.290.0"
+    }
   ]
 }

--- a/ports/vulkan-tools/vcpkg.json
+++ b/ports/vulkan-tools/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vulkan-tools",
   "version": "1.3.290.0",
+  "port-version": 1,
   "description": "Vulkan Development Tools",
   "homepage": "https://github.com/KhronosGroup/Vulkan-Tools",
   "license": "Apache-2.0",
@@ -14,7 +15,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "volk",
-    "vulkan-headers"
+    {
+      "name": "volk",
+      "version>=": "1.3.290.0"
+    },
+    {
+      "name": "vulkan-headers",
+      "version>=": "1.3.290.0"
+    }
   ]
 }

--- a/ports/vulkan-utility-libraries/vcpkg.json
+++ b/ports/vulkan-utility-libraries/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vulkan-utility-libraries",
   "version": "1.3.290.0",
+  "port-version": 1,
   "description": "Utility libraries for Vulkan developers",
   "homepage": "https://github.com/KhronosGroup/Vulkan-Utility-Libraries",
   "license": null,
@@ -13,6 +14,9 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "vulkan-headers"
+    {
+      "name": "vulkan-headers",
+      "version>=": "1.3.290.0"
+    }
   ]
 }

--- a/ports/vulkan-validationlayers/vcpkg.json
+++ b/ports/vulkan-validationlayers/vcpkg.json
@@ -1,16 +1,35 @@
 {
   "name": "vulkan-validationlayers",
   "version": "1.3.290.0",
+  "port-version": 1,
   "description": "Vulkan Validation Layers (VVL)",
   "homepage": "https://github.com/KhronosGroup/Vulkan-ValidationLayers",
   "license": null,
   "dependencies": [
-    "mimalloc",
-    "robin-hood-hashing",
-    "spirv-cross",
-    "spirv-headers",
-    "spirv-reflect",
-    "spirv-tools",
+    {
+      "name": "mimalloc",
+      "version>=": "2.1.2"
+    },
+    {
+      "name": "robin-hood-hashing",
+      "version>=": "3.11.5"
+    },
+    {
+      "name": "spirv-cross",
+      "version>=": "1.3.290.0#1"
+    },
+    {
+      "name": "spirv-headers",
+      "version>=": "1.3.290.0"
+    },
+    {
+      "name": "spirv-reflect",
+      "version>=": "1.3.290.0"
+    },
+    {
+      "name": "spirv-tools",
+      "version>=": "1.3.290.0#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -19,7 +38,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "vulkan-headers",
-    "vulkan-utility-libraries"
+    {
+      "name": "vulkan-headers",
+      "version>=": "1.3.290.0"
+    },
+    {
+      "name": "vulkan-utility-libraries",
+      "version>=": "1.3.290.0#1"
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5574,7 +5574,7 @@
     },
     "lunarg-vulkantools": {
       "baseline": "1.3.290.0",
-      "port-version": 0
+      "port-version": 1
     },
     "lunasvg": {
       "baseline": "2.4.0",
@@ -8478,7 +8478,7 @@
     },
     "spirv-cross": {
       "baseline": "1.3.290.0",
-      "port-version": 0
+      "port-version": 1
     },
     "spirv-headers": {
       "baseline": "1.3.290.0",
@@ -8490,7 +8490,7 @@
     },
     "spirv-tools": {
       "baseline": "1.3.290.0",
-      "port-version": 0
+      "port-version": 1
     },
     "spout2": {
       "baseline": "2.007.010",
@@ -9394,7 +9394,7 @@
     },
     "vulkan-loader": {
       "baseline": "1.3.290.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vulkan-memory-allocator": {
       "baseline": "3.1.0",
@@ -9410,15 +9410,15 @@
     },
     "vulkan-tools": {
       "baseline": "1.3.290.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vulkan-utility-libraries": {
       "baseline": "1.3.290.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vulkan-validationlayers": {
       "baseline": "1.3.290.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vvenc": {
       "baseline": "1.7.0",

--- a/versions/l-/lunarg-vulkantools.json
+++ b/versions/l-/lunarg-vulkantools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29b5f320c6c9dba88cf0d220c7920b9ba6816cd1",
+      "version": "1.3.290.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "240a486e9ff90eb839c20595efb197234f2cee57",
       "version": "1.3.290.0",
       "port-version": 0

--- a/versions/s-/spirv-cross.json
+++ b/versions/s-/spirv-cross.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4174b6820f1c6ccc468eaf886195facd2ee7e05a",
+      "version": "1.3.290.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "915b615224c502d1efa827d287af5a5ae58081ad",
       "version": "1.3.290.0",
       "port-version": 0

--- a/versions/s-/spirv-tools.json
+++ b/versions/s-/spirv-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "668b4bf235a9d1c73910214e4289c620c69796e1",
+      "version": "1.3.290.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2d453d5afb41ffadc2625644c74b4423e2991e6b",
       "version": "1.3.290.0",
       "port-version": 0

--- a/versions/v-/vulkan-loader.json
+++ b/versions/v-/vulkan-loader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fdb744cd17647fd344404d484de0b41253325ff4",
+      "version": "1.3.290.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "587eccab043d27e654b2d48091677f08fb099233",
       "version": "1.3.290.0",
       "port-version": 0

--- a/versions/v-/vulkan-tools.json
+++ b/versions/v-/vulkan-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40e8a6f92182830b1b63bad30fe4f77a435576f5",
+      "version": "1.3.290.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bc9bba0720b8490ec2da60a3c2ae63716442d428",
       "version": "1.3.290.0",
       "port-version": 0

--- a/versions/v-/vulkan-utility-libraries.json
+++ b/versions/v-/vulkan-utility-libraries.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "231f29758d26c1fa60f421a83bdcc64cc3f4183c",
+      "version": "1.3.290.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c53a45159266fe31815e92e69b95d1a9cc479321",
       "version": "1.3.290.0",
       "port-version": 0

--- a/versions/v-/vulkan-validationlayers.json
+++ b/versions/v-/vulkan-validationlayers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "db26fe2d93c3858e4d202f7036b0864cbadf55c8",
+      "version": "1.3.290.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "08ea5f84250843428fab203e3f3bc59bc1502aec",
       "version": "1.3.290.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #40603

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Similarly to Boost's multiple ports, Vulkan-related ports require that their version stay in sync (this represents the multiple "1.3.290.0" version contraints).
I believe this part complies with the [Version constraints in ports](https://github.com/microsoft/vcpkg-docs/blob/f79f9ac5e4508c646206901d446be0d7b804789c/vcpkg/contributing/maintainer-guide.md#version-constraints-in-ports) chapter maintener guide.

I also added constraints for a few third-party dependencies (`jsoncpp`, `valijson`, etc.) because each of the vulkan repos have a `scripts/known_good.json` file that list these required dependencies and their version.
The last sentence of the "Version constraints in ports" chapter is a bit unclear so I am not sure if this part complies with it.

Last but not least, I did not touche the `vulkan-sdk-components` port as this PR is more of a hotfix and this port need a bit more investigation.
Notably, some dependencies listed in the SDK's [config.json](https://sdk.lunarg.com/sdk/download/1.3.290.0/windows/config.json) file are not available on vcpkg (`MoltenVK`, etc.) and some other do not have the exact version available on vcpkg (`directx-dxc`, etc.)