### PR TITLE
[msquic] update to 2.4.5, Change to openssl3 and remove uwp support.

### DIFF
--- a/ports/msquic/portfile.cmake
+++ b/ports/msquic/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH QUIC_SOURCE_PATH
     REPO microsoft/msquic
     REF "v${VERSION}"
-    SHA512 87bb96bc77c30a39e419be2592199de8f9fa74179852637d2902c50d555bad24d2a664b888434fbc1df461ece69a52097634a47f0edbb78b0b0eed6e5a94033f
+    SHA512 51afee7e28a7d6ae1b5491edd635e0c88a92a00bacedeaac632a0f19762e9940c9b819a9d33072d3553c004acd4ec0cdf645301f712b408498053de065b2b1cf
     HEAD_REF master
     PATCHES
         fix-install.patch # Adjust install path of build outputs
@@ -20,13 +20,13 @@ file(REMOVE "${QUIC_SOURCE_PATH}/src/bin/winuser/pgo_x86/msquic.pgd")
 vcpkg_from_github(
     OUT_SOURCE_PATH OPENSSL_SOURCE_PATH
     REPO quictls/openssl
-    REF 612d8e44d687e4b71c4724319d7aa27a733bcbca
-    SHA512 ff487d882c2b70ed8915a88ecf0a64724435a96187a7bb3bf401f4a2c4dc572a93f7e788040ccbd29da8bc6ac49ee11550c9d56153262c05fae173ac1d242baa
-    HEAD_REF openssl-3.1.5+quic
+    REF openssl-3.1.7-quic1
+    SHA512 230f48a4ef20bfd492b512bd53816a7129d70849afc1426e9ce813273c01884d5474552ecaede05231ca354403f25e2325c972c9c7950ae66dae310800bd19e7
+    HEAD_REF openssl-3.1.7+quic
 )
 
-file(REMOVE_RECURSE "${QUIC_SOURCE_PATH}/submodules/openssl")
-file(RENAME "${OPENSSL_SOURCE_PATH}" "${QUIC_SOURCE_PATH}/submodules/openssl")
+file(REMOVE_RECURSE "${QUIC_SOURCE_PATH}/submodules/openssl3")
+file(RENAME "${OPENSSL_SOURCE_PATH}" "${QUIC_SOURCE_PATH}/submodules/openssl3")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH XDP_WINDOWS
@@ -61,7 +61,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${QUIC_SOURCE_PATH}"
     OPTIONS
         -DQUIC_SOURCE_LINK=OFF
-        -DQUIC_TLS=openssl
+        -DQUIC_TLS=openssl3
         -DQUIC_USE_SYSTEM_LIBCRYPTO=OFF
         -DQUIC_BUILD_PERF=OFF
         -DQUIC_BUILD_TEST=OFF

--- a/ports/msquic/vcpkg.json
+++ b/ports/msquic/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "msquic",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Cross-platform, C implementation of the IETF QUIC protocol",
   "homepage": "https://github.com/microsoft/msquic",
   "license": "MIT",
-  "supports": "!(static & staticcrt)",
+  "supports": "!((static & staticcrt) | uwp)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6105,7 +6105,7 @@
       "port-version": 4
     },
     "msquic": {
-      "baseline": "2.4.4",
+      "baseline": "2.4.5",
       "port-version": 0
     },
     "mstch": {

--- a/versions/m-/msquic.json
+++ b/versions/m-/msquic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a037eeff81951b04f28f6ed7c0988618d801afb0",
+      "version": "2.4.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "519570ca834d486ddb5fc0fd43094079ef27b568",
       "version": "2.4.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.