### PR TITLE
[openimageio] Fix iv.exe tool to provide windeployqt bt qtbase

### DIFF
--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -28,6 +28,10 @@ file(REMOVE
     "${SOURCE_PATH}/src/cmake/modules/FindTBB.cmake"
 )
 
+if("viewer" IN_LIST FEATURES)
+    message(WARNING "iv.exe requires tool windeployqt.exe provided by qtbase ")  
+endif()
+
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         libraw      USE_LIBRAW

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openimageio",
   "version": "2.5.14.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -120,6 +120,10 @@
           ]
         },
         {
+            "name": "qtbase"
+            "default-features": false   
+        },
+        {
           "name": "qtbase",
           "default-features": false
         }

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -120,8 +120,8 @@
           ]
         },
         {
-            "name": "qtbase"
-            "default-features": false   
+          "name": "qtbase",
+          "default-features": false
         },
         {
           "name": "qtbase",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6646,7 +6646,7 @@
     },
     "openimageio": {
       "baseline": "2.5.14.0",
-      "port-version": 1
+      "port-version": 2
     },
     "openjpeg": {
       "baseline": "2.5.2",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "abd57021c9a3e24f86548c933fbf1a68add06826",
+      "version": "2.5.14.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "59dd4d494969cad63902ddaeca3dad341b918fd0",
       "version": "2.5.14.0",
       "port-version": 1


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/41399

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.