### PR TITLE
[realsense2] Apply upstream arm64 fix

### DIFF
--- a/ports/realsense2/portfile.cmake
+++ b/ports/realsense2/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(ARM64_DETECTION_FIX
+    URLS https://github.com/IntelRealSense/librealsense/commit/5a244052e2df7842940dfb5a9011973a09626300.patch?full_desc=1
+    FILENAME realsense2-arm64-detection-fix-5a244052e2df7842940dfb5a9011973a09626300.patch
+    SHA512 2897a55a58ec549914378213a5decd0092a527268651e7cb140ce2dad3ee99ddde2735113a448d8a191552fc32fa40a45422b274f617c98cda3d1b3ce948204b
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO IntelRealSense/librealsense
@@ -7,6 +13,7 @@ vcpkg_from_github(
     PATCHES
         fix_openni2.patch
         fix-osx.patch # from https://github.com/IntelRealSense/librealsense/pull/11997
+        "${ARM64_DETECTION_FIX}"
 )
 
 file(COPY "${SOURCE_PATH}/src/win7/drivers/IntelRealSense_D400_series_win7.inf" DESTINATION "${SOURCE_PATH}")

--- a/ports/realsense2/vcpkg.json
+++ b/ports/realsense2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "realsense2",
   "version": "2.54.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Intel® RealSense™ SDK 2.0 is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).",
   "homepage": "https://github.com/IntelRealSense/librealsense",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7822,7 +7822,7 @@
     },
     "realsense2": {
       "baseline": "2.54.2",
-      "port-version": 2
+      "port-version": 3
     },
     "recast": {
       "baseline": "deprecated",

--- a/versions/r-/realsense2.json
+++ b/versions/r-/realsense2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6206dc9c187261a734853fb0983ac24302fc07ae",
+      "version": "2.54.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "b15354f0a205d2288e63564e2789e317442bd999",
       "version": "2.54.2",
       "port-version": 2


### PR DESCRIPTION
This fixes the build of librealsense on macOS 15 "Sequoia" / XCode Command Line Tools 16

https://github.com/IntelRealSense/librealsense/commit/5a244052e2df7842940dfb5a9011973a09626300

Related: https://github.com/microsoft/vcpkg/pull/41307/