### PR TITLE
[apr] Add HOST_TOOLS_DIR/gen_test_char for cross-compiling to Windows

### DIFF
--- a/ports/activemq-cpp/vcpkg.json
+++ b/ports/activemq-cpp/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "activemq-cpp",
   "version-semver": "3.9.5",
-  "port-version": 16,
+  "port-version": 17,
   "description": "Apache ActiveMQ is the most popular and powerful open source messaging and Integration Patterns server.",
   "license": "Apache-2.0",
-  "supports": "!(uwp | osx)",
+  "supports": "(windows & !uwp & (x86 | x64)) | (!windows & !osx)",
   "dependencies": [
     "apr",
     {

--- a/ports/apr/0100-add-host-tools-dir.diff
+++ b/ports/apr/0100-add-host-tools-dir.diff
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d16eec6..92146f4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -87,13 +87,17 @@ STRING(REGEX REPLACE ".*#define APR_PATCH_VERSION[ \t]+([0-9]+).*" "\\1" APR_PAT
+ 
+ CONFIGURE_FILE(include/apr.hwc
+                ${PROJECT_BINARY_DIR}/apr.h)
+
+ ADD_EXECUTABLE(gen_test_char tools/gen_test_char.c)
+
++set(UNOFFICIAL_APR_HOST_TOOLS_DIR "$<TARGET_FILE_DIR:gen_test_char>" CACHE STRING "")
++set(UNOFFICIAL_APR_HOST_EXECUTABLE_SUFFIX "$<TARGET_PROPERTY:gen_test_char,SUFFIX>" CACHE STRING "")
++install(TARGETS gen_test_char)
++
+ ADD_CUSTOM_COMMAND(
+   COMMENT "Generating character tables, apr_escape_test_char.h, for current locale"
+   DEPENDS gen_test_char
+-  COMMAND $<TARGET_FILE:gen_test_char> > ${PROJECT_BINARY_DIR}/apr_escape_test_char.h
++  COMMAND "${UNOFFICIAL_APR_HOST_TOOLS_DIR}/gen_test_char${UNOFFICIAL_APR_HOST_EXECUTABLE_SUFFIX}" > ${PROJECT_BINARY_DIR}/apr_escape_test_char.h
+   OUTPUT ${PROJECT_BINARY_DIR}/apr_escape_test_char.h
+ )
+ ADD_CUSTOM_TARGET(

--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -1,6 +1,3 @@
-
-set(VERSION 1.7.5)
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/apr/apr-${VERSION}.tar.bz2"
     FILENAME "apr-${VERSION}.tar.bz2"
@@ -11,7 +8,18 @@ vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
         unglue.patch
+        0100-add-host-tools-dir.diff
 )
+
+set(CURRENT_HOST_TOOLS_DIR "${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}")
+
+set(CROSSCOMPILING_OPTIONS "")
+if(VCPKG_CROSSCOMPILING)
+    list(APPEND CROSSCOMPILING_OPTIONS
+        "-DUNOFFICIAL_APR_HOST_TOOLS_DIR=${CURRENT_HOST_TOOLS_DIR}"
+        "-DUNOFFICIAL_APR_HOST_EXECUTABLE_SUFFIX=${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+    )
+endif()
 
 if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -32,6 +40,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
             -DMIN_WINDOWS_VER=Windows7
             -DAPR_HAVE_IPV6=ON
             ${FEATURE_OPTIONS}
+            ${CROSSCOMPILING_OPTIONS}
     )
 
     vcpkg_cmake_install()
@@ -42,6 +51,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
     )
     # There is no way to suppress installation of the headers in debug builds.
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+    vcpkg_copy_tools(TOOL_NAMES gen_test_char AUTO_CLEAN)
 
     vcpkg_copy_pdbs()
 

--- a/ports/apr/vcpkg.json
+++ b/ports/apr/vcpkg.json
@@ -1,12 +1,17 @@
 {
   "name": "apr",
   "version": "1.7.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.",
   "homepage": "https://apr.apache.org/",
   "license": "Apache-2.0",
-  "supports": "!uwp",
+  "supports": "!uwp & !mingw",
   "dependencies": [
+    {
+      "name": "apr",
+      "host": true,
+      "platform": "windows"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true,

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -51,8 +51,6 @@ allegro5:x64-android=fail
 apr:arm-neon-android=fail
 apr:arm64-android=fail
 apr:x64-android=fail
-# Cross compiling CI machine cannot run gen_test_char to generate apr_escape_test_char.h
-apr:arm64-windows=fail
 apsi:arm-neon-android=fail
 apsi:x64-android=fail
 # Broken with CUDA 12; needs update to 3.8.3 and https://github.com/arrayfire/arrayfire/issues/3349 fixed

--- a/versions/a-/activemq-cpp.json
+++ b/versions/a-/activemq-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0066f657df214848cbfd6b991e8ff4a52902e81b",
+      "version-semver": "3.9.5",
+      "port-version": 17
+    },
+    {
       "git-tree": "1644c99e45b2364ea36c0307b4d7171f4717ccdc",
       "version-semver": "3.9.5",
       "port-version": 16

--- a/versions/a-/apr.json
+++ b/versions/a-/apr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dfa11d3e5058b640b37c1a6845dbc2980496a7c8",
+      "version": "1.7.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "499cf5fc0959f4a049ec72f0f556400e7191ffd3",
       "version": "1.7.5",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -34,7 +34,7 @@
     },
     "activemq-cpp": {
       "baseline": "3.9.5",
-      "port-version": 16
+      "port-version": 17
     },
     "ada-url": {
       "baseline": "2.9.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -170,7 +170,7 @@
     },
     "apr": {
       "baseline": "1.7.5",
-      "port-version": 1
+      "port-version": 2
     },
     "apr-util": {
       "baseline": "1.6.3",


### PR DESCRIPTION
Fix #40827, missing native tool `gen_test_char` on cross-compiling to Windows.

### Change

* Add host tool `gen_test_char` for cross-compiling to Windows
  + Add CMake install target `gen_test_char`
  + Add itself as host dependency
  + Add `UNOFFICIAL_APR_HOST_TOOLS_DIR` adn `UNOFFICIAL_APR_HOST_EXECUTABLE_SUFFIX` to set the host tool
* Exclude `mingw` from the `supports`
  + Wrong capitalization of `Shellapi.h`
  + Bug for `mingw` https://bz.apache.org/bugzilla/show_bug.cgi?id=56342
* Port `activemq-cpp`: Only allow x86 and x64 under Windows platform
  + https://github.com/apache/activemq-cpp/blob/activemq-cpp-3.9.5/activemq-cpp/vs2010-build/activemq-cpp.sln

For cross-compiling on Linux, see https://github.com/apache/apr/pull/8

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port usage tests pass on host `x64-windows` with the following triplets:

* arm64-windows
* x86-windows
* x64-windows