### PR TITLE
z_vcpkg_fixup_rpath_macho.cmake: Fix empty list check

### DIFF
--- a/scripts/cmake/z_vcpkg_fixup_rpath_macho.cmake
+++ b/scripts/cmake/z_vcpkg_fixup_rpath_macho.cmake
@@ -142,7 +142,7 @@ function(z_vcpkg_fixup_macho_rpath_in_dir)
             foreach(rpath IN LISTS rpath_list)
                 list(APPEND rpath_args "-delete_rpath" "${rpath}")
             endforeach()
-            if(rpath_args STREQUAL "")
+            if(NOT rpath_args)
                 continue()
             endif()
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/41122, alternative to https://github.com/microsoft/vcpkg/pull/41146 