### PR TITLE
[projectm-eval] Fix/add "ns-eel2" feature

### DIFF
--- a/ports/projectm-eval/portfile.cmake
+++ b/ports/projectm-eval/portfile.cmake
@@ -17,8 +17,14 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-  PACKAGE_NAME "projectm-eval"
-  CONFIG_PATH "lib/cmake/projectM-Eval"
+    PACKAGE_NAME "projectm-eval"
+    CONFIG_PATH "lib/cmake/projectM-Eval"
+    DO_NOT_DELETE_PARENT_CONFIG_PATH
+)
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "projectM-EvalMilkdrop"
+    CONFIG_PATH "lib/cmake/projectM-EvalMilkdrop"
 )
 
 vcpkg_fixup_pkgconfig()

--- a/ports/projectm-eval/usage
+++ b/ports/projectm-eval/usage
@@ -2,3 +2,8 @@ projectm-eval provides CMake targets:
 
   find_package(projectM-Eval REQUIRED)
   target_link_libraries(main PRIVATE projectM::Eval)
+
+To use the ns-eel2 shim with the Milkdrop codebase:
+
+  find_package(projectM-Eval REQUIRED COMPONENTS Milkdrop)
+  target_link_libraries(main PRIVATE projectM::ns-eel2)

--- a/ports/projectm-eval/vcpkg.json
+++ b/ports/projectm-eval/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "projectm-eval",
   "version": "1.0.0",
+  "port-version": 1,
   "description": "The projectM Expression Evaluation Library. A portable drop-in replacement of Milkdrop's \"ns-eel2\" expression parser for use in Milkdrop, projectM and other applications.",
   "homepage": "https://github.com/projectM-visualizer/projectm-eval",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7102,7 +7102,7 @@
     },
     "projectm-eval": {
       "baseline": "1.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "prometheus-cpp": {
       "baseline": "1.2.4",

--- a/versions/p-/projectm-eval.json
+++ b/versions/p-/projectm-eval.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c21e929bb3f98383e81a4821e0aa8b2cb1413f88",
+      "version": "1.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3c32881926b002ddd0fa05b351774ebe69f81fa1",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This portfile update fixes installation of the ns-eel2 shim library, adding it as a feature. No upstream version changes in this PR.

Made the feature default on Windows, as this is the only platform the shim is currently useful on, plus most use cases on this platform will require the shim to be available. If the ns-eel2 feature is enabled, it will add an additional package component "Milkdrop", an additional header and a small static library containing the required proxy function implementations.

If this is still considered to violate the "Default features should enable behaviors, not APIs" rule, I can remove it as a default feature, but then most Windows devs would have to enable it manually.

Users of other platforms can still manually enable the feature if required, e.g. when building with MinGW or porting the original Milkdrop code to other platforms.

Also added usage information for the optional "Milkdrop" component added by the "ns-eel2" feature.