### PR TITLE
[nanodbc] update to 2.14.0

### DIFF
--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nanodbc/nanodbc
-    REF 7404a4dd7697e188df5724ab95a7553d2fc404eb # v2.13.0
-    SHA512 35ca098e783d771f3df611bce84e9b8207a6a5b72c492d2f3909977bc91a7c22bb262c34768b0d97ebfbdf12eeda0214064a8ea171e7bdda7b759f93ff346f45
+    REF "v${VERSION}"
+    SHA512 4ac6b4034548369e452bb73589be0245493edc139e6e305e35428be5eacbbaa64483797825c075ea0079ddbbdf1acb735dbb7c0168a385450e28fcd46a41f6fd
     HEAD_REF master
     PATCHES
         rename-version.patch

--- a/ports/nanodbc/vcpkg.json
+++ b/ports/nanodbc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nanodbc",
-  "version": "2.13.0",
-  "port-version": 8,
+  "version": "2.14.0",
   "description": "A small C++ wrapper for the native C ODBC API.",
   "homepage": "https://github.com/nanodbc/nanodbc",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6173,8 +6173,8 @@
       "port-version": 0
     },
     "nanodbc": {
-      "baseline": "2.13.0",
-      "port-version": 8
+      "baseline": "2.14.0",
+      "port-version": 0
     },
     "nanoflann": {
       "baseline": "1.6.1",

--- a/versions/n-/nanodbc.json
+++ b/versions/n-/nanodbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "79af8cdf521b63ff139c39f9970f4e1fdf51f18b",
+      "version": "2.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "47782a521b53acaa6ee44a2956a2e98d17a20e50",
       "version": "2.13.0",
       "port-version": 8


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

