### PR TITLE
[json-rpc-cxx] update to 0.3.2

### DIFF
--- a/ports/json-rpc-cxx/portfile.cmake
+++ b/ports/json-rpc-cxx/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jsonrpcx/json-rpc-cxx
     REF "v${VERSION}"
-    SHA512 0b8f2b1c8ff95bee14585f6b363f6aa4bf046e3905f7a65cf2e562e5c9181a3ba882baded36fab4d3ff9ac5b2f3245eeb54260f2163491af7fba264ff547f6d8
+    SHA512 fa4ee807dd29027edd86949a8632adede77c3706406e6b78a8b6e38003f80103082ef70e0b89293a608db238d6f5662669b69cf0cb3d607bcc959c8801c5f3e0
     HEAD_REF master
     PATCHES
        fix-config.patch

--- a/ports/json-rpc-cxx/vcpkg.json
+++ b/ports/json-rpc-cxx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rpc-cxx",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A JSON-RPC 2.0 framework implemented in C++17 using the nlohmann's json for modern C++.",
   "homepage": "https://github.com/jsonrpcx/json-rpc-cxx",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3849,7 +3849,7 @@
       "port-version": 0
     },
     "json-rpc-cxx": {
-      "baseline": "0.3.1",
+      "baseline": "0.3.2",
       "port-version": 0
     },
     "json-schema-validator": {

--- a/versions/j-/json-rpc-cxx.json
+++ b/versions/j-/json-rpc-cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d1470b7bf2e3b95a53d6f8ec3aceadc30cab7f25",
+      "version": "0.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e5c4ccb3e679891167fa7d4b6a14ac5dbae14c40",
       "version": "0.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
