### PR TITLE
[mimalloc] Fix build error on x64-android

### DIFF
--- a/ports/mimalloc/fix-param.patch
+++ b/ports/mimalloc/fix-param.patch
@@ -1,0 +1,13 @@
+diff --git a/src/arena.c b/src/arena.c
+index 648ee84..ee55989 100644
+--- a/src/arena.c
++++ b/src/arena.c
+@@ -794,7 +794,7 @@ bool _mi_arena_segment_clear_abandoned(mi_segment_t* segment )
+ // clears the thread_id.
+ void _mi_arena_segment_mark_abandoned(mi_segment_t* segment) 
+ {
+-  mi_atomic_store_release(&segment->thread_id, 0);
++  mi_atomic_store_release(&segment->thread_id, (uintptr_t)0);
+   mi_assert_internal(segment->used == segment->abandoned);
+   if (segment->memid.memkind != MI_MEM_ARENA) {
+     // not in an arena; count it as abandoned and return

--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-cmake.patch
         add_ref_to_page_malloc_zero.patch
+        fix-param.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mimalloc",
   "version": "2.1.7",
+  "port-version": 1,
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5890,7 +5890,7 @@
     },
     "mimalloc": {
       "baseline": "2.1.7",
-      "port-version": 0
+      "port-version": 1
     },
     "minc": {
       "baseline": "2.4.03",

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c5bd4a682e8abd9ad95f184c32040d4fed94dfb",
+      "version": "2.1.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "36add89e108365f4632d31d0ff7cc877101a9fad",
       "version": "2.1.7",
       "port-version": 0


### PR DESCRIPTION
```
/home/vzhli17/jim/vcpkg/buildtrees/mimalloc/src/v2.1.7-d58a1dd7b9/src/arena.c:798:3: error: no matching function for call to 'atomic_store_explicit'
  mi_atomic_store_release(&segment->thread_id, 0);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Refer to upstream PR [694](https://github.com/microsoft/mimalloc/pull/694) for modification.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.


Compile test pass with following triplets:
```

x64-windows
x64-android
```