### PR TITLE
[roaring] update to 4.1.2

### DIFF
--- a/ports/roaring/portfile.cmake
+++ b/ports/roaring/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RoaringBitmap/CRoaring
     REF "v${VERSION}"
-    SHA512 f2963c1ece4f8ce5b88b594b821972eb29c0fd2d5d4b66518877e89c232d34e4f0fa5722823093d8089f6ec5dea769c1a7d09c212509b5817646b9f990ada8f8
+    SHA512 6a81d4425f9dd422aafc04b49ca5f70ca87f1cc64be15b936ffd89fe23c3b50c6a615e9af5ccdcdd5f5ad5851d2de762b8fb3412c65b243c12acb7abcb3bce58
     HEAD_REF master
 )
 

--- a/ports/roaring/vcpkg.json
+++ b/ports/roaring/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "roaring",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "A better compressed bitset in C (and C++)",
   "homepage": "https://github.com/RoaringBitmap/CRoaring",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7873,7 +7873,7 @@
       "port-version": 0
     },
     "roaring": {
-      "baseline": "4.1.1",
+      "baseline": "4.1.2",
       "port-version": 0
     },
     "robin-hood-hashing": {

--- a/versions/r-/roaring.json
+++ b/versions/r-/roaring.json
@@ -1,10 +1,15 @@
 {
   "versions": [
     {
+      "git-tree": "8e8e8dad98996839e8fbab2a942466556deb3335",
+      "version": "4.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c036b926559c1f8bcb09d09a714c6750dcc1ffa6",
       "version": "4.1.1",
       "port-version": 0
-    },  
+    },
     {
       "git-tree": "0b75f1e0ab32aa84c8680cc6d70bc3784b56c5ee",
       "version": "4.0.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
