### PR TITLE
[7-zip] Only build Windows sources for Windows

### DIFF
--- a/ports/7zip/CMakeLists.txt
+++ b/ports/7zip/CMakeLists.txt
@@ -149,16 +149,6 @@ target_sources(7zip PRIVATE
     CPP/Common/XzCrc64Reg.cpp
     CPP/Common/Xxh64Reg.cpp
 
-    CPP/Windows/FileDir.cpp
-    CPP/Windows/FileFind.cpp
-    CPP/Windows/FileIO.cpp
-    CPP/Windows/FileName.cpp
-    CPP/Windows/PropVariant.cpp
-    CPP/Windows/PropVariantUtils.cpp
-    CPP/Windows/Synchronization.cpp
-    CPP/Windows/System.cpp
-    CPP/Windows/TimeUtils.cpp
-
     CPP/7zip/Common/CreateCoder.cpp
     CPP/7zip/Common/CWrappers.cpp
     CPP/7zip/Common/InBuffer.cpp
@@ -301,6 +291,20 @@ target_sources(7zip PRIVATE
     CPP/7zip/Archive/Archive2.def
     C/Util/LzmaLib/LzmaLib.def
 )
+
+if(WIN32)
+    target_sources(7zip PRIVATE
+        CPP/Windows/FileDir.cpp
+        CPP/Windows/FileFind.cpp
+        CPP/Windows/FileIO.cpp
+        CPP/Windows/FileName.cpp
+        CPP/Windows/PropVariant.cpp
+        CPP/Windows/PropVariantUtils.cpp
+        CPP/Windows/Synchronization.cpp
+        CPP/Windows/System.cpp
+        CPP/Windows/TimeUtils.cpp
+    )
+endif()
 
 # 7zCrcOpt
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/7zip/vcpkg.json
+++ b/ports/7zip/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "7zip",
   "version-string": "24.08",
+  "port-version": 1,
   "description": "Library for archiving file with a high compression ratio.",
   "homepage": "https://www.7-zip.org",
   "license": "LGPL-2.1-or-later",

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "36bee800b8aadc1908cc02cc1561dee40a3b43f6",
+      "version-string": "24.08",
+      "port-version": 1
+    },
+    {
       "git-tree": "f8021d6c213215f0eb9e99500d348291ac5898c5",
       "version-string": "24.08",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6,7 +6,7 @@
     },
     "7zip": {
       "baseline": "24.08",
-      "port-version": 0
+      "port-version": 1
     },
     "ableton": {
       "baseline": "3.0.6",


### PR DESCRIPTION
I've got no idea why these were here (it was in the initial PR without any explanation) and can't make any sense of the upstream makefiles, but it seems like the things in the Windows directory ought to only be built for Windows. This fixes compilation errors with NDK r28.