### PR TITLE
[luafilesystem] Fixes header file lfs.h not found

### DIFF
--- a/ports/luafilesystem/CMakeLists.txt
+++ b/ports/luafilesystem/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(lfs src/lfs.h src/lfs.c src/lfs.def)
 
 target_include_directories(lfs PRIVATE ${LFS_INCLUDES})
 target_link_libraries(lfs PRIVATE ${LFS_LIBRARIES})
+target_include_directories(lfs INTERFACE $<INSTALL_INTERFACE:include/luafilesystem>) 
 
 install(TARGETS lfs
     EXPORT "unofficial-${PROJECT_NAME}-targets"
@@ -31,6 +32,8 @@ write_basic_package_version_file(
   VERSION       "${LFS_VERSION}"
   COMPATIBILITY SameMajorVersion
 )
+
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/lfs.h" DESTINATION "include/luafilesystem")
 
 install(
   FILES "${CMAKE_CURRENT_BINARY_DIR}/unofficial-${PROJECT_NAME}-config.cmake"

--- a/ports/luafilesystem/portfile.cmake
+++ b/ports/luafilesystem/portfile.cmake
@@ -29,8 +29,5 @@ file(REMOVE_RECURSE
 )
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
-# Allow empty include directory
-set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)

--- a/ports/luafilesystem/vcpkg.json
+++ b/ports/luafilesystem/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "luafilesystem",
   "version": "1.8.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "LuaFileSystem is a Lua library developed to complement the set of functions related to file systems offered by the standard Lua distribution.",
   "homepage": "https://github.com/keplerproject/luafilesystem",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5602,7 +5602,7 @@
     },
     "luafilesystem": {
       "baseline": "1.8.0",
-      "port-version": 6
+      "port-version": 7
     },
     "luajit": {
       "baseline": "2023-01-04",

--- a/versions/l-/luafilesystem.json
+++ b/versions/l-/luafilesystem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00b7638338af5a3a2d95c3c9b1ed870ed0cfb9fc",
+      "version": "1.8.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "4b474bdcc3f49eef949ba79ad3294556e39af778",
       "version": "1.8.0",
       "port-version": 6


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/40847
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
