### PR TITLE
[azure-identity-cpp] Update the azure-core-cpp dependency.

### DIFF
--- a/ports/azure-identity-cpp/vcpkg.json
+++ b/ports/azure-identity-cpp/vcpkg.json
@@ -5,6 +5,7 @@
   ],
   "name": "azure-identity-cpp",
   "version-semver": "1.10.0",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Identity SDK for C++",
     "This library provides common authentication-related abstractions for Azure SDK."

--- a/ports/azure-identity-cpp/vcpkg.json
+++ b/ports/azure-identity-cpp/vcpkg.json
@@ -15,7 +15,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.9.0"
+      "version>=": "1.14.0"
     },
     {
       "name": "openssl",

--- a/versions/a-/azure-identity-cpp.json
+++ b/versions/a-/azure-identity-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e34818074344451c91bda6706bf359f84a3b69b8",
+      "version-semver": "1.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "63ed30855e25a06b3b9ce7594e4a3de84f729039",
       "version-semver": "1.10.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -466,7 +466,7 @@
     },
     "azure-identity-cpp": {
       "baseline": "1.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-iot-sdk-c": {
       "baseline": "2024-08-12",


### PR DESCRIPTION
Porting over the dependency version fix from https://github.com/Azure/azure-sdk-for-cpp/pull/6086

Follow-up to https://github.com/microsoft/vcpkg/pull/41432

`azure-identity-cpp` now depends on the latest `azure-core-cpp` that shipped (1.14.0)

cc @antkmsft, @BillyONeal, @jdblischak 