### PR TITLE
[raylib] Fix link warning

### DIFF
--- a/ports/raylib/fix-link-path.patch
+++ b/ports/raylib/fix-link-path.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/raylib-config.cmake b/cmake/raylib-config.cmake
+index 700965c..4815cd6 100644
+--- a/cmake/raylib-config.cmake
++++ b/cmake/raylib-config.cmake
+@@ -65,7 +65,7 @@ if (NOT TARGET raylib)
+       IMPORTED_LOCATION             "${raylib_LIBRARIES}"
+       IMPORTED_IMPLIB               "${raylib_LIBRARIES}"
+       INTERFACE_INCLUDE_DIRECTORIES "${raylib_INCLUDE_DIRS}"
+-      INTERFACE_LINK_LIBRARIES      "${raylib_LDFLAGS}"
++      INTERFACE_LINK_LIBRARIES      "${raylib_LIBRARIES}"
+       INTERFACE_COMPILE_OPTIONS     "${raylib_DEFINITIONS}"
+     )
+ 

--- a/ports/raylib/portfile.cmake
+++ b/ports/raylib/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         android.diff
+        fix-link-path.patch
 )
 file(GLOB vendored_headers RELATIVE "${SOURCE_PATH}/src/external"
     "${SOURCE_PATH}/src/external/cgltf.h"

--- a/ports/raylib/vcpkg.json
+++ b/ports/raylib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "raylib",
   "version": "5.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A simple and easy-to-use library to enjoy videogames programming",
   "homepage": "https://github.com/raysan5/raylib",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7774,7 +7774,7 @@
     },
     "raylib": {
       "baseline": "5.0",
-      "port-version": 1
+      "port-version": 2
     },
     "rbdl": {
       "baseline": "3.3.0",

--- a/versions/r-/raylib.json
+++ b/versions/r-/raylib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e16299f8e3d6b40674ce53b106b764bd7459ad63",
+      "version": "5.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "6ef397a5c5afb217736842e45d9610d084a1fb2d",
       "version": "5.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/41257

Fix link library path.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Usage test pass with following triplets:

```
x64-windows
x64-linux
```