### PR TITLE
[wcdb-sqlcipher] add new port `wcdb-sqlcipher` which maintained by WeChat team

### DIFF
--- a/ports/wcdb-sqlcipher/portfile.cmake
+++ b/ports/wcdb-sqlcipher/portfile.cmake
@@ -1,0 +1,22 @@
+#if(EXISTS "${CURRENT_INSTALLED_DIR}/share/libressl/copyright"
+#    OR EXISTS "${CURRENT_INSTALLED_DIR}/share/boringssl/copyright")
+#    message(FATAL_ERROR "Can't build openssl if libressl/boringssl is installed. Please remove libressl/boringssl, and try install openssl again if you need it.")
+#endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO RightFS/sqlcipher
+    REF 85adde3392c8474dcbb32ce628834886c9a1efcf
+    HEAD_REF wcdb
+    SHA512 bcfc8a1d1abe2e71384a165ac35236b83edcb8dcbc11da081cc7eabd1a07b46b857b15d5e13ae63b46416aade5efb97689cafce0bf5d8ebd644e989fbb16554e
+)
+
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "sqlcipher")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/wcdb-sqlcipher/portfile.cmake
+++ b/ports/wcdb-sqlcipher/portfile.cmake
@@ -6,9 +6,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RightFS/sqlcipher
-    REF 85adde3392c8474dcbb32ce628834886c9a1efcf
+    REF 5f7ef74d1b0134ec505e8341eabcf62170347b68
     HEAD_REF wcdb
-    SHA512 bcfc8a1d1abe2e71384a165ac35236b83edcb8dcbc11da081cc7eabd1a07b46b857b15d5e13ae63b46416aade5efb97689cafce0bf5d8ebd644e989fbb16554e
+    SHA512 ddd883c48a65873f8160518c932ee21e71c8876972aa708e234bb951b4687d5f96b6cd9b2daf565676af0db91dae3d379269780880d89e52008f81026c077e5a
 )
 
 vcpkg_cmake_configure(

--- a/ports/wcdb-sqlcipher/usage
+++ b/ports/wcdb-sqlcipher/usage
@@ -1,0 +1,5 @@
+sqlcipher is compatible with built-in CMake targets:
+
+  find_package(sqlcipher REQUIRED)
+  target_link_libraries(main PRIVATE sqlcipher::sqlcipher)
+

--- a/ports/wcdb-sqlcipher/vcpkg.json
+++ b/ports/wcdb-sqlcipher/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "wcdb-sqlcipher",
+  "version-string": "1.4.6",
+  "builtin-baseline": "509f71e53f45e46c13fa7935d2f6a45803580c07",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
+    {
+      "name": "openssl",
+      "version>=": "3.3.2#1"
+    }
+  ]
+}

--- a/ports/wcdb-sqlcipher/vcpkg.json
+++ b/ports/wcdb-sqlcipher/vcpkg.json
@@ -2,6 +2,9 @@
   "name": "wcdb-sqlcipher",
   "version": "1.4.6",
   "builtin-baseline": "509f71e53f45e46c13fa7935d2f6a45803580c07",
+  "description": "The sqlcipher whitch is maintained by WeChat team. The repo in homepage is just a wrap for vcpkg",
+  "homepage": "https://github.com/RightFS/sqlcipher",
+  "license": "BSD 3-Clause License",
   "dependencies": [
     {
       "name": "openssl",

--- a/ports/wcdb-sqlcipher/vcpkg.json
+++ b/ports/wcdb-sqlcipher/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wcdb-sqlcipher",
   "version": "1.4.6",
-  "description": "The sqlcipher whitch is maintained by WeChat team. The repo in homepage is just a wrap for vcpkg",
+  "description": "The sqlcipher which is maintained by WeChat team. The repo in homepage is just a wrap for vcpkg",
   "homepage": "https://github.com/RightFS/sqlcipher",
   "license": "BSD-3-Clause",
   "builtin-baseline": "509f71e53f45e46c13fa7935d2f6a45803580c07",

--- a/ports/wcdb-sqlcipher/vcpkg.json
+++ b/ports/wcdb-sqlcipher/vcpkg.json
@@ -1,8 +1,12 @@
 {
   "name": "wcdb-sqlcipher",
-  "version-string": "1.4.6",
+  "version": "1.4.6",
   "builtin-baseline": "509f71e53f45e46c13fa7935d2f6a45803580c07",
   "dependencies": [
+    {
+      "name": "openssl",
+      "version>=": "3.3.2#1"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -14,10 +18,6 @@
     {
       "name": "vcpkg-cmake-get-vars",
       "host": true
-    },
-    {
-      "name": "openssl",
-      "version>=": "3.3.2#1"
     }
   ]
 }

--- a/ports/wcdb-sqlcipher/vcpkg.json
+++ b/ports/wcdb-sqlcipher/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "wcdb-sqlcipher",
   "version": "1.4.6",
-  "builtin-baseline": "509f71e53f45e46c13fa7935d2f6a45803580c07",
   "description": "The sqlcipher whitch is maintained by WeChat team. The repo in homepage is just a wrap for vcpkg",
   "homepage": "https://github.com/RightFS/sqlcipher",
-  "license": "BSD 3-Clause License",
+  "license": "BSD-3-Clause",
+  "builtin-baseline": "509f71e53f45e46c13fa7935d2f6a45803580c07",
   "dependencies": [
     {
       "name": "openssl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9512,6 +9512,10 @@
       "baseline": "1.31",
       "port-version": 1
     },
+    "wcdb-sqlcipher": {
+      "baseline": "1.4.6",
+      "port-version": 0
+    },
     "wcslib": {
       "baseline": "8.2.1",
       "port-version": 0

--- a/versions/w-/wcdb-sqlcipher.json
+++ b/versions/w-/wcdb-sqlcipher.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b819c115a71fc591ffe5b6708f417d98fa3a9514",
+      "version": "1.4.6",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/w-/wcdb-sqlcipher.json
+++ b/versions/w-/wcdb-sqlcipher.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "01c3779eee344d460db93959978b9434ddcde876",
+      "git-tree": "01247e29c67beebc3fa19be3e8d691e4c685ecf2",
       "version": "1.4.6",
       "port-version": 0
     }

--- a/versions/w-/wcdb-sqlcipher.json
+++ b/versions/w-/wcdb-sqlcipher.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b819c115a71fc591ffe5b6708f417d98fa3a9514",
+      "git-tree": "01c3779eee344d460db93959978b9434ddcde876",
       "version": "1.4.6",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


tested on Windows/MacOS/iOS/Android,

I will create a new pr for the WCDB which a multifunctional library based on sqlcipher