### PR TITLE
[llhttp] update to 9.2.1

### DIFF
--- a/ports/llhttp/portfile.cmake
+++ b/ports/llhttp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nodejs/llhttp
     REF refs/tags/release/v${VERSION}
-    SHA512 563a97301cc07ef8d64ee52572faaa705de0daf1bb428651ada0f22ea0bf7cc617c31883734d8786599c0eff223edfe637739169ee31da5b10f49db8c3ca6ed7
+    SHA512 7e6f5427b4b6d778ecefff892db78894ef4fd22a79e9c1f2c24d38d603d885755bdc8b0e8202b47c8bc209d3caf45a7293214617390a7a9c33bffbaab59fe5da
     PATCHES
         fix-usage.patch
 )

--- a/ports/llhttp/vcpkg.json
+++ b/ports/llhttp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "llhttp",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Port of http_parser to llparse.",
   "homepage": "https://github.com/nodejs/llhttp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5501,7 +5501,7 @@
       "port-version": 0
     },
     "llhttp": {
-      "baseline": "9.2.0",
+      "baseline": "9.2.1",
       "port-version": 0
     },
     "llnl-units": {

--- a/versions/l-/llhttp.json
+++ b/versions/l-/llhttp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d59b0801cd7dd4850fee67f24ae329c72db84458",
+      "version": "9.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "563107afde7d8885774875d0adcbdaaf06798f7e",
       "version": "9.2.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

