### PR TITLE
[cppwinrt] update to 2.0.240405.15

### DIFF
--- a/ports/cppwinrt/portfile.cmake
+++ b/ports/cppwinrt/portfile.cmake
@@ -2,7 +2,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Windows.CppWinRT/${VERSION}"
     FILENAME "cppwinrt.${VERSION}.zip"
-    SHA512 c6c38b81640d7d96d3ca76c321289d6f92eec9bb593a11824640c7dc3651dc69cce1e85ca0324396b4a4d55f790f2c16f835da261e7821137de1eb491b52ffc8
+    SHA512 74460c233655e180dcceebdf16ad2d2f19d178c7c592c0677c623361558126930581556e39f6e12bd8ac4f57792be2d3f1b80188ef1a5de7cd7e8c72b7d598c1
 )
 
 vcpkg_extract_source_archive(

--- a/ports/cppwinrt/vcpkg.json
+++ b/ports/cppwinrt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppwinrt",
-  "version": "2.0.240111.5",
+  "version": "2.0.240405.15",
   "description": "C++/WinRT is a standard C++ language projection for the Windows Runtime.",
   "homepage": "https://github.com/microsoft/cppwinrt",
   "documentation": "https://docs.microsoft.com/windows/uwp/cpp-and-winrt-apis/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1981,7 +1981,7 @@
       "port-version": 3
     },
     "cppwinrt": {
-      "baseline": "2.0.240111.5",
+      "baseline": "2.0.240405.15",
       "port-version": 0
     },
     "cppxaml": {

--- a/versions/c-/cppwinrt.json
+++ b/versions/c-/cppwinrt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef233ec464cf3483066900c8be82bd2e77266d85",
+      "version": "2.0.240405.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "a2cf04c5162520cb5b3784e0cf09da9416929ab4",
       "version": "2.0.240111.5",
       "port-version": 0


### PR DESCRIPTION
Update `cppwinrt` to the latest version 2.0.240405.15.
No feature need to be tested.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.