### PR TITLE
[bit7z] new port

### DIFF
--- a/ports/bit7z/fix_dependency.patch
+++ b/ports/bit7z/fix_dependency.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b308be0..d4f8feb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -194,14 +194,23 @@ include( cmake/BuildOptions.cmake )
+ include( cmake/CompilerOptions.cmake )
+ 
+ # dependencies
+-include( cmake/Dependencies.cmake )
++# include( cmake/Dependencies.cmake )
++find_package(7zip CONFIG REQUIRED)
+ 
+ # 7-zip source code
+-target_link_libraries( ${LIB_TARGET} PRIVATE 7-zip )
++target_link_libraries( ${LIB_TARGET} PRIVATE 7zip::7zip )
+ 
+ # filesystem library (needed if std::filesystem is not available)
+-if( ghc_filesystem_ADDED )
+-    target_link_libraries( ${LIB_TARGET} PRIVATE ghc_filesystem )
++if(0)
++ # filesystem library (needed if std::filesystem is not available)
++ if( ghc_filesystem_ADDED )
++     target_link_libraries( ${LIB_TARGET} PRIVATE ghc_filesystem )
++ endif()
++else()
++if(NOT USE_STANDARD_FILESYSTEM OR NOT STANDARD_FILESYSTEM_COMPILES)
++    find_package(ghc_filesystem CONFIG REQUIRED)
++    target_link_libraries(${LIB_TARGET} PRIVATE ghcFilesystem::ghc_filesystem )
++endif()
+ endif()
+ 
+ # public includes

--- a/ports/bit7z/fix_dependency.patch
+++ b/ports/bit7z/fix_dependency.patch
@@ -1,32 +1,30 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b308be0..d4f8feb 100644
+index f8ff6f0..855b78d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -194,14 +194,23 @@ include( cmake/BuildOptions.cmake )
+@@ -194,15 +194,24 @@ include( cmake/BuildOptions.cmake )
  include( cmake/CompilerOptions.cmake )
  
  # dependencies
 -include( cmake/Dependencies.cmake )
 +# include( cmake/Dependencies.cmake )
 +find_package(7zip CONFIG REQUIRED)
++add_library(7-zip ALIAS 7zip::7zip)
  
  # 7-zip source code
--target_link_libraries( ${LIB_TARGET} PRIVATE 7-zip )
-+target_link_libraries( ${LIB_TARGET} PRIVATE 7zip::7zip )
+ target_link_libraries( ${LIB_TARGET} PRIVATE 7-zip )
  
  # filesystem library (needed if std::filesystem is not available)
--if( ghc_filesystem_ADDED )
--    target_link_libraries( ${LIB_TARGET} PRIVATE ghc_filesystem )
 +if(0)
-+ # filesystem library (needed if std::filesystem is not available)
-+ if( ghc_filesystem_ADDED )
-+     target_link_libraries( ${LIB_TARGET} PRIVATE ghc_filesystem )
-+ endif()
-+else()
-+if(NOT USE_STANDARD_FILESYSTEM OR NOT STANDARD_FILESYSTEM_COMPILES)
-+    find_package(ghc_filesystem CONFIG REQUIRED)
-+    target_link_libraries(${LIB_TARGET} PRIVATE ghcFilesystem::ghc_filesystem )
-+endif()
+ if( ghc_filesystem_ADDED )
+     target_link_libraries( ${LIB_TARGET} PRIVATE ghc_filesystem )
  endif()
++else()
++    if(NOT USE_STANDARD_FILESYSTEM OR NOT STANDARD_FILESYSTEM_COMPILES)
++        find_package(ghc_filesystem CONFIG REQUIRED)
++        target_link_libraries(${LIB_TARGET} PRIVATE ghcFilesystem::ghc_filesystem )
++    endif()
++endif()
  
  # public includes
