### PR TITLE
[libtorch] Fix libtorch[core] compilation error

### DIFF
--- a/ports/libtorch/portfile.cmake
+++ b/ports/libtorch/portfile.cmake
@@ -95,8 +95,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
   FEATURES
     dist    USE_DISTRIBUTED # MPI, Gloo, TensorPipe
     zstd    USE_ZSTD
-    fftw3   USE_FFTW
-    fftw3   AT_FFTW_ENABLED
     fbgemm  USE_FBGEMM
     opencv  USE_OPENCV
     # These are alternatives !
@@ -122,7 +120,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     mpi     USE_MPI
     nnpack  USE_NNPACK  # todo: check use of `DISABLE_NNPACK_AND_FAMILY`
     nnpack  AT_NNPACK_ENABLED
-    xnnpack USE_XNNPACK
     qnnpack USE_QNNPACK # todo: check use of `USE_PYTORCH_QNNPACK`
 #   No feature in vcpkg yet so disabled. -> Requires numpy build by vcpkg itself
     python  BUILD_PYTHON
@@ -183,7 +180,6 @@ vcpkg_cmake_configure(
         -DUSE_SYSTEM_PTHREADPOOL=ON
         -DUSE_SYSTEM_PYBIND11=ON
         -DUSE_SYSTEM_ZSTD=ON
-        -DUSE_SYSTEM_XNNPACK=ON
         -DUSE_SYSTEM_GLOO=ON
         -DUSE_SYSTEM_NCCL=ON
         -DUSE_SYSTEM_LIBS=ON

--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtorch",
   "version": "2.1.2",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
   "homepage": "https://pytorch.org/",
   "license": null,
@@ -10,6 +10,7 @@
     "blas",
     "cpuinfo",
     "eigen3",
+    "fftw3",
     "flatbuffers",
     {
       "name": "flatbuffers",
@@ -47,16 +48,15 @@
     {
       "name": "vcpkg-get-python-packages",
       "host": true
-    }
+    },
+    "xnnpack"
   ],
   "default-features": [
     {
       "name": "cuda",
       "platform": "windows & !x86"
     },
-    "fftw3",
     "opencv",
-    "xnnpack",
     "zstd"
   ],
   "features": {
@@ -92,12 +92,6 @@
           "name": "tensorpipe",
           "platform": "linux | osx"
         }
-      ]
-    },
-    "fftw3": {
-      "description": "Build with fftw3",
-      "dependencies": [
-        "fftw3"
       ]
     },
     "leveldb": {
@@ -138,16 +132,6 @@
         "vulkan",
         "vulkan-loader",
         "vulkan-memory-allocator"
-      ]
-    },
-    "xnnpack": {
-      "description": "Build with XNNPack",
-      "dependencies": [
-        {
-          "name": "fxdiv",
-          "platform": "!windows"
-        },
-        "xnnpack"
       ]
     },
     "zstd": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5142,7 +5142,7 @@
     },
     "libtorch": {
       "baseline": "2.1.2",
-      "port-version": 5
+      "port-version": 6
     },
     "libtorrent": {
       "baseline": "2.0.10",

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "12485495c895b105a0b0a35558edce15579a5a98",
+      "version": "2.1.2",
+      "port-version": 6
+    },
+    {
       "git-tree": "6d1fe8207d6f9680a243fe20ed6a222f1174d708",
       "version": "2.1.2",
       "port-version": 5


### PR DESCRIPTION
One of the fixes for the https://github.com/microsoft/vcpkg/issues/32398 issue.
The following error occurs when installing libtorch[core].

```
CMake Error at cmake/Dependencies.cmake:288 (find_library):
  Could not find LIBFFTW3 using the following names: fftw3
CMake Error at cmake/Dependencies.cmake:665 (find_library):
  Could not find XNNPACK_LIBRARY using the following names: XNNPACK
```
Change xnnpack and fftw3 from default-feature to dependencies.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Test libtorch[core] is installed and passed under x64-windows and x64-linux.