### PR TITLE
[zimpl] Update to 3.6.1

### DIFF
--- a/ports/zimpl/msvc.diff
+++ b/ports/zimpl/msvc.diff
@@ -3,7 +3,7 @@ index 7cf9d85..85d33a7 100644
 --- a/zimpl/CMakeLists.txt
 +++ b/zimpl/CMakeLists.txt
 @@ -4,7 +4,7 @@ project(ZIMPL
-     VERSION 3.5.3
+     VERSION 3.6.1
      LANGUAGES C)
  
 -if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/ports/zimpl/portfile.cmake
+++ b/ports/zimpl/portfile.cmake
@@ -1,10 +1,10 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 # The latest version of ZIMPL is included in the SCIP Optimization Suite.
-set(scipoptsuite_version 8.0.4)
+set(scipoptsuite_version 9.1.0)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://scipopt.org/download/release/scipoptsuite-${scipoptsuite_version}.tgz"
-    SHA512 46b56b3a4a5fcb4d6d53b5ffd9320bdf37fb55b9b8450a065312aa1e4f88863d3c563a495cf2622ef70a80132149c7b8f36cdb9a9e43906f4cfcafcb9dd6d606
+    SHA512 03c1c49dd5e4dbc5bfd4f07305937079773f6912c87b0ba86166fc02996928e8d23332137a944f16f2488a88dc12a4a2c6ebde216eb4532135ed282a182bfdaf
     FILENAME "scipoptsuite-${scipoptsuite_version}.tgz"
 )
 vcpkg_extract_source_archive(

--- a/ports/zimpl/vcpkg.json
+++ b/ports/zimpl/vcpkg.json
@@ -9,10 +9,6 @@
     "gmp",
     {
       "name": "pcre2",
-      "platform": "windows & !mingw"
-    },
-    {
-      "name": "pcre2",
       "platform": "windows"
     },
     {

--- a/ports/zimpl/vcpkg.json
+++ b/ports/zimpl/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "zimpl",
-  "version": "3.5.3",
+  "version": "3.6.1",
   "description": "Zuse Institut Mathematical Programming Language",
   "homepage": "http://zimpl.zib.de/",
   "license": "LGPL-3.0-or-later",
   "supports": "!uwp",
   "dependencies": [
     "gmp",
+    {
+      "name": "pcre2",
+      "platform": "windows & !mingw"
+    },
     {
       "name": "pcre2",
       "platform": "windows"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9809,7 +9809,7 @@
       "port-version": 2
     },
     "zimpl": {
-      "baseline": "3.5.3",
+      "baseline": "3.6.1",
       "port-version": 0
     },
     "zint": {

--- a/versions/z-/zimpl.json
+++ b/versions/z-/zimpl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fecfdb732d67c4d18cb446e2052e7fc425872525",
+      "version": "3.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6598ebbe8c537c546a9cc0d71c8fd9e0a4dd6b94",
       "version": "3.5.3",
       "port-version": 0


### PR DESCRIPTION
Update `zimpl` to 3.6.1. 

No feature needs to be tested, the usage test successfully on `x64-windows`(header file found):
```
zimpl provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(zimpl CONFIG REQUIRED)
  target_link_libraries(main PRIVATE libzimpl libzimpl-pic)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.