### PR TITLE
[glib] Disable host introspection

### DIFF
--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -50,6 +50,7 @@ vcpkg_configure_meson(
         ${OPTIONS}
         -Ddocumentation=false
         -Dinstalled_tests=false
+        -Dintrospection=disabled
         -Dlibelf=disabled
         -Dman-pages=disabled
         -Dtests=false

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "glib",
   "version": "2.80.0",
+  "port-version": 1,
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3126,7 +3126,7 @@
     },
     "glib": {
       "baseline": "2.80.0",
-      "port-version": 0
+      "port-version": 1
     },
     "glib-networking": {
       "baseline": "2.78.0",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3898752019d0ae61bd13a758b603325c152aec87",
+      "version": "2.80.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "98c1acbee23caa1307827ce7d8e4f6e38954e560",
       "version": "2.80.0",
       "port-version": 0


### PR DESCRIPTION
Fix #41478, disable host introspection feature introduced in [GNOME - GLib - 2.79.0](https://gitlab.gnome.org/GNOME/glib/-/releases/2.79.0).

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux