### PR TITLE
[popsift] Fixes build check failure in x64-windows-static-md triplet

### DIFF
--- a/ports/popsift/fix-post-check-failed.patch
+++ b/ports/popsift/fix-post-check-failed.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9735bc2..e83f5bb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,7 +35,7 @@ else()
+ endif()
+ 
+ # ensure the proper linker flags when building the static version on MSVC
+-if(MSVC AND NOT BUILD_SHARED_LIBS)
++if(0)
+   foreach(config "DEBUG" "RELEASE" "MINSIZEREL" "RELWITHDEBINFO")
+     string(REPLACE /MD /MT CMAKE_C_FLAGS_${config} "${CMAKE_C_FLAGS_${config}}")
+     string(REPLACE /MD /MT CMAKE_CXX_FLAGS_${config} "${CMAKE_CXX_FLAGS_${config}}")

--- a/ports/popsift/portfile.cmake
+++ b/ports/popsift/portfile.cmake
@@ -1,13 +1,14 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alicevision/popsift
-    REF v0.9
+    REF "v${VERSION}"
     SHA512 56789520872203eea86e07e8210e00c0b67d85486af16df9d620b1aff10f8d9ef5d910cf1dda6c68af7ca2ed11658ab5414ac79117b543f91a7d8d6a96a17ce0
     HEAD_REF develop
     PATCHES
         fix_missing_thrust_include.patch
         144.patch
         cuda_12_1.patch
+        fix-post-check-failed.patch
 )
 
 vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT)
@@ -36,4 +37,4 @@ if ("apps" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES popsift-demo AUTO_CLEAN)
 endif()
 
-file(INSTALL "${SOURCE_PATH}/COPYING.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.md")

--- a/ports/popsift/vcpkg.json
+++ b/ports/popsift/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "popsift",
   "version": "0.9",
-  "port-version": 5,
+  "port-version": 6,
   "description": "PopSift is an implementation of the SIFT algorithm in CUDA.",
   "homepage": "https://github.com/alicevision/popsift",
   "supports": "!(uwp | arm | arm64 | android | x86)",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -916,7 +916,6 @@ plplot:arm64-windows=fail
 pmdk:x64-android=fail
 pmdk:x64-osx=fail
 pmdk:x64-windows-static=fail
-popsift:x64-windows-static-md=fail
 popsift:x64-linux=fail # segfaults :(
 ptex:arm-neon-android=fail
 ptex:arm64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7042,7 +7042,7 @@
     },
     "popsift": {
       "baseline": "0.9",
-      "port-version": 5
+      "port-version": 6
     },
     "portable-file-dialogs": {
       "baseline": "0.1.0",

--- a/versions/p-/popsift.json
+++ b/versions/p-/popsift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03ff5117004df492a6342ef9a94b8c4039899c28",
+      "version": "0.9",
+      "port-version": 6
+    },
+    {
       "git-tree": "df628dcfa7ee8110e38f7a449b599e3b014645eb",
       "version": "0.9",
       "port-version": 5


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40559
Disable the code that forcefully replaces `/MD` with `/MT`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
