### PR TITLE
[librtpi] include condition_variable.hpp fix

### DIFF
--- a/ports/librtpi/condition_variable-fix-wait_until-predicate-evaluation.patch
+++ b/ports/librtpi/condition_variable-fix-wait_until-predicate-evaluation.patch
@@ -1,0 +1,26 @@
+From 75409d8ec67146e0c245316cb564aed5ffda5041 Mon Sep 17 00:00:00 2001
+From: Ryan Zoeller <ryan.zoeller@aliaro.com>
+Date: Fri, 30 Aug 2024 10:51:27 -0500
+Subject: [PATCH] condition_variable: fix wait_until predicate evaluation
+
+Signed-off-by: Ryan Zoeller <ryan.zoeller@aliaro.com>
+---
+ src/rtpi/condition_variable.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rtpi/condition_variable.hpp b/src/rtpi/condition_variable.hpp
+index 9041ab7..6fd82d8 100644
+--- a/src/rtpi/condition_variable.hpp
++++ b/src/rtpi/condition_variable.hpp
+@@ -185,7 +185,7 @@ class condition_variable {
+ 		   const std::chrono::time_point<Clock, Duration> &timeout_time,
+ 		   Predicate stop_waiting)
+ 	{
+-		while (!stop_waiting) {
++		while (!stop_waiting()) {
+ 			if (wait_until(lock, timeout_time) ==
+ 			    cv_status::timeout)
+ 				return stop_waiting();
+-- 
+2.43.5
+

--- a/ports/librtpi/portfile.cmake
+++ b/ports/librtpi/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_gitlab(
     REF "${VERSION}"
     SHA512 fb0cdd14f3c94f610fc153154ea09d5cfd7d3def16bdaabf8c2b4e0a8b7fa8ddec4cde6ae0b8726d58ee4a773df5c4f13002e565fb06ad3c8e9731a45122704f
     HEAD_REF main
+    PATCHES
+        condition_variable-fix-wait_until-predicate-evaluation.patch
 )
 
 vcpkg_configure_make(

--- a/ports/librtpi/vcpkg.json
+++ b/ports/librtpi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "librtpi",
   "version": "1.0.0",
+  "port-version": 1,
   "description": "The Real-Time Priority Inheritance Library (librtpi) is intended to bridge the gap between the glibc pthread implementation and a functionally correct priority inheritance for pthread locking primitives, such as pthread_mutex and pthread_condvar.",
   "homepage": "https://gitlab.com/linux-rt/librtpi",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5022,7 +5022,7 @@
     },
     "librtpi": {
       "baseline": "1.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "librttopo": {
       "baseline": "1.1.0",

--- a/versions/l-/librtpi.json
+++ b/versions/l-/librtpi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a224c4751a43ecde77210db70bc9f0b233a1b9c0",
+      "version": "1.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ccd041402709075b83bb6a23ff2c85ce6c8358ac",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.