### PR TITLE
[directxtk(12), directxmesh, directxtex, uvatlas] Update ports for Sept 2024

### DIFF
--- a/ports/directxmesh/portfile.cmake
+++ b/ports/directxmesh/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXMESH_TAG jun2024)
+set(DIRECTXMESH_TAG sep2024)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMesh
     REF ${DIRECTXMESH_TAG}
-    SHA512 883149da7eefbff7630aa1d5b0e0104dbb7eca9153d385dd35b82319d3091f7ff75a353ef29f1f3ec5f34b4a89f5d08d4a69bd70842134db5ebe36111c654e71
+    SHA512 ea0f39c14613e60e967eaea2735f73730a1c79f9fdd9b3d799b6c765843804dd7c002dedac8f566989bac99dc41dfa9b1a9a14e141a0917f888d3e3c6ecf47cb
     HEAD_REF main
 )
 
@@ -41,7 +41,7 @@ if("tools" IN_LIST FEATURES)
       MESHCONVERT_EXE
       URLS "https://github.com/Microsoft/DirectXMesh/releases/download/${DIRECTXMESH_TAG}/meshconvert.exe"
       FILENAME "meshconvert-${DIRECTXMESH_TAG}.exe"
-      SHA512 fe1b2faab2f138a09706c956b5283a8f6e915bc57e670243f1ef21be85c6d030e45eff8b4e46551b7ccaa70e99651efbe99c63a927a24125f4bf1567d9f7698d
+      SHA512 f7cfd5d89d92bfe9e6b58691444b9b49e42b88b721f52abe40af4a090f3ff45476727116131fae2d4bbb74e81ff7d998ccbdb01bb037391d743e44823c490786
     )
 
     file(INSTALL
@@ -50,13 +50,13 @@ if("tools" IN_LIST FEATURES)
 
     file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-${DIRECTXMESH_TAG}.exe" "${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe")
 
-  elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+  elseif((VCPKG_TARGET_ARCHITECTURE STREQUAL arm64) OR (VCPKG_TARGET_ARCHITECTURE STREQUAL arm64ec))
 
     vcpkg_download_distfile(
       MESHCONVERT_EXE
       URLS "https://github.com/Microsoft/DirectXMesh/releases/download/${DIRECTXMESH_TAG}/meshconvert_arm64.exe"
       FILENAME "meshconvert-${DIRECTXMESH_TAG}-arm64.exe"
-      SHA512 d4be686a2e65f1385e71ed0a23e17827ae4717ab61e54c80c72170df60cc29cb3f5408b04ce9bec562519c0238c05ed976e04a58ec327775bc0d26cf13971c73
+      SHA512 71d677b95fa964dc3a6d3e3804fa86fb86ec0a5165045baeb42fa4e025c68806edf4cb737906f1f4287e877d5443eda9e5c38e51a9aa62c76ba84f68ba48c69e
     )
 
     file(INSTALL

--- a/ports/directxmesh/vcpkg.json
+++ b/ports/directxmesh/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "directxmesh",
-  "version-date": "2024-06-04",
+  "version-date": "2024-09-04",
   "description": "DirectXMesh geometry processing library",
   "homepage": "https://github.com/Microsoft/DirectXMesh",
   "documentation": "https://github.com/microsoft/DirectXMesh/wiki",
   "license": "MIT",
-  "supports": "windows | linux",
+  "supports": "(windows & !arm32) | linux",
   "dependencies": [
     {
       "name": "directx-headers",

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXTEX_TAG jun2024)
+set(DIRECTXTEX_TAG sep2024)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
     REF ${DIRECTXTEX_TAG}
-    SHA512 5ad160d4279c4b74c5ad29c7d830972ad8b9f8b42c3c0d3d889cc6c98f97c9285cd4c753ffcb88ed23cb40786071ea50917fd273b653f55f497e6ea10181c560
+    SHA512 c76c6d33f6a06e28e27c36be0f56b2c880cdd221b12680cc390f6f05a2c80169266cce9f0ac1803e7160d098f02f25a358ea73a116fd4186f4e0de17aba81ab7
     HEAD_REF main
     )
 
@@ -67,21 +67,21 @@ if("tools" IN_LIST FEATURES)
       TEXASSEMBLE_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texassemble.exe"
       FILENAME "texassemble-${DIRECTXTEX_TAG}.exe"
-      SHA512 1226bbb29ebe750d4371bf07dfab3511a22c371964cc4b977917466af5619517a6d4ac02a5da2d69676524d17a5c1efabc11328db41515cd7ae911efcb919397
+      SHA512 17ae3ce91135e6c442c6127b77a4407ee5e029f1239cdc9066f34ddae9a3982de67d5314b5f03fde77802525e770be49f719fb6ddeb4d5316f440fb4ab24113a
     )
 
     vcpkg_download_distfile(
       TEXCONV_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texconv.exe"
       FILENAME "texconv-${DIRECTXTEX_TAG}.exe"
-      SHA512 e28e29af20f3703bf88dc43f9dbbad4844c8746a8b22aa74dbe7f0ea8668b263a7798ab99373c61b7ed89efbc31946b0d75dde6acadcc649ad8fde4d78887c2f
+      SHA512 856648b04c9d9eab5a63b1abf226eac8509b400a2087dae32fddcc61ea6d7d8426b07d710f765a01ab1bacbd8a9731684c42a72e2bd4f7f3477f379cec39c409
     )
 
     vcpkg_download_distfile(
       TEXDIAG_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texdiag.exe"
       FILENAME "texdiag-${DIRECTXTEX_TAG}.exe"
-      SHA512 b535c9a9f36e35821a300f32dc193493e8e27a262e221d60719bf47e5da8927da50faad6a37995f520c4411af083ed36c2248c60be28e9bd8bdb482f71e8fb50
+      SHA512 38f083bbcf80b30b7d36312e824e03e25396f8801d8c13f6d4029731226415a3596e61863c7f8fd54f71afd6770e6e08bfc4118d65b48a977613b81f221e08d8
     )
 
     file(INSTALL
@@ -94,27 +94,27 @@ if("tools" IN_LIST FEATURES)
     file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-${DIRECTXTEX_TAG}.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
     file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-${DIRECTXTEX_TAG}.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
 
-  elseif((VCPKG_TARGET_ARCHITECTURE STREQUAL arm64) AND (NOT ("openexr" IN_LIST FEATURES)))
+  elseif(((VCPKG_TARGET_ARCHITECTURE STREQUAL arm64) OR (VCPKG_TARGET_ARCHITECTURE STREQUAL arm64ec)) AND (NOT ("openexr" IN_LIST FEATURES)))
 
     vcpkg_download_distfile(
       TEXASSEMBLE_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texassemble_arm64.exe"
       FILENAME "texassemble-${DIRECTXTEX_TAG}-arm64.exe"
-      SHA512 18a9022d550a8c9d0a74f1a86749c3c2766f71c23ad93efeab2240f35bfe5dcce575d0f13a1e5bfc4fe1a2abd2903c1b71dc0dcab9c30821710e4f3a2595d674
+      SHA512 4026647c8e18fc54a28fdec31e9b5c26dba4d6141e2fee53dc94c84bc1bdfb446b40c31a0f4babbaf1eda2a25589486ae5898210f2a5644bc29959ddbe88a475
     )
 
     vcpkg_download_distfile(
       TEXCONV_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texconv_arm64.exe"
       FILENAME "texconv-${DIRECTXTEX_TAG}-arm64.exe"
-      SHA512 27d92c44cd34421ba2c79da83a817c16ad67091286be3d64ad90dd0a3ceaf59c92c8268fe12293adbd6e84a22647eb50e74ec933365d5bf04a7bf391a9e13150
+      SHA512 2556604381e5c45aa137bf868db27013bee4bec1860df25f991f104a4c606bfde90e0eba8a347e5a5fc145c6a6a0b28529c6c7edd9cec0a5310dcec50d295b50
     )
 
     vcpkg_download_distfile(
       TEXDIAG_EXE
       URLS "https://github.com/Microsoft/DirectXTex/releases/download/${DIRECTXTEX_TAG}/texdiag_arm64.exe"
       FILENAME "texdiag-${DIRECTXTEX_TAG}-arm64.exe"
-      SHA512 c179b7729bce61a20268fe69814fc3764104902748f98567e00c8d50860d515b94b1806caed4b07c76da1ddbb43390fa2d6c9cb33ad404456e05fde2b48a52a1
+      SHA512 dfa8d2046cc18541998b719ace66b6807e59ea480febf41852b5973eb60aea20cb66702cab578d6e4474ecd782c03c061f363deb8e1bcb6a4c8f5002a521fe88
     )
 
     file(INSTALL

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "directxtex",
-  "version-date": "2024-06-04",
+  "version-date": "2024-09-04",
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",
   "license": "MIT",
-  "supports": "windows | linux",
+  "supports": "(windows & !arm32) | linux",
   "dependencies": [
     {
       "name": "directx-headers",

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXTK_TAG jun2024)
+set(DIRECTXTK_TAG sep2024)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
     REF ${DIRECTXTK_TAG}
-    SHA512 24ba038557ccf78553db52eade8515091cf712574c7edcd6fcaeadf59c44331737c5014f3092daa26bde05df1bca7b62a531136a370bc6baaaf112d5b7da53fc
+    SHA512 82a47ea210bf7878fdb33960ce38b0d797e8d782ac92d69e82fefa31377b4ba52a4d65d40bb4f136015d65648e42898adf9edb6dbc203885c6718e2db9a6587d
     HEAD_REF main
 )
 
@@ -39,7 +39,7 @@ if("tools" IN_LIST FEATURES)
     MAKESPRITEFONT_EXE
     URLS "https://github.com/Microsoft/DirectXTK/releases/download/${DIRECTXTK_TAG}/MakeSpriteFont.exe"
     FILENAME "makespritefont-${DIRECTXTK_TAG}.exe"
-    SHA512 e516558dbe6d1364a7bd747a0af83033e226ff62e89ae45d876e12f67f42b39351e9ddc98f701c172f78075ef93fbbab9ca732257bad7b161632cacbb1085df6
+    SHA512 15ba6d2b17a43335782cd0f34c017085a747d3308a73f2ae48423873c7e2e3a22bae292c2dc812b67077f96faa41ba81cca4f8a3a36f497f7f6517e24f41474b
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -54,20 +54,20 @@ if("tools" IN_LIST FEATURES)
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK/releases/download/${DIRECTXTK_TAG}/XWBTool.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}.exe"
-      SHA512 4fb31b291acae6d5f9266c2d8c975396df7f33a0fd7c667e1ec56ad2090f7822aaa39d25fddb2406a655f9060ab205810ed1ce440d2454d0f55771823327fd9e
+      SHA512 33413514de463d771950caab415cd1ae499dd9ab8f7b2580e7de6e7a49e413f35cd44f8f0a561a1f99f331e5375d91f81b2d47184c4ab30d326feab2c49a82bc
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
 
     file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-${DIRECTXTK_TAG}.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
 
-  elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+  elseif((VCPKG_TARGET_ARCHITECTURE STREQUAL arm64) OR (VCPKG_TARGET_ARCHITECTURE STREQUAL arm64ec))
 
     vcpkg_download_distfile(
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK/releases/download/${DIRECTXTK_TAG}/XWBTool_arm64.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}-arm64.exe"
-      SHA512 a11d144388f8d3fc235a67b12e8ecb0c4325f89d61572e0110aa5894ade851fd9850595ee5d838965c1a1f04d45a63712e027836e1ac03870880e9c777c10b0f
+      SHA512 90af7b04ee0b152e3f08891f85cf970330d2ff16e6f7ac2269f4a5803dddb891e0cca186c56ef38d2b64f40c86889e31f0c4b017845decf3e6660c9654a0eea8
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "directxtk",
-  "version-date": "2024-06-04",
+  "version-date": "2024-09-04",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",
   "license": "MIT",
-  "supports": "windows & !xbox",
+  "supports": "windows & !xbox & !arm32",
   "dependencies": [
     "directxmath",
     {

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXTK_TAG jun2024)
+set(DIRECTXTK_TAG sep2024)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
     REF ${DIRECTXTK_TAG}
-    SHA512 c56e8344abe21ddb525744458473073c68373b9bce4ffbf00a8a5ac3842d53a010e911dcaa19dcf012065c15e4c97df3de8a6c5bac5be56da0b0d05fe6932961
+    SHA512 902f2ee19953cb36e5982930f3f2cdd7915fadc0e2e97388e44ce677dd9598ccd588b9157179edd2348cef48af7061944083ada1398a47a6805c5d7c1c4c73d3
     HEAD_REF main
 )
 
@@ -40,7 +40,7 @@ if("tools" IN_LIST FEATURES)
     MAKESPRITEFONT_EXE
     URLS "https://github.com/Microsoft/DirectXTK12/releases/download/${DIRECTXTK_TAG}/MakeSpriteFont.exe"
     FILENAME "makespritefont-${DIRECTXTK_TAG}.exe"
-    SHA512 e516558dbe6d1364a7bd747a0af83033e226ff62e89ae45d876e12f67f42b39351e9ddc98f701c172f78075ef93fbbab9ca732257bad7b161632cacbb1085df6
+    SHA512 15ba6d2b17a43335782cd0f34c017085a747d3308a73f2ae48423873c7e2e3a22bae292c2dc812b67077f96faa41ba81cca4f8a3a36f497f7f6517e24f41474b
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -55,20 +55,20 @@ if("tools" IN_LIST FEATURES)
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK12/releases/download/${DIRECTXTK_TAG}/XWBTool.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}.exe"
-      SHA512 4fb31b291acae6d5f9266c2d8c975396df7f33a0fd7c667e1ec56ad2090f7822aaa39d25fddb2406a655f9060ab205810ed1ce440d2454d0f55771823327fd9e
+      SHA512 33413514de463d771950caab415cd1ae499dd9ab8f7b2580e7de6e7a49e413f35cd44f8f0a561a1f99f331e5375d91f81b2d47184c4ab30d326feab2c49a82bc
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
 
     file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-${DIRECTXTK_TAG}.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
 
-  elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+  elseif((VCPKG_TARGET_ARCHITECTURE STREQUAL arm64) OR (VCPKG_TARGET_ARCHITECTURE STREQUAL arm64ec))
 
     vcpkg_download_distfile(
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK12/releases/download/${DIRECTXTK_TAG}/XWBTool_arm64.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}-arm64.exe"
-      SHA512 a11d144388f8d3fc235a67b12e8ecb0c4325f89d61572e0110aa5894ade851fd9850595ee5d838965c1a1f04d45a63712e027836e1ac03870880e9c777c10b0f
+      SHA512 90af7b04ee0b152e3f08891f85cf970330d2ff16e6f7ac2269f4a5803dddb891e0cca186c56ef38d2b64f40c86889e31f0c4b017845decf3e6660c9654a0eea8
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk12",
-  "version-date": "2024-09-05",
+  "version-date": "2024-09-04",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "directxtk12",
-  "version-date": "2024-06-04",
+  "version-date": "2024-09-05",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",
   "license": "MIT",
-  "supports": "windows",
+  "supports": "windows & !arm32",
   "dependencies": [
     {
       "name": "directx-dxc",
@@ -39,7 +39,7 @@
     },
     "tools": {
       "description": "MakeSpriteFont and xwbtool command-line tools",
-      "supports": "windows & !uwp & !xbox & (x64 | arm64)"
+      "supports": "windows & !uwp & !xbox & (x64 | arm64 | arm64ec)"
     },
     "xaudio2-9": {
       "description": "Build with XAudio 2.9 support for Windows 10/11"

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -1,4 +1,4 @@
-set(UVATLAS_TAG jun2024)
+set(UVATLAS_TAG sep2024)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/UVAtlas
     REF ${UVATLAS_TAG}
-    SHA512 b1e4be095be8db87bdebbebb2069f8803dcf1db1033b69bef273a1d460fa4a83a33101202918d77f877dae7e7823768bea31726589d4f3a3c9a8cb54881ad6ea
+    SHA512 89807b52a3802f3147415d1d42dda279c04c17c5fa23e2516f6f1e72f00205f5a45842970d06ddfc86c0aae0d7c432c440a7650d94dc786b5bdc62db809e9498
     HEAD_REF main
 )
 
@@ -41,7 +41,7 @@ if("tools" IN_LIST FEATURES)
       UVATLASTOOL_EXE
       URLS "https://github.com/Microsoft/UVAtlas/releases/download/${UVATLAS_TAG}/uvatlastool.exe"
       FILENAME "uvatlastool-${UVATLAS_TAG}.exe"
-      SHA512 203f4b07ce1052e5263dc7f6ad6704c275ed2dde03cba278c35d7b113aade6e39596f106190527052648a65d43769c4bca0b11c3e058bb3a4d0e2ed5ca115986
+      SHA512 7e747fd8ae93f00d2691af748d6d7c9c42773a704132d5e9cc3230dfaff93490bf3e7273a08af5c2a92cd5344d881255d0788df3f13f288767b11789d8775da0
     )
 
     file(INSTALL

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uvatlas",
-  "version-date": "2024-09-05",
+  "version-date": "2024-09-04",
   "description": "UVAtlas isochart texture atlas",
   "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "uvatlas",
-  "version-date": "2024-06-05",
+  "version-date": "2024-09-05",
   "description": "UVAtlas isochart texture atlas",
   "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",
   "license": "MIT",
-  "supports": "windows | linux",
+  "supports": "(windows & !arm32) | linux",
   "dependencies": [
     {
       "name": "directx-headers",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2277,7 +2277,7 @@
       "port-version": 1
     },
     "directxmesh": {
-      "baseline": "2024-06-04",
+      "baseline": "2024-09-04",
       "port-version": 0
     },
     "directxsdk": {
@@ -2285,15 +2285,15 @@
       "port-version": 8
     },
     "directxtex": {
-      "baseline": "2024-06-04",
+      "baseline": "2024-09-04",
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "2024-06-04",
+      "baseline": "2024-09-04",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "2024-06-04",
+      "baseline": "2024-09-05",
       "port-version": 0
     },
     "dirent": {
@@ -9181,7 +9181,7 @@
       "port-version": 1
     },
     "uvatlas": {
-      "baseline": "2024-06-05",
+      "baseline": "2024-09-05",
       "port-version": 0
     },
     "uvw": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2293,7 +2293,7 @@
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "2024-09-05",
+      "baseline": "2024-09-04",
       "port-version": 0
     },
     "dirent": {
@@ -9181,7 +9181,7 @@
       "port-version": 1
     },
     "uvatlas": {
-      "baseline": "2024-09-05",
+      "baseline": "2024-09-04",
       "port-version": 0
     },
     "uvw": {

--- a/versions/d-/directxmesh.json
+++ b/versions/d-/directxmesh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b78a6fc9cca45bce5e15011fc0022a140d480ac1",
+      "version-date": "2024-09-04",
+      "port-version": 0
+    },
+    {
       "git-tree": "50c6663abb6f47af897610f0b1a647adbb8a618a",
       "version-date": "2024-06-04",
       "port-version": 0

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf509ba95b00e84e46e805c9b607f4e5b9cc8e01",
+      "version-date": "2024-09-04",
+      "port-version": 0
+    },
+    {
       "git-tree": "2fa96376ca7abd8de7124b6a110bdf1afd695259",
       "version-date": "2024-06-04",
       "port-version": 0

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7ecae1b4319528b67d6cc9aa66e5e2a58f21008",
+      "version-date": "2024-09-04",
+      "port-version": 0
+    },
+    {
       "git-tree": "84c1b8fc7032a0cf2025e0b53f51be03b8e3393a",
       "version-date": "2024-06-04",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "20632c5db9553b40845d682047f14cffb024cb73",
+      "git-tree": "cdddbfa0d0b483bb76aafbc6f6d601d171770a17",
       "version-date": "2024-09-04",
       "port-version": 0
     },

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20632c5db9553b40845d682047f14cffb024cb73",
+      "version-date": "2024-09-05",
+      "port-version": 0
+    },
+    {
       "git-tree": "d17dfb088b2fa80b1a6b73db2a58e7db20722775",
       "version-date": "2024-06-04",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "20632c5db9553b40845d682047f14cffb024cb73",
-      "version-date": "2024-09-05",
+      "version-date": "2024-09-04",
       "port-version": 0
     },
     {

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1e52674087e6fcde46b76678b2335118b4931447",
+      "git-tree": "1e1cf99e5b991e2c335ba171022ac5861c50b23e",
       "version-date": "2024-09-04",
       "port-version": 0
     },

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "1e52674087e6fcde46b76678b2335118b4931447",
-      "version-date": "2024-09-05",
+      "version-date": "2024-09-04",
       "port-version": 0
     },
     {

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e52674087e6fcde46b76678b2335118b4931447",
+      "version-date": "2024-09-05",
+      "port-version": 0
+    },
+    {
       "git-tree": "a51183d7e26e3c94e9f19f508f687bdb97a053b6",
       "version-date": "2024-06-05",
       "port-version": 0


### PR DESCRIPTION
Updates directxtk, directxtk12, directxtex, directxmesh, and uvatlas for September 2024 releases.

* ARM64EC support in CMake and vcpkg port
* Explicitly blocks ARM32 usage (32-bit ARM is deprecated)
* Various fixes as noted on the GitHub project sites

https://github.com/microsoft/DirectXTK/releases/tag/sep2024
https://github.com/microsoft/DirectXTK12/releases/tag/sep2024
https://github.com/microsoft/DirectXMesh/releases/tag/sep2024
https://github.com/microsoft/DirectXTex/releases/tag/sep2024
https://github.com/microsoft/UVAtlas/releases/tag/sep2024