### PR TITLE
[range-v3, simsimd] Ban $/include/module.modulemap

### DIFF
--- a/ports/range-v3/portfile.cmake
+++ b/ports/range-v3/portfile.cmake
@@ -1,4 +1,4 @@
-if(EXISTS ${CURRENT_INSTALLED_DIR}/share/range-v3-vs2015/copyright)
+if(EXISTS "${CURRENT_INSTALLED_DIR}/share/range-v3-vs2015/copyright")
     message(FATAL_ERROR "'${PORT}' conflicts with 'range-v3-vs2015'. Please remove range-v3-vs2015:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
 endif()
 vcpkg_from_github(
@@ -22,7 +22,11 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/range-v3)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/include/module.modulemap"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
 
 vcpkg_copy_pdbs()
 

--- a/ports/range-v3/vcpkg.json
+++ b/ports/range-v3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "range-v3",
   "version": "0.12.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Range library for C++14/17/20, basis for C++20's std::ranges",
   "homepage": "https://github.com/ericniebler/range-v3",
   "license": "BSL-1.0 AND MIT AND (NCSA OR MIT)",

--- a/ports/simsimd/portfile.cmake
+++ b/ports/simsimd/portfile.cmake
@@ -7,5 +7,6 @@ vcpkg_from_github(
 )
 
 file(INSTALL "${SOURCE_PATH}/include" DESTINATION "${CURRENT_PACKAGES_DIR}")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/include/module.modulemap")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/simsimd/vcpkg.json
+++ b/ports/simsimd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "simsimd",
   "version": "5.2.1",
+  "port-version": 1,
   "description": "Fastest similarity-measures and distance functions on the Wild West – vectors, strings, short molecules, and even DNA sequences. All with a pinch of SIMD for both x86 and ARM.",
   "homepage": "https://github.com/ashvardanian/SimSIMD",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7718,7 +7718,7 @@
     },
     "range-v3": {
       "baseline": "0.12.0",
-      "port-version": 3
+      "port-version": 4
     },
     "range-v3-vs2015": {
       "baseline": "20151130-vcpkg5",
@@ -8326,7 +8326,7 @@
     },
     "simsimd": {
       "baseline": "5.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "sjpeg": {
       "baseline": "2021-10-31",

--- a/versions/r-/range-v3.json
+++ b/versions/r-/range-v3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "909bba8e9818ca395699107ce92bdb73c221ace2",
+      "version": "0.12.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "6c5cc9ec0604083c62d9f92276a0751076f28c0d",
       "version": "0.12.0",
       "port-version": 3

--- a/versions/s-/simsimd.json
+++ b/versions/s-/simsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2196ab7b52b8fd6c85ac7afea6c52240a266e46d",
+      "version": "5.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "b0a5b4fd3ee94ca1876ae615c289c92e984e11f8",
       "version": "5.2.1",
       "port-version": 0


### PR DESCRIPTION
Resolves file conflicts detected in vcpkg's 2024-09-16 full build: https://dev.azure.com/vcpkg/public/_build/results?buildId=107008&

```
error: The following files are already installed in D:/installed/x64-windows-static and are in conflict with simsimd:x64-windows-static
Installed by range-v3:x64-windows-static  
include/module.modulemap
```