### PR TITLE
[libdeflate] Update to v1.22

### DIFF
--- a/ports/libdeflate/portfile.cmake
+++ b/ports/libdeflate/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ebiggers/libdeflate
     REF "v${VERSION}"
-    SHA512 7cd9bc91992ef824a0fdf175b0da081b8381decc325013477a3fbfcfe6cf240f66cedbeec830a51343fedb8c27c76fba8782c1aed3fc538e3afd6c9f8cdc90fb
+    SHA512 ca3ec7eb3e44da13164f33e56c856dbffc4ccc7b86d995afca6a23fa3f201b766d08a047871407e14a7964dd3da843be23c316e51d981cdd98f25166092de3a9
     HEAD_REF master
     PATCHES
         remove_wrong_c_flags_modification.diff

--- a/ports/libdeflate/vcpkg.json
+++ b/ports/libdeflate/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdeflate",
-  "version": "1.21",
+  "version": "1.22",
   "description": "libdeflate is a library for fast, whole-buffer DEFLATE-based compression and decompression.",
   "homepage": "https://github.com/ebiggers/libdeflate",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4405,7 +4405,7 @@
       "port-version": 0
     },
     "libdeflate": {
-      "baseline": "1.21",
+      "baseline": "1.22",
       "port-version": 0
     },
     "libdisasm": {

--- a/versions/l-/libdeflate.json
+++ b/versions/l-/libdeflate.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "db7abc03a06bc3b794ee65f4859a58bc6a441502",
+      "version": "1.22",
+      "port-version": 0
+    },
+    {
       "git-tree": "f9ff3bada26cff48e11e2b2ffa89b948436f4b97",
       "version": "1.21",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.