### PR TITLE
[octave] Without suitesparse, curl and qhall. With more libs

### DIFF
--- a/ports/octave/portfile.cmake
+++ b/ports/octave/portfile.cmake
@@ -35,13 +35,16 @@ vcpkg_configure_make(
     AUTOCONFIG
     OPTIONS
     --disable-docs
-    --without-hdf5
     --without-amd
     --without-camd
-    --without-colamd
     --without-ccolamd
     --without-cholmod
+    --without-colamd
+    --without-curl
     --without-cxsparse
+    --without-hdf5
+    --without-qhull
+    --without-qrupdate
     --without-umfpack
 )
 

--- a/ports/octave/portfile.cmake
+++ b/ports/octave/portfile.cmake
@@ -36,6 +36,13 @@ vcpkg_configure_make(
     OPTIONS
     --disable-docs
     --without-hdf5
+    --without-amd
+    --without-camd
+    --without-colamd
+    --without-ccolamd
+    --without-cholmod
+    --without-cxsparse
+    --without-umfpack
 )
 
 vcpkg_install_make()

--- a/ports/octave/vcpkg.json
+++ b/ports/octave/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "octave",
   "version": "9.2.0",
+  "port-version": 1,
   "description": "High-level interpreted language, primarily intended for numerical computations.",
   "homepage": "https://octave.org/",
   "license": "GPL-3.0-or-later",

--- a/ports/octave/vcpkg.json
+++ b/ports/octave/vcpkg.json
@@ -8,16 +8,15 @@
   "supports": "!arm",
   "dependencies": [
     "blas",
-    {
-      "name": "curl",
-      "default-features": false
-    },
     "fftw3",
+    "glpk",
     "lapack",
+    "libsndfile",
     "opengl",
     "pcre2",
-    "qhull",
+    "portaudio",
     "readline",
+    "sundials",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6426,7 +6426,7 @@
     },
     "octave": {
       "baseline": "9.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "octomap": {
       "baseline": "1.10.0",

--- a/versions/o-/octave.json
+++ b/versions/o-/octave.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "881eba0c8ec458987106a66333366a8aacab1f86",
+      "version": "9.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6bb24fb39b584c5298f49de82807d011368c9eeb",
       "version": "9.2.0",
       "port-version": 0

--- a/versions/o-/octave.json
+++ b/versions/o-/octave.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "881eba0c8ec458987106a66333366a8aacab1f86",
+      "git-tree": "50aea0f8c6c48fa888e1b8ef0bdd611ca14a375d",
       "version": "9.2.0",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.