### PR TITLE
[tracy] Update to v0.11.1

### DIFF
--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfpld/tracy
     REF "v${VERSION}"
-    SHA512 8c33a22f43b895f3e00f231f002c8272f72a3d7ce60858d58caf916c2721de478710dbd6ab6b16621a796491303fbce9c2315008b00d7a53d05ee7660b414874
+    SHA512 d3d99284e3c3172236c3f02b3bc52df111ef650fb8609e54fb3302ece28e55a06cd16713ed532f1e1aad66678ff09639dfc7e01a1e96880fb923b267a1b1b79b
     HEAD_REF master
     PATCHES
         build-tools.patch
@@ -14,6 +14,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         fibers	  TRACY_FIBERS
         cli-tools VCPKG_CLI_TOOLS
         gui-tools VCPKG_GUI_TOOLS
+        verbose   TRACY_VERBOSE
     INVERTED_FEATURES
         crash-handler TRACY_NO_CRASH_HANDLER
 )

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tracy",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",
@@ -81,6 +81,9 @@
     },
     "on-demand": {
       "description": "Enable on-demand profiling"
+    },
+    "verbose": {
+      "description": "Enables verbose logging"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8965,7 +8965,7 @@
       "port-version": 4
     },
     "tracy": {
-      "baseline": "0.11.0",
+      "baseline": "0.11.1",
       "port-version": 0
     },
     "transwarp": {

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4af568b6d5180007564a094751cb736d136f1e0",
+      "version": "0.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "aa1a3312579f656635fbce79edcb1ddb0688186f",
       "version": "0.11.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.