### PR TITLE
[libics] update to 1.6.8

### DIFF
--- a/ports/libics/portfile.cmake
+++ b/ports/libics/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO svi-opensource/libics
     REF "${VERSION}"
-    SHA512 290d6d7bd3f5611d0b46aa6406ef10449ee768bc14d0b34f0bb365ca46f98b7fd4065c94fd9594e357427a4d0644f2724a1f773c7f3b43adc3db2389b94ee88e
+    SHA512 0eba280c1174cbd0e1fe6da1502345720793df2f3f6ec31fe0043d79a31d7b79cac5d7da726891faacedc91056e6337a3a694e50d0baafa08314a2867ff3e62f
     HEAD_REF master
     PATCHES fix-integral-include.patch
 )

--- a/ports/libics/vcpkg.json
+++ b/ports/libics/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libics",
-  "version": "1.6.6",
+  "version": "1.6.8",
   "description": "Reference library for ICS (Image Cytometry Standard), an open standard for writing images of any dimensionality and data type to file, together with associated information regarding the recording equipment or recorded subject.",
   "homepage": "https://github.com/svi-opensource/libics",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4629,7 +4629,7 @@
       "port-version": 4
     },
     "libics": {
-      "baseline": "1.6.6",
+      "baseline": "1.6.8",
       "port-version": 0
     },
     "libid3tag": {

--- a/versions/l-/libics.json
+++ b/versions/l-/libics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52843a6b1d983426e492b9046056e16df6f1f4bc",
+      "version": "1.6.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "dd79bb59a4716358360e475a7aaa3ec6a20c80e1",
       "version": "1.6.6",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

