### PR TITLE
[arrayfire] Add missing header files

### DIFF
--- a/ports/arrayfire/fix-miss-header-file.patch
+++ b/ports/arrayfire/fix-miss-header-file.patch
@@ -1,0 +1,12 @@
+diff --git a/src/backend/common/half.hpp b/src/backend/common/half.hpp
+index fb25d03..2f6a8a4 100644
+--- a/src/backend/common/half.hpp
++++ b/src/backend/common/half.hpp
+@@ -33,6 +33,7 @@
+ #endif
+ 
+ #include <backend.hpp>
++#include <cstdint>
+ 
+ #ifdef __CUDACC_RTC__
+ using uint16_t = unsigned short;

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     CUDA_PATCHES
     URLS "https://github.com/arrayfire/arrayfire/pull/3552/commits/674e7bec90b90467139d32bf633467fe60824617.diff?full_index=1"
     FILENAME "fix-cuda-674e7bec90b90467139d32bf633467fe60824617.patch"
-    SHA512 e584033fb79c602a19222c177d5db28f9887dd17e741844d57f2236a5749ac4c02cc0740f8011ca990602887a6ee3dd21ae0b695455c447686b1a6c8bda2e092
+    SHA512 201ba8c46f5eafd5d8dbc78ddc1fb4c24b8d820f034e081b8ff30712705fe059c2850bbb7394d81931620619071559fed0e98b13cc4f985103e354c44a322e78
 )
 
 vcpkg_from_github(

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -15,8 +15,8 @@ vcpkg_from_github(
     build.patch
     Fix-constexpr-error-with-vs2019-with-half.patch
     fix-dependency-clfft.patch
-	fix-miss-header-file.patch
-	"${CUDA_PATCHES}"
+    fix-miss-header-file.patch
+    "${CUDA_PATCHES}"
 )
 
 # arrayfire cpu thread lib needed as a submodule for the CPU backend
@@ -100,7 +100,7 @@ vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-if(NOT VCPKG_TARGET_IS_WINDOWS)
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_LINUX)
     vcpkg_cmake_config_fixup(CONFIG_PATH share/ArrayFire/cmake)
 else()
     vcpkg_cmake_config_fixup(CONFIG_PATH cmake)

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     build.patch
     Fix-constexpr-error-with-vs2019-with-half.patch
     fix-dependency-clfft.patch
+	fix-miss-header-file.patch
 )
 
 # arrayfire cpu thread lib needed as a submodule for the CPU backend
@@ -91,7 +92,7 @@ vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-if(VCPKG_TARGET_IS_OSX)
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_LINUX)
     vcpkg_cmake_config_fixup(CONFIG_PATH share/ArrayFire/cmake)
 else()
     vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
@@ -103,6 +104,9 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/examples"
     "${CURRENT_PACKAGES_DIR}/LICENSES"
     "${CURRENT_PACKAGES_DIR}/debug/LICENSES")
+if(FEATURES STREQUAL "core")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+endif()
 
 # Copyright and license
 file(INSTALL "${SOURCE_PATH}/COPYRIGHT.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -100,7 +100,7 @@ vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_LINUX)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
     vcpkg_cmake_config_fixup(CONFIG_PATH share/ArrayFire/cmake)
 else()
     vcpkg_cmake_config_fixup(CONFIG_PATH cmake)

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -92,7 +92,7 @@ vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_LINUX)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
     vcpkg_cmake_config_fixup(CONFIG_PATH share/ArrayFire/cmake)
 else()
     vcpkg_cmake_config_fixup(CONFIG_PATH cmake)

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -1,3 +1,10 @@
+vcpkg_download_distfile(
+    CUDA_PATCHES
+    URLS "https://github.com/arrayfire/arrayfire/pull/3552/commits/674e7bec90b90467139d32bf633467fe60824617.diff?full_index=1"
+    FILENAME "fix-cuda-674e7bec90b90467139d32bf633467fe60824617.patch"
+    SHA512 e584033fb79c602a19222c177d5db28f9887dd17e741844d57f2236a5749ac4c02cc0740f8011ca990602887a6ee3dd21ae0b695455c447686b1a6c8bda2e092
+)
+
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO arrayfire/arrayfire
@@ -9,6 +16,7 @@ vcpkg_from_github(
     Fix-constexpr-error-with-vs2019-with-half.patch
     fix-dependency-clfft.patch
 	fix-miss-header-file.patch
+	"${CUDA_PATCHES}"
 )
 
 # arrayfire cpu thread lib needed as a submodule for the CPU backend

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrayfire",
   "version-semver": "3.8.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "ArrayFire is a general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.",
   "homepage": "https://github.com/arrayfire/arrayfire",
   "license": "BSD-3-Clause",

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "02dd94d188b84cff328868b3febc6d3c116e72cd",
+      "git-tree": "0ee8cfc2d3d33c7d7d878d55934840bb57f8a5fb",
       "version-semver": "3.8.0",
       "port-version": 7
     },

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c02be217338ba006b71ed4174ca8660d8c3ac459",
+      "git-tree": "66df519af6427e2e9352bd166d1a54886e478af3",
       "version-semver": "3.8.0",
       "port-version": 7
     },

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6a1b40a57d45268f3d9714559b3aa357b935e2b2",
+      "git-tree": "985696275cbb76cb02d89d11f8e2490921c09874",
       "version-semver": "3.8.0",
       "port-version": 7
     },

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "66df519af6427e2e9352bd166d1a54886e478af3",
+      "git-tree": "02dd94d188b84cff328868b3febc6d3c116e72cd",
       "version-semver": "3.8.0",
       "port-version": 7
     },

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c02be217338ba006b71ed4174ca8660d8c3ac459",
+      "version-semver": "3.8.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "45bae5e28a1c092e6024e21dcc4bab12c4e03440",
       "version-semver": "3.8.0",
       "port-version": 6

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0ee8cfc2d3d33c7d7d878d55934840bb57f8a5fb",
+      "git-tree": "6a1b40a57d45268f3d9714559b3aa357b935e2b2",
       "version-semver": "3.8.0",
       "port-version": 7
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -242,7 +242,7 @@
     },
     "arrayfire": {
       "baseline": "3.8.0",
-      "port-version": 6
+      "port-version": 7
     },
     "arrow": {
       "baseline": "17.0.0",


### PR DESCRIPTION
One of the fixes for the https://github.com/microsoft/vcpkg/issues/32398 issue.
The following error occurs when installing arrayfire[core]:x64-linux.
```
CMake Error at installed/x64-linux/share/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake:36 (message):
  '/mnt/vcpkg/packages/arrayfire_x64-linux/debug/cmake' does not exist.
Call Stack (most recent call first):
/mnt/vcpkg/buildtrees/arrayfire/src/27f04d5188-42e72796d0.clean/src/backend/common/half.hpp:57:23: error: ‘uint16_t’ does not name a type
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features passed with following triplets:

```
x64-windows
x64-linux
```