+ target_include_directories( ${LIB_TARGET} PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"

--- a/ports/bit7z/fix_dependency.patch
+++ b/ports/bit7z/fix_dependency.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index f8ff6f0..855b78d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -194,15 +194,24 @@ include( cmake/BuildOptions.cmake )
+@@ -194,15 +194,22 @@ include( cmake/BuildOptions.cmake )
  include( cmake/CompilerOptions.cmake )
  
  # dependencies
@@ -20,10 +20,8 @@ index f8ff6f0..855b78d 100644
      target_link_libraries( ${LIB_TARGET} PRIVATE ghc_filesystem )
  endif()
 +else()
-+    if(NOT USE_STANDARD_FILESYSTEM OR NOT STANDARD_FILESYSTEM_COMPILES)
-+        find_package(ghc_filesystem CONFIG REQUIRED)
-+        target_link_libraries(${LIB_TARGET} PRIVATE ghcFilesystem::ghc_filesystem )
-+    endif()
++    find_package(ghc_filesystem CONFIG REQUIRED)
++    target_link_libraries(${LIB_TARGET} PRIVATE ghcFilesystem::ghc_filesystem )
 +endif()
  
  # public includes

--- a/ports/bit7z/fix_install.patch
+++ b/ports/bit7z/fix_install.patch
@@ -1,0 +1,48 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2eb8634..74f0137 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -179,7 +179,7 @@ message( STATUS "Language Standard for bit7z: C++${CMAKE_CXX_STANDARD}" )
+ set( LIB_TARGET bit7z${ARCH_POSTFIX} )
+ add_library( ${LIB_TARGET} STATIC )
+ target_sources( ${LIB_TARGET}
+-                PUBLIC ${PUBLIC_HEADERS}
++                # PUBLIC ${PUBLIC_HEADERS}
+                 PRIVATE ${HEADERS} ${SOURCES} )
+
+ # additional target without the architecture suffix in the name
+@@ -205,12 +205,12 @@ if( ghc_filesystem_ADDED )
+ endif()
+
+ # public includes
+-target_include_directories( ${LIB_TARGET} PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
++target_include_directories( ${LIB_TARGET} PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
+                                                  "$<INSTALL_INTERFACE:include>" )
+
+ # private includes
+-target_include_directories( ${LIB_TARGET} PRIVATE "${PROJECT_SOURCE_DIR}/include/bit7z"
+-                                                  "${PROJECT_SOURCE_DIR}/src" )
++target_include_directories( ${LIB_TARGET} PRIVATE "${CMAKE_SOURCE_DIR}/include/bit7z"
++                                                  "${CMAKE_SOURCE_DIR}/src" )
+
+ # 7-zip compilation definitions
+ target_compile_definitions( ${LIB_TARGET} PRIVATE UNICODE _UNICODE )
+@@ -246,3 +246,18 @@ endif()
+ if( BIT7Z_BUILD_DOCS )
+     add_subdirectory( docs )
+ endif()
++
++include(GNUInstallDirs)
++install(
++    TARGETS ${LIB_TARGET}
++    EXPORT bit7z
++    COMPONENT bit7z
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    PUBLIC_HEADER DESTINATION include/bit7z)
++
++install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/bit7z
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++
++install(EXPORT bit7z FILE unofficial-bit7z-config.cmake NAMESPACE unofficial::bit7z:: DESTINATION share/unofficial-bit7z)

--- a/ports/bit7z/fix_install.patch
+++ b/ports/bit7z/fix_install.patch
@@ -11,7 +11,7 @@ index 2eb8634..f8ff6f0 100644
                  PRIVATE ${HEADERS} ${SOURCES} )
  
  # additional target without the architecture suffix in the name
-@@ -246,3 +246,32 @@ endif()
+@@ -246,3 +246,29 @@ endif()
  if( BIT7Z_BUILD_DOCS )
      add_subdirectory( docs )
  endif()

--- a/ports/bit7z/fix_install.patch
+++ b/ports/bit7z/fix_install.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2eb8634..74f0137 100644
+index 2eb8634..f8ff6f0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -179,7 +179,7 @@ message( STATUS "Language Standard for bit7z: C++${CMAKE_CXX_STANDARD}" )
@@ -9,40 +9,35 @@ index 2eb8634..74f0137 100644
 -                PUBLIC ${PUBLIC_HEADERS}
 +                # PUBLIC ${PUBLIC_HEADERS}
                  PRIVATE ${HEADERS} ${SOURCES} )
-
+ 
  # additional target without the architecture suffix in the name
