### PR TITLE
[tiff] Do not use CMAKE_FIND_PACKAGE_PREFER_CONFIG

### DIFF
--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_gitlab(
     HEAD_REF master
     PATCHES
         FindCMath.patch
+        prefer-config.diff
         requires-lerc.patch
 )
 
@@ -34,7 +35,6 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
-        -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON
         -Dtiff-docs=OFF
         -Dtiff-contrib=OFF
         -Dtiff-tests=OFF

--- a/ports/tiff/prefer-config.diff
+++ b/ports/tiff/prefer-config.diff
@@ -2,13 +2,15 @@ diff --git a/cmake/LERCCodec.cmake b/cmake/LERCCodec.cmake
 index 54504ca..8dc8e1b 100644
 --- a/cmake/LERCCodec.cmake
 +++ b/cmake/LERCCodec.cmake
-@@ -25,7 +25,8 @@
+@@ -25,7 +25,10 @@
  
  # libLerc
  set(LERC_SUPPORT FALSE)
 -find_package(LERC)
 +find_package(LERC NAMES unofficial-lerc)
-+add_library(LERC::LERC ALIAS unofficial::Lerc::Lerc)
++if(TARGET unofficial::Lerc::Lerc)
++    add_library(LERC::LERC ALIAS unofficial::Lerc::Lerc)
++endif()
  option(lerc "use libLerc (required for LERC compression)" ${LERC_FOUND})
  if (lerc AND LERC_FOUND AND ZIP_SUPPORT)
      set(LERC_SUPPORT TRUE)

--- a/ports/tiff/prefer-config.diff
+++ b/ports/tiff/prefer-config.diff
@@ -1,0 +1,40 @@
+diff --git a/cmake/LERCCodec.cmake b/cmake/LERCCodec.cmake
+index 54504ca..8dc8e1b 100644
+--- a/cmake/LERCCodec.cmake
++++ b/cmake/LERCCodec.cmake
+@@ -25,7 +25,8 @@
+ 
+ # libLerc
+ set(LERC_SUPPORT FALSE)
+-find_package(LERC)
++find_package(LERC NAMES unofficial-lerc)
++add_library(LERC::LERC ALIAS unofficial::Lerc::Lerc)
+ option(lerc "use libLerc (required for LERC compression)" ${LERC_FOUND})
+ if (lerc AND LERC_FOUND AND ZIP_SUPPORT)
+     set(LERC_SUPPORT TRUE)
+diff --git a/cmake/WebPCodec.cmake b/cmake/WebPCodec.cmake
+index 1d676a7..7776917 100644
+--- a/cmake/WebPCodec.cmake
++++ b/cmake/WebPCodec.cmake
+@@ -26,7 +26,7 @@
+ # libwebp
+ set(WEBP_SUPPORT FALSE)
+ 
+-find_package(WebP)
++find_package(WebP CONFIG)
+ 
+ option(webp "use libwebp (required for WEBP compression)" ${WebP_FOUND})
+ 
+diff --git a/cmake/ZSTDCodec.cmake b/cmake/ZSTDCodec.cmake
+index 3fac861..2957aa3 100644
+--- a/cmake/ZSTDCodec.cmake
++++ b/cmake/ZSTDCodec.cmake
+@@ -28,7 +28,7 @@
+ set(ZSTD_SUPPORT FALSE)
+ set(ZSTD_USABLE FALSE)
+ 
+-find_package(ZSTD)
++find_package(ZSTD NAMES zstd)
+ 
+ if(ZSTD_FOUND)
+     if(TARGET zstd::libzstd_shared)

--- a/ports/tiff/vcpkg.json
+++ b/ports/tiff/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tiff",
   "version": "4.6.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A library that supports the manipulation of TIFF image files",
   "homepage": "https://libtiff.gitlab.io/libtiff/",
   "license": "libtiff",

--- a/scripts/test_ports/vcpkg-ci-gdal/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-gdal/vcpkg.json
@@ -40,6 +40,15 @@
         "aws-ec2-windows"
       ],
       "platform": "windows & !mingw"
+    },
+    {
+      "name": "tiff",
+      "features": [
+        "lerc",
+        "libdeflate",
+        "webp",
+        "zstd"
+      ]
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8846,7 +8846,7 @@
     },
     "tiff": {
       "baseline": "4.6.0",
-      "port-version": 4
+      "port-version": 5
     },
     "tinkerforge": {
       "baseline": "2.1.25",

--- a/versions/t-/tiff.json
+++ b/versions/t-/tiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f72c77b88fcf07680b80d6342d4c1c900e29a459",
+      "version": "4.6.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "9aa03ccc8de52590c49943ca462d6f833d0a9118",
       "version": "4.6.0",
       "port-version": 4

--- a/versions/t-/tiff.json
+++ b/versions/t-/tiff.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f72c77b88fcf07680b80d6342d4c1c900e29a459",
+      "git-tree": "6a3bae487fe89087457e2a391ee9720d68393616",
       "version": "4.6.0",
       "port-version": 5
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40914.
Fixes `tiff[lerc]`.
Enforces CI coverage for all features.