### PR TITLE
[gtsam] Update to 4.2.0

### DIFF
--- a/ports/gtsam/portfile.cmake
+++ b/ports/gtsam/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO borglab/gtsam
     REF ${VERSION}
-    SHA512 0aae0b785a3f7ae25008d0938848e93519786521cca9cd0cd1a8937ec5ac46f3b1ca1bfaaff1ca5812c92f8ef55b729a06c57632da5dd8fc38afc22d3047f8e0
-    HEAD_REF master    
+    SHA512 c0e5de8d86ea8241b49449bd291999ec0d6530bc9943b213e7c650b0ab29894ab53636bd1a0ed82d9d9d148dfc399ebff28e108b060d2d2176b584823bd722cd
+    HEAD_REF develop    
     PATCHES
         build-fixes.patch
         path-fixes.patch
@@ -17,8 +17,8 @@ vcpkg_cmake_configure(
         -DGTSAM_BUILD_TIMING_ALWAYS=OFF
         -DGTSAM_BUILD_UNSTABLE=OFF
         -DGTSAM_UNSTABLE_BUILD_PYTHON=OFF
-        -DGTSAM_USE_SYSTEM_EIGEN=On
-        -DGTSAM_USE_SYSTEM_METIS=On
+        -DGTSAM_USE_SYSTEM_EIGEN=ON
+        -DGTSAM_USE_SYSTEM_METIS=ON
         -DGTSAM_INSTALL_CPPUNITLITE=OFF
         -DGTSAM_BUILD_TYPE_POSTFIXES=OFF
         -DCMAKE_CXX_STANDARD=11 # Boost v1.84.0 libraries require C++11

--- a/ports/gtsam/vcpkg.json
+++ b/ports/gtsam/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gtsam",
-  "version-string": "4.2a9",
-  "port-version": 2,
+  "version": "4.2.0",
   "description": "GTSAM is a library of C++ classes that implement smoothing and mapping (SAM) in robotics and vision, using factor graphs and Bayes networks as the underlying computing paradigm rather than sparse matrices.",
   "homepage": "https://github.com/borglab/gtsam",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3285,8 +3285,8 @@
       "port-version": 9
     },
     "gtsam": {
-      "baseline": "4.2a9",
-      "port-version": 2
+      "baseline": "4.2.0",
+      "port-version": 0
     },
     "guetzli": {
       "baseline": "2020-09-14",

--- a/versions/g-/gtsam.json
+++ b/versions/g-/gtsam.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a6bc1e174acef86e1f288d2be7ac6095ed02cbe",
+      "version": "4.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9c2a1fefb94d0fe792cde3fe6519ce59e181685a",
       "version-string": "4.2a9",
       "port-version": 2


### PR DESCRIPTION
Add a port feature which provides access to the cmake option `GTSAM_BUILD_WITH_MARCH_NATIVE` which in turn controls building with `-march=native`. This is important when the consuming application has native instructions enabled. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
