### PR TITLE
[vcpkg-tool-bazel] Update to 6.5.0

### DIFF
--- a/ports/vcpkg-tool-bazel/portfile.cmake
+++ b/ports/vcpkg-tool-bazel/portfile.cmake
@@ -1,64 +1,83 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 
-set(program bazel)
-set(program_version 5.2.0)
-
-if(VCPKG_CROSSCOMPILING)
-    message(FATAL_ERROR "This is a host only port!")
-endif()
-
-if(VCPKG_TARGET_IS_LINUX)
-    set(tool_subdirectory "${program_version}-linux")
-    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
-        set(download_urls "https://github.com/bazelbuild/bazel/releases/download/${program_version}/bazel-${tool_subdirectory}-arm64")
-        set(download_filename "bazel-${tool_subdirectory}-arm64")
-        set(raw_executable ON)
-        set(download_sha512 11e953717f0edd599053a9c6ab849c266f6b34cd6f39dd99301a138aeb9d10113d055f7a2452f6ae601a9e9c19c816d22732958bb147e493dae9c63b13e0f1e0)
-    else()
-        set(download_urls "https://github.com/bazelbuild/bazel/releases/download/${program_version}/bazel-${tool_subdirectory}-x86_64")
-        set(download_filename "bazel-${tool_subdirectory}-x86_64")
-        set(raw_executable ON)
-        set(download_sha512 c9f117414f31bc85a1f6a91f3d1c0a4884a4bb346bb60b00599c2da8225d085f67bc865f1429c897681cb99471767171aed148c77ce80d9525841c873d9cc912)
-    endif()
-elseif(VCPKG_TARGET_IS_OSX)
-    set(tool_subdirectory "${program_version}-darwin")
-    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
-        set(download_urls "https://github.com/bazelbuild/bazel/releases/download/${program_version}/bazel-${tool_subdirectory}-arm64")
-        set(download_filename "bazel-${tool_subdirectory}-arm64")
-        set(raw_executable ON)
-        set(download_sha512 303b5c897eab93fb164dda53ecf6294fd3376a5de17a752388f4e7f612a8a537acc7d99a021ca616c1d7989d10c3c14cd87689dad60b9f654bf75ecc606bb23e)
-    else()
-        set(download_urls "https://github.com/bazelbuild/bazel/releases/download/${program_version}/bazel-${tool_subdirectory}-x86_64")
-        set(download_filename "bazel-${tool_subdirectory}-x86_64")
-        set(raw_executable ON)
-        set(download_sha512 609db0a2f9d6eab292271b44acf08978159ca43a90f3228e32afe430e830f5418a041480d75e5b502be192897693f6b80a9ab9e7ce549e3655e188c39d29baaf)
-    endif()
+set(key NOTFOUND)
+if(VCPKG_CMAKE_SYSTEM_NAME)
+    set(key "${VCPKG_CMAKE_SYSTEM_NAME}-${VCPKG_TARGET_ARCHITECTURE}")
 elseif(VCPKG_TARGET_IS_WINDOWS)
-    set(tool_subdirectory "${program_version}-windows")
-    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
-        set(download_urls "https://github.com/bazelbuild/bazel/releases/download/${program_version}/bazel-${tool_subdirectory}-arm64.exe")
-        set(download_filename "bazel-${tool_subdirectory}-arm64.exe")
-        set(download_sha512 02c8f331daa3ea37319cf06d96618f433e297f749a1a6de863d243e2b826bfb12c058696cd6216afe38d35177f52cc1c66af98a8bcb191e198f436a44f2c2a1a)
-    else()
-        set(download_urls "https://github.com/bazelbuild/bazel/releases/download/${program_version}/bazel-${tool_subdirectory}-x86_64.exe")
-        set(download_filename "bazel-${tool_subdirectory}-x86_64.exe")
-        set(download_sha512 4917dd714345359c24e40451e20862b2ed705824ceffe536d42e56ffcd66fcea581317857dfb5339b56534b0681efd8376e8eebdcf9daff0d087444b060bdc53)
-    endif()
+    set(key "Windows-${VCPKG_TARGET_ARCHITECTURE}")
 endif()
 
