### PR TITLE
[pcl] Backport MSVC optimizer workaround of openNURBS

### DIFF
--- a/ports/pcl/0012-msvc-optimizer-workaround.patch
+++ b/ports/pcl/0012-msvc-optimizer-workaround.patch
@@ -1,0 +1,28 @@
+diff --git a/surface/src/3rdparty/opennurbs/opennurbs_lookup.cpp b/surface/src/3rdparty/opennurbs/opennurbs_lookup.cpp
+index 13584fbbdb3..e006d3a5667 100644
+--- a/surface/src/3rdparty/opennurbs/opennurbs_lookup.cpp
++++ b/surface/src/3rdparty/opennurbs/opennurbs_lookup.cpp
+@@ -666,9 +666,13 @@ std::size_t ON_SerialNumberMap::ActiveIdCount() const
+   return m_active_id_count;
+ }
+ 
+-#if (_MSC_VER >= 1930 && _MSC_VER <= 1939)
++#if (_MSC_VER >= 1930 && _MSC_VER <= 1949)
+ // Solves internal compiler error on MSVC 2022
+ // (see https://github.com/microsoft/vcpkg/issues/19561)
++#define ON_VS2022_COMPILER_CRASH
++#endif
++
++#if defined(ON_VS2022_COMPILER_CRASH)
+ #pragma optimize("", off)
+ #endif
+ struct ON_SerialNumberMap::SN_ELEMENT* ON_SerialNumberMap::FirstElement() const
+@@ -722,7 +726,7 @@ struct ON_SerialNumberMap::SN_ELEMENT* ON_SerialNumberMap::FirstElement() const
+   }
+   return e;
+ }
+-#if (_MSC_VER >= 1930 && _MSC_VER <= 1939)
++#if defined(ON_VS2022_COMPILER_CRASH)
+ #pragma optimize("", on)
+ #endif
+ 

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
         io_ply.patch
         6053.diff # https://github.com/PointCloudLibrary/pcl/pull/6053
         6990a3b0d7dd3c1ca04a1a473cc172a937418060.diff # https://github.com/PointCloudLibrary/pcl/pull/6105
+        0012-msvc-optimizer-workaround.patch # backport pcl #6143 and #6154
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" PCL_SHARED_LIBS)

--- a/ports/pcl/vcpkg.json
+++ b/ports/pcl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pcl",
   "version": "1.14.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.",
   "homepage": "https://github.com/PointCloudLibrary/pcl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6870,7 +6870,7 @@
     },
     "pcl": {
       "baseline": "1.14.1",
-      "port-version": 2
+      "port-version": 3
     },
     "pcre": {
       "baseline": "8.45",

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "57795e21c0c37576db6bfb1df3b134de461d10e0",
+      "version": "1.14.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "00b339d9b6b61b9f0742cfea4c482e70e9ac5ad8",
       "version": "1.14.1",
       "port-version": 2


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/41592

### Backport

* https://github.com/PointCloudLibrary/pcl/pull/6143
* https://github.com/PointCloudLibrary/pcl/pull/6154

### Related

* https://github.com/microsoft/vcpkg/issues/19561
* https://github.com/microsoft/vcpkg/pull/23252

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port feature `surface-on-nurbs` installation tests pass with the following triplets:

* x64-windows