### PR TITLE
[DPP] Bump to version 10.0.32

### DIFF
--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,8 +1,8 @@
 diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
-index 16df61f4..e2e5b5f0 100644
+index 3148b616..e2e5b5f0 100644
 --- a/library-vcpkg/CMakeLists.txt
 +++ b/library-vcpkg/CMakeLists.txt
-@@ -15,6 +15,9 @@
+@@ -15,15 +15,13 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
  #
@@ -12,7 +12,17 @@ index 16df61f4..e2e5b5f0 100644
  
  add_compile_definitions(HAVE_VOICE)
  
-@@ -51,8 +54,6 @@ if(WIN32)
+-if (HAVE_VOICE)
+-	file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/enabled/*.cpp" "${DPP_ROOT_PATH}/dpp/dave/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
+-else()
+-	file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/stub/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
+-endif()
+-
++file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/enabled/*.cpp" "${DPP_ROOT_PATH}/dpp/dave/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
+ 
+ set(LIB_NAME "${PROJECT_NAME}")
+ 
+@@ -56,8 +54,6 @@ if(WIN32)
  	add_compile_definitions(WIN32_LEAN_AND_MEAN)
  	add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
  	add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE)
@@ -21,19 +31,21 @@ index 16df61f4..e2e5b5f0 100644
  endif()
  
  target_compile_options(
-@@ -82,11 +83,6 @@ target_include_directories(
+@@ -87,13 +83,6 @@ target_include_directories(
  	"$<INSTALL_INTERFACE:include>"
  )
  
--add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
--include_directories("${DPP_ROOT_PATH}/mlspp/include")
--include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
--include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
+-if (HAVE_VOICE)
+-	add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
+-	include_directories("${DPP_ROOT_PATH}/mlspp/include")
+-	include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
+-	include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
+-endif()
 -
  set_target_properties(
  	"${LIB_NAME}" PROPERTIES
  	OUTPUT_NAME "dpp"
-@@ -103,6 +99,11 @@ find_package(OpenSSL REQUIRED)
+@@ -110,6 +99,11 @@ find_package(OpenSSL REQUIRED)
  find_package(Opus CONFIG REQUIRED)
  find_package(ZLIB REQUIRED)
  
@@ -45,19 +57,21 @@ index 16df61f4..e2e5b5f0 100644
  target_link_libraries(
  	"${LIB_NAME}" PUBLIC
  	$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
-@@ -113,16 +114,6 @@ target_link_libraries(
+@@ -120,18 +114,6 @@ target_link_libraries(
  	$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
  )
  
--# Private statically linked dependencies
--target_link_libraries(
--	${LIB_NAME} PRIVATE
--	mlspp
--	mls_vectors
--	bytes
--	tls_syntax
--	hpke
--)
+-if (HAVE_VOICE)
+-	# Private statically linked dependencies
+-	target_link_libraries(
+-		${LIB_NAME} PRIVATE
+-		mlspp
+-		mls_vectors
+-		bytes
+-		tls_syntax
+-		hpke
+-	)
+-endif()
 -
  set(CONFIG_FILE_NAME "${PROJECT_NAME}Config.cmake")
  set(EXPORTED_TARGETS_NAME "${PROJECT_NAME}Targets")

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,8 +1,8 @@
-diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
-index 16df61f4..e2e5b5f0 100644
+diff --git a/library-vcpkg/CMakeLists.txt b/../D++/library-vcpkg/CMakeLists.txt
+index 3148b616..e2e5b5f0 100644
 --- a/library-vcpkg/CMakeLists.txt
-+++ b/library-vcpkg/CMakeLists.txt
-@@ -15,6 +15,9 @@
++++ b/../D++/library-vcpkg/CMakeLists.txt
+@@ -15,15 +15,13 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
  #
@@ -12,7 +12,17 @@ index 16df61f4..e2e5b5f0 100644
  
  add_compile_definitions(HAVE_VOICE)
  
-@@ -51,8 +54,6 @@ if(WIN32)
+-if (HAVE_VOICE)
+-	file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/enabled/*.cpp" "${DPP_ROOT_PATH}/dpp/dave/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
+-else()
+-	file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/stub/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
+-endif()
+-
++file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/enabled/*.cpp" "${DPP_ROOT_PATH}/dpp/dave/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
+ 
+ set(LIB_NAME "${PROJECT_NAME}")
+ 
+@@ -56,8 +54,6 @@ if(WIN32)
  	add_compile_definitions(WIN32_LEAN_AND_MEAN)
  	add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
  	add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE)
@@ -21,19 +31,21 @@ index 16df61f4..e2e5b5f0 100644
  endif()
  
  target_compile_options(
-@@ -82,11 +83,6 @@ target_include_directories(
+@@ -87,13 +83,6 @@ target_include_directories(
  	"$<INSTALL_INTERFACE:include>"
  )
  
--add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
--include_directories("${DPP_ROOT_PATH}/mlspp/include")
--include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
--include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
+-if (HAVE_VOICE)
+-	add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
+-	include_directories("${DPP_ROOT_PATH}/mlspp/include")
+-	include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
+-	include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
+-endif()
 -
  set_target_properties(
  	"${LIB_NAME}" PROPERTIES
  	OUTPUT_NAME "dpp"
-@@ -103,6 +99,11 @@ find_package(OpenSSL REQUIRED)
+@@ -110,6 +99,11 @@ find_package(OpenSSL REQUIRED)
  find_package(Opus CONFIG REQUIRED)
  find_package(ZLIB REQUIRED)
  
@@ -45,19 +57,21 @@ index 16df61f4..e2e5b5f0 100644
  target_link_libraries(
  	"${LIB_NAME}" PUBLIC
  	$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
-@@ -113,16 +114,6 @@ target_link_libraries(
+@@ -120,18 +114,6 @@ target_link_libraries(
  	$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
  )
  
--# Private statically linked dependencies
--target_link_libraries(
--	${LIB_NAME} PRIVATE
--	mlspp
--	mls_vectors
--	bytes
--	tls_syntax
--	hpke
--)
+-if (HAVE_VOICE)
+-	# Private statically linked dependencies
+-	target_link_libraries(
+-		${LIB_NAME} PRIVATE
+-		mlspp
+-		mls_vectors
+-		bytes
+-		tls_syntax
+-		hpke
+-	)
+-endif()
 -
  set(CONFIG_FILE_NAME "${PROJECT_NAME}Config.cmake")
  set(EXPORTED_TARGETS_NAME "${PROJECT_NAME}Targets")

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,11 +1,11 @@
 diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
-index 16df61f4..6441c48b 100644
+index 16df61f4..0c3ee8ca 100644
 --- a/library-vcpkg/CMakeLists.txt
 +++ b/library-vcpkg/CMakeLists.txt
 @@ -15,6 +15,10 @@
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
 +set(HAVE_VOICE 1)
 +# Fake ssl version number for broken third party build scripts. Does not matter what
 +# value is set here so long as it is >= 1.1.1

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,8 +1,24 @@
+diff --git a/include/dpp/isa/fallback.h b/include/dpp/isa/fallback.h
+index 87a219f0..17c18232 100644
+--- a/include/dpp/isa/fallback.h
++++ b/include/dpp/isa/fallback.h
+@@ -20,6 +20,11 @@
+  ************************************************************************************/
+ #pragma once
+ 
++#ifdef _WIN32
++	#ifndef NOMINMAX
++		#define NOMINMAX
++	#endif
++#endif
+ #include <numeric>
+ #include <cstdint>
+ #include <limits>
 diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
