### PR TITLE
[hwinfo] add new port

### DIFF
--- a/ports/hwinfo/portfile.cmake
+++ b/ports/hwinfo/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lfreist/hwinfo
+    REF 90829612dd4b67356fd643bd9ceee44b04dc8fde
+    SHA512 9f27c983d8e435c12455001cb7c2a535e9c7d94fec871a8b82d965d41f9a6e739fe4263bb18a66cf50fb826e505cbc0ff6a7c8408a3d74f783f56fefb88110cc
+    HEAD_REF main
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" HWINFO_BUILD_SHARED)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" HWINFO_BUILD_STATIC)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_TESTING=OFF
+        -DHWINFO_SHARED=${HWINFO_BUILD_SHARED}
+        -DHWINFO_STATIC=${HWINFO_BUILD_STATIC}
+    )
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH "lib/cmake/hwinfo"
+)
+vcpkg_copy_pdbs()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include )
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share )
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+

--- a/ports/hwinfo/usage
+++ b/ports/hwinfo/usage
@@ -1,0 +1,4 @@
+hwinfo provides CMake targets :
+    # this is heuristically generated, and may not be correct
+    find_package(hwinfo CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE hwinfo::hwinfo)

--- a/ports/hwinfo/vcpkg.json
+++ b/ports/hwinfo/vcpkg.json
@@ -1,0 +1,16 @@
+{
+    "name": "hwinfo",
+    "version-string": "lastest",
+    "description": "hwinfo provides an easy-to-use and modern C++ API for retrieving hardware information of your systems components such as CPU, RAM, GPU, Disks, Mainboard, ...",
+    "homepage": "https://github.com/lfreist/hwinfo",
+    "dependencies": [
+        {
+            "name": "vcpkg-cmake",
+            "host": true
+        },
+        {
+            "name": "vcpkg-cmake-config",
+            "host": true
+        }
+    ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
