### PR TITLE
[sonyflakepp] add new port

### DIFF
--- a/ports/sonyflakepp/portfile.cmake
+++ b/ports/sonyflakepp/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Shadowrom2020/sonyflakepp
+    REF 1.0.1
+    SHA512 efa07aa17109bf97cc3fcb93f40c840a0ecd29754699c5739c9cbe805d6b0d3aef93ab885bd45f1d0278a9b3ef42ce163dc0751084df33375d39fdeb4ef0c5cf
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS 
+        -DBUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/sonyflakepp/cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/sonyflakepp/vcpkg.json
+++ b/ports/sonyflakepp/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "sonyflakepp",
+  "version": "1.0.1",
+  "description": "Sonyflake is a distributed unique ID generator inspired by Twitter's Snowflake.",
+  "homepage": "https://github.com/Shadowrom2020/sonyflakepp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8468,6 +8468,10 @@
       "baseline": "3.5.8",
       "port-version": 2
     },
+    "sonyflakepp": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "sophus": {
       "baseline": "1.24.6-r1",
       "port-version": 0

--- a/versions/s-/sonyflakepp.json
+++ b/versions/s-/sonyflakepp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "772b95be07b2f4bd64fc7b0ab5ebc95ec5cf2a37",
+      "version": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
