### PR TITLE
[parson] Update to 2023-10-31

### DIFF
--- a/ports/parson/portfile.cmake
+++ b/ports/parson/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kgabis/parson
-    REF 1314bf8ad6f22edd2feb9d8c867756f41db21f2a # accessed on 2022-11-13
-    SHA512 5f6003caea40c093dedfbd85dfe6d33202708b37b59ad9eeb815a5d287dd7b37f3522d3bf35fb718eab13260bb0c129b691703f04b9f1c3dbe7bef4b494928be
+    REF ba29f4eda9ea7703a9f6a9cf2b0532a2605723c3 # accessed on 2023-10-31
+    SHA512 fdb8c66e9b8966488a22db2e6437d0bfa521c73abc043c7bd18227247fd52de9dd1856dec0d5ebd88f1dacce2493b2c68707b5e16ca4e3032ff6342933f16030
     HEAD_REF master
     PATCHES
         fix-cmake-files-path.patch
@@ -19,8 +19,6 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL
-    ${SOURCE_PATH}/LICENSE
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_copy_pdbs()

--- a/ports/parson/vcpkg.json
+++ b/ports/parson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "parson",
-  "version-date": "2022-11-13",
+  "version-date": "2023-10-31",
   "description": "a lightweight json library written in C",
   "homepage": "https://github.com/kgabis/parson",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6857,7 +6857,7 @@
       "port-version": 0
     },
     "parson": {
-      "baseline": "2022-11-13",
+      "baseline": "2023-10-31",
       "port-version": 0
     },
     "pbc": {

--- a/versions/p-/parson.json
+++ b/versions/p-/parson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bdf972c3f23e82b339cf0f57ab65d2a8cd6306e8",
+      "version-date": "2023-10-31",
+      "port-version": 0
+    },
+    {
       "git-tree": "a154132abe66de11955af5aaca44575373120acd",
       "version-date": "2022-11-13",
       "port-version": 0


### PR DESCRIPTION
Update `parson` to 2023-10-31. No feature needs to be tested.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] When updating the upstream version, the `"port-version"` is reset (removed from `vcpkg.json`).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
