### PR TITLE
[libdjinterop] Update to 0.22.1

### DIFF
--- a/ports/libdjinterop/portfile.cmake
+++ b/ports/libdjinterop/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xsco/libdjinterop
     REF "${VERSION}"
-    SHA512 c2784ffc6b0ddc9ad92a227621bb00cd1c88aa8f8abe82401774102f9be16dfbe9f0745523d517594faecba60b650a53613c7867afe57e6bcd8a2cc6288dd9ff
+    SHA512 1c35d8609342f133cf002d1908d5746c411a9d5e74b42a7ec045545f07a3f4b8a89ce9a95d2fc17edd8970facafbee1b6d8a9283fcd8c74c9cb96ff61f15d47d
     HEAD_REF master
 )
 

--- a/ports/libdjinterop/vcpkg.json
+++ b/ports/libdjinterop/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdjinterop",
-  "version": "0.21.0",
+  "version": "0.22.1",
   "description": "C++ library for access to DJ record libraries. Currently only supports Denon Engine Prime databases",
   "homepage": "https://github.com/xsco/libdjinterop",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4417,7 +4417,7 @@
       "port-version": 0
     },
     "libdjinterop": {
-      "baseline": "0.21.0",
+      "baseline": "0.22.1",
       "port-version": 0
     },
     "libdmx": {

--- a/versions/l-/libdjinterop.json
+++ b/versions/l-/libdjinterop.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fda458a81fa4a8520df2baf8dcf5211f60669707",
+      "version": "0.22.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c643a7969afe7b095d0c6e779adbe14b09ad39d0",
       "version": "0.21.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
