### PR TITLE
[magma] Fix build for Windows with CUDA 12.6

### DIFF
--- a/ports/magma/fix-min-max.patch
+++ b/ports/magma/fix-min-max.patch
@@ -1,0 +1,56 @@
+diff --git a/magmablas/cgbtf2_kernels.cu b/magmablas/cgbtf2_kernels.cu
+index 1b44273..13cb442 100644
+--- a/magmablas/cgbtf2_kernels.cu
++++ b/magmablas/cgbtf2_kernels.cu
+@@ -12,6 +12,9 @@
+ 
+ #include "magma_internal.h"
+ #if   defined(MAGMA_HAVE_CUDA)
++// the cuda cooperative_groups.h file conflicts with magma's definition of min and max
++#undef min
++#undef max
+ #include <cooperative_groups.h>
+ namespace cg = cooperative_groups;
+ #elif defined(MAGMA_HAVE_HIP)
+diff --git a/magmablas/dgbtf2_kernels.cu b/magmablas/dgbtf2_kernels.cu
+index c2af4f4..df0384b 100644
+--- a/magmablas/dgbtf2_kernels.cu
++++ b/magmablas/dgbtf2_kernels.cu
+@@ -12,6 +12,9 @@
+ 
+ #include "magma_internal.h"
+ #if   defined(MAGMA_HAVE_CUDA)
++// the cuda cooperative_groups.h file conflicts with magma's definition of min and max
++#undef min
++#undef max
+ #include <cooperative_groups.h>
+ namespace cg = cooperative_groups;
+ #elif defined(MAGMA_HAVE_HIP)
+diff --git a/magmablas/sgbtf2_kernels.cu b/magmablas/sgbtf2_kernels.cu
+index bbc691a..8f2409c 100644
+--- a/magmablas/sgbtf2_kernels.cu
++++ b/magmablas/sgbtf2_kernels.cu
+@@ -12,6 +12,9 @@
+ 
+ #include "magma_internal.h"
+ #if   defined(MAGMA_HAVE_CUDA)
++// the cuda cooperative_groups.h file conflicts with magma's definition of min and max
++#undef min
++#undef max
+ #include <cooperative_groups.h>
+ namespace cg = cooperative_groups;
+ #elif defined(MAGMA_HAVE_HIP)
+diff --git a/magmablas/zgbtf2_kernels.cu b/magmablas/zgbtf2_kernels.cu
+index c1afa3b..bb58d93 100644
+--- a/magmablas/zgbtf2_kernels.cu
++++ b/magmablas/zgbtf2_kernels.cu
+@@ -12,6 +12,9 @@
+ 
+ #include "magma_internal.h"
+ #if   defined(MAGMA_HAVE_CUDA)
++// the cuda cooperative_groups.h file conflicts with magma's definition of min and max
++#undef min
++#undef max
+ #include <cooperative_groups.h>
+ namespace cg = cooperative_groups;
+ #elif defined(MAGMA_HAVE_HIP)

--- a/ports/magma/fix-min-max.patch
+++ b/ports/magma/fix-min-max.patch
@@ -1,56 +1,60 @@
 diff --git a/magmablas/cgbtf2_kernels.cu b/magmablas/cgbtf2_kernels.cu
-index 1b44273..13cb442 100644
+index 1b44273..e769534 100644
 --- a/magmablas/cgbtf2_kernels.cu
 +++ b/magmablas/cgbtf2_kernels.cu
-@@ -12,6 +12,9 @@
+@@ -12,6 +12,10 @@
  
  #include "magma_internal.h"
  #if   defined(MAGMA_HAVE_CUDA)
-+// the cuda cooperative_groups.h file conflicts with magma's definition of min and max
-+#undef min
++#if CUDA_VERSION >= 12060
 +#undef max
++#undef min
++#endif
  #include <cooperative_groups.h>
  namespace cg = cooperative_groups;
  #elif defined(MAGMA_HAVE_HIP)
 diff --git a/magmablas/dgbtf2_kernels.cu b/magmablas/dgbtf2_kernels.cu
