### PR TITLE
[vcpkg baseline][pipewire] Fix compilation errors under Linux

### DIFF
--- a/ports/pipewire/portfile.cmake
+++ b/ports/pipewire/portfile.cmake
@@ -70,6 +70,7 @@ vcpkg_configure_meson(
         -Dx11-xfixes=disabled
         -Dx11=disabled
         -Dsession-managers=[]
+        -Dc_args=-Wno-strict-prototypes
 )
 vcpkg_install_meson()
 vcpkg_copy_pdbs()

--- a/ports/pipewire/vcpkg.json
+++ b/ports/pipewire/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pipewire",
   "version": "1.0.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Low-latency audio/video router and processor. This port only builds the client library, not the server.",
   "homepage": "https://pipewire.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6902,7 +6902,7 @@
     },
     "pipewire": {
       "baseline": "1.0.4",
-      "port-version": 1
+      "port-version": 2
     },
     "pistache": {
       "baseline": "2021-03-31",

--- a/versions/p-/pipewire.json
+++ b/versions/p-/pipewire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ab306b1419e587cc0025b4cb9bec1194e6c2b496",
+      "version": "1.0.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "156fac228a2b2cdbc747c95719e211bbebc2124b",
       "version": "1.0.4",
       "port-version": 1


### PR DESCRIPTION
Fixes regression: https://dev.azure.com/vcpkg/public/_build/results?buildId=106388&view=results
`REGRESSION: pipewire:x64-linux failed with BUILD_FAILED.`
Error:
```
/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/readline/rltypedefs.h:35:1: error: function declaration isn’t a prototype [-Werror=strict-prototypes]
   35 | typedef int Function () __attribute__((deprecated));
      | ^~~~~~~
/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/readline/rltypedefs.h:36:1: error: function declaration isn’t a prototype [-Werror=strict-prototypes]
   36 | typedef void VFunction () __attribute__((deprecated));
      | ^~~~~~~
/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/readline/rltypedefs.h:37:1: error: function declaration isn’t a prototype [-Werror=strict-prototypes]
   37 | typedef char *CPFunction () __attribute__((deprecated));
      | ^~~~~~~
/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/readline/rltypedefs.h:38:1: error: function declaration isn’t a prototype [-Werror=strict-prototypes]
   38 | typedef char **CPPFunction () __attribute__((deprecated));
      | ^~~~~~~
In file included from ../src/1.0.4-12f0412d7f.clean/src/tools/pw-cli.c:19:
/mnt/vcpkg-ci/installed/x64-linux/debug/lib/pkgconfig/../../../include/readline/readline.h:410:1: error: function declaration isn’t a prototype [-Werror=strict-prototypes]
  410 | extern int rl_message ();
      | ^~~~~~
cc1: some warnings being treated as errors
```
Add compile option `-Wno-strict-prototypes` to not force check that function parameters must be filled with void when they are empty, otherwise an error will be prompted.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Compile test pass with following triplet:
```
x64-linux
```