### PR TITLE
[pcapplusplus] Suppress warning STL4043 as workaround

### DIFF
--- a/ports/pcapplusplus/0001-warn-STL4043-for-v23.09.patch
+++ b/ports/pcapplusplus/0001-warn-STL4043-for-v23.09.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0f24d43..858424c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -219,6 +219,7 @@ if(PCAPPP_TARGET_COMPILER_MSVC)
+   # Disable VS warnings: Unknown pragma (4068), Zero-sized array in struct/union (4200), Possible loss of data (4244),
+   # Possible loss of data (4267), Character may not be represented (4819)
+   add_definitions("/wd4068 /wd4200 /wd4244 /wd4267 /wd4819")
++  add_compile_definitions(_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING)
+ endif()
+ 
+ if(PCAPPP_BUILD_COVERAGE)

--- a/ports/pcapplusplus/portfile.cmake
+++ b/ports/pcapplusplus/portfile.cmake
@@ -11,6 +11,8 @@ vcpkg_from_github(
     REF "v${PCAPPLUSPLUS_VERSION}"
     SHA512 e7dc1dbd85c9f0d2f9c5d3e436456c2cd183fb508c869fa8fb83f46aac99b868a16283204e5d57a0bfd7587f6ac2582b3e14c6098683fad4501708c8fededd6a
     HEAD_REF master
+    PATCHES
+        0001-warn-STL4043-for-v23.09.patch # just workaround, which has been fixed on mainline
 )
 
 vcpkg_cmake_configure(

--- a/ports/pcapplusplus/vcpkg.json
+++ b/ports/pcapplusplus/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pcapplusplus",
   "version": "23.9",
-  "port-version": 1,
+  "port-version": 2,
   "description": "PcapPlusPlus is a multi-platform C++ library for capturing, parsing and crafting of network packets",
   "homepage": "https://github.com/seladb/PcapPlusPlus",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6806,7 +6806,7 @@
     },
     "pcapplusplus": {
       "baseline": "23.9",
-      "port-version": 1
+      "port-version": 2
     },
     "pcg": {
       "baseline": "2021-04-06",

--- a/versions/p-/pcapplusplus.json
+++ b/versions/p-/pcapplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f7f815b341f0f5a5d1456894d8b30786ae24abf",
+      "version": "23.9",
+      "port-version": 2
+    },
+    {
       "git-tree": "51f8425ebc003224002c45c5f7454ebf2fb79a82",
       "version": "23.9",
       "port-version": 1


### PR DESCRIPTION
Fix #40622, failed with `warning C4996: 'stdext::checked_array_iterator<uint8_t *>': warning STL4043` on VS `17.11`.

Add `_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING` to suppress warning STL4043. The warning has been fixed on upstream mainline.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-windows (VS 17.11)