-index c2af4f4..df0384b 100644
+index c2af4f4..c2e0b4d 100644
 --- a/magmablas/dgbtf2_kernels.cu
 +++ b/magmablas/dgbtf2_kernels.cu
-@@ -12,6 +12,9 @@
+@@ -12,6 +12,10 @@
  
  #include "magma_internal.h"
  #if   defined(MAGMA_HAVE_CUDA)
-+// the cuda cooperative_groups.h file conflicts with magma's definition of min and max
-+#undef min
++#if CUDA_VERSION >= 12060
 +#undef max
++#undef min
++#endif
  #include <cooperative_groups.h>
  namespace cg = cooperative_groups;
  #elif defined(MAGMA_HAVE_HIP)
 diff --git a/magmablas/sgbtf2_kernels.cu b/magmablas/sgbtf2_kernels.cu
-index bbc691a..8f2409c 100644
+index bbc691a..752c5f7 100644
 --- a/magmablas/sgbtf2_kernels.cu
 +++ b/magmablas/sgbtf2_kernels.cu
-@@ -12,6 +12,9 @@
+@@ -12,6 +12,10 @@
  
  #include "magma_internal.h"
  #if   defined(MAGMA_HAVE_CUDA)
-+// the cuda cooperative_groups.h file conflicts with magma's definition of min and max
-+#undef min
++#if CUDA_VERSION >= 12060
 +#undef max
++#undef min
++#endif
  #include <cooperative_groups.h>
  namespace cg = cooperative_groups;
  #elif defined(MAGMA_HAVE_HIP)
 diff --git a/magmablas/zgbtf2_kernels.cu b/magmablas/zgbtf2_kernels.cu
-index c1afa3b..bb58d93 100644
+index c1afa3b..3ea8136 100644
 --- a/magmablas/zgbtf2_kernels.cu
 +++ b/magmablas/zgbtf2_kernels.cu
-@@ -12,6 +12,9 @@
+@@ -12,6 +12,10 @@
  
  #include "magma_internal.h"
  #if   defined(MAGMA_HAVE_CUDA)
-+// the cuda cooperative_groups.h file conflicts with magma's definition of min and max
-+#undef min
++#if CUDA_VERSION >= 12060
 +#undef max
++#undef min
++#endif
  #include <cooperative_groups.h>
  namespace cg = cooperative_groups;
  #elif defined(MAGMA_HAVE_HIP)

--- a/ports/magma/portfile.cmake
+++ b/ports/magma/portfile.cmake
@@ -17,10 +17,11 @@ vcpkg_download_distfile(
 vcpkg_extract_source_archive(
     src_path
     ARCHIVE "${dist_file}"
-    PATCHES 
+    PATCHES
       disable-openmp-msvc.patch
       no-tests.patch
       clang-cuda.patch
+      fix-min-max.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/magma/vcpkg.json
+++ b/ports/magma/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "magma",
   "version": "2.8.0",
+  "port-version": 1,
   "description": "Matrix Algebra on GPU and Multi-core Architectures (MAGMA) is a collection of next-generation linear algebra libraries for heterogeneous computing",
   "homepage": "https://icl.utk.edu/magma/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5662,7 +5662,7 @@
     },
     "magma": {
       "baseline": "2.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "magnum": {
       "baseline": "2020.06",

--- a/versions/m-/magma.json
+++ b/versions/m-/magma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dcbe47160a1be5e945c599a2402acc3ffa9a3b8c",
+      "version": "2.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "07a55182c9e5bace6cbaff6e08c77a54fdcdcdbc",
       "version": "2.8.0",
       "port-version": 0

--- a/versions/m-/magma.json
+++ b/versions/m-/magma.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dcbe47160a1be5e945c599a2402acc3ffa9a3b8c",
+      "git-tree": "1f027fdb55e2bea18637a7cbe85c2ea544ee2f6d",
       "version": "2.8.0",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #40941 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
