### PR TITLE
[openimageio] update to 2.5.16.0

### DIFF
--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/OpenImageIO
     REF "v${VERSION}"
-    SHA512 2d9423e16613a9daa6faa53e2f52ad6af749f07f73251f44720eba468635b70aec97b5aeaac2f67a8b260158808458e5408ced75908b00379eb6640b1413f463
+    SHA512 1e24d7ffc3ad65a1fe1f53ae59006de912c0a8d85827d64671fab95350977e22e2d147cf26ffe362646c768747ec11e6f9aeae04ea66030f82ad597adf3135a5
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openimageio",
-  "version": "2.5.14.0",
-  "port-version": 1,
+  "version": "2.5.16.0",
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6645,8 +6645,8 @@
       "port-version": 4
     },
     "openimageio": {
-      "baseline": "2.5.14.0",
-      "port-version": 1
+      "baseline": "2.5.16.0",
+      "port-version": 0
     },
     "openjpeg": {
       "baseline": "2.5.2",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80b1b56e35349c234510ff58abf197eb9cad7a3c",
+      "version": "2.5.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "59dd4d494969cad63902ddaeca3dad341b918fd0",
       "version": "2.5.14.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

