### PR TITLE
[openssl] Add upstream patch to fix build with old versions of perl

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -7,6 +7,12 @@ if(VCPKG_TARGET_IS_EMSCRIPTEN)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
+vcpkg_download_distfile(PATCH_FIX_BUILD_WITH_OLD_PERL
+    URLS https://github.com/openssl/openssl/commit/210dc9a50dfd99caa1cf7c3d2fa42850124b1bbc.patch?full_index=1
+    SHA512 62f69f0e2664dc3b6a3090a3b2e142d50b14467f0e862784d9e306a503d4c34e77cd546d3a04dcf1b059e8300646b8ba5168579a0f2a33cfa9cffcbfd4f309e7
+    FILENAME openssl-openssl-210dc9a50dfd99caa1cf7c3d2fa42850124b1bbc.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
@@ -23,6 +29,7 @@ vcpkg_from_github(
         unix/move-openssldir.patch
         unix/no-empty-dirs.patch
         unix/no-static-libs-for-shared.patch
+        "${PATCH_FIX_BUILD_WITH_OLD_PERL}"
 )
 
 vcpkg_list(SET CONFIGURE_OPTIONS

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openssl",
   "version": "3.3.2",
+  "port-version": 1,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6662,7 +6662,7 @@
     },
     "openssl": {
       "baseline": "3.3.2",
-      "port-version": 0
+      "port-version": 1
     },
     "openssl-unix": {
       "baseline": "deprecated",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c0920b57254210866a89aa705291b452a31df48",
+      "version": "3.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "c80018162ae742240d1e914c46f0a9eaee583daa",
       "version": "3.3.2",
       "port-version": 0


### PR DESCRIPTION
The issue is described here: https://github.com/openssl/openssl/issues/25366

Although vcpkg doesn't support RHEL7 anymore, the upstream accepted the patch.