### PR TITLE
[aliyun-oss-cpp-sdk] Add option to disable parallel builds

### DIFF
--- a/ports/aliyun-oss-cpp-sdk/portfile.cmake
+++ b/ports/aliyun-oss-cpp-sdk/portfile.cmake
@@ -12,6 +12,7 @@ file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/0002-unofficial-export.cmake" DESTINATIO
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBUILD_SAMPLE=OFF
 )

--- a/ports/aliyun-oss-cpp-sdk/vcpkg.json
+++ b/ports/aliyun-oss-cpp-sdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "aliyun-oss-cpp-sdk",
   "version": "1.10.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Alibaba Cloud Object Storage Service (OSS) is a cloud storage service provided by Alibaba Cloud, featuring massive capacity, security, a low cost, and high reliability.",
   "homepage": "https://github.com/aliyun/aliyun-oss-cpp-sdk",
   "license": "Apache-2.0",

--- a/versions/a-/aliyun-oss-cpp-sdk.json
+++ b/versions/a-/aliyun-oss-cpp-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca0c99c6cdc51c43705f89baf7ee8a4e61b25fe2",
+      "version": "1.10.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "732b0995e1fae92ab6192bbf41f0e40a459d9ac7",
       "version": "1.10.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -82,7 +82,7 @@
     },
     "aliyun-oss-cpp-sdk": {
       "baseline": "1.10.0",
-      "port-version": 1
+      "port-version": 2
     },
     "allegro5": {
       "baseline": "5.2.9.1",


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/pull/40954#issuecomment-2362172587

Add `DISABLE_PARALLEL_CONFIGURE` to disable parallel builds.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.