### PR TITLE
[libical] update to 3.0.18

### DIFF
--- a/ports/libical/portfile.cmake
+++ b/ports/libical/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libical/libical
     REF "v${VERSION}"
-    SHA512 11fbb4aba7503a3264b0efa30ad56aa923d31ec193bdb0b87b92bc88db9019fa670c8c9ee7998caa3a870e706446a58ead475f31bd703f0d2cb7aabf0f6a3aa7
+    SHA512 53ecf6c14a68d569dd11bfdeb1a072def847a14d189c6af16eab202e004350ee7d9488c6b63e9cb67889e8c2dec90643fef46aec143a915f28270d0752eaa9d5
 )
 
 vcpkg_find_acquire_program(PERL)

--- a/ports/libical/vcpkg.json
+++ b/ports/libical/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libical",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "description": "Reference implementation of the iCalendar data type and serialization format",
   "homepage": "https://github.com/libical/libical",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4617,7 +4617,7 @@
       "port-version": 0
     },
     "libical": {
-      "baseline": "3.0.17",
+      "baseline": "3.0.18",
       "port-version": 0
     },
     "libice": {

--- a/versions/l-/libical.json
+++ b/versions/l-/libical.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ccfb365a99b0784a89dedeedc3d78d876606afe",
+      "version": "3.0.18",
+      "port-version": 0
+    },
+    {
       "git-tree": "ef8cbea0185c5c9154f2ef0a38db78541f2e5769",
       "version": "3.0.17",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

