### PR TITLE
[libyuv] Add tools feature

### DIFF
--- a/ports/libyuv/cmake.diff
+++ b/ports/libyuv/cmake.diff
@@ -1,18 +1,33 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9a20941..945c5a4 100644
+index 9a20941d..d161326c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -4,8 +4,8 @@
+@@ -4,8 +4,9 @@
  
  include(CheckCSourceCompiles)
  
 +cmake_minimum_required(VERSION 3.12)
  project ( YUV C CXX )	# "C" is required even for C++ projects
 -cmake_minimum_required( VERSION 2.8.12 )
++option( BUILD_TOOLS "Build tools" OFF )
  option( UNIT_TEST "Built unit tests" OFF )
  
  set ( ly_base_dir	${PROJECT_SOURCE_DIR} )
-@@ -164,7 +164,8 @@ target_link_libraries  ( yuvconstants ${ly_lib_static} )
+@@ -149,6 +150,8 @@ if(WIN32)
+   set_target_properties( ${ly_lib_shared} PROPERTIES IMPORT_PREFIX "lib" )
+ endif()
+ 
++if (BUILD_TOOLS)
++
+ # this creates the cpuid tool
+ add_executable      ( cpuid ${ly_base_dir}/util/cpuid.c )
+ target_link_libraries  ( cpuid ${ly_lib_static} )
+@@ -161,10 +164,13 @@ target_link_libraries	( yuvconvert ${ly_lib_static} )
+ add_executable      ( yuvconstants ${ly_base_dir}/util/yuvconstants.c )
+ target_link_libraries  ( yuvconstants ${ly_lib_static} )
+ 
++endif()
++
  find_package ( JPEG )
  if (JPEG_FOUND)
    include_directories( ${JPEG_INCLUDE_DIR} )
@@ -22,14 +37,16 @@ index 9a20941..945c5a4 100644
    add_definitions( -DHAVE_JPEG )
  endif()
  
-@@ -211,9 +212,18 @@ endif()
+@@ -211,9 +217,20 @@ endif()
  
  
  # install the conversion tool, .so, .a, and all the header files
 -install ( PROGRAMS ${CMAKE_BINARY_DIR}/yuvconvert			DESTINATION bin )
 -install ( TARGETS ${ly_lib_static}						DESTINATION lib )
 -install ( TARGETS ${ly_lib_shared} LIBRARY				DESTINATION lib RUNTIME DESTINATION bin )
-+install(TARGETS yuvconvert)
++if (BUILD_TOOLS)
++  install(TARGETS yuvconvert yuvconstants)
++endif()
 +if(BUILD_SHARED_LIBS)
 +  target_include_directories(${ly_lib_shared} PUBLIC $<INSTALL_INTERFACE:include>)
 +  install(TARGETS ${ly_lib_shared} EXPORT libyuv-targets)

--- a/ports/libyuv/portfile.cmake
+++ b/ports/libyuv/portfile.cmake
@@ -16,6 +16,8 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+    OPTIONS_DEBUG
+        -DBUILD_TOOLS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/libyuv/portfile.cmake
+++ b/ports/libyuv/portfile.cmake
@@ -7,14 +7,22 @@ vcpkg_from_git(
         cmake.diff
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools BUILD_TOOLS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
-vcpkg_copy_pdbs()
-vcpkg_copy_tools(TOOL_NAMES yuvconvert AUTO_CLEAN)
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES yuvconvert yuvconstants AUTO_CLEAN)
+endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libyuv/basic_types.h" "defined(LIBYUV_USING_SHARED_LIBRARY)" "1")

--- a/ports/libyuv/vcpkg.json
+++ b/ports/libyuv/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libyuv",
   "version": "1895",
+  "port-version": 1,
   "description": "libyuv is an open source project that includes YUV scaling and conversion functionality",
   "homepage": "https://chromium.googlesource.com/libyuv/libyuv",
   "license": null,
@@ -18,5 +19,11 @@
       "name": "vcpkg-cmake-get-vars",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "build command line tool",
+      "supports": "!android & !ios & !xbox & !wasm32"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5402,7 +5402,7 @@
     },
     "libyuv": {
       "baseline": "1895",
-      "port-version": 0
+      "port-version": 1
     },
     "libzen": {
       "baseline": "0.4.41",

--- a/versions/l-/libyuv.json
+++ b/versions/l-/libyuv.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "558d5638e4e2cb7cec2a0dd327a8216fae3b0893",
+      "git-tree": "9a0250bfbce25cfd98ed744db8528d4214fe3d56",
       "version": "1895",
       "port-version": 1
     },

--- a/versions/l-/libyuv.json
+++ b/versions/l-/libyuv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "558d5638e4e2cb7cec2a0dd327a8216fae3b0893",
+      "version": "1895",
+      "port-version": 1
+    },
+    {
       "git-tree": "8248e631c414a1497fe1c8100a658b6f9f180a4d",
       "version": "1895",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

1. Add `tools` feature
2. Fix build on `arm64-ios`