### PR TITLE
[iir1] Update to 1.9.5

### DIFF
--- a/ports/iir1/portfile.cmake
+++ b/ports/iir1/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO berndporr/iir1
     REF "${VERSION}"
-    SHA512 e69b79ba48aa5d5ec2ddb0a31461ac4c15b0489df80fddc1f1f8adc143726fa189dc0dd94a0ed2bb7aa73712f953e27b345a762120ab2d10f54f57a868f0ea42
+    SHA512 2b0658a621cdfb57796cf2fea5411975b442af4af267bce2f613ae53f43572f208fdea59d7ea0178e9984e311c406f289166789aa423505ac8ed2b889ddc9f64
     HEAD_REF master
     PATCHES
         fix-shared-lib.patch

--- a/ports/iir1/vcpkg.json
+++ b/ports/iir1/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "iir1",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Realtime C++ filter library",
   "homepage": "https://github.com/berndporr/iir1",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3649,7 +3649,7 @@
       "port-version": 0
     },
     "iir1": {
-      "baseline": "1.9.4",
+      "baseline": "1.9.5",
       "port-version": 0
     },
     "ijg-libjpeg": {

--- a/versions/i-/iir1.json
+++ b/versions/i-/iir1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6badd4b5988c56b5188d865a2f31d5d225e38d9f",
+      "version": "1.9.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "a2d76abe2dc41ff907a66db3a54a510edc322d2d",
       "version": "1.9.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

