### PR TITLE
[wolfssl] Add 'asio' feature flag

### DIFF
--- a/ports/wolfssl/portfile.cmake
+++ b/ports/wolfssl/portfile.cmake
@@ -7,6 +7,12 @@ vcpkg_from_github(
     PATCHES
     )
 
+if ("asio" IN_LIST FEATURES)
+    set(ENABLE_ASIO yes)
+else()
+    set(ENABLE_ASIO no)
+endif()
+
 if ("dtls" IN_LIST FEATURES)
     set(ENABLE_DTLS yes)
 else()
@@ -43,6 +49,7 @@ vcpkg_cmake_configure(
       -DWOLFSSL_OCSPSTAPLING_V2=yes
       -DWOLFSSL_CRL=yes
       -DWOLFSSL_DES3=yes
+      -DWOLFSSL_ASIO=${ENABLE_ASIO}
       -DWOLFSSL_DTLS=${ENABLE_DTLS}
       -DWOLFSSL_DTLS13=${ENABLE_DTLS}
       -DWOLFSSL_DTLS_CID=${ENABLE_DTLS}

--- a/ports/wolfssl/vcpkg.json
+++ b/ports/wolfssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wolfssl",
   "version": "5.7.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "TLS and Cryptographic library for many platforms",
   "homepage": "https://wolfssl.com",
   "license": "GPL-2.0-or-later",
@@ -21,6 +21,9 @@
     }
   ],
   "features": {
+    "asio": {
+      "description": "Enable asio support"
+    },
     "dtls": {
       "description": "DTLS support"
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9582,7 +9582,7 @@
     },
     "wolfssl": {
       "baseline": "5.7.2",
-      "port-version": 2
+      "port-version": 3
     },
     "wolftpm": {
       "baseline": "3.4.0",

--- a/versions/w-/wolfssl.json
+++ b/versions/w-/wolfssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b727cbf6fb63837145ccca10c947805eaaf21a9",
+      "version": "5.7.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "1e1315afd8abfaee90ea4b173ac95594208eff46",
       "version": "5.7.2",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