-vcpkg_download_distfile(archive_path
-    URLS ${download_urls}
-    SHA512 "${download_sha512}"
-    FILENAME "${download_filename}"
-)
+set(archive_path NOTFOUND)
+# For convenient updates, use 
+# vcpkg install vcpkg-tool-bazel --cmake-args=-DVCPKG_BAZEL_UPDATE=1
+if(key STREQUAL "Linux-arm64" OR VCPKG_BAZEL_UPDATE)
+    set(filename "bazel-${VERSION}-linux-arm64")
+    vcpkg_download_distfile(archive_path
+		URLS "https://github.com/bazelbuild/bazel/releases/download/${VERSION}/${filename}"
+		FILENAME "${filename}"
+		SHA512 c3277c84db26c3fb18852aa450bd27f2b2a2e1dce0d3d5257469f6986387609c242b2e15bfc1534a4a5616b877924e54a994c2d3ecb9e26cf7a60816c7dbe50b
+	)
+endif()
+if(key STREQUAL "Linux-x64" OR VCPKG_BAZEL_UPDATE)
+    set(filename "bazel-${VERSION}-linux-x86_64")
+    vcpkg_download_distfile(archive_path
+		URLS "https://github.com/bazelbuild/bazel/releases/download/${VERSION}/${filename}"
+		FILENAME "${filename}"
+		SHA512 6c4a7d4baebef47a81f5c6377fa8919f66c96f22f73f945e37b82d61f1a94ec52a3d222dea401cfc7eff6bba8a43923d4cce1f74f2124a6362a0afac892137ad
+	)
+endif()
+if(key STREQUAL "Darwin-arm64" OR VCPKG_BAZEL_UPDATE)
+    set(filename "bazel-${VERSION}-darwin-arm64")
+    vcpkg_download_distfile(archive_path
+		URLS "https://github.com/bazelbuild/bazel/releases/download/${VERSION}/${filename}"
+		FILENAME "${filename}"
+		SHA512 269ad12b8fcb2e561366d8980b5ca297d254a074cbd121691415e3cf9a221706772aac26cb823fe114232ca43e4387fb9f3a1e38d3b61254848d636a2850b3b4
+	)
+endif()
+if(key STREQUAL "Darwin-x64" OR VCPKG_BAZEL_UPDATE)
+    set(filename "bazel-${VERSION}-darwin-x86_64")
+    vcpkg_download_distfile(archive_path
+		URLS "https://github.com/bazelbuild/bazel/releases/download/${VERSION}/${filename}"
+		FILENAME "${filename}"
+		SHA512 6b50164eb6f72a08f6a54bea960dec2dd7da3c7acc076643a989816f80507eee4271f673a8ef749b5168b31b0cb271dbc374daf2afe8b4acf7ad176ae778e571
+	)
+endif()
+if(key STREQUAL "Windows-arm64" OR VCPKG_BAZEL_UPDATE)
+    set(filename "bazel-${VERSION}-windows-arm64.exe")
+    vcpkg_download_distfile(archive_path
+		URLS "https://github.com/bazelbuild/bazel/releases/download/${VERSION}/${filename}"
+		FILENAME "${filename}"
+		SHA512 5fe6cb55df6d47e40590ee08a2ea11e3a11e8e9001a6a9cb1da7e8960b38242b9733df4b29fba58882b97da76773a1fa696e1f50f19810bd1867e1ed5afe4abb
+	)
+endif()
+if(key STREQUAL "Windows-x64" OR VCPKG_BAZEL_UPDATE)
+    set(filename "bazel-${VERSION}-windows-x86_64.exe")
+    vcpkg_download_distfile(archive_path
+		URLS "https://github.com/bazelbuild/bazel/releases/download/${VERSION}/${filename}"
+		FILENAME "${filename}"
+		SHA512 a6a028c7965ed391b786e1ccb67c4c4bfeee063dfa60b0ed3c8dee3317ce1e2e18914fcf053ba5c00e95d03ac15a55c719285448626a560fa1dd95baa351f145
+	)
+endif()
+if(NOT archive_path)
+	message(FATAL_ERROR "Unsupported platform. Please implement me!")
+endif()
+
+if(VCPKG_BAZEL_UPDATE)
+	message(STATUS "All downloads are up-to-date.")
+	message(FATAL_ERROR "Stopping due to VCPKG_BAZEL_UPDATE being enabled.")
+endif()
+
 message(STATUS "archive_path: '${archive_path}'")
 
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
 file(INSTALL "${archive_path}"
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools"
-    RENAME "${program}"
+    RENAME "bazel"
     FILE_PERMISSIONS
         OWNER_READ OWNER_WRITE OWNER_EXECUTE
         GROUP_READ GROUP_EXECUTE
         WORLD_READ WORLD_EXECUTE
 )
+
+# Avoid breaking the code signature.
+set(VCPKG_FIXUP_MACHO_RPATH OFF)

--- a/ports/vcpkg-tool-bazel/vcpkg.json
+++ b/ports/vcpkg-tool-bazel/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-tool-bazel",
-  "version": "5.2.0",
+  "version": "6.5.0",
   "description": "Bazel build system",
   "homepage": "https://github.com/bazelbuild/bazel",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9289,7 +9289,7 @@
       "port-version": 3
     },
     "vcpkg-tool-bazel": {
-      "baseline": "5.2.0",
+      "baseline": "6.5.0",
       "port-version": 0
     },
     "vcpkg-tool-gn": {

--- a/versions/v-/vcpkg-tool-bazel.json
+++ b/versions/v-/vcpkg-tool-bazel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98635bd2bec0f5304f90ffae9653a2bf72f9bea5",
+      "version": "6.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2594b8f7c3cb557af7882e87fee900f76fe895a8",
       "version": "5.2.0",
       "port-version": 0


### PR DESCRIPTION
Version chosen to match tensorflow 2.17 requirements.

Implements port update procedure [as appreciated in shader-slang](https://github.com/microsoft/vcpkg/pull/40866#issuecomment-2339541453).