### PR TITLE
[libyuv] Fix build error on macOS with llvm 19

### DIFF
--- a/ports/libyuv/cmake.diff
+++ b/ports/libyuv/cmake.diff
@@ -41,9 +41,9 @@ index 9a20941d..d161326c 100644
  
  
  # install the conversion tool, .so, .a, and all the header files
--install ( PROGRAMS ${CMAKE_BINARY_DIR}/yuvconvert			DESTINATION bin )
+-install ( TARGETS yuvconvert	DESTINATION bin )
 -install ( TARGETS ${ly_lib_static}						DESTINATION lib )
--install ( TARGETS ${ly_lib_shared} LIBRARY				DESTINATION lib RUNTIME DESTINATION bin )
+-install ( TARGETS ${ly_lib_shared} LIBRARY	DESTINATION lib RUNTIME DESTINATION bin ARCHIVE DESTINATION lib )
 +if (BUILD_TOOLS)
 +  install(TARGETS yuvconvert yuvconstants)
 +endif()

--- a/ports/libyuv/portfile.cmake
+++ b/ports/libyuv/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://chromium.googlesource.com/libyuv/libyuv
-    REF c21dda06dd8d19b6e50168c28c324c1f32e94407 # 6 commits after switch to 1895, reason: CMake changes
+    REF a37e6bc81b52d39cdcfd0f1428f5d6c2b2bc9861 # 1896 Fixes build error on macOS Homebrew LLVM 19
     # Check https://chromium.googlesource.com/libyuv/libyuv/+/refs/heads/main/include/libyuv/version.h for a version!
     PATCHES
         cmake.diff

--- a/ports/libyuv/vcpkg.json
+++ b/ports/libyuv/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libyuv",
-  "version": "1895",
+  "version": "1896",
   "port-version": 1,
   "description": "libyuv is an open source project that includes YUV scaling and conversion functionality",
   "homepage": "https://chromium.googlesource.com/libyuv/libyuv",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5441,7 +5441,7 @@
       "port-version": 5
     },
     "libyuv": {
-      "baseline": "1895",
+      "baseline": "1896",
       "port-version": 1
     },
     "libzen": {

--- a/versions/l-/libyuv.json
+++ b/versions/l-/libyuv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb6412fd44057b52849ebf8807a0c339cb525104",
+      "version": "1896",
+      "port-version": 1
+    },
+    {
       "git-tree": "9a0250bfbce25cfd98ed744db8528d4214fe3d56",
       "version": "1895",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

LLVM clang causes an undefined symbol error after updating to llvm 19 when building Ladybird.