### PR TITLE
[avro-cpp] Update to 1.12.0

### DIFF
--- a/ports/avro-cpp/fix-cmake.patch
+++ b/ports/avro-cpp/fix-cmake.patch
@@ -1,34 +1,36 @@
 diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
-index 472684f4c..edde09e40 100644
+index 19059a4..8f9dd6c 100644
 --- a/lang/c++/CMakeLists.txt
 +++ b/lang/c++/CMakeLists.txt
-@@ -51,20 +51,16 @@ list(GET AVRO_VERSION 2 AVRO_VERSION_PATCH)
- project (Avro-cpp)
- set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
- 
-+find_package(ZLIB REQUIRED)
-+
- if (WIN32 AND NOT CYGWIN AND NOT MSYS)
-     add_definitions (/EHa)
--    add_definitions (
--        -DNOMINMAX
--        -DBOOST_REGEX_DYN_LINK
--        -DBOOST_FILESYSTEM_DYN_LINK
--        -DBOOST_SYSTEM_DYN_LINK
--        -DBOOST_IOSTREAMS_DYN_LINK
--        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
--        -DBOOST_ALL_NO_LIB)
-+    add_definitions (-DNOMINMAX)
+@@ -68,7 +68,8 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
  endif()
  
  if (CMAKE_COMPILER_IS_GNUCXX)
--    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Wconversion -pedantic -Werror")
 +    # Remove " -Werror" because of warning from boost-math (will require C++ 14 soon)
-+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Wconversion -pedantic")
  if (AVRO_ADD_PROTECTOR_FLAGS)
      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector-all -D_GLIBCXX_DEBUG")
      # Unset _GLIBCXX_DEBUG for avrogencpp.cc because using Boost Program Options
-@@ -114,7 +110,7 @@ set (AVRO_SOURCE_FILES
+@@ -82,16 +83,7 @@ endif ()
+ find_package (Boost 1.38 REQUIRED
+     COMPONENTS filesystem iostreams program_options regex system)
+ 
+-include(FetchContent)
+-FetchContent_Declare(
+-        fmt
+-        GIT_REPOSITORY  https://github.com/fmtlib/fmt.git
+-        GIT_TAG         10.2.1
+-        GIT_PROGRESS    TRUE
+-        USES_TERMINAL_DOWNLOAD TRUE
+-)
+-FetchContent_MakeAvailable(fmt)
+-
++find_package(fmt CONFIG REQUIRED)
+ find_package(Snappy)
+ if (SNAPPY_FOUND)
+     set(SNAPPY_PKG libsnappy)
+@@ -128,7 +120,7 @@ set (AVRO_SOURCE_FILES
          impl/CustomAttributes.cc
          )
  
@@ -37,48 +39,33 @@ index 472684f4c..edde09e40 100644
  
  set_property (TARGET avrocpp
      APPEND PROPERTY COMPILE_DEFINITIONS AVRO_DYN_LINK)
-@@ -131,12 +127,12 @@ set_target_properties (avrocpp PROPERTIES
- set_target_properties (avrocpp_s PROPERTIES
-     VERSION ${AVRO_VERSION_MAJOR}.${AVRO_VERSION_MINOR}.${AVRO_VERSION_PATCH})
- 
--target_link_libraries (avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
-+target_link_libraries (avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} ZLIB::ZLIB)
- target_include_directories(avrocpp PRIVATE ${SNAPPY_INCLUDE_DIR})
- 
- add_executable (precompile test/precompile.cc)
- 
--target_link_libraries (precompile avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
-+target_link_libraries (precompile avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} ZLIB::ZLIB)
- 
- macro (gen file ns)
-     add_custom_command (OUTPUT ${file}.hh
-@@ -166,13 +162,14 @@ gen (primitivetypes pt)
- gen (cpp_reserved_words cppres)
- 
- add_executable (avrogencpp impl/avrogencpp.cc)
--target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
-+target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} ZLIB::ZLIB)
+@@ -194,6 +186,7 @@ target_include_directories(avrocpp PUBLIC
+   $<INSTALL_INTERFACE:include>
+ )
  
 +if(BUILD_TESTING)
  enable_testing()
  
  macro (unittest name)
--    add_executable (${name} test/${name}.cc)
--    target_link_libraries (${name} avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
-+    add_executable (${name} test/${name}.cc impl/json/JsonIO.cc impl/json/JsonDom.cc)
-+    target_link_libraries (${name} avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} ZLIB::ZLIB)
-     add_test (NAME ${name} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${name})
- endmacro (unittest)
-@@ -197,6 +194,7 @@ add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
-     union_array_union_hh union_map_union_hh union_conflict_hh
-     recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
-     primitivetypes_hh empty_record_hh)
-+endif()
+@@ -220,23 +213,26 @@ unittest (CommonsSchemasTests)
+ add_dependencies (AvrogencppTestReservedWords cpp_reserved_words_hh)
  
