### PR TITLE
[boinc] update to 8.0.4

### DIFF
--- a/ports/boinc/portfile.cmake
+++ b/ports/boinc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BOINC/boinc
     REF "client_release/${MAJOR_MINOR}/${VERSION}"
-    SHA512 a53506bc3e92c813e7cc1a9be8741822aabc843f6ca824e35a0cd48cec34d0965d51bf97dfea2ec4898c5c36887c8bbdc4919a46a093ad2ac43b081eca3ad882
+    SHA512 0e0c4f7647325f8f1e8a87da0d7ff43d1a3e5d3ef0dc3daf1fb974a47c0e4fb7318b3fdde77d0ae6ec4f3d30be113a5ceff33658facc8f3c2c325c8c61942698
     HEAD_REF master
 )
 

--- a/ports/boinc/vcpkg.json
+++ b/ports/boinc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "boinc",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "Open-source software for volunteer computing and grid computing.",
   "homepage": "https://boinc.berkeley.edu/",
   "license": "LGPL-3.0-or-later",

--- a/versions/b-/boinc.json
+++ b/versions/b-/boinc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dceee841c00561abe3de8241f9399dd60db96193",
+      "version": "8.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "2585b14e3aac8df4a8942c42305c72178f11d684",
       "version": "8.0.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -717,7 +717,7 @@
       "port-version": 0
     },
     "boinc": {
-      "baseline": "8.0.3",
+      "baseline": "8.0.4",
       "port-version": 0
     },
     "bond": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

