### PR TITLE
[nghttp3] update to 1.5.0

### DIFF
--- a/ports/nghttp3/portfile.cmake
+++ b/ports/nghttp3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ngtcp2/nghttp3
     REF v${VERSION}
-    SHA512 56b5ac28f01a9210f0bd3de06dabe9f34867b72c68df0776f8faf3f03a4b82185fd16891f67f710b8c7db56523e29a7c51e4b2337ea9e5331bc6c21a26ed12dd
+    SHA512 d8b6db7a1323e036cd2d1aab1ded299e83024ce451cddbfe0ea102d968bdcb57221dbcc231b73880e0987cf3ed7ecd2c2b5f53b10947d9accb7603d7c3fcbb95
     HEAD_REF main
 )
 

--- a/ports/nghttp3/portfile.cmake
+++ b/ports/nghttp3/portfile.cmake
@@ -36,7 +36,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/nghttp3/portfile.cmake
+++ b/ports/nghttp3/portfile.cmake
@@ -36,7 +36,6 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE

--- a/ports/nghttp3/portfile.cmake
+++ b/ports/nghttp3/portfile.cmake
@@ -37,6 +37,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/nghttp3/vcpkg.json
+++ b/ports/nghttp3/vcpkg.json
@@ -8,6 +8,10 @@
     {
       "name": "vcpkg-cmake",
       "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ]
 }

--- a/ports/nghttp3/vcpkg.json
+++ b/ports/nghttp3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nghttp3",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "description": "Implementation of RFC 9114 HTTP/3 mapping over QUIC and RFC 9204 QPACK in C",
   "homepage": "https://github.com/ngtcp2/nghttp3",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6233,7 +6233,7 @@
       "port-version": 1
     },
     "nghttp3": {
-      "baseline": "1.3.0",
+      "baseline": "1.5.0",
       "port-version": 0
     },
     "ngspice": {

--- a/versions/n-/nghttp3.json
+++ b/versions/n-/nghttp3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2cd9b1286cf8dc8403f5ae71f279c361faaf3281",
+      "git-tree": "ee55bf90558805f7d3e3c627e767c9cf0c6bf688",
       "version": "1.5.0",
       "port-version": 0
     },

--- a/versions/n-/nghttp3.json
+++ b/versions/n-/nghttp3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "56db247e0a3c1376a8df128afc253cb6250e795c",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a503d4283d1d25411c53bce53ff5bc0a8c66592c",
       "version": "1.3.0",
       "port-version": 0

--- a/versions/n-/nghttp3.json
+++ b/versions/n-/nghttp3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "56db247e0a3c1376a8df128afc253cb6250e795c",
+      "git-tree": "e8be4ee0dc45315d1d808d5446402d04ec32acf2",
       "version": "1.5.0",
       "port-version": 0
     },

--- a/versions/n-/nghttp3.json
+++ b/versions/n-/nghttp3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "600b89e0607dec888b8a7e1ec7bfa8e1609b5c4a",
+      "git-tree": "2cd9b1286cf8dc8403f5ae71f279c361faaf3281",
       "version": "1.5.0",
       "port-version": 0
     },

--- a/versions/n-/nghttp3.json
+++ b/versions/n-/nghttp3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e8be4ee0dc45315d1d808d5446402d04ec32acf2",
+      "git-tree": "600b89e0607dec888b8a7e1ec7bfa8e1609b5c4a",
       "version": "1.5.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
