### PR TITLE
Switch CI image to Android NDK r27c

### DIFF
--- a/scripts/azure-pipelines/android/Dockerfile
+++ b/scripts/azure-pipelines/android/Dockerfile
@@ -3,7 +3,6 @@
 FROM ubuntu:focal-20240918
 
 ADD https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb /packages-microsoft-prod.deb
-ADD https://dl.google.com/android/repository/android-ndk-r26d-linux.zip /android-ndk-r26d-linux.zip
 ADD https://dl.google.com/android/repository/android-ndk-r27c-linux.zip /android-ndk-r27c-linux.zip
 
 # Add apt packages
@@ -61,12 +60,10 @@ apt-get -y dist-upgrade
 apt-get -y --no-install-recommends install $APT_PACKAGES
 
 # Android NDK
-unzip /android-ndk-r26d-linux.zip
-rm -f android-ndk-r26d-linux.zip
 unzip /android-ndk-r27c-linux.zip
 rm -f android-ndk-r27c-linux.zip
 END_OF_SCRIPT
 
-ENV ANDROID_NDK_HOME /android-ndk-r26d
+ENV ANDROID_NDK_HOME /android-ndk-r27c
 
 WORKDIR /vcpkg

--- a/scripts/azure-pipelines/android/Dockerfile
+++ b/scripts/azure-pipelines/android/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:focal-20240918
 
 ADD https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb /packages-microsoft-prod.deb
 ADD https://dl.google.com/android/repository/android-ndk-r26d-linux.zip /android-ndk-r26d-linux.zip
+ADD https://dl.google.com/android/repository/android-ndk-r27c-linux.zip /android-ndk-r27c-linux.zip
 
 # Add apt packages
 
@@ -62,6 +63,8 @@ apt-get -y --no-install-recommends install $APT_PACKAGES
 # Android NDK
 unzip /android-ndk-r26d-linux.zip
 rm -f android-ndk-r26d-linux.zip
+unzip /android-ndk-r27c-linux.zip
+rm -f android-ndk-r27c-linux.zip
 END_OF_SCRIPT
 
 ENV ANDROID_NDK_HOME /android-ndk-r26d


### PR DESCRIPTION
r27c seems mature enough to be used in vcpkg CI.
Similar to the r26 transition:
1. Add r27c to the image. This PR, plus @BillyONeal doing the actual rollout.
2. Switch https://github.com/microsoft/vcpkg/pull/40339 to use the new NDK from the image, fix and merge.
3. Remove r26c from the image. Future PR.