### PR TITLE
[gstreamer] update to 1.24.7

### DIFF
--- a/ports/gstreamer/fix-clang-cl-bad.patch
+++ b/ports/gstreamer/fix-clang-cl-bad.patch
@@ -11,25 +11,11 @@ index c4868a4..6b34cb7 100644
    # autotools didn't use the libdca pkg-config cflags, and they
    # can point to a non-existing location (/usr/include/dca)
    no_warn_c_args = ['-Wno-missing-include-dirs']
-diff --git a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build
-index 160080a..6acf110 100644
---- a/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build
-+++ b/subprojects/gst-plugins-bad/gst-libs/gst/d3d11/meson.build
-@@ -158,7 +158,7 @@ endif
- 
- # MinGW 32bits compiler seems to be complaining about redundant-decls
- # when ComPtr is in use. Let's just disable the warning
--if cc.get_id() != 'msvc'
-+if cc.get_argument_syntax() != 'msvc'
-   extra_args = cc.get_supported_arguments([
-     '-Wno-redundant-decls',
-   ])
 diff --git a/subprojects/gst-plugins-bad/meson.build b/subprojects/gst-plugins-bad/meson.build
-index 84eeb17..1743f41 100644
+index 6707dce..b8c6018 100644
 --- a/subprojects/gst-plugins-bad/meson.build
 +++ b/subprojects/gst-plugins-bad/meson.build
 @@ -54,7 +54,7 @@ endif
-
  cdata = configuration_data()
  cdata.set('ENABLE_NLS', 1)
  
@@ -52,10 +38,10 @@ index c61ad4e..b30793c 100644
      error('asio plugin can only be built with MSVC')
    else
 diff --git a/subprojects/gst-plugins-bad/sys/d3d11/meson.build b/subprojects/gst-plugins-bad/sys/d3d11/meson.build
-index 1368b79..8dd3b30 100644
+index ff557be..d5bf0db 100644
 --- a/subprojects/gst-plugins-bad/sys/d3d11/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/d3d11/meson.build
-@@ -96,7 +96,7 @@ endif
+@@ -118,7 +118,7 @@ endif
  
  # MinGW 32bits compiler seems to be complaining about redundant-decls
  # when ComPtr is in use. Let's just disable the warning
@@ -64,19 +50,6 @@ index 1368b79..8dd3b30 100644
    extra_mingw_args = cc.get_supported_arguments([
      '-Wno-redundant-decls',
    ])
-diff --git a/subprojects/gst-plugins-bad/sys/decklink/meson.build b/subprojects/gst-plugins-bad/sys/decklink/meson.build
-index d869e79a4..c7b37a7c6 100644
---- a/subprojects/gst-plugins-bad/sys/decklink/meson.build
-+++ b/subprojects/gst-plugins-bad/sys/decklink/meson.build
-@@ -18,7 +18,7 @@ decklink_libs = []
- 
- if host_system == 'windows'
-   decklink_sources += ['win/DeckLinkAPIDispatch.cpp', 'win/DeckLinkAPI_i.c']
--  if cxx.get_id() == 'msvc'
-+  if cxx.get_argument_syntax() == 'msvc'
-     # FIXME: Use commsuppwd.lib for debug builds?
-     comutil_dep = cxx.find_library('comsuppw', required : get_option('decklink'))
-     if comutil_dep.found()
 diff --git a/subprojects/gst-plugins-bad/sys/mediafoundation/meson.build b/subprojects/gst-plugins-bad/sys/mediafoundation/meson.build
 index 6b9a059..40713ce 100644
 --- a/subprojects/gst-plugins-bad/sys/mediafoundation/meson.build
@@ -91,10 +64,10 @@ index 6b9a059..40713ce 100644
      error('mediafoundation plugin can only be built with MSVC')
    endif
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/meson.build b/subprojects/gst-plugins-bad/sys/msdk/meson.build
-index 659b96c..92e6bc4 100644
+index 51bf953..e30e138 100644
 --- a/subprojects/gst-plugins-bad/sys/msdk/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/msdk/meson.build
-@@ -176,12 +176,12 @@ if use_onevpl and have_mfx_ver205
+@@ -175,12 +175,12 @@ if use_onevpl and have_mfx_ver205
  endif
  
  if host_machine.system() == 'windows'
@@ -108,4 +81,4 @@ index 659b96c..92e6bc4 100644
 +  msdk_deps_found = d3d11_dep.found() and legacy_stdio_dep.found() and cc.get_argument_syntax() == 'msvc'
  else
    libdl_dep = cc.find_library('dl', required: get_option('msdk'))
-   libgudev_dep = dependency('gudev-1.0', required: get_option('msdk'))
+   libgudev_dep = dependency('gudev-1.0', required: get_option('msdk'), allow_fallback: true)

