### PR TITLE
[sassc] Exclude dependency getopt

### DIFF
--- a/ports/sassc/portfile.cmake
+++ b/ports/sassc/portfile.cmake
@@ -1,7 +1,9 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sass/sassc
-    REF 3.6.2
+    REF "${VERSION}"
     SHA512 fff3995ce8608bdaed5f4f1352ae4f1f882de58663b932c598d6168df421e4dbf907ec0f8caebb1e56490a71ca11105726f291b475816dd53e705bc53121969f
     HEAD_REF master
     PATCHES remove_compiler_flags.patch
@@ -9,26 +11,23 @@ vcpkg_from_github(
 
 find_library(LIBSASS_DEBUG sass PATHS "${CURRENT_INSTALLED_DIR}/debug/lib/" NO_DEFAULT_PATH)
 find_library(LIBSASS_RELEASE sass PATHS "${CURRENT_INSTALLED_DIR}/lib/" NO_DEFAULT_PATH)
-if(VCPKG_TARGET_IS_WINDOWS)
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     set(ENV{LIBS} "$ENV{LIBS} -lgetopt")
 endif()
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
     OPTIONS
-        --with-libsass-include='${CURRENT_INSTALLED_DIR}/include'
+        "--with-libsass-include='${CURRENT_INSTALLED_DIR}/include'"
     OPTIONS_DEBUG
-        --with-libsass-lib='${LIBSASS_DEBUG}'
+        "--with-libsass-lib='${LIBSASS_DEBUG}'"
     OPTIONS_RELEASE
-        --with-libsass-lib='${LIBSASS_RELEASE}'
+        "--with-libsass-lib='${LIBSASS_RELEASE}'"
 )
 vcpkg_install_make(MAKEFILE GNUmakefile)
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
 vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin")
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-
-set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)

--- a/ports/sassc/vcpkg.json
+++ b/ports/sassc/vcpkg.json
@@ -1,10 +1,14 @@
 {
   "name": "sassc",
   "version": "3.6.2",
+  "port-version": 1,
   "description": "SassC is a wrapper around libsass (http://github.com/sass/libsass) used to generate a useful command-line application that can be installed and packaged for several operating systems.",
   "homepage": "https://github.com/sass/sassc",
   "dependencies": [
-    "getopt",
+    {
+      "name": "getopt",
+      "platform": "windows & !mingw"
+    },
     "libsass"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8010,7 +8010,7 @@
     },
     "sassc": {
       "baseline": "3.6.2",
-      "port-version": 0
+      "port-version": 1
     },
     "saucer": {
       "baseline": "2.3.0",

--- a/versions/s-/sassc.json
+++ b/versions/s-/sassc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "937f959ed298caa217edd7352d5743b073ff27f7",
+      "version": "3.6.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "ac068d38115fa4710289d76d3a02a1b6c2650785",
       "version": "3.6.2",
       "port-version": 0


### PR DESCRIPTION
Fix #40753

Change lib dependency `getopt` to be consistent with support of port `getopt-win32`.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-mingw-dynamic
* x64-windows