### PR TITLE
[faiss] Don't support arm64-windows

### DIFF
--- a/ports/faiss/vcpkg.json
+++ b/ports/faiss/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "Faiss is a library for efficient similarity search and clustering of dense vectors.",
   "homepage": "https://github.com/facebookresearch/faiss",
   "license": "MIT",
-  "supports": "!uwp & !osx & !x86 & !(arm & windows)",
+  "supports": "!uwp & !osx & !x86 & !(arm64 & windows)",
   "dependencies": [
     "lapack",
     "openblas",

--- a/ports/faiss/vcpkg.json
+++ b/ports/faiss/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "faiss",
   "version": "1.7.4",
+  "port-version": 1,
   "description": "Faiss is a library for efficient similarity search and clustering of dense vectors.",
   "homepage": "https://github.com/facebookresearch/faiss",
   "license": "MIT",
-  "supports": "!uwp & !osx & !x86",
+  "supports": "!uwp & !osx & !x86 & !(arm & windows)",
   "dependencies": [
     "lapack",
     "openblas",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -329,7 +329,6 @@ epsilon:x64-uwp=fail
 evpp:arm-neon-android=fail
 evpp:arm64-android=fail
 evpp:x64-android=fail
-faiss:arm64-windows=fail
 fastrtps:arm-neon-android=fail
 fastrtps:arm64-android=fail
 fastrtps:x64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2618,7 +2618,7 @@
     },
     "faiss": {
       "baseline": "1.7.4",
-      "port-version": 0
+      "port-version": 1
     },
     "fakeit": {
       "baseline": "2.4.0",

--- a/versions/f-/faiss.json
+++ b/versions/f-/faiss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f23586d2052bbd58cac5b0db51ffcf4239117e9",
+      "version": "1.7.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "e2f2e6695629b11c85f79e4fc8b962134396a953",
       "version": "1.7.4",
       "port-version": 0

--- a/versions/f-/faiss.json
+++ b/versions/f-/faiss.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1f23586d2052bbd58cac5b0db51ffcf4239117e9",
+      "git-tree": "bc836dd883cc277c5b11a98e8155f53503ef37f9",
       "version": "1.7.4",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #40798, the upstream of `faiss` doesn't support build arm on windows. The related PR: https://github.com/facebookresearch/faiss/pull/2801.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.