### PR TITLE
[dtl] update to 1.21

### DIFF
--- a/ports/dtl/portfile.cmake
+++ b/ports/dtl/portfile.cmake
@@ -4,8 +4,8 @@ include(CMakePackageConfigHelpers)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cubicdaiya/dtl
-    REF v1.20
-    SHA512 44cdaf190d8a103effbca8df244c652b642590795f7307f5f7fdf64fc34bdbe2fa5ab2e1a08185abf099e35b0d9158306a80a8dc24bba9eccab4c77c7b1eed5e
+    REF "v${VERSION}"
+    SHA512 53a448ce499d96c5030ff787db68dd4cb52ee9686453da81aeb5c143e21d4a10fcc4c9b88ebf86d71824cb919d6e4ebf39df52b74bd9333f411935e5f23bfa86
     HEAD_REF master
 )
 

--- a/ports/dtl/vcpkg.json
+++ b/ports/dtl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dtl",
-  "version": "1.20",
+  "version": "1.21",
   "description": "Diff template library",
   "license": "BSD-4-Clause"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2401,7 +2401,7 @@
       "port-version": 1
     },
     "dtl": {
-      "baseline": "1.20",
+      "baseline": "1.21",
       "port-version": 0
     },
     "duckx": {

--- a/versions/d-/dtl.json
+++ b/versions/d-/dtl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc2a9bc914be91c0ec64e0666a95551b71422e4d",
+      "version": "1.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "26d9843aad03516522a267da5b086985a413eed5",
       "version": "1.20",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

