### PR TITLE
[onednn] Disable docs, examples and tests.

### DIFF
--- a/ports/onednn/portfile.cmake
+++ b/ports/onednn/portfile.cmake
@@ -13,6 +13,9 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${DNNL_OPTIONS}
+        -DDNNL_BUILD_DOC=OFF
+        -DDNNL_BUILD_EXAMPLES=OFF
+        -DDNNL_BUILD_TESTS=OFF
 )
 vcpkg_cmake_install()
 
@@ -21,6 +24,5 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME dnnl CONFIG_PATH lib/cmake/dnnl)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc/dnnl/reference/html")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/onednn/vcpkg.json
+++ b/ports/onednn/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "onednn",
   "version": "3.5.3",
+  "port-version": 1,
   "description": "oneAPI Deep Neural Network Library (oneDNN)",
   "homepage": "https://github.com/oneapi-src/oneDNN",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6482,7 +6482,7 @@
     },
     "onednn": {
       "baseline": "3.5.3",
-      "port-version": 0
+      "port-version": 1
     },
     "oniguruma": {
       "baseline": "6.9.7.1",

--- a/versions/o-/onednn.json
+++ b/versions/o-/onednn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3f7e47f97bc658f31fef1558c67f80993cc41269",
+      "version": "3.5.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "95af2680791b8c27b837d21867822c2904dd3b7f",
       "version": "3.5.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #40855

Explicitly disable docs, examples and tests when building onednn libraries.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


