### PR TITLE
[liburing] Prevent undefined memset with Clang

### DIFF
--- a/ports/liburing/portfile.cmake
+++ b/ports/liburing/portfile.cmake
@@ -9,6 +9,9 @@ vcpkg_from_github(
         disable-tests-and-examples.patch
 )
 
+# https://github.com/axboe/liburing/blob/liburing-2.7/src/Makefile#L13
+set(ENV{CFLAGS} "$ENV{CFLAGS} -O3 -Wall -Wextra -fno-stack-protector")
+
 # note: check ${SOURCE_PATH}/liburing.spec before updating configure options
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/liburing/vcpkg.json
+++ b/ports/liburing/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "liburing",
   "version": "2.7",
+  "port-version": 1,
   "description": "Linux-native io_uring I/O access library",
   "homepage": "https://github.com/axboe/liburing",
   "license": "(MIT OR LGPL-2.1) AND (MIT OR (GPL-2.0 WITH Linux-syscall-note))",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5198,7 +5198,7 @@
     },
     "liburing": {
       "baseline": "2.7",
-      "port-version": 0
+      "port-version": 1
     },
     "libusb": {
       "baseline": "1.0.27",

--- a/versions/l-/liburing.json
+++ b/versions/l-/liburing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aadbba17ecb5910ff9da4e903f822e700aa29f8d",
+      "version": "2.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "ad61eac7577882455b11c4347d77ece27a42256b",
       "version": "2.7",
       "port-version": 0


### PR DESCRIPTION
Fix #40808, failed with `undefined reference to `memset'` for Clang.

When there is no optimization option, Clang introduces symbol `memset`, while GCC does not:

```objdump
0000000000000000         *UND*  0000000000000000 memset
```

Add `-O3` to `CFLAGS` from https://github.com/axboe/liburing/blob/liburing-2.7/src/Makefile#L13 to fix.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass under GNU and Clang18 with the following triplets:

* x64-linux