### PR TITLE
[skia] Bump dng_sdk version in portfile.cmake to fix build on musl

### DIFF
--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -37,7 +37,7 @@ declare_external_from_git(dawn
 )
 declare_external_from_git(dng_sdk
     URL "https://android.googlesource.com/platform/external/dng_sdk.git"
-    REF "c8d0c9b1d16bfda56f15165d39e0ffa360a11123"
+    REF "42db4d19acb658d6dcd059a319a378c89c3df75a"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(jinja2

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -37,7 +37,7 @@ declare_external_from_git(dawn
 )
 declare_external_from_git(dng_sdk
     URL "https://android.googlesource.com/platform/external/dng_sdk.git"
-    REF "42db4d19acb658d6dcd059a319a378c89c3df75a"
+    REF "679499cc9b92cfb0ae1dccbfd7e97ce719d23576"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(jinja2

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "skia",
-  "version": "129",
+  "version": "130",
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "skia",
-  "version": "130",
+  "version": "129",
+  "port-version": 1,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8353,8 +8353,8 @@
       "port-version": 0
     },
     "skia": {
-      "baseline": "130",
-      "port-version": 0
+      "baseline": "129",
+      "port-version": 1
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8353,7 +8353,7 @@
       "port-version": 0
     },
     "skia": {
-      "baseline": "129",
+      "baseline": "130",
       "port-version": 0
     },
     "skyr-url": {

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "886519547ba2addf980c4c567bca7f4c4d686d2f",
+      "version": "129",
+      "port-version": 1
+    },
+    {
       "git-tree": "b1b41ea4aa83a480efa70455bcc708bb0721cb05",
       "version": "130",
       "port-version": 0

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -6,11 +6,6 @@
       "port-version": 1
     },
     {
-      "git-tree": "b1b41ea4aa83a480efa70455bcc708bb0721cb05",
-      "version": "130",
-      "port-version": 0
-    },
-    {
       "git-tree": "76a242d24e0e810ad8c78e3deaef69d4b634e8fc",
       "version": "129",
       "port-version": 0

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1b41ea4aa83a480efa70455bcc708bb0721cb05",
+      "version": "130",
+      "port-version": 0
+    },
+    {
       "git-tree": "76a242d24e0e810ad8c78e3deaef69d4b634e8fc",
       "version": "129",
       "port-version": 0


### PR DESCRIPTION
Fixes #41365 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.