### PR TITLE
[boringssl] update to 0.20240913.0

### DIFF
--- a/ports/boringssl/0002-remove-WX-Werror.patch
+++ b/ports/boringssl/0002-remove-WX-Werror.patch
@@ -1,23 +1,28 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ce60e8daf..015adf4c0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -140,7 +140,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CLANG)
+@@ -105,7 +105,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
+ if(CMAKE_COMPILER_IS_GNUCXX OR CLANG)
    # Note clang-cl is odd and sets both CLANG and MSVC. We base our configuration
    # primarily on our normal Clang one.
-   # TODO(bbe) took out -Wmissing-field-initializers for pki - fix and put back or disable only for pki
--  set(C_CXX_FLAGS "-Werror -Wformat=2 -Wsign-compare -Wwrite-strings -Wvla -Wshadow -Wtype-limits")
-+  set(C_CXX_FLAGS "-Wformat=2 -Wsign-compare -Wwrite-strings -Wvla -Wshadow -Wtype-limits")
+-  set(C_CXX_FLAGS "-Werror -Wformat=2 -Wsign-compare -Wwrite-strings -Wvla -Wshadow -Wtype-limits -Wmissing-field-initializers")
++  set(C_CXX_FLAGS "-Wformat=2 -Wsign-compare -Wwrite-strings -Wvla -Wshadow -Wtype-limits -Wmissing-field-initializers")
    if(MSVC)
      # clang-cl sets different default warnings than clang. It also treats -Wall
      # as -Weverything, to match MSVC. Instead -W3 is the alias for -Wall.
-@@ -211,8 +211,8 @@ elseif(MSVC)
+@@ -192,12 +192,12 @@ elseif(MSVC)
        )
    string(REPLACE "C" " -wd" MSVC_DISABLED_WARNINGS_STR
                              ${MSVC_DISABLED_WARNINGS_LIST})
 -  set(CMAKE_C_FLAGS   "-utf-8 -W4 -WX ${MSVC_DISABLED_WARNINGS_STR}")
--  set(CMAKE_CXX_FLAGS "-utf-8 -W4 -WX ${MSVC_DISABLED_WARNINGS_STR}")
 +  set(CMAKE_C_FLAGS   "-utf-8 -W4 ${MSVC_DISABLED_WARNINGS_STR}")
-+  set(CMAKE_CXX_FLAGS "-utf-8 -W4 ${MSVC_DISABLED_WARNINGS_STR}")
+   # Without /Zc:__cplusplus, MSVC does not define the right value for
+   # __cplusplus. See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+   # If this becomes too problematic for downstream code, we can look at
+   # _MSVC_LANG.
+-  set(CMAKE_CXX_FLAGS "-utf-8 -W4 -WX ${MSVC_DISABLED_WARNINGS_STR} -Zc:__cplusplus")
++  set(CMAKE_CXX_FLAGS "-utf-8 -W4 ${MSVC_DISABLED_WARNINGS_STR} -Zc:__cplusplus")
  endif()
  
  if(WIN32)

--- a/ports/boringssl/0003-fix-shared-symbol-visibility.patch
+++ b/ports/boringssl/0003-fix-shared-symbol-visibility.patch
@@ -1,7 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2308d5721..d14f02b66 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -252,8 +252,6 @@ if(FUZZ)
+@@ -237,8 +237,6 @@ if(FUZZ)
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,fuzzer-no-link -fsanitize-coverage=edge,indirect-calls")
  endif()
  
@@ -10,34 +11,27 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
  if(BUILD_SHARED_LIBS)
    add_definitions(-DBORINGSSL_SHARED_LIBRARY)
    # Enable position-independent code globally. This is needed because
