### PR TITLE
[libmupdf] Update to 1.24.10

### DIFF
--- a/ports/libmupdf/dont-generate-extract-3rd-party-things.patch
+++ b/ports/libmupdf/dont-generate-extract-3rd-party-things.patch
@@ -1,6 +1,8 @@
+diff --git a/Makethird b/Makethird
+index f9c7896..63799b1 100644
 --- a/Makethird
 +++ b/Makethird
-@@ -238,6 +238,7 @@ endif
+@@ -253,6 +253,7 @@ endif
  
  # --- EXTRACT ---
  
@@ -8,9 +10,11 @@
  THIRD_CFLAGS += $(EXTRACT_CFLAGS)
  THIRD_LIBS += $(EXTRACT_LIBS)
  THIRD_SRC += $(EXTRACT_SRC)
-@@ -268,3 +269,4 @@ thirdparty/extract/src/odt_template.c: thirdparty/extract/src/template.odt third
-        @touch $@
+@@ -283,6 +284,7 @@ thirdparty/extract/src/odt_template.c: thirdparty/extract/src/template.odt third
+ 	@touch $@
  
  generate: thirdparty/extract/src/docx_template.c
 +endif
-
+ 
+ # --- LIBARCHIVE ---
+ 

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ArtifexSoftware/mupdf
     REF "${VERSION}"
-    SHA512 248340d2cde5d97b4ccfabbdf5e8f2080dba6233031fa384dcfdb98022ecfd7d7feebe38b19f9b94c2768bfef41c361417c73240ea7f8a458c6b9ea9cfedf665
+    SHA512 b3a3e9ba000d920641647b936c01bf88d6df4f3cd5635240fc50402e7ed1663015deb5de09f51c698181cb33ea4c76441a5bdbace81d6e472275afd02d0f84d7
     HEAD_REF master
     PATCHES
         dont-generate-extract-3rd-party-things.patch
@@ -23,7 +23,7 @@ vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBUILD_EXAMPLES=OFF
-	${FEATURE_OPTIONS}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
@@ -32,4 +32,4 @@ file(COPY "${SOURCE_PATH}/include/mupdf" DESTINATION "${CURRENT_PACKAGES_DIR}/in
 
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libmupdf/vcpkg.json
+++ b/ports/libmupdf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmupdf",
-  "version": "1.23.11",
+  "version": "1.24.10",
   "description": "a lightweight PDF, XPS, and E-book library",
   "homepage": "https://github.com/ArtifexSoftware/mupdf",
   "license": "AGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4801,7 +4801,7 @@
       "port-version": 0
     },
     "libmupdf": {
-      "baseline": "1.23.11",
+      "baseline": "1.24.10",
       "port-version": 0
     },
     "libmysofa": {

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc4b20674350d09f28dfe7af3c520f16fc06e25a",
+      "version": "1.24.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "ea6f82cee63a1056bfa2d88f5e7d0dbee3f64a5f",
       "version": "1.23.11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Feature `libmupdf[ocr]` passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```