### PR TITLE
[gmsh] Export unofficial config files

### DIFF
--- a/ports/gmsh/fix-install.patch
+++ b/ports/gmsh/fix-install.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2e65c4f..c5614ba 100644
+index 2e65c4f..50bea50 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1947,12 +1947,38 @@ endif()
+@@ -1947,13 +1947,37 @@ endif()
  
  # mark targets as optional so we can install them separately if needed
  # (e.g. "make lib" or "make shared" followed by "make install/fast")
@@ -25,6 +25,7 @@ index 2e65c4f..c5614ba 100644
  endif()
  if(ENABLE_BUILD_SHARED OR ENABLE_BUILD_DYNAMIC)
 -  install(TARGETS shared DESTINATION ${GMSH_LIB} OPTIONAL)
+-endif()
 +  install(
 +    TARGETS shared
 +    EXPORT unofficial-gmsh-config
@@ -35,12 +36,11 @@ index 2e65c4f..c5614ba 100644
 +  )
 +  TARGET_INCLUDE_DIRECTORIES(shared PUBLIC $<INSTALL_INTERFACE:include>)
 +endif()
-+if(ENABLE_BUILD_LIB OR ENABLE_BUILD_SHARED OR ENABLE_BUILD_DYNAMIC)
-+  install(
-+    EXPORT unofficial-gmsh-config
-+    NAMESPACE unofficial::gmsh:: 
-+    DESTINATION share/unofficial-gmsh
-+  )
- endif()
++install(
++  EXPORT unofficial-gmsh-config
++  NAMESPACE unofficial::gmsh:: 
++  DESTINATION share/unofficial-gmsh
++)
  
  if(ENABLE_ONELAB AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/contrib/onelab)
+   install(FILES ${ONELAB_PY} DESTINATION ${GMSH_BIN})

--- a/ports/gmsh/fix-install.patch
+++ b/ports/gmsh/fix-install.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7040709..a4b8c61 100644
+index 2e65c4f..c5614ba 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1872,12 +1872,30 @@ endif()
+@@ -1947,12 +1947,38 @@ endif()
  
  # mark targets as optional so we can install them separately if needed
  # (e.g. "make lib" or "make shared" followed by "make install/fast")
@@ -10,28 +10,36 @@ index 7040709..a4b8c61 100644
 +install(
 +  TARGETS gmsh
 +  RUNTIME DESTINATION bin
-+  LIBRARY DESTINATION lib
-+  ARCHIVE DESTINATION lib
 +  OPTIONAL
 +)
  if(ENABLE_BUILD_LIB)
 -  install(TARGETS lib DESTINATION ${GMSH_LIB} OPTIONAL)
 +  install(
 +    TARGETS lib
-+    RUNTIME DESTINATION bin
++    EXPORT unofficial-gmsh-config
 +    LIBRARY DESTINATION lib
 +    ARCHIVE DESTINATION lib
 +    OPTIONAL
 +  )
++  TARGET_INCLUDE_DIRECTORIES(lib PUBLIC $<INSTALL_INTERFACE:include>)
  endif()
  if(ENABLE_BUILD_SHARED OR ENABLE_BUILD_DYNAMIC)
 -  install(TARGETS shared DESTINATION ${GMSH_LIB} OPTIONAL)
 +  install(
 +    TARGETS shared
++    EXPORT unofficial-gmsh-config
 +    RUNTIME DESTINATION bin
 +    LIBRARY DESTINATION lib
 +    ARCHIVE DESTINATION lib
 +    OPTIONAL
++  )
++  TARGET_INCLUDE_DIRECTORIES(shared PUBLIC $<INSTALL_INTERFACE:include>)
++endif()
++if(ENABLE_BUILD_LIB OR ENABLE_BUILD_SHARED OR ENABLE_BUILD_DYNAMIC)
++  install(
++    EXPORT unofficial-gmsh-config
++    NAMESPACE unofficial::gmsh:: 
++    DESTINATION share/unofficial-gmsh
 +  )
  endif()
  

--- a/ports/gmsh/portfile.cmake
+++ b/ports/gmsh/portfile.cmake
@@ -108,6 +108,8 @@ vcpkg_cmake_install()
 
 vcpkg_copy_tools(TOOL_NAMES gmsh AUTO_CLEAN)
 
+vcpkg_cmake_config_fixup(PACKAGE_NAME "unofficial-gmsh")
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/gmsh/vcpkg.json
+++ b/ports/gmsh/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gmsh",
   "version": "4.12.2",
+  "port-version": 1,
   "description": "Gmsh is an open source 3D finite element mesh generator with a built-in CAD engine and post-processor.",
   "homepage": "https://gmsh.info",
   "license": "LGPL-2.0-or-later",
@@ -9,6 +10,10 @@
     "blas",
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3162,7 +3162,7 @@
     },
     "gmsh": {
       "baseline": "4.12.2",
-      "port-version": 0
+      "port-version": 1
     },
     "gobject-introspection": {
       "baseline": "1.72.0",

--- a/versions/g-/gmsh.json
+++ b/versions/g-/gmsh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb92d497693d809ff43dbe02d77032954af3f3c7",
+      "version": "4.12.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "d97f6df221dfe46e532d3f9d27c4dbd3bbdac0ea",
       "version": "4.12.2",
       "port-version": 0

--- a/versions/g-/gmsh.json
+++ b/versions/g-/gmsh.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fb92d497693d809ff43dbe02d77032954af3f3c7",
+      "git-tree": "b32cf3fd3185169073c2aa58a2758fa7fe153808",
       "version": "4.12.2",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #40813. Export the `gmsh` config files.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The usage test passed on `x64-windows` (header files found):
```
gmsh provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(unofficial-gmsh CONFIG REQUIRED)
  target_link_libraries(main PRIVATE unofficial::gmsh::shared)
```