### PR TITLE
SomeMerges About Build OpenSceneGraph With -j1, etc

### DIFF
--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -132,7 +132,7 @@ vcpkg_cmake_configure(
         USE_3RDPARTY_BIN
         ${plugin_vars}
 )
-vcpkg_cmake_install()
+vcpkg_cmake_install(DISABLE_PARALLEL)
 vcpkg_copy_pdbs()
 configure_file("${CMAKE_CURRENT_LIST_DIR}/unofficial-osg-config.cmake" "${CURRENT_PACKAGES_DIR}/share/unofficial-osg/unofficial-osg-config.cmake" @ONLY)
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-osg)

--- a/ports/osg/vcpkg.json
+++ b/ports/osg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osg",
   "version": "3.6.5",
-  "port-version": 25,
+  "port-version": 26,
   "description": "The OpenSceneGraph is an open source high performance 3D graphics toolkit.",
   "homepage": "https://www.openscenegraph.com/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6762,7 +6762,7 @@
     },
     "osg": {
       "baseline": "3.6.5",
-      "port-version": 25
+      "port-version": 26
     },
     "osg-qt": {
       "baseline": "Qt5",

--- a/versions/o-/osg.json
+++ b/versions/o-/osg.json
@@ -1,5 +1,10 @@
 {
   "versions": [
+	{
+      "git-tree": "040e77694057a2f267465d22771c3a603939078a",
+      "version": "3.6.5",
+      "port-version": 26
+    },
     {
       "git-tree": "c4fe8448842ded8e44e53c90f6a02b08a1582266",
       "version": "3.6.5",

--- a/versions/o-/osg.json
+++ b/versions/o-/osg.json
@@ -1,5 +1,10 @@
 {
   "versions": [
+	{
+      "git-tree": "405a2ff4460a45e5f964ed83d968b89e8de926df",
+      "version": "3.6.5",
+      "port-version": 26
+    },
     {
       "git-tree": "c4fe8448842ded8e44e53c90f6a02b08a1582266",
       "version": "3.6.5",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.