### PR TITLE
Add jigson

### DIFF
--- a/ports/jigson/portfile.cmake
+++ b/ports/jigson/portfile.cmake
@@ -1,0 +1,13 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO JoshuaSledden/Jigson
+  REF v0.1.2
+  SHA512 a46f0fba97af44a01776214ffed17de67d21fafc73b0be32d40b6d11f39f8fb6c2e5762a57e8394c3eb80c8202cdc94621f4cd860c4a467a8a79ae0478bc48fb
+)
+
+file(INSTALL "${SOURCE_PATH}/Jigson.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/ports/jigson/vcpkg.json
+++ b/ports/jigson/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "jigson",
+  "version": "0.1.2",
+  "description": "A JSON mapping library for C++",
+  "homepage": "https://github.com/JoshuaSledden/Jigson",
+  "license": "MIT",
+  "dependencies": ["nlohmann-json"],
+  "features": {
+    "test": {
+      "description": "Build tests",
+      "dependencies": ["gtest"]
+    }
+  }
+}

--- a/versions/j-/jigson.json
+++ b/versions/j-/jigson.json
@@ -1,0 +1,8 @@
+{
+  "versions": [
+    {
+      "version": "0.1.2",
+      "git-tree": "0eadccbf41de3af2127a9cfff0fcb88db5b6b791"
+    }
+  ]
+}


### PR DESCRIPTION
Jigson is a header-only C++ library that facilitates mapping between JSON data
and C++ class objects. The name is a play on "Jigsaw" and "JSON", reflecting
its purpose of piecing class objects together from JSON data.

Features:
- Header-only library for easy integration
- Depends on nlohmann-json for JSON parsing
- Supports C++20
- Provides intuitive mapping between JSON and C++ objects

This commit adds the initial port for Jigson version 0.1.2.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

