### PR TITLE
[influxdb-cxx] Move headers due to conflict with Proxy.h

### DIFF
--- a/ports/influxdb-cxx/268.patch
+++ b/ports/influxdb-cxx/268.patch
@@ -1,0 +1,39 @@
+From 2588071852747d48e27c1ab8f478c3e24209b23f Mon Sep 17 00:00:00 2001
+From: offa <bm-dev@yandex.com>
+Date: Mon, 14 Oct 2024 18:11:39 +0200
+Subject: [PATCH] Install public API Header to InfluxDB/ subdirectory
+
+Adaption of #264
+---
+ CMakeLists.txt     | 4 ++--
+ src/CMakeLists.txt | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 310aa12c5dbe54db2b2587290a1e4ff65ad8d716..6acb4e6c74891569b71ee84245cd54b55d7897e8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -149,8 +149,8 @@ write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/cmake/InfluxDBConf
+ )
+ 
+ # Install headers
+-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+-install(FILES ${PROJECT_BINARY_DIR}/src/influxdb_export.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/InfluxDB")
++install(FILES ${PROJECT_BINARY_DIR}/src/influxdb_export.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/InfluxDB")
+ 
+ # Export targets
+ install(EXPORT InfluxDBTargets
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 3c58bd299b47e647afa42c1594a129a4eee7c5d8..d68b69eeb3f28199993d90e147a4d562fb766472 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -71,7 +71,7 @@ generate_export_header(InfluxDB)
+ 
+ target_include_directories(InfluxDB
+   PUBLIC
+-    $<INSTALL_INTERFACE:include>
++    $<INSTALL_INTERFACE:include/InfluxDB>
+     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+     # for export header
+     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>

--- a/ports/influxdb-cxx/portfile.cmake
+++ b/ports/influxdb-cxx/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 ac16178a17ac9b43a23d64f56d0012aeda896d3065246166abdef1441cf466453a6972c5820411936dcfa10a21505b654dfe981449c1d4cc169807f1db5d099f
     HEAD_REF master
-    PATCHES fix-dllexports.patch
+    PATCHES
+        fix-dllexports.patch
+        268.patch # https://github.com/offa/influxdb-cxx/pull/268
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/influxdb-cxx/vcpkg.json
+++ b/ports/influxdb-cxx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "influxdb-cxx",
   "version": "0.7.2",
+  "port-version": 1,
   "description": "InfluxDB C++ client library",
   "homepage": "https://github.com/offa/influxdb-cxx",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3702,7 +3702,7 @@
     },
     "influxdb-cxx": {
       "baseline": "0.7.2",
-      "port-version": 0
+      "port-version": 1
     },
     "infoware": {
       "baseline": "2023-04-12",

--- a/versions/i-/influxdb-cxx.json
+++ b/versions/i-/influxdb-cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1352a7a7701709dddd91bca356b81ecaf9450501",
+      "version": "0.7.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "1fd656270f4061beeca3b7aee1346ae242c041c0",
       "version": "0.7.2",
       "port-version": 0


### PR DESCRIPTION
Related https://github.com/microsoft/vcpkg/pull/41435

An existing issue where `libproxy` and `influxdb-cxx` both try to take `include/Proxy.h`/`include/proxy.h` went undetected before https://github.com/microsoft/vcpkg-tool/pull/1483 . The vcpkg maintainers discussed this and believe that `libproxy` should be the owner of `include/[Pp]proxy\.h`. It's both in the name and appears to be a much more widely used component.

We are going to skip `influxdb-cxx` in CI testing for now to unblock making our thrice-weekly CI runs green.

/cc @draveness @autoantwort @offa

<s>We're going to give `influxdb-cxx`'s maintainers 60 days to respond by hopefully renaming the headers in question. I've also filed a PR that does that to hopefully help: https://github.com/offa/influxdb-cxx/pull/263 . If there is no response in that time we'll move to remove `influxdb-cxx` from the registry.</s>

Upstream made changes: https://github.com/offa/influxdb-cxx/pull/264 /  https://github.com/offa/influxdb-cxx/pull/268