### PR TITLE
[calceph] update to version 4.0.1

### DIFF
--- a/ports/calceph/portfile.cmake
+++ b/ports/calceph/portfile.cmake
@@ -1,4 +1,4 @@
-set(CALCEPH_HASH f8d7d2ce2e043f79364bb7bf5e8d74a9b0be8a6c29895068ac8f5936d11fd3c82747a3ab2f9fefc6a66762f35d622497b6088d24b76060b5b722e3c8c3b76c6b)
+set(CALCEPH_HASH 1b03bc62ab32ab56a95ca33612824a1f2104a8cca225b6cbedc656655ab4477a922053257341f36b95792f002b39cbee6a1dd2522cacdac36282aa044e121d86)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-${VERSION}.tar.gz"

--- a/ports/calceph/vcpkg.json
+++ b/ports/calceph/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "calceph",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "C library to access the binary planetary ephemeris files.",
   "homepage": "https://www.imcce.fr/inpop/calceph/",
   "documentation": "https://calceph.imcce.fr/docs/latest/html/c/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1485,7 +1485,7 @@
       "port-version": 0
     },
     "calceph": {
-      "baseline": "4.0.0",
+      "baseline": "4.0.1",
       "port-version": 0
     },
     "camport3": {

--- a/versions/c-/calceph.json
+++ b/versions/c-/calceph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39ac246456a1696374698c2544fd23da60fbe918",
+      "version": "4.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0e91c8461694ab6c706f739be3be47f367464157",
       "version": "4.0.0",
       "port-version": 0


### PR DESCRIPTION

- [ X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ X] SHA512s are updated for each updated download.
- [ X] The "supports" clause reflects platforms that may be fixed by this new version.
- [ X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ X] Any patches that are no longer applied are deleted from the port's directory.
- [X ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ X] Only one version is added to each modified port's versions file.
