### PR TITLE
[redis-plus-plus] update to 1.3.13

### DIFF
--- a/ports/redis-plus-plus/fix-absolute-path.patch
+++ b/ports/redis-plus-plus/fix-absolute-path.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a075aca..8657ef7 100644
+index c329f9b..785ca3c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -168,7 +168,7 @@ set(CMAKE_REQUIRED_LIBRARIES ${HIREDIS_FEATURE_TEST_LIB})
- 
+@@ -180,7 +180,7 @@ set(CMAKE_REQUIRED_LIBRARIES ${HIREDIS_FEATURE_TEST_LIB})
  CHECK_SYMBOL_EXISTS(redisEnableKeepAliveWithInterval ${HIREDIS_FEATURE_TEST_HEADER} REDIS_PLUS_PLUS_HAS_redisEnableKeepAliveWithInterval)
  
--configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hiredis_features.h.in ${CMAKE_CURRENT_SOURCE_DIR}/${REDIS_PLUS_PLUS_SOURCE_DIR}/hiredis_features.h)
-+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/hiredis_features.h.in" "${CMAKE_CURRENT_SOURCE_DIR}/${REDIS_PLUS_PLUS_SOURCE_DIR}/hiredis_features.h")
+ set(REDIS_PLUS_PLUS_GENERATED_HEADER_DIR ${CMAKE_CURRENT_BINARY_DIR}/${REDIS_PLUS_PLUS_HEADER_DIR})
+-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hiredis_features.h.in ${CMAKE_CURRENT_BINARY_DIR}/${REDIS_PLUS_PLUS_SOURCE_DIR}/hiredis_features.h)
++configure_file("${CMAKE_CURRENT_SOURCE_DIR}/hiredis_features.h.in" "${CMAKE_CURRENT_BINARY_DIR}/${REDIS_PLUS_PLUS_SOURCE_DIR}/hiredis_features.h")
  
  # Restore CMAKE_REQUIRED_LIBRARIES
  set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_BACK})

--- a/ports/redis-plus-plus/fix-conversion.patch
+++ b/ports/redis-plus-plus/fix-conversion.patch
@@ -1,13 +1,13 @@
 diff --git a/src/sw/redis++/shards.cpp b/src/sw/redis++/shards.cpp
-index c5baf5a..08e96cd 100644
+index fc58eea..ea57266 100644
 --- a/src/sw/redis++/shards.cpp
 +++ b/src/sw/redis++/shards.cpp
-@@ -41,7 +41,7 @@ std::pair<Slot, Node> RedirectionError::_parse_error(const std::string &msg) con
+@@ -42,7 +42,7 @@ std::pair<Slot, Node> RedirectionError::_parse_error(const std::string &msg) con
          auto host = msg.substr(space_pos + 1, colon_pos - space_pos - 1);
          auto port = std::stoi(msg.substr(colon_pos + 1));
  
 -        return {slot, {host, port}};
 +        return {static_cast<std::size_t>(slot), {host, port}};
-     } catch (const std::exception &e) {
-         throw ProtoError("Invalid ASK error message: " + msg);
+     } catch (const std::exception &) {
+         throw ProtoError("invalid redirection error message: " + msg);
      }

--- a/ports/redis-plus-plus/fix-dependency-libuv.patch
+++ b/ports/redis-plus-plus/fix-dependency-libuv.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e85a158..e67681c 100644
+index ae2507e..c329f9b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -30,8 +30,8 @@ if(REDIS_PLUS_PLUS_BUILD_ASYNC)
+@@ -45,8 +45,8 @@ if(REDIS_PLUS_PLUS_BUILD_ASYNC)
          message(STATUS "redis-plus-plus build async interface with libuv")
  
          # libuv dependency
@@ -13,7 +13,7 @@ index e85a158..e67681c 100644
      else()
          message(FATAL_ERROR "invalid REDIS_PLUS_PLUS_BUILD_ASYNC")
      endif()
-@@ -150,7 +150,6 @@ if(REDIS_PLUS_PLUS_BUILD_STATIC)
+@@ -228,7 +228,6 @@ if(REDIS_PLUS_PLUS_BUILD_STATIC)
  
      if(REDIS_PLUS_PLUS_BUILD_ASYNC)
          target_include_directories(${STATIC_LIB} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${REDIS_PLUS_PLUS_ASYNC_FUTURE_HEADER}>)

--- a/ports/redis-plus-plus/portfile.cmake
+++ b/ports/redis-plus-plus/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sewenew/redis-plus-plus
     REF "${VERSION}"
-    SHA512 ad6a26d3466d45daa70f2bb43e28d76c07a15ddb1a3d667d10cc5201951e7b7ee56baf084dc9653f78679a2e6756ba7f66b1e71daa5dd8e19c4699fa59c2f1d8
+    SHA512 c2892ec1b2f242ee19c727cd9dd1bc4e08b9f515f5736bffee5b5a12a2f1b2eddec0ebeba7998a5abc5620bdff37b5d745abdf0d7586b89535ce0ae035988ef4
     HEAD_REF master
     PATCHES
         fix-conversion.patch

--- a/ports/redis-plus-plus/vcpkg.json
+++ b/ports/redis-plus-plus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-plus-plus",
-  "version-semver": "1.3.12",
+  "version-semver": "1.3.13",
   "description": "This is a C++ client for Redis. It's based on hiredis, and written in C++ 11",
   "homepage": "https://github.com/sewenew/redis-plus-plus",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7853,7 +7853,7 @@
       "port-version": 0
     },
     "redis-plus-plus": {
-      "baseline": "1.3.12",
+      "baseline": "1.3.13",
       "port-version": 0
     },
     "refl-cpp": {

--- a/versions/r-/redis-plus-plus.json
+++ b/versions/r-/redis-plus-plus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b71d9c749dee1f0c35069eb08e871ab34740690f",
+      "git-tree": "91fb6d6b9e220a2a75c0df8572ef980fc2313dab",
       "version-semver": "1.3.13",
       "port-version": 0
     },

--- a/versions/r-/redis-plus-plus.json
+++ b/versions/r-/redis-plus-plus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b71d9c749dee1f0c35069eb08e871ab34740690f",
+      "version-semver": "1.3.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "730950cc05d074e23016ee21482de47864501437",
       "version-semver": "1.3.12",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

