### PR TITLE
Add rpath tests for macho

### DIFF
--- a/scripts/test_ports/rpath-macho-test-binaries/portfile.cmake
+++ b/scripts/test_ports/rpath-macho-test-binaries/portfile.cmake
@@ -1,0 +1,46 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+    OPTIONS_RELEASE
+        -DTEST_STRING=release
+    OPTIONS_DEBUG
+        -DTEST_STRING=debug
+)
+vcpkg_cmake_install()
+
+function(make_rpath_absolute lib_dir)
+string(REPLACE "/" "_" logname "make_rpath_absolute-${lib_dir}")
+    vcpkg_execute_required_process(
+        COMMAND "install_name_tool" -id ${CURRENT_INSTALLED_DIR}/${lib_dir}/librpath-macho-backend-lib++.dylib ${CURRENT_PACKAGES_DIR}/${lib_dir}/librpath-macho-backend-lib++.dylib
+        WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}"
+        LOGNAME "${logname}-id"
+    )
+    
+    vcpkg_execute_required_process(
+        COMMAND "install_name_tool" -change @rpath/librpath-macho-backend-lib++.dylib ${CURRENT_INSTALLED_DIR}/${lib_dir}/librpath-macho-backend-lib++.dylib ${CURRENT_PACKAGES_DIR}/${lib_dir}/librpath-macho-test-lib.dylib
+        WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}"
+        LOGNAME "${logname}-change"
+    )
+endfunction()
+
+if(NOT VCPKG_BUILD_TYPE)
+    vcpkg_copy_tools(TOOL_NAMES rpath-macho-test-tool
+        SEARCH_DIR "${CURRENT_PACKAGES_DIR}/debug/bin"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/tools/${PORT}"
+    )
+    vcpkg_copy_tools(TOOL_NAMES rpath-macho-test-tool
+        SEARCH_DIR "${CURRENT_PACKAGES_DIR}/debug/bin"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/manual-tools/${PORT}/debug"
+    )
+    vcpkg_copy_tools(TOOL_NAMES rpath-macho-test-tool
+        SEARCH_DIR "${CURRENT_PACKAGES_DIR}/debug/bin"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug"
+    )
+    make_rpath_absolute("debug/lib")
+endif()
+make_rpath_absolute("lib")
+vcpkg_copy_tools(TOOL_NAMES rpath-macho-test-tool DESTINATION "${CURRENT_PACKAGES_DIR}/manual-tools/${PORT}")
+vcpkg_copy_tools(TOOL_NAMES rpath-macho-test-tool AUTO_CLEAN)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "This test port is part of vcpkg.")

--- a/scripts/test_ports/rpath-macho-test-binaries/project/CMakeLists.txt
+++ b/scripts/test_ports/rpath-macho-test-binaries/project/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.7)
+project(rpath-macho-test CXX)
+
+set(TEST_STRING "" CACHE STRING "")
+
+set(CMAKE_SKIP_INSTALL_RPATH TRUE)
+
+add_library(rpath-macho-backend-lib++ transitive.cpp)
+target_compile_definitions(rpath-macho-backend-lib++ PRIVATE "TEST_STRING=\"${TEST_STRING}\"")
+
+add_library(rpath-macho-test-lib lib.cpp)
+target_link_libraries(rpath-macho-test-lib PRIVATE rpath-macho-backend-lib++)
+
+add_executable(rpath-macho-test-tool main.cpp)
+target_link_libraries(rpath-macho-test-tool PRIVATE rpath-macho-test-lib)
+
+install(TARGETS rpath-macho-backend-lib++ rpath-macho-test-lib rpath-macho-test-tool)

--- a/scripts/test_ports/rpath-macho-test-binaries/project/lib.cpp
+++ b/scripts/test_ports/rpath-macho-test-binaries/project/lib.cpp
@@ -1,0 +1,6 @@
+extern const char* getTestStringBackend();
+
+const char* getTestString()
+{
+    return getTestStringBackend();
+}

--- a/scripts/test_ports/rpath-macho-test-binaries/project/main.cpp
+++ b/scripts/test_ports/rpath-macho-test-binaries/project/main.cpp
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+extern const char* getTestString();
+
+int main()
+{
+    puts(getTestString());
+}

