### PR TITLE
[fontconfig] Enable WebAssembly atomics and bulk-memory

### DIFF
--- a/ports/fontconfig/fix-wasm-shared-memory-atomics.patch
+++ b/ports/fontconfig/fix-wasm-shared-memory-atomics.patch
@@ -1,12 +1,14 @@
 diff --git a/meson.build b/meson.build
-index 8e78700..022d055 100644
+index 8e78700..95bae59 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -112,6 +112,7 @@ check_alignofs = [
+@@ -112,6 +112,9 @@ check_alignofs = [
  ]
  
  add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
-+add_project_arguments('-matomics', '-mbulk-memory', language: 'c')
++if cc.get_id() == 'clang' and host_machine.cpu_family() == 'wasm'
++    add_project_arguments('-matomics', '-mbulk-memory', language: 'c')
++endif
  
  c_args = []
  

--- a/ports/fontconfig/fix-wasm-shared-memory-atomics.patch
+++ b/ports/fontconfig/fix-wasm-shared-memory-atomics.patch
@@ -1,0 +1,12 @@
+diff --git a/meson.build b/meson.build
+index 8e78700..022d055 100644
+--- a/meson.build
++++ b/meson.build
+@@ -112,6 +112,7 @@ check_alignofs = [
+ ]
+ 
+ add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
++add_project_arguments('-matomics', '-mbulk-memory', language: 'c')
+ 
+ c_args = []
+ 

--- a/ports/fontconfig/portfile.cmake
+++ b/ports/fontconfig/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_gitlab(
     PATCHES
         no-etc-symlinks.patch
         libgetopt.patch
+        fix-wasm-shared-memory-atomics.patch
 )
 
 vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/gperf")

--- a/ports/fontconfig/vcpkg.json
+++ b/ports/fontconfig/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fontconfig",
   "version": "2.15.0",
+  "port-version": 1,
   "description": "Library for configuring and customizing font access.",
   "homepage": "https://www.freedesktop.org/wiki/Software/fontconfig",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2854,7 +2854,7 @@
     },
     "fontconfig": {
       "baseline": "2.15.0",
-      "port-version": 0
+      "port-version": 1
     },
     "foonathan-lexy": {
       "baseline": "2022.12.1",

--- a/versions/f-/fontconfig.json
+++ b/versions/f-/fontconfig.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8d93b6a335534b4e0093e5e9ca355db134ab7675",
+      "git-tree": "443f2cc8005cd715e8786521c1c2cd990a1320a8",
       "version": "2.15.0",
       "port-version": 1
     },

--- a/versions/f-/fontconfig.json
+++ b/versions/f-/fontconfig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d93b6a335534b4e0093e5e9ca355db134ab7675",
+      "version": "2.15.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2a11e54fe49673d52f0c4d2df73870f36a228990",
       "version": "2.15.0",
       "port-version": 0


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/41141

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Added `-matomics` and `-mbulk-memory` compiler flags using `add_project_arguments` in `meson.build`.
Ensured compatibility with `WebAssembly's shared memory (--shared-memory)` during the linking stage by enabling the required features.