### PR TITLE
[directx-dxc] fix error location path

### DIFF
--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -15,7 +15,7 @@ set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
 
 add_library(Microsoft::DXIL SHARED IMPORTED)
 set_target_properties(Microsoft::DXIL PROPERTIES
-   IMPORTED_LOCATION                    "${CURRENT_INSTALLED_DIR}/@dll_dir@/@dll_name_dxil@"
+   IMPORTED_LOCATION                    "${CMAKE_CURRENT_LIST_DIR}/../../@dll_dir@/@dll_name_dxil@"
    IMPORTED_IMPLIB                      "${_dxc_root}/lib/@lib_name@"
    IMPORTED_SONAME                      "@lib_name@"
    INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"

--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -15,9 +15,9 @@ set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
 
 add_library(Microsoft::DXIL SHARED IMPORTED)
 set_target_properties(Microsoft::DXIL PROPERTIES
-   IMPORTED_LOCATION                    "${CMAKE_CURRENT_LIST_DIR}/../../@dll_dir@/@dll_name_dxil@"
+   IMPORTED_LOCATION                    "${_dxc_root}/@dll_dir@/@dll_name_dxil@"
    IMPORTED_IMPLIB                      "${_dxc_root}/lib/@lib_name@"
-   IMPORTED_SONAME                      "@lib_name@"
+   IMPORTED_NO_SONAME                   TRUE
    INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
    IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 

--- a/ports/directx-dxc/vcpkg.json
+++ b/ports/directx-dxc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "directx-dxc",
   "version-date": "2024-07-31",
-  "port-version": 1,
+  "port-version": 2,
   "description": "DirectX Shader Compiler (LLVM/Clang)",
   "homepage": "https://github.com/microsoft/DirectXShaderCompiler",
   "documentation": "https://github.com/microsoft/DirectXShaderCompiler/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2278,7 +2278,7 @@
     },
     "directx-dxc": {
       "baseline": "2024-07-31",
-      "port-version": 1
+      "port-version": 2
     },
     "directx-headers": {
       "baseline": "1.614.1",

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5638ff21ed83cd2b83dc9a4fabd9f3a9812c62a5",
+      "version-date": "2024-07-31",
+      "port-version": 2
+    },
+    {
       "git-tree": "b338248d2d23bf37932394facc59075f4ad1d7a1",
       "version-date": "2024-07-31",
       "port-version": 1

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5638ff21ed83cd2b83dc9a4fabd9f3a9812c62a5",
+      "git-tree": "31adbee92ae8d9b17303da6c5cb3e276c34a2b51",
       "version-date": "2024-07-31",
       "port-version": 2
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/41428

Usage tested pass on x64-windows and x64-linux.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
