### PR TITLE
[libfido2] Update to 1.15.0

### DIFF
--- a/ports/libfido2/portfile.cmake
+++ b/ports/libfido2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Yubico/libfido2
     REF ${VERSION}
-    SHA512 83454b0db0cc8546f377d0dd59f95785fe6b73cf28e499a6182a6ece4b7bce17c3e750155262adf71f339ec0b3b6c3d3d64a07b01c8428b4b91de97ae768f0e6
+    SHA512 97932ca1a9f8d1bb3cb4b4a8d56ef70085d19ad2bd27c67944fa17ed033bfa45d28d7ad3fa318723e79b17ef5a882ac4f999ad8a6b9965c58665d99c4da7b5ee
     HEAD_REF master
     PATCHES
         "fix_cmakelists.patch"
@@ -23,6 +23,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/libfido2/portfile.cmake
+++ b/ports/libfido2/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO Yubico/libfido2
     REF ${VERSION}
     SHA512 97932ca1a9f8d1bb3cb4b4a8d56ef70085d19ad2bd27c67944fa17ed033bfa45d28d7ad3fa318723e79b17ef5a882ac4f999ad8a6b9965c58665d99c4da7b5ee
-    HEAD_REF master
+    HEAD_REF main
     PATCHES
         "fix_cmakelists.patch"
 )

--- a/ports/libfido2/portfile.cmake
+++ b/ports/libfido2/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_cmake_configure(
         -DBUILD_STATIC_LIBS=${LIBFIDO2_BUILD_STATIC}
         -DBUILD_SHARED_LIBS=${LIBFIDO2_BUILD_SHARED}
         -DBUILD_TOOLS=OFF
+        -DBUILD_TESTS=OFF
  )
 
 vcpkg_cmake_install()

--- a/ports/libfido2/vcpkg.json
+++ b/ports/libfido2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libfido2",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Provides library functionality to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.",
   "homepage": "https://developers.yubico.com/libfido2/",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4493,7 +4493,7 @@
       "port-version": 0
     },
     "libfido2": {
-      "baseline": "1.14.0",
+      "baseline": "1.15.0",
       "port-version": 0
     },
     "libflac": {

--- a/versions/l-/libfido2.json
+++ b/versions/l-/libfido2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05c73986ac00311a01ec83d22cb86d3b7867ef52",
+      "version": "1.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6cdf57908524a456c4736785582dc28f1484584b",
       "version": "1.14.0",
       "port-version": 0

--- a/versions/l-/libfido2.json
+++ b/versions/l-/libfido2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "05c73986ac00311a01ec83d22cb86d3b7867ef52",
+      "git-tree": "89765c0a5d3dc689e1b44531b53cd059adb37bc3",
       "version": "1.15.0",
       "port-version": 0
     },

--- a/versions/l-/libfido2.json
+++ b/versions/l-/libfido2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "89765c0a5d3dc689e1b44531b53cd059adb37bc3",
+      "git-tree": "e422fffa6ba8b16a5aff5176841f704048e5fbd1",
       "version": "1.15.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The following usage passed on x64-windows:
```
libfido2 provides pkg-config modules:

  # A FIDO2 library
  libfido2
```