--- a/scripts/test_ports/rpath-macho-test-binaries/project/transitive.cpp
+++ b/scripts/test_ports/rpath-macho-test-binaries/project/transitive.cpp
@@ -1,0 +1,4 @@
+const char* getTestStringBackend()
+{
+    return TEST_STRING;
+}

--- a/scripts/test_ports/rpath-macho-test-binaries/vcpkg.json
+++ b/scripts/test_ports/rpath-macho-test-binaries/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "rpath-macho-test-binaries",
+  "version-string": "ci",
+  "description": "Provides installed binaries for rpath macho fixup test",
+  "supports": "native & osx",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/scripts/test_ports/rpath-macho-test/portfile.cmake
+++ b/scripts/test_ports/rpath-macho-test/portfile.cmake
@@ -1,0 +1,62 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+foreach(dir IN ITEMS tools/rpath-macho-test-binaries manual-tools/rpath-macho-test-binaries)
+    string(REPLACE "/" "_" logname "execute-rel-${dir}")
+    vcpkg_execute_required_process(
+        COMMAND "${CURRENT_INSTALLED_DIR}/${dir}/rpath-macho-test-tool"
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
+        OUTPUT_VARIABLE output
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        LOGNAME "${logname}"
+    )
+    if(NOT output STREQUAL "release")
+        message(SEND_ERROR "${dir}: $Actual: '${output}', expected: 'release'")
+    endif()
+endforeach()
+
+if(NOT VCPKG_BUILD_TYPE)
+    foreach(dir IN ITEMS tools/rpath-macho-test-binaries/debug manual-tools/rpath-macho-test-binaries/debug debug/tools/rpath-macho-test-binaries)
+        string(REPLACE "/" "_" logname "execute-dbg-${dir}")
+        vcpkg_execute_required_process(
+            COMMAND "${CURRENT_INSTALLED_DIR}/${dir}/rpath-macho-test-tool"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
+            OUTPUT_VARIABLE output
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            LOGNAME "${logname}"
+        )
+        if(NOT output STREQUAL "debug")
+            message(SEND_ERROR "${dir}: Actual: '${output}', expected: 'debug'")
+        endif()
+    endforeach()
+endif()
+
+function(check_proper_rpath macho_lib)
+    vcpkg_execute_required_process(
+        COMMAND "otool" "-L" "${macho_lib}"
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
+        OUTPUT_VARIABLE output
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        LOGNAME "${logname}"
+    )
+
+    set(found_rpath_backend_lib OFF)
+
+    string(REPLACE "\n" ";" output_lines "${output}")
+    # Ignore first line, it contains the path to the lib which we are checking
+    list(REMOVE_AT output_lines 0)
+    foreach(line IN LISTS output_lines)
+        if("${line}" MATCHES "\\s+/.*librpath-macho-backend-lib\\+\\+\\.dylib")
+            message(SEND_ERROR "${line} contains an absolute path")
+        endif()
+        if("${line}" MATCHES "@rpath/librpath-macho-backend-lib\\+\\+.dylib")
+            set(found_rpath_backend_lib ON)
+        endif()
+    endforeach()
+
+    if(NOT found_rpath_backend_lib)
+        message(SEND_ERROR "@rpath/librpath-macho-backend-lib++.dylib not found in ${output}")
+    endif()
+endfunction()
+
+check_proper_rpath("${CURRENT_INSTALLED_DIR}/lib/librpath-macho-test-lib.dylib")
+check_proper_rpath("${CURRENT_INSTALLED_DIR}/debug/lib/librpath-macho-test-lib.dylib")

--- a/scripts/test_ports/rpath-macho-test/vcpkg.json
+++ b/scripts/test_ports/rpath-macho-test/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "rpath-macho-test",
+  "version-string": "ci",
+  "description": "Test rpath macho fixup",
+  "dependencies": [
+    "rpath-macho-test-binaries"
+  ]
+}


### PR DESCRIPTION
Expected to fail

Tests for https://github.com/microsoft/vcpkg/pull/39889
This mimics the situation of libssl/libcrypto of the `openssl` port.

A lot of boilerplate code is copied from the existing rpath tests, interesting addition is here https://github.com/microsoft/vcpkg/compare/master...m-kuhn:vcpkg:rpath-macho-test?expand=1#diff-df76c3210c8286fde1e58d91e8aec9b40df0dc0d76a238e918c8533971c3e4f7R33-R59