### PR TITLE
[fixed-containers] add new port

### DIFF
--- a/ports/fixed-containers/add-install-configuration.patch
+++ b/ports/fixed-containers/add-install-configuration.patch
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2738060..76e2314 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -236,6 +236,13 @@ if (FIXED_CONTAINERS_OPT_INSTALL)
+     target_include_directories(fixed_containers INTERFACE $<INSTALL_INTERFACE:include>)
+ 
+     include(CMakePackageConfigHelpers)
++
++    configure_package_config_file(
++      ${PROJECT_NAME}Config.cmake.in
++      "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
++      INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}/
++      NO_CHECK_REQUIRED_COMPONENTS_MACRO)
++
+     write_basic_package_version_file(${PROJECT_NAME}ConfigVersion.cmake
+             VERSION "0.0.0"
+             COMPATIBILITY AnyNewerVersion
+@@ -249,11 +256,14 @@ if (FIXED_CONTAINERS_OPT_INSTALL)
+ 
+     install(EXPORT ${PROJECT_NAME}Config
+             NAMESPACE ${PROJECT_NAME}::
++            FILE ${PROJECT_NAME}-targets.cmake
+             DESTINATION lib/cmake/${PROJECT_NAME})
+ 
+     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include
+             DESTINATION .)
++install(
++  FILES
++  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
++  DESTINATION lib/cmake/${PROJECT_NAME})
+ 
+-    export(EXPORT ${PROJECT_NAME}Config
+-            NAMESPACE ${PROJECT_NAME}::)
+ endif()
+diff --git a/fixed_containersConfig.cmake.in b/fixed_containersConfig.cmake.in
+new file mode 100644
+index 0000000..a8e659e
+--- /dev/null
++++ b/fixed_containersConfig.cmake.in
+@@ -0,0 +1,9 @@
++
++@PACKAGE_INIT@
++
++include(CMakeFindDependencyMacro)
++
++find_dependency(magic_enum CONFIG)
++
++include("${CMAKE_CURRENT_LIST_DIR}/fixed_containers-targets.cmake")
++

--- a/ports/fixed-containers/add-install-configuration.patch
+++ b/ports/fixed-containers/add-install-configuration.patch
@@ -33,18 +33,3 @@ index 2738060..4f3aedd 100644
 +      "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
 +      DESTINATION lib/cmake/${PROJECT_NAME})
  endif()
-diff --git a/fixed_containersConfig.cmake.in b/fixed_containersConfig.cmake.in
-new file mode 100644
-index 0000000..a8e659e
---- /dev/null
-+++ b/fixed_containersConfig.cmake.in
-@@ -0,0 +1,9 @@
-+
-+@PACKAGE_INIT@
-+
-+include(CMakeFindDependencyMacro)
-+
-+find_dependency(magic_enum CONFIG)
-+
-+include("${CMAKE_CURRENT_LIST_DIR}/fixed_containers-targets.cmake")
-+

--- a/ports/fixed-containers/add-install-configuration.patch
+++ b/ports/fixed-containers/add-install-configuration.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2738060..76e2314 100644
+index 2738060..4f3aedd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -236,6 +236,13 @@ if (FIXED_CONTAINERS_OPT_INSTALL)
@@ -25,13 +25,13 @@ index 2738060..76e2314 100644
  
      install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include
              DESTINATION .)
-+install(
-+  FILES
-+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-+  DESTINATION lib/cmake/${PROJECT_NAME})
  
 -    export(EXPORT ${PROJECT_NAME}Config
 -            NAMESPACE ${PROJECT_NAME}::)
++    install(
++      FILES
++      "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
++      DESTINATION lib/cmake/${PROJECT_NAME})
  endif()
 diff --git a/fixed_containersConfig.cmake.in b/fixed_containersConfig.cmake.in
 new file mode 100644

--- a/ports/fixed-containers/fixed_containersConfig.cmake.in
+++ b/ports/fixed-containers/fixed_containersConfig.cmake.in
@@ -1,0 +1,9 @@
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(magic_enum CONFIG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/fixed_containers-targets.cmake")
+

--- a/ports/fixed-containers/portfile.cmake
+++ b/ports/fixed-containers/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO teslamotors/fixed-containers
+    REF 1ad10a6ca835611124f54a1d8ed04bcf7ab53da4
+    SHA512 71b7ea86ed45bac39c2f22c572f84d3a9862aab350eeef5d72c6061d42c10bf7fad26cafc6c6b991cdf3ac758b23c29fd8d3414f1b2af7c65058bc31d000b49b
+    HEAD_REF main
+    PATCHES add-install-configuration.patch
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+    -DBUILD_TESTS=OFF
+    -DFIXED_CONTAINERS_OPT_INSTALL=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME fixed_containers CONFIG_PATH lib/cmake/fixed_containers)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fixed-containers/portfile.cmake
+++ b/ports/fixed-containers/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
 
 set(VCPKG_BUILD_TYPE release) # header-only
 
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/fixed_containersConfig.cmake.in" DESTINATION "${SOURCE_PATH}")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/fixed-containers/vcpkg.json
+++ b/ports/fixed-containers/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "fixed-containers",
+  "version-date": "2024-09-19",
+  "description": "C++ Fixed Containers",
+  "homepage": "https://github.com/teslamotors/fixed-containers",
+  "license": "MIT",
+  "dependencies": [
+    "magic-enum",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2756,6 +2756,10 @@
       "baseline": "2023-07-31",
       "port-version": 0
     },
+    "fixed-containers": {
+      "baseline": "2024-09-19",
+      "port-version": 0
+    },
     "fixed-string": {
       "baseline": "0.1.1",
       "port-version": 0

--- a/versions/f-/fixed-containers.json
+++ b/versions/f-/fixed-containers.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c10e1fbc2f7f08fd4481a1771151d983cbb34c15",
+      "version-date": "2024-09-19",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/f-/fixed-containers.json
+++ b/versions/f-/fixed-containers.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c10e1fbc2f7f08fd4481a1771151d983cbb34c15",
+      "git-tree": "df7eaca532d35f09faf63721a245c1fccafddc29",
       "version-date": "2024-09-19",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.