-@@ -205,12 +205,12 @@ if( ghc_filesystem_ADDED )
- endif()
-
- # public includes
--target_include_directories( ${LIB_TARGET} PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
-+target_include_directories( ${LIB_TARGET} PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
-                                                  "$<INSTALL_INTERFACE:include>" )
-
- # private includes
--target_include_directories( ${LIB_TARGET} PRIVATE "${PROJECT_SOURCE_DIR}/include/bit7z"
--                                                  "${PROJECT_SOURCE_DIR}/src" )
-+target_include_directories( ${LIB_TARGET} PRIVATE "${CMAKE_SOURCE_DIR}/include/bit7z"
-+                                                  "${CMAKE_SOURCE_DIR}/src" )
-
- # 7-zip compilation definitions
- target_compile_definitions( ${LIB_TARGET} PRIVATE UNICODE _UNICODE )
-@@ -246,3 +246,18 @@ endif()
+@@ -246,3 +246,29 @@ endif()
  if( BIT7Z_BUILD_DOCS )
      add_subdirectory( docs )
  endif()
 +
++include(CMakePackageConfigHelpers)
++configure_package_config_file(
++  "${CMAKE_CURRENT_SOURCE_DIR}/unofficial-bit7z-config.cmake.in"
++  "${CMAKE_CURRENT_BINARY_DIR}/unofficial-bit7z-config.cmake"
++  INSTALL_DESTINATION "share/unofficial-bit7z"
++)
++install(
++  FILES "${CMAKE_CURRENT_BINARY_DIR}/unofficial-bit7z-config.cmake"
++  DESTINATION "share/unofficial-bit7z"
++)
++
 +include(GNUInstallDirs)
 +install(
 +    TARGETS ${LIB_TARGET}
-+    EXPORT bit7z
++    EXPORT unofficial-bit7z-targets
 +    COMPONENT bit7z
 +    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 +    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+    PUBLIC_HEADER DESTINATION include/bit7z)
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 +
 +install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/bit7z
 +        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 +
-+install(EXPORT bit7z FILE unofficial-bit7z-config.cmake NAMESPACE unofficial::bit7z:: DESTINATION share/unofficial-bit7z)
++install(EXPORT unofficial-bit7z-targets FILE unofficial-bit7z-targets.cmake NAMESPACE unofficial::bit7z:: DESTINATION share/unofficial-bit7z)
++

--- a/ports/bit7z/fix_install.patch
+++ b/ports/bit7z/fix_install.patch
@@ -11,10 +11,16 @@ index 2eb8634..f8ff6f0 100644
                  PRIVATE ${HEADERS} ${SOURCES} )
  
  # additional target without the architecture suffix in the name
-@@ -246,3 +246,29 @@ endif()
+@@ -246,3 +246,32 @@ endif()
  if( BIT7Z_BUILD_DOCS )
      add_subdirectory( docs )
  endif()
++
++set(_includes)
++foreach(_include_dir ${PUBLIC_HEADERS})
++    list(APPEND _includes "${CMAKE_CURRENT_SOURCE_DIR}/${_include_dir}")
++endforeach()
++set_target_properties( ${LIB_TARGET} PROPERTIES PUBLIC_HEADER "${_includes}")
 +
 +include(CMakePackageConfigHelpers)
 +configure_package_config_file(
@@ -34,10 +40,8 @@ index 2eb8634..f8ff6f0 100644
 +    COMPONENT bit7z
 +    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 +    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+
-+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/bit7z
-+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/bit7z COMPONENT bit7z_development)
 +
 +install(EXPORT unofficial-bit7z-targets FILE unofficial-bit7z-targets.cmake NAMESPACE unofficial::bit7z:: DESTINATION share/unofficial-bit7z)
 +

--- a/ports/bit7z/fix_install.patch
+++ b/ports/bit7z/fix_install.patch
@@ -16,11 +16,7 @@ index 2eb8634..f8ff6f0 100644
      add_subdirectory( docs )
  endif()
 +
