### PR TITLE
[alpaca] update to 2.5.0

### DIFF
--- a/ports/alpaca/portfile.cmake
+++ b/ports/alpaca/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO p-ranav/alpaca
     REF v${VERSION}
-    SHA512 3c61bd177f4118d8e270df24285d59e294d9eeb25daddac2d39d867188699955422fee92c875961c0fd1a77b46fe8d866310e578fd201e566e57c00539f85cfd
+    SHA512 0
     HEAD_REF master
 )
 

--- a/ports/alpaca/vcpkg.json
+++ b/ports/alpaca/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "alpaca",
-  "version": "0.2.1",
+  "version": "2.5.0",
   "description": "Alpaca is a serialization library written in C++17 - Pack C++ structs into a compact byte-array without any macros or boilerplate code",
   "homepage": "https://github.com/p-ranav/alpaca",
   "license": "MIT",

--- a/versions/a-/alpaca.json
+++ b/versions/a-/alpaca.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d41fba25791d398b79ea0c1b43b38552cf39795e",
+      "version": "2.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9533d25c8a1eabb24839c4ed613d10be95101b4b",
       "version": "0.2.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -89,7 +89,7 @@
       "port-version": 0
     },
     "alpaca": {
-      "baseline": "0.2.1",
+      "baseline": "2.5.0",
       "port-version": 0
     },
     "alpaka": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

