### PR TITLE
[imguizmo] Remove keyword unofficial of imguizmo's usage

### DIFF
--- a/ports/imguizmo/CMakeLists.txt
+++ b/ports/imguizmo/CMakeLists.txt
@@ -31,7 +31,7 @@ target_sources(
 
 install(
     TARGETS ${PROJECT_NAME}
-    EXPORT unofficial-${PROJECT_NAME}-target
+    EXPORT ${PROJECT_NAME}-target
     ARCHIVE DESTINATION lib
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin
@@ -51,8 +51,8 @@ if (NOT IMGUIZMO_SKIP_HEADERS)
 endif()
 
 install(
-    EXPORT unofficial-${PROJECT_NAME}-target
-    NAMESPACE unofficial::${PROJECT_NAME}::
-    FILE unofficial-${PROJECT_NAME}-config.cmake
-    DESTINATION share/unofficial-${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-target
+    NAMESPACE ${PROJECT_NAME}::
+    FILE ${PROJECT_NAME}-config.cmake
+    DESTINATION share/${PROJECT_NAME}
 )

--- a/ports/imguizmo/portfile.cmake
+++ b/ports/imguizmo/portfile.cmake
@@ -19,6 +19,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT} CONFIG_PATH share/unofficial-${PORT})
+vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT} CONFIG_PATH share/${PORT})
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/imguizmo/vcpkg.json
+++ b/ports/imguizmo/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imguizmo",
   "version-date": "2024-05-29",
+  "port-version": 1,
   "description": "Immediate mode 3D gizmo for scene editing and other controls based on Dear ImGui",
   "homepage": "https://github.com/CedricGuillemet/ImGuizmo",
   "license": "MIT",

--- a/ports/libigl/dependencies.patch
+++ b/ports/libigl/dependencies.patch
@@ -78,7 +78,7 @@ index d7ffb9d..6152756 100644
 -include(imguizmo)
 -include(libigl_imgui_fonts)
 +find_package(imgui CONFIG REQUIRED)
-+find_package(unofficial-imguizmo CONFIG REQUIRED)
++find_package(imguizmo CONFIG REQUIRED)
  igl_include(glfw)
  target_link_libraries(igl_imgui ${IGL_SCOPE}
      igl::core
@@ -86,7 +86,7 @@ index d7ffb9d..6152756 100644
      imgui::imgui
 -    imguizmo::imguizmo
 -    igl::imgui_fonts
-+    unofficial::imguizmo::imguizmo
++    imguizmo::imguizmo
  )
 diff --git a/cmake/igl/modules/opengl.cmake b/cmake/igl/modules/opengl.cmake
 index 4580c03..dfadb38 100644

--- a/ports/libigl/install-extra-targets.patch
+++ b/ports/libigl/install-extra-targets.patch
@@ -128,7 +128,7 @@ index 6152756..34359c6 100644
 +++ b/cmake/igl/modules/imgui.cmake
 @@ -23,3 +23,6 @@ target_link_libraries(igl_imgui ${IGL_SCOPE}
      imgui::imgui
-     unofficial::imguizmo::imguizmo
+     imguizmo::imguizmo
  )
 +
 +igl_install(igl_imgui ${INC_FILES} ${SRC_FILES})

--- a/ports/libigl/portfile.cmake
+++ b/ports/libigl/portfile.cmake
@@ -67,10 +67,6 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/libigl-config.cmake"
-"find_dependency(imguizmo)"
-[[find_dependency(unofficial-imguizmo)]])
-
 if(NOT LIBIGL_COPYLEFT_CGAL)
     vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.MPL2")
 else()

--- a/ports/libigl/portfile.cmake
+++ b/ports/libigl/portfile.cmake
@@ -67,6 +67,10 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/libigl-config.cmake"
+"find_dependency(imguizmo)"
+[[find_dependency(unofficial-imguizmo)]])
+
 if(NOT LIBIGL_COPYLEFT_CGAL)
     vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.MPL2")
 else()

--- a/ports/libigl/vcpkg.json
+++ b/ports/libigl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libigl",
   "version": "2.5.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.",
   "homepage": "https://github.com/libigl/libigl",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4610,7 +4610,7 @@
     },
     "libigl": {
       "baseline": "2.5.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libilbc": {
       "baseline": "3.0.4",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3662,7 +3662,7 @@
     },
     "imguizmo": {
       "baseline": "2024-05-29",
-      "port-version": 0
+      "port-version": 1
     },
     "immer": {
       "baseline": "0.8.1",

--- a/versions/i-/imguizmo.json
+++ b/versions/i-/imguizmo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "febc8a87c4fbc76155d002254572154b44b3d850",
+      "version-date": "2024-05-29",
+      "port-version": 1
+    },
+    {
       "git-tree": "be2cf5fafba779840d87110933298add1dcb60f5",
       "version-date": "2024-05-29",
       "port-version": 0

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f49912f45d5005ca27e9fdadf7db99d0ebd6d242",
+      "git-tree": "97c212824af2073c76a3437ffad728205eba3ce7",
       "version": "2.5.0",
       "port-version": 2
     },

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f49912f45d5005ca27e9fdadf7db99d0ebd6d242",
+      "version": "2.5.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "ef3f6b72109e34fd02b28936fdc955e91044e089",
       "version": "2.5.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #40672, remove keyword `unofficial` of `imguizmo`'s usage, keep consistent with upstream documentation https://github.com/CedricGuillemet/ImGuizmo/blob/master/vcpkg-example/README.md#how-it-works.

Usage passed on x64-windows.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.