### PR TITLE
#40740: changed to future official repository on qknight github

### DIFF
--- a/ports/libnoise/portfile.cmake
+++ b/ports/libnoise/portfile.cmake
@@ -3,7 +3,7 @@ set( LIBNOISE_COMMIT "d7e68784a2b24c632868506780eba336ede74ecd" )
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO RobertHue/libnoise
+    REPO qknight/libnoise
     REF ${LIBNOISE_COMMIT}
     SHA512 8c4d654acb4ae3d90ee62ebdf0447f876022dcb887ebfad88f39b09d29183a58e6fc1b1f1d03edff804975c8befcc6eda33c44797495285aae338c2e869a14d7
     HEAD_REF master

--- a/ports/libnoise/vcpkg.json
+++ b/ports/libnoise/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "port-version": 3,
   "description": "A general-purpose library that generates three-dimensional coherent noise. Useful for terrain generation and procedural texture generation. Uses a broad number of techniques (Perlin noise, ridged multifractal, etc.) and combinations of those techniques.",
-  "homepage": "https://github.com/RobertHue/libnoise",
+  "homepage": "https://github.com/qknight/libnoise",
   "license": "LGPL-2.1",
   "dependencies": [
     {


### PR DESCRIPTION
Fixes #40740 

PR updates an existing port:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download. 
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

-> bullet points are not needed because it is still pointing to the same commit, only another official repository.