### PR TITLE
[fastdds] update to 3.1.0

### DIFF
--- a/ports/fastdds/portfile.cmake
+++ b/ports/fastdds/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eProsima/Fast-DDS
     REF "v${VERSION}"
-    SHA512 84333bef4b5264b72129e515c2208048c25794d7d653073298cbf5f43ba95c85f2aa64f30e6911a69daf9affc4dc1e10cea4064da43fdd709bbe04ef1cf1f4d7
+    SHA512 c2b22f6355fc38ccf49d41f7fe074092c6962d2fa759351b37d83af863c60839d9579bfef0f96540276229bcdb2d3d218e18777db89cf16092d09c26f2e24533
     HEAD_REF master
     PATCHES
         fix-find-package-asio.patch

--- a/ports/fastdds/vcpkg.json
+++ b/ports/fastdds/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastdds",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "eprosima Fast DDS (formerly Fast RTPS) is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.",
   "homepage": "https://www.eprosima.com/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2677,7 +2677,7 @@
       "port-version": 5
     },
     "fastdds": {
-      "baseline": "3.0.1",
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "fastfeat": {

--- a/versions/f-/fastdds.json
+++ b/versions/f-/fastdds.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d63c40face8c3e65be51da586f4aaee1d79a138",
+      "version": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6ff9b97e272f2c114ff8da8e63e5a04426f49722",
       "version": "3.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
