### PR TITLE
[angle] Fix display selection for macOS and iOS platforms

### DIFF
--- a/ports/angle/004-fix-display-selection-macos-ios.patch
+++ b/ports/angle/004-fix-display-selection-macos-ios.patch
@@ -1,5 +1,5 @@
 diff --git a/src/libANGLE/Display.cpp b/src/libANGLE/Display.cpp
-index f677745..fb691e5 100644
+index f677745..5005916 100644
 --- a/src/libANGLE/Display.cpp
 +++ b/src/libANGLE/Display.cpp
 @@ -419,6 +419,9 @@ rx::DisplayImpl *CreateDisplayFromAttribs(EGLAttrib displayType,
@@ -8,7 +8,7 @@ index f677745..fb691e5 100644
              impl = new rx::DisplayAndroid(state);
 +#    elif defined(ANGLE_PLATFORM_MACOS) || defined(ANGLE_PLATFORM_IOS)
 +            #include "libANGLE/renderer/gl/apple/DisplayApple_api.h"
-+            impl = rx::CreateDisplayCGLOrEAGL(state)
++            impl = rx::CreateDisplayCGLOrEAGL(state);
  #    else
              // No GLES support on this platform, fail display creation.
              impl = nullptr;

--- a/ports/angle/004-fix-display-selection-macos-ios.patch
+++ b/ports/angle/004-fix-display-selection-macos-ios.patch
@@ -1,0 +1,14 @@
+diff --git a/src/libANGLE/Display.cpp b/src/libANGLE/Display.cpp
+index f677745..fb691e5 100644
+--- a/src/libANGLE/Display.cpp
++++ b/src/libANGLE/Display.cpp
+@@ -419,6 +419,9 @@ rx::DisplayImpl *CreateDisplayFromAttribs(EGLAttrib displayType,
+             }
+ #    elif defined(ANGLE_PLATFORM_ANDROID)
+             impl = new rx::DisplayAndroid(state);
++#    elif defined(ANGLE_PLATFORM_MACOS) || defined(ANGLE_PLATFORM_IOS)
++            #include "libANGLE/renderer/gl/apple/DisplayApple_api.h"
++            impl = rx::CreateDisplayCGLOrEAGL(state)
+ #    else
+             // No GLES support on this platform, fail display creation.
+             impl = nullptr;

--- a/ports/angle/portfile.cmake
+++ b/ports/angle/portfile.cmake
@@ -46,6 +46,7 @@ vcpkg_from_github(
         001-fix-uwp.patch
         002-fix-builder-error.patch
         003-fix-mingw.patch
+        004-fix-display-selection-macos-ios.patch
 )
 
 # Generate angle_commit.h

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_5414",
-  "port-version": 9,
+  "port-version": 10,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7ae3f1fdc4602f33622e87a9ac1f427121b2d03b",
+      "git-tree": "7ccfae2289ffc3193bdd28a03bb0bdefb165d3ee",
       "version-string": "chromium_5414",
       "port-version": 10
     },

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ae3f1fdc4602f33622e87a9ac1f427121b2d03b",
+      "version-string": "chromium_5414",
+      "port-version": 10
+    },
+    {
       "git-tree": "b0e6049d392ece97ba5be00c7c3e4410aa78d3f0",
       "version-string": "chromium_5414",
       "port-version": 9

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -134,7 +134,7 @@
     },
     "angle": {
       "baseline": "chromium_5414",
-      "port-version": 9
+      "port-version": 10
     },
     "ankurvdev-embedresource": {
       "baseline": "0.0.11",


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/40634


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


1. Added direct inclusion of `DisplayApple_api.h` for `macOS` and `iOS` support.

2. Updated the display creation logic to utilize `rx::CreateDisplayCGLOrEAGL` instead of `rx::DisplayEGL`([Upstream usage](https://github.com/google/angle/blob/aa63ea230e0c507e7b4b164a30e502fb17168c17/src/libANGLE/Display.cpp#L346)). 
3. Kept existing implementations for Windows, Linux, and Android platforms intact.