-index 3148b616..e2e5b5f0 100644
+index 16df61f4..e2e5b5f0 100644
 --- a/library-vcpkg/CMakeLists.txt
 +++ b/library-vcpkg/CMakeLists.txt
-@@ -15,15 +15,13 @@
+@@ -15,6 +15,9 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
  #
@@ -12,17 +28,7 @@ index 3148b616..e2e5b5f0 100644
  
  add_compile_definitions(HAVE_VOICE)
  
--if (HAVE_VOICE)
--	file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/enabled/*.cpp" "${DPP_ROOT_PATH}/dpp/dave/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
--else()
--	file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/stub/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
--endif()
--
-+file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/enabled/*.cpp" "${DPP_ROOT_PATH}/dpp/dave/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
- 
- set(LIB_NAME "${PROJECT_NAME}")
- 
-@@ -56,8 +54,6 @@ if(WIN32)
+@@ -51,8 +54,6 @@ if(WIN32)
  	add_compile_definitions(WIN32_LEAN_AND_MEAN)
  	add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
  	add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE)
@@ -31,21 +37,19 @@ index 3148b616..e2e5b5f0 100644
  endif()
  
  target_compile_options(
-@@ -87,13 +83,6 @@ target_include_directories(
+@@ -82,11 +83,6 @@ target_include_directories(
  	"$<INSTALL_INTERFACE:include>"
  )
  
--if (HAVE_VOICE)
--	add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
--	include_directories("${DPP_ROOT_PATH}/mlspp/include")
--	include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
--	include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
--endif()
+-add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
+-include_directories("${DPP_ROOT_PATH}/mlspp/include")
+-include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
+-include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
 -
  set_target_properties(
  	"${LIB_NAME}" PROPERTIES
  	OUTPUT_NAME "dpp"
-@@ -110,6 +99,11 @@ find_package(OpenSSL REQUIRED)
+@@ -103,6 +99,11 @@ find_package(OpenSSL REQUIRED)
  find_package(Opus CONFIG REQUIRED)
  find_package(ZLIB REQUIRED)
  
@@ -57,21 +61,19 @@ index 3148b616..e2e5b5f0 100644
  target_link_libraries(
  	"${LIB_NAME}" PUBLIC
  	$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
-@@ -120,18 +114,6 @@ target_link_libraries(
+@@ -113,16 +114,6 @@ target_link_libraries(
  	$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
  )
  
--if (HAVE_VOICE)
--	# Private statically linked dependencies
--	target_link_libraries(
--		${LIB_NAME} PRIVATE
--		mlspp
--		mls_vectors
--		bytes
--		tls_syntax
--		hpke
--	)
--endif()
+-# Private statically linked dependencies
+-target_link_libraries(
+-	${LIB_NAME} PRIVATE
+-	mlspp
+-	mls_vectors
+-	bytes
+-	tls_syntax
+-	hpke
+-)
 -
  set(CONFIG_FILE_NAME "${PROJECT_NAME}Config.cmake")
  set(EXPORTED_TARGETS_NAME "${PROJECT_NAME}Targets")

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,19 +1,3 @@
-diff --git a/include/dpp/isa/fallback.h b/include/dpp/isa/fallback.h
-index 87a219f0..17c18232 100644
---- a/include/dpp/isa/fallback.h
-+++ b/include/dpp/isa/fallback.h
-@@ -20,6 +20,11 @@
-  ************************************************************************************/
- #pragma once
- 
-+#ifdef _WIN32
-+	#ifndef NOMINMAX
-+		#define NOMINMAX
-+	#endif
-+#endif
- #include <numeric>
- #include <cstdint>
- #include <limits>
 diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
 index 16df61f4..e2e5b5f0 100644
 --- a/library-vcpkg/CMakeLists.txt
