### PR TITLE
[htslib, htscodecs] Update to latest versions.

### DIFF
--- a/ports/htscodecs/portfile.cmake
+++ b/ports/htscodecs/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO samtools/htscodecs
     REF "v${VERSION}"
-    SHA512 7533570b8b1cad0b9ed118170e5a9ff34fdde40b090f4ba3756f7899e2cd7230f8172425ecf6bd7b83b0b0b1a2a24f3d21795db7f0bc2c3add0a55342b970d1a
+    SHA512 5e3e1f916cb14fe7e1292f3a07e9d9704b11be38014db5884b334235c25dbe61dffecf3f12c448a7a13f65c6d19dbc7cc5c77ba0861b31a0375d71030dd02480
     HEAD_REF master
     PATCHES
         0001-no-tests.patch # https://github.com/samtools/htscodecs/pull/120

--- a/ports/htscodecs/vcpkg.json
+++ b/ports/htscodecs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "htscodecs",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Custom compression for CRAM and others.",
   "homepage": "https://github.com/samtools/htscodecs",
   "license": "MIT",

--- a/ports/htslib/0002-pthread-flag.patch
+++ b/ports/htslib/0002-pthread-flag.patch
@@ -74,5 +74,5 @@ index f6e154f..fb4f527 100644
 -	$(CC) $(LDFLAGS) -o $@ tabix.o libhts.a $(LIBS) -lpthread
 +	$(CC) $(LDFLAGS) -o $@ tabix.o libhts.a $(LIBS) $(PTHREAD)
  
- annot-tsv.o: annot-tsv.c config.h $(htslib_hts_h) $(htslib_hts_defs_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_regidx_h)
+ annot-tsv.o: annot-tsv.c config.h $(htslib_hts_h) $(htslib_hts_defs_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_regidx_h) $(textutils_internal_h)
  bgzip.o: bgzip.c config.h $(htslib_bgzf_h) $(htslib_hts_h) $(htslib_hfile_h)

--- a/ports/htslib/0003-no-tests.patch
+++ b/ports/htslib/0003-no-tests.patch
@@ -6,8 +6,8 @@ index fb4f527..751df4b 100644
  	test/thrash_threads6 \
  	test/thrash_threads7
  
--all: lib-static lib-shared $(BUILT_PROGRAMS) plugins $(BUILT_TEST_PROGRAMS) \
-+all: lib-static lib-shared $(BUILT_PROGRAMS) plugins \
-      htslib_static.mk htslib-uninstalled.pc
+ all: lib-static lib-shared $(BUILT_PROGRAMS) plugins \
+-	$(BUILT_TEST_PROGRAMS) htslib_static.mk htslib-uninstalled.pc
++	htslib_static.mk htslib-uninstalled.pc
  
- ALL_CPPFLAGS = -I. $(CPPFLAGS)
+ # Report compiler and version

--- a/ports/htslib/0005-remove-duplicate-lhts.patch
+++ b/ports/htslib/0005-remove-duplicate-lhts.patch
@@ -1,0 +1,11 @@
+diff --git a/htslib.pc.in b/htslib.pc.in
+index d969d6b..fdeeba9 100644
+--- a/htslib.pc.in
++++ b/htslib.pc.in
+@@ -11,5 +11,5 @@ Description: C library for high-throughput sequencing data formats
+ Version: @-PACKAGE_VERSION@
+ Cflags: -I${includedir}
+ Libs: -L${libdir} -lhts
+-Libs.private: -L${libdir} @private_LIBS@ -lhts -lm -lpthread
++Libs.private: -L${libdir} @private_LIBS@ -lm -lpthread
+ Requires.private: zlib @pc_requires@

--- a/ports/htslib/portfile.cmake
+++ b/ports/htslib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO samtools/htslib
     REF "${VERSION}"
-    SHA512 b9de3769db6153f66348c7c4ffbfc5ac7cd4a4d4450c9d1c5ea8fdd8f4f9d38d1d0ba5b4ac9c53f1a754d3985dc483fe22e76f93a8bbe8ae29ef3b98136e7d2e
+    SHA512 6df1a493ac9f13cae5a510537bdf83aa9635a79efe635b8a5a5cbd89345c75c9a42e686c4f0497761ddfad3b86a9814ed35ba2ac340d0f1c7b5e2e186b152875
     HEAD_REF develop
     PATCHES
         0001-set-linkage.patch

--- a/ports/htslib/portfile.cmake
+++ b/ports/htslib/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         0002-pthread-flag.patch
         0003-no-tests.patch
         0004-fix-find-htscodecs.patch
+        0005-remove-duplicate-lhts.patch # https://github.com/samtools/htslib/pull/1852
 )
 
 set(FEATURE_OPTIONS "")

--- a/ports/htslib/vcpkg.json
+++ b/ports/htslib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "htslib",
-  "version": "1.20",
+  "version": "1.21",
   "description": "C library for high-throughput sequencing data formats",
   "homepage": "https://github.com/samtools/htslib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3509,11 +3509,11 @@
       "port-version": 1
     },
     "htscodecs": {
-      "baseline": "1.6.0",
+      "baseline": "1.6.1",
       "port-version": 0
     },
     "htslib": {
-      "baseline": "1.20",
+      "baseline": "1.21",
       "port-version": 0
     },
     "http-parser": {

--- a/versions/h-/htscodecs.json
+++ b/versions/h-/htscodecs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7eaba66bb4d3bf35e1a6b9b70e91edccaccf071",
+      "version": "1.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9475b0327f2fedd60e7c2d71351fed598c9ba3f9",
       "version": "1.6.0",
       "port-version": 0

--- a/versions/h-/htslib.json
+++ b/versions/h-/htslib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76f12c76144128b5c812e8c80957daa446b8b29e",
+      "version": "1.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "94372bcc6471960499da89e7ca144bb90b43a235",
       "version": "1.20",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.