### PR TITLE
[quantlib] update to v1.36

### DIFF
--- a/ports/quantlib/portfile.cmake
+++ b/ports/quantlib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lballabio/QuantLib
     REF "v${VERSION}"
-    SHA512 5017548669fec649a9324298d828e11e44b9fb12924f5bfebbe90d2893bd02c627c38f7e8516416d894ab82f3fa3c77cba2a2ba09a25c19dc0efa130a3dba72c
+    SHA512 5c8cf1cc28a23d6586a542746ac61264dfdbe88c5a92a1292dfe19fadcdb23729fbbdca44da2fdd2917a48f0ba864c79c525d4e9ac5bbaef58e03a7ddaa177b0
     HEAD_REF master
 )
 

--- a/ports/quantlib/vcpkg.json
+++ b/ports/quantlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quantlib",
-  "version": "1.35",
+  "version": "1.36",
   "description": "The QuantLib C++ library",
   "homepage": "https://www.quantlib.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7673,7 +7673,7 @@
       "port-version": 0
     },
     "quantlib": {
-      "baseline": "1.35",
+      "baseline": "1.36",
       "port-version": 0
     },
     "quaternions": {

--- a/versions/q-/quantlib.json
+++ b/versions/q-/quantlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23781cb492d79ad899f97d89b7479e978c52b71d",
+      "version": "1.36",
+      "port-version": 0
+    },
+    {
       "git-tree": "b0dfe33379e9412c9ef411bdd5505d76728b8a61",
       "version": "1.35",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.