### PR TITLE
[mimicpp] new port

### DIFF
--- a/ports/mimicpp/portfile.cmake
+++ b/ports/mimicpp/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO DNKpp/mimicpp
+    REF "v${VERSION}"
+    SHA512 a1c9496c28ad7940a91e6491d9a5992533c72fe3dcd19a3397ae40bc0de363bc796db1168a3caf66c8fc6718a100ab83cb0458e2b68e564efd2cf146db45b221
+    HEAD_REF main
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DMIMICPP_BUILD_TESTS=OFF
+        -DMIMICPP_BUILD_EXAMPLES=OFF
+        -DMIMICPP_CONFIGURE_DOXYGEN=OFF
+        -DMIMICPP_ENABLE_AMALGAMATE_HEADERS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/mimipp/cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE_1_0.txt")

--- a/ports/mimicpp/vcpkg.json
+++ b/ports/mimicpp/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "mimicpp",
+  "version": "3",
+  "description": "mimic++, a modern and (mostly) macro free mocking framework.",
+  "homepage": "https://github.com/DNKpp/mimicpp",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5840,6 +5840,10 @@
       "baseline": "2.1.7",
       "port-version": 0
     },
+    "mimicpp": {
+      "baseline": "3",
+      "port-version": 0
+    },
     "minc": {
       "baseline": "2.4.03",
       "port-version": 3

--- a/versions/m-/mimicpp.json
+++ b/versions/m-/mimicpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ef648806009c754d8077dad2e1fd9e434616f427",
+      "version": "3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] ~Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).~
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.