### PR TITLE
[avro-cpp] Update to 1.12.0 and fix the dependencies

### DIFF
--- a/ports/avro-cpp/fix-cmake.patch
+++ b/ports/avro-cpp/fix-cmake.patch
@@ -1,8 +1,8 @@
 diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
-index 472684f4c..edde09e40 100644
+index 19059a4..b9960ec 100644
 --- a/lang/c++/CMakeLists.txt
 +++ b/lang/c++/CMakeLists.txt
-@@ -51,20 +51,16 @@ list(GET AVRO_VERSION 2 AVRO_VERSION_PATCH)
+@@ -55,20 +55,16 @@ list(GET AVRO_VERSION 2 AVRO_VERSION_PATCH)
  project (Avro-cpp)
  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
  
@@ -22,13 +22,30 @@ index 472684f4c..edde09e40 100644
  endif()
  
  if (CMAKE_COMPILER_IS_GNUCXX)
--    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Wconversion -pedantic -Werror")
 +    # Remove " -Werror" because of warning from boost-math (will require C++ 14 soon)
-+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Wconversion -pedantic")
  if (AVRO_ADD_PROTECTOR_FLAGS)
      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector-all -D_GLIBCXX_DEBUG")
      # Unset _GLIBCXX_DEBUG for avrogencpp.cc because using Boost Program Options
-@@ -114,7 +110,7 @@ set (AVRO_SOURCE_FILES
+@@ -82,15 +78,7 @@ endif ()
+ find_package (Boost 1.38 REQUIRED
+     COMPONENTS filesystem iostreams program_options regex system)
+ 
+-include(FetchContent)
+-FetchContent_Declare(
+-        fmt
+-        GIT_REPOSITORY  https://github.com/fmtlib/fmt.git
+-        GIT_TAG         10.2.1
+-        GIT_PROGRESS    TRUE
+-        USES_TERMINAL_DOWNLOAD TRUE
+-)
+-FetchContent_MakeAvailable(fmt)
++find_package(fmt CONFIG REQUIRED)
+ 
+ find_package(Snappy)
+ if (SNAPPY_FOUND)
+@@ -128,14 +116,14 @@ set (AVRO_SOURCE_FILES
          impl/CustomAttributes.cc
          )
  
@@ -37,27 +54,26 @@ index 472684f4c..edde09e40 100644
  
  set_property (TARGET avrocpp
      APPEND PROPERTY COMPILE_DEFINITIONS AVRO_DYN_LINK)
-@@ -131,12 +127,12 @@ set_target_properties (avrocpp PROPERTIES
+ 
+ add_library (avrocpp_s STATIC ${AVRO_SOURCE_FILES})
+ target_include_directories(avrocpp_s PRIVATE ${SNAPPY_INCLUDE_DIR})
+-target_link_libraries(avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} fmt::fmt-header-only)
++target_link_libraries(avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} fmt::fmt-header-only ZLIB::ZLIB)
+ 
+ set_property (TARGET avrocpp avrocpp_s
+     APPEND PROPERTY COMPILE_DEFINITIONS AVRO_SOURCE)
+@@ -146,7 +134,7 @@ set_target_properties (avrocpp PROPERTIES
  set_target_properties (avrocpp_s PROPERTIES
      VERSION ${AVRO_VERSION_MAJOR}.${AVRO_VERSION_MINOR}.${AVRO_VERSION_PATCH})
  
--target_link_libraries (avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
-+target_link_libraries (avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} ZLIB::ZLIB)
+-target_link_libraries (avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} fmt::fmt-header-only)
++target_link_libraries (avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} fmt::fmt-header-only ZLIB::ZLIB)
  target_include_directories(avrocpp PRIVATE ${SNAPPY_INCLUDE_DIR})
  
  add_executable (precompile test/precompile.cc)
- 
--target_link_libraries (precompile avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
-+target_link_libraries (precompile avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} ZLIB::ZLIB)
- 
- macro (gen file ns)
-     add_custom_command (OUTPUT ${file}.hh
-@@ -166,13 +162,14 @@ gen (primitivetypes pt)
- gen (cpp_reserved_words cppres)
- 
- add_executable (avrogencpp impl/avrogencpp.cc)
--target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
-+target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} ZLIB::ZLIB)
+@@ -194,11 +182,12 @@ target_include_directories(avrocpp PUBLIC
+   $<INSTALL_INTERFACE:include>
+ )
  
 +if(BUILD_TESTING)
  enable_testing()
@@ -70,15 +86,15 @@ index 472684f4c..edde09e40 100644
      add_test (NAME ${name} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${name})
  endmacro (unittest)
-@@ -197,6 +194,7 @@ add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
-     union_array_union_hh union_map_union_hh union_conflict_hh
+@@ -225,6 +214,7 @@ add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
      recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
