### PR TITLE
 [libvmaf] New port 

### DIFF
--- a/ports/libvmaf/android-off_t.patch
+++ b/ports/libvmaf/android-off_t.patch
@@ -1,0 +1,16 @@
+--- a/libvmaf/src/meson.build
++++ b/libvmaf/src/meson.build
+@@ -13,6 +13,13 @@ if cc.get_id() != 'msvc'
+         '-pedantic',
+         '-DOC_NEW_STYLE_INCLUDES',
+     ]
++    # If the target is Android, define _LIBCPP_HAS_NO_OFF_T_FUNCTIONS unconditionally
++    # to work around the fact that meson always defines _FILE_OFFSET_BITS=64, which
++    # causes issues for API levels below 24 in 32-bit architectures.
++    # See https://github.com/mesonbuild/meson/issues/3049 for more details.
++    if target_machine.system() == 'android'
++        vmaf_cflags_common += '-D_LIBCPP_HAS_NO_OFF_T_FUNCTIONS'
++    endif
+ else
+     vmaf_cflags_common = [
+       '-wd4028', # parameter different from declaration

--- a/ports/libvmaf/no-tools.patch
+++ b/ports/libvmaf/no-tools.patch
@@ -1,0 +1,10 @@
+Skip tools subdir in libvmaf to build only the library.
+--- a/libvmaf/meson.build
++++ b/libvmaf/meson.build
+@@ -51,6 +51,5 @@ endif
+ 
+ subdir('include')
+ subdir('src')
+-subdir('tools')
+ subdir('doc')
+ subdir('test')

--- a/ports/libvmaf/portfile.cmake
+++ b/ports/libvmaf/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         no-tools.patch
+        android-off_t.patch
 )
 
 vcpkg_find_acquire_program(NASM)

--- a/ports/libvmaf/portfile.cmake
+++ b/ports/libvmaf/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Netflix/vmaf
+    REF "v${VERSION}"
+    SHA512 9e356bb274ce7d5d85a64d2a1a122ea9d267809edd83bb6e663fb348a1a46355882eb9044982bf679f03df7f93c6f66c9b0d9a94661979b2c722db30b21c4f32
+    HEAD_REF master
+    PATCHES
+        no-tools.patch
+)
+
+vcpkg_find_acquire_program(NASM)
+get_filename_component(NASM_PATH "${NASM}" DIRECTORY)
+vcpkg_add_to_path("${NASM_PATH}")
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}/libvmaf"
+    OPTIONS
+        -Denable_tests=false
+        -Denable_docs=false
+)
+
+vcpkg_install_meson()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libvmaf/vcpkg.json
+++ b/ports/libvmaf/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "libvmaf is a library developed by Netflix to compute the VMAF (Video Multi-Method Assessment Fusion) metric.",
   "homepage": "https://github.com/Netflix/vmaf",
   "license": "BSD-2-Clause-Patent",
-  "supports": "!windows",
+  "supports": "!windows & !android & !ios",
   "dependencies": [
     {
       "name": "vcpkg-tool-meson",

--- a/ports/libvmaf/vcpkg.json
+++ b/ports/libvmaf/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "libvmaf",
+  "version": "3.0.0",
+  "port-version": 1,
+  "description": "libvmaf is a library developed by Netflix to compute the VMAF (Video Multi-Method Assessment Fusion) metric.",
+  "homepage": "https://github.com/Netflix/vmaf",
+  "license": "BSD-2-Clause-Patent",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/ports/libvmaf/vcpkg.json
+++ b/ports/libvmaf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libvmaf",
   "version": "3.0.0",
-  "port-version": 1,
   "description": "libvmaf is a library developed by Netflix to compute the VMAF (Video Multi-Method Assessment Fusion) metric.",
   "homepage": "https://github.com/Netflix/vmaf",
   "license": "BSD-2-Clause-Patent",

--- a/ports/libvmaf/vcpkg.json
+++ b/ports/libvmaf/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "libvmaf is a library developed by Netflix to compute the VMAF (Video Multi-Method Assessment Fusion) metric.",
   "homepage": "https://github.com/Netflix/vmaf",
   "license": "BSD-2-Clause-Patent",
-  "supports": "!windows & !android & !ios",
+  "supports": "!windows",
   "dependencies": [
     {
       "name": "vcpkg-tool-meson",

--- a/ports/libvmaf/vcpkg.json
+++ b/ports/libvmaf/vcpkg.json
@@ -5,6 +5,7 @@
   "description": "libvmaf is a library developed by Netflix to compute the VMAF (Video Multi-Method Assessment Fusion) metric.",
   "homepage": "https://github.com/Netflix/vmaf",
   "license": "BSD-2-Clause-Patent",
+  "supports": "!windows",
   "dependencies": [
     {
       "name": "vcpkg-tool-meson",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5260,6 +5260,10 @@
       "baseline": "20231127",
       "port-version": 0
     },
+    "libvmaf": {
+      "baseline": "3.0.0",
+      "port-version": 1
+    },
     "libvmdk": {
       "baseline": "20221124",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5262,7 +5262,7 @@
     },
     "libvmaf": {
       "baseline": "3.0.0",
-      "port-version": 1
+      "port-version": 0
     },
     "libvmdk": {
       "baseline": "20221124",

--- a/versions/l-/libvmaf.json
+++ b/versions/l-/libvmaf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0dd987af51a76e8b775c3e73dbb38f21a4d69b65",
+      "version": "3.0.0",
+      "port-version": 1
+    }
+  ]
+}

--- a/versions/l-/libvmaf.json
+++ b/versions/l-/libvmaf.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "0dd987af51a76e8b775c3e73dbb38f21a4d69b65",
+      "git-tree": "180c069c610bb347936a6fe1e3d11374bd6ad8c2",
       "version": "3.0.0",
-      "port-version": 1
+      "port-version": 0
     }
   ]
 }

--- a/versions/l-/libvmaf.json
+++ b/versions/l-/libvmaf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "180c069c610bb347936a6fe1e3d11374bd6ad8c2",
+      "git-tree": "01baad74661c761572624fd0eed900ee6fc7b2eb",
       "version": "3.0.0",
       "port-version": 0
     }


### PR DESCRIPTION
Fixes #41129.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

