### PR TITLE
[simsimd] update to 5.4.1

### DIFF
--- a/ports/simsimd/portfile.cmake
+++ b/ports/simsimd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/SimSIMD
     REF "v${VERSION}"
-    SHA512 cb1d190218dc86cc39f6343ebd7d396006d5d97eeba3f6eabac8c17bbbe9903e8e215d9968e9c3be35af475dc14579e746183216e56fa94118dc4d6e6adc17a1
+    SHA512 b4c0150d0a679f6ff5eb7d0a8816f713f9d72a4cbc5e230d9553584283deba2090d13ececddda22a8242d1923ca4f3771b3bea60e3dc40b77c546197d0d1ce6a
     HEAD_REF main
     PATCHES
         export-target.patch

--- a/ports/simsimd/vcpkg.json
+++ b/ports/simsimd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simsimd",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Fastest similarity-measures and distance functions on the Wild West – vectors, strings, short molecules, and even DNA sequences. All with a pinch of SIMD for both x86 and ARM.",
   "homepage": "https://github.com/ashvardanian/SimSIMD",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8325,7 +8325,7 @@
       "port-version": 0
     },
     "simsimd": {
-      "baseline": "5.4.0",
+      "baseline": "5.4.1",
       "port-version": 0
     },
     "sjpeg": {

--- a/versions/s-/simsimd.json
+++ b/versions/s-/simsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ccf891a395b5acb9b95e9120e646169ded5c142",
+      "version": "5.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a743669d8336cd1aaf4fb8ca23ec6a0b98e3a09",
       "version": "5.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
