### PR TITLE
[libice] Update version to 1.1.1

### DIFF
--- a/ports/libice/fix_build.patch
+++ b/ports/libice/fix_build.patch
@@ -1,5 +1,5 @@
 diff --git a/src/error.c b/src/error.c
-index 055452ec3..0ce530a96 100644
+index 055452e..0ce530a 100644
 --- a/src/error.c
 +++ b/src/error.c
 @@ -32,7 +32,11 @@ Author: Ralph Mor, X Consortium
@@ -15,14 +15,13 @@ index 055452ec3..0ce530a96 100644
  
  void
 diff --git a/src/iceauth.c b/src/iceauth.c
-index 147efc76c..ea6d1a67b 100644
+index 5a4d400..4549f0e 100644
 --- a/src/iceauth.c
 +++ b/src/iceauth.c
-@@ -38,8 +38,12 @@ Author: Ralph Mor, X Consortium
- #ifdef HAVE_LIBBSD
- #include <bsd/stdlib.h>	/* for arc4random_buf() */
+@@ -39,7 +39,12 @@ Author: Ralph Mor, X Consortium
+ #include <stdlib.h>	/* for arc4random_buf() */
  #endif
--
+ 
 +#ifdef HAVE_UNISTD_H
  #include <unistd.h>
 +#elif _MSC_VER

--- a/ports/libice/portfile.cmake
+++ b/ports/libice/portfile.cmake
@@ -7,8 +7,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libice
-    REF 8e6a14c63d6b73cde87cb331439f2a4d19cba5b9 # 1.0.10
-    SHA512  ad79cfbc3b1d51fb1f019bc088999ac8a64062a71667dbb4ffb62fe6d1b7dba7665944f64be6dcd27de08cc77e91512de97231db1e4ac018088727e90113d040
+    REF be1888a46e446dfcaa62ac0a97d96bb77b6816d4 # 1.1.1
+    SHA512  0892ee9210302e787297763bcf0c7788bcd5f5572d5fd86472e8104dc291e7e190effc0100bbca98c6b048b445bd9e8bdf490287e1dbf2a64693aa1895950610
     HEAD_REF master
     PATCHES fix_build.patch
             replace_macros.patch

--- a/ports/libice/replace_macros.patch
+++ b/ports/libice/replace_macros.patch
@@ -1,5 +1,5 @@
 diff --git a/include/X11/ICE/ICElib.h b/include/X11/ICE/ICElib.h
-index 402cbc8bd..506c18baf 100644
+index 402cbc8..506c18b 100644
 --- a/include/X11/ICE/ICElib.h
 +++ b/include/X11/ICE/ICElib.h
 @@ -32,8 +32,8 @@ Author: Ralph Mor, X Consortium

--- a/ports/libice/vcpkg.json
+++ b/ports/libice/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libice",
-  "version": "1.0.10",
-  "port-version": 1,
+  "version": "1.1.1",
   "description": "Inter-Client Exchange Library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libice",
   "license": "MIT-open-group",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4581,8 +4581,8 @@
       "port-version": 0
     },
     "libice": {
-      "baseline": "1.0.10",
-      "port-version": 1
+      "baseline": "1.1.1",
+      "port-version": 0
     },
     "libiconv": {
       "baseline": "1.17",

--- a/versions/l-/libice.json
+++ b/versions/l-/libice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6c69693bd283d8e6b8e9c1303f7cafbd0ecec572",
+      "version": "1.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c19081b820dd8056dbb7bbb052ca0c3bcf628cd7",
       "version": "1.0.10",
       "port-version": 1


### PR DESCRIPTION
Update `libice` version to 1.1.1.
No feature need to test.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.