### PR TITLE
[bustache] update 0.1.0

### DIFF
--- a/ports/bustache/portfile.cmake
+++ b/ports/bustache/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jamboree/bustache
     REF 1a6d4422bff46c7c8f37d2ba48c910532bdc8b37
-    SHA512 0
+    SHA512 a6eccc815c9ee1d7de9e1c8e2affc6d1a393fe3017eb492cbb3698282d567304a6b234d37aac6a48cd315c68187ec89f62c63ea4e9786bbb963b35f7d18990d9
 
     HEAD_REF master
 )
@@ -20,7 +20,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH "share/bustache/cmake")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/bustache/cmake")
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/bustache/portfile.cmake
+++ b/ports/bustache/portfile.cmake
@@ -20,7 +20,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/bustache/cmake")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/bustache")
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/bustache/portfile.cmake
+++ b/ports/bustache/portfile.cmake
@@ -1,13 +1,22 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jamboree/bustache
-    REF abb25ca189425783c6b7ec5c17c5284dccb59faf
-    SHA512 be00451f6a85edccacbdd5d8478d7af4f3162f9a9a31af876004237ca7f303c1262b2ea623e6ec595d73440dc14fcf22d185bc521fd3aca6e28ec43890d611c5
+    REF 1a6d4422bff46c7c8f37d2ba48c910532bdc8b37
+    SHA512 0
+
     HEAD_REF master
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        fmt BUSTACHE_USE_FMT)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        BUSTACHE_USE_FMT
 )
 
 vcpkg_cmake_install()

--- a/ports/bustache/vcpkg.json
+++ b/ports/bustache/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bustache",
-  "version": "0.1.0",
+  "version": "2024-09-04.0.1.0",
   "description": "C++20 implementation of {{ mustache }}",
   "homepage": "https://github.com/jamboree/bustache",
   "license": "BSL-1.0",

--- a/ports/bustache/vcpkg.json
+++ b/ports/bustache/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "bustache",
   "version": "0.1.0",
+  "port-version": 1,
   "description": "C++20 implementation of {{ mustache }}",
   "homepage": "https://github.com/jamboree/bustache",
   "license": "BSL-1.0",

--- a/ports/bustache/vcpkg.json
+++ b/ports/bustache/vcpkg.json
@@ -1,13 +1,10 @@
 {
   "name": "bustache",
-  "version": "1.1.0",
-  "port-version": 2,
-  "description": "C++11 implementation of {{ mustache }}",
+  "version": "0.1.0",
+  "description": "C++20 implementation of {{ mustache }}",
   "homepage": "https://github.com/jamboree/bustache",
   "license": "BSL-1.0",
   "dependencies": [
-    "boost-unordered",
-    "boost-utility",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -16,5 +13,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "fmt": {
+      "description": "Build with fmtlib",
+      "dependencies": [
+        "fmt"
+      ]
+    }
+  }
 }

--- a/ports/bustache/vcpkg.json
+++ b/ports/bustache/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "bustache",
   "version": "0.1.0",
-  "port-version": 1,
   "description": "C++20 implementation of {{ mustache }}",
   "homepage": "https://github.com/jamboree/bustache",
   "license": "BSL-1.0",

--- a/versions/b-/bustache.json
+++ b/versions/b-/bustache.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cf8100ae4f7c7d4d68e129e71c1983af944d509b",
+      "version": "0.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8e9abc9f41df5fb578afff7cea5d0dd475924c96",
       "version": "0.1.0",
       "port-version": 0

--- a/versions/b-/bustache.json
+++ b/versions/b-/bustache.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "2deefe412d69d6d77d14eefd2457a79c3726b96f",
-      "version": "0.1.0",
+      "git-tree": "cf8100ae4f7c7d4d68e129e71c1983af944d509b",
+      "version": "2024-09-04.0.1.0",
       "port-version": 0
     },
     {

--- a/versions/b-/bustache.json
+++ b/versions/b-/bustache.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e9abc9f41df5fb578afff7cea5d0dd475924c96",
+      "version": "0.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "888d4f529ac5ecc9a12049beb50337d237f97e28",
       "version": "1.1.0",
       "port-version": 2

--- a/versions/b-/bustache.json
+++ b/versions/b-/bustache.json
@@ -1,12 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cf8100ae4f7c7d4d68e129e71c1983af944d509b",
-      "version": "0.1.0",
-      "port-version": 1
-    },
-    {
-      "git-tree": "8e9abc9f41df5fb578afff7cea5d0dd475924c96",
+      "git-tree": "2deefe412d69d6d77d14eefd2457a79c3726b96f",
       "version": "0.1.0",
       "port-version": 0
     },

--- a/versions/b-/bustache.json
+++ b/versions/b-/bustache.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cf8100ae4f7c7d4d68e129e71c1983af944d509b",
+      "git-tree": "909302c5c1e5966bc2271e260d01260557eb200d",
       "version": "2024-09-04.0.1.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1414,7 +1414,7 @@
     },
     "bustache": {
       "baseline": "0.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "butteraugli": {
       "baseline": "2019-05-08",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1414,7 +1414,7 @@
     },
     "bustache": {
       "baseline": "0.1.0",
-      "port-version": 1
+      "port-version": 0
     },
     "butteraugli": {
       "baseline": "2019-05-08",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1413,8 +1413,8 @@
       "port-version": 2
     },
     "bustache": {
-      "baseline": "1.1.0",
-      "port-version": 2
+      "baseline": "0.1.0",
+      "port-version": 0
     },
     "butteraugli": {
       "baseline": "2019-05-08",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1413,7 +1413,7 @@
       "port-version": 2
     },
     "bustache": {
-      "baseline": "0.1.0",
+      "baseline": "2024-09-04.0.1.0",
       "port-version": 0
     },
     "butteraugli": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:-->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
~~- [ ] The "supports" clause reflects platforms that may be fixed by this new version.~~
~~- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
~~- [ ] Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This is my first time trying to update a port in vcpkg so if there are any mistakes let me know.

The previous version was on 1.1.0 and Project's CMake went back to 0.1.0. I don't know if this as any unintended consequences.