--- a/ports/gstreamer/gstreamer-disable-no-unused.patch
+++ b/ports/gstreamer/gstreamer-disable-no-unused.patch
@@ -1,14 +1,13 @@
 diff --git a/subprojects/gstreamer/meson.build b/subprojects/gstreamer/meson.build
-index bed8c4e..772809e 100644
+index 3b2cbba..18dd8d0 100644
 --- a/subprojects/gstreamer/meson.build
 +++ b/subprojects/gstreamer/meson.build
-@@ -435,8 +435,8 @@ if cc.has_header('execinfo.h')
-   endif
+@@ -493,7 +493,7 @@ if cc.has_header('execinfo.h')
  endif
  
  gst_debug = get_option('gst_debug')
 -if not gst_debug
 +if not gst_debug and cc.has_argument('-Wno-unused')
-   add_project_arguments(['-Wno-unused'], language: 'c')
- endif
- 
+   if cc.get_argument_syntax() == 'msvc'
+     msvc_args = cc.get_supported_arguments([
+       '/wd4101', # 'identifier' : unreferenced local variable

--- a/ports/gstreamer/no-downloads.patch
+++ b/ports/gstreamer/no-downloads.patch
@@ -1,17 +1,26 @@
 diff --git a/meson.build b/meson.build
-index df015cb..93cf7e9 100644
+index 3815aa3..6aeeab4 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -105,12 +105,6 @@ subprojects = [
-   ['gst-plugins-rs', { 'option': get_option('rs'), 'build-hotdoc': true, 'match_gst_version': false}],
+@@ -125,20 +125,7 @@ subprojects = [
  ]
- 
--if build_system == 'windows'
--  subproject('win-flex-bison-binaries')
--  subproject('win-nasm')
--elif build_system == 'darwin'
--  subproject('macos-bison-binary')
--endif
- 
+
+ if get_option('build-tools-source') == 'subproject'
+-  if build_system == 'windows'
+-    subproject('win-flex-bison-binaries')
+-    subproject('win-nasm')
+-    subproject('win-pkgconfig')
+-  elif build_system == 'darwin'
+-    subproject('macos-bison-binary')
+-    # Newer macOS provides /usr/lib/pkgconfig/libpcre2-8.pc which is broken
+-    # because it says headers are in /usr/include but that directory doesn't
+-    # exist. It can only be used to find the library, which only exists on
+-    # newer macOS at /usr/lib/libpcre2-8.dylib, so it's also unusable.
+-    #
+-    # jit support requires macOS 11.0 or newer, so disable it by default
+-    subproject('pcre2', default_options: ['default_library=static', 'jit=disabled'])
+-  endif
++
+ endif
+
  orc_option = get_option('orc')
- # There is a check below to keep this in sync with subprojects/gst-plugins-base/meson.build

--- a/ports/gstreamer/plugin-base-disable-no-unused.patch
+++ b/ports/gstreamer/plugin-base-disable-no-unused.patch
@@ -1,26 +1,21 @@
 diff --git a/subprojects/gst-plugins-base/meson.build b/subprojects/gst-plugins-base/meson.build
-index 9b00253..495671e 100644
+index 2c09e7b..e51f5a8 100644
 --- a/subprojects/gst-plugins-base/meson.build
 +++ b/subprojects/gst-plugins-base/meson.build
-@@ -388,10 +388,11 @@ int32x4_t testfunc(int16_t *a, int16_t *b) {
-   endif
+@@ -412,6 +412,7 @@ int32x4_t testfunc(int16_t *a, int16_t *b) {
  endif
  
+ # Disable compiler warnings for unused variables and args if gst debug system is disabled
 +build_system = build_machine.system()
  if gst_dep.type_name() == 'internal'
-     gst_proj = subproject('gstreamer')
+   gst_proj = subproject('gstreamer')
+   gst_debug_disabled = not gst_proj.get_variable('gst_debug')
+@@ -421,7 +422,7 @@ else
+   gst_debug_disabled = cc.has_header_symbol('gst/gstconfig.h', 'GST_DISABLE_GST_DEBUG', dependencies: gst_dep)
+ endif
  
--    if not gst_proj.get_variable('gst_debug')
-+    if not gst_proj.get_variable('gst_debug') and build_system != 'windows'
-         message('GStreamer debug system is disabled')
-         add_project_arguments('-Wno-unused', language: 'c')
-     else
-@@ -404,7 +405,7 @@ else
- #include <gst/gstconfig.h>
- #ifdef GST_DISABLE_GST_DEBUG
- #error "debugging disabled, make compiler fail"
--#endif''' , dependencies: gst_dep)
-+#endif''' , dependencies: gst_dep) and build_system != 'windows'
-         message('GStreamer debug system is disabled')
-         add_project_arguments('-Wno-unused', language: 'c')
-     else
+-if gst_debug_disabled
++if gst_debug_disabled and build_system != 'windows'
+   message('GStreamer debug system is disabled')
+   if cc.get_argument_syntax() == 'msvc'
+     msvc_args = cc.get_supported_arguments([

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gstreamer/gstreamer
     REF "${VERSION}"
-    SHA512 0d69896d0a83452320df0d0f56c710df1365a259cd3f48dc7cd4df18d45b27caea7174aafa15ae5eb8637ccdef192c1047185b369b7232db4eaacbc57ffaaa22
+    SHA512 c181c8048ef859dfdd17d2bf1487d078704fdd289fed4e13fc00aebca055965c186286e60f3703c69d816734ef4be344b32650058d72517576927f9df18db2df
     HEAD_REF main
     PATCHES
         fix-clang-cl.patch
@@ -21,7 +21,6 @@ vcpkg_from_gitlab(
         gstreamer-disable-no-unused.patch
         srtp_fix.patch
         fix-bz2-windows-debug-dependency.patch
-        base-must-be-enabled.patch
         no-downloads.patch
         ${PATCHES}
 )
@@ -156,7 +155,6 @@ vcpkg_configure_meson(
         -Dlibnice=disabled
         -Ddevtools=disabled
         -Drtsp_server=disabled
-        -Domx=disabled
         -Dvaapi=disabled
         -Dsharp=disabled
         -Drs=disabled
@@ -209,8 +207,6 @@ vcpkg_configure_meson(
         -Dgst-plugins-good:wavpack=disabled # Error during plugin build
         # gst-plugins-ugly
         -Dgst-plugins-ugly:a52dec=disabled
-        -Dgst-plugins-ugly:amrnb=disabled
-        -Dgst-plugins-ugly:amrwbdec=disabled
         -Dgst-plugins-ugly:cdio=disabled
         -Dgst-plugins-ugly:dvdread=disabled
         -Dgst-plugins-ugly:mpeg2dec=disabled # libmpeg2 not found
@@ -240,7 +236,6 @@ vcpkg_configure_meson(
         -Dgst-plugins-bad:gsm=disabled
         -Dgst-plugins-bad:ipcpipeline=auto
         -Dgst-plugins-bad:iqa=disabled
-        -Dgst-plugins-bad:kate=disabled
         -Dgst-plugins-bad:kms=disabled
         -Dgst-plugins-bad:ladspa=disabled
         -Dgst-plugins-bad:ldac=disabled

--- a/ports/gstreamer/srtp_fix.patch
+++ b/ports/gstreamer/srtp_fix.patch
@@ -1,25 +1,26 @@
 diff --git a/subprojects/gst-plugins-bad/ext/srtp/meson.build b/subprojects/gst-plugins-bad/ext/srtp/meson.build
-index 49eed5b..db5aed0 100644
+index d15d58c..0a3b1a2 100644
 --- a/subprojects/gst-plugins-bad/ext/srtp/meson.build
 +++ b/subprojects/gst-plugins-bad/ext/srtp/meson.build
-@@ -6,13 +6,15 @@ srtp_sources = [
+@@ -6,6 +6,8 @@ srtp_sources = [
    'gstsrtpenc.c',
  ]
  
 +gst_plugins_install_dir = join_paths(get_option('libdir'), 'gstreamer-1.0')
 +
  srtp_cargs = []
- if get_option('srtp').disabled()
-   srtp_dep = dependency('', required : false)
+ srtp_option = get_option('srtp').enable_if(get_option('webrtc').enabled(), error_message: 'webrtc option is enabled')
+ if srtp_option.disabled()
+@@ -13,7 +15,7 @@ if srtp_option.disabled()
    subdir_done()
  endif
  
--srtp_dep = dependency('libsrtp2', version : '>= 2.1.0', required : false)
+-srtp_dep = dependency('libsrtp2', version : '>= 2.1.0', required : false, allow_fallback: true)
 +srtp_dep = dependency('libSRTP', modules: ['libSRTP::srtp2'], version : '>= 2.1.0', required : false)
  if srtp_dep.found()
    srtp_cargs += ['-DHAVE_SRTP2']
  else
-@@ -38,7 +40,7 @@ if srtp_dep.found()
+@@ -39,7 +41,7 @@ if srtp_dep.found()
      include_directories : [configinc],
      dependencies : [gstrtp_dep, gstvideo_dep, srtp_dep],
      install : true,

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gstreamer",
-  "version": "1.22.5",
-  "port-version": 8,
+  "version": "1.24.7",
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3277,8 +3277,8 @@
       "port-version": 2
     },
     "gstreamer": {
-      "baseline": "1.22.5",
-      "port-version": 8
+      "baseline": "1.24.7",
+      "port-version": 0
     },
     "gtest": {
       "baseline": "1.15.2",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0fbc36e567269da127885e9eff36b6083ecd1561",
+      "version": "1.24.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "a4f5984869f07999b31721a248e129b3de531436",
       "version": "1.22.5",
       "port-version": 8


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40923

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplet:

```
x64-windows
```