### PR TITLE
Add instruction to reset port version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
 - [ ] The "supports" clause reflects platforms that may be fixed by this new version.
 - [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
 - [ ] Any patches that are no longer applied are deleted from the port's directory.
+- [ ] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
 - [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
 - [ ] Only one version is added to each modified port's versions file.
 


### PR DESCRIPTION
Instruct port update PR authors to reset the port version when updating the upstream version.

I am suggesting this task to prevent the mistake that I made in
<https://github.com/microsoft/vcpkg/pull/40836>. It looks like this could be a common mistake to make when making port updates...