+ add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
+-    tweet_hh
+-    union_array_union_hh union_map_union_hh union_conflict_hh
+-    recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
+-    primitivetypes_hh empty_record_hh cpp_reserved_words_union_typedef_hh
+-    union_empty_record_hh)
+-
++   tweet_hh
++   union_array_union_hh union_map_union_hh union_conflict_hh
++   recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
++   primitivetypes_hh empty_record_hh cpp_reserved_words_union_typedef_hh
++   union_empty_record_hh)
++endif()
  include (InstallRequiredSystemLibraries)
  
-@@ -204,10 +202,14 @@ set (CPACK_PACKAGE_FILE_NAME "avrocpp-${AVRO_VERSION_MAJOR}")
+ set (CPACK_PACKAGE_FILE_NAME "avrocpp-${AVRO_VERSION_MAJOR}")
  
  include (CPack)
  
@@ -87,13 +74,13 @@ index 472684f4c..edde09e40 100644
 -    ARCHIVE DESTINATION lib
 -    RUNTIME DESTINATION lib)
 +install(TARGETS avrocpp EXPORT unofficial-avro-cpp)
-+
+ 
 +install(
 +    EXPORT unofficial-avro-cpp
 +    FILE unofficial-avro-cpp-config.cmake
 +    DESTINATION share/unofficial-avro-cpp
 +    NAMESPACE unofficial::avro-cpp::
 +)
- 
  install (TARGETS avrogencpp RUNTIME DESTINATION bin)
  
+ install (DIRECTORY include/avro DESTINATION include

--- a/ports/avro-cpp/fix-cmake.patch
+++ b/ports/avro-cpp/fix-cmake.patch
@@ -1,8 +1,19 @@
 diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
-index 19059a4..8f9dd6c 100644
+index 19059a4..c49e9c2 100644
 --- a/lang/c++/CMakeLists.txt
 +++ b/lang/c++/CMakeLists.txt
-@@ -68,7 +68,8 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
+@@ -58,17 +58,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
+ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
+     add_definitions (/EHa)
+     add_definitions (
+-        -DNOMINMAX
+-        -DBOOST_REGEX_DYN_LINK
+-        -DBOOST_FILESYSTEM_DYN_LINK
+-        -DBOOST_SYSTEM_DYN_LINK
+-        -DBOOST_IOSTREAMS_DYN_LINK
+-        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
+-        -DBOOST_ALL_NO_LIB)
++        -DNOMINMAX)
  endif()
  
  if (CMAKE_COMPILER_IS_GNUCXX)
@@ -12,7 +23,7 @@ index 19059a4..8f9dd6c 100644
  if (AVRO_ADD_PROTECTOR_FLAGS)
      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector-all -D_GLIBCXX_DEBUG")
      # Unset _GLIBCXX_DEBUG for avrogencpp.cc because using Boost Program Options
-@@ -82,16 +83,7 @@ endif ()
+@@ -82,16 +77,7 @@ endif ()
  find_package (Boost 1.38 REQUIRED
      COMPONENTS filesystem iostreams program_options regex system)
  
