### PR TITLE
[superlu] Update to 7.0.0

### DIFF
--- a/ports/superlu/portfile.cmake
+++ b/ports/superlu/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiaoyeli/superlu
     REF "v${VERSION}"
-    SHA512 6dd2baeff9ca7ed4761845b9a30c6dca4e19ca498e10ea7360013b3aece576ca996a8bf31c4479321feda6f5266235d68ea9a2e256f0ffe91f804d4cdecd3847
+    SHA512 d2b35ccfd4bee6f5967a1a65edc07d32a7d842aa3f623494de78cf69dc5f4819d82f675d6b2aec035fcbca0a8a3966ab76fa105e6162e8242eb6a56870e41cba
     HEAD_REF master
     PATCHES
         remove-make.inc.patch

--- a/ports/superlu/vcpkg.json
+++ b/ports/superlu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "superlu",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "description": "Supernodal sparse direct solver.",
   "homepage": "https://github.com/xiaoyeli/superlu",
   "license": "BSD-3-Clause-LBNL",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8725,7 +8725,7 @@
       "port-version": 0
     },
     "superlu": {
-      "baseline": "6.0.1",
+      "baseline": "7.0.0",
       "port-version": 0
     },
     "swenson-sort": {

--- a/versions/s-/superlu.json
+++ b/versions/s-/superlu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e542e8e80447c6d92875effae17aec8568816006",
+      "version": "7.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ae6007b0b5334eb0dc0e8ee97e8c24355a77323",
       "version": "6.0.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #41610. Update `superlu` to 7.0.0.

No feature needs to be tested, the usage test passed on `x64-windows` (header files found).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.