### PR TITLE
[libvault] update to 0.61.0

### DIFF
--- a/ports/libvault/0001-fix-dependencies.patch
+++ b/ports/libvault/0001-fix-dependencies.patch
@@ -1,27 +1,3 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index cd4482b..ac50fb5 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -17,9 +17,8 @@ option(LINK_CURL "Link curl library for vault" OFF)
- option(BUILD_SHARED_LIBS "Build vault as a shared library" ON)
- option(INSTALL "Run install targets" ON)
- 
--find_package(CURL)
-+find_package(CURL CONFIG REQUIRED)
- if(CURL_FOUND)
--  include_directories(${CURL_INCLUDE_DIR})
- else(CURL_FOUND)
-   message(FATAL_ERROR "CURL not found")
- endif(CURL_FOUND)
-@@ -126,7 +125,7 @@ set_target_properties(
- target_include_directories(vault PRIVATE src)
- 
- if(LINK_CURL)
--  target_link_libraries(vault curl)
-+  target_link_libraries(vault CURL::libcurl)
- endif(LINK_CURL)
- 
- if(ENABLE_COVERAGE)
 diff --git a/VaultConfig.cmake.in b/VaultConfig.cmake.in
 index 67a40ab..82db52d 100644
 --- a/VaultConfig.cmake.in

--- a/ports/libvault/portfile.cmake
+++ b/ports/libvault/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            abedra/libvault
-    REF             0.56.0
-    SHA512          6a8d14a755ea3d39c2912ee6d33cec9c6f30a498c57efc40603cecbbd90d400dba52be7b42287c87cd425694c89edbae86218021b2beaa5edca748c3d5dd7c77
+    REF "${VERSION}"
+    SHA512 20a7e8ae5bac5278ff2c9588d24f853b0c80169e008e930c390a78e15d18f36c68c2666a4c6c4aa263689d5b89a8c9945eead4d88087035fafb9865fcc3466ca
     PATCHES
         0001-fix-dependencies.patch
 )

--- a/ports/libvault/vcpkg.json
+++ b/ports/libvault/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libvault",
-  "version": "0.56.0",
+  "version": "0.61.0",
   "description": "A C++ library for Hashicorp Vault",
   "homepage": "https://github.com/abedra/libvault",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5261,7 +5261,7 @@
       "port-version": 1
     },
     "libvault": {
-      "baseline": "0.56.0",
+      "baseline": "0.61.0",
       "port-version": 0
     },
     "libvhdi": {

--- a/versions/l-/libvault.json
+++ b/versions/l-/libvault.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "436b6b9fcad7195ce891257b3da9ed08828ea11c",
+      "git-tree": "dcdc4c8aa3972fd6419a4203105ac1d57444b30f",
       "version": "0.61.0",
       "port-version": 0
     },

--- a/versions/l-/libvault.json
+++ b/versions/l-/libvault.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "436b6b9fcad7195ce891257b3da9ed08828ea11c",
+      "version": "0.61.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3ab55180dfc75f58d833bae81f6e303416c992e6",
       "version": "0.56.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

