### PR TITLE
[ls-qpack] Detect xxhash with pkgconf as upstream

### DIFF
--- a/ports/ls-qpack/cmake-export.patch
+++ b/ports/ls-qpack/cmake-export.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ff26bc3..6df9654 100644
+index 56c3e23..7a4a2d6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -17,7 +17,10 @@ option(LSQPACK_XXH "Include XXH" ON)

--- a/ports/ls-qpack/portfile.cmake
+++ b/ports/ls-qpack/portfile.cmake
@@ -37,7 +37,8 @@ file(REMOVE_RECURSE
 file(READ "${CURRENT_PACKAGES_DIR}/share/unofficial-ls-qpack/unofficial-ls-qpack-config.cmake" cmake_config)
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/unofficial-ls-qpack/unofficial-ls-qpack-config.cmake"
 "include(CMakeFindDependencyMacro)
-find_dependency(xxHash CONFIG)
+find_dependency(PkgConfig)
+pkg_check_modules(XXH REQUIRED IMPORTED_TARGET libxxhash)
 ${cmake_config}
 ")
 

--- a/ports/ls-qpack/vcpkg.json
+++ b/ports/ls-qpack/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ls-qpack",
   "version": "2.5.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "QPACK compression library for use with HTTP/3",
   "homepage": "https://github.com/litespeedtech/ls-qpack",
   "license": "MIT",

--- a/ports/ls-qpack/xxhash.patch
+++ b/ports/ls-qpack/xxhash.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1a1f8e9..cf207d2 100644
+index 1a1f8e9..56c3e23 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -20,9 +20,12 @@ add_library(ls-qpack "")
+@@ -20,9 +20,13 @@ add_library(ls-qpack "")
  target_include_directories(ls-qpack PUBLIC .)
  target_sources(ls-qpack PRIVATE lsqpack.c)
  
@@ -10,9 +10,10 @@ index 1a1f8e9..cf207d2 100644
  if(LSQPACK_XXH)
      target_sources(ls-qpack PRIVATE deps/xxhash/xxhash.c)
 +else()
-+    find_package(xxHash CONFIG REQUIRED)
-+    target_link_libraries(ls-qpack PUBLIC xxHash::xxhash)
-+    set(LSQPACK_DEPENDS "libxxhash")
++	find_package(PkgConfig REQUIRED)
++	pkg_check_modules(XXH REQUIRED IMPORTED_TARGET libxxhash)
++	target_link_libraries(ls-qpack PUBLIC PkgConfig::XXH)
++	set(LSQPACK_DEPENDS "libxxhash")
  endif()
  
  if(WIN32)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5518,7 +5518,7 @@
     },
     "ls-qpack": {
       "baseline": "2.5.4",
-      "port-version": 2
+      "port-version": 3
     },
     "ltla-aarand": {
       "baseline": "2023-03-19",

--- a/versions/l-/ls-qpack.json
+++ b/versions/l-/ls-qpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8b9ac167ce7e831b1434cff6f3da33cdcee974d",
+      "version": "2.5.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "1d9eb013f6b98de2b479869b6571ac7d0c929b0e",
       "version": "2.5.4",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
