### PR TITLE
[librtpi] add port

### DIFF
--- a/ports/librtpi/portfile.cmake
+++ b/ports/librtpi/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_gitlab(
+    OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://gitlab.com
+    REPO linux-rt/librtpi
+    REF "${VERSION}"
+    SHA512 fb0cdd14f3c94f610fc153154ea09d5cfd7d3def16bdaabf8c2b4e0a8b7fa8ddec4cde6ae0b8726d58ee4a773df5c4f13002e565fb06ad3c8e9731a45122704f
+    HEAD_REF main
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+)
+
+vcpkg_install_make()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CURRENT_PORT_DIR}/unofficial-${PORT}-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}")

--- a/ports/librtpi/unofficial-librtpi-config.cmake
+++ b/ports/librtpi/unofficial-librtpi-config.cmake
@@ -1,0 +1,25 @@
+if(NOT TARGET unofficial::librtpi::librtpi)
+    get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+    get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+    get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+
+    add_library(unofficial::librtpi::librtpi UNKNOWN IMPORTED)
+
+    set_target_properties(unofficial::librtpi::librtpi PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+    )
+
+    find_library(LIBRTPI_LIBRARY_DEBUG NAMES rtpi librtpi PATHS "${_IMPORT_PREFIX}/debug" PATH_SUFFIXES lib NO_DEFAULT_PATH)
+    if(EXISTS "${LIBRTPI_LIBRARY_DEBUG}")
+        set_property(TARGET unofficial::librtpi::librtpi APPEND PROPERTY IMPORTED_CONFIGURATIONS "Debug")
+        set_target_properties(unofficial::librtpi::librtpi PROPERTIES IMPORTED_LOCATION_DEBUG "${LIBRTPI_LIBRARY_DEBUG}")
+    endif()
+
+    find_library(LIBRTPI_LIBRARY_RELEASE NAMES rtpi librtpi PATHS "${_IMPORT_PREFIX}/" PATH_SUFFIXES lib NO_DEFAULT_PATH)
+    if(EXISTS "${LIBRTPI_LIBRARY_RELEASE}")
+        set_property(TARGET unofficial::librtpi::librtpi APPEND PROPERTY IMPORTED_CONFIGURATIONS "Release")
+        set_target_properties(unofficial::librtpi::librtpi PROPERTIES IMPORTED_LOCATION_RELEASE "${LIBRTPI_LIBRARY_RELEASE}")
+    endif()
+
+    unset(_IMPORT_PREFIX)
+endif()

--- a/ports/librtpi/vcpkg.json
+++ b/ports/librtpi/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "librtpi",
+  "version": "1.0.0",
+  "description": "The Real-Time Priority Inheritance Library (librtpi) is intended to bridge the gap between the glibc pthread implementation and a functionally correct priority inheritance for pthread locking primitives, such as pthread_mutex and pthread_condvar.",
+  "homepage": "https://gitlab.com/linux-rt/librtpi",
+  "license": "LGPL-2.1-only",
+  "supports": "linux"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5012,6 +5012,10 @@
       "baseline": "2019-11-11",
       "port-version": 4
     },
+    "librtpi": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "librttopo": {
       "baseline": "1.1.0",
       "port-version": 8

--- a/versions/l-/librtpi.json
+++ b/versions/l-/librtpi.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ccd041402709075b83bb6a23ff2c85ce6c8358ac",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.