### PR TITLE
[mariadb-connector-cpp] update to 1.1.5

### DIFF
--- a/ports/mariadb-connector-cpp/libmariadb.diff
+++ b/ports/mariadb-connector-cpp/libmariadb.diff
@@ -1,16 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 43bc4a2..5a10e1e 100644
+index db28fd9..1692f72 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -545,7 +545,11 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/src/maconncpp.def.in
-                ${CMAKE_SOURCE_DIR}/src/maconncpp.def)
+@@ -545,7 +545,11 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/src/maconncpp.def.in
+                ${CMAKE_CURRENT_SOURCE_DIR}/src/maconncpp.def)
  
  # Dynamic linking is default on non-Windows
 -IF(MARIADB_LINK_DYNAMIC)
 +IF(1)
-+  find_package(unofficial-libmariadb CONFIG REQUIRED)
-+  set(MARIADB_CLIENT_TARGET_NAME unofficial::libmariadb)
-+  add_library(mariadbclient ALIAS unofficial::libmariadb)
++  FIND_PACKAGE(unofficial-libmariadb CONFIG REQUIRED)
++  SET(MARIADB_CLIENT_TARGET_NAME unofficial::libmariadb)
++  ADD_LIBRARY(mariadbclient ALIAS unofficial::libmariadb)
 +ELSEIF(MARIADB_LINK_DYNAMIC)
    IF(USE_SYSTEM_INSTALLED_LIB)
      IF(MINGW)
@@ -19,7 +19,7 @@ index 43bc4a2..5a10e1e 100644
  
  
  ADD_LIBRARY(${LIBRARY_NAME}_obj OBJECT ${MACPP_SOURCES})
-+target_link_libraries(${LIBRARY_NAME}_obj PRIVATE unofficial::libmariadb)
++TARGET_LINK_LIBRARIES(${LIBRARY_NAME}_obj PRIVATE unofficial::libmariadb)
  IF(UNIX)
    SET_TARGET_PROPERTIES(${LIBRARY_NAME}_obj PROPERTIES COMPILE_FLAGS "${CMAKE_SHARED_LIBRARY_C_FLAGS}")
  ENDIF()

--- a/ports/mariadb-connector-cpp/portfile.cmake
+++ b/ports/mariadb-connector-cpp/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO mariadb-corporation/mariadb-connector-cpp
     REF ${VERSION}
     HEAD_REF master
-    SHA512 da1a2d28c1c56a14674c500ebc8ab0d0b7d9053335f147c2353832f05c2527f4bddd1fe4fff55f625b9e6085111e3b615f5a1a6484dd1fd61a7e6a8cabfd8c57
+    SHA512 90ce780e19babda02608134c99e8c0e7601a41ee5531097735beb54ec94c2dd38ecf4f457e9cac04831d7e886fe7c7b7a6d9fe799bf71d52ba168158ec36dc67
     PATCHES
         fix-carray.diff
         libmariadb.diff

--- a/ports/mariadb-connector-cpp/vcpkg.json
+++ b/ports/mariadb-connector-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mariadb-connector-cpp",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Connector/c++ for MariaDB.",
   "homepage": "https://mariadb.com/docs/appdev/connector-cpp/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5725,7 +5725,7 @@
       "port-version": 0
     },
     "mariadb-connector-cpp": {
-      "baseline": "1.1.4",
+      "baseline": "1.1.5",
       "port-version": 0
     },
     "marisa-trie": {

--- a/versions/m-/mariadb-connector-cpp.json
+++ b/versions/m-/mariadb-connector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8a524f1d1b8b7acc17f2d78730b3e6682b45976a",
+      "git-tree": "1983f1fab25432ab561ae4bee2e81243a1af9993",
       "version": "1.1.5",
       "port-version": 0
     },

--- a/versions/m-/mariadb-connector-cpp.json
+++ b/versions/m-/mariadb-connector-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a524f1d1b8b7acc17f2d78730b3e6682b45976a",
+      "version": "1.1.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "8cc12b00f195b480d285ebd6e549539db76ed36a",
       "version": "1.1.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
