### PR TITLE
[cmark] Update to 0.31.1

### DIFF
--- a/ports/cmark/add-feature-tools.patch
+++ b/ports/cmark/add-feature-tools.patch
@@ -1,41 +1,23 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 3a78d0b..7065c89 100644
+index 523b2cb..fac823e 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -52,6 +52,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmark_version.h.in
- include(GNUInstallDirs)
- include (GenerateExportHeader)
+@@ -51,6 +51,7 @@ generate_export_header(cmark
+ # path for OSS Fuzz.
+ add_custom_target(cmark_static DEPENDS cmark)
  
 +if (BUILD_TOOLS)
- add_executable(${PROGRAM} ${PROGRAM_SOURCES})
- cmark_add_compile_options(${PROGRAM})
- set_target_properties(${PROGRAM} PROPERTIES
-@@ -65,6 +66,7 @@ if (CMARK_STATIC)
- elseif (CMARK_SHARED)
-   target_link_libraries(${PROGRAM} ${LIBRARY})
- endif()
+ add_executable(cmark_exe
+   main.c)
+ cmark_add_compile_options(cmark_exe)
+@@ -59,14 +60,22 @@ set_target_properties(cmark_exe PROPERTIES
+   INSTALL_RPATH "${Base_rpath}")
+ target_link_libraries(cmark_exe PRIVATE
+   cmark)
 +endif()
  
- # -fvisibility=hidden
- set(CMAKE_C_VISIBILITY_PRESET hidden)
-@@ -114,23 +116,30 @@ if (CMARK_STATIC)
-   list(APPEND CMARK_INSTALL ${STATICLIBRARY})
- endif()
- 
--if (MSVC)
-+if (MSVC AND BUILD_TOOLS)
-   set_property(TARGET ${PROGRAM}
-     APPEND PROPERTY LINK_FLAGS /INCREMENTAL:NO)
--endif(MSVC)
-+endif(MSVC AND BUILD_TOOLS)
- 
- if(NOT MSVC OR CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
-   set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
-   include(InstallRequiredSystemLibraries)
- endif()
- 
--install(TARGETS ${PROGRAM} ${CMARK_INSTALL}
-+install(TARGETS ${CMARK_INSTALL}
+-install(TARGETS cmark_exe cmark
++install(TARGETS cmark
    EXPORT cmark-targets
    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -43,12 +25,12 @@ index 3a78d0b..7065c89 100644
    )
  
 +if (BUILD_TOOLS)
-+    install(TARGETS ${PROGRAM}
++    install(TARGETS cmark_exe
 +        EXPORT cmark-targets
 +        RUNTIME DESTINATION tools/cmark
 +    )
 +endif()
 +
- if(CMARK_SHARED OR CMARK_STATIC)
-   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libcmark.pc.in
-     ${CMAKE_CURRENT_BINARY_DIR}/libcmark.pc @ONLY)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libcmark.pc
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ 

--- a/ports/cmark/portfile.cmake
+++ b/ports/cmark/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO commonmark/cmark
     REF "${VERSION}"
-    SHA512 27383bfef95ae1390c26aff0dd2cbca33704e7d20116bf29da4695d2c9a4146b86daba0da1e91bdb9eab95671702f885e832b3d31d51601731f1dc630df5237b
+    SHA512 3b4f8b47d8ea270078ab986aa22fc32b227786459bd33c7225aac578d8dd014e3d8788a6add60ea10571fdb4c7dc6a1ece960815a02f04f153b1775c73ccff8f
     HEAD_REF master
     PATCHES
         add-feature-tools.patch
@@ -20,7 +20,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         ${FEATURE_OPTIONS}
-        -DCMARK_TESTS=OFF
+        -DBUILD_TESTING=OFF
         -DCMARK_SHARED=${CMARK_SHARED}
         -DCMARK_STATIC=${CMARK_STATIC}
 )
@@ -41,4 +41,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/cmark/vcpkg.json
+++ b/ports/cmark/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "cmark",
-  "version-semver": "0.30.3",
+  "version-semver": "0.31.1",
   "description": "CommonMark parsing and rendering library",
   "homepage": "https://github.com/commonmark/cmark",
+  "license": "BSD-2-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1741,7 +1741,7 @@
       "port-version": 0
     },
     "cmark": {
-      "baseline": "0.30.3",
+      "baseline": "0.31.1",
       "port-version": 0
     },
     "cminpack": {

--- a/versions/c-/cmark.json
+++ b/versions/c-/cmark.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "159e4cc034614fb2158e373eb2d992a4fa29a343",
+      "version-semver": "0.31.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "46de0e92eb13e52bb044f1d925a477483fe23c80",
       "version-semver": "0.30.3",
       "port-version": 0


### PR DESCRIPTION
Update `cmark` to 0.31.1.
Feature `tools` passed on `x64-windows`.
The following usage test passed on `x64-windows`.
```
cmark provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(cmark CONFIG REQUIRED)
  target_link_libraries(main PRIVATE cmark::cmark)

cmark provides pkg-config modules:

  # CommonMark parsing, rendering, and manipulation
  libcmark
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
