### PR TITLE
[zziplib] Update version to 0.13.78

### DIFF
--- a/ports/zziplib/no-release-postfix.patch
+++ b/ports/zziplib/no-release-postfix.patch
@@ -1,24 +1,24 @@
 diff --git a/zzip/CMakeLists.txt b/zzip/CMakeLists.txt
-index a9f6e3a..407827b 100644
+index 28f03aa..6f34cc8 100644
 --- a/zzip/CMakeLists.txt
 +++ b/zzip/CMakeLists.txt
-@@ -180,16 +180,16 @@ target_link_libraries(libzzipmmapped ZLIB::ZLIB )
- target_include_directories (libzzipmmapped PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+@@ -248,16 +248,16 @@ add_custom_command(OUTPUT libzzipmmapped.so.gcov
+ add_custom_target(libzzipmmapped.gcov DEPENDS libzzipmmapped.so.gcov)
  endif()
-
+ 
 -set_target_properties(libzzip PROPERTIES OUTPUT_NAME "zzip" RELEASE_POSTFIX "-${RELNUM}")
 +set_target_properties(libzzip PROPERTIES OUTPUT_NAME "zzip")
  SET_TARGET_PROPERTIES(libzzip PROPERTIES VERSION ${VERNUM}.${FIXNUM} SOVERSION ${VERNUM})
-
+ 
  if(ZZIPFSEEKO)
 -set_target_properties(libzzipfseeko PROPERTIES OUTPUT_NAME "zzipfseeko" RELEASE_POSTFIX "-${RELNUM}")
 +set_target_properties(libzzipfseeko PROPERTIES OUTPUT_NAME "zzipfseeko")
  SET_TARGET_PROPERTIES(libzzipfseeko PROPERTIES VERSION ${VERNUM}.${FIXNUM} SOVERSION ${VERNUM})
  endif()
-
+ 
  if(ZZIPMMAPPED)
 -set_target_properties(libzzipmmapped PROPERTIES OUTPUT_NAME "zzipmmapped" RELEASE_POSTFIX "-${RELNUM}")
 +set_target_properties(libzzipmmapped PROPERTIES OUTPUT_NAME "zzipmmapped")
  SET_TARGET_PROPERTIES(libzzipmmapped PROPERTIES VERSION ${VERNUM}.${FIXNUM} SOVERSION ${VERNUM})
  endif()
-
+ 

--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gdraheim/zziplib
     REF "v${VERSION}"
-    SHA512 95557147d374d0e9074b83319350db9085b8ae98ff7cf7ab96a3209564597744252504adfaf4d17b0243ffb118adf2afabe7dd736e6514a7e74360cd0955e4f5
+    SHA512 e96771c310a1a9eb227027e8c2a495409c01dd273b483b3a04119d6a273cce7c88ba77c192fcde5e85d0a37c847a0df8e521f460d00920e62153400f0743ea78
     PATCHES
         no-release-postfix.patch
 )
@@ -28,7 +28,7 @@ vcpkg_cmake_configure(
         -DZZIPWRAP=OFF
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME zziplib)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/zziplib")
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE

--- a/ports/zziplib/vcpkg.json
+++ b/ports/zziplib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zziplib",
-  "version": "0.13.73",
+  "version": "0.13.78",
   "description": "library providing read access on ZIP-archives",
   "homepage": "https://github.com/gdraheim/zziplib",
   "license": "LGPL-2.0-or-later OR MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9897,7 +9897,7 @@
       "port-version": 5
     },
     "zziplib": {
-      "baseline": "0.13.73",
+      "baseline": "0.13.78",
       "port-version": 0
     }
   }

--- a/versions/z-/zziplib.json
+++ b/versions/z-/zziplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0fc955f622b2ca33bbab5ce2276168eef784f14e",
+      "version": "0.13.78",
+      "port-version": 0
+    },
+    {
       "git-tree": "a525f08ad4196f5324f29cd4f77b50ad7d39af58",
       "version": "0.13.73",
       "port-version": 0


### PR DESCRIPTION
Update `zziplib` version tp 0.3.78.
No feature need to test.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.