-@@ -563,7 +561,7 @@ if(APPLE)
- endif()
+@@ -579,6 +577,7 @@ target_include_directories(crypto PUBLIC
+   $<INSTALL_INTERFACE:include>
+ )
+ set_property(TARGET crypto PROPERTY EXPORT_NAME Crypto)
++target_compile_definitions(crypto PRIVATE BORINGSSL_IMPLEMENTATION)
+ 
+ if(FIPS_SHARED)
+   # Rewrite libcrypto.so to inject the correct module hash value. This assumes
+@@ -624,6 +623,7 @@ add_library(ssl ${SSL_SOURCES})
+ # here.
+ set_property(TARGET ssl PROPERTY EXPORT_NAME SSL)
+ target_link_libraries(ssl crypto)
++target_compile_definitions(ssl PRIVATE BORINGSSL_IMPLEMENTATION)
+ 
+ add_library(decrepit ${DECREPIT_SOURCES})
+ target_link_libraries(decrepit crypto ssl)
+@@ -665,6 +665,7 @@ endif()
  
  add_library(pki ${PKI_SOURCES})
--target_compile_definitions(pki PRIVATE _BORINGSSL_LIBPKI_)
-+target_compile_definitions(pki PRIVATE _BORINGSSL_LIBPKI_ BORINGSSL_IMPLEMENTATION)
  target_link_libraries(pki crypto)
++target_compile_definitions(pki PRIVATE BORINGSSL_IMPLEMENTATION)
  
  add_executable(pki_test ${PKI_TEST_SOURCES})
-diff --git a/crypto/CMakeLists.txt b/crypto/CMakeLists.txt
---- a/crypto/CMakeLists.txt
-+++ b/crypto/CMakeLists.txt
-@@ -294,6 +294,7 @@ add_library(
-   $<TARGET_OBJECTS:fipsmodule>
-   ${CRYPTO_FIPS_OBJECTS}
- )
-+target_compile_definitions(crypto PRIVATE BORINGSSL_IMPLEMENTATION)
- if(OPENSSL_ASM)
-   target_sources(crypto PRIVATE ${CRYPTO_SOURCES_ASM})
- endif()
-diff --git a/ssl/CMakeLists.txt b/ssl/CMakeLists.txt
---- a/ssl/CMakeLists.txt
-+++ b/ssl/CMakeLists.txt
-@@ -39,6 +39,7 @@ add_library(
-   tls13_enc.cc
-   tls13_server.cc
- )
-+target_compile_definitions(ssl PRIVATE BORINGSSL_IMPLEMENTATION)
- # Although libssl also provides headers that require an include directory, the
- # flag is already specified by libcrypto, so we omit target_include_directories
- # here.
+ target_link_libraries(pki_test test_support_lib boringssl_gtest pki crypto)

--- a/ports/boringssl/portfile.cmake
+++ b/ports/boringssl/portfile.cmake
@@ -17,8 +17,8 @@ vcpkg_add_to_path("${GO_EXE_PATH}")
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO google/boringssl
-  REF cfcb954901e264edb9915e501de64a81732c5edd
-  SHA512 6fc7fff24c85ed580fb362f788b216ef04ca16976656c68c75d3fd72c84e28ed39a3ab8fcb064b7c7061f93a4d37d5426e36d259e1714fa62d90b99659a3ddc2
+  REF 0.20240913.0
+  SHA512 bfb36d7d0a90bbede3f77967525cd9377e7488114c3d0fb576015d0361e7f4460801aab8ef8a470908541bc9d7f76cdbdd823af4fd6aaebb4cac711ee5b5b9fa
   HEAD_REF master
   PATCHES
     0001-static-gtest.patch

--- a/ports/boringssl/vcpkg.json
+++ b/ports/boringssl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "boringssl",
-  "version-date": "2023-10-13",
+  "version-date": "2024-09-13",
   "description": "BoringSSL is a fork of OpenSSL developed by Google",
   "homepage": "https://boringssl.googlesource.com/boringssl",
   "supports": "!uwp",

--- a/versions/b-/boringssl.json
+++ b/versions/b-/boringssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "075a0df31951d14eb7bdfe1a6ba728ddfd46a3a2",
+      "version-date": "2024-09-13",
+      "port-version": 0
+    },
+    {
       "git-tree": "2b809260036c7ee69cbf1a8a06e015354121d741",
       "version-date": "2023-10-13",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1365,7 +1365,7 @@
       "port-version": 1
     },
     "boringssl": {
-      "baseline": "2023-10-13",
+      "baseline": "2024-09-13",
       "port-version": 0
     },
     "botan": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

fix #41229