### PR TITLE
actions stale bot: Use actions/stale@v9 bot with two merged PRs to fix caching when using the action multiple times

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,20 +4,22 @@ on:
     - cron: '30 1 * * *'
 
 permissions:
+  actions: write # for caching state
   issues: write
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: autoantwort/stale@v1.0.0  # actions/stale@v9 with merged PR #1152 and #1169 to fix caching
         with:
           stale-issue-message: 'This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 28 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment.'
           any-of-labels: 'category:question,requires:repro,requires:more-information'
           days-before-issue-stale: 28
           days-before-pr-stale: -1
           days-before-close: 14
-      - uses: actions/stale@v8
+          cache-prefix: no-activity
+      - uses: autoantwort/stale@v1.0.0  # actions/stale@v9 with merged PR #1152 and #1169 to fix caching
         with:
           stale-issue-message: "This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 60 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment."
           any-of-labels: 'category:new-port'
@@ -25,7 +27,8 @@ jobs:
           days-before-issue-stale: 60
           days-before-pr-stale: -1
           days-before-close: 14
-      - uses: actions/stale@v8
+          cache-prefix: new-port
+      - uses: autoantwort/stale@v1.0.0  # actions/stale@v9 with merged PR #1152 and #1169 to fix caching
         with:
           stale-issue-message: "This is an automated message. Per our repo policy, stale issues get closed if there has been no activity in the past 180 days. The issue will be automatically closed in 14 days. If you wish to keep this issue open, please add a new comment."
           exempt-issue-labels: 'no-stale,category:new-port,category:question,requires:repro,requires:more-information'
@@ -33,3 +36,4 @@ jobs:
           days-before-pr-stale: -1
           days-before-close: 14
           operations-per-run: 50
+          cache-prefix: stale-issues


### PR DESCRIPTION
The bot was already updated in the past, but this was reverted because the action contained bugs. With these [PRs](https://github.com/actions/stale/pull/1169) the bugs are fixed. 
This would fix "errors" like this one: https://github.com/microsoft/vcpkg/issues/34268#issuecomment-1832974449 since every issue is visited after some time. 