### PR TITLE
[libjpeg-turbo] Update to 3.0.4

### DIFF
--- a/ports/libjpeg-turbo/portfile.cmake
+++ b/ports/libjpeg-turbo/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libjpeg-turbo/libjpeg-turbo
     REF "${VERSION}"
-    SHA512 46c44be837654e201d11bbf8d9fbb35b775a7d4bf653e9e709279437b10d5c8b0825ece4c8ee33f66689c263234fa2b08240fb5f5ba80e76e03891da8f64eda8
+    SHA512 f43e1b6b9d048e29e381796c71e1c34a04c0f1c52c1f462db9f9930cfc75d69a50861be2570a6a4adc26a4183b6601300fd9d5553c06bc042f0d32fc1e408ed9
     HEAD_REF master
     PATCHES
         add-options-for-exes-docs-headers.patch

--- a/ports/libjpeg-turbo/vcpkg.json
+++ b/ports/libjpeg-turbo/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libjpeg-turbo",
-  "version": "3.0.3",
-  "port-version": 1,
+  "version": "3.0.4",
   "description": "libjpeg-turbo is a JPEG image codec that uses SIMD instructions (MMX, SSE2, NEON, AltiVec) to accelerate baseline JPEG compression and decompression on x86, x86-64, ARM, and PowerPC systems.",
   "homepage": "https://github.com/libjpeg-turbo/libjpeg-turbo",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4657,8 +4657,8 @@
       "port-version": 2
     },
     "libjpeg-turbo": {
-      "baseline": "3.0.3",
-      "port-version": 1
+      "baseline": "3.0.4",
+      "port-version": 0
     },
     "libjuice": {
       "baseline": "1.5.2",

--- a/versions/l-/libjpeg-turbo.json
+++ b/versions/l-/libjpeg-turbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fbedc8ef954f9951c7d169c9bac3f9534b4b2c77",
+      "version": "3.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "191ba1685e900d722a9ddc0be6bdd939990f0984",
       "version": "3.0.3",
       "port-version": 1


### PR DESCRIPTION
Updates to latest release https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/3.0.4

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
