### PR TITLE
[rmlui] Add feature for SVG rendering using lunasvg

### DIFF
--- a/ports/rmlui/portfile.cmake
+++ b/ports/rmlui/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         lua             RMLUI_LUA_BINDINGS
+        svg             RMLUI_SVG_PLUGIN
 )
 
 if("freetype" IN_LIST FEATURES)

--- a/ports/rmlui/vcpkg.json
+++ b/ports/rmlui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "rmlui",
   "version": "6.0",
+  "port-version": 1,
   "maintainers": "Michael R. P. Ragazzon <mikke89@users.noreply.github.com>",
   "description": "RmlUi is the C++ user interface library based on the HTML and CSS standards, designed as a complete solution for any project's interface needs.",
   "homepage": "https://github.com/mikke89/RmlUi",
@@ -34,6 +35,12 @@
       "description": "Build Lua bindings",
       "dependencies": [
         "lua"
+      ]
+    },
+    "svg": {
+      "description": "Enable plugin for SVG images",
+      "dependencies": [
+        "lunasvg"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7862,7 +7862,7 @@
     },
     "rmlui": {
       "baseline": "6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "rmqcpp": {
       "baseline": "1.0.0",

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fdd8836a66e7c33d1454a1a1376ad32bf78da5f1",
+      "version": "6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "845eceb8c79319709a6bee36adacb6b58ab81a05",
       "version": "6.0",
       "port-version": 0


### PR DESCRIPTION
When rmlui was first added to vcpkg, the lunasvg library necessary for SVG rendering support was not yet available in vcpkg. Since lunasvg is now in vcpkg, I've added a feature flag to build rmlui with SVG support.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
