### PR TITLE
[libuv] Update to 1.49.2

### DIFF
--- a/ports/libuv/portfile.cmake
+++ b/ports/libuv/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libuv/libuv
     REF "v${VERSION}"
-    SHA512 aaaff8a609f8d8e40ce863f05b443d73ea85c5cda2756e8d05db9b31bf704573ed8788319fed195874fb5e20f4aa947e6af8a78f8284d6719b9fc791d03c7a6e
+    SHA512 e90680128bfaac215e5eebd9c8e5ce08e5fe68a7258f65bfcf56377756e9dbf527a232dfaf9d217c7374e713660ec99eeaae05d6fee2b8c5c9b71ad1b0b4dd72
     HEAD_REF v1.x
     PATCHES 
         fix-build-type.patch

--- a/ports/libuv/vcpkg.json
+++ b/ports/libuv/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libuv",
-  "version-semver": "1.49.1",
+  "version-semver": "1.49.2",
   "description": "libuv is a multi-platform support library with a focus on asynchronous I/O.",
   "homepage": "https://github.com/libuv/libuv",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5261,7 +5261,7 @@
       "port-version": 14
     },
     "libuv": {
-      "baseline": "1.49.1",
+      "baseline": "1.49.2",
       "port-version": 0
     },
     "libuvc": {

--- a/versions/l-/libuv.json
+++ b/versions/l-/libuv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e894cf3c8d353e40f1822b8fe302b720a705f6d8",
+      "version-semver": "1.49.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "81bdbea50fcae6cbb7589016444ef5d7eb0cd00b",
       "version-semver": "1.49.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
