### PR TITLE
[ngtcp2] Add boringssl feature

### DIFF
--- a/ports/ngtcp2/boringssl.patch
+++ b/ports/ngtcp2/boringssl.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 11848ecb..27bca1bc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -170,6 +170,11 @@ endif()
+ include(CheckCXXSymbolExists)
+ if(ENABLE_BORINGSSL)
+   cmake_push_check_state()
++  find_package(OpenSSL REQUIRED)
++  set(BORINGSSL_INCLUDE_DIR     "${OPENSSL_INCLUDE_DIR}")
++  set(BORINGSSL_LIBRARIES       "${OPENSSL_LIBRARIES}")
++  set(OPENSSL_INCLUDE_DIRS  "")
++  set(OPENSSL_LIBRARIES     "")
+   set(CMAKE_REQUIRED_INCLUDES   "${BORINGSSL_INCLUDE_DIR}")
+   set(CMAKE_REQUIRED_LIBRARIES  "${BORINGSSL_LIBRARIES}")
+   check_cxx_symbol_exists(SSL_set_quic_early_data_context "openssl/ssl.h" HAVE_SSL_SET_QUIC_EARLY_DATA_CONTEXT)

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 0fa71544d70080ed9b0373383aaf985c7ed162913a480371affb3131cb3bb55e9a9653896da3801f5b1d121fc654232f5e463298f8070413f309bb4a514898f8
     HEAD_REF main
+    PATCHES
+        boringssl.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC_LIB)
@@ -11,9 +13,10 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED_LIB)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        wolfssl  ENABLE_WOLFSSL
-        gnutls   ENABLE_GNUTLS
-        libressl ENABLE_OPENSSL
+        wolfssl     ENABLE_WOLFSSL
+        gnutls      ENABLE_GNUTLS
+        libressl    ENABLE_OPENSSL
+        boringssl   ENABLE_BORINGSSL
 )
 
 vcpkg_cmake_configure(

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ngtcp2",
   "version": "1.9.1",
+  "port-version": 1,
   "description": "ngtcp2 project is an effort to implement RFC9000 QUIC protocol.",
   "homepage": "https://github.com/ngtcp2/ngtcp2",
   "license": "MIT",
@@ -15,6 +16,12 @@
     }
   ],
   "features": {
+    "boringssl": {
+      "description": "Compile with boringssl",
+      "dependencies": [
+        "boringssl"
+      ]
+    },
     "gnutls": {
       "description": "Compile with gnutls",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6362,7 +6362,7 @@
     },
     "ngtcp2": {
       "baseline": "1.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "nifly": {
       "baseline": "1.0.0",

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "faf91ac8e78edc14c28170c9158a4802d19349d4",
+      "version": "1.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "963e4c47fa03f36483347f322dc64fdcfbe40272",
       "version": "1.9.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
