### PR TITLE
[simsimd] Update to 5.4.0 and use the upstream-provided CMake build system

### DIFF
--- a/ports/simsimd/export-target.patch
+++ b/ports/simsimd/export-target.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index aa0daf4..f976fb1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -108,6 +108,23 @@ endif ()
+ if (SIMSIMD_BUILD_SHARED)
+     set(SIMSIMD_SOURCES ${SIMSIMD_SOURCES} c/lib.c)
+     add_library(simsimd_shared SHARED ${SIMSIMD_SOURCES})
+-    target_include_directories(simsimd_shared PUBLIC "${PROJECT_SOURCE_DIR}/include")
++    target_include_directories(simsimd_shared PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+     set_target_properties(simsimd_shared PROPERTIES OUTPUT_NAME simsimd)
++    
++    install(TARGETS simsimd_shared EXPORT unofficial-simsimd-config
++    	LIBRARY DESTINATION lib
++    	ARCHIVE DESTINATION lib
++        RUNTIME DESTINATION bin)
++        
++    install(EXPORT unofficial-simsimd-config
++        FILE unofficial-simsimd-config.cmake
++        NAMESPACE unofficial::simsimd::
++        DESTINATION share/unofficial-simsimd
++    )
+ endif ()
++
++install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
++    	DESTINATION include
++        FILES_MATCHING
++        PATTERN *.h
++)

--- a/ports/simsimd/export-target.patch
+++ b/ports/simsimd/export-target.patch
@@ -11,19 +11,19 @@ index aa0daf4..f976fb1 100644
      set_target_properties(simsimd_shared PROPERTIES OUTPUT_NAME simsimd)
 +    
 +    install(TARGETS simsimd_shared EXPORT unofficial-simsimd-config
-+    	LIBRARY DESTINATION lib
-+    	ARCHIVE DESTINATION lib
-+        RUNTIME DESTINATION bin)
++       LIBRARY DESTINATION lib
++       ARCHIVE DESTINATION lib
++       RUNTIME DESTINATION bin)
 +        
 +    install(EXPORT unofficial-simsimd-config
-+        FILE unofficial-simsimd-config.cmake
-+        NAMESPACE unofficial::simsimd::
-+        DESTINATION share/unofficial-simsimd
++       FILE unofficial-simsimd-config.cmake
++       NAMESPACE unofficial::simsimd::
++       DESTINATION share/unofficial-simsimd
 +    )
  endif ()
 +
 +install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
-+    	DESTINATION include
-+        FILES_MATCHING
-+        PATTERN *.h
++   DESTINATION include
++   FILES_MATCHING
++   PATTERN *.h
 +)

--- a/ports/simsimd/portfile.cmake
+++ b/ports/simsimd/portfile.cmake
@@ -2,10 +2,29 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/SimSIMD
     REF "v${VERSION}"
-    SHA512 8263aada695ce68a1eb671c46a294fd317f9bb5d3a3ec5b4a8ab27b8b8ea5801c639b6bac3ba889bd6153444c76b7fa6d2982c25003af4cdfd0d8bc007b783f8
+    SHA512 cb1d190218dc86cc39f6343ebd7d396006d5d97eeba3f6eabac8c17bbbe9903e8e215d9968e9c3be35af475dc14579e746183216e56fa94118dc4d6e6adc17a1
     HEAD_REF main
+    PATCHES
+        export-target.patch
 )
 
-file(INSTALL "${SOURCE_PATH}/include" DESTINATION "${CURRENT_PACKAGES_DIR}")
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSIMSIMD_BUILD_TESTS=OFF
+        -DSIMSIMD_BUILD_BENCHMARKS=OFF
+        "-DSIMSIMD_BUILD_SHARED=${BUILD_SHARED}"
+)
+
+vcpkg_cmake_install()
+
+if(BUILD_SHARED)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-simsimd)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+else()
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/simsimd/vcpkg.json
+++ b/ports/simsimd/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "simsimd",
-  "version": "5.2.1",
+  "version": "5.4.0",
   "description": "Fastest similarity-measures and distance functions on the Wild West – vectors, strings, short molecules, and even DNA sequences. All with a pinch of SIMD for both x86 and ARM.",
   "homepage": "https://github.com/ashvardanian/SimSIMD",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8325,8 +8325,8 @@
       "port-version": 0
     },
     "simsimd": {
-      "baseline": "5.4.0",
-      "port-version": 0
+      "baseline": "5.2.1",
+      "port-version": 1
     },
     "sjpeg": {
       "baseline": "2021-10-31",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8325,13 +8325,8 @@
       "port-version": 0
     },
     "simsimd": {
-<<<<<<< HEAD
       "baseline": "5.2.1",
       "port-version": 1
-=======
-      "baseline": "5.4.0",
-      "port-version": 0
->>>>>>> 4e461ab4e89d53b681fc593a09bd1cce4dda7b58
     },
     "sjpeg": {
       "baseline": "2021-10-31",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8325,8 +8325,8 @@
       "port-version": 0
     },
     "simsimd": {
-      "baseline": "5.2.1",
-      "port-version": 1
+      "baseline": "5.4.0",
+      "port-version": 0
     },
     "sjpeg": {
       "baseline": "2021-10-31",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8325,7 +8325,7 @@
       "port-version": 0
     },
     "simsimd": {
-      "baseline": "5.2.1",
+      "baseline": "5.4.0",
       "port-version": 0
     },
     "sjpeg": {

--- a/versions/s-/simsimd.json
+++ b/versions/s-/simsimd.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "3e0f28814224e5c5eec6b579d8124c498bb41c54",
-      "version": "5.4.0",
-      "port-version": 0
-    },
-    {
       "git-tree": "2196ab7b52b8fd6c85ac7afea6c52240a266e46d",
       "version": "5.2.1",
       "port-version": 1

--- a/versions/s-/simsimd.json
+++ b/versions/s-/simsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ad1e7d28dfb22564d552a1866ef3473d05bba8a",
+      "version": "5.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b0a5b4fd3ee94ca1876ae615c289c92e984e11f8",
       "version": "5.2.1",
       "port-version": 0

--- a/versions/s-/simsimd.json
+++ b/versions/s-/simsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e0f28814224e5c5eec6b579d8124c498bb41c54",
+      "version": "5.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2196ab7b52b8fd6c85ac7afea6c52240a266e46d",
       "version": "5.2.1",
       "port-version": 1

--- a/versions/s-/simsimd.json
+++ b/versions/s-/simsimd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3e0f28814224e5c5eec6b579d8124c498bb41c54",
+      "git-tree": "4a743669d8336cd1aaf4fb8ca23ec6a0b98e3a09",
       "version": "5.4.0",
       "port-version": 0
     },


### PR DESCRIPTION
1. Update port with the latest version.
2. Use the upstream-provided CMake build system.  
3. Fix upstream usage issues, export targets, and install header files. 
4. Add `"supports": "!uwp"` because upstream has below setting: (ASan is not supported on the UWP platform)
```
set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address")
set(CMAKE_C_FLAGS_DEBUG "-g -fsanitize=address")
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
