### PR TITLE
[Onnxruntime-gpu] update v1.19.2

### DIFF
--- a/ports/onnxruntime-gpu/portfile.cmake
+++ b/ports/onnxruntime-gpu/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-win-x64-gpu-${VERSION}.zip"
     FILENAME "onnxruntime-win-x64-gpu-${VERSION}.zip"
-    SHA512 7ab350a2ede0fc8c716cf083e16a9303acbcc855982e53900f8843773ec32fd20a7396f0bde82bb29f382012b1d05dea41708797f112d9096c8b5048fc5eb7d8
+    SHA512 9576eafca59fc7f2af9f62d7ee8aa31208ef965d17f3ad71747d5a9a46cdffd6b3958dc945109d82937555df8bb35319ce92925e66ab707f1ca8e7564ecb3ced
 )
 
 vcpkg_extract_source_archive(
@@ -17,7 +17,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH REPO_PATH
     REPO microsoft/onnxruntime
     REF v${VERSION}
-    SHA512 f2fec4ded88da6bf67ae7d0aa3082736cb3b8ba29e723b5a516d7632b68ce02aed461f24d3e82cbab20757729e0ab45d736bd986c9b7395f2879b16a091c12a1
+    SHA512 3bf25e431d175c61953d28b1bf8f6871376684263992451a5b2a66e670768fc66e7027f141c6e3f4d1eddeebeda51f31ea0adf4749e50d99ee89d0a26bec77ce
 )
 
 file(COPY

--- a/ports/onnxruntime-gpu/vcpkg.json
+++ b/ports/onnxruntime-gpu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "onnxruntime-gpu",
-  "version": "1.16.3",
+  "version": "1.19.2",
   "description": "onnxruntime (GPU)",
   "homepage": "https://github.com/microsoft/onnxruntime",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6525,7 +6525,7 @@
       "port-version": 0
     },
     "onnxruntime-gpu": {
-      "baseline": "1.16.3",
+      "baseline": "1.19.2",
       "port-version": 0
     },
     "oof": {

--- a/versions/o-/onnxruntime-gpu.json
+++ b/versions/o-/onnxruntime-gpu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e9ce6c51894e80beece7446b501ef2263578ad29",
+      "version": "1.19.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "77632d67293cb70293c7fd22a3897e48c6efabe4",
       "version": "1.16.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.