### PR TITLE
[microsoft-signalr] Add missing header files

### DIFF
--- a/ports/microsoft-signalr/fix-miss-header.patch
+++ b/ports/microsoft-signalr/fix-miss-header.patch
@@ -1,0 +1,36 @@
+diff --git a/src/signalrclient/binary_message_parser.h b/src/signalrclient/binary_message_parser.h
+index 349b979..f33533d 100644
+--- a/src/signalrclient/binary_message_parser.h
++++ b/src/signalrclient/binary_message_parser.h
+@@ -5,6 +5,7 @@
+ #pragma once
+ 
+ #ifdef USE_MSGPACK
++#include <cstddef>
+ 
+ namespace signalr
+ {
+diff --git a/src/signalrclient/signalr_client_config.cpp b/src/signalrclient/signalr_client_config.cpp
+index adbc3ae..dbca837 100644
+--- a/src/signalrclient/signalr_client_config.cpp
++++ b/src/signalrclient/signalr_client_config.cpp
+@@ -5,6 +5,7 @@
+ #include "stdafx.h"
+ #include "signalrclient/signalr_client_config.h"
+ #include "signalr_default_scheduler.h"
++#include <stdexcept>
+ 
+ namespace signalr
+ {
+diff --git a/src/signalrclient/transport_factory.cpp b/src/signalrclient/transport_factory.cpp
+index 7443672..a8add79 100644
+--- a/src/signalrclient/transport_factory.cpp
++++ b/src/signalrclient/transport_factory.cpp
+@@ -6,6 +6,7 @@
+ #include "transport_factory.h"
+ #include "websocket_transport.h"
+ #include "signalrclient/websocket_client.h"
++#include <stdexcept>
+ 
+ namespace signalr
+ {

--- a/ports/microsoft-signalr/portfile.cmake
+++ b/ports/microsoft-signalr/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
     PATCHES
         find-msgpack.patch
         "${PATCH_FIX_GCC_13_COMPILATION}"
+        fix-miss-header.patch
 )
 
 vcpkg_check_features(

--- a/ports/microsoft-signalr/vcpkg.json
+++ b/ports/microsoft-signalr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "microsoft-signalr",
   "version": "0.1.0-alpha4",
-  "port-version": 11,
+  "port-version": 12,
   "description": "C++ Client for ASP.NET Core SignalR.",
   "homepage": "https://github.com/aspnet/SignalR-Client-Cpp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5842,7 +5842,7 @@
     },
     "microsoft-signalr": {
       "baseline": "0.1.0-alpha4",
-      "port-version": 11
+      "port-version": 12
     },
     "mikktspace": {
       "baseline": "2020-10-06",

--- a/versions/m-/microsoft-signalr.json
+++ b/versions/m-/microsoft-signalr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fbeec8cc91b3ef1fd17afc17a0cb7361138ab1a6",
+      "version": "0.1.0-alpha4",
+      "port-version": 12
+    },
+    {
       "git-tree": "2b29ee52721e3f9ba79a0348a731d9f8a26ef89a",
       "version": "0.1.0-alpha4",
       "port-version": 11


### PR DESCRIPTION
One of the fixes for the https://github.com/microsoft/vcpkg/issues/32398 issue.
The following error occurs when installing  microsoft-signalr[core,messagepack]:x64-linux.
```
/mnt/vcpkg/buildtrees/microsoft-signalr/src/1.0-alpha4-e34fa42a98/src/signalrclient/binary_message_parser.h:13:62: error: ‘size_t’ has not been declared
/mnt/vcpkg/buildtrees/microsoft-signalr/src/1.0-alpha4-e34fa42a98/src/signalrclient/transport_factory.cpp:26:20: error: ‘runtime_error’ is not a member of ‘std’
Line 39:    26 |         throw std::runtime_error("not implemented");
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

The feature test pass with following triplets:
```
x64-windows
x64-linux
```