### PR TITLE
[openvdb] Fix CUDA headers installation path

### DIFF
--- a/ports/openvdb/fix_nanovdb.patch
+++ b/ports/openvdb/fix_nanovdb.patch
@@ -1,5 +1,5 @@
 diff --git a/nanovdb/nanovdb/CMakeLists.txt b/nanovdb/nanovdb/CMakeLists.txt
-index 7bb3ab86..9311ed17 100644
+index 7bb3ab86..76da9071 100644
 --- a/nanovdb/nanovdb/CMakeLists.txt
 +++ b/nanovdb/nanovdb/CMakeLists.txt
 @@ -127,7 +127,7 @@ if(NANOVDB_USE_TBB AND NOT TARGET TBB::tbb)
@@ -11,7 +11,58 @@ index 7bb3ab86..9311ed17 100644
  endif()
  
  if(NANOVDB_USE_ZLIB AND NOT TARGET ZLIB::ZLIB)
-@@ -236,7 +236,7 @@ if(NANOVDB_USE_TBB)
+@@ -169,17 +169,6 @@ set(NANOVDB_INCLUDE_UTILFILES
+   util/CpuTimer.h
+   util/CreateNanoGrid.h
+   util/CSampleFromVoxels.h
+-  util/cuda/CudaAddBlindData.cuh
+-  util/cuda/CudaDeviceBuffer.h
+-  util/cuda/CudaGridChecksum.cuh
+-  util/cuda/CudaGridHandle.cuh
+-  util/cuda/CudaGridStats.cuh
+-  util/cuda/CudaIndexToGrid.cuh
+-  util/cuda/CudaNodeManager.cuh
+-  util/cuda/CudaPointsToGrid.cuh
+-  util/cuda/CudaSignedFloodFill.cuh
+-  util/cuda/CudaUtils.h
+-  util/cuda/GpuTimer.h
+   util/DitherLUT.h
+   util/ForEach.h
+   util/GridBuilder.h
+@@ -203,6 +192,20 @@ set(NANOVDB_INCLUDE_UTILFILES
+   util/Stencils.h
+ )
+ 
++set(NANOVDB_INCLUDE_UTILCUDAFILES
++  util/cuda/CudaAddBlindData.cuh
++  util/cuda/CudaDeviceBuffer.h
++  util/cuda/CudaGridChecksum.cuh
++  util/cuda/CudaGridHandle.cuh
++  util/cuda/CudaGridStats.cuh
++  util/cuda/CudaIndexToGrid.cuh
++  util/cuda/CudaNodeManager.cuh
++  util/cuda/CudaPointsToGrid.cuh
++  util/cuda/CudaSignedFloodFill.cuh
++  util/cuda/CudaUtils.h
++  util/cuda/GpuTimer.h
++)
++
+ add_library(nanovdb INTERFACE)
+ target_include_directories(nanovdb INTERFACE ../)
+ target_compile_options(nanovdb INTERFACE
+@@ -268,9 +271,11 @@ endif()
+ 
+ set(NANOVDB_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/nanovdb)
+ set(NANOVDB_INSTALL_UTILDIR ${NANOVDB_INSTALL_INCLUDEDIR}/util)
++set(NANOVDB_INSTALL_UTILCUDADIR ${NANOVDB_INSTALL_UTILDIR}/cuda)
+ 
+ install(FILES ${NANOVDB_INCLUDE_FILES} DESTINATION ${NANOVDB_INSTALL_INCLUDEDIR})
+ install(FILES ${NANOVDB_INCLUDE_UTILFILES} DESTINATION ${NANOVDB_INSTALL_UTILDIR})
++install(FILES ${NANOVDB_INCLUDE_UTILCUDAFILES} DESTINATION ${NANOVDB_INSTALL_UTILCUDADIR})
+ 
+ ###############################################################################
+ # Options
+@@ -236,7 +239,7 @@ if(NANOVDB_USE_TBB)
  endif()
  
  if(NANOVDB_USE_BLOSC)

--- a/ports/openvdb/vcpkg.json
+++ b/ports/openvdb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openvdb",
   "version": "11.0.0",
+  "port-version": 1,
   "description": "Sparse volume data structure and tools",
   "homepage": "https://github.com/dreamworksanimation/openvdb",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6714,7 +6714,7 @@
     },
     "openvdb": {
       "baseline": "11.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openvino": {
       "baseline": "2024.3.0",

--- a/versions/o-/openvdb.json
+++ b/versions/o-/openvdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3113d160824650fa6aea8d6791d819c99c0c897",
+      "version": "11.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6997652c81d0f91033cb3cce2bf6e55674725400",
       "version": "11.0.0",
       "port-version": 0


### PR DESCRIPTION
The scope of this PR is to fix nanovdb compiled with CUDA.

The issue is that the following lines of code are evaluated when compiling with nvcc:

https://github.com/AcademySoftwareFoundation/openvdb/blob/6c044e628a1ac3546eed48b6f5e9c76dfaa2143e/nanovdb/nanovdb/util/GridHandle.h#L492

But the `util/cuda/` directory wasn't correctly installed (all files went under the `util` directory).
Therefore the compiler was unable to find `util/cuda/` files.

The issue is a openvdb `v11.0.0` issue (latest stable version?), I'm not sure if persists in the upstream. See:

https://github.com/AcademySoftwareFoundation/openvdb/blob/6c044e628a1ac3546eed48b6f5e9c76dfaa2143e/nanovdb/nanovdb/CMakeLists.txt#L273

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [ ] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

<!-- END OF PORT UPDATE CHECKLIST (delete this line) -->

