### PR TITLE
[stb] Update to 2024-07-29

### DIFF
--- a/ports/stb/portfile.cmake
+++ b/ports/stb/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nothings/stb
-    REF 5736b15f7ea0ffb08dd38af21067c314d6a3aae9 # committed on 2023-04-11
-    SHA512 55bc75284cf8a092c527d1ae18c461c9d0ab6aacdcf3b873abde54c06d9b8a0ae249ce47c7ad25809e075bfbb58e9c879d43e1df2708083860c07ac3bbb30d60
+    REF f75e8d1cad7d90d72ef7a4661f1b994ef78b4e31 # committed on 2024-07-29
+    SHA512 4a733aefb816a366c999663e3d482144616721b26c321ee5dd0dce611a34050b6aef97d46bd2c4f8a9631d83b097491a7ce88607fd9493d880aaa94567a68cce
     HEAD_REF master
 )
 

--- a/ports/stb/vcpkg.json
+++ b/ports/stb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stb",
-  "version-date": "2023-04-11",
+  "version-date": "2024-07-29",
   "port-version": 1,
   "description": "public domain header-only libraries",
   "homepage": "https://github.com/nothings/stb",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8593,7 +8593,7 @@
       "port-version": 3
     },
     "stb": {
-      "baseline": "2023-04-11",
+      "baseline": "2024-07-29",
       "port-version": 1
     },
     "stdexec": {

--- a/versions/s-/stb.json
+++ b/versions/s-/stb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c362152d1d02973e7b1ce777960f8a6876656560",
+      "version-date": "2024-07-29",
+      "port-version": 1
+    },
+    {
       "git-tree": "acd9c2bf96a3e32fbf629b1bfd6cba4827761069",
       "version-date": "2023-04-11",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
