### PR TITLE
[godot-cpp] Update to 4.3

### DIFF
--- a/ports/godot-cpp/packagable.patch
+++ b/ports/godot-cpp/packagable.patch
@@ -6,7 +6,7 @@ index e715102..b000066 100644
  # Todo
  # Test build for Windows, Mac and mingw.
  
--cmake_minimum_required(VERSION 3.12)
+-cmake_minimum_required(VERSION 3.13)
 +cmake_minimum_required(VERSION 3.19)
  project(godot-cpp LANGUAGES CXX)
  

--- a/ports/godot-cpp/portfile.cmake
+++ b/ports/godot-cpp/portfile.cmake
@@ -1,11 +1,10 @@
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "godotengine/godot-cpp"
     REF "godot-${VERSION}-stable"
-    SHA512 "820e07ffb0545324f01598898bb342d7e143dcc8b83818824e7e1bc22937d3e8016b435f1ec085ebaae8b26e6f6dfb5500f120089316fc0f0c4153c340226941"
+    SHA512 "4012e2c8cbdbccf5362b139a6318785af6e2cfdc99848734d5e3825afba8b8a46cdd7fff63887e2503cf3195efe79c0bd39a900b535322ab0fb51c3452dc07f5"
     HEAD_REF "master"
     PATCHES
         "packagable.patch"

--- a/ports/godot-cpp/vcpkg.json
+++ b/ports/godot-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-cpp",
-  "version": "4.2.1",
+  "version": "4.3",
   "description": "C++ bindings for the Godot script API",
   "homepage": "https://github.com/godotengine/godot-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3189,7 +3189,7 @@
       "port-version": 8
     },
     "godot-cpp": {
-      "baseline": "4.2.1",
+      "baseline": "4.3",
       "port-version": 0
     },
     "google-cloud-cpp": {

--- a/versions/g-/godot-cpp.json
+++ b/versions/g-/godot-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "561f56e438444e007a1b6abbcd77b33b6d64ff2c",
+      "version": "4.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "3125afbc0a8a200f3a3213b8a4be710ad3190890",
       "version": "4.2.1",
       "port-version": 0


### PR DESCRIPTION
Update `godot-cpp` to 4.3.
Usage passed on `x64-windows`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.