### PR TITLE
[cmark] update to 0.31.1

### DIFF
--- a/ports/cmark/portfile.cmake
+++ b/ports/cmark/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO commonmark/cmark
     REF "${VERSION}"
-    SHA512 27383bfef95ae1390c26aff0dd2cbca33704e7d20116bf29da4695d2c9a4146b86daba0da1e91bdb9eab95671702f885e832b3d31d51601731f1dc630df5237b
+    SHA512 3b4f8b47d8ea270078ab986aa22fc32b227786459bd33c7225aac578d8dd014e3d8788a6add60ea10571fdb4c7dc6a1ece960815a02f04f153b1775c73ccff8f
     HEAD_REF master
     PATCHES
         add-feature-tools.patch

--- a/ports/cmark/vcpkg.json
+++ b/ports/cmark/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cmark",
-  "version-semver": "0.30.3",
+  "version-semver": "0.31.1",
   "description": "CommonMark parsing and rendering library",
   "homepage": "https://github.com/commonmark/cmark",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1741,7 +1741,7 @@
       "port-version": 0
     },
     "cmark": {
-      "baseline": "0.30.3",
+      "baseline": "0.31.1",
       "port-version": 0
     },
     "cminpack": {

--- a/versions/c-/cmark.json
+++ b/versions/c-/cmark.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "debb1ab539f70b9e03f86cb4300e1342751ed5cd",
+      "version-semver": "0.31.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "46de0e92eb13e52bb044f1d925a477483fe23c80",
       "version-semver": "0.30.3",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

