### PR TITLE
[libnick] Update to 2024.9.1

### DIFF
--- a/ports/libnick/portfile.cmake
+++ b/ports/libnick/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NickvisionApps/libnick
     REF "${VERSION}"
-    SHA512 35be8c87c8aa8b4f7e609387b5fe29406678b3c7a6c51861b755b76bc21cb9ebddf446c797f3903d3ae82d5ceae9f03ae6ec6386055bb731d0e5ce8f75411283
+    SHA512 74cf2dd316812bb565ee123ec441c90f141bcb5281faf8daa1ada5ab7b7e63c2e1cb3d00c44ea16e2e31e96d30d51aeb1946589d1bceea87949b1297bb098cfa
     HEAD_REF main
 )
 

--- a/ports/libnick/portfile.cmake
+++ b/ports/libnick/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NickvisionApps/libnick
     REF "${VERSION}"
-    SHA512 74cf2dd316812bb565ee123ec441c90f141bcb5281faf8daa1ada5ab7b7e63c2e1cb3d00c44ea16e2e31e96d30d51aeb1946589d1bceea87949b1297bb098cfa
+    SHA512 b0e1252f6081a51445cb2429ed3bf46befbdefd9278ac749fdc77e82603ae0e574e3e39d6f3ce5c8fc6c430482e92d45b7e54f91a6017a8d5c951461e80e7e14
     HEAD_REF main
 )
 

--- a/ports/libnick/vcpkg.json
+++ b/ports/libnick/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libnick",
-  "version": "2024.8.3",
+  "version": "2024.9.0",
   "maintainers": "Nicholas Logozzo nlogozzo225@gmail.com",
   "description": "A cross-platform base for native Nickvision applications.",
   "homepage": "https://github.com/NickvisionApps/libnick",
@@ -8,13 +8,13 @@
   "license": "GPL-3.0-only",
   "supports": "windows | linux | osx",
   "dependencies": [
+    "boost-json",
     "curl",
     "gettext-libintl",
     {
       "name": "glib",
       "platform": "linux | osx"
     },
-    "jsoncpp",
     {
       "name": "libsecret",
       "platform": "linux"

--- a/ports/libnick/vcpkg.json
+++ b/ports/libnick/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libnick",
-  "version": "2024.9.0",
+  "version": "2024.9.1",
   "maintainers": "Nicholas Logozzo nlogozzo225@gmail.com",
   "description": "A cross-platform base for native Nickvision applications.",
   "homepage": "https://github.com/NickvisionApps/libnick",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4785,7 +4785,7 @@
       "port-version": 4
     },
     "libnick": {
-      "baseline": "2024.8.3",
+      "baseline": "2024.9.1",
       "port-version": 0
     },
     "libnoise": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4785,7 +4785,7 @@
       "port-version": 4
     },
     "libnick": {
-      "baseline": "2024.9.0",
+      "baseline": "2024.8.3",
       "port-version": 0
     },
     "libnoise": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4785,7 +4785,7 @@
       "port-version": 4
     },
     "libnick": {
-      "baseline": "2024.8.3",
+      "baseline": "2024.9.0",
       "port-version": 0
     },
     "libnoise": {

--- a/versions/l-/libnick.json
+++ b/versions/l-/libnick.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d12802b4c5fce87a98df1f0d9a0338ea97f32fd",
+      "version": "2024.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7bcd184ced6e1ddc1b4bac4c37406aa83b4d7d97",
       "version": "2024.8.3",
       "port-version": 0

--- a/versions/l-/libnick.json
+++ b/versions/l-/libnick.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74d1adf0b8b0d629d71647147eec428eb7861c9b",
+      "version": "2024.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7bcd184ced6e1ddc1b4bac4c37406aa83b4d7d97",
       "version": "2024.8.3",
       "port-version": 0

--- a/versions/l-/libnick.json
+++ b/versions/l-/libnick.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "74d1adf0b8b0d629d71647147eec428eb7861c9b",
-      "version": "2024.9.0",
-      "port-version": 0
-    },
-    {
       "git-tree": "7bcd184ced6e1ddc1b4bac4c37406aa83b4d7d97",
       "version": "2024.8.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.