### PR TITLE
[uv] add support for astral-sh uv

### DIFF
--- a/ports/uv/portfile.cmake
+++ b/ports/uv/portfile.cmake
@@ -1,0 +1,26 @@
+set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
+if(VCPKG_TARGET_IS_WINDOWS)
+    find_program(PWSH_PATH pwsh)
+    execute_process(
+        COMMAND "${PWSH_PATH}" -ExecutionPolicy ByPass -c "irm https://github.com/astral-sh/uv/releases/download/${VERSION}/uv-installer.ps1 | iex"
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+else()
+    find_dependency(CURL)
+    find_program(BASH NAME bash HINTS ${MSYS_ROOT}/usr/bin REQUIRED)
+    execute_process(
+        COMMAND "${CURL}" --proto '=https' --tlsv1.2 -LsSf "https://github.com/astral-sh/uv/releases/download/${VERSION}/uv-installer.sh" | ${BASH}
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO astral-sh/uv
+    REF ${VERSION}
+    SHA512 9582d8f97515bc182d699f9994a21f7c883203dabb338848c751d97737c864272e5efbaf3a81d08545caac6643ba9cbde2fe11769ec6b98062416d7501d022f8
+    HEAD_REF main
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-MIT")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/uv/vcpkg.json
+++ b/ports/uv/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "uv",
+  "version": "0.4.10",
+  "description": "An extremely fast Python package and project manager, written in Rust.",
+  "homepage": "https://github.com/astral-sh/uv",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9208,6 +9208,10 @@
       "baseline": "2.0.1",
       "port-version": 1
     },
+    "uv": {
+      "baseline": "0.4.10",
+      "port-version": 0
+    },
     "uvatlas": {
       "baseline": "2024-09-04",
       "port-version": 0

--- a/versions/u-/uv.json
+++ b/versions/u-/uv.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "048235c5671cde2af285d2833d419e3d24dd6ab7",
+      "version": "0.4.10",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add a port for [uv](https://github.com/astral-sh/uv). This port could potentially lead to a lot of improvements in how to use Python across vcpkg and the repositories that use it

UV is an extremely fast Python package and project manager, written in Rust.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
