### PR TITLE
[ms-gsl] update GSL to version 4.1.0

### DIFF
--- a/ports/ms-gsl/portfile.cmake
+++ b/ports/ms-gsl/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/GSL
-    REF a3534567187d2edc428efd3f13466ff75fe5805c
-    SHA512 5bd6aad37fee3b56a2ee2fed10d6ef02fdcf37a1f40b3fb1bbec8146a573e235169b315405d010ab75175674ed82658c8202f40b128a849c5250b4a1b8b0a1b3
+    REF v${VERSION}
+    SHA512 1db14bebab5f2bc0752214f9bf1b84a056b7d83b4a9d296663c43103387baee60373447f62c4e9bc0b8df06a7ce0571a4e2b4a31441c866894eee3ae258fdfc8
     HEAD_REF main
 )
 
@@ -22,5 +22,4 @@ vcpkg_cmake_config_fixup(
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-# Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ms-gsl/vcpkg.json
+++ b/ports/ms-gsl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ms-gsl",
-  "version": "4.0.0",
-  "port-version": 1,
+  "version": "4.1.0",
   "description": "Microsoft implementation of the Guidelines Support Library",
   "homepage": "https://github.com/Microsoft/GSL",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6073,8 +6073,8 @@
       "port-version": 2
     },
     "ms-gsl": {
-      "baseline": "4.0.0",
-      "port-version": 1
+      "baseline": "4.1.0",
+      "port-version": 0
     },
     "ms-ifc-sdk": {
       "baseline": "0.43.1",

--- a/versions/m-/ms-gsl.json
+++ b/versions/m-/ms-gsl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d71696a526519c3f680b1b77e87d39f8eb94e650",
+      "version": "4.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7d8da50e7ffaa4a1460036950f527b0a5e64c02a",
       "version": "4.0.0",
       "port-version": 1


### PR DESCRIPTION
GSL version 4.1.0 was released on 10/21/24.

Release notes: https://github.com/microsoft/GSL/releases/tag/v4.1.0

---

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.