### PR TITLE
[perfetto] update to 48.0

### DIFF
--- a/ports/perfetto/portfile.cmake
+++ b/ports/perfetto/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/perfetto
     REF "v${VERSION}"
-    SHA512 4aa83f121fdc9c8f8d1bfdb22bfa78a8658352ccef58e0efbfa88dbda5e1bc6bca4a3d2cb45bdc6c91d6cfced0e7df7dce678a034935aa247e0f92bfb6adf2b2
+    SHA512 59243b459d56ff573d5091a150ccd78a3fff200d22d5ab3f33dfa88b0642c281478c3fa883aa497b21a0a5c9657e829471aa3040fcf45c2c0144f698945367ab
     HEAD_REF main
 )
 

--- a/ports/perfetto/vcpkg.json
+++ b/ports/perfetto/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "perfetto",
-  "version": "47.0",
+  "version": "48.0",
   "description": "System profiling, app tracing and trace analysis",
   "homepage": "https://perfetto.dev",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6917,7 +6917,7 @@
       "port-version": 3
     },
     "perfetto": {
-      "baseline": "47.0",
+      "baseline": "48.0",
       "port-version": 0
     },
     "pffft": {

--- a/versions/p-/perfetto.json
+++ b/versions/p-/perfetto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1b010e3002240f3a7b5d1f4faef4d4ccaef9931",
+      "version": "48.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a21f08b9f5fbf6b716698ed7a1499f61eadca1f3",
       "version": "47.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.