### PR TITLE
Libcred

### DIFF
--- a/ports/libcred/portfile.cmake
+++ b/ports/libcred/portfile.cmake
@@ -6,10 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-  SOURCE_PATH "${SOURCE_PATH}"
-  PREFER_NINJA
-)
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_cmake_install()
 
-vcpkg_install_cmake()
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libcred" RENAME copyright)

--- a/ports/libcred/portfile.cmake
+++ b/ports/libcred/portfile.cmake
@@ -10,3 +10,5 @@ vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libcred" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/libcred" RENAME copyright)
+vcpkg_cmake_config_fixup()

--- a/ports/libcred/portfile.cmake
+++ b/ports/libcred/portfile.cmake
@@ -1,0 +1,15 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Shadowrom2020/libcred
+    REF baca5ae1f19d644ccb3b994f0a6530290cbb2fb2 #v0.1.0
+    SHA512 d63a51a790e3888f01efa9185e52f02ac0b49a14b15a75815b571216f1f7e825ae0e175dff41f0997595f7cbe6c6e76dc6ed357ddd58f58dc07531aba0404b05
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+  SOURCE_PATH "${SOURCE_PATH}"
+  PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libcred" RENAME copyright)

--- a/ports/libcred/vcpkg.json
+++ b/ports/libcred/vcpkg.json
@@ -2,5 +2,16 @@
   "name": "libcred",
   "version": "0.1.0",
   "description": "a cross-platform credentials helper library",
-  "homepage": "https://github.com/mamba-org/libcred"
+  "homepage": "https://github.com/mamba-org/libcred",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/libcred/vcpkg.json
+++ b/ports/libcred/vcpkg.json
@@ -1,6 +1,6 @@
 {
-    "name": "libcred",
-    "version-string": "0.1.0",
-    "homepage": "https://github.com/mamba-org/libcred",
-    "description": "a cross-platform credentials helper library"
-  }
+  "name": "libcred",
+  "version": "0.1.0",
+  "description": "a cross-platform credentials helper library",
+  "homepage": "https://github.com/mamba-org/libcred"
+}

--- a/ports/libcred/vcpkg.json
+++ b/ports/libcred/vcpkg.json
@@ -1,0 +1,6 @@
+{
+    "name": "libcred",
+    "version-string": "0.1.0",
+    "homepage": "https://github.com/mamba-org/libcred",
+    "description": "a cross-platform credentials helper library"
+  }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4372,6 +4372,10 @@
       "baseline": "1.0",
       "port-version": 2
     },
+    "libcred": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "libcroco": {
       "baseline": "0.6.13",
       "port-version": 7

--- a/versions/l-/libcred.json
+++ b/versions/l-/libcred.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f4c28062ff6d9065128bfbf83f239f732d78497",
+      "git-tree": "738cbf11dec1e10b12466cbe9abbf384cb07ea9b",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/l-/libcred.json
+++ b/versions/l-/libcred.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "388b65179a055f54b99ecf9e600eaaaceb470cf9",
+      "git-tree": "2f4c28062ff6d9065128bfbf83f239f732d78497",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/l-/libcred.json
+++ b/versions/l-/libcred.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "388b65179a055f54b99ecf9e600eaaaceb470cf9",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
