### PR TITLE
[snitch] Update version to 1.2.5

### DIFF
--- a/ports/snitch/portfile.cmake
+++ b/ports/snitch/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO snitch-org/snitch
-    REF v1.2.4
-    SHA512 783c4667d5c75d5d719d6c85a47ee795099256bacd01324d9bd5550be5f77be265f3372190b89ac109a11479bbf99f90a9e7afb32e6bdfeaab3a936ad50a219a
+    REF "v${VERSION}"
+    SHA512 bb51c7ec51ab934ccd05b8e653ba3da8f321702307fa28b11b8a7ec31e170e337c2ccbe8f4895a25e4fdec1358f90d11a51c489511af95a65311c57e4a4164ef
 )
 
 vcpkg_cmake_configure(

--- a/ports/snitch/vcpkg.json
+++ b/ports/snitch/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "snitch",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Lightweight C++20 testing framework.",
   "homepage": "https://github.com/snitch-org/snitch",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8353,7 +8353,7 @@
       "port-version": 2
     },
     "snitch": {
-      "baseline": "1.2.4",
+      "baseline": "1.2.5",
       "port-version": 0
     },
     "snowhouse": {

--- a/versions/s-/snitch.json
+++ b/versions/s-/snitch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c37a07694cc20611cbc38fde944569673e22cad",
+      "version": "1.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "565f1464cf23c18da8ac0f547d3907f732249957",
       "version": "1.2.4",
       "port-version": 0


### PR DESCRIPTION
Update `snitch` version to 1.2.5

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.