### PR TITLE
[msquic] Update to v2.3.6

### DIFF
--- a/ports/msquic/portfile.cmake
+++ b/ports/msquic/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH QUIC_SOURCE_PATH
     REPO microsoft/msquic
     REF "v${VERSION}"
-    SHA512 5937fbc2f287567d590fc0afc947459359e5413fa25f2f193434ad6d7016f7cb0dede4e2ef5e1e4e8b21b556c5ad8ce4cb612514403bb593a49af0fb42d1cb15
+    SHA512 9025520d5a4cf1f2046959942fa83f73e49e836dcd20a0dde34bd34cbe071c9ffd5b195a13ab77a6a85d71ae91baa839b12a7f1fc27fcb79660561a2a07b6013
     HEAD_REF master
     PATCHES
         fix-install.patch # Adjust install path of build outputs

--- a/ports/msquic/vcpkg.json
+++ b/ports/msquic/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "msquic",
-  "version": "2.3.5",
-  "port-version": 2,
+  "version": "2.3.6",
   "description": "Cross-platform, C implementation of the IETF QUIC protocol",
   "homepage": "https://github.com/microsoft/msquic",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6057,8 +6057,8 @@
       "port-version": 4
     },
     "msquic": {
-      "baseline": "2.3.5",
-      "port-version": 2
+      "baseline": "2.3.6",
+      "port-version": 0
     },
     "mstch": {
       "baseline": "1.0.2",

--- a/versions/m-/msquic.json
+++ b/versions/m-/msquic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03c8b1fae017fc4b512f48444ae5c0d07f5233dd",
+      "version": "2.3.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "637f7184ab6b84691b2ac5ff61186b53b13a9660",
       "version": "2.3.5",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
