### PR TITLE
[angelscript] update to 2.37.0

### DIFF
--- a/ports/angelscript/portfile.cmake
+++ b/ports/angelscript/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://angelcode.com/angelscript/sdk/files/angelscript_2.36.1.zip"
-    FILENAME "angelscript_2.36.1.zip"
-    SHA512 d6d213ce72135c89e47e67521f654611ff67673f3decd9db3da4b7bf317a04a3f91c5c6ae36658ec3f2b20498facd069af02a91255a24ec79c96d8c90d6b554e
+    URLS "https://angelcode.com/angelscript/sdk/files/angelscript_${VERSION}.zip"
+    FILENAME "angelscript_${VERSION}.zip"
+    SHA512 ba7d88a42e1443fd12196da723538b24d999bc7ade92c0231237e4c5b8b0cb586931262c941898c62f454fd453d653724c74b6857e8a43eea6e34669795fc9cd
 )
 
 vcpkg_extract_source_archive(

--- a/ports/angelscript/vcpkg.json
+++ b/ports/angelscript/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "angelscript",
-  "version": "2.36.1",
-  "port-version": 1,
+  "version": "2.37.0",
   "description": "The AngelCode Scripting Library, or AngelScript as it is also known, is an extremely flexible cross-platform scripting library designed to allow applications to extend their functionality through external scripts. It has been designed from the beginning to be an easy to use component, both for the application programmer and the script writer.",
   "homepage": "https://angelcode.com/angelscript",
   "license": "Zlib",

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb5cf64b9cd72cbcebfb4e68d3e82627541a39c6",
+      "version": "2.37.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5c1bc126371829227e923c11f029a539a234a483",
       "version": "2.36.1",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -125,8 +125,8 @@
       "port-version": 8
     },
     "angelscript": {
-      "baseline": "2.36.1",
-      "port-version": 1
+      "baseline": "2.37.0",
+      "port-version": 0
     },
     "angle": {
       "baseline": "chromium_5414",


### PR DESCRIPTION
Fixes #40769

Update port `angelscript` to the latest version 2.37.0

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Tested feature `addons` successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static