### PR TITLE
[poselib] add new port

### DIFF
--- a/ports/poselib/portfile.cmake
+++ b/ports/poselib/portfile.cmake
@@ -1,0 +1,25 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO PoseLib/PoseLib
+    REF "v${VERSION}"
+    SHA512 adc43c4f0fd8544d2c7ef05538696a8ae614837f5e90c31b8b9c8f4b5a11eb773229c22444e01482de697a0f5b3137d4a63a24ba9fcc72b366a347252d3c16b1
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DMARCH_NATIVE=OFF
+        -DWITH_BENCHMARK=OFF
+        -DPYTHON_PACKAGE=OFF
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/PoseLib)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/poselib/vcpkg.json
+++ b/ports/poselib/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "poselib",
+  "version": "2.0.4",
+  "description": "Minimal solvers for calibrated camera pose estimation",
+  "homepage": "https://github.com/PoseLib/PoseLib",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "eigen3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7116,6 +7116,10 @@
       "baseline": "239",
       "port-version": 0
     },
+    "poselib": {
+      "baseline": "2.0.4",
+      "port-version": 0
+    },
     "ppconsul": {
       "baseline": "0.5",
       "port-version": 5

--- a/versions/p-/poselib.json
+++ b/versions/p-/poselib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "adf31292beb503a1ff13f6ecffd2697c0f56bbe2",
+      "version": "2.0.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.