### PR TITLE
[live555] Update to version 2024.09.20

### DIFF
--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://live555.com/liveMedia/public/live.2024.06.26.tar.gz"
-    FILENAME "live.2024.06.26.tar.gz"
-    SHA512 ece875ed82bb122bb2fb237a5d83b4ae16a2fed0cd3e6c5477a16558545d59898a2acf75293f11c0adf1f57453443e969e22c482ec241e45a61f9048e53c7b44
+    URLS "http://live555.com/liveMedia/public/live.2024.09.20.tar.gz"
+    FILENAME "live.2024.09.20.tar.gz"
+    SHA512 3ae1b08a4675435ed66b37cc63bddefe074c917e32a2b745a8013d80f1921de7a706cd0d7834e26ff7d531a14d5de7757ccc5e3e437275c91b54ed9c39facb24
 )
 
 vcpkg_extract_source_archive(

--- a/ports/live555/vcpkg.json
+++ b/ports/live555/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "live555",
-  "version-date": "2024-06-26",
+  "version-date": "2024-09-20",
   "description": "A complete RTSP server application",
   "homepage": "http://www.live555.com/liveMedia",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5485,7 +5485,7 @@
       "port-version": 0
     },
     "live555": {
-      "baseline": "2024-06-26",
+      "baseline": "2024-09-20",
       "port-version": 0
     },
     "llfio": {

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82d646c91df429a3a9825eb99822a4e475a8ff33",
+      "version-date": "2024-09-20",
+      "port-version": 0
+    },
+    {
       "git-tree": "3d2da6e5375448975a15bc611704a5d4f3614905",
       "version-date": "2024-06-26",
       "port-version": 0


### PR DESCRIPTION
I tried `vcpkg.exe install live555:x64-windows` and it works fine.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.