### PR TITLE
[google-cloud-cpp] update to the latest release (v2.30.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
     REF "v${VERSION}"
-    SHA512 0ea58e933f5b57cd7c734c8139c3e334d1427a255b918cbabb35d909e9b5faf8a89bf174cff55468ea97ab7f472d96236c573093fc279fdccb0af64747f2af3a
+    SHA512 9020e5f762285df163b91ac8cea3198d5744a772374237959896a5e5837010de87b8f637b13ac96effde2053217bb91e1275ab9a0e27bf946e0189b2289b29ef
     HEAD_REF main
 )
 
@@ -31,9 +31,9 @@ if ("dialogflow-es" IN_LIST FEATURES)
     list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "dialogflow-es")
     list(APPEND GOOGLE_CLOUD_CPP_ENABLE "dialogflow_es")
 endif ()
-if ("experimental-storage-grpc" IN_LIST FEATURES)
-    list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "experimental-storage-grpc")
-    list(APPEND GOOGLE_CLOUD_CPP_ENABLE "experimental-storage_grpc")
+if ("storage-grpc" IN_LIST FEATURES)
+    list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "storage-grpc")
+    list(APPEND GOOGLE_CLOUD_CPP_ENABLE "storage_grpc")
 endif ()
 
 vcpkg_cmake_configure(

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -718,20 +718,6 @@
           "default-features": false,
           "features": [
             "grpc-common"
-          ]
-        }
-      ]
-    },
-    "experimental-storage-grpc": {
-      "description": "The GCS+gRPC plugin",
-      "dependencies": [
-        {
-          "name": "google-cloud-cpp",
-          "default-features": false,
-          "features": [
-            "grpc-common",
-            "opentelemetry",
-            "storage"
           ]
         }
       ]
@@ -1508,6 +1494,20 @@
           "default-features": false,
           "features": [
             "rest-common"
+          ]
+        }
+      ]
+    },
+    "storage-grpc": {
+      "description": "The GCS+gRPC plugin",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common",
+            "opentelemetry",
+            "storage"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3189,7 +3189,7 @@
       "port-version": 0
     },
     "google-cloud-cpp": {
-      "baseline": "2.29.0",
+      "baseline": "2.30.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50da62f4ab118b0cec820174bf07744014b03591",
+      "version": "2.30.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "13cd537faaf0b58a05831fd38ce7e1d9950709dc",
       "version": "2.29.0",
       "port-version": 0


### PR DESCRIPTION
Updates google-cloud-cpp to the latest release (v2.30.0)

The `experimental-storage_grpc` feature was released. It is now just called `storage_grpc`.

Tested locally (on x64-linux) with:

```
./vcpkg remove google-cloud-cpp && ./vcpkg install 'google-cloud-cpp[core,storage-grpc]'
./vcpkg remove google-cloud-cpp && ./vcpkg install 'google-cloud-cpp[*]'
```

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.