### PR TITLE
[materialx] update to 1.39.1

### DIFF
--- a/ports/materialx/portfile.cmake
+++ b/ports/materialx/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/MaterialX
     REF "v${VERSION}"
-    SHA512 e527c2d160502b79edc33e801351d2d40b6419b853aa6b3e8c4a54787006baed236829ec8e4db32469daffec8bc1aa1ba35588a49d414fb38feee36fac7e3fb7
+    SHA512 ca743e619f51bddd67419c79a31e9fb92dd7883e8c182897c1d8cea2e5dc51cddf13ac8cc798cfa0f022dacf4fd77881aefc24f3184f8b7273651ba55c7df400
     HEAD_REF main
 )
 

--- a/ports/materialx/vcpkg.json
+++ b/ports/materialx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "materialx",
-  "version": "1.38.9",
+  "version": "1.39.1",
   "description": "MaterialX is an open standard for the exchange of rich material and look-development content across applications and renderers.",
   "homepage": "https://www.materialx.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5753,7 +5753,7 @@
       "port-version": 0
     },
     "materialx": {
-      "baseline": "1.38.9",
+      "baseline": "1.39.1",
       "port-version": 0
     },
     "mathc": {

--- a/versions/m-/materialx.json
+++ b/versions/m-/materialx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43f4bdc0c36c5c07302761341423d663f9fbea47",
+      "version": "1.39.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d2a74dccc02854ec1ef84d3ef6b4defcfeb2b0ea",
       "version": "1.38.9",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

