### PR TITLE
[caf] update to 1.0.1

### DIFF
--- a/ports/caf/fix_cxx17.patch
+++ b/ports/caf/fix_cxx17.patch
@@ -1,40 +1,20 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f088f6a..a8bcf80 100644
+index 0622702..f44e0f5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -134,7 +134,7 @@ endif()
- 
- if(NOT DEFINED CAF_USE_STD_FORMAT)
-   set(CAF_USE_STD_FORMAT OFF CACHE BOOL "Enable std::format support" FORCE)
--  if(NOT CMAKE_CROSSCOMPILING)
-+  if(0)
-     set(snippet "#include <format>
-                  #include <iostream>
-                  int main() { std::cout << std::format(\"{}\", \"ok\"); }")
-@@ -180,8 +180,6 @@ endif()
+@@ -158,7 +158,6 @@ install(TARGETS caf_internal EXPORT CAFTargets)
  
  # -- create the libcaf_test target ahead of time for caf_core ------------------
  
 -add_library(libcaf_test)
--
+ 
  # -- add uninstall target if it does not exist yet -----------------------------
  
- if(NOT TARGET uninstall)
-@@ -326,8 +324,6 @@ function(caf_add_component name)
-     list(APPEND targets ${tst_bin_target})
-     add_executable(${tst_bin_target}
-                    ${CAF_ADD_COMPONENT_LEGACY_TEST_SOURCES})
--    target_link_libraries(${tst_bin_target} PRIVATE libcaf_test
--                          ${CAF_ADD_COMPONENT_DEPENDENCIES} ${lib_target})
-     target_include_directories(${tst_bin_target} PRIVATE
-                                "${CMAKE_CURRENT_SOURCE_DIR}/tests/legacy")
-     if(CAF_ADD_COMPONENT_LEGACY_TEST_SUITES)
-@@ -383,8 +379,6 @@ endfunction()
+@@ -351,7 +350,6 @@ endfunction()
  
  add_subdirectory(libcaf_core)
  
 -add_subdirectory(libcaf_test)
--
+ 
  if(CAF_ENABLE_NET_MODULE)
    add_subdirectory(libcaf_net)
- endif()

--- a/ports/caf/portfile.cmake
+++ b/ports/caf/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO actor-framework/actor-framework
     REF "${VERSION}"
-    SHA512 8a7aacbd9bf18318d9ca1f5fb30c101220c1eef2c4bfe82c53760024022473109038872c0deb5a60d732a91da8d863c556a27018e6b667bfcfbf536df3cebcaf
-    HEAD_REF master
+    SHA512 0849a0b17a2c011142dd56ff88b01d764dc57b40de5d8467bcf1aa2ddd7540415228dc05f8652b9534e18fb8c2e28465bf881fe1e1bf5c7f9919cfb3edd573d3
+    HEAD_REF main
     PATCHES
         fix_dependency.patch
         fix_cxx17.patch
@@ -12,7 +12,6 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
         -DCAF_ENABLE_CURL_EXAMPLES=OFF
         -DCAF_ENABLE_PROTOBUF_EXAMPLES=OFF
         -DCAF_ENABLE_QT6_EXAMPLES=OFF
@@ -20,10 +19,8 @@ vcpkg_cmake_configure(
         -DCAF_ENABLE_ACTOR_PROFILER=OFF
         -DCAF_ENABLE_EXAMPLES=OFF
         -DCAF_ENABLE_TESTING=OFF
-        -DCAF_ENABLE_TOOLS=OFF
         -DCAF_ENABLE_IO_MODULE=ON
         -DCAF_ENABLE_EXCEPTIONS=ON
-        -DCAF_ENABLE_UTILITY_TARGETS=OFF
 )
 
 vcpkg_cmake_install()
@@ -33,5 +30,6 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME CAF CONFIG_PATH lib/cmake/CAF)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/caf/internal")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/caf/vcpkg.json
+++ b/ports/caf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "caf",
-  "version": "0.19.6",
+  "version": "1.0.1",
   "description": "an open source implementation of the actor model for C++ featuring lightweight & fast actor implementations, pattern matching for messages, network transparent messaging, and more.",
   "homepage": "https://github.com/actor-framework/actor-framework",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1469,7 +1469,7 @@
       "port-version": 0
     },
     "caf": {
-      "baseline": "0.19.6",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "caffe2": {

--- a/versions/c-/caf.json
+++ b/versions/c-/caf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2cb6b24903b98d8335f18f4964ce6823550b836b",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e71a51cfec683161a30d2dcca04fe5fc7f063ea7",
       "version": "0.19.6",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40764
1. Remove unused config parameters.
2. Remove empty folders in the package to fix post build check issues.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
