### PR TITLE
[msquic] fix linking with Debug build

### DIFF
--- a/ports/msquic/portfile.cmake
+++ b/ports/msquic/portfile.cmake
@@ -65,12 +65,14 @@ vcpkg_cmake_configure(
         -DQUIC_USE_SYSTEM_LIBCRYPTO=OFF
         -DQUIC_BUILD_PERF=OFF
         -DQUIC_BUILD_TEST=OFF
+        -DCMAKE_DEBUG_POSTFIX=d
         "-DQUIC_STATIC_LINK_CRT=${STATIC_CRT}"
         "-DQUIC_STATIC_LINK_PARTIAL_CRT=${STATIC_CRT}"
         "-DQUIC_UWP_BUILD=${VCPKG_TARGET_IS_UWP}"
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
 vcpkg_copy_pdbs()
 vcpkg_install_copyright(FILE_LIST "${QUIC_SOURCE_PATH}/LICENSE")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"

--- a/ports/msquic/vcpkg.json
+++ b/ports/msquic/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "msquic",
   "version": "2.3.6",
+  "port-version": 1,
   "description": "Cross-platform, C implementation of the IETF QUIC protocol",
   "homepage": "https://github.com/microsoft/msquic",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6086,7 +6086,7 @@
     },
     "msquic": {
       "baseline": "2.3.6",
-      "port-version": 0
+      "port-version": 1
     },
     "mstch": {
       "baseline": "1.0.2",

--- a/versions/m-/msquic.json
+++ b/versions/m-/msquic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ba908ead14078300c7e5babd3d725dc58746b3c3",
+      "version": "2.3.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "03c8b1fae017fc4b512f48444ae5c0d07f5233dd",
       "version": "2.3.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.