### PR TITLE
[cudnn] Add version v9.4

### DIFF
--- a/ports/cudnn/FindCUDNN.cmake
+++ b/ports/cudnn/FindCUDNN.cmake
@@ -23,11 +23,15 @@
 #
 
 include(FindPackageHandleStandardArgs)
+file(GLOB CUDNN_VERSION_DIRS
+  LIST_DIRECTORIES true
+  "$ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v[1-9]*.[1-9]*"
+)
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
   PATH_SUFFIXES cuda/include include include/11.8 include/12.0 include/12.1 include/12.2 include/12.3 include/12.4 include/12.5 include/12.6)
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
   PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/11.8/x64 lib/12.0/x64 lib/12.1/x64 lib/12.2/x64 lib/12.3/x64 lib/12.4/x64 lib/12.5/x64 lib/12.6/x64)
 
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -3,9 +3,13 @@ set(MINIMUM_CUDNN_VERSION "7.6.5")
 vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT OUT_CUDA_VERSION CUDA_VERSION)
 
 # Try to find CUDNN if it exists; only download if it doesn't exist
-find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.4 /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
-  PATH_SUFFIXES cuda/include include include/11.8 include/12.0 include/12.1 include/12.2 include/12.3 include/12.4 include/12.5 include/12.6)
+file(GLOB_RECURSE CUDNN_INCLUDE_FILES
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.4
+  PATHS /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
+  NAMES cudnn.h cudnn_v*.h
+)
+list(GET CUDNN_INCLUDE_FILES 0 FIRST_CUDNN_INCLUDE_FILE)
+get_filename_component(CUDNN_INCLUDE_DIR ${FIRST_CUDNN_INCLUDE_FILE} DIRECTORY)
 message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
   HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.4 /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -3,17 +3,16 @@ set(MINIMUM_CUDNN_VERSION "7.6.5")
 vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT OUT_CUDA_VERSION CUDA_VERSION)
 
 # Try to find CUDNN if it exists; only download if it doesn't exist
-file(GLOB_RECURSE CUDNN_INCLUDE_FILES
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.4
-  PATHS /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
-  NAMES cudnn.h cudnn_v*.h
+file(GLOB CUDNN_VERSION_DIRS
+  LIST_DIRECTORIES true
+  "$ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v[1-9]*.[1-9]*"
 )
-foreach(CUDNN_INCLUDE_FILE ${CUDNN_INCLUDE_FILES})
-    get_filename_component(CUDNN_INCLUDE_DIR ${CUDNN_INCLUDE_FILE} DIRECTORY)
-endforeach()
+find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
+  PATH_SUFFIXES cuda/include include include/11.8 include/12.0 include/12.1 include/12.2 include/12.3 include/12.4 include/12.5 include/12.6)
 message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.4 /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
   PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/11.8/x64 lib/12.0/x64 lib/12.1/x64 lib/12.2/x64 lib/12.3/x64 lib/12.4/x64 lib/12.5/x64 lib/12.6/x64)
 message(STATUS "CUDNN_LIBRARY: ${CUDNN_LIBRARY}")
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -8,8 +8,9 @@ file(GLOB_RECURSE CUDNN_INCLUDE_FILES
   PATHS /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
   NAMES cudnn.h cudnn_v*.h
 )
-list(GET CUDNN_INCLUDE_FILES 0 FIRST_CUDNN_INCLUDE_FILE)
-get_filename_component(CUDNN_INCLUDE_DIR ${FIRST_CUDNN_INCLUDE_FILE} DIRECTORY)
+foreach(CUDNN_INCLUDE_FILE ${CUDNN_INCLUDE_FILES})
+    get_filename_component(CUDNN_INCLUDE_DIR ${CUDNN_INCLUDE_FILE} DIRECTORY)
+endforeach()
 message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
   HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.4 /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -4,11 +4,11 @@ vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT OUT_CUDA_VERSION CUDA_VE
 
 # Try to find CUDNN if it exists; only download if it doesn't exist
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.4 /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
   PATH_SUFFIXES cuda/include include include/11.8 include/12.0 include/12.1 include/12.2 include/12.3 include/12.4 include/12.5 include/12.6)
 message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.0 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.1 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.2 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.3 $ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v9.4 /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
   PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/11.8/x64 lib/12.0/x64 lib/12.1/x64 lib/12.2/x64 lib/12.3/x64 lib/12.4/x64 lib/12.5/x64 lib/12.6/x64)
 message(STATUS "CUDNN_LIBRARY: ${CUDNN_LIBRARY}")
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")

--- a/ports/cudnn/vcpkg.json
+++ b/ports/cudnn/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cudnn",
   "version": "7.6.5",
-  "port-version": 13,
+  "port-version": 14,
   "description": "NVIDIA's cuDNN deep neural network acceleration library.",
   "homepage": "https://developer.nvidia.com/cudnn",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2102,7 +2102,7 @@
     },
     "cudnn": {
       "baseline": "7.6.5",
-      "port-version": 13
+      "port-version": 14
     },
     "cunit": {
       "baseline": "2.1.3",

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dee0c1b576643653102214e57964110275f7eaa6",
+      "version": "7.6.5",
+      "port-version": 14
+    },
+    {
       "git-tree": "92d21a780ad42ae4fa7aaf9481d8a43a832d6e4c",
       "version": "7.6.5",
       "port-version": 13

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dee0c1b576643653102214e57964110275f7eaa6",
+      "git-tree": "e7eda2a8fbbde66f6a1cee03f77f23d74bbf367d",
       "version": "7.6.5",
       "port-version": 14
     },

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fb4d214bd5d4acbbf6843c2439f413515fa7fc35",
+      "git-tree": "8f57d7b277ba90ea49bbcc82dc2d4be9e16e15dd",
       "version": "7.6.5",
       "port-version": 14
     },

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8f57d7b277ba90ea49bbcc82dc2d4be9e16e15dd",
+      "git-tree": "8e17b3aaaea3a6da5858cb6202c3e2cd8e9f9a5e",
       "version": "7.6.5",
       "port-version": 14
     },

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e7eda2a8fbbde66f6a1cee03f77f23d74bbf367d",
+      "git-tree": "fb4d214bd5d4acbbf6843c2439f413515fa7fc35",
       "version": "7.6.5",
       "port-version": 14
     },


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/40882

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.