### PR TITLE
[libxcrypt] fix compile error due to bad array length

### DIFF
--- a/ports/libxcrypt/fix-base64-bad-length.patch
+++ b/ports/libxcrypt/fix-base64-bad-length.patch
@@ -1,0 +1,9 @@
+diff --git a/lib/util-base64.c b/lib/util-base64.c
+--- a/lib/util-base64.c
++++ b/lib/util-base64.c
+@@ -24,4 +24,4 @@
+   "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+ /* 0000000000111111111122222222223333333333444444444455555555556666 */
+ /* 0123456789012345678901234567890123456789012345678901234567890123 */
+-  "\x00";
++;

--- a/ports/libxcrypt/portfile.cmake
+++ b/ports/libxcrypt/portfile.cmake
@@ -20,6 +20,8 @@ vcpkg_from_github(
     REPO besser82/libxcrypt
     REF "v${VERSION}"
     SHA512 61e5e393654f37775457474d4170098314879ee79963d423c1c461e80dc5dc74f0c161dd8754f016ce96109167be6c580ad23994fa1d2c38c54b96e602f3aece
+    PATCHES
+        fix-base64-bad-length.patch
 )
 
 vcpkg_configure_make(

--- a/ports/libxcrypt/vcpkg.json
+++ b/ports/libxcrypt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libxcrypt",
   "version": "4.4.36",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libxcrypt is a modern library for one-way hashing of passwords. On Linux-based systems, by default libxcrypt will be binary backward compatible with the libcrypt.so.1 shipped as part of the GNU C Library.",
   "homepage": "https://github.com/besser82/libxcrypt",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5366,7 +5366,7 @@
     },
     "libxcrypt": {
       "baseline": "4.4.36",
-      "port-version": 1
+      "port-version": 2
     },
     "libxcvt": {
       "baseline": "0.1.2",

--- a/versions/l-/libxcrypt.json
+++ b/versions/l-/libxcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d4ec9d9e2160c28ad52fe6e6956a9673d5313d0",
+      "version": "4.4.36",
+      "port-version": 2
+    },
+    {
       "git-tree": "89d7de97e87cb0eb10479d47ec43e1cc732b2734",
       "version": "4.4.36",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/41695
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.