### PR TITLE
[Daxa] Fix missing header <algorithm> for std::sort

### DIFF
--- a/ports/daxa/fix-std-sort.patch
+++ b/ports/daxa/fix-std-sort.patch
@@ -1,0 +1,12 @@
+diff --git a/src/impl_instance.cpp b/src/impl_instance.cpp
+index 1c49a91..300d0db 100644
+--- a/src/impl_instance.cpp
++++ b/src/impl_instance.cpp
+@@ -3,6 +3,7 @@
+ #include "impl_device.hpp"
+ #include "impl_features.hpp"
+ 
++#include <algorithm>
+ #include <vector>
+ 
+ // --- Begin API Functions ---

--- a/ports/daxa/portfile.cmake
+++ b/ports/daxa/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 53e31bd89170ee18f404ae778c6fd0d5a1cefa2faf9f28e98d793c79dddeb03acda5525c98b875e45024de5db9c5e9cd9216042978c3a107587fefb6343db1e0
     HEAD_REF master
     PATCHES
-        fix-std-sort.patch
+        fix-std-sort.patch #https://github.com/Ipotrick/Daxa/pull/96
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/daxa/portfile.cmake
+++ b/ports/daxa/portfile.cmake
@@ -52,7 +52,4 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/LICENSE"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-    RENAME copyright
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/daxa/portfile.cmake
+++ b/ports/daxa/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF ${VERSION}
     SHA512 53e31bd89170ee18f404ae778c6fd0d5a1cefa2faf9f28e98d793c79dddeb03acda5525c98b875e45024de5db9c5e9cd9216042978c3a107587fefb6343db1e0
     HEAD_REF master
+    PATCHES
+        fix-std-sort.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/daxa/vcpkg.json
+++ b/ports/daxa/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "daxa",
   "version": "3.0.2",
+  "port-version": 1,
   "description": "Daxa C++ Vulkan Abstraction",
   "homepage": "https://github.com/Ipotrick/Daxa",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2222,7 +2222,7 @@
     },
     "daxa": {
       "baseline": "3.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "dbg-macro": {
       "baseline": "0.5.1",

--- a/versions/d-/daxa.json
+++ b/versions/d-/daxa.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7959ebb11a647a798fa2ee7a1d9dcf455540038a",
+      "git-tree": "1dbfcadfc493c0cffc92118ce35cb94a51a6ccf0",
       "version": "3.0.2",
       "port-version": 1
     },

--- a/versions/d-/daxa.json
+++ b/versions/d-/daxa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7959ebb11a647a798fa2ee7a1d9dcf455540038a",
+      "version": "3.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "11b337b86d5d7f3962cdc06942918607f7bd4489",
       "version": "3.0.2",
       "port-version": 0

--- a/versions/d-/daxa.json
+++ b/versions/d-/daxa.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1dbfcadfc493c0cffc92118ce35cb94a51a6ccf0",
+      "git-tree": "320d4418d0cdcf84777100c9a53c170227c3b4dc",
       "version": "3.0.2",
       "port-version": 1
     },


### PR DESCRIPTION
This PR resolves a compilation error in `impl_instance.cpp` caused by the absence of the `<algorithm>`.

This issue can be reproduced in the latest preview version `Visual Studio 2022 v17.12 Preview 2.1`.
```
D:/b/daxa/src/3.0.2-e19dccb089.clean/src/impl_instance.cpp(194): error C2039: 'sort': is not a member of 'std'

```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.