-     primitivetypes_hh empty_record_hh)
+     primitivetypes_hh empty_record_hh cpp_reserved_words_union_typedef_hh
+     union_empty_record_hh)
 +endif()
  
  include (InstallRequiredSystemLibraries)
  
-@@ -204,10 +202,14 @@ set (CPACK_PACKAGE_FILE_NAME "avrocpp-${AVRO_VERSION_MAJOR}")
+@@ -232,10 +222,14 @@ set (CPACK_PACKAGE_FILE_NAME "avrocpp-${AVRO_VERSION_MAJOR}")
  
  include (CPack)
  

--- a/ports/avro-cpp/portfile.cmake
+++ b/ports/avro-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/avro
     REF "release-${VERSION}"
-    SHA512 728609f562460e1115366663ede2c5d4acbdd6950c1ee3e434ffc65d28b72e3a43c3ebce93d0a8459f0c4f6c492ebb9444e2127a0385f38eb7cdf74b28f0c3ed
+    SHA512 8cc6ef3cf1e0a919118c8ba5817a1866dc4f891fa95873c0fe1b4b388858fbadee8ed50406fa0006882cab40807fcf00c5a2dcd500290f3868d9d06b287eacb6
     HEAD_REF master
     PATCHES
         fix-cmake.patch
@@ -29,12 +29,16 @@ if("snappy" IN_LIST FEATURES)
 "include(CMakeFindDependencyMacro)
 find_dependency(ZLIB)
 find_dependency(Snappy)
+find_dependency(fmt CONFIG)
+find_dependency(Boost COMPONENTS filesystem iostreams program_options regex system)
 ${cmake_config}
 ")
 else()
     file(WRITE "${CURRENT_PACKAGES_DIR}/share/unofficial-avro-cpp/unofficial-avro-cpp-config.cmake"
 "include(CMakeFindDependencyMacro)
 find_dependency(ZLIB)
+find_dependency(fmt CONFIG)
+find_dependency(Boost COMPONENTS filesystem iostreams program_options regex system)
 ${cmake_config}
 ")
 endif()

--- a/ports/avro-cpp/vcpkg.json
+++ b/ports/avro-cpp/vcpkg.json
@@ -16,6 +16,7 @@
     "boost-program-options",
     "boost-random",
     "boost-tuple",
+    "fmt",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/avro-cpp/vcpkg.json
+++ b/ports/avro-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "avro-cpp",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "description": "Apache Avro is a data serialization system",
   "homepage": "https://github.com/apache/avro",
   "license": "Apache-2.0",

--- a/versions/a-/avro-cpp.json
+++ b/versions/a-/avro-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4dad7d73a28fbf88dc0d33492722a8444d5c39cf",
+      "git-tree": "689e0f0cad808c8771fbafc5e179a4fef5059899",
       "version": "1.12.0",
       "port-version": 0
     },

--- a/versions/a-/avro-cpp.json
+++ b/versions/a-/avro-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4dad7d73a28fbf88dc0d33492722a8444d5c39cf",
+      "version": "1.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e5b130595cfdd2c5fcecf41bcbbed730aab60285",
       "version": "1.11.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -373,7 +373,7 @@
       "port-version": 0
     },
     "avro-cpp": {
-      "baseline": "1.11.3",
+      "baseline": "1.12.0",
       "port-version": 0
     },
     "awlib": {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/27826#issuecomment-2322949173, update `avro-cpp` to 1.12.0.


* Fix the following errors:
    ```
    CMake Error at CMakeLists.txt:145 (target_link_libraries):
      Target "avrocpp" links to:

        fmt::fmt-header-only

      but the target was not found.  Possible reasons include:

        * There is a typo in the target name.
        * A find_package call is missing for an IMPORTED target.
        * An ALIAS target is missing.
    ```
    ```
    1> [CMake] CMake Error at F:/vcpkg/installed/x64-windows/share/unofficial-avro-cpp/unofficial-avro-cpp-config.cmake:64 (set_target_properties):
    1> [CMake]   The link interface of target "unofficial::avro-cpp::avrocpp" contains:
    1> [CMake] 
    1> [CMake]     Boost::filesystem
    1> [CMake] 
    1> [CMake]   but the target was not found.  Possible reasons include:
    1> [CMake] 
    1> [CMake]     * There is a typo in the target name.
    1> [CMake]     * A find_package call is missing for an IMPORTED target.
    1> [CMake]     * An ALIAS target is missing.
    ```


* All features are tested successfully in the following triplet:
    ```
    x86-windows
    x64-windows
    x64-windows-static
    ```

* The usage test passed on `x64-windows` (header files found):
    ```
    avro-cpp provides CMake targets:

        find_package(unofficial-avro-cpp CONFIG REQUIRED)
        target_link_libraries(main PRIVATE unofficial::avro-cpp::avrocpp)
    ```





- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.