### PR TITLE
[crashpad] Use even more different-er names.

### DIFF
--- a/ports/crashpad/crashpadConfig.cmake.in
+++ b/ports/crashpad/crashpadConfig.cmake.in
@@ -13,7 +13,7 @@ if(NOT TARGET crashpad::crashpad)
   add_library(crashpad::crashpad INTERFACE IMPORTED)
   target_include_directories(crashpad::crashpad INTERFACE "${_IMPORT_PREFIX}/include/crashpad")
 
-  set(_libs crashpad_client crashpad_client_common crashpad_util crashpad_base)
+  set(_libs vcpkg_crashpad_client vcpkg_crashpad_client_common vcpkg_crashpad_util vcpkg_crashpad_base)
   if(APPLE)
     list(APPEND _libs mig_output)
   endif()

--- a/ports/crashpad/fix-lib-name-conflict-1.patch
+++ b/ports/crashpad/fix-lib-name-conflict-1.patch
@@ -6,7 +6,7 @@ index 0bcf519..c637f2b 100644
  import("../build/platform.gni")
  
  static_library("base") {
-+  output_name = "crashpad_base"
++  output_name = "vcpkg_crashpad_base"
    sources = [
      "atomicops.h",
      "atomicops_internals_atomicword_compat.h",

--- a/ports/crashpad/fix-lib-name-conflict.patch
+++ b/ports/crashpad/fix-lib-name-conflict.patch
@@ -6,7 +6,7 @@ index bd150ab..5cbf469 100644
  import("../build/crashpad_buildconfig.gni")
  
  crashpad_static_library("client") {
-+  output_name = "crashpad_client"
++  output_name = "vcpkg_crashpad_client"
    sources = [
      "crashpad_client.h",
      "prune_crash_reports.cc",
@@ -14,7 +14,7 @@ index bd150ab..5cbf469 100644
  }
  
  static_library("common") {
-+  output_name = "crashpad_client_common"
++  output_name = "vcpkg_crashpad_client_common"
    sources = [
      "annotation.cc",
      "annotation.h",
@@ -26,7 +26,7 @@ index a2d6f7f..70a997e 100644
  }
  
  static_library("common") {
-+  output_name = "crashpad_handler_common"
++  output_name = "vcpkg_crashpad_handler_common"
    sources = [
      "crash_report_upload_thread.cc",
      "crash_report_upload_thread.h",
@@ -38,7 +38,7 @@ index e7ff4a8..9efcb41 100644
  }
  
  crashpad_static_library("util") {
-+  output_name = "crashpad_util"
++  output_name = "vcpkg_crashpad_util"
    sources = [
      "file/delimited_file_reader.cc",
      "file/delimited_file_reader.h",

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2024-04-11",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2030,7 +2030,7 @@
     },
     "crashpad": {
       "baseline": "2024-04-11",
-      "port-version": 3
+      "port-version": 4
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e260774308b256e5831185d41b76510c7268782",
+      "version-date": "2024-04-11",
+      "port-version": 4
+    },
+    {
       "git-tree": "3c65a9330a2d6d53ab6afad83ec165e708b1cc4e",
       "version-date": "2024-04-11",
       "port-version": 3


### PR DESCRIPTION
Restores the status quo before https://github.com/microsoft/vcpkg/pull/40729 . This is horrible as described in https://github.com/microsoft/vcpkg/issues/40919 but at least unblocks vcpkg's registry builds.
