### PR TITLE
[vcpkg baseline][libconfuse,onednn] Passing remove form fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -529,10 +529,6 @@ libcaer:x64-android=fail
 libcanberra:arm-neon-android=fail
 libcanberra:arm64-android=fail
 libcanberra:x64-android=fail
-# needs android-24
-libconfuse:arm-neon-android=fail
-libconfuse:arm64-android=fail
-libconfuse:x64-android=fail
 libcoro:x64-osx=fail
 libcoro:arm64-osx=fail
 libcpplocate:arm-neon-android=fail
@@ -830,7 +826,6 @@ omplapp:arm64-osx=skip
 omplapp:x64-osx=skip
 omplapp:x64-linux=skip
 # opencc/deps/rapidjson-1.1.0/rapidjson.h: Unknown machine endianess detected
-onednn:x64-android=fail
 # opencc/deps/marisa-0.2.5/lib/marisa/grimoire/io/mapper.cc currently doesn't support UWP.
 opencc:x64-android=fail
 opencv2:arm-neon-android=fail


### PR DESCRIPTION
```
PASSING, REMOVE FROM FAIL LIST: libconfuse:arm-neon-android
PASSING, REMOVE FROM FAIL LIST: libconfuse:x64-android
PASSING, REMOVE FROM FAIL LIST: libconfuse:arm64-android

PASSING, REMOVE FROM FAIL LIST: onednn:x64-android
```
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=106807&view=results.
Fixed by PR https://github.com/microsoft/vcpkg/pull/40856, #40851.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.