### PR TITLE
[pcapplusplus] Bump PcapPlusPlus to 24.09 and Add documentation link

### DIFF
--- a/ports/pcapplusplus/portfile.cmake
+++ b/ports/pcapplusplus/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO seladb/PcapPlusPlus
     REF "v${PCAPPLUSPLUS_VERSION}"
-    SHA512 e7dc1dbd85c9f0d2f9c5d3e436456c2cd183fb508c869fa8fb83f46aac99b868a16283204e5d57a0bfd7587f6ac2582b3e14c6098683fad4501708c8fededd6a
+    SHA512 ae68a61a41915b1272aa7f8d1b70889216ea50e966c594d408d79fbca2667ff5aa073fe21a72c7e0916f744a925ac1e85e1d1f02e458b3f289201b88c8101fa3
     HEAD_REF master
     PATCHES
         0001-warn-STL4043-for-v23.09.patch # just workaround, which has been fixed on mainline

--- a/ports/pcapplusplus/vcpkg.json
+++ b/ports/pcapplusplus/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 2,
   "description": "PcapPlusPlus is a multi-platform C++ library for capturing, parsing and crafting of network packets",
   "homepage": "https://github.com/seladb/PcapPlusPlus",
+  "documentation": "https://pcapplusplus.github.io",
   "license": null,
   "dependencies": [
     {

--- a/ports/pcapplusplus/vcpkg.json
+++ b/ports/pcapplusplus/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pcapplusplus",
-  "version": "23.9",
-  "port-version": 2,
+  "version": "24.9",
   "description": "PcapPlusPlus is a multi-platform C++ library for capturing, parsing and crafting of network packets",
   "homepage": "https://github.com/seladb/PcapPlusPlus",
   "documentation": "https://pcapplusplus.github.io",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6853,8 +6853,8 @@
       "port-version": 9
     },
     "pcapplusplus": {
-      "baseline": "23.9",
-      "port-version": 2
+      "baseline": "24.9",
+      "port-version": 0
     },
     "pcg": {
       "baseline": "2021-04-06",

--- a/versions/p-/pcapplusplus.json
+++ b/versions/p-/pcapplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b165fe065b7d33ca9731cc4af4acee2f81bd2cf2",
+      "version": "24.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "5f7f815b341f0f5a5d1456894d8b30786ae24abf",
       "version": "23.9",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.