### PR TITLE
[ruckig] Add new port

### DIFF
--- a/ports/ruckig/portfile.cmake
+++ b/ports/ruckig/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO pantor/ruckig
+    REF "v${VERSION}"
+    SHA512 cd8e31d4cc41cf90a23095f39f58e7139ac12a34c7699f3274c6389916cbed56a6e8627facaf34e5a888d43b78e43cb01dce1cd1ef45201652d3ded917a80075
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_CLOUD_CLIENT=OFF
+        -DBUILD_TESTS=OFF
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_SHARED_LIBS=${VCPKG_LIBRARY_LINKAGE}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH "lib/cmake/ruckig"
+    )
+vcpkg_copy_pdbs()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/ruckig/portfile.cmake
+++ b/ports/ruckig/portfile.cmake
@@ -12,13 +12,10 @@ vcpkg_cmake_configure(
         -DBUILD_CLOUD_CLIENT=OFF
         -DBUILD_TESTS=OFF
         -DBUILD_EXAMPLES=OFF
-        -DBUILD_SHARED_LIBS=${VCPKG_LIBRARY_LINKAGE}
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(
-    CONFIG_PATH "lib/cmake/ruckig"
-    )
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/ruckig")
 vcpkg_copy_pdbs()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ruckig/vcpkg.json
+++ b/ports/ruckig/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "ruckig",
+  "version": "0.14.0",
+  "description": "Ruckig generates trajectories on-the-fly, allowing robots and machines to react instantaneously to sensor input.",
+  "homepage": "https://ruckig.com/",
+  "license": "MIT",
+  "dependencies": [
+    "eigen3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8012,6 +8012,10 @@
       "baseline": "3.3.0",
       "port-version": 1
     },
+    "ruckig": {
+      "baseline": "0.14.0",
+      "port-version": 0
+    },
     "rxcpp": {
       "baseline": "4.1.1",
       "port-version": 1

--- a/versions/r-/ruckig.json
+++ b/versions/r-/ruckig.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "88bc7dc920c13ca6ace4946c21272d29de88f98b",
+      "git-tree": "830d50b509f03638a9066a73d0979eddac5acc68",
       "version": "0.14.0",
       "port-version": 0
     }

--- a/versions/r-/ruckig.json
+++ b/versions/r-/ruckig.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "88bc7dc920c13ca6ace4946c21272d29de88f98b",
+      "version": "0.14.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.