### PR TITLE
[libsrt] Fix feature tool 

### DIFF
--- a/ports/libsrt/fix-tool.patch
+++ b/ports/libsrt/fix-tool.patch
@@ -1,36 +1,30 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7e8062a..ecf77fd 100644
+index 7e8062a..2277e33 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -436,6 +436,8 @@ if (ENABLE_ENCRYPTION)
- 			set (SSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
- 			set (SSL_LIBRARIES ${OPENSSL_LIBRARIES})
- 			message(STATUS "SSL via find_package(OpenSSL): -I ${SSL_INCLUDE_DIRS} -l;${SSL_LIBRARIES}")
-+			include_directories(${SSL_INCLUDE_DIRS})
-+			link_libraries(${SSL_LIBRARIES})
- 		endif()
- 
- 	endif()
-@@ -1300,11 +1302,11 @@ if (ENABLE_APPS)
+@@ -1300,11 +1300,13 @@ if (ENABLE_APPS)
  
  	# Applications
  
 -	srt_add_application(srt-live-transmit ${VIRTUAL_srtsupport})
 +	srt_add_application(srt-live-transmit ${VIRTUAL_srtsupport} ${VIRTUAL_srt})
++	target_link_libraries(srt-live-transmit ${SSL_LIBRARIES})
  	if (DEFINED EXTRA_stransmit)
  		set_target_properties(srt-live-transmit PROPERTIES COMPILE_FLAGS "${EXTRA_stransmit}")
  	endif()
 -	srt_add_application(srt-file-transmit ${VIRTUAL_srtsupport})
 +	srt_add_application(srt-file-transmit ${VIRTUAL_srtsupport} ${VIRTUAL_srt})
++	target_link_libraries(srt-file-transmit ${SSL_LIBRARIES})
  
  	if (MINGW)
  		# FIXME: with MINGW, it fails to build apps that require C++11
-@@ -1313,7 +1315,7 @@ if (ENABLE_APPS)
+@@ -1313,7 +1315,8 @@ if (ENABLE_APPS)
  	else()
  		# srt-multiplex temporarily blocked
  		#srt_add_application(srt-multiplex ${VIRTUAL_srtsupport})
 -		srt_add_application(srt-tunnel ${VIRTUAL_srtsupport})
 +		srt_add_application(srt-tunnel ${VIRTUAL_srtsupport} ${VIRTUAL_srt})
++		target_link_libraries(srt-tunnel ${SSL_LIBRARIES})
  		target_compile_definitions(srt-tunnel PUBLIC -DSRT_ENABLE_VERBOSE_LOCK)
  	endif()
  

--- a/ports/libsrt/fix-tool.patch
+++ b/ports/libsrt/fix-tool.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7e8062a..ecf77fd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -436,6 +436,8 @@ if (ENABLE_ENCRYPTION)
+ 			set (SSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
+ 			set (SSL_LIBRARIES ${OPENSSL_LIBRARIES})
+ 			message(STATUS "SSL via find_package(OpenSSL): -I ${SSL_INCLUDE_DIRS} -l;${SSL_LIBRARIES}")
++			include_directories(${SSL_INCLUDE_DIRS})
++			link_libraries(${SSL_LIBRARIES})
+ 		endif()
+ 
+ 	endif()
+@@ -1300,11 +1302,11 @@ if (ENABLE_APPS)
+ 
+ 	# Applications
+ 
+-	srt_add_application(srt-live-transmit ${VIRTUAL_srtsupport})
++	srt_add_application(srt-live-transmit ${VIRTUAL_srtsupport} ${VIRTUAL_srt})
+ 	if (DEFINED EXTRA_stransmit)
+ 		set_target_properties(srt-live-transmit PROPERTIES COMPILE_FLAGS "${EXTRA_stransmit}")
+ 	endif()
+-	srt_add_application(srt-file-transmit ${VIRTUAL_srtsupport})
++	srt_add_application(srt-file-transmit ${VIRTUAL_srtsupport} ${VIRTUAL_srt})
+ 
+ 	if (MINGW)
+ 		# FIXME: with MINGW, it fails to build apps that require C++11
+@@ -1313,7 +1315,7 @@ if (ENABLE_APPS)
+ 	else()
+ 		# srt-multiplex temporarily blocked
+ 		#srt_add_application(srt-multiplex ${VIRTUAL_srtsupport})
+-		srt_add_application(srt-tunnel ${VIRTUAL_srtsupport})
++		srt_add_application(srt-tunnel ${VIRTUAL_srtsupport} ${VIRTUAL_srt})
+ 		target_compile_definitions(srt-tunnel PUBLIC -DSRT_ENABLE_VERBOSE_LOCK)
+ 	endif()
+ 

--- a/ports/libsrt/portfile.cmake
+++ b/ports/libsrt/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-static.patch
         pkgconfig.diff
+        fix-tool.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" KEYSTONE_BUILD_STATIC)

--- a/ports/libsrt/vcpkg.json
+++ b/ports/libsrt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsrt",
   "version": "1.5.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Secure Reliable Transport (SRT) is an open source transport technology that optimizes streaming performance across unpredictable networks, such as the Internet.",
   "homepage": "https://github.com/Haivision/srt",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5106,7 +5106,7 @@
     },
     "libsrt": {
       "baseline": "1.5.3",
-      "port-version": 2
+      "port-version": 3
     },
     "libsrtp": {
       "baseline": "2.5.0",

--- a/versions/l-/libsrt.json
+++ b/versions/l-/libsrt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a20e32149b709c108aac421f0dca08f945c5e839",
+      "git-tree": "d9f3ed628ea5aed328a62750b1af9c4d9685225d",
       "version": "1.5.3",
       "port-version": 3
     },

--- a/versions/l-/libsrt.json
+++ b/versions/l-/libsrt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a20e32149b709c108aac421f0dca08f945c5e839",
+      "version": "1.5.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "578c7b45771245ff525647973280f997fef43d9b",
       "version": "1.5.3",
       "port-version": 2


### PR DESCRIPTION
Fixes #37085. Fix feature `tool`, resolve the following errors:
```
[52/57] C:\Windows\system32\cmd.exe /C "cd . && F:\vcpkg\downloads\tools\cmake-3.29.2-windows\cmake-3.29.2-windows-i386\bin\cmake.exe -E vs_link_exe --intdir=CMakeFiles\srt-file-transmit.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MIB055~1\2022\ENTERP~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\link.exe  CMakeFiles\srtsupport_virtual.dir\apps\apputil.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\statswriter.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\logsupport.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\logsupport_appdefs.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\socketoptions.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\transmitmedia.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\uriparser.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\verbose.cpp.obj CMakeFiles\srt-file-transmit.dir\apps\srt-file-transmit.cpp.obj  /out:srt-file-transmit.exe /implib:srt-file-transmit.lib /pdb:srt-file-transmit.pdb /version:0.0 /machine:x64 /nologo    /debug /INCREMENTAL /subsystem:console  srt.lib  Ws2_32.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
FAILED: srt-file-transmit.exe 
C:\Windows\system32\cmd.exe /C "cd . && F:\vcpkg\downloads\tools\cmake-3.29.2-windows\cmake-3.29.2-windows-i386\bin\cmake.exe -E vs_link_exe --intdir=CMakeFiles\srt-file-transmit.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MIB055~1\2022\ENTERP~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\link.exe  CMakeFiles\srtsupport_virtual.dir\apps\apputil.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\statswriter.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\logsupport.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\logsupport_appdefs.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\socketoptions.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\transmitmedia.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\uriparser.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\verbose.cpp.obj CMakeFiles\srt-file-transmit.dir\apps\srt-file-transmit.cpp.obj  /out:srt-file-transmit.exe /implib:srt-file-transmit.lib /pdb:srt-file-transmit.pdb /version:0.0 /machine:x64 /nologo    /debug /INCREMENTAL /subsystem:console  srt.lib  Ws2_32.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
LINK Pass 1: command "C:\PROGRA~1\MIB055~1\2022\ENTERP~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\link.exe CMakeFiles\srtsupport_virtual.dir\apps\apputil.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\statswriter.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\logsupport.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\logsupport_appdefs.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\socketoptions.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\transmitmedia.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\uriparser.cpp.obj CMakeFiles\srtsupport_virtual.dir\apps\verbose.cpp.obj CMakeFiles\srt-file-transmit.dir\apps\srt-file-transmit.cpp.obj /out:srt-file-transmit.exe /implib:srt-file-transmit.lib /pdb:srt-file-transmit.pdb /version:0.0 /machine:x64 /nologo /debug /INCREMENTAL /subsystem:console srt.lib Ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:CMakeFiles\srt-file-transmit.dir/intermediate.manifest CMakeFiles\srt-file-transmit.dir/manifest.res" failed (exit code 1120) with the following output:
transmitmedia.cpp.obj : error LNK2001: unresolved external symbol srt_msgctrl_default
srt-file-transmit.exe : fatal error LNK1120: 1 unresolved externals
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
