### PR TITLE
[triangle] Revise CMakeLists.txt and exported config

### DIFF
--- a/ports/triangle/CMakeLists.txt
+++ b/ports/triangle/CMakeLists.txt
@@ -1,45 +1,47 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5...3.30)
 project(triangle)
+
+option(BUILD_TOOL "Build the command line tool" OFF)
 
 include(GNUInstallDirs)
 
-add_library(triangleLib triangle.c exports.def)
-add_executable(triangle triangle.c)
+add_library(triangle triangle.c exports.def)
+set_target_properties(triangle PROPERTIES PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/triangle.h")
+target_compile_definitions(triangle PRIVATE -DTRILIBRARY)
 
-target_compile_definitions(triangleLib PRIVATE -DTRILIBRARY -DANSI_DECLARATORS)
-target_compile_definitions(triangle PRIVATE -DANSI_DECLARATORS)
-if(WIN32)
-   target_compile_definitions(triangleLib PRIVATE -DNO_TIMER)
-   target_compile_definitions(triangle PRIVATE -DNO_TIMER)
-endif()
+add_executable(triangle_exe triangle.c)
+set_target_properties(triangle_exe PROPERTIES OUTPUT_NAME "triangle")
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    target_link_libraries(triangle m)
-endif()
+foreach(target IN ITEMS triangle triangle_exe)
+    target_compile_definitions(${target} PRIVATE -DANSI_DECLARATORS)
+    target_include_directories(${target} PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>"
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+    )
+    if(WIN32)
+        target_compile_definitions(${target} PRIVATE -DNO_TIMER)
+    endif()
+    if(UNIX AND NOT APPLE AND NOT ANDROID)
+        target_link_libraries(${target} PRIVATE m)
+    endif()
+endforeach()
 
-target_include_directories(triangleLib PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-)
-
-set_target_properties(triangleLib PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
-set_target_properties(triangleLib PROPERTIES PUBLIC_HEADER
-    "${CMAKE_SOURCE_DIR}/triangle.h"
-)
-
-set_target_properties(triangleLib PROPERTIES OUTPUT_NAME "triangle")
-
-install(TARGETS triangleLib EXPORT triangleTargets
+install(TARGETS triangle
+    EXPORT triangle-targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-install(TARGETS triangle DESTINATION tools/triangle)
-
-install(EXPORT triangleTargets
-  FILE triangleConfig.cmake
-  NAMESPACE triangle::
-  DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/triangle"
+install(EXPORT triangle-targets
+  FILE unofficial-triangle-config.cmake
+  NAMESPACE unofficial::triangle::
+  DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/unofficial-triangle"
 )
+
+if(BUILD_TOOL)
+    install(TARGETS triangle_exe DESTINATION tools/triangle)
+else()
+    set_target_properties(triangle_exe PROPERTIES EXCLUDE_FROM_ALL 1)
+endif()

--- a/ports/triangle/portfile.cmake
+++ b/ports/triangle/portfile.cmake
@@ -11,21 +11,31 @@ vcpkg_extract_source_archive(
     PATCHES
         "enable_64bit_architecture.patch"
 )
-
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/exports.def" DESTINATION "${SOURCE_PATH}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS options
+    FEATURES
+        tool    BUILD_TOOL
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${options}
+    OPTIONS_DEBUG
+        -DBUILD_TOOL=OFF
 )
 
 vcpkg_cmake_install()
-
 vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-triangle)
 
-vcpkg_cmake_config_fixup()
+# migration polyfill
+file(COPY "${CURRENT_PORT_DIR}/triangleConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/triangle")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/tools")
 
+file(COPY "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/triangle")
 file(INSTALL "${SOURCE_PATH}/README" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/triangle/triangleConfig.cmake
+++ b/ports/triangle/triangleConfig.cmake
@@ -1,0 +1,6 @@
+file(READ "${CMAKE_CURRENT_LIST_DIR}/usage" usage)
+message(WARNING "find_package(${CMAKE_FIND_PACKAGE_NAME}) is deprecated.\n${usage}")
+
+include(CMakeFindDependencyMacro)
+find_dependency(unofficial-triangle)
+add_library(triangleLib ALIAS unofficial::triangle::triangle)

--- a/ports/triangle/usage
+++ b/ports/triangle/usage
@@ -1,0 +1,4 @@
+triangle provides CMake targets:
+
+  find_package(unofficial-triangle CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE unofficial::triangle::triangle)

--- a/ports/triangle/vcpkg.json
+++ b/ports/triangle/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "triangle",
   "version": "1.6",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A Two-Dimensional Quality Mesh Generator and Delaunay Triangulator.",
   "homepage": "http://www.cs.cmu.edu/~quake/triangle.html",
+  "license": null,
   "supports": "!uwp",
   "dependencies": [
     {
@@ -14,5 +15,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tool": {
+      "description": "Build the command line tool."
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9054,7 +9054,7 @@
     },
     "triangle": {
       "baseline": "1.6",
-      "port-version": 3
+      "port-version": 4
     },
     "triton": {
       "baseline": "2023-08-16",

--- a/versions/t-/triangle.json
+++ b/versions/t-/triangle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd79d7af32634104384879113cbf1158b1e72a8f",
+      "version": "1.6",
+      "port-version": 4
+    },
+    {
       "git-tree": "b751d577254b617b208ac8e1e828be1a539f8123",
       "version": "1.6",
       "port-version": 3


### PR DESCRIPTION
Fix CMake warnings.
Export include dir property.
Use canonical "unofficial" prefix. (Polyfill included.)
Add feature to control build of executable tool.