### PR TITLE
[openssl] update to 3.3.2

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
     REF "openssl-${VERSION}"
-    SHA512 5282e078eb205ef691647e07d65186d81f9328329a06cca209a138adf10b95f12c16742ac61b4ab86e5098c153645ea413088d8263ff7054fdd40decd85b271f
+    SHA512 c6c152fa3eb06c8dcd4de9fccfd42165ba98715cc560454930709554bcb060db5a8465b70ee1d53e6df6ddc85507f66da745b1f2e2fae9605d808ea861d8f57d
     PATCHES
         cmake-config.patch
         command-line-length.patch

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openssl",
-  "version": "3.3.1",
-  "port-version": 1,
+  "version": "3.3.2",
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6637,8 +6637,8 @@
       "port-version": 4
     },
     "openssl": {
-      "baseline": "3.3.1",
-      "port-version": 1
+      "baseline": "3.3.2",
+      "port-version": 0
     },
     "openssl-unix": {
       "baseline": "deprecated",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c80018162ae742240d1e914c46f0a9eaee583daa",
+      "version": "3.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "038ce0eca1d7e3f285a8de86c75bb8b89255994d",
       "version": "3.3.1",
       "port-version": 1


### PR DESCRIPTION
Fixes #40793
Update openssl to the latest version 3.3.2

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
