### PR TITLE
[discount] update to 3.0.0d

### DIFF
--- a/ports/discount/portfile.cmake
+++ b/ports/discount/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Orc/discount
     REF "v${VERSION}"
-    SHA512 d86bfc6d3e11131622046418a1f54bd9dfa5f1233e510189cd2c89dc857da31e88ffbe6670cc506ca8b9763e8fb74ed215f1018f83e25767c77acb8a7c296b8a
+    SHA512 ab24722bb8513f64eed59bb2770276b91615033b494a0492a331f36c5fcd2e32b7a9f3bd7ef0bb74c107f1e0e955522c83ddba6c482fca7f18cf275334707c4d
     HEAD_REF master
     PATCHES
       generate-blocktags-command.patch

--- a/ports/discount/vcpkg.json
+++ b/ports/discount/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "discount",
-  "version-string": "3.0.0a",
+  "version-string": "3.0.0d",
   "description": "DISCOUNT is a implementation of John Gruber & Aaron Swartz's Markdown markup language.",
   "homepage": "https://github.com/Orc/discount",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2333,7 +2333,7 @@
       "port-version": 0
     },
     "discount": {
-      "baseline": "3.0.0a",
+      "baseline": "3.0.0d",
       "port-version": 0
     },
     "discreture": {

--- a/versions/d-/discount.json
+++ b/versions/d-/discount.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2535603f8d96c4d723dc1a90425e6e4004a40115",
+      "version-string": "3.0.0d",
+      "port-version": 0
+    },
+    {
       "git-tree": "0964d0b7e61494ef8a5c81def6fe5070b3d60d4f",
       "version-string": "3.0.0a",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

