### PR TITLE
[qtkeychain] Upgraded to version 0.14.3

### DIFF
--- a/ports/qtkeychain-qt6/portfile.cmake
+++ b/ports/qtkeychain-qt6/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO frankosterfeld/qtkeychain
     REF "${VERSION}"
-    SHA512 bf84b19090e667a2946297e63d9813574193d80e4eecbde2fdfca317a66da3f029b3abef326f4ffb32de032a48004f9cf1bc818468af612723d762652dc25eb6
+    SHA512 d1d87553db94bf54da1373016a847476e6cd608db6d427ed72532658e2272501daf45d7c9976efdde2f26ab3810ba9dbfec2518d46dee5a76ecaa369bfee2e4a
     HEAD_REF master
 )
 

--- a/ports/qtkeychain-qt6/vcpkg.json
+++ b/ports/qtkeychain-qt6/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "qtkeychain-qt6",
-  "version": "0.14.1",
-  "port-version": 1,
+  "version": "0.14.3",
   "description": "(Unaffiliated with Qt) Platform-independent Qt6 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",

--- a/ports/qtkeychain/portfile.cmake
+++ b/ports/qtkeychain/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO frankosterfeld/qtkeychain
     REF "${VERSION}"
-    SHA512 bf84b19090e667a2946297e63d9813574193d80e4eecbde2fdfca317a66da3f029b3abef326f4ffb32de032a48004f9cf1bc818468af612723d762652dc25eb6
+    SHA512 d1d87553db94bf54da1373016a847476e6cd608db6d427ed72532658e2272501daf45d7c9976efdde2f26ab3810ba9dbfec2518d46dee5a76ecaa369bfee2e4a
     HEAD_REF master
 )
 

--- a/ports/qtkeychain/vcpkg.json
+++ b/ports/qtkeychain/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qtkeychain",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "description": "(Unaffiliated with Qt) Platform-independent Qt5 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7501,12 +7501,12 @@
       "port-version": 0
     },
     "qtkeychain": {
-      "baseline": "0.14.1",
+      "baseline": "0.14.3",
       "port-version": 0
     },
     "qtkeychain-qt6": {
-      "baseline": "0.14.1",
-      "port-version": 1
+      "baseline": "0.14.3",
+      "port-version": 0
     },
     "qtlanguageserver": {
       "baseline": "6.7.2",

--- a/versions/q-/qtkeychain-qt6.json
+++ b/versions/q-/qtkeychain-qt6.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0f1eccb793a59b60f7fea5541a3aea7461a85233",
+      "version": "0.14.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "43422edc152951a565a24a097c3c52a1b1ac1e4f",
       "version": "0.14.1",
       "port-version": 1

--- a/versions/q-/qtkeychain.json
+++ b/versions/q-/qtkeychain.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ae7e39857c4652e28924bae5146cd5362936c2f",
+      "version": "0.14.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "a1cf630fddc142e2a81d7f198eb8c93b40c64a34",
       "version": "0.14.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.