### PR TITLE
[zug] Update to 2024-04-26

### DIFF
--- a/ports/zug/portfile.cmake
+++ b/ports/zug/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO arximboldi/zug
-    REF 033dadbed463ff3430b7ebc36df8a46f4f0f5078
-    SHA512 a8067a90f7a427775872f8198419aa791b647e273ed148b93c189d3b81a4564a19b9321b4bb8cd5681627d8ab13e40be09ed1d75c7b65d74078f21daddaef929
+    REF 7c22cc138e2a9a61620986d1a7e1e9730123f22b
+    SHA512 ecf88ca56ae70ca87391ed34d6d6561e7da9810bba71e6abce2cd150b07cbb7180a7b90db96d0dc5f761fdeb43d75f5f0b47cbf45d78694c3177155d2005fe89
     HEAD_REF master
 )
 
@@ -24,4 +24,4 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Zug)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/zug/vcpkg.json
+++ b/ports/zug/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "zug",
-  "version-date": "2021-04-23",
-  "port-version": 1,
+  "version-date": "2024-04-26",
   "description": "Transducers for C++",
   "homepage": "https://sinusoid.es/zug/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9889,8 +9889,8 @@
       "port-version": 1
     },
     "zug": {
-      "baseline": "2021-04-23",
-      "port-version": 1
+      "baseline": "2024-04-26",
+      "port-version": 0
     },
     "zycore": {
       "baseline": "1.5.0",

--- a/versions/z-/zug.json
+++ b/versions/z-/zug.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6502a3391ee8a0c9eb83d7c9eae79326bb443fe4",
+      "version-date": "2024-04-26",
+      "port-version": 0
+    },
+    {
       "git-tree": "ebb162e61d6a161de1d01184b20389079eb3fdc6",
       "version-date": "2021-04-23",
       "port-version": 1


### PR DESCRIPTION
Update `zug` to 2024-04-26.

No feature needs to be tested, the usage test successfully `on x64-windows`(header file found):
```
zug provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(Zug CONFIG REQUIRED)
  target_link_libraries(main PRIVATE zug)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] `The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ·Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
