### PR TITLE
[simdjson] update to 3.10.1

### DIFF
--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO simdjson/simdjson
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 b6c2260f3732a61ffac54b4e66a56de034c25b01e00cc559b89662cf0da093c187f5cff15aa1ccebf4016e125199ddef47144f8436facb50d868c55719fb871a
+    SHA512 b19fde8d81eaff34b83bb41028d7ee3a408ae5bc896277148e96879b1cba1a7cfc4af0064973bcb07e2b56e0955c3a3a581910d7af23d68510374e7f297c3b7c
 )
 
 vcpkg_check_features(

--- a/ports/simdjson/vcpkg.json
+++ b/ports/simdjson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdjson",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "An extremely fast JSON library that can parse gigabytes of JSON per second",
   "homepage": "https://simdjson.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8261,7 +8261,7 @@
       "port-version": 0
     },
     "simdjson": {
-      "baseline": "3.10.0",
+      "baseline": "3.10.1",
       "port-version": 0
     },
     "simdutf": {

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d2103b03c687dbd783b48300c35531b9961d0523",
+      "version": "3.10.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "32e426da6bdcfff2b473cbc0ca10dcc639ac8539",
       "version": "3.10.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
