### PR TITLE
[bgfx] Update to 1.128.8786-481

### DIFF
--- a/ports/bgfx/portfile.cmake
+++ b/ports/bgfx/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_download_distfile(
   ARCHIVE_FILE
   URLS https://github.com/bkaradzic/bgfx.cmake/releases/download/v${VERSION}/bgfx.cmake.v${VERSION}.tar.gz
   FILENAME bgfx.cmake.v${VERSION}.tar.gz
-  SHA512 23e334deed4ca6429c474b3b12b250ee1c660b524a05c6c9699c353509e51adcf8cbee9974313ae8c8e1a36891404f50c5be7673de4194a31fe37093548b4652
+  SHA512 227caf8b7cee5fe84c078a473c25e636e3cb32ae4b252cdb193f0cef069cfc32f9eb6ef52f96d5e547a3bd20360e5f09147c0c8ba5f3b20541a0082171fda076
 )
 
 vcpkg_extract_source_archive(

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bgfx",
-  "version": "1.128.8786-480",
+  "version": "1.128.8786-481",
   "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
   "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
   "homepage": "https://bkaradzic.github.io/bgfx/overview.html",

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "059b5b641de1b56edd27101a5d0ce1093cceaa5a",
+      "version": "1.128.8786-481",
+      "port-version": 0
+    },
+    {
       "git-tree": "ce8b9fb8c5bb63ede2168612877dd02b9187942f",
       "version": "1.128.8786-480",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -633,7 +633,7 @@
       "port-version": 0
     },
     "bgfx": {
-      "baseline": "1.128.8786-480",
+      "baseline": "1.128.8786-481",
       "port-version": 0
     },
     "bigint": {


### PR DESCRIPTION
Fix incorrect adding .h in bgfx_compile_shaders.

Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
 
SHA512s are updated for each updated download.

 
Only one version is added to each modified port's versions file.