@@ -78,3 +62,15 @@ index 16df61f4..e2e5b5f0 100644
  set(CONFIG_FILE_NAME "${PROJECT_NAME}Config.cmake")
  set(EXPORTED_TARGETS_NAME "${PROJECT_NAME}Targets")
  set(EXPORTED_TARGETS_FILE_NAME "${EXPORTED_TARGETS_NAME}.cmake")
+diff --git a/src/dpp/discordvoiceclient.cpp b/src/dpp/discordvoiceclient.cpp
+index 64e15982..ddc11430 100644
+--- a/src/dpp/discordvoiceclient.cpp
++++ b/src/dpp/discordvoiceclient.cpp
+@@ -20,6 +20,7 @@
+  *
+  ************************************************************************************/
+ 
++#include <dpp/export.h>
+ #ifdef _WIN32
+ 	#include <WinSock2.h>
+ 	#include <WS2tcpip.h>

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,5 +1,5 @@
 diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
-index 3148b616..73dce32c 100644
+index 3148b616..6ffac39d 100644
 --- a/library-vcpkg/CMakeLists.txt
 +++ b/library-vcpkg/CMakeLists.txt
 @@ -15,15 +15,13 @@
@@ -45,7 +45,7 @@ index 3148b616..73dce32c 100644
  set_target_properties(
  	"${LIB_NAME}" PROPERTIES
  	OUTPUT_NAME "dpp"
-@@ -107,31 +96,30 @@ target_link_options(
+@@ -107,28 +96,44 @@ target_link_options(
  
  find_package(nlohmann_json CONFIG REQUIRED)
  find_package(OpenSSL REQUIRED)
@@ -54,12 +54,7 @@ index 3148b616..73dce32c 100644
 +find_package(Opus REQUIRED)
  find_package(ZLIB REQUIRED)
  
-+add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
-+include_directories("${DPP_ROOT_PATH}/mlspp/include")
-+include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
-+include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
-+
- target_link_libraries(
+-target_link_libraries(
 -	"${LIB_NAME}" PUBLIC
 -	$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
 -	$<$<TARGET_EXISTS:OpenSSL::SSL>:OpenSSL::SSL>
@@ -67,36 +62,53 @@ index 3148b616..73dce32c 100644
 -	$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
 -	$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
 -	$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
-+		"${LIB_NAME}" PUBLIC
-+		$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
-+		$<$<TARGET_EXISTS:OpenSSL::SSL>:OpenSSL::SSL>
-+		$<$<TARGET_EXISTS:OpenSSL::Crypto>:OpenSSL::Crypto>
-+		$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
-+		$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
-+		$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
-+		mlspp.a
-+		mls_vectors.a
-+		bytes.a
-+		tls_syntax.a
-+		hpke.a
- )
+-)
++add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
++include_directories("${DPP_ROOT_PATH}/mlspp/include")
++include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
++include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
  
 -if (HAVE_VOICE)
 -	# Private statically linked dependencies
--	target_link_libraries(
++if (_WIN32)
++	target_link_libraries(
++			"${LIB_NAME}" PUBLIC
++			$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
++			$<$<TARGET_EXISTS:OpenSSL::SSL>:OpenSSL::SSL>
++			$<$<TARGET_EXISTS:OpenSSL::Crypto>:OpenSSL::Crypto>
++			$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
++			$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
++			$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
++			mlspp
++			mls_vectors
++			bytes
++			tls_syntax
++			hpke
++	)
++else()
+ 	target_link_libraries(
 -		${LIB_NAME} PRIVATE
 -		mlspp
 -		mls_vectors
 -		bytes
 -		tls_syntax
 -		hpke
--	)
--endif()
--
- set(CONFIG_FILE_NAME "${PROJECT_NAME}Config.cmake")
- set(EXPORTED_TARGETS_NAME "${PROJECT_NAME}Targets")
- set(EXPORTED_TARGETS_FILE_NAME "${EXPORTED_TARGETS_NAME}.cmake")
-@@ -158,6 +146,7 @@ write_basic_package_version_file(
++			"${LIB_NAME}" PUBLIC
++			$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
++			$<$<TARGET_EXISTS:OpenSSL::SSL>:OpenSSL::SSL>
++			$<$<TARGET_EXISTS:OpenSSL::Crypto>:OpenSSL::Crypto>
++			$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
++			$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
++			$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
++			mlspp.a
++			mls_vectors.a
++			bytes.a
++			tls_syntax.a
++			hpke.a
+ 	)
+ endif()
+ 
+@@ -158,6 +163,7 @@ write_basic_package_version_file(
  	COMPATIBILITY AnyNewerVersion
  )
  

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,0 +1,12 @@
+diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
+index 16df61f4..6441c48b 100644
+--- a/library-vcpkg/CMakeLists.txt
++++ b/library-vcpkg/CMakeLists.txt
+@@ -15,6 +15,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
++set(HAVE_VOICE 1)
+ 
+ add_compile_definitions(HAVE_VOICE)
+ 

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,5 +1,5 @@
 diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
-index 3148b616..e2e5b5f0 100644
+index 3148b616..82bed881 100644
 --- a/library-vcpkg/CMakeLists.txt
 +++ b/library-vcpkg/CMakeLists.txt
 @@ -15,15 +15,13 @@
@@ -18,7 +18,7 @@ index 3148b616..e2e5b5f0 100644
 -	file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/stub/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
 -endif()
 -
-+file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${modules_dir}/dpp/voice/enabled/*.cpp" "${DPP_ROOT_PATH}/dpp/dave/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
++file(GLOB THE_SOURCES "${DPP_ROOT_PATH}/src/dpp/events/*.cpp" "${DPP_ROOT_PATH}/src/dpp/voice/enabled/*.cpp" "${DPP_ROOT_PATH}/src/dpp/dave/*.cpp" "${DPP_ROOT_PATH}/src/dpp/cluster/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.cpp" "${DPP_ROOT_PATH}/src/dpp/*.rc")
  
  set(LIB_NAME "${PROJECT_NAME}")
  
@@ -57,8 +57,15 @@ index 3148b616..e2e5b5f0 100644
  target_link_libraries(
  	"${LIB_NAME}" PUBLIC
  	$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
-@@ -120,18 +114,6 @@ target_link_libraries(
+@@ -118,20 +112,13 @@ target_link_libraries(
+ 	$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
+ 	$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
  	$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
++	$<$<PLATFORM_ID:Windows>:mlspp.lib:mlspp.a>
++	$<$<PLATFORM_ID:Windows>:mls_vectors.lib:mls_vectors.a>
++	$<$<PLATFORM_ID:Windows>:bytes.lib:bytes.a>
++	$<$<PLATFORM_ID:Windows>:tls_syntax.lib:tls_syntax.a>
++	$<$<PLATFORM_ID:Windows>:hpke.lib:hpke.a>
  )
  
 -if (HAVE_VOICE)
@@ -76,6 +83,14 @@ index 3148b616..e2e5b5f0 100644
  set(CONFIG_FILE_NAME "${PROJECT_NAME}Config.cmake")
  set(EXPORTED_TARGETS_NAME "${PROJECT_NAME}Targets")
  set(EXPORTED_TARGETS_FILE_NAME "${EXPORTED_TARGETS_NAME}.cmake")
+@@ -158,6 +145,7 @@ write_basic_package_version_file(
+ 	COMPATIBILITY AnyNewerVersion
+ )
+ 
++# Private statically linked dependencies
+ install(
+ 	DIRECTORY "${DPP_ROOT_PATH}/include/"
+ 	DESTINATION "include"
 diff --git a/src/dpp/discordvoiceclient.cpp b/src/dpp/discordvoiceclient.cpp
 index 64e15982..ddc11430 100644
 --- a/src/dpp/discordvoiceclient.cpp

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,4 +1,4 @@
-diff --git a/library-vcpkg/CMakeLists.txt b/../D++/library-vcpkg/CMakeLists.txt
+diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
 index 3148b616..e2e5b5f0 100644
 --- a/library-vcpkg/CMakeLists.txt
 +++ b/../D++/library-vcpkg/CMakeLists.txt

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,7 +1,7 @@
 diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
 index 3148b616..e2e5b5f0 100644
 --- a/library-vcpkg/CMakeLists.txt
-+++ b/../D++/library-vcpkg/CMakeLists.txt
++++ b/library-vcpkg/CMakeLists.txt
 @@ -15,15 +15,13 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -70,7 +70,7 @@ index 3148b616..6ffac39d 100644
  
 -if (HAVE_VOICE)
 -	# Private statically linked dependencies
-+if (_WIN32)
++if (WIN32)
 +	target_link_libraries(
 +			"${LIB_NAME}" PUBLIC
 +			$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,5 +1,5 @@
 diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
-index 3148b616..82bed881 100644
+index 3148b616..9574b161 100644
 --- a/library-vcpkg/CMakeLists.txt
 +++ b/library-vcpkg/CMakeLists.txt
 @@ -15,15 +15,13 @@
@@ -45,45 +45,70 @@ index 3148b616..82bed881 100644
  set_target_properties(
  	"${LIB_NAME}" PROPERTIES
  	OUTPUT_NAME "dpp"
-@@ -110,6 +99,11 @@ find_package(OpenSSL REQUIRED)
- find_package(Opus CONFIG REQUIRED)
+@@ -107,28 +96,44 @@ target_link_options(
+ 
+ find_package(nlohmann_json CONFIG REQUIRED)
+ find_package(OpenSSL REQUIRED)
+-find_package(Opus CONFIG REQUIRED)
++include("${CMAKE_CURRENT_SOURCE_DIR}/../cmake/FindOpus.cmake")
++find_package(Opus REQUIRED)
  find_package(ZLIB REQUIRED)
  
+-target_link_libraries(
+-	"${LIB_NAME}" PUBLIC
+-	$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
+-	$<$<TARGET_EXISTS:OpenSSL::SSL>:OpenSSL::SSL>
+-	$<$<TARGET_EXISTS:OpenSSL::Crypto>:OpenSSL::Crypto>
+-	$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
+-	$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
+-	$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
+-)
 +add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
 +include_directories("${DPP_ROOT_PATH}/mlspp/include")
 +include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
 +include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
-+
- target_link_libraries(
- 	"${LIB_NAME}" PUBLIC
- 	$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
-@@ -118,20 +112,13 @@ target_link_libraries(
- 	$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
- 	$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
- 	$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
-+	$<$<PLATFORM_ID:Windows>:mlspp.lib:mlspp.a>
-+	$<$<PLATFORM_ID:Windows>:mls_vectors.lib:mls_vectors.a>
-+	$<$<PLATFORM_ID:Windows>:bytes.lib:bytes.a>
-+	$<$<PLATFORM_ID:Windows>:tls_syntax.lib:tls_syntax.a>
-+	$<$<PLATFORM_ID:Windows>:hpke.lib:hpke.a>
- )
  
 -if (HAVE_VOICE)
 -	# Private statically linked dependencies
--	target_link_libraries(
++if (_WIN32)
++	target_link_libraries(
++			"${LIB_NAME}" PUBLIC
++			$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
++			$<$<TARGET_EXISTS:OpenSSL::SSL>:OpenSSL::SSL>
++			$<$<TARGET_EXISTS:OpenSSL::Crypto>:OpenSSL::Crypto>
++			$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
++			$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
++			$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
++			mlspp.lib
++			mls_vectors.lib
++			bytes.lib
++			tls_syntax.lib
++			hpke.lib
++	)
++else()
+ 	target_link_libraries(
 -		${LIB_NAME} PRIVATE
 -		mlspp
 -		mls_vectors
 -		bytes
 -		tls_syntax
 -		hpke
--	)
--endif()
--
- set(CONFIG_FILE_NAME "${PROJECT_NAME}Config.cmake")
- set(EXPORTED_TARGETS_NAME "${PROJECT_NAME}Targets")
- set(EXPORTED_TARGETS_FILE_NAME "${EXPORTED_TARGETS_NAME}.cmake")
-@@ -158,6 +145,7 @@ write_basic_package_version_file(
++			"${LIB_NAME}" PUBLIC
++			$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
++			$<$<TARGET_EXISTS:OpenSSL::SSL>:OpenSSL::SSL>
++			$<$<TARGET_EXISTS:OpenSSL::Crypto>:OpenSSL::Crypto>
++			$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
++			$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
++			$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
++			mlspp.a
++			mls_vectors.a
++			bytes.a
++			tls_syntax.a
++			hpke.a
+ 	)
+ endif()
+ 
+@@ -158,6 +163,7 @@ write_basic_package_version_file(
  	COMPATIBILITY AnyNewerVersion
  )
  

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -2,11 +2,14 @@ diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
 index 16df61f4..6441c48b 100644
 --- a/library-vcpkg/CMakeLists.txt
 +++ b/library-vcpkg/CMakeLists.txt
-@@ -15,6 +15,7 @@
- # See the License for the specific language governing permissions and
- # limitations under the License.
- #
+@@ -15,6 +15,10 @@
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 +set(HAVE_VOICE 1)
++# Fake ssl version number for broken third party build scripts. Does not matter what
++# value is set here so long as it is >= 1.1.1
++set(OPENSSL_VERSION "1.1.1f")
  
  add_compile_definitions(HAVE_VOICE)
  

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -79,11 +79,11 @@ index 3148b616..6ffac39d 100644
 +			$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
 +			$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
 +			$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
-+			mlspp
-+			mls_vectors
-+			bytes
-+			tls_syntax
-+			hpke
++			mlspp.lib
++			mls_vectors.lib
++			bytes.lib
++			tls_syntax.lib
++			hpke.lib
 +	)
 +else()
  	target_link_libraries(

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,5 +1,5 @@
 diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
-index 3148b616..9574b161 100644
+index 3148b616..73dce32c 100644
 --- a/library-vcpkg/CMakeLists.txt
 +++ b/library-vcpkg/CMakeLists.txt
 @@ -15,15 +15,13 @@
@@ -45,7 +45,7 @@ index 3148b616..9574b161 100644
  set_target_properties(
  	"${LIB_NAME}" PROPERTIES
  	OUTPUT_NAME "dpp"
-@@ -107,28 +96,44 @@ target_link_options(
+@@ -107,31 +96,30 @@ target_link_options(
  
  find_package(nlohmann_json CONFIG REQUIRED)
  find_package(OpenSSL REQUIRED)
@@ -54,7 +54,12 @@ index 3148b616..9574b161 100644
 +find_package(Opus REQUIRED)
  find_package(ZLIB REQUIRED)
  
--target_link_libraries(
++add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
++include_directories("${DPP_ROOT_PATH}/mlspp/include")
++include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
++include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
++
+ target_link_libraries(
 -	"${LIB_NAME}" PUBLIC
 -	$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
 -	$<$<TARGET_EXISTS:OpenSSL::SSL>:OpenSSL::SSL>
@@ -62,53 +67,36 @@ index 3148b616..9574b161 100644
 -	$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
 -	$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
 -	$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
--)
-+add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
-+include_directories("${DPP_ROOT_PATH}/mlspp/include")
-+include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
-+include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
++		"${LIB_NAME}" PUBLIC
++		$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
++		$<$<TARGET_EXISTS:OpenSSL::SSL>:OpenSSL::SSL>
++		$<$<TARGET_EXISTS:OpenSSL::Crypto>:OpenSSL::Crypto>
++		$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
++		$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
++		$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
++		mlspp.a
++		mls_vectors.a
++		bytes.a
++		tls_syntax.a
++		hpke.a
+ )
  
 -if (HAVE_VOICE)
 -	# Private statically linked dependencies
-+if (_WIN32)
-+	target_link_libraries(
-+			"${LIB_NAME}" PUBLIC
-+			$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
-+			$<$<TARGET_EXISTS:OpenSSL::SSL>:OpenSSL::SSL>
-+			$<$<TARGET_EXISTS:OpenSSL::Crypto>:OpenSSL::Crypto>
-+			$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
-+			$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
-+			$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
-+			mlspp.lib
-+			mls_vectors.lib
-+			bytes.lib
-+			tls_syntax.lib
-+			hpke.lib
-+	)
-+else()
- 	target_link_libraries(
+-	target_link_libraries(
 -		${LIB_NAME} PRIVATE
 -		mlspp
 -		mls_vectors
 -		bytes
 -		tls_syntax
 -		hpke
-+			"${LIB_NAME}" PUBLIC
-+			$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
-+			$<$<TARGET_EXISTS:OpenSSL::SSL>:OpenSSL::SSL>
-+			$<$<TARGET_EXISTS:OpenSSL::Crypto>:OpenSSL::Crypto>
-+			$<$<TARGET_EXISTS:Opus::opus>:Opus::opus>
-+			$<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
-+			$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
-+			mlspp.a
-+			mls_vectors.a
-+			bytes.a
-+			tls_syntax.a
-+			hpke.a
- 	)
- endif()
- 
-@@ -158,6 +163,7 @@ write_basic_package_version_file(
+-	)
+-endif()
+-
+ set(CONFIG_FILE_NAME "${PROJECT_NAME}Config.cmake")
+ set(EXPORTED_TARGETS_NAME "${PROJECT_NAME}Targets")
+ set(EXPORTED_TARGETS_FILE_NAME "${EXPORTED_TARGETS_NAME}.cmake")
+@@ -158,6 +146,7 @@ write_basic_package_version_file(
  	COMPATIBILITY AnyNewerVersion
  )
  

--- a/ports/dpp/explicit-set-have-voice.patch
+++ b/ports/dpp/explicit-set-have-voice.patch
@@ -1,15 +1,64 @@
 diff --git a/library-vcpkg/CMakeLists.txt b/library-vcpkg/CMakeLists.txt
-index 16df61f4..0c3ee8ca 100644
+index 16df61f4..e2e5b5f0 100644
 --- a/library-vcpkg/CMakeLists.txt
 +++ b/library-vcpkg/CMakeLists.txt
-@@ -15,6 +15,10 @@
+@@ -15,6 +15,9 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
  #
 +set(HAVE_VOICE 1)
 +# Fake ssl version number for broken third party build scripts. Does not matter what
 +# value is set here so long as it is >= 1.1.1
-+set(OPENSSL_VERSION "1.1.1f")
  
  add_compile_definitions(HAVE_VOICE)
  
+@@ -51,8 +54,6 @@ if(WIN32)
+ 	add_compile_definitions(WIN32_LEAN_AND_MEAN)
+ 	add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+ 	add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE)
+-	# Fake an ssl version number to satisfy MLSPP
+-	set(OPENSSL_VERSION "1.1.1f")
+ endif()
+ 
+ target_compile_options(
+@@ -82,11 +83,6 @@ target_include_directories(
+ 	"$<INSTALL_INTERFACE:include>"
+ )
+ 
+-add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
+-include_directories("${DPP_ROOT_PATH}/mlspp/include")
+-include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
+-include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
+-
+ set_target_properties(
+ 	"${LIB_NAME}" PROPERTIES
+ 	OUTPUT_NAME "dpp"
+@@ -103,6 +99,11 @@ find_package(OpenSSL REQUIRED)
+ find_package(Opus CONFIG REQUIRED)
+ find_package(ZLIB REQUIRED)
+ 
++add_subdirectory("${DPP_ROOT_PATH}/mlspp" "mlspp")
++include_directories("${DPP_ROOT_PATH}/mlspp/include")
++include_directories("${DPP_ROOT_PATH}/mlspp/lib/bytes/include")
++include_directories("${DPP_ROOT_PATH}/mlspp/lib/hpke/include")
++
+ target_link_libraries(
+ 	"${LIB_NAME}" PUBLIC
+ 	$<$<TARGET_EXISTS:nlohmann_json::nlohmann_json>:nlohmann_json::nlohmann_json>
+@@ -113,16 +114,6 @@ target_link_libraries(
+ 	$<$<TARGET_EXISTS:Threads::Threads>:Threads::Threads>
+ )
+ 
+-# Private statically linked dependencies
+-target_link_libraries(
+-	${LIB_NAME} PRIVATE
+-	mlspp
+-	mls_vectors
+-	bytes
+-	tls_syntax
+-	hpke
+-)
+-
+ set(CONFIG_FILE_NAME "${PROJECT_NAME}Config.cmake")
+ set(EXPORTED_TARGETS_NAME "${PROJECT_NAME}Targets")
+ set(EXPORTED_TARGETS_FILE_NAME "${EXPORTED_TARGETS_NAME}.cmake")

--- a/ports/dpp/portfile.cmake
+++ b/ports/dpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO brainboxdotcc/DPP
     REF "v${VERSION}"
-    SHA512 0aac06f8ee67e3b4c430c9844beb6bdc3e31adebfcb2c077d18be8a8295451d70735f96dd5316d299df30b4cc4229180ffbad5095e51b49adf182290a8133a90
+    SHA512 664f669ecb2d8cafdfa6dd776fb429cde7d5692157d34f300ffe42cb7711dec69ce194ece5d372c8b070f979e2a341ecb7c018f8825a8acc148d17b3d4043c9b
 )
 
 vcpkg_cmake_configure(

--- a/ports/dpp/portfile.cmake
+++ b/ports/dpp/portfile.cmake
@@ -3,6 +3,8 @@ vcpkg_from_github(
     REPO brainboxdotcc/DPP
     REF "v${VERSION}"
     SHA512 664f669ecb2d8cafdfa6dd776fb429cde7d5692157d34f300ffe42cb7711dec69ce194ece5d372c8b070f979e2a341ecb7c018f8825a8acc148d17b3d4043c9b
+    PATCHES
+        make-pkgconfig-required.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/dpp/portfile.cmake
+++ b/ports/dpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 664f669ecb2d8cafdfa6dd776fb429cde7d5692157d34f300ffe42cb7711dec69ce194ece5d372c8b070f979e2a341ecb7c018f8825a8acc148d17b3d4043c9b
     PATCHES
-        make-pkgconfig-required.patch
+        explicit-set-have-voice.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/dpp/vcpkg.json
+++ b/ports/dpp/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "D++ Extremely Lightweight C++ Discord Library.",
   "homepage": "https://dpp.dev/",
   "license": "Apache-2.0",
-  "supports": "(windows & !static & !uwp) | linux | osx",
+  "supports": "(windows & !static & !uwp & !arm64) | linux | osx",
   "dependencies": [
     "nlohmann-json",
     "openssl",

--- a/ports/dpp/vcpkg.json
+++ b/ports/dpp/vcpkg.json
@@ -1,12 +1,11 @@
 {
   "name": "dpp",
-  "version": "10.0.31",
+  "version": "10.0.32",
   "description": "D++ Extremely Lightweight C++ Discord Library.",
   "homepage": "https://dpp.dev/",
   "license": "Apache-2.0",
   "supports": "(windows & !static & !uwp) | linux | osx",
   "dependencies": [
-    "libsodium",
     "nlohmann-json",
     "openssl",
     "opus",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2377,7 +2377,7 @@
       "port-version": 0
     },
     "dpp": {
-      "baseline": "10.0.31",
+      "baseline": "10.0.32",
       "port-version": 0
     },
     "draco": {

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7543dc1ca437d9f26cb6754b9f60ff58901c0e2a",
+      "version": "10.0.32",
+      "port-version": 0
+    },
+    {
       "git-tree": "190a206eddf272472a4668d756e0293096341f97",
       "version": "10.0.31",
       "port-version": 0

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1ea3cd5c3d81a31e59d95bea30f917ee5de21c20",
+      "git-tree": "87d356134c88935e750d3e0234e21120674a9c91",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "23a932ec2f11b8204abe09e1910272a0ed1b3222",
+      "git-tree": "33866c956e94573d09b6521fe1e504573335eef2",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c13ae323a5035d919eebed32d3f37cd645098097",
+      "git-tree": "80e4023a9575fe6982beffbd2d24eaacd4bada8c",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e06cc158951c02a0ebfa75b3cb449804c3053381",
+      "git-tree": "8406ac1bea09af01ad784279a3bcf5e976728111",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "80e4023a9575fe6982beffbd2d24eaacd4bada8c",
+      "git-tree": "dbfe7694a884e3235ed211f5e2ee03dc856d2c62",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b91959b92377f6c4b03f9fac71936dd8f7918495",
+      "git-tree": "af6a9f4424cbfb1a0713d9175a354283f6479e6d",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8406ac1bea09af01ad784279a3bcf5e976728111",
+      "git-tree": "23a932ec2f11b8204abe09e1910272a0ed1b3222",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7c42495e50bc17e42ae6f529683915cb8cb24ce2",
+      "git-tree": "1ea3cd5c3d81a31e59d95bea30f917ee5de21c20",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dbfe7694a884e3235ed211f5e2ee03dc856d2c62",
+      "git-tree": "7c42495e50bc17e42ae6f529683915cb8cb24ce2",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c76dbcf13107be6ef19fcbb0da7bae60a2e69a0c",
+      "git-tree": "884b1bfa14d0d78c0af83978a987bc056e7d5c00",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "884b1bfa14d0d78c0af83978a987bc056e7d5c00",
+      "git-tree": "b91959b92377f6c4b03f9fac71936dd8f7918495",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ee95a4fc24ae5728c63c714b182062899233d8d0",
+      "git-tree": "e06cc158951c02a0ebfa75b3cb449804c3053381",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7543dc1ca437d9f26cb6754b9f60ff58901c0e2a",
+      "git-tree": "c13ae323a5035d919eebed32d3f37cd645098097",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "28180299383ada190870051d9768a839cd883ec6",
+      "git-tree": "c76dbcf13107be6ef19fcbb0da7bae60a2e69a0c",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "af6a9f4424cbfb1a0713d9175a354283f6479e6d",
+      "git-tree": "ee95a4fc24ae5728c63c714b182062899233d8d0",
       "version": "10.0.32",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "87d356134c88935e750d3e0234e21120674a9c91",
+      "git-tree": "28180299383ada190870051d9768a839cd883ec6",
       "version": "10.0.32",
       "port-version": 0
     },


### PR DESCRIPTION
**This PR updates DPP package to 10.0.32**

**__NOTE__: This release removes dependency upon libsodium, we use openssl primitives to achieve the same result without the extra dependency.**

Our vcpkg update is built from our CI actions.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `Triplets are unchanged, baseline not updated.`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  `Yes`


