### PR TITLE
[ngtcp2] Add libressl feature

### DIFF
--- a/ports/ngtcp2/openssl_required.patch
+++ b/ports/ngtcp2/openssl_required.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -119,9 +119,9 @@
+ if(ENABLE_GNUTLS)
+   find_package(GnuTLS 3.7.2)
+ endif()
+ if(ENABLE_OPENSSL)
+-  find_package(OpenSSL 1.1.1)
++  find_package(OpenSSL REQUIRED)
+ endif()
+ if(ENABLE_WOLFSSL)
+   find_package(wolfssl 5.5.0)
+ endif()

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
       export-unofficical-target.patch
+      openssl_required.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC_LIB)
@@ -15,6 +16,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         wolfssl     ENABLE_WOLFSSL
         gnutls      ENABLE_GNUTLS
+        libressl    ENABLE_OPENSSL
 )
 
 vcpkg_cmake_configure(
@@ -24,7 +26,6 @@ vcpkg_cmake_configure(
         "-DENABLE_STATIC_LIB=${ENABLE_STATIC_LIB}"
         "-DENABLE_SHARED_LIB=${ENABLE_SHARED_LIB}"
         -DBUILD_TESTING=OFF
-        -DENABLE_OPENSSL=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_Libev=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Libnghttp3=ON
         -DCMAKE_INSTALL_DOCDIR=share/ngtcp2

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ngtcp2",
   "version": "1.6.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "ngtcp2 project is an effort to implement RFC9000 QUIC protocol.",
   "homepage": "https://github.com/ngtcp2/ngtcp2",
   "license": "MIT",
@@ -27,6 +27,12 @@
           "name": "shiftmedia-libgnutls",
           "platform": "windows & !mingw"
         }
+      ]
+    },
+    "libressl": {
+      "description": "Compile with libressl",
+      "dependencies": [
+        "libressl"
       ]
     },
     "wolfssl": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6242,7 +6242,7 @@
     },
     "ngtcp2": {
       "baseline": "1.6.0",
-      "port-version": 2
+      "port-version": 3
     },
     "nifly": {
       "baseline": "1.0.0",

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "192385868c5b3a7048f4496493e6fc55a564dbc8",
+      "version": "1.6.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "ddfa61f547e616e5d2ae460b5f759a702e8c067d",
       "version": "1.6.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
