### PR TITLE
[pybind11] make python3 optional

### DIFF
--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,12 +1,12 @@
 {
   "name": "pybind11",
   "version": "2.13.5",
+  "port-version": 1,
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "license": "BSD-3-Clause",
   "supports": "!(arm & windows)",
   "dependencies": [
-    "python3",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -15,5 +15,16 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "local-python3"
+  ],
+  "features": {
+    "local-python3": {
+      "description": "Use python3 from vcpkg instead of the system's one",
+      "dependencies": [
+        "python3"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7190,7 +7190,7 @@
     },
     "pybind11": {
       "baseline": "2.13.5",
-      "port-version": 0
+      "port-version": 1
     },
     "pystring": {
       "baseline": "1.1.4",

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c631a21bc5e74aff910b8c0772229a1389154f36",
+      "version": "2.13.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "f02c4e33cba72e478d122bc1e76fb027466579e5",
       "version": "2.13.5",
       "port-version": 0


### PR DESCRIPTION
I have a project that uses pybind11. I want to be able to build my project using the system's python3 via `pip install`.

However, if my system's Python version is 3.12, pybind11 will not be able to find it because the Python version provided by vcpkg is 3.11.

Not installing Python 3 from vcpkg solves this issue because, without it, vcpkg will try to find the Python 3 headers from the system instead of from vcpkg.

I know that there are many issues between pybind11 and Python 3 (#37758, #36585, #22743, #34338, #34678).

Therefore, my suggestion is to add a default feature called "local-python3" that adds the Python 3 port as a dependency.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
