### PR TITLE
[aliyun-oss-cpp-sdk] Change to find package config mode

### DIFF
--- a/ports/aliyun-oss-cpp-sdk/0001-dependency-and-targets.patch
+++ b/ports/aliyun-oss-cpp-sdk/0001-dependency-and-targets.patch
@@ -1,5 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ea0d8d6..2a853a0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -78,8 +78,8 @@ if (${TARGET_OS} STREQUAL "WINDOWS")
+ 	set(CLIENT_INCLUDE_DIRS 
+ 		${CMAKE_SOURCE_DIR}/third_party/include) 
+ else()
+-	include(FindCURL)
+-	include(FindOpenSSL)
++	find_package(CURL CONFIG REQUIRED)
++	find_package(OpenSSL CONFIG REQUIRED)
+ 
+ 	if(NOT CURL_FOUND)
+ 		message(FATAL_ERROR "Could not find curl")
 diff --git a/sdk/CMakeLists.txt b/sdk/CMakeLists.txt
-index 28d04c2..c7b2e6c 100644
+index 28d04c2..d5d715d 100644
 --- a/sdk/CMakeLists.txt
 +++ b/sdk/CMakeLists.txt
 @@ -146,6 +146,13 @@ set_target_properties(${PROJECT_NAME}${STATIC_LIB_SUFFIX}
@@ -16,25 +31,22 @@ index 28d04c2..c7b2e6c 100644
  target_include_directories(${PROJECT_NAME}${STATIC_LIB_SUFFIX}
      PRIVATE include
      PRIVATE include/alibabacloud/oss    
-@@ -172,7 +179,11 @@ if (BUILD_SHARED_LIBS)
-         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+@@ -173,6 +180,9 @@ if (BUILD_SHARED_LIBS)
          OUTPUT_NAME ${TARGET_OUTPUT_NAME_PREFIX}${PROJECT_NAME}
          )
--    
-+
+     
 +    target_include_directories(${PROJECT_NAME}
 +        PUBLIC $<INSTALL_INTERFACE:include>
 +    )
-+
      target_include_directories(${PROJECT_NAME}
          PRIVATE include
          PRIVATE include/alibabacloud/oss    
-@@ -210,16 +221,22 @@ install(FILES ${sdk_encryption_header}
+@@ -210,16 +220,18 @@ install(FILES ${sdk_encryption_header}
  install(FILES ${sdk_public_header}
      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/alibabacloud/oss)
  
 -install(TARGETS  ${PROJECT_NAME}${STATIC_LIB_SUFFIX}
-+install(TARGETS  ${PROJECT_NAME}${STATIC_LIB_SUFFIX} EXPORT unofficial-aliyun-oss-cpp-sdk-config
++install(TARGETS  ${PROJECT_NAME}${STATIC_LIB_SUFFIX} EXPORT unofficial-aliyun-oss-cpp-sdk-targets
      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -42,7 +54,7 @@ index 28d04c2..c7b2e6c 100644
  
  if (BUILD_SHARED_LIBS)
 -install(TARGETS  ${PROJECT_NAME}
-+install(TARGETS  ${PROJECT_NAME} EXPORT unofficial-aliyun-oss-cpp-sdk-config
++install(TARGETS  ${PROJECT_NAME} EXPORT unofficial-aliyun-oss-cpp-sdk-targets
      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -51,8 +63,4 @@ index 28d04c2..c7b2e6c 100644
 \ No newline at end of file
 +endif()
 +
-+install(
-+    EXPORT unofficial-aliyun-oss-cpp-sdk-config
-+    NAMESPACE unofficial::aliyun-oss-cpp-sdk::
-+    DESTINATION share/unofficial-aliyun-oss-cpp-sdk
-+)
++include(0002-unofficial-export.cmake)

--- a/ports/aliyun-oss-cpp-sdk/0002-unofficial-export.cmake
+++ b/ports/aliyun-oss-cpp-sdk/0002-unofficial-export.cmake
@@ -1,0 +1,26 @@
+
+install(
+    EXPORT unofficial-aliyun-oss-cpp-sdk-targets
+    NAMESPACE unofficial::aliyun-oss-cpp-sdk::
+    DESTINATION share/unofficial-aliyun-oss-cpp-sdk
+)
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-aliyun-oss-cpp-sdk-config.cmake.in" [[
+@PACKAGE_INIT@
+include(CMakeFindDependencyMacro)
+find_dependency(CURL REQUIRED)
+find_dependency(OpenSSL REQUIRED)
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-aliyun-oss-cpp-sdk-targets.cmake")
+]]
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file("${CMAKE_CURRENT_BINARY_DIR}/unofficial-aliyun-oss-cpp-sdk-config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/unofficial-aliyun-oss-cpp-sdk-config.cmake"
+    INSTALL_DESTINATION "share/unofficial-aliyun-oss-cpp-sdk"
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/unofficial-aliyun-oss-cpp-sdk-config.cmake"
+    DESTINATION "share/unofficial-aliyun-oss-cpp-sdk"
+)

--- a/ports/aliyun-oss-cpp-sdk/0003-suppress-fmt-warning.patch
+++ b/ports/aliyun-oss-cpp-sdk/0003-suppress-fmt-warning.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ea0d8d6..2a853a0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -119,7 +119,7 @@ else()
+ 	endif()
+ 	
+ 	list(APPEND SDK_COMPILER_FLAGS "-Wall" "-Werror" "-pedantic" "-Wextra")
+-	
++	list(APPEND SDK_COMPILER_FLAGS "-Wno-error=deprecated-declarations")
+ 	if (ENABLE_COVERAGE)
+ 	SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
+ 	SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")

--- a/ports/aliyun-oss-cpp-sdk/portfile.cmake
+++ b/ports/aliyun-oss-cpp-sdk/portfile.cmake
@@ -5,8 +5,10 @@ vcpkg_from_github(
     SHA512 7773961ad380d28cda96e16ae6491a76e03f0cb5f0c5135b660179dd449d730e1dfffb916489ed60e13815f53566c24cd9cfd8985c468438369341358eeed3bd
     HEAD_REF master
     PATCHES
-        cmake-export.patch
+        0001-dependency-and-targets.patch
+        0003-suppress-fmt-warning.patch
 )
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/0002-unofficial-export.cmake" DESTINATION "${SOURCE_PATH}/sdk/")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -17,8 +19,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
-
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/aliyun-oss-cpp-sdk/usage
+++ b/ports/aliyun-oss-cpp-sdk/usage
@@ -1,4 +1,0 @@
-The package aliyun-oss-cpp-sdk provides CMake targets:
-
-    find_package(unofficial-aliyun-oss-cpp-sdk CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE unofficial::aliyun-oss-cpp-sdk::cpp-sdk)

--- a/ports/aliyun-oss-cpp-sdk/vcpkg.json
+++ b/ports/aliyun-oss-cpp-sdk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "aliyun-oss-cpp-sdk",
   "version": "1.10.0",
+  "port-version": 1,
   "description": "Alibaba Cloud Object Storage Service (OSS) is a cloud storage service provided by Alibaba Cloud, featuring massive capacity, security, a low cost, and high reliability.",
   "homepage": "https://github.com/aliyun/aliyun-oss-cpp-sdk",
   "license": "Apache-2.0",

--- a/versions/a-/aliyun-oss-cpp-sdk.json
+++ b/versions/a-/aliyun-oss-cpp-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "732b0995e1fae92ab6192bbf41f0e40a459d9ac7",
+      "version": "1.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "cb847011bd7b34fe9ce8ce2ebf15141de1588003",
       "version": "1.10.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -82,7 +82,7 @@
     },
     "aliyun-oss-cpp-sdk": {
       "baseline": "1.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "allegro5": {
       "baseline": "5.2.9.1",


### PR DESCRIPTION
Related https://github.com/microsoft/vcpkg/pull/40597.

Change `include(...)` to `find_package(... CONFIG REQUIRED)`.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port usage tests pass with the following triplets:

* x64-linux