-+set(_includes)
-+foreach(_include_dir ${PUBLIC_HEADERS})
-+    list(APPEND _includes "${CMAKE_CURRENT_SOURCE_DIR}/${_include_dir}")
-+endforeach()
-+set_target_properties( ${LIB_TARGET} PROPERTIES PUBLIC_HEADER "${_includes}")
++set_target_properties(${LIB_TARGET} PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")
 +
 +include(CMakePackageConfigHelpers)
 +configure_package_config_file(

--- a/ports/bit7z/portfile.cmake
+++ b/ports/bit7z/portfile.cmake
@@ -16,16 +16,16 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-bit7z-config.cmake.in" DESTINATI
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        auto-format                     BIT7Z_AUTO_FORMAT
-        auto-prefix-long-paths          BIT7Z_AUTO_PREFIX_LONG_PATHS
-        disable-zip-ascii-pwd-check     BIT7Z_DISABLE_ZIP_ASCII_PWD_CHECK
-        path-sanitization               BIT7Z_PATH_SANITIZATION
         regex-matching                  BIT7Z_REGEX_MATCHING
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DBIT7Z_AUTO_FORMAT=ON
+        -DBIT7Z_AUTO_PREFIX_LONG_PATHS=ON
+        -DBIT7Z_DISABLE_ZIP_ASCII_PWD_CHECK=OFF
+        -DBIT7Z_PATH_SANITIZATION=ON
         -DBIT7Z_DISABLE_USE_STD_FILESYSTEM=OFF
         -DBIT7Z_USE_STD_BYTE=OFF
         -DBIT7Z_USE_NATIVE_STRING=OFF

--- a/ports/bit7z/portfile.cmake
+++ b/ports/bit7z/portfile.cmake
@@ -1,0 +1,39 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO rikyoz/bit7z
+    REF "v${VERSION}"
+    SHA512 02ee10a66598e9a2f5b47f35392dc8f3de11e01dac9d657e1321d1de97baf9832b1f1559054160d122dddd0427f54076820d7252185912c38b2f277d9c5fa1c0
+    HEAD_REF master
+    PATCHES
+      fix_install.patch
+      fix_dependency.patch
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        auto-format                   BIT7Z_AUTO_FORMAT
+        auto-prefix-long-paths        BIT7Z_AUTO_PREFIX_LONG_PATHS
+        disable-use-std-filesystem    BIT7Z_DISABLE_USE_STD_FILESYSTEM
+        disable-zip-ascii-pwd-check   BIT7Z_DISABLE_ZIP_ASCII_PWD_CHECK
+        path-sanitization             BIT7Z_PATH_ANITIZATION
+        regex-matching                BIT7Z_REGEX_MATCHING
+        use-std-byte                  BIT7Z_USE_STD_BYTE
+        use-native-string             BIT7Z_USE_NATIVE_STRING
+        use-system-codepage           BIT7Z_USE_SYSTEM_CODEPAGE
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-bit7z CONFIG_PATH share/unofficial-bit7z)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/bit7z/portfile.cmake
+++ b/ports/bit7z/portfile.cmake
@@ -28,6 +28,8 @@ vcpkg_check_features(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DBIT7Z_BUILD_TESTS=OFF
+        -DBIT7Z_BUILD_DOCS=OFF
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/bit7z/portfile.cmake
+++ b/ports/bit7z/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rikyoz/bit7z

--- a/ports/bit7z/portfile.cmake
+++ b/ports/bit7z/portfile.cmake
@@ -11,23 +11,25 @@ vcpkg_from_github(
       fix_dependency.patch
 )
 
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-bit7z-config.cmake.in" DESTINATION "${SOURCE_PATH}")
+
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         auto-format                     BIT7Z_AUTO_FORMAT
         auto-prefix-long-paths          BIT7Z_AUTO_PREFIX_LONG_PATHS
-        disable-use-std-filesystem      BIT7Z_DISABLE_USE_STD_FILESYSTEM
         disable-zip-ascii-pwd-check     BIT7Z_DISABLE_ZIP_ASCII_PWD_CHECK
-        path-sanitization               BIT7Z_PATH_ANITIZATION
+        path-sanitization               BIT7Z_PATH_SANITIZATION
         regex-matching                  BIT7Z_REGEX_MATCHING
-        use-std-byte                    BIT7Z_USE_STD_BYTE
-        use-native-string               BIT7Z_USE_NATIVE_STRING
-        use-system-codepage             BIT7Z_USE_SYSTEM_CODEPAGE
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DBIT7Z_DISABLE_USE_STD_FILESYSTEM=OFF
+        -DBIT7Z_USE_STD_BYTE=OFF
+        -DBIT7Z_USE_NATIVE_STRING=OFF
+        -DBIT7Z_USE_SYSTEM_CODEPAGE=OFF
         -DBIT7Z_BUILD_TESTS=OFF
         -DBIT7Z_BUILD_DOCS=OFF
         ${FEATURE_OPTIONS}
@@ -40,4 +42,4 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-bit7z CONFIG_PATH share/unoffic
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/bit7z/portfile.cmake
+++ b/ports/bit7z/portfile.cmake
@@ -14,15 +14,15 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        auto-format                   BIT7Z_AUTO_FORMAT
-        auto-prefix-long-paths        BIT7Z_AUTO_PREFIX_LONG_PATHS
-        disable-use-std-filesystem    BIT7Z_DISABLE_USE_STD_FILESYSTEM
-        disable-zip-ascii-pwd-check   BIT7Z_DISABLE_ZIP_ASCII_PWD_CHECK
-        path-sanitization             BIT7Z_PATH_ANITIZATION
-        regex-matching                BIT7Z_REGEX_MATCHING
-        use-std-byte                  BIT7Z_USE_STD_BYTE
-        use-native-string             BIT7Z_USE_NATIVE_STRING
-        use-system-codepage           BIT7Z_USE_SYSTEM_CODEPAGE
+        auto-format                     BIT7Z_AUTO_FORMAT
+        auto-prefix-long-paths          BIT7Z_AUTO_PREFIX_LONG_PATHS
+        disable-use-std-filesystem      BIT7Z_DISABLE_USE_STD_FILESYSTEM
+        disable-zip-ascii-pwd-check     BIT7Z_DISABLE_ZIP_ASCII_PWD_CHECK
+        path-sanitization               BIT7Z_PATH_ANITIZATION
+        regex-matching                  BIT7Z_REGEX_MATCHING
+        use-std-byte                    BIT7Z_USE_STD_BYTE
+        use-native-string               BIT7Z_USE_NATIVE_STRING
+        use-system-codepage             BIT7Z_USE_SYSTEM_CODEPAGE
 )
 
 vcpkg_cmake_configure(

--- a/ports/bit7z/unofficial-bit7z-config.cmake.in
+++ b/ports/bit7z/unofficial-bit7z-config.cmake.in
@@ -1,5 +1,7 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
 include("${CMAKE_CURRENT_LIST_DIR}/unofficial-bit7z-targets.cmake")
 
 find_dependency(7zip CONFIG)

--- a/ports/bit7z/unofficial-bit7z-config.cmake.in
+++ b/ports/bit7z/unofficial-bit7z-config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-bit7z-targets.cmake")
+
+find_dependency(7zip CONFIG)
+find_dependency(ghc_filesystem CONFIG)
+
+check_required_components(bit7z)

--- a/ports/bit7z/unofficial-bit7z-config.cmake.in
+++ b/ports/bit7z/unofficial-bit7z-config.cmake.in
@@ -2,9 +2,9 @@
 
 include(CMakeFindDependencyMacro)
 
-include("${CMAKE_CURRENT_LIST_DIR}/unofficial-bit7z-targets.cmake")
-
 find_dependency(7zip CONFIG)
 find_dependency(ghc_filesystem CONFIG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-bit7z-targets.cmake")
 
 check_required_components(bit7z)

--- a/ports/bit7z/vcpkg.json
+++ b/ports/bit7z/vcpkg.json
@@ -1,0 +1,51 @@
+{
+  "name": "bit7z",
+  "version": "4.0.8",
+  "description": "A C++ static library offering a clean and simple interface to the 7-zip shared libraries.",
+  "homepage": "https://github.com/rikyoz/bit7z",
+  "license": "MPL-2.0",
+  "dependencies": [
+    "7zip",
+    "ghc-filesystem",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "auto-format": {
+      "description": "Enables the automatic format detection of input archives"
+    },
+    "auto-prefix-long-paths": {
+      "description": "Enables or disables automatically prepending paths with the Windows long path prefix, allowing to handle archives and files with long paths",
+      "supports": "windows"
+    },
+    "disable-use-std-filesystem": {
+      "description": "Disable using the standard filesystem library and always use ghc::filesystem"
+    },
+    "disable-zip-ascii-pwd-check": {
+      "description": "Disables checking if passwords are ASCII when compressing using the Zip format"
+    },
+    "path-sanitization": {
+      "description": "Enables or disables path sanitization when extracting archives containing files with invalid Windows filenames",
+      "supports": "windows"
+    },
+    "regex-matching": {
+      "description": "Enables the support for extracting files matching regular expressions"
+    },
+    "use-native-string": {
+      "description": "Enables using the OS native string type(i.e., std::wstring on Windows, std::string elsewhere)"
+    },
+    "use-std-byte": {
+      "description": "Enables using a type-safe byte type (like C++17's std::byte) for buffers"
+    },
+    "use-system-codepage": {
+      "description": "Enables or disables using the default Windows codepage for string conversions",
+      "supports": "windows"
+    }
+  }
+}

--- a/ports/bit7z/vcpkg.json
+++ b/ports/bit7z/vcpkg.json
@@ -17,20 +17,6 @@
     }
   ],
   "features": {
-    "auto-format": {
-      "description": "Enables the automatic format detection of input archives"
-    },
-    "auto-prefix-long-paths": {
-      "description": "Enables or disables automatically prepending paths with the Windows long path prefix, allowing to handle archives and files with long paths",
-      "supports": "windows"
-    },
-    "disable-zip-ascii-pwd-check": {
-      "description": "Disables checking if passwords are ASCII when compressing using the Zip format"
-    },
-    "path-sanitization": {
-      "description": "Enables or disables path sanitization when extracting archives containing files with invalid Windows filenames",
-      "supports": "windows"
-    },
     "regex-matching": {
       "description": "Enables the support for extracting files matching regular expressions"
     }

--- a/ports/bit7z/vcpkg.json
+++ b/ports/bit7z/vcpkg.json
@@ -24,9 +24,6 @@
       "description": "Enables or disables automatically prepending paths with the Windows long path prefix, allowing to handle archives and files with long paths",
       "supports": "windows"
     },
-    "disable-use-std-filesystem": {
-      "description": "Disable using the standard filesystem library and always use ghc::filesystem"
-    },
     "disable-zip-ascii-pwd-check": {
       "description": "Disables checking if passwords are ASCII when compressing using the Zip format"
     },
@@ -36,16 +33,6 @@
     },
     "regex-matching": {
       "description": "Enables the support for extracting files matching regular expressions"
-    },
-    "use-native-string": {
-      "description": "Enables using the OS native string type(i.e., std::wstring on Windows, std::string elsewhere)"
-    },
-    "use-std-byte": {
-      "description": "Enables using a type-safe byte type (like C++17's std::byte) for buffers"
-    },
-    "use-system-codepage": {
-      "description": "Enables or disables using the default Windows codepage for string conversions",
-      "supports": "windows"
     }
   }
 }

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f079ac86ebb38511681038850829ae0fa0c4357d",
+      "git-tree": "ff7b6fd37ec1d349bd32b378de4eb254388d41ba",
       "version": "4.0.8",
       "port-version": 0
     }

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ff7b6fd37ec1d349bd32b378de4eb254388d41ba",
+      "git-tree": "70d2843c6913bd01d46107c817c90ceb55830ecb",
       "version": "4.0.8",
       "port-version": 0
     }

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "60c10bee63a8c6db09c62294931b73f5993f3a2a",
+      "version": "4.0.8",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b3c1233cfa1f2591ad2764c2f578868b227526ce",
+      "git-tree": "2da3232eb2ed5041343a00bc8f0593337d0d5fe1",
       "version": "4.0.8",
       "port-version": 0
     }

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ae4527dee70621eef9ba2380ba58d4ea1e4e6ea3",
+      "git-tree": "07fa7b0762a888e367f01bd9ba8674c7a0d7ffdb",
       "version": "4.0.8",
       "port-version": 0
     }

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "70d2843c6913bd01d46107c817c90ceb55830ecb",
+      "git-tree": "b3c1233cfa1f2591ad2764c2f578868b227526ce",
       "version": "4.0.8",
       "port-version": 0
     }

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2da3232eb2ed5041343a00bc8f0593337d0d5fe1",
+      "git-tree": "ae4527dee70621eef9ba2380ba58d4ea1e4e6ea3",
       "version": "4.0.8",
       "port-version": 0
     }

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "60c10bee63a8c6db09c62294931b73f5993f3a2a",
+      "git-tree": "f079ac86ebb38511681038850829ae0fa0c4357d",
       "version": "4.0.8",
       "port-version": 0
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -644,6 +644,10 @@
       "baseline": "3.0",
       "port-version": 3
     },
+    "bit7z": {
+      "baseline": "4.0.8",
+      "port-version": 0
+    },
     "bitmagic": {
       "baseline": "7.13.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.