### PR TITLE
[tcl] Fix release builds on Windows

### DIFF
--- a/ports/tcl/portfile.cmake
+++ b/ports/tcl/portfile.cmake
@@ -91,6 +91,13 @@ if (VCPKG_TARGET_IS_WINDOWS)
                             "${CURRENT_PACKAGES_DIR}/lib/tcl8.6"
                             "${CURRENT_PACKAGES_DIR}/lib/tdbcsqlite31.1.0"
         )
+        file(CHMOD_RECURSE
+                "${CURRENT_PACKAGES_DIR}/tools/tcl/lib/tcl9.0/msgs" "${CURRENT_PACKAGES_DIR}/tools/tcl/lib/tcl9.0/tzdata"
+            PERMISSIONS
+                OWNER_READ OWNER_WRITE
+                GROUP_READ GROUP_WRITE
+                WORLD_READ WORLD_WRITE
+        )
     endif()
     if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL debug)
         file(GLOB_RECURSE TOOL_BIN
@@ -112,6 +119,14 @@ if (VCPKG_TARGET_IS_WINDOWS)
                             "${CURRENT_PACKAGES_DIR}/debug/lib/tcl8.6"
                             "${CURRENT_PACKAGES_DIR}/debug/lib/tdbcsqlite31.1.0"
         )
+
+        file(CHMOD_RECURSE
+                "${CURRENT_PACKAGES_DIR}/tools/tcl/debug/lib/tcl9.0/msgs" "${CURRENT_PACKAGES_DIR}/tools/tcl/debug/lib/tcl9.0/tzdata"
+            PERMISSIONS
+                OWNER_READ OWNER_WRITE
+                GROUP_READ GROUP_WRITE
+                WORLD_READ WORLD_WRITE
+        )
     endif()
     
     if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
@@ -119,15 +134,6 @@ if (VCPKG_TARGET_IS_WINDOWS)
     endif()
     
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-    
-    file(CHMOD_RECURSE
-            "${CURRENT_PACKAGES_DIR}/tools/tcl/debug/lib/tcl9.0/msgs" "${CURRENT_PACKAGES_DIR}/tools/tcl/debug/lib/tcl9.0/tzdata"
-            "${CURRENT_PACKAGES_DIR}/tools/tcl/lib/tcl9.0/msgs" "${CURRENT_PACKAGES_DIR}/tools/tcl/lib/tcl9.0/tzdata"
-        PERMISSIONS
-            OWNER_READ OWNER_WRITE
-            GROUP_READ GROUP_WRITE
-            WORLD_READ WORLD_WRITE
-    )
 else()
     file(REMOVE "${SOURCE_PATH}/unix/configure")
     vcpkg_configure_make(
@@ -146,4 +152,4 @@ endif()
     
 file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/tclConfig.sh" "${CURRENT_PACKAGES_DIR}/debug/lib/tclConfig.sh")
 
-file(INSTALL "${SOURCE_PATH}/license.terms" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license.terms")

--- a/ports/tcl/vcpkg.json
+++ b/ports/tcl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tcl",
   "version-string": "core-9-0-a1",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Tcl provides a powerful platform for creating integration applications that tie together diverse applications, protocols, devices, and frameworks. When paired with the Tk toolkit, Tcl provides the fastest and most powerful way to create GUI applications that run on PCs, Unix, and Mac OS X. Tcl can also be used for a variety of web-related tasks and for creating powerful command languages for applications.",
   "homepage": "https://github.com/tcltk/tcl",
   "supports": "!android & !(windows & arm) & !uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8758,7 +8758,7 @@
     },
     "tcl": {
       "baseline": "core-9-0-a1",
-      "port-version": 7
+      "port-version": 8
     },
     "tclap": {
       "baseline": "1.2.5",

--- a/versions/t-/tcl.json
+++ b/versions/t-/tcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e17d8c12a1c924cfd28ae1ad9e5fad178b63eee5",
+      "version-string": "core-9-0-a1",
+      "port-version": 8
+    },
+    {
       "git-tree": "cf292d0782ec4b951e94467bd26a6b4a1db5874f",
       "version-string": "core-9-0-a1",
       "port-version": 7


### PR DESCRIPTION
Fixes #41000. 

Fix release builds on Windows:
```
-- Building and installing x64-windows-release-rel
CMake Error at ports/tcl/portfile.cmake:123 (file):
  file does not exist:

    E:/vcpkg/packages/tcl_x64-windows-release/tools/tcl/debug/lib/tcl9.0/msgs
Call Stack (most recent call first):
  scripts/ports.cmake:192 (include)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ·SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.
- [ ] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
