### PR TITLE
[libressl] Fail if openssl is installed

### DIFF
--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -1,7 +1,5 @@
 if(EXISTS "${CURRENT_INSTALLED_DIR}/include/openssl/ssl.h")
-  message(WARNING "Can't build libressl if openssl is installed. Please remove openssl, and try install libressl again if you need it. Build will continue since libressl is a subset of openssl")
-  set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-  return()
+  message(FATAL_ERROR "Can't build libressl if openssl is installed. Please remove openssl, and try install libressl again if you need it. Build will continue since libressl is a subset of openssl")
 endif()
 
 vcpkg_download_distfile(

--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -1,5 +1,5 @@
 if(EXISTS "${CURRENT_INSTALLED_DIR}/include/openssl/ssl.h")
-  message(FATAL_ERROR "Can't build libressl if openssl is installed. Please remove openssl, and try install libressl again if you need it. Build will continue since libressl is a subset of openssl")
+    message(FATAL_ERROR "Can't build libressl if openssl is installed. Please remove openssl, and try install libressl again if you need it.")
 endif()
 
 vcpkg_download_distfile(

--- a/ports/libressl/vcpkg.json
+++ b/ports/libressl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libressl",
   "version": "3.9.2",
+  "port-version": 1,
   "description": "LibreSSL is a version of the TLS/crypto stack forked from OpenSSL in 2014, with goals of modernizing the codebase, improving security, and applying best practice development processes.",
   "license": "ISC",
   "dependencies": [

--- a/scripts/test_ports/vcpkg-ci-libressl/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-libressl/portfile.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-libressl/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-libressl/project/CMakeLists.txt
@@ -5,7 +5,6 @@ project(libressl-test CXX)
 # NB: The port doesn't provide a wrapper, so there is no support
 #     for multi-config and for transitive usage requirements.
 find_package(OpenSSL MODULE REQUIRED)
-
 foreach(target IN ITEMS OpenSSL::SSL OpenSSL::Crypto)
     set(location_found FALSE)
     foreach(property IN ITEMS IMPORTED_LOCATION IMPORTED_LOCATION_DEBUG IMPORTED_LOCATION_RELEASE)
@@ -15,9 +14,9 @@ foreach(target IN ITEMS OpenSSL::SSL OpenSSL::Crypto)
         endif()
         set(location_found TRUE)
         message(STATUS "${target} ${property}: ${location}")
-        string(FIND "${location}" "${CURRENT_INSTALLED_DIR}" index)
+        string(FIND "${location}" "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" index)
         if(NOT index STREQUAL "0")
-            message(SEND_ERROR "${target} ${property} is not from CURRENT_INSTALLED_DIR.")
+            message(SEND_ERROR "${target} ${property} is not from vcpkg.")
         endif()
     endforeach()
     if(NOT location_found)
@@ -25,10 +24,10 @@ foreach(target IN ITEMS OpenSSL::SSL OpenSSL::Crypto)
     endif()
 endforeach()
 
-# libressl provides cmake targets
+# libressl provides cmake config
 find_package(LibreSSL CONFIG REQUIRED)
 message(STATUS "LibreSSL CONFIG: ${LibreSSL_DIR}")
-string(FIND "${LibreSSL_DIR}" "${CURRENT_INSTALLED_DIR}" index)
+string(FIND "${LibreSSL_DIR}" "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" index)
 if(NOT index STREQUAL "0")
-    message(SEND_ERROR "LibreSSL CONFIG is not from CURRENT_INSTALLED_DIR.")
+    message(SEND_ERROR "LibreSSL CONFIG is not from vcpkg.")
 endif()

--- a/scripts/test_ports/vcpkg-ci-libressl/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-libressl/project/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.7)
+project(libressl-test CXX)
+
+# libressl promises openssl compatibility
+# NB: The port doesn't provide a wrapper, so there is no support
+#     for multi-config and for transitive usage requirements.
+find_package(OpenSSL MODULE REQUIRED)
+
+foreach(target IN ITEMS OpenSSL::SSL OpenSSL::Crypto)
+    set(location_found FALSE)
+    foreach(property IN ITEMS IMPORTED_LOCATION IMPORTED_LOCATION_DEBUG IMPORTED_LOCATION_RELEASE)
+        get_target_property(location ${target} ${property})
+        if(NOT location)
+            continue()
+        endif()
+        set(location_found TRUE)
+        message(STATUS "${target} ${property}: ${location}")
+        string(FIND "${location}" "${CURRENT_INSTALLED_DIR}" index)
+        if(NOT index STREQUAL "0")
+            message(SEND_ERROR "${target} ${property} is not from CURRENT_INSTALLED_DIR.")
+        endif()
+    endforeach()
+    if(NOT location_found)
+        message(SEND_ERROR "No location for ${target} binary")
+    endif()
+endforeach()
+
+# libressl provides cmake targets
+find_package(LibreSSL CONFIG REQUIRED)
+message(STATUS "LibreSSL CONFIG: ${LibreSSL_DIR}")
+string(FIND "${LibreSSL_DIR}" "${CURRENT_INSTALLED_DIR}" index)
+if(NOT index STREQUAL "0")
+    message(SEND_ERROR "LibreSSL CONFIG is not from CURRENT_INSTALLED_DIR.")
+endif()

--- a/scripts/test_ports/vcpkg-ci-libressl/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-libressl/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-libressl",
+  "version-string": "ci",
+  "description": "Validates libressl",
+  "dependencies": [
+    "libressl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4982,7 +4982,7 @@
     },
     "libressl": {
       "baseline": "3.9.2",
-      "port-version": 0
+      "port-version": 1
     },
     "librsvg": {
       "baseline": "2.40.20",

--- a/versions/l-/libressl.json
+++ b/versions/l-/libressl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "73860a14e745562d15c6dfac7640dd8ed8106177",
+      "git-tree": "f9e56b0af8f93ed5c5adc5e2ba1696e5c16420be",
       "version": "3.9.2",
       "port-version": 1
     },

--- a/versions/l-/libressl.json
+++ b/versions/l-/libressl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "73860a14e745562d15c6dfac7640dd8ed8106177",
+      "version": "3.9.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "212859e945d993b860716eaa47b8f83ef52efbb2",
       "version": "3.9.2",
       "port-version": 0


### PR DESCRIPTION
The artifact cache key doesn't depend on openssl, so the presence of openssl must not change the package contents.

As already handled in `boringssl`.

Note: libressl is skipped in vcpkg CI. So the added test port does not run in CI, but can be used manually.

Related: https://github.com/microsoft/vcpkg/issues/40915#issuecomment-2345306311