### PR TITLE
[ls-qpack] Add cmake export

### DIFF
--- a/ports/ls-qpack/cmake-export.patch
+++ b/ports/ls-qpack/cmake-export.patch
@@ -1,0 +1,46 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ff26bc3..6df9654 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,7 +17,10 @@ option(LSQPACK_XXH "Include XXH" ON)
+ 
+ # Use `cmake -DBUILD_SHARED_LIBS=OFF` to build a static library.
+ add_library(ls-qpack "")
+-target_include_directories(ls-qpack PUBLIC .)
++target_include_directories(ls-qpack PUBLIC 
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++    $<INSTALL_INTERFACE:include>
++)
+ target_sources(ls-qpack PRIVATE lsqpack.c)
+ 
+ if(LSQPACK_XXH)
+@@ -30,7 +33,10 @@ else()
+ endif()
+ 
+ if(WIN32)
+-    target_include_directories(ls-qpack PUBLIC wincompat)
++    target_include_directories(ls-qpack PUBLIC
++        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/wincompat>
++        $<INSTALL_INTERFACE:include>
++    )
+ endif()
+ 
+ if(MSVC)
+@@ -106,7 +112,16 @@ if(LSQPACK_BIN)
+     add_subdirectory(bin)
+ endif()
+ 
+-install(TARGETS ls-qpack)
++install(TARGETS ls-qpack EXPORT unofficial-ls-qpack-config
++    RUNTIME DESTINATION bin
++    LIBRARY DESTINATION lib
++    ARCHIVE DESTINATION lib
++)
++install(
++  EXPORT unofficial-ls-qpack-config
++  NAMESPACE unofficial::ls-qpack::
++  DESTINATION share/unofficial-ls-qpack
++)
+ install(FILES lsqpack.h lsxpack_header.h DESTINATION include)
+ if(WIN32)
+     install(DIRECTORY wincompat/sys DESTINATION include)

--- a/ports/ls-qpack/portfile.cmake
+++ b/ports/ls-qpack/portfile.cmake
@@ -27,8 +27,18 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-ls-qpack)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(READ "${CURRENT_PACKAGES_DIR}/share/unofficial-ls-qpack/unofficial-ls-qpack-config.cmake" cmake_config)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/unofficial-ls-qpack/unofficial-ls-qpack-config.cmake"
+"include(CMakeFindDependencyMacro)
+find_dependency(xxhash CONFIG)
+${cmake_config}
+")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ls-qpack/portfile.cmake
+++ b/ports/ls-qpack/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         xxhash.patch
+        cmake-export.patch
 )
 
 vcpkg_find_acquire_program(PKGCONFIG)
@@ -28,6 +29,6 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ls-qpack/usage
+++ b/ports/ls-qpack/usage
@@ -1,7 +1,0 @@
-The package ls-qpack can be used via CMake:
-
-    find_path(LSQPACK_INCLUDE_DIRS "lsqpack.h")
-    find_library(LSQPACK_LIBRARY ls-qpack REQUIRED)
-
-    target_include_directories(main PRIVATE ${LSQPACK_INCLUDE_DIRS})
-    target_link_libraries(main PRIVATE ${LSQPACK_LIBRARY})

--- a/ports/ls-qpack/vcpkg.json
+++ b/ports/ls-qpack/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ls-qpack",
   "version": "2.5.4",
+  "port-version": 1,
   "description": "QPACK compression library for use with HTTP/3",
   "homepage": "https://github.com/litespeedtech/ls-qpack",
   "license": "MIT",

--- a/ports/ls-qpack/vcpkg.json
+++ b/ports/ls-qpack/vcpkg.json
@@ -11,6 +11,10 @@
       "name": "vcpkg-cmake",
       "host": true
     },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "xxhash"
   ]
 }

--- a/ports/ls-qpack/xxhash.patch
+++ b/ports/ls-qpack/xxhash.patch
@@ -1,19 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1a1f8e9..949d7f1 100644
+index 1a1f8e9..cf207d2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -20,9 +20,14 @@ add_library(ls-qpack "")
+@@ -20,9 +20,12 @@ add_library(ls-qpack "")
  target_include_directories(ls-qpack PUBLIC .)
  target_sources(ls-qpack PRIVATE lsqpack.c)
  
 -target_include_directories(ls-qpack PRIVATE deps/xxhash/)
-+# target_include_directories(ls-qpack PRIVATE deps/xxhash/)
  if(LSQPACK_XXH)
      target_sources(ls-qpack PRIVATE deps/xxhash/xxhash.c)
 +else()
-+    find_package(PkgConfig REQUIRED)
-+    pkg_check_modules(XXH REQUIRED IMPORTED_TARGET libxxhash)
-+    target_link_libraries(ls-qpack PUBLIC PkgConfig::XXH)
++    find_package(xxHash CONFIG REQUIRED)
++    target_link_libraries(ls-qpack PUBLIC xxHash::xxhash)
 +    set(LSQPACK_DEPENDS "libxxhash")
  endif()
  

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5514,7 +5514,7 @@
     },
     "ls-qpack": {
       "baseline": "2.5.4",
-      "port-version": 0
+      "port-version": 1
     },
     "ltla-aarand": {
       "baseline": "2023-03-19",

--- a/versions/l-/ls-qpack.json
+++ b/versions/l-/ls-qpack.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "879be72c87fa3007461b4a9a6885ea1984503413",
+      "git-tree": "1740a9928aea7bdf09afeb0abf677ecb83151309",
       "version": "2.5.4",
       "port-version": 1
     },

--- a/versions/l-/ls-qpack.json
+++ b/versions/l-/ls-qpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "879be72c87fa3007461b4a9a6885ea1984503413",
+      "version": "2.5.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "6b05f64e6b3116005c25b7b9b585e8770abcdae7",
       "version": "2.5.4",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
