### PR TITLE
[tidy-html5] cmake find_package() support

### DIFF
--- a/ports/tidy-html5/cmake_find_package_support.patch
+++ b/ports/tidy-html5/cmake_find_package_support.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8efec25..13a36ef 100644
+index 8efec25..02173ea 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -407,10 +407,11 @@ else ()
@@ -11,7 +11,7 @@ index 8efec25..13a36ef 100644
      list ( APPEND add_LIBS ${name} )
  endif ()    
 -install(TARGETS ${name}
-+install(TARGETS ${name} EXPORT tidy-html5Config
++install(TARGETS ${name} EXPORT unofficial-tidy-html5Config
          RUNTIME DESTINATION ${BIN_INSTALL_DIR}
          ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
          LIBRARY DESTINATION ${LIB_INSTALL_DIR}
@@ -21,7 +21,7 @@ index 8efec25..13a36ef 100644
                                     COMPILE_FLAGS "-DBUILD_SHARED_LIB -DBUILDING_SHARED_LIB")
 -    install(TARGETS ${name}
 +    target_include_directories( ${name} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
-+    install(TARGETS ${name} EXPORT tidy-html5Config
++    install(TARGETS ${name} EXPORT unofficial-tidy-html5Config
          RUNTIME DESTINATION ${BIN_INSTALL_DIR}
          ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
          LIBRARY DESTINATION ${LIB_INSTALL_DIR}
@@ -32,9 +32,9 @@ index 8efec25..13a36ef 100644
 +#------------------------------------------------------------------------
 +# CMake FIND_PACKAGE() Support
 +#------------------------------------------------------------------------
-+install(EXPORT tidy-html5Config
-+	DESTINATION ${LIB_INSTALL_DIR}/cmake/tidy-html5
-+	NAMESPACE tidy-html5::)
++install(EXPORT unofficial-tidy-html5Config
++	DESTINATION ${LIB_INSTALL_DIR}/cmake/unofficial-tidy-html5
++	NAMESPACE unofficial::tidy-html5::)
 +
  
  #------------------------------------------------------------------------

--- a/ports/tidy-html5/cmake_find_package_support.patch
+++ b/ports/tidy-html5/cmake_find_package_support.patch
@@ -1,0 +1,41 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8efec25..13a36ef 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -407,10 +407,11 @@ else ()
+                            OUTPUT_NAME ${LIB_NAME} )
+ 
+ endif ()
++target_include_directories( ${name} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+ if (NOT TIDY_CONSOLE_SHARED) # user wants default static linkage
+     list ( APPEND add_LIBS ${name} )
+ endif ()    
+-install(TARGETS ${name}
++install(TARGETS ${name} EXPORT tidy-html5Config
+         RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+         ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+         LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+@@ -440,7 +441,8 @@ if (BUILD_SHARED_LIB)
+                                    NO_SONAME ${NO_SONAME} )
+     set_target_properties( ${name} PROPERTIES 
+                                    COMPILE_FLAGS "-DBUILD_SHARED_LIB -DBUILDING_SHARED_LIB")
+-    install(TARGETS ${name}
++    target_include_directories( ${name} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
++    install(TARGETS ${name} EXPORT tidy-html5Config
+         RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+         ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+         LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+@@ -450,6 +452,13 @@ if (BUILD_SHARED_LIB)
+     endif ()    
+ endif ()
+ 
++#------------------------------------------------------------------------
++# CMake FIND_PACKAGE() Support
++#------------------------------------------------------------------------
++install(EXPORT tidy-html5Config
++	DESTINATION ${LIB_INSTALL_DIR}/cmake/tidy-html5
++	NAMESPACE tidy-html5::)
++
+ 
+ #------------------------------------------------------------------------
+ # Main Executable

--- a/ports/tidy-html5/cmake_find_package_support.patch
+++ b/ports/tidy-html5/cmake_find_package_support.patch
@@ -1,11 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8efec25..02173ea 100644
+index 8efec25..3fedb02 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -407,10 +407,11 @@ else ()
+@@ -407,10 +407,12 @@ else ()
                             OUTPUT_NAME ${LIB_NAME} )
  
  endif ()
++set_target_properties(${name} PROPERTIES EXPORT_NAME tidy)
 +target_include_directories( ${name} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
  if (NOT TIDY_CONSOLE_SHARED) # user wants default static linkage
      list ( APPEND add_LIBS ${name} )
@@ -15,17 +16,18 @@ index 8efec25..02173ea 100644
          RUNTIME DESTINATION ${BIN_INSTALL_DIR}
          ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
          LIBRARY DESTINATION ${LIB_INSTALL_DIR}
-@@ -440,7 +441,8 @@ if (BUILD_SHARED_LIB)
+@@ -440,7 +442,9 @@ if (BUILD_SHARED_LIB)
                                     NO_SONAME ${NO_SONAME} )
      set_target_properties( ${name} PROPERTIES 
                                     COMPILE_FLAGS "-DBUILD_SHARED_LIB -DBUILDING_SHARED_LIB")
 -    install(TARGETS ${name}
++    set_target_properties(${name} PROPERTIES EXPORT_NAME tidy)
 +    target_include_directories( ${name} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 +    install(TARGETS ${name} EXPORT unofficial-tidy-html5Config
          RUNTIME DESTINATION ${BIN_INSTALL_DIR}
          ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
          LIBRARY DESTINATION ${LIB_INSTALL_DIR}
-@@ -450,6 +452,13 @@ if (BUILD_SHARED_LIB)
+@@ -450,6 +454,13 @@ if (BUILD_SHARED_LIB)
      endif ()    
  endif ()
  

--- a/ports/tidy-html5/portfile.cmake
+++ b/ports/tidy-html5/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         static-vs-shared.patch
         debug-postfix.patch
         fix_unsupport_func_uwp.patch
+		cmake_find_package_support.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIB)
@@ -21,6 +22,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/tidy-html5)
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/tidy-html5/portfile.cmake
+++ b/ports/tidy-html5/portfile.cmake
@@ -22,7 +22,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/unofficial-tidy-html5)
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-tidy-html5 CONFIG_PATH lib/cmake/unofficial-tidy-html5)
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/tidy-html5/portfile.cmake
+++ b/ports/tidy-html5/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
         static-vs-shared.patch
         debug-postfix.patch
         fix_unsupport_func_uwp.patch
-		cmake_find_package_support.patch
+        cmake_find_package_support.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIB)
@@ -22,7 +22,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/tidy-html5)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/unofficial-tidy-html5)
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/tidy-html5/vcpkg.json
+++ b/ports/tidy-html5/vcpkg.json
@@ -1,13 +1,17 @@
 {
   "name": "tidy-html5",
   "version": "5.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Tidy tidies HTML and XML. It can tidy your documents by itself, and developers can easily integrate its features into even more powerful tools.",
   "homepage": "https://www.html-tidy.org",
   "license": null,
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8862,7 +8862,7 @@
     },
     "tidy-html5": {
       "baseline": "5.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "tiff": {
       "baseline": "4.6.0",

--- a/versions/t-/tidy-html5.json
+++ b/versions/t-/tidy-html5.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c1e9da031ce89e89de06a85b18cdeea254d656ab",
+      "git-tree": "24f53a11ec9d660daf1819fe37d6377d927695a0",
       "version": "5.8.0",
       "port-version": 2
     },

--- a/versions/t-/tidy-html5.json
+++ b/versions/t-/tidy-html5.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "710a3ca84e1ffe01611354af9c0eeb9c83d08dbc",
+      "git-tree": "c1e9da031ce89e89de06a85b18cdeea254d656ab",
       "version": "5.8.0",
       "port-version": 2
     },

--- a/versions/t-/tidy-html5.json
+++ b/versions/t-/tidy-html5.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1934d2710d85be058939998291f2d048261ac6da",
+      "git-tree": "7337a076037d8bf318bec1988798b6f6215efec0",
       "version": "5.8.0",
       "port-version": 2
     },

--- a/versions/t-/tidy-html5.json
+++ b/versions/t-/tidy-html5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1934d2710d85be058939998291f2d048261ac6da",
+      "version": "5.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "3ff916aaab30ac5a85e702ab9cf4e8092db79477",
       "version": "5.8.0",
       "port-version": 1

--- a/versions/t-/tidy-html5.json
+++ b/versions/t-/tidy-html5.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7337a076037d8bf318bec1988798b6f6215efec0",
+      "git-tree": "710a3ca84e1ffe01611354af9c0eeb9c83d08dbc",
       "version": "5.8.0",
       "port-version": 2
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
