### PR TITLE
[conjure-enum] update to 1.1.0

### DIFF
--- a/ports/conjure-enum/portfile.cmake
+++ b/ports/conjure-enum/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fix8mt/conjure_enum
     REF "v${VERSION}"
-    SHA512 b9054a62ba10dd7b27b0fa6d2fd6a0c03eaea0f39fc0ba954e12351face02969fccd393278a9e29fa3f8af52b285b16e5ca6d0bc00a05a6ad08d7482bc1c587c
+    SHA512 af8127f2d958227a7168a7d808d7ff7f699b250c04b4a079f6ef9e034ee6d165e4d51054c2ec4dcec64291d3e11c507d73937dbee22e9bc5fcbdb73e127e0275
     HEAD_REF master
 )
 

--- a/ports/conjure-enum/vcpkg.json
+++ b/ports/conjure-enum/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "conjure-enum",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Lightweight header-only C++20 enum and typename reflection.",
   "homepage": "https://github.com/fix8mt/conjure_enum",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1841,7 +1841,7 @@
       "port-version": 0
     },
     "conjure-enum": {
-      "baseline": "1.0.1",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "console-bridge": {

--- a/versions/c-/conjure-enum.json
+++ b/versions/c-/conjure-enum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cdcabd848476256a49a36322bc7e6c4fefc6abd0",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "78574a0113c4bcf9bad05d2fcef406d0bc1d0891",
       "version": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.