### PR TITLE
[mongo-cxx-driver] Fix compilation error under VS17.11.2

### DIFF
--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(
         STRING_PATCHES
         URLS "https://github.com/mongodb/mongo-cxx-driver/commit/55ad3447dbd46560eca6e99adfcf195ecd7c1c7a.diff?full_index=1"
-        FILENAME "add-string.patch"
+        FILENAME "mongo-cxx-driver-add-string-55ad3447dbd46560eca6e99adfcf195ecd7c1c7a.patch"
         SHA512 a617f3657a065ddc1963007b164f7e96a1e3a53a91a3fefd97ae0be8b42036b1ed572f60f1d7074f6194640bfe37c5c2d5713c7b0853b252fe340c83eb6c852a
     )
 vcpkg_from_github(

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(
+        STRING_PATCHES
+        URLS "https://github.com/mongodb/mongo-cxx-driver/commit/55ad3447dbd46560eca6e99adfcf195ecd7c1c7a.diff?full_index=1"
+        FILENAME "add-string.patch"
+        SHA512 a617f3657a065ddc1963007b164f7e96a1e3a53a91a3fefd97ae0be8b42036b1ed572f60f1d7074f6194640bfe37c5c2d5713c7b0853b252fe340c83eb6c852a
+    )
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-cxx-driver
@@ -6,7 +12,9 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-dependencies.patch
+        ${STRING_PATCHES}
 )
+
 file(WRITE "${SOURCE_PATH}/build/VERSION_CURRENT" "${VERSION}")
 
 # This port offered C++17 ABI alternative via features.

--- a/ports/mongo-cxx-driver/vcpkg.json
+++ b/ports/mongo-cxx-driver/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mongo-cxx-driver",
   "version": "3.10.2",
+  "port-version": 1,
   "description": "MongoDB C++ Driver.",
   "homepage": "https://github.com/mongodb/mongo-cxx-driver",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5946,7 +5946,7 @@
     },
     "mongo-cxx-driver": {
       "baseline": "3.10.2",
-      "port-version": 0
+      "port-version": 1
     },
     "mongoose": {
       "baseline": "7.15",

--- a/versions/m-/mongo-cxx-driver.json
+++ b/versions/m-/mongo-cxx-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd5e267390b6e6f9baa75bd0b34a0aa24a060f39",
+      "version": "3.10.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "e246a2d1a2ff8883db714ee2ca91b0522f40d532",
       "version": "3.10.2",
       "port-version": 0

--- a/versions/m-/mongo-cxx-driver.json
+++ b/versions/m-/mongo-cxx-driver.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bd5e267390b6e6f9baa75bd0b34a0aa24a060f39",
+      "git-tree": "5bb1f83d08ff4f9441ac8273fabab84d16dc56fe",
       "version": "3.10.2",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40807
```
F:\tv\buildtrees\mongo-cxx-driver\src\r3.10.2-4749d7b703.clean\src\mongocxx\include\mongocxx\v_noabi\mongocxx/events/heartbeat_failed_event.hpp(50): error C2039: 'string': is not a member of 'std'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\__msvc_string_view.hpp(22): note: see declaration of 'std'
F:\tv\buildtrees\mongo-cxx-driver\src\r3.10.2-4749d7b703.clean\src\mongocxx\include\mongocxx\v_noabi\mongocxx/events/heartbeat_failed_event.hpp(50): error C3646: 'message': unknown override specifier
```
Download upstream PR [1193](https://github.com/mongodb/mongo-cxx-driver/pull/1193) to fix the issue.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplet:

```
x64-windows
```