### PR TITLE
[vcpkg baseline][vcpkg-ci-vxl] Passing remove form fail list 

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1350,7 +1350,6 @@ vcpkg-ci-sqlpp11:x86-windows=pass
 vcpkg-ci-vxl:arm-neon-android=pass
 vcpkg-ci-vxl:arm64-android=pass
 vcpkg-ci-vxl:arm64-windows=pass
-vcpkg-ci-vxl:x64-android=fail
 vcpkg-ci-vxl:x64-linux=pass
 vcpkg-ci-vxl:x64-osx=pass
 vcpkg-ci-vxl:x64-windows=pass

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1350,6 +1350,7 @@ vcpkg-ci-sqlpp11:x86-windows=pass
 vcpkg-ci-vxl:arm-neon-android=pass
 vcpkg-ci-vxl:arm64-android=pass
 vcpkg-ci-vxl:arm64-windows=pass
+vcpkg-ci-vxl:x64-android=pass
 vcpkg-ci-vxl:x64-linux=pass
 vcpkg-ci-vxl:x64-osx=pass
 vcpkg-ci-vxl:x64-windows=pass


### PR DESCRIPTION
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=107918&view=results.
```
PASSING, REMOVE FROM FAIL LIST: vcpkg-ci-vxl:x64-android 
```

Added `vcpkg-ci-vxl=fail` to `ci.baseline.txt` by #29406. This issue is now fixed by #41310.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~