### PR TITLE
[directx-dxc] fix libdxil.so not found

### DIFF
--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -15,10 +15,9 @@ set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
 
 add_library(Microsoft::DXIL SHARED IMPORTED)
 set_target_properties(Microsoft::DXIL PROPERTIES
-   IMPORTED_LOCATION                    "${_dxc_root}/@dll_dir@/@dll_name_dxil@"
+   IMPORTED_LOCATION                    "${CURRENT_INSTALLED_DIR}/@dll_dir@/@dll_name_dxil@"
    IMPORTED_IMPLIB                      "${_dxc_root}/lib/@lib_name@"
    IMPORTED_SONAME                      "@lib_name@"
-   IMPORTED_SONAME                      "@dll_name_dxil@"
    INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
    IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 

--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -18,6 +18,7 @@ set_target_properties(Microsoft::DXIL PROPERTIES
    IMPORTED_LOCATION                    "${_dxc_root}/@dll_dir@/@dll_name_dxil@"
    IMPORTED_IMPLIB                      "${_dxc_root}/lib/@lib_name@"
    IMPORTED_SONAME                      "@lib_name@"
+   IMPORTED_SONAME                      "@dll_name_dxil@"
    INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
    IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 

--- a/ports/directx-dxc/vcpkg.json
+++ b/ports/directx-dxc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "directx-dxc",
   "version-date": "2024-07-31",
+  "port-version": 1,
   "description": "DirectX Shader Compiler (LLVM/Clang)",
   "homepage": "https://github.com/microsoft/DirectXShaderCompiler",
   "documentation": "https://github.com/microsoft/DirectXShaderCompiler/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2278,7 +2278,7 @@
     },
     "directx-dxc": {
       "baseline": "2024-07-31",
-      "port-version": 0
+      "port-version": 1
     },
     "directx-headers": {
       "baseline": "1.614.1",

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad865809bf209465952aa2f0d89b8d992a8785ce",
+      "git-tree": "b338248d2d23bf37932394facc59075f4ad1d7a1",
       "version-date": "2024-07-31",
       "port-version": 1
     },

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad865809bf209465952aa2f0d89b8d992a8785ce",
+      "version-date": "2024-07-31",
+      "port-version": 1
+    },
+    {
       "git-tree": "496868ff6ea29c1574cdde3889ece938b185762c",
       "version-date": "2024-07-31",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/41428
Error:
```
myprogram: error while loading shared libraries: vcpkg_installed/x64-linux/lib/libdxil.so: cannot open shared object file: No such file or directory
```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.