### PR TITLE
[vcpkg_find_acquire_program] Fix extraction, cleanup

### DIFF
--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -12,7 +12,7 @@ parameters:
   - name: tripletPattern
     displayName: 'Enable triplets which contain this substring'
     type: string
-    default: '-'
+    default: 'x64-windows$'
 
 jobs:
 - template: windows/azure-pipelines.yml

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -12,7 +12,7 @@ parameters:
   - name: tripletPattern
     displayName: 'Enable triplets which contain this substring'
     type: string
-    default: 'x64-windows$'
+    default: '-'
 
 jobs:
 - template: windows/azure-pipelines.yml

--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -199,6 +199,15 @@ function(vcpkg_find_acquire_program program)
                         WORLD_READ WORLD_EXECUTE
                 )
             endif()
+        elseif(tool_subdirectory STREQUAL "")
+            # The effective tool subdir is owned by the extracted paths of the archive.
+            # *** This behavior is provided for convenience and short paths. ***
+            # There must be no overlap between different providers of subdirs.
+            # Otherwise tool_subdirectory must be used in order to separate extracted trees.
+            file(REMOVE_RECURSE "${full_subdirectory}.temp")
+            vcpkg_extract_archive(ARCHIVE "${archive_path}" DESTINATION "${full_subdirectory}.temp")
+            file(COPY "${full_subdirectory}.temp/" DESTINATION "${full_subdirectory}")
+            file(REMOVE_RECURSE "${full_subdirectory}.temp")
         else()
             vcpkg_extract_archive(ARCHIVE "${archive_path}" DESTINATION "${full_subdirectory}")
         endif()

--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -200,7 +200,6 @@ function(vcpkg_find_acquire_program program)
                 )
             endif()
         else()
-            file(REMOVE_RECURSE "${full_subdirectory}")
             vcpkg_extract_archive(ARCHIVE "${archive_path}" DESTINATION "${full_subdirectory}")
         endif()
 

--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -200,6 +200,7 @@ function(vcpkg_find_acquire_program program)
                 )
             endif()
         else()
+            file(REMOVE_RECURSE "${full_subdirectory}")
             vcpkg_extract_archive(ARCHIVE "${archive_path}" DESTINATION "${full_subdirectory}")
         endif()
 

--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -127,10 +127,13 @@ function(vcpkg_find_acquire_program program)
         message(FATAL_ERROR "Internal error: failed to initialize program_name for program ${program}")
     endif()
 
-    set(full_subdirectory "${DOWNLOADS}/tools/${program_name}")
+    set(full_subdirectory "${DOWNLOADS}/tools/${program_name}/${tool_subdirectory}")
     if(NOT "${tool_subdirectory}" STREQUAL "")
-        string(APPEND full_subdirectory "/${tool_subdirectory}")
-        list(APPEND paths_to_search "${full_subdirectory}")
+        list(APPEND paths_to_search ${full_subdirectory})
+    endif()
+    if("${full_subdirectory}" MATCHES [[^(.*)[/\\]+$]])
+        # remove trailing slashes, which may turn into a trailing `\` which CMake _does not like_
+        set(full_subdirectory "${CMAKE_MATCH_1}")
     endif()
 
     if("${search_names}" STREQUAL "")

--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -127,13 +127,10 @@ function(vcpkg_find_acquire_program program)
         message(FATAL_ERROR "Internal error: failed to initialize program_name for program ${program}")
     endif()
 
-    set(full_subdirectory "${DOWNLOADS}/tools/${program_name}/${tool_subdirectory}")
+    set(full_subdirectory "${DOWNLOADS}/tools/${program_name}")
     if(NOT "${tool_subdirectory}" STREQUAL "")
-        list(APPEND paths_to_search ${full_subdirectory})
-    endif()
-    if("${full_subdirectory}" MATCHES [[^(.*)[/\\]+$]])
-        # remove trailing slashes, which may turn into a trailing `\` which CMake _does not like_
-        set(full_subdirectory "${CMAKE_MATCH_1}")
+        string(APPEND full_subdirectory "/${tool_subdirectory}")
+        list(APPEND paths_to_search "${full_subdirectory}")
     endif()
 
     if("${search_names}" STREQUAL "")

--- a/scripts/test_ports/vcpkg-find-acquire-program/portfile.cmake
+++ b/scripts/test_ports/vcpkg-find-acquire-program/portfile.cmake
@@ -27,6 +27,11 @@ if(VCPKG_HOST_IS_LINUX)
 endif()
 
 if(VCPKG_HOST_IS_WINDOWS)
+    # The version-agnostic tool dir may already exist.
+    # Simulate/test with NASM.
+    file(REMOVE_RECURSE "${DOWNLOADS}/tools/nasm")
+    file(MAKE_DIRECTORY "${DOWNLOADS}/tools/nasm")
+
     list(APPEND variables 7Z ARIA2 CLANG DARK DOXYGEN GASPREPROCESSOR GO GPERF JOM NASM NUGET PYTHON2 RUBY SCONS SWIG)
     vcpkg_find_acquire_program(7Z)
     vcpkg_find_acquire_program(ARIA2)


### PR DESCRIPTION
Amends #34881.

`vcpkg_extract_archive` expects the destination to not exist:
https://github.com/microsoft/vcpkg/blob/ee2d2a100103e0f3613c60655dcf15be7d5157b8/scripts/cmake/vcpkg_extract_archive.cmake#L18-L20
but there was no code to ensure that property, leading to  
https://github.com/microsoft/vcpkg/issues/40902#issuecomment-2344467731

In addition, simplify processing of the optional `tool_subdirectory` variable.