### PR TITLE
[azure-kinect-sensor-sdk] Fix missing header files and adapt to new version of imgui

### DIFF
--- a/ports/azure-kinect-sensor-sdk/fix-build-imgui.patch
+++ b/ports/azure-kinect-sensor-sdk/fix-build-imgui.patch
@@ -11,3 +11,47 @@ index 4289f71..407e912 100644
      }
  
      ImGui::EndChild();
+diff --git a/tools/k4aviewer/k4asourceselectiondockcontrol.cpp b/tools/k4aviewer/k4asourceselectiondockcontrol.cpp
+index 812608b..31e961d 100644
+--- a/tools/k4aviewer/k4asourceselectiondockcontrol.cpp
++++ b/tools/k4aviewer/k4asourceselectiondockcontrol.cpp
+@@ -34,7 +34,7 @@ K4ASourceSelectionDockControl::K4ASourceSelectionDockControl()
+ 
+ K4ADockControlStatus K4ASourceSelectionDockControl::Show()
+ {
+-    ImGui::SetNextTreeNodeOpen(true, ImGuiCond_FirstUseEver);
++    ImGui::SetNextItemOpen(true, ImGuiCond_FirstUseEver);
+     if (ImGui::TreeNode("Open Device"))
+     {
+         ImGuiExtensions::K4AComboBox("Device S/N",
+diff --git a/tools/k4aviewer/k4adevicedockcontrol.cpp b/tools/k4aviewer/k4adevicedockcontrol.cpp
+index 8fe5687..6d1e95a 100644
+--- a/tools/k4aviewer/k4adevicedockcontrol.cpp
++++ b/tools/k4aviewer/k4adevicedockcontrol.cpp
+@@ -333,7 +333,7 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
+ 
+     if (m_firstRun || depthEnabledStateChanged)
+     {
+-        ImGui::SetNextTreeNodeOpen(m_config.EnableDepthCamera);
++        ImGui::SetNextItemOpen(m_config.EnableDepthCamera);
+     }
+ 
+     ImGui::Indent();
+@@ -376,7 +376,7 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
+ 
+     if (m_firstRun || colorEnableStateChanged)
+     {
+-        ImGui::SetNextTreeNodeOpen(m_config.EnableColorCamera);
++        ImGui::SetNextItemOpen(m_config.EnableColorCamera);
+     }
+ 
+     ImGui::Indent();
+@@ -710,7 +710,7 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
+ 
+     if (m_firstRun && (m_syncInConnected || m_syncOutConnected))
+     {
+-        ImGui::SetNextTreeNodeOpen(true);
++        ImGui::SetNextItemOpen(true);
+     }
+     if (ImGui::TreeNode("External Sync"))
+     {

--- a/ports/azure-kinect-sensor-sdk/fix-header.patch
+++ b/ports/azure-kinect-sensor-sdk/fix-header.patch
@@ -1,0 +1,48 @@
+diff --git a/tools/k4aviewer/k4aaudiochanneldatagraph.h b/tools/k4aviewer/k4aaudiochanneldatagraph.h
+index 9aede89..56d2c77 100644
+--- a/tools/k4aviewer/k4aaudiochanneldatagraph.h
++++ b/tools/k4aviewer/k4aaudiochanneldatagraph.h
+@@ -7,6 +7,7 @@
+ // System headers
+ //
+ #include <array>
++#include <string>
+ 
+ // Library headers
+ //
+diff --git a/tools/k4aviewer/k4aaudiowindow.h b/tools/k4aviewer/k4aaudiowindow.h
+index 87b63b3..fcfc86e 100644
+--- a/tools/k4aviewer/k4aaudiowindow.h
++++ b/tools/k4aviewer/k4aaudiowindow.h
+@@ -8,6 +8,7 @@
+ //
+ #include <array>
+ #include <memory>
++#include <string>
+ 
+ // Library headers
+ //
+diff --git a/tools/k4aviewer/k4amicrophonelistener.cpp b/tools/k4aviewer/k4amicrophonelistener.cpp
+index db7b546..8baa05c 100644
+--- a/tools/k4aviewer/k4amicrophonelistener.cpp
++++ b/tools/k4aviewer/k4amicrophonelistener.cpp
+@@ -8,6 +8,7 @@
+ // System headers
+ //
+ #include <regex>
++#include <string>
+ 
+ // Library headers
+ //
+diff --git a/tools/k4aviewer/perfcounter.h b/tools/k4aviewer/perfcounter.h
+index b39e721..c3e28d2 100644
+--- a/tools/k4aviewer/perfcounter.h
++++ b/tools/k4aviewer/perfcounter.h
+@@ -13,6 +13,7 @@
+ #include <mutex>
+ #include <numeric>
+ #include <ratio>
++#include <string>
+ 
+ // Library headers
+ //

--- a/ports/azure-kinect-sensor-sdk/portfile.cmake
+++ b/ports/azure-kinect-sensor-sdk/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         fix-linux.patch
         fix-calibration-c.patch
         fix-build-imgui.patch
+        fix-header.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/azure-kinect-sensor-sdk/vcpkg.json
+++ b/ports/azure-kinect-sensor-sdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-kinect-sensor-sdk",
   "version": "1.4.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Azure Kinect SDK is a cross platform (Linux and Windows) user mode SDK to read data from your Azure Kinect device.",
   "homepage": "https://github.com/microsoft/Azure-Kinect-Sensor-SDK",
   "supports": "linux | windows",

--- a/versions/a-/azure-kinect-sensor-sdk.json
+++ b/versions/a-/azure-kinect-sensor-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a684e03aa0836ede2caba93683bee3fd3d1ed15f",
+      "version": "1.4.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "f5fbd0b39a805bc47da22f4bc462bec175518ae1",
       "version": "1.4.1",
       "port-version": 6

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -470,7 +470,7 @@
     },
     "azure-kinect-sensor-sdk": {
       "baseline": "1.4.1",
-      "port-version": 6
+      "port-version": 7
     },
     "azure-macro-utils-c": {
       "baseline": "2022-01-21",


### PR DESCRIPTION
One of the fixes for the https://github.com/microsoft/vcpkg/issues/32398 issue.
The following error occurs when installing azure-kinect-sensor-sdk[core,tool].
```
error: field ‘m_name’ has incomplete type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
field ‘m_zoomSliderLabel’ has incomplete type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
error: ‘SetNextTreeNodeOpen’ is not a member of ‘ImGui’; did you mean ‘SetNextItemOpen’?
```
1. Add the required header file <string>.
2. Use the functions in the new version of imgui to replace the old version functions.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplet:

```
x64-windows
```