### PR TITLE
[gstreamer] To fix the issue of multiple definitions of a function

### DIFF
--- a/ports/gstreamer/fix-multiple-def.patch
+++ b/ports/gstreamer/fix-multiple-def.patch
@@ -1,0 +1,25 @@
+diff --git a/subprojects/gst-plugins-bad/gst/siren/common.c b/subprojects/gst-plugins-bad/gst/siren/common.c
+index 2e07748..48ef10f 100644
+--- a/subprojects/gst-plugins-bad/gst/siren/common.c
++++ b/subprojects/gst-plugins-bad/gst/siren/common.c
+@@ -44,7 +44,7 @@ int max_bin[8] = {
+   1
+ };
+ 
+-float step_size[8] = {
++float static step_size[8] = {
+   0.3536f,
+   0.5f,
+   0.70709997f,
+diff --git a/subprojects/gst-plugins-bad/gst/siren/common.h b/subprojects/gst-plugins-bad/gst/siren/common.h
+index e09e533..8d6bb71 100644
+--- a/subprojects/gst-plugins-bad/gst/siren/common.h
++++ b/subprojects/gst-plugins-bad/gst/siren/common.h
+@@ -95,7 +95,6 @@ extern int vector_dimension[8];
+ extern int number_of_vectors[8];
+ extern float dead_zone[8];
+ extern int max_bin[8];
+-extern float step_size[8];
+ extern float step_size_inverse[8];
+ 
+ 

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_from_gitlab(
         base-must-be-enabled.patch
         no-downloads.patch
         ${PATCHES}
+        fix-multiple-def.patch
 )
 
 vcpkg_find_acquire_program(FLEX)

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.22.5",
-  "port-version": 8,
+  "port-version": 9,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3258,7 +3258,7 @@
     },
     "gstreamer": {
       "baseline": "1.22.5",
-      "port-version": 8
+      "port-version": 9
     },
     "gtest": {
       "baseline": "1.15.2",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e3f4023e3ef8b075164a5700b9296fda6a82d87",
+      "version": "1.22.5",
+      "port-version": 9
+    },
+    {
       "git-tree": "a4f5984869f07999b31721a248e129b3de531436",
       "version": "1.22.5",
       "port-version": 8


### PR DESCRIPTION
One of the fixes for the [32398](https://github.com/microsoft/vcpkg/issues/32398) issue.

The following error occurs when installing `gstreamer[core,sndfile]` under Linux.
```
/usr/bin/ld: /mnt/vcpkg/installed/x64-linux/debug/lib/pkgconfig/../../lib/libsndfile.a(g72x.c.o): in function `step_size':
/mnt/vcpkg/buildtrees/libsndfile/src/1.2.2-fa730f3d73.clean/src/G72x/g72x.c:299: multiple definition of `step_size'; subprojects/gst-plugins-bad/gst/siren/libgstsiren.a(common.c.o):/mnt/vcpkg/buildtrees/gstreamer/x64-linux-dbg/../src/1.22.5-850ed10f2f.clean/subprojects/gst-plugins-bad/gst/siren/common.c:47: first defined here
```
Fix the multiple definitions of the step_size function in gstreamer and libsndfile.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

The feature sndfile test pass with following triplet:
```
x64-windows
x64-linux
```