@@ -30,7 +41,7 @@ index 19059a4..8f9dd6c 100644
  find_package(Snappy)
  if (SNAPPY_FOUND)
      set(SNAPPY_PKG libsnappy)
-@@ -128,7 +120,7 @@ set (AVRO_SOURCE_FILES
+@@ -128,7 +114,7 @@ set (AVRO_SOURCE_FILES
          impl/CustomAttributes.cc
          )
  
@@ -39,7 +50,7 @@ index 19059a4..8f9dd6c 100644
  
  set_property (TARGET avrocpp
      APPEND PROPERTY COMPILE_DEFINITIONS AVRO_DYN_LINK)
-@@ -194,6 +186,7 @@ target_include_directories(avrocpp PUBLIC
+@@ -194,6 +180,7 @@ target_include_directories(avrocpp PUBLIC
    $<INSTALL_INTERFACE:include>
  )
  
@@ -47,7 +58,7 @@ index 19059a4..8f9dd6c 100644
  enable_testing()
  
  macro (unittest name)
-@@ -220,23 +213,26 @@ unittest (CommonsSchemasTests)
+@@ -220,23 +207,26 @@ unittest (CommonsSchemasTests)
  add_dependencies (AvrogencppTestReservedWords cpp_reserved_words_hh)
  
  add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh

--- a/ports/avro-cpp/fix-fmt.patch
+++ b/ports/avro-cpp/fix-fmt.patch
@@ -1,0 +1,38 @@
+diff --git a/lang/c++/include/avro/Node.hh b/lang/c++/include/avro/Node.hh
+index f76078b..75619d9 100644
+--- a/lang/c++/include/avro/Node.hh
++++ b/lang/c++/include/avro/Node.hh
+@@ -219,8 +219,8 @@ inline std::ostream &operator<<(std::ostream &os, const avro::Node &n) {
+ template<>
+ struct fmt::formatter<avro::Name> : fmt::formatter<std::string> {
+     template<typename FormatContext>
+-    auto format(const avro::Name &n, FormatContext &ctx) {
+-        return fmt::formatter<std::string>::format(n.fullname(), ctx);
++    auto format(const avro::Name &n, FormatContext &ctx) const {
++        return fmt::format_to(ctx.out(), "{}", n.fullname());
+     }
+ };
+ 
+diff --git a/lang/c++/include/avro/Types.hh b/lang/c++/include/avro/Types.hh
+index 84a3397..4fe018e 100644
+--- a/lang/c++/include/avro/Types.hh
++++ b/lang/c++/include/avro/Types.hh
+@@ -19,6 +19,7 @@
+ #ifndef avro_Types_hh__
+ #define avro_Types_hh__
+ 
++#include <fmt/core.h>
+ #include <fmt/format.h>
+ #include <iostream>
+ 
+@@ -113,8 +114,8 @@ std::ostream &operator<<(std::ostream &os, const Null &null);
+ template<>
+ struct fmt::formatter<avro::Type> : fmt::formatter<std::string> {
+     template<typename FormatContext>
+-    auto format(avro::Type t, FormatContext &ctx) {
+-        return fmt::formatter<std::string>::format(avro::toString(t), ctx);
++    auto format(avro::Type t, FormatContext &ctx) const {
++        return fmt::format_to(ctx.out(), "{}", avro::toString(const_cast<avro::Type&>(t)));
+     }
+ };
+ 

--- a/ports/avro-cpp/portfile.cmake
+++ b/ports/avro-cpp/portfile.cmake
@@ -2,10 +2,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/avro
     REF "release-${VERSION}"
-    SHA512 728609f562460e1115366663ede2c5d4acbdd6950c1ee3e434ffc65d28b72e3a43c3ebce93d0a8459f0c4f6c492ebb9444e2127a0385f38eb7cdf74b28f0c3ed
+    SHA512 8cc6ef3cf1e0a919118c8ba5817a1866dc4f891fa95873c0fe1b4b388858fbadee8ed50406fa0006882cab40807fcf00c5a2dcd500290f3868d9d06b287eacb6
     HEAD_REF master
     PATCHES
         fix-cmake.patch
+        fix-fmt.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -27,14 +28,16 @@ file(READ "${CURRENT_PACKAGES_DIR}/share/unofficial-avro-cpp/unofficial-avro-cpp
 if("snappy" IN_LIST FEATURES)
     file(WRITE "${CURRENT_PACKAGES_DIR}/share/unofficial-avro-cpp/unofficial-avro-cpp-config.cmake"
 "include(CMakeFindDependencyMacro)
-find_dependency(ZLIB)
+find_dependency(Boost REQUIRED COMPONENTS filesystem iostreams program_options regex system)
+find_dependency(fmt CONFIG)
 find_dependency(Snappy)
 ${cmake_config}
 ")
 else()
     file(WRITE "${CURRENT_PACKAGES_DIR}/share/unofficial-avro-cpp/unofficial-avro-cpp-config.cmake"
 "include(CMakeFindDependencyMacro)
-find_dependency(ZLIB)
+find_dependency(Boost REQUIRED COMPONENTS filesystem iostreams program_options regex system)
+find_dependency(fmt CONFIG)
 ${cmake_config}
 ")
 endif()

--- a/ports/avro-cpp/vcpkg.json
+++ b/ports/avro-cpp/vcpkg.json
@@ -16,6 +16,7 @@
     "boost-program-options",
     "boost-random",
     "boost-tuple",
+    "fmt",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/avro-cpp/vcpkg.json
+++ b/ports/avro-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "avro-cpp",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "description": "Apache Avro is a data serialization system",
   "homepage": "https://github.com/apache/avro",
   "license": "Apache-2.0",

--- a/versions/a-/avro-cpp.json
+++ b/versions/a-/avro-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a869770cbad5ff4ebeee5c243bb4bd367eae28c6",
+      "git-tree": "d2891b88b1dbc936d2378919f72ebaf3b08748f7",
       "version": "1.12.0",
       "port-version": 0
     },

--- a/versions/a-/avro-cpp.json
+++ b/versions/a-/avro-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a869770cbad5ff4ebeee5c243bb4bd367eae28c6",
+      "version": "1.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e5b130595cfdd2c5fcecf41bcbbed730aab60285",
       "version": "1.11.3",
       "port-version": 0

--- a/versions/a-/avro-cpp.json
+++ b/versions/a-/avro-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d2891b88b1dbc936d2378919f72ebaf3b08748f7",
+      "git-tree": "d177503c9c4f90f723a50e01156fbb79b479237d",
       "version": "1.12.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -373,7 +373,7 @@
       "port-version": 0
     },
     "avro-cpp": {
-      "baseline": "1.11.3",
+      "baseline": "1.12.0",
       "port-version": 0
     },
     "awlib": {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40750
Fix the following errors:
```
F:\vcpkg\installed\x64-windows\include\fmt\base.h(1402): error C2662: 'fmt::v11::appender fmt::v11::formatter<avro::Name,char,void>::format<Context>(const avro::Name &,FormatContext &)': cannot convert 'this' pointer from 'const Formatter' to 'fmt::v11::formatter<avro::Name,char,void> &'
        with
        [
            Context=fmt::v11::format_context,
            FormatContext=fmt::v11::format_context
        ]
        and
        [
            Formatter=fmt::v11::formatter<avro::Name,char,void>
        ]
F:\vcpkg\installed\x64-windows\include\fmt\base.h(1402): note: Conversion loses qualifiers
F:\vcpkg\buildtrees\avro-cpp\src\ase-1.12.0-db93b3d4a6.clean\lang\c++\include\avro\Node.hh(222): note: see declaration of 'fmt::v11::formatter<avro::Name,char,void>::format'
F:\vcpkg\installed\x64-windows\include\fmt\base.h(1402): note: while trying to match the argument list '(fmt::v11::detail::value<Context>::format_custom_arg::qualified_type, Context)'
        with
        [
            Context=fmt::v11::context
        ]
```
1. Modify the fmt search method.
2. Modify the function call to adapt to the latest version of fmt.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplet:
`x64-windows`