### PR TITLE
[mp-units] update to 2.2.1

### DIFF
--- a/ports/mp-units/portfile.cmake
+++ b/ports/mp-units/portfile.cmake
@@ -11,15 +11,9 @@ vcpkg_from_github(
       config.patch
 )
 
-set(USE_STD_FORMAT TRUE)
-if ("use-libfmt" IN_LIST FEATURES)
-    set(USE_STD_FORMAT FALSE)
-endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/src"
-    OPTIONS
-    -DMP_UNITS_API_STD_FORMAT=${USE_STD_FORMAT}
 )
 
 vcpkg_cmake_install()

--- a/ports/mp-units/portfile.cmake
+++ b/ports/mp-units/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mpusz/units
     REF "v${VERSION}"
-    SHA512 7968b215c6b27a7a988ce41235139a57be6bb849db6d6ea0df46b0a40d279d4be4c53646c5a4bf695fb9e70ff4967d3fd443fec8ee40c4ab7f0c90d8695632c3
+    SHA512 40bf0921e7411bb2adc5151bd9e09f759d3bcb4adffcb2861922c605731ed1ad1f1a56f89c4f734fab16843f36f5a67b244ce3e6e54e82b86e57c4a5d5e0fc59
     PATCHES
       config.patch
 )

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mp-units",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "mp-units - A Units Library for C++",
   "homepage": "https://github.com/mpusz/units",
   "license": "MIT",

--- a/ports/mp-units/vcpkg.json
+++ b/ports/mp-units/vcpkg.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/mpusz/units",
   "license": "MIT",
   "dependencies": [
+    "fmt",
     "gsl-lite",
     {
       "name": "vcpkg-cmake",
@@ -14,28 +15,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "default-features": [
-    "default-features"
-  ],
-  "features": {
-    "default-features": {
-      "description": "Platform specific default features",
-      "dependencies": [
-        {
-          "name": "mp-units",
-          "features": [
-            "use-libfmt"
-          ],
-          "platform": "osx"
-        }
-      ]
-    },
-    "use-libfmt": {
-      "description": "Use libfmt instead of std::format",
-      "dependencies": [
-        "fmt"
-      ]
-    }
-  }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5993,7 +5993,7 @@
       "port-version": 1
     },
     "mp-units": {
-      "baseline": "2.2.0",
+      "baseline": "2.2.1",
       "port-version": 0
     },
     "mp3lame": {

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85bd468494699187bc3c9a6d8511d273f31aaa36",
+      "version": "2.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "32d38ebf2cf91ab717ba623e298ec889635ac4a6",
       "version": "2.2.0",
       "port-version": 0

--- a/versions/m-/mp-units.json
+++ b/versions/m-/mp-units.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "85bd468494699187bc3c9a6d8511d273f31aaa36",
+      "git-tree": "bdc98457b93451bd4e80152a65ce8ec971aaddf0",
       "version": "2.2.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

