### PR TITLE
[roaring] update to 4.1.3

### DIFF
--- a/ports/roaring/portfile.cmake
+++ b/ports/roaring/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RoaringBitmap/CRoaring
     REF "v${VERSION}"
-    SHA512 6a81d4425f9dd422aafc04b49ca5f70ca87f1cc64be15b936ffd89fe23c3b50c6a615e9af5ccdcdd5f5ad5851d2de762b8fb3412c65b243c12acb7abcb3bce58
+    SHA512 632bdc7dd4f66a5034653ebcf17532e680a07f05456640ceea704d3b0f360b3d514a68bf513074f9f3b23e06cfa06814f0df0337003f70f33768c041bc5e82c5
     HEAD_REF master
 )
 

--- a/ports/roaring/vcpkg.json
+++ b/ports/roaring/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "roaring",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "A better compressed bitset in C (and C++)",
   "homepage": "https://github.com/RoaringBitmap/CRoaring",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7909,7 +7909,7 @@
       "port-version": 1
     },
     "roaring": {
-      "baseline": "4.1.2",
+      "baseline": "4.1.3",
       "port-version": 0
     },
     "robin-hood-hashing": {

--- a/versions/r-/roaring.json
+++ b/versions/r-/roaring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3d86b5e35bc1f6655fe75db03d7ed895f1050831",
+      "version": "4.1.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "8e8e8dad98996839e8fbab2a942466556deb3335",
       "version": "4.1.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
