### PR TITLE
[libfido2] update to 1.15.0

### DIFF
--- a/ports/libfido2/portfile.cmake
+++ b/ports/libfido2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Yubico/libfido2
     REF ${VERSION}
-    SHA512 83454b0db0cc8546f377d0dd59f95785fe6b73cf28e499a6182a6ece4b7bce17c3e750155262adf71f339ec0b3b6c3d3d64a07b01c8428b4b91de97ae768f0e6
+    SHA512 97932ca1a9f8d1bb3cb4b4a8d56ef70085d19ad2bd27c67944fa17ed033bfa45d28d7ad3fa318723e79b17ef5a882ac4f999ad8a6b9965c58665d99c4da7b5ee
     HEAD_REF master
     PATCHES
         "fix_cmakelists.patch"

--- a/ports/libfido2/vcpkg.json
+++ b/ports/libfido2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libfido2",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Provides library functionality to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.",
   "homepage": "https://developers.yubico.com/libfido2/",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4493,7 +4493,7 @@
       "port-version": 0
     },
     "libfido2": {
-      "baseline": "1.14.0",
+      "baseline": "1.15.0",
       "port-version": 0
     },
     "libflac": {

--- a/versions/l-/libfido2.json
+++ b/versions/l-/libfido2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "994499e1b88ed1457ea032128db4d0424dcaf298",
+      "version": "1.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6cdf57908524a456c4736785582dc28f1484584b",
       "version": "1.14.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

