### PR TITLE
[sail] Update to 0.9.6

### DIFF
--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO HappySeaFox/sail
     REF "v${VERSION}"
-    SHA512 4d61489405f5468eac2fb0261ec0b54bfa6f619b1acdca405c4b09261c233d0b7063df71143add87f866bfa7ed9eabdf3a910f03f8494f14a62e4f124eb260be
+    SHA512 7c6af5a381535515882dbbecf988a3cb10d2859e71084b8c9eeefac8a546df38c1438ac741535db668e8a6da09185e04ef016f71dffec297d4f5a8764653dff8
     HEAD_REF master
     PATCHES
         fix-include-directory.patch

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sail",
-  "version-semver": "0.9.5",
-  "port-version": 1,
+  "version-semver": "0.9.6",
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8045,8 +8045,8 @@
       "port-version": 0
     },
     "sail": {
-      "baseline": "0.9.5",
-      "port-version": 1
+      "baseline": "0.9.6",
+      "port-version": 0
     },
     "sajson": {
       "baseline": "2018-09-21",

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "abb07777f295e65107e9238e55b913e577e6a7b0",
+      "version-semver": "0.9.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "a392dad5e96d94ccab10fa8ce41e5c36fdd47fd2",
       "version-semver": "0.9.5",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
