### PR TITLE
[eventbus] Add new port

### DIFF
--- a/ports/eventbus/portfile.cmake
+++ b/ports/eventbus/portfile.cmake
@@ -23,8 +23,5 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/eventbus)
-endif()
-
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/eventbus)
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/eventbus/portfile.cmake
+++ b/ports/eventbus/portfile.cmake
@@ -22,6 +22,9 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/eventbus)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/eventbus)
+endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/eventbus/portfile.cmake
+++ b/ports/eventbus/portfile.cmake
@@ -1,18 +1,22 @@
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
+
+# before this revision the build would fail on windows
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gelldur/EventBus
-    REF master
-    SHA512 68be92be9a1adc37498e24850ae87384a34ed0343f29a5e525c984f5e220dd721b506fdd7f627e369300c07300f5fff06d88991f69c1e9bc0fff0d2a5b8f0eba
+    REF 4689564c4c775456bfa0dfd976b4f48aca5f4d2a
+    SHA512 0f1f3c21d1c5a18da87e331f252cb464143ba2038a26e6edb6b11c9544c02dd1919fe728e803b382e8f6b89550582d7905170437c184f784cfa3f28c784a7e59
     HEAD_REF master
 )
+
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    WINDOWS_USE_MSBUILD
     OPTIONS
     -DENABLE_TEST=OFF 
+    -DCMAKE_CXX_STANDARD=17
 )
 
 vcpkg_cmake_install()

--- a/ports/eventbus/portfile.cmake
+++ b/ports/eventbus/portfile.cmake
@@ -15,8 +15,8 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-    -DENABLE_TEST=OFF 
-    -DCMAKE_CXX_STANDARD=17
+        -DCMAKE_CXX_STANDARD=17
+        -DENABLE_TEST=OFF 
 )
 
 vcpkg_cmake_install()

--- a/ports/eventbus/portfile.cmake
+++ b/ports/eventbus/portfile.cmake
@@ -23,5 +23,5 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/eventbus)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/EventBus)
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/eventbus/portfile.cmake
+++ b/ports/eventbus/portfile.cmake
@@ -1,0 +1,23 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gelldur/EventBus
+    REF master
+    SHA512 68be92be9a1adc37498e24850ae87384a34ed0343f29a5e525c984f5e220dd721b506fdd7f627e369300c07300f5fff06d88991f69c1e9bc0fff0d2a5b8f0eba
+    HEAD_REF master
+)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    WINDOWS_USE_MSBUILD
+    OPTIONS
+    -DENABLE_TEST=OFF 
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/eventbus)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/eventbus/vcpkg.json
+++ b/ports/eventbus/vcpkg.json
@@ -12,5 +12,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-    ]
+  ]
 }

--- a/ports/eventbus/vcpkg.json
+++ b/ports/eventbus/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "eventbus",
+  "version": "3.1.2",
+  "description": "Simple and very fast event bus.",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+    ]
+}

--- a/ports/eventbus/vcpkg.json
+++ b/ports/eventbus/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "eventbus",
   "version": "3.1.2",
   "description": "Simple and very fast event bus.",
+  "homepage": "https://github.com/gelldur/EventBus",
   "license": "Apache-2.0",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2592,6 +2592,10 @@
       "baseline": "2023.2.15",
       "port-version": 0
     },
+    "eventbus": {
+      "baseline": "3.1.2",
+      "port-version": 0
+    },
     "eventpp": {
       "baseline": "0.1.3",
       "port-version": 1

--- a/versions/e-/eventbus.json
+++ b/versions/e-/eventbus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "01839b9f46686cffaa3f70f12b76fc8c0c7b9408",
+      "git-tree": "d424c1792a726756225d5988c5c31080cd8fe8a7",
       "version": "3.1.2",
       "port-version": 0
     }

--- a/versions/e-/eventbus.json
+++ b/versions/e-/eventbus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d424c1792a726756225d5988c5c31080cd8fe8a7",
+      "git-tree": "a042276e659403d1417119961c89d3646b4f6a3f",
       "version": "3.1.2",
       "port-version": 0
     }

--- a/versions/e-/eventbus.json
+++ b/versions/e-/eventbus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a042276e659403d1417119961c89d3646b4f6a3f",
+      "git-tree": "99744eb5c1976adc3690dee995b516244b2a5eab",
       "version": "3.1.2",
       "port-version": 0
     }

--- a/versions/e-/eventbus.json
+++ b/versions/e-/eventbus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0c470733c54afbaba845f06f6d23d9cf06108308",
+      "git-tree": "01839b9f46686cffaa3f70f12b76fc8c0c7b9408",
       "version": "3.1.2",
       "port-version": 0
     }

--- a/versions/e-/eventbus.json
+++ b/versions/e-/eventbus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f97f52c7baa94af1f321ab60276c97af264fb545",
+      "git-tree": "0c470733c54afbaba845f06f6d23d9cf06108308",
       "version": "3.1.2",
       "port-version": 0
     }

--- a/versions/e-/eventbus.json
+++ b/versions/e-/eventbus.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f97f52c7baa94af1f321ab60276c97af264fb545",
+      "version": "3.1.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



Fixes##41549


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

