### PR TITLE
[coin] Update to 4.0.3

### DIFF
--- a/ports/coin/portfile.cmake
+++ b/ports/coin/portfile.cmake
@@ -17,7 +17,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Coin3D/coin
     REF "v${VERSION}"
-    SHA512 f913f1b1ec5819d72e054dc94702effe9ee2a28547fc9bebc2f6b2e55d8a67c6cfa05e43239461e806cbead0a7548f82b31d5b86181eed4ffc5c801d3b94aa67
+    SHA512 c526c0545efa9852c647e163bbf69caae2e3a0eb4e99a8fc7a313172b8d1006e304a4d19bacbd8820443b0d4f90775ee31ca711da4ad2d432783ef5c8bc85074
     HEAD_REF master
     PATCHES
         remove-default-config.patch

--- a/ports/coin/vcpkg.json
+++ b/ports/coin/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "coin",
-  "version": "4.0.2",
-  "port-version": 3,
+  "version": "4.0.3",
   "description": "A high-level 3D visualization library with Open Inventor 2.1 API",
   "homepage": "https://github.com/coin3d/coin",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1749,8 +1749,8 @@
       "port-version": 1
     },
     "coin": {
-      "baseline": "4.0.2",
-      "port-version": 3
+      "baseline": "4.0.3",
+      "port-version": 0
     },
     "coin-or-buildtools": {
       "baseline": "2023-02-02",

--- a/versions/c-/coin.json
+++ b/versions/c-/coin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2e30210c211c4f2e33abcbb9962b8ee03c8711b",
+      "version": "4.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "9747cd35a942a8d806f44a70bdda8833823826e5",
       "version": "4.0.2",
       "port-version": 3


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40826

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplets:

```
x64-windows
x64-windows-static
```