### PR TITLE
[vcpkg baseline][pipewire] Disable optional dependency opus

### DIFF
--- a/ports/pipewire/portfile.cmake
+++ b/ports/pipewire/portfile.cmake
@@ -43,6 +43,7 @@ vcpkg_configure_meson(
         -Dlibusb=disabled
         -Dlv2=disabled
         -Dman=disabled
+        -Dopus=disabled
         -Dpipewire-alsa=disabled
         -Dpipewire-jack=disabled
         -Dpipewire-v4l2=disabled

--- a/ports/pipewire/vcpkg.json
+++ b/ports/pipewire/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pipewire",
   "version": "1.0.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Low-latency audio/video router and processor. This port only builds the client library, not the server.",
   "homepage": "https://pipewire.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6914,7 +6914,7 @@
     },
     "pipewire": {
       "baseline": "1.0.4",
-      "port-version": 2
+      "port-version": 3
     },
     "pistache": {
       "baseline": "2021-03-31",

--- a/versions/p-/pipewire.json
+++ b/versions/p-/pipewire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1538246b12f82dde1b814eeaf3c4e94f5b1171bd",
+      "version": "1.0.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "ab306b1419e587cc0025b4cb9bec1194e6c2b496",
       "version": "1.0.4",
       "port-version": 2


### PR DESCRIPTION
Fix https://dev.azure.com/vcpkg/public/_build/results?buildId=106641&view=logs&j=f79cfdd7-47a8-597f-8f57-dc3e21a8f2ad&t=4f03addf-ef5a-50a2-71be-19894d9df4e3&l=50450

Disable the optional dependency https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/1.0.4/meson.build#L305 `opus`.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux