### PR TITLE
[msquic] Fix dynamic CRT linkage

### DIFF
--- a/ports/msquic/portfile.cmake
+++ b/ports/msquic/portfile.cmake
@@ -65,6 +65,7 @@ vcpkg_cmake_configure(
         -DQUIC_BUILD_PERF=OFF
         -DQUIC_BUILD_TEST=OFF
         "-DQUIC_STATIC_LINK_CRT=${STATIC_CRT}"
+        "-DQUIC_STATIC_LINK_PARTIAL_CRT=${STATIC_CRT}"
         "-DQUIC_UWP_BUILD=${VCPKG_TARGET_IS_UWP}"
 )
 

--- a/ports/msquic/vcpkg.json
+++ b/ports/msquic/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "msquic",
   "version": "2.3.5",
+  "port-version": 1,
   "description": "Cross-platform, C implementation of the IETF QUIC protocol",
   "homepage": "https://github.com/microsoft/msquic",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6054,7 +6054,7 @@
     },
     "msquic": {
       "baseline": "2.3.5",
-      "port-version": 0
+      "port-version": 1
     },
     "mstch": {
       "baseline": "1.0.2",

--- a/versions/m-/msquic.json
+++ b/versions/m-/msquic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85ab1ddebbe0f051950212c6dc07ea3ad96cb271",
+      "version": "2.3.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "20a3ca5768fb1bb7781563159dc5400b0b2bb978",
       "version": "2.3.5",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.



