### PR TITLE
[ngtcp2] fix: detect the libressl in vcpkg

### DIFF
--- a/ports/ngtcp2/libressl_detected.patch
+++ b/ports/ngtcp2/libressl_detected.patch
@@ -1,13 +1,14 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -119,9 +119,9 @@
+@@ -119,9 +119,10 @@
  if(ENABLE_GNUTLS)
    find_package(GnuTLS 3.7.2)
  endif()
  if(ENABLE_OPENSSL)
 -  find_package(OpenSSL 1.1.1)
-+  find_package(OpenSSL REQUIRED)
++  find_package(OPENSSL CONFIG NAMES LibreSSL REQUIRED)
++  set(OPENSSL_LIBRARIES "LibreSSL::SSL" "LibreSSL::TLS" "LibreSSL::Crypto")
  endif()
  if(ENABLE_WOLFSSL)
    find_package(wolfssl 5.5.0)

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 891a7339122f60b1796bb24d29ab75d0316717c2a64a45bade805242b70cb8713abc7642cdf0ec646ab9e80085d65117f0ea9b1e671d76bcd54038b0ea9bc868
     HEAD_REF main
     PATCHES
-        openssl_required.patch
+        libressl_detected.patch
         popcnt_intrinsic.patch # https://github.com/ngtcp2/ngtcp2/pull/1351
 )
 

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ngtcp2",
   "version": "1.7.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "ngtcp2 project is an effort to implement RFC9000 QUIC protocol.",
   "homepage": "https://github.com/ngtcp2/ngtcp2",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6286,7 +6286,7 @@
     },
     "ngtcp2": {
       "baseline": "1.7.0",
-      "port-version": 1
+      "port-version": 2
     },
     "nifly": {
       "baseline": "1.0.0",

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66b2a52d286e31f447902060c99dbb141c490c2f",
+      "version": "1.7.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b0694dae4b89a7212beb478571821e45c3715335",
       "version": "1.7.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

fix #40915 
