### PR TITLE
[vincentlaucsb-csv-parser] Fix gcov linking errors on linux.

### DIFF
--- a/ports/vincentlaucsb-csv-parser/003-disable-coverage.patch
+++ b/ports/vincentlaucsb-csv-parser/003-disable-coverage.patch
@@ -1,0 +1,11 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -29,7 +29,6 @@ if(MSVC)
+ else()
+ 	# Ignore Visual Studio pragma regions
+ 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} --coverage -Og")
+ endif(MSVC)
+ 
+ set(CSV_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})

--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         001-fix-cmake.patch
         002-fix-include.patch
+		003-disable-coverage.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vincentlaucsb-csv-parser",
   "version": "2.2.3",
+  "port-version": 1,
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9378,7 +9378,7 @@
     },
     "vincentlaucsb-csv-parser": {
       "baseline": "2.2.3",
-      "port-version": 0
+      "port-version": 1
     },
     "visit-struct": {
       "baseline": "1.1.0",

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c82b4467c59f180e2508928b5512aa1c357cf80",
+      "version": "2.2.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "6bea0ccfd4832f3c1aeea917bd8c709c19750ebd",
       "version": "2.2.3",
       "port-version": 0


### PR DESCRIPTION
On linux programs using this port in debug mode fail because the library is being compiled with coverage rigging.

This patch disables that unused instrumentation.
