### PR TITLE
[cddlib] new port

### DIFF
--- a/ports/cddlib/0001-disable-doc-target.patch
+++ b/ports/cddlib/0001-disable-doc-target.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile.am b/Makefile.am
+index e08cd91..bcde34b 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,5 +1,5 @@
+ # Directories where we can build something.
+-SUBDIRS          = doc lib-src src
++SUBDIRS          = lib-src src
+ 
+ # Install the examples into /usr/share/doc/cddlib/examples*
+ nobase_doc_DATA = $(srcdir)/examples/* $(srcdir)/examples-ine/* $(srcdir)/examples-ine3d/* $(srcdir)/examples-ext/*
+

--- a/ports/cddlib/0002-disable-dd-log.patch
+++ b/ports/cddlib/0002-disable-dd-log.patch
@@ -1,0 +1,25 @@
+diff --git a/src/lcdd.c b/src/lcdd.c
+index 473e6c5..cafc1a5 100644
+--- a/src/lcdd.c
++++ b/src/lcdd.c
+@@ -44,7 +44,6 @@ int main(int argc, char *argv[])
+   dd_ErrorType err;
+ 
+   dd_set_global_constants();  /* First, this must be called. */
+-  dd_log=dd_TRUE; /* Output log */
+ 
+   if (argc > 2)  
+     dd_DDFile2File(argv[1],argv[2],&err);
+diff --git a/src/scdd.c b/src/scdd.c
+index e9e0c59..9e6ed32 100644
+--- a/src/scdd.c
++++ b/src/scdd.c
+@@ -66,7 +66,6 @@ int main(int argc, char *argv[])
+   FILE *reading=NULL, *writing;
+ 
+   dd_set_global_constants();  /* First, this must be called. */
+-  dd_log=dd_TRUE;  /* output log */
+ 
+   if (argc>1) strcpy(inputfile,argv[1]);
+   if (argc<=1 || !SetInputFile(&reading,argv[1])){
+

--- a/ports/cddlib/portfile.cmake
+++ b/ports/cddlib/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO cddlib/cddlib
+    REF ${VERSION}
+    SHA512 8591ebe9e2a09683bb01b478df6536d1291012927d343013f8593126d3570f7883e125c63c68cd21eeea142a450847dc609e373e39cffb308bed1b56d6342ac1
+    HEAD_REF master
+    PATCHES
+        0001-disable-doc-target.patch  # disable building docs, as they require latex
+        0002-disable-dd-log.patch  # windows does not export global variables
+)
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    COPY_SOURCE  # ensure generated files are found
+)
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${SOURCE_PATH}/COPYING")
+

--- a/ports/cddlib/portfile.cmake
+++ b/ports/cddlib/portfile.cmake
@@ -16,4 +16,4 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${SOURCE_PATH}/COPYING")
-
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/cddlib/vcpkg.json
+++ b/ports/cddlib/vcpkg.json
@@ -3,7 +3,7 @@
   "version-string": "0.94m",
   "description": "C implementation of the Double Description Method",
   "homepage": "https://github.com/cddlib/cddlib",
-  "license": "GPL-2.0",
+  "license": "GPL-2.0-or-later",
   "dependencies": [
     "gmp"
   ]

--- a/ports/cddlib/vcpkg.json
+++ b/ports/cddlib/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "cddlib",
+  "version-string": "0.94m",
+  "port-version": 0,
+  "description": "C implementation of the Double Description Method",
+  "homepage": "https://github.com/cddlib/cddlib",
+  "license": "GPL-2.0",
+  "dependencies": [
+    {
+      "name": "gmp"
+    }
+  ]
+}
+

--- a/ports/cddlib/vcpkg.json
+++ b/ports/cddlib/vcpkg.json
@@ -1,14 +1,10 @@
 {
   "name": "cddlib",
   "version-string": "0.94m",
-  "port-version": 0,
   "description": "C implementation of the Double Description Method",
   "homepage": "https://github.com/cddlib/cddlib",
   "license": "GPL-2.0",
   "dependencies": [
-    {
-      "name": "gmp"
-    }
+    "gmp"
   ]
 }
-

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1540,6 +1540,10 @@
       "baseline": "2.4",
       "port-version": 0
     },
+    "cddlib": {
+      "baseline": "0.94m",
+      "port-version": 0
+    },
     "cdt": {
       "baseline": "1.4.1",
       "port-version": 0

--- a/versions/c-/cddlib.json
+++ b/versions/c-/cddlib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0bb4839476e2e904a3afcde5003ae2fe7237efd7",
+      "version-string": "0.94m",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
# Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

# Notes

No usage text is included with the library.

I've included two very small patches to fix the following issues:

* The upstream documentation is built using LaTeX. To avoid needing LaTeX, I've added a patch that explicitly removes the "doc" target.
* Some of the sample applications use a global variable ``dd_log`` that is compiled into the library. This works for linux, but obviously breaks on windows (since it does not export such symbols by default, from what I understand). This flag only appears in two places in the sample applications, and is not documented in the manual. So, as a workaround, to allow compiling also the sample applications on windows, I've removed these references. Alternatively, a patch might simply remove the offending binaries from being compiled.

For reference, upstream issue for cddlib windows builds: https://github.com/cddlib/cddlib/issues/35