### PR TITLE
[folly] Fix build folder have special characters

### DIFF
--- a/ports/folly/fix-character-in-folder.patch
+++ b/ports/folly/fix-character-in-folder.patch
@@ -1,0 +1,41 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c58dedc..c9561c1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -113,6 +113,8 @@ set(
+   FOLLY_DIR_PREFIXES
+   "${CMAKE_CURRENT_SOURCE_DIR}:${CMAKE_CURRENT_BINARY_DIR}"
+ )
++# https://gitlab.kitware.com/cmake/cmake/-/issues/18580#note_1405108
++string(REGEX REPLACE "(.)" "\\\\\\1" FOLLY_DIR_REGEX_ESCAPED "${FOLLY_DIR}")
+ 
+ include(GNUInstallDirs)
+ 
+@@ -163,12 +165,12 @@ auto_sources(hfiles "*.h" "RECURSE" "${FOLLY_DIR}")
+ # library sources.  Test sources are listed separately below.
+ REMOVE_MATCHES_FROM_LISTS(files hfiles
+   MATCHES
+-    "^${FOLLY_DIR}/build/"
+-    "^${FOLLY_DIR}/docs/examples/"
+-    "^${FOLLY_DIR}/logging/example/"
+-    "^${FOLLY_DIR}/(.*/)?test/"
+-    "^${FOLLY_DIR}/(.*/)?tool/"
+-    "^${FOLLY_DIR}/facebook/"
++    "^${FOLLY_DIR_REGEX_ESCAPED}/build/"
++    "^${FOLLY_DIR_REGEX_ESCAPED}/docs/examples/"
++    "^${FOLLY_DIR_REGEX_ESCAPED}/logging/example/"
++    "^${FOLLY_DIR_REGEX_ESCAPED}/(.*/)?test/"
++    "^${FOLLY_DIR_REGEX_ESCAPED}/(.*/)?tool/"
++    "^${FOLLY_DIR_REGEX_ESCAPED}/facebook/"
+     "Benchmark.cpp$"
+     "Test.cpp$"
+ )
+@@ -177,7 +179,7 @@ REMOVE_MATCHES_FROM_LISTS(files hfiles
+ if (${FOLLY_NO_EXCEPTION_TRACER})
+   REMOVE_MATCHES_FROM_LISTS(files hfiles
+     MATCHES
+-      "^${FOLLY_DIR}/debugging/exception_tracer/"
++      "^${FOLLY_DIR_REGEX_ESCAPED}/debugging/exception_tracer/"
+   )
+ endif()
+ 

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_github(
         disable-uninitialized-resize-on-new-stl.patch
         fix-unistd-include.patch
         fix-fmt11-cmake.patch
+        fix-character-in-folder.patch # https://github.com/facebook/folly/commit/0f698c382d34a2e139d5b2c071151ab33e1ffbd3
 )
 
 file(REMOVE "${SOURCE_PATH}/CMake/FindFmt.cmake")

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "folly",
   "version-string": "2024.08.26.00",
+  "port-version": 1,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2826,7 +2826,7 @@
     },
     "folly": {
       "baseline": "2024.08.26.00",
-      "port-version": 0
+      "port-version": 1
     },
     "font-chef": {
       "baseline": "1.1.0",

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3853e408c3b7432b3db7080a38252eb07cbe31d8",
+      "version-string": "2024.08.26.00",
+      "port-version": 1
+    },
+    {
       "git-tree": "fc8cca13cb39a5e46abdeaedbd23156c5260ff47",
       "version-string": "2024.08.26.00",
       "port-version": 0


### PR DESCRIPTION
Fixes #22076, fix the build error of build folder have special characters.
The fix of upstream: https://github.com/facebook/folly/commit/0f698c382d34a2e139d5b2c071151ab33e1ffbd3.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
