### PR TITLE
[simsimd] update to 5.7.3

### DIFF
--- a/ports/simsimd/portfile.cmake
+++ b/ports/simsimd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/SimSIMD
     REF "v${VERSION}"
-    SHA512 abddc3522f28602c0bfbdcdf3f045b3ffbb88cc9182741333df7a7e6d8fcf523dbd876b30381cdc741b712c42665f65796477ec3c458cdd9ef4ac4e4038b9052
+    SHA512 ab78d4415ed0f2964470ccd36d3d737a2715b1a5a4222613d2f0f4be6a516da0e339329cbd421c6b7f6a1bc701da6ec2f3937cba5a8ea1f632beea8000d90c8f
     HEAD_REF main
     PATCHES
         export-target.patch

--- a/ports/simsimd/vcpkg.json
+++ b/ports/simsimd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simsimd",
-  "version": "5.4.4",
+  "version": "5.7.3",
   "description": "Fastest similarity-measures and distance functions on the Wild West – vectors, strings, short molecules, and even DNA sequences. All with a pinch of SIMD for both x86 and ARM.",
   "homepage": "https://github.com/ashvardanian/SimSIMD",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8349,7 +8349,7 @@
       "port-version": 0
     },
     "simsimd": {
-      "baseline": "5.4.4",
+      "baseline": "5.7.3",
       "port-version": 0
     },
     "sjpeg": {

--- a/versions/s-/simsimd.json
+++ b/versions/s-/simsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5f06e761acc5b1adf55c5495b5eb113f0fda049",
+      "version": "5.7.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "a1620e76488c7d67a53aa3ebe9d894e495bf5176",
       "version": "5.4.4",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/41619.
`simsimd_find_metric_punned` have been exported in  latest release.

```
Dump of file C:\mengna\vcpkg\installed\x64-windows\bin\simsimd.dll

File Type: DLL

  Section contains the following exports for simsimd.dll

    00000000 characteristics
    FFFFFFFF time date stamp
        0.00 version
           1 ordinal base
          65 number of functions
          65 number of names

          1    0 000118C0 simsimd_bilinear_bf16 = simsimd_bilinear_bf16
          2    1 00011760 simsimd_bilinear_f16 = simsimd_bilinear_f16
          ....
         19   12 0000DEB0 simsimd_find_metric_punned = simsimd_find_metric_punned

```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
