### PR TITLE
[xsimd] Fix build error under windows

### DIFF
--- a/ports/xsimd/portfile.cmake
+++ b/ports/xsimd/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(
     WIN_PATCHES
     URLS "https://github.com/xtensor-stack/xsimd/pull/1040/commits/e8cb862e434eb1e367afb83e1a3685bccff3e566.diff?full_index=1"
-    FILENAME "e8cb862e434eb1e367afb83e1a3685bccff3e566.patch"
+    FILENAME "xsimd-e8cb862e434eb1e367afb83e1a3685bccff3e566.patch"
     SHA512 e584033fb79c602a19222c177d5db28f9887dd17e741844d57f2236a5749ac4c02cc0740f8011ca990602887a6ee3dd21ae0b695455c447686b1a6c8bda2e092
 )
 vcpkg_from_github(

--- a/ports/xsimd/portfile.cmake
+++ b/ports/xsimd/portfile.cmake
@@ -1,9 +1,17 @@
+ vcpkg_download_distfile(
+            WIN_PATCHES
+            URLS "https://github.com/xtensor-stack/xsimd/pull/1040/commits/e8cb862e434eb1e367afb83e1a3685bccff3e566.diff?full_index=1"
+            FILENAME "e8cb862e434eb1e367afb83e1a3685bccff3e566.patch"
+            SHA512 e584033fb79c602a19222c177d5db28f9887dd17e741844d57f2236a5749ac4c02cc0740f8011ca990602887a6ee3dd21ae0b695455c447686b1a6c8bda2e092
+        )
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xsimd
     REF "${VERSION}"
     SHA512 cdc42ddad3353297cf25ea2b6b3f09967f5f388efc26241f2997979fdbbac072819ff771145bc5bfa86cb326cca84b4119e8e6e3f658407961cf203a40603a7f
     HEAD_REF master
+	PATCHES
+	    ${WIN_PATCHES}
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/xsimd/portfile.cmake
+++ b/ports/xsimd/portfile.cmake
@@ -10,8 +10,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 cdc42ddad3353297cf25ea2b6b3f09967f5f388efc26241f2997979fdbbac072819ff771145bc5bfa86cb326cca84b4119e8e6e3f658407961cf203a40603a7f
     HEAD_REF master
-	PATCHES
-	    ${WIN_PATCHES}
+    PATCHES
+        ${WIN_PATCHES}
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/xsimd/portfile.cmake
+++ b/ports/xsimd/portfile.cmake
@@ -1,9 +1,9 @@
  vcpkg_download_distfile(
-            WIN_PATCHES
-            URLS "https://github.com/xtensor-stack/xsimd/pull/1040/commits/e8cb862e434eb1e367afb83e1a3685bccff3e566.diff?full_index=1"
-            FILENAME "e8cb862e434eb1e367afb83e1a3685bccff3e566.patch"
-            SHA512 e584033fb79c602a19222c177d5db28f9887dd17e741844d57f2236a5749ac4c02cc0740f8011ca990602887a6ee3dd21ae0b695455c447686b1a6c8bda2e092
-        )
+    WIN_PATCHES
+    URLS "https://github.com/xtensor-stack/xsimd/pull/1040/commits/e8cb862e434eb1e367afb83e1a3685bccff3e566.diff?full_index=1"
+    FILENAME "e8cb862e434eb1e367afb83e1a3685bccff3e566.patch"
+    SHA512 e584033fb79c602a19222c177d5db28f9887dd17e741844d57f2236a5749ac4c02cc0740f8011ca990602887a6ee3dd21ae0b695455c447686b1a6c8bda2e092
+)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xsimd

--- a/ports/xsimd/portfile.cmake
+++ b/ports/xsimd/portfile.cmake
@@ -1,4 +1,4 @@
- vcpkg_download_distfile(
+vcpkg_download_distfile(
     WIN_PATCHES
     URLS "https://github.com/xtensor-stack/xsimd/pull/1040/commits/e8cb862e434eb1e367afb83e1a3685bccff3e566.diff?full_index=1"
     FILENAME "e8cb862e434eb1e367afb83e1a3685bccff3e566.patch"
@@ -11,7 +11,7 @@ vcpkg_from_github(
     SHA512 cdc42ddad3353297cf25ea2b6b3f09967f5f388efc26241f2997979fdbbac072819ff771145bc5bfa86cb326cca84b4119e8e6e3f658407961cf203a40603a7f
     HEAD_REF master
     PATCHES
-        ${WIN_PATCHES}
+        "${WIN_PATCHES}"
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/xsimd/vcpkg.json
+++ b/ports/xsimd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "xsimd",
   "version": "13.0.0",
+  "port-version": 1,
   "description": "Modern, portable C++ wrappers for SIMD intrinsics",
   "homepage": "https://github.com/xtensor-stack/xsimd",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9758,7 +9758,7 @@
     },
     "xsimd": {
       "baseline": "13.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "xtensor": {
       "baseline": "0.25.0",

--- a/versions/x-/xsimd.json
+++ b/versions/x-/xsimd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0296b9972d65d4d2ff13bccb19c14a6e793b9de8",
+      "git-tree": "5abac857df65de3b3f734398f7500df42456cb2c",
       "version": "13.0.0",
       "port-version": 1
     },

--- a/versions/x-/xsimd.json
+++ b/versions/x-/xsimd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5abac857df65de3b3f734398f7500df42456cb2c",
+      "git-tree": "f32923512f532dd165f1379bdb3c810b9d31d7d3",
       "version": "13.0.0",
       "port-version": 1
     },

--- a/versions/x-/xsimd.json
+++ b/versions/x-/xsimd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ffb588a33e592f72443e44023aa6b8f0a0a0c68f",
+      "git-tree": "0296b9972d65d4d2ff13bccb19c14a6e793b9de8",
       "version": "13.0.0",
       "port-version": 1
     },

--- a/versions/x-/xsimd.json
+++ b/versions/x-/xsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "408ea9932d5f22753b1f447f35cdc23a6e61ab5e",
+      "version": "13.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b79289e60e4e2319af838958ca258ea6dbbffb14",
       "version": "13.0.0",
       "port-version": 0

--- a/versions/x-/xsimd.json
+++ b/versions/x-/xsimd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "408ea9932d5f22753b1f447f35cdc23a6e61ab5e",
+      "git-tree": "ffb588a33e592f72443e44023aa6b8f0a0a0c68f",
       "version": "13.0.0",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39810
Fix the issue using the upstream fix.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test pass with following triplet:

```
x64-windows
```