### PR TITLE
[capstone] update to 5.0.3

### DIFF
--- a/ports/capstone/portfile.cmake
+++ b/ports/capstone/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "capstone-engine/capstone"
     REF "${VERSION}"
-    SHA512 350aba77ce2d96b5c25764913591ba80e4497177ae0a8b2c820c6755ee8310848fbfc54e7ccac27fafc2dbc6778118ad92c53d1b5cb601d4fa146dec7d7e11e5
+    SHA512 2fd3194dd37065e6091d208c7670b12c0ca6872931eef794bd6b2dd624601c843e8ee6c5714eae0372e394e91a9bc1e4de7dfea6b1087542dd461226569101de
     HEAD_REF next
     PATCHES
         001-silence-windows-crt-secure-warnings.patch

--- a/ports/capstone/vcpkg.json
+++ b/ports/capstone/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "capstone",
-  "version": "5.0.1",
-  "port-version": 1,
+  "version": "5.0.3",
   "description": "Multi-architecture disassembly framework",
   "homepage": "https://github.com/capstone-engine/capstone",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1501,8 +1501,8 @@
       "port-version": 0
     },
     "capstone": {
-      "baseline": "5.0.1",
-      "port-version": 1
+      "baseline": "5.0.3",
+      "port-version": 0
     },
     "cargs": {
       "baseline": "1.1.0",

--- a/versions/c-/capstone.json
+++ b/versions/c-/capstone.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb3992e2d7e4d93f74f8e3eaa659a0fea78cce75",
+      "version": "5.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "d2879a914b5c261ad9fb1b48b921a4d53a486eb0",
       "version": "5.0.1",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

