### PR TITLE
[md4c] New port (#40799)

### DIFF
--- a/ports/md4c/cmake.patch
+++ b/ports/md4c/cmake.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index aec8293..600d51b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,16 +51,6 @@ elseif(MSVC)
+     # Disable warnings about the so-called unsecured functions:
+     add_definitions(/D_CRT_SECURE_NO_WARNINGS)
+     add_compile_options(/W3)
+-
+-    # Specify proper C runtime library:
+-    string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+-    string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+-    string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_RELWITHDEBINFO "{$CMAKE_C_FLAGS_RELWITHDEBINFO}")
+-    string(REGEX REPLACE "/M[DT]d?" "" CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL}")
+-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
+-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
+-    set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELEASE} /MT")
+-    set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_RELEASE} /MT")
+ endif()
+ 
+ include(GNUInstallDirs)

--- a/ports/md4c/portfile.cmake
+++ b/ports/md4c/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mity/md4c
+    REF "release-${VERSION}"
+    SHA512 30607ba39d6c59329f5a56a90cd816ff60b82ea752ac2b9df356d756529cfc49170019fae5df32fa94afc0e2a186c66eaf56fa6373d18436c06ace670675ba85
+    HEAD_REF master
+    PATCHES
+        "cmake.patch"
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS -DBUILD_MD2HTML_EXECUTABLE=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/md4c")
+vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/md4c/usage
+++ b/ports/md4c/usage
@@ -1,0 +1,4 @@
+md4c provides CMake targets:
+
+find_package(md4c CONFIG REQUIRED)
+target_link_libraries(main PRIVATE md4c::md4c)

--- a/ports/md4c/vcpkg.json
+++ b/ports/md4c/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "md4c",
+  "version": "0.5.2",
+  "description": "MD4C is a C library providing a Markdown parser.",
+  "homepage": "https://github.com/mity/md4c",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5752,6 +5752,10 @@
       "baseline": "2.7.2.14",
       "port-version": 5
     },
+    "md4c": {
+      "baseline": "0.5.2",
+      "port-version": 0
+    },
     "mdl-sdk": {
       "baseline": "2021.1.2",
       "port-version": 5

--- a/versions/m-/md4c.json
+++ b/versions/m-/md4c.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3d6a0dd2cd6d89e4c83bebf016a978b82c0733c5",
+      "version": "0.5.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: #40799 

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
