### PR TITLE
[shiftmedia-libgnutls] Fix mkdir too many arguments

### DIFF
--- a/ports/shiftmedia-libgnutls/mkdir.patch
+++ b/ports/shiftmedia-libgnutls/mkdir.patch
@@ -1,0 +1,13 @@
+diff --git a/SMP/unistd.h b/SMP/unistd.h
+index b54d4be15..273204e00 100644
+--- a/SMP/unistd.h
++++ b/SMP/unistd.h
+@@ -32,6 +32,8 @@
+ #include <direct.h>
+ #include <fcntl.h>
+ 
++#define mkdir(path, mode) _mkdir(path)
++
+ #define R_OK    4       /* Test for read permission.  */
+ #define W_OK    2       /* Test for write permission.  */
+ //#define   X_OK    1       /* execute permission - unsupported in windows*/

--- a/ports/shiftmedia-libgnutls/portfile.cmake
+++ b/ports/shiftmedia-libgnutls/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         pkgconfig.patch
         ssize_t_already_define.patch
         fix-warnings.patch
+        mkdir.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/devel/perlasm")

--- a/ports/shiftmedia-libgnutls/vcpkg.json
+++ b/ports/shiftmedia-libgnutls/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "shiftmedia-libgnutls",
   "version": "3.8.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Unofficial GnuTLS fork with added custom native Visual Studio project build tools. ",
   "homepage": "https://github.com/ShiftMediaProject/gnutls",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8214,7 +8214,7 @@
     },
     "shiftmedia-libgnutls": {
       "baseline": "3.8.4",
-      "port-version": 2
+      "port-version": 3
     },
     "shiftmedia-libgpg-error": {
       "baseline": "1.45",

--- a/versions/s-/shiftmedia-libgnutls.json
+++ b/versions/s-/shiftmedia-libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b18bd4e582995b852d1b9eac4b79805d84aaa656",
+      "version": "3.8.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "1d4b38dbf344dc537c0f0e8fae77706d09ef0126",
       "version": "3.8.4",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fix #40738 

From here:
https://stackoverflow.com/questions/12102147/too-many-arguments-to-function-int-mkdirconst-char