### PR TITLE
opencv4 regex patch for x64-uwp-static-md triplet

### DIFF
--- a/ports/opencv4/0023-fix-regex-OpenCVUtils.patch
+++ b/ports/opencv4/0023-fix-regex-OpenCVUtils.patch
@@ -1,0 +1,11 @@
+--- a/cmake/OpenCVUtils.cmake.original	2024-10-01 16:59:17.788263700 +0200
++++ b/cmake/OpenCVUtils.cmake	2024-10-01 17:10:11.870857900 +0200
+@@ -1638,7 +1638,7 @@
+       AND NOT (CMAKE_VERSION VERSION_LESS "3.13.0")  # upgrade CMake: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/2152
+   )
+     foreach(tgt in ${ARGN})
+-      if(tgt MATCHES "^ocv\.3rdparty\.")
++      if(tgt MATCHES "^ocv\\.3rdparty\\.")
+         list(FIND __OPENCV_EXPORTED_EXTERNAL_TARGETS "${tgt}" _found)
+         if(_found EQUAL -1)  # don't export target twice
+           install(TARGETS ${tgt} EXPORT OpenCVModules)

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -39,6 +39,7 @@ vcpkg_from_github(
       "${ARM64_WINDOWS_FIX}"
       0022-fix-supportqnx.patch
       "${CUDA_12_4_FIX}"
+      0023-fix-regex-OpenCVUtils.patch
 )
 # Disallow accidental build of vendored copies
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/openexr")

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.8.0",
-  "port-version": 22,
+  "port-version": 23,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6610,7 +6610,7 @@
     },
     "opencv4": {
       "baseline": "4.8.0",
-      "port-version": 22
+      "port-version": 23
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -3,6 +3,11 @@
     {
       "git-tree": "f1c14acfbb673af2479af39dd8424c8f151752ad",
       "version": "4.8.0",
+      "port-version": 23
+    },
+    {
+      "git-tree": "f1c14acfbb673af2479af39dd8424c8f151752ad",
+      "version": "4.8.0",
       "port-version": 22
     },
     {

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f1c14acfbb673af2479af39dd8424c8f151752ad",
+      "git-tree": "151657a2ac1a8807772091d2c73b645ecdfdcc84",
       "version": "4.8.0",
       "port-version": 23
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- The machine setup:
Windows 10 Pro 22H2
cmake 3.30
- The steps to reproduce: 
command : vcpkg.exe install opencv4:x64-uwp-static-md --allow-unsupported
- The outcome you expected: 
No error on installation
- The actual outcome: 
["I get a crash dialog"](error: building opencv4:x64-uwp-static-md failed with: BUILD_FAILED)
- Logs :
vcpkg\buildtrees\opencv4\config-x64-uwp-static-md-out.log : 
```
CMake Error at cmake/OpenCVUtils.cmake:1641 (if):
  Syntax error in cmake code at
    C:/NextBIM_NN/opencvtest/vcpkg/buildtrees/opencv4/src/4.8.0-f4e8005717.clean/cmake/OpenCVUtils.cmake:1641
  when parsing string
    ^ocv\.3rdparty\.
  Invalid escape sequence \.
```
Solution : Patch --> 0023-fix-regex-OpenCVUtils.patch

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
