### PR TITLE
[json-schema-validator] update to 2.3.1

### DIFF
--- a/ports/json-schema-validator/portfile.cmake
+++ b/ports/json-schema-validator/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pboettch/json-schema-validator
     REF "${VERSION}"
-    SHA512 6d207031acdb94c44f96ff6346dccaf98f2c9d3619d71e419ddabff548ea34d50e8eb103622c99ae28ecb7fddedd687b297e5ad934aa0106c58ac59fc4d65ea9
+    SHA512 5c165b50813b0d9937ff0eb4d4a81e2d1e77718ac3b0d02b93931c8eddb4e06e4fae1822c5cc97a5b01c995916a29d0af03fcbcd8f059cb29cfeb0e2371b15e3
     HEAD_REF master
     PATCHES
         "${PATCH_JSON_SCHEMA_VALIDATOR_PR_315}"

--- a/ports/json-schema-validator/vcpkg.json
+++ b/ports/json-schema-validator/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "json-schema-validator",
-  "version": "2.3.0",
-  "port-version": 2,
+  "version": "2.3.1",
   "description": "C++ library for validating JSON documents based on a JSON Schema. This validator is based on the nlohmann-json library.",
   "homepage": "https://github.com/pboettch/json-schema-validator",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3849,8 +3849,8 @@
       "port-version": 0
     },
     "json-schema-validator": {
-      "baseline": "2.3.0",
-      "port-version": 2
+      "baseline": "2.3.1",
+      "port-version": 0
     },
     "json-spirit": {
       "baseline": "4.1.0",

--- a/versions/j-/json-schema-validator.json
+++ b/versions/j-/json-schema-validator.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa1123d809dd990fa3ca63364793df54c8e9b10c",
+      "version": "2.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8982b7778711884f44358d66f92ddb1f0ad4b99d",
       "version": "2.3.0",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

