### PR TITLE
[audit] update to version 4.0.2 and fix the issue of multiple definitions of a function

### DIFF
--- a/ports/audit/fix-multiple-def.patch
+++ b/ports/audit/fix-multiple-def.patch
@@ -1,0 +1,26 @@
+diff --git a/src/ausearch-lookup.c b/src/ausearch-lookup.c
+index 2d6f48c..8c610e9 100644
+--- a/src/ausearch-lookup.c
++++ b/src/ausearch-lookup.c
+@@ -242,7 +242,7 @@ const char *aulookup_uid(uid_t uid, char *buf, size_t size)
+ 	return buf;
+ }
+ 
+-void aulookup_destroy_uid_list(void)
++void aulookup_destroy_uid_nvl_list(void)
+ {
+ 	if (uid_list_created == 0)
+ 		return;
+diff --git a/src/ausearch-lookup.h b/src/ausearch-lookup.h
+index c80f782..67f1e56 100644
+--- a/src/ausearch-lookup.h
++++ b/src/ausearch-lookup.h
+@@ -38,7 +38,7 @@ const char *aulookup_syscall(llist *l, char *buf, size_t size)
+ 	__attr_access ((__write_only__, 2, 3));
+ const char *aulookup_uid(uid_t uid, char *buf, size_t size)
+ 	__attr_access ((__write_only__, 2, 3));
+-void aulookup_destroy_uid_list(void);
++void aulookup_destroy_uid_nvl_list(void);
+ char *unescape(const char *buf);
+ void print_tty_data(const char *val);
+ void safe_print_string_n(const char *s, unsigned int len, int ret)

--- a/ports/audit/portfile.cmake
+++ b/ports/audit/portfile.cmake
@@ -1,17 +1,9 @@
-vcpkg_download_distfile(PATCH_FIX_MISSING_HEADERS_IN_AUDISP_FILTER
-    URLS https://github.com/linux-audit/audit-userspace/commit/f8e9bc5914d715cdacb2edc938ab339d5094d017.patch?full_index=1
-    SHA512 b9606c711befe99ce9540b9885e943733ab06faa55d32bf029b23e1984adf2e914d46bd95b81a2517380c6b9e714b3b3d2181b86586c97dc09a0418ae40bd33f
-    FILENAME 0000-fix-missing-header-in-audisp-filter.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO linux-audit/audit-userspace
-    SHA512 297664a55ab44b40c9280202c19612cfbfdacc209c4d226461ea5faa638e35617cb516e53d1f0bc3748cdd038d9524f3e5ebe11c8de4a5511ab4f12b7d06478c
+    SHA512 558b9211a5dc1062eee98aa7bcd292797f06109a8ee735da1d704bc18d97b0bee93487ef9303404016df2e08cff32d90f1dd056797ac05beaabe3cccb5db5af2
     REF "v${VERSION}"
     HEAD_REF master
-    PATCHES
-        "${PATCH_FIX_MISSING_HEADERS_IN_AUDISP_FILTER}"
 )
 
 message(STATUS "${PORT} currently requires the following libraries from the system package manager:\n"

--- a/ports/audit/portfile.cmake
+++ b/ports/audit/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     SHA512 558b9211a5dc1062eee98aa7bcd292797f06109a8ee735da1d704bc18d97b0bee93487ef9303404016df2e08cff32d90f1dd056797ac05beaabe3cccb5db5af2
     REF "v${VERSION}"
     HEAD_REF master
+    PATCHES
+        fix-multiple-def.patch
 )
 
 message(STATUS "${PORT} currently requires the following libraries from the system package manager:\n"

--- a/ports/audit/vcpkg.json
+++ b/ports/audit/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "audit",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Library for working with audit subsystem",
   "homepage": "https://github.com/linux-audit/audit-userspace",
   "license": "GPL-2.0-or-later OR LGPL-2.1-or-later",

--- a/versions/a-/audit.json
+++ b/versions/a-/audit.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0201aea990447f328e6ed6a409ba94928e966d27",
+      "git-tree": "7bc8ba38796968e68cd87e9537c85a803c203b1a",
       "version": "4.0.2",
       "port-version": 0
     },

--- a/versions/a-/audit.json
+++ b/versions/a-/audit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0201aea990447f328e6ed6a409ba94928e966d27",
+      "version": "4.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "926ccd42caae517216220ee699e30c86abdf7ed9",
       "version": "4.0.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -345,7 +345,7 @@
       "port-version": 0
     },
     "audit": {
-      "baseline": "4.0.1",
+      "baseline": "4.0.2",
       "port-version": 0
     },
     "aurora": {


### PR DESCRIPTION
Update `audit` to the latest version 4.0.2.
No feature need to be tested.
The following error occurs when installing under Linux.
```
/usr/bin/ld: /usr/bin/ld: ../auparse/.libs/libauparse.a(interpret.o): in function `aulookup_destroy_uid_list':
/mnt/vcpkg-ci/b/audit/x64-linux-dbg/auparse/.././../src/v4.0.2-90950820cd.clean/auparse/interpret.c:598: multiple definition of `aulookup_destroy_uid_list'; ausearch-lookup.o:/mnt/vcpkg-ci/b/audit/x64-linux-dbg/src/.././../src/v4.0.2-90950820cd.clean/src/ausearch-lookup.c:246: first defined here
```
Fix the multiple definitions of the `aulookup_destroy_uid_list` function in interpret.c.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.