### PR TITLE
[flecs] Update to 4.0.2

### DIFF
--- a/ports/flecs/portfile.cmake
+++ b/ports/flecs/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SanderMertens/flecs
     REF "v${VERSION}"
-    SHA512 9c8db31ae1925e3765d5948aa8870f5c2995bd6500f61dcee294b2ff9424fbb487059afe5bbc8efdbd34a9ed2ca31bc1ae8dc90f59faf6f24eaf0c68bab21e72
+    SHA512 a9d2c2b78a6f145163f6cd5ed9b26adf90c0d529cd9f62fb20c8eae48974a6866945f022b69f1d34b9cf0c6255e30770096de34a9691ad8355d6c2b596e36262
     HEAD_REF master
 )
 

--- a/ports/flecs/vcpkg.json
+++ b/ports/flecs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "flecs",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A fast entity component system (ECS) for C & C++",
   "homepage": "https://github.com/SanderMertens/flecs",
   "documentation": "https://www.flecs.dev/flecs/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2805,7 +2805,7 @@
       "port-version": 0
     },
     "flecs": {
-      "baseline": "4.0.1",
+      "baseline": "4.0.2",
       "port-version": 0
     },
     "flint": {

--- a/versions/f-/flecs.json
+++ b/versions/f-/flecs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "db6c6ba0ca94df28206e66bc8a06938a691b66e5",
+      "version": "4.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "81eb57cc956e2c094e86b32d874e2ab3a003eb41",
       "version": "4.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
