### PR TITLE
[libdivide] update to 5.1

### DIFF
--- a/ports/libdivide/portfile.cmake
+++ b/ports/libdivide/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ridiculousfish/libdivide
-    REF 5.0
-    SHA512 89581efab63a0668405196d4d8188e03f3b87027e9014ef7238e1d79fe369d8abbca0e44b00cf02b00be29c272feb34c9b9290313596adbef9b46ae0715c29dd
+    REF "v${VERSION}"
+    SHA512 1c94dabca83984ef8190ba91b328e5e994a9bc41b4f4b6800d7417db3312283576759ba3039741a4f045adab6f0391b82ba93523b802bb6a37bc3fd693a80e05
     HEAD_REF master
     PATCHES
         no-werror.patch

--- a/ports/libdivide/vcpkg.json
+++ b/ports/libdivide/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libdivide",
-  "version": "5.0",
-  "port-version": 1,
+  "version": "5.1",
   "description": "libdivide.h is a header-only C/C++ library for optimizing integer division.",
   "homepage": "https://github.com/ridiculousfish/libdivide",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4409,8 +4409,8 @@
       "port-version": 11
     },
     "libdivide": {
-      "baseline": "5.0",
-      "port-version": 1
+      "baseline": "5.1",
+      "port-version": 0
     },
     "libdjinterop": {
       "baseline": "0.21.0",

--- a/versions/l-/libdivide.json
+++ b/versions/l-/libdivide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad57bd243a7411f834cb0dafae9f2b4ffa76c0a3",
+      "version": "5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c646f5a84a408b48ecdad13220a2186fa4b4e692",
       "version": "5.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

