### PR TITLE
[libheif] Update to 1.18.2

### DIFF
--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -1,16 +1,16 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO  strukturag/libheif 
+    REPO  strukturag/libheif
     REF "v${VERSION}"
-    SHA512 e8f7a9d8d7af1947e9ca43e8387fc082551c884bb66fef7484c82748f3b81524efa7a2988f31d059a85a10539ff42bd3125b0f066f7b8b652bd9450737b2bc89
+    SHA512 0fcb6340694d5f30a355a0e1224bdbcb35d898594739ffd767cc882842887011a418aa67df08b8cdccc06fa2e477768de90704c8d6f5a827f6878252a13c7734
     HEAD_REF master
     PATCHES
         gdk-pixbuf.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-	FEATURES
-		hevc    WITH_X265
+    FEATURES
+        hevc    WITH_X265
 )
 
 vcpkg_cmake_configure(
@@ -18,7 +18,6 @@ vcpkg_cmake_configure(
     OPTIONS
         -DWITH_EXAMPLES=OFF
         -DWITH_DAV1D=OFF
-        -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON
         ${FEATURE_OPTIONS}
 )
 vcpkg_cmake_install()

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libheif",
-  "version": "1.17.6",
-  "port-version": 2,
+  "version": "1.18.2",
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4589,8 +4589,8 @@
       "port-version": 6
     },
     "libheif": {
-      "baseline": "1.17.6",
-      "port-version": 2
+      "baseline": "1.18.2",
+      "port-version": 0
     },
     "libhsplasma": {
       "baseline": "2024-03-07",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "71eb8d4a8f9e764ba9514dc621e05c361bcfbb59",
+      "version": "1.18.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "b359025d1bbdb502626c0b8c5918848ad0c901dc",
       "version": "1.17.6",
       "port-version": 2


### PR DESCRIPTION
Close https://github.com/microsoft/vcpkg/issues/40546

Suppress un-used var warning `PKG_CONFIG_USE_CMAKE_PREFIX_PATH`.

Format portfile.

### Checklist

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-windows