### PR TITLE
[bark] New port v0.3.0

### DIFF
--- a/ports/bark/portfile.cmake
+++ b/ports/bark/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO twig-energy/bark
+  REF "${VERSION}"
+  HEAD_REF main
+  SHA512 96fca5df5a3a0bc91d8b626f1538c517df778dc2a0cf29f1061ef041a270bb2f798525ad4c6a64fbaf7c5e0617475a0abf581eb3f15003e769adc317f1c9e746
+)
+
+if(VCPKG_TARGET_IS_WINDOWS)  
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)  
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_CXX_STANDARD=20
+        -DCMAKE_CXX_STANDARD_REQUIRED=ON
+        -DCMAKE_CXX_EXTENSIONS=OFF)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/bark)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}") 
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/bark/usage
+++ b/ports/bark/usage
@@ -1,0 +1,4 @@
+bark provides CMake targets:
+
+  find_package(bark CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE twig::bark)

--- a/ports/bark/vcpkg.json
+++ b/ports/bark/vcpkg.json
@@ -1,0 +1,31 @@
+{
+  "name": "bark",
+  "version-semver": "0.3.0",
+  "description": "A modern, low latency datadog client for C++",
+  "homepage": "https://github.com/twig-energy/bark",
+  "license": "MIT",
+  "supports": "!(uwp | osx)",
+  "dependencies": [
+    "asio",
+    "fmt",
+    "mpmcqueue",
+    "spscqueue",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "test": {
+      "description": "Dependencies for testing",
+      "dependencies": [
+        "benchmark",
+        "doctest"
+      ]
+    }
+  }
+}

--- a/versions/b-/bark.json
+++ b/versions/b-/bark.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "07b2df93bac4785ff63f152e6616d86c4dd0c16e",
+      "version-semver": "0.3.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -560,6 +560,10 @@
       "baseline": "3.15.0",
       "port-version": 0
     },
+    "bark": {
+      "baseline": "0.3.0",
+      "port-version": 0
+    },
     "basisu": {
       "baseline": "1.16.4",
       "port-version": 0


### PR DESCRIPTION
[bark](https://github.com/twig-energy/bark/) is a modern, low latency datadog client for C++.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- ~[ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.~
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

I opted to override windows shared library builds to be static, since the library does not yet produce the correct DLLs.