### PR TITLE
[clipper2] update to 1.4.0

### DIFF
--- a/ports/clipper2/portfile.cmake
+++ b/ports/clipper2/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AngusJohnson/Clipper2
     REF "Clipper2_${VERSION}"
-    SHA512 64028ab0610dc2b44e48a299d8498de59807f36d8471c4758e3bbf87de682b0d0a29d027a495f36dd5432737cedc44f09a8336f0d620846d58616244c72e226c
+    SHA512 91036e81244f3615095d7cd8522f9c4a32ea66f802e3d190393eb8939e1a706b69c69c3a5b7c6522235c075dd6ecd45f21bffb47448ba72191ddcf05e9e93128
     HEAD_REF main
 )
 
@@ -19,6 +19,7 @@ vcpkg_cmake_configure(
         -DCLIPPER2_UTILS=ON
 )
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/clipper2/usage
+++ b/ports/clipper2/usage
@@ -10,3 +10,12 @@ The package clipper2 can be imported via CMake FindPkgConfig module:
     pkg_check_modules(Clipper2Z REQUIRED IMPORTED_TARGET Clipper2Z)
     target_link_libraries(main PkgConfig::Clipper2Z)
 
+clipper2 provides CMake targets:
+
+    # Clipper2
+    find_package(Clipper2 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Clipper2::Clipper2)
+
+    # Clipper2Z
+    find_package(Clipper2 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Clipper2::Clipper2Z)

--- a/ports/clipper2/vcpkg.json
+++ b/ports/clipper2/vcpkg.json
@@ -1,13 +1,16 @@
 {
   "name": "clipper2",
-  "version": "1.3.0",
-  "port-version": 1,
+  "version": "1.4.0",
   "description": "Polygon Clipping and Offsetting",
   "homepage": "http://www.angusj.com/clipper2",
   "license": "BSL-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1701,8 +1701,8 @@
       "port-version": 2
     },
     "clipper2": {
-      "baseline": "1.3.0",
-      "port-version": 1
+      "baseline": "1.4.0",
+      "port-version": 0
     },
     "clockutils": {
       "baseline": "1.1.1",

--- a/versions/c-/clipper2.json
+++ b/versions/c-/clipper2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b7c4d5dff8e0b28ad089e870674d497d4be1adb",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "666b9d81d31d70d3d691e2286d951168c5d9d970",
       "version": "1.3.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
