### PR TITLE
[libdvdcss] New port

### DIFF
--- a/ports/libdvdcss/portfile.cmake
+++ b/ports/libdvdcss/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_gitlab(
+    OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://code.videolan.org/
+    REPO videolan/libdvdcss
+    REF ${VERSION}
+    SHA512 b4265ea7c31ca863569b6b20caf158d7ecf9ef6ca8ea3fb372ab7a730e2cb0fdfc2331e6b7aba102faa7751301e063f466dc5dc50a467dd659e008ee7c73383a
+    HEAD_REF master
+)
+file(WRITE "${SOURCE_PATH}/ChangeLog" "Cf. https://code.videolan.org/videolan/libdvdcss/-/commits/${VERSION}/") # not in git
+
+set(cppflags "")
+if(VCPKG_TARGET_IS_WINDOWS)
+    # PATH_MAX from msvc/libdvdcss.vcxproj
+    set(cppflags "CPPFLAGS=\$CPPFLAGS -DPATH_MAX=2048 -DWIN32_LEAN_AND_MEAN")
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS
+        --disable-doc
+        ${cppflags}
+)
+vcpkg_install_make()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libdvdcss/vcpkg.json
+++ b/ports/libdvdcss/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "libdvdcss",
+  "version-semver": "1.4.3",
+  "description": "Accessing DVDs like a block device library",
+  "homepage": "https://www.videolan.org/developers/libdvdcss.html",
+  "license": "GPL-2.0-or-later",
+  "supports": "!uwp & !xbox"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4400,6 +4400,10 @@
       "baseline": "0.6.0",
       "port-version": 3
     },
+    "libdvdcss": {
+      "baseline": "1.4.3",
+      "port-version": 0
+    },
     "libdwarf": {
       "baseline": "0.11.0",
       "port-version": 0

--- a/versions/l-/libdvdcss.json
+++ b/versions/l-/libdvdcss.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "879280b3353aac493a996c9ed8da98699734d12d",
+      "version-semver": "1.4.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- Pristine porting, alternative to #40693. CC @capric8416
- The gitlab source doesn't include the `ChangeLog` file, and a full git checkout would be need to generate it. Possible alternative: Using dist tarballs. (Mirrored at mirrorservice.org.)
- There is some legal FUD in particular with regard to US legislation. IANAL and I can't answer how it affects a vcpkg port which is a mere build recipe IMO. References:  
  https://www.videolan.org/legal.html  
  https://en.wikipedia.org/wiki/Libdvdcss
- uwp unsupported by upstream.
 