### PR TITLE
[libtommath] update to 1.3.0

### DIFF
--- a/ports/libtommath/portfile.cmake
+++ b/ports/libtommath/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libtom/libtommath
     REF "v${VERSION}"
-    SHA512 8da4a935913e8a44a24ba7d8c2bc4926398bdc9aea0cd4975418771979c2b7667c2ee04e8a7e38f04cc87abe5bb369fcbf9167ab662ad747602fc840cb3788e6
+    SHA512 3dbd7053a670afa563a069a9785f1aa4cab14a210bcd05d8fc7db25bd3dcce36b10a3f4f54ca92d75a694f891226f01bdf6ac15bacafeb93a8be6b04c579beb3
     HEAD_REF develop
 )
 

--- a/ports/libtommath/vcpkg.json
+++ b/ports/libtommath/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtommath",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "LibTomMath is a free open source portable number theoretic multiple-precision integer library written entirely in C.",
   "homepage": "https://www.libtom.net/LibTomMath/"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5165,7 +5165,7 @@
       "port-version": 3
     },
     "libtommath": {
-      "baseline": "1.2.1",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "libtorch": {

--- a/versions/l-/libtommath.json
+++ b/versions/l-/libtommath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2fd65dd0d956f575d8333a0b35ef08c3bc9bcbcd",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cc02d14942e13f536bc7d8d08d9af160f8bbd387",
       "version": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

