### PR TITLE
[libmysql] Update to 8.0.40

### DIFF
--- a/ports/libmysql/fix_dup_symbols.patch
+++ b/ports/libmysql/fix_dup_symbols.patch
@@ -1,8 +1,8 @@
 diff --git a/client/CMakeLists.txt b/client/CMakeLists.txt
-index 058967b..bcd8841 100644
+index d54f4a6f..cd2132c9 100644
 --- a/client/CMakeLists.txt
 +++ b/client/CMakeLists.txt
-@@ -43,7 +43,6 @@ MYSQL_ADD_EXECUTABLE(mysql
+@@ -44,7 +44,6 @@ MYSQL_ADD_EXECUTABLE(mysql
    pattern_matcher.cc
    readline.cc
    client_query_attributes.cc
@@ -10,11 +10,11 @@ index 058967b..bcd8841 100644
    ${CMAKE_CURRENT_SOURCE_DIR}/common/user_registration.cc
    LINK_LIBRARIES mysqlclient client_base ${EDITLINE_LIBRARY}
    )
-@@ -226,7 +226,6 @@ SET(MYSQLBINLOG_SOURCES
+@@ -232,7 +231,6 @@ SET(MYSQLBINLOG_SOURCES
    ${CMAKE_SOURCE_DIR}/sql/binlog_reader.cc
    ${CMAKE_SOURCE_DIR}/sql/stream_cipher.cc
    ${CMAKE_SOURCE_DIR}/sql/rpl_log_encryption.cc
 -  ${CMAKE_SOURCE_DIR}/libbinlogevents/src/trx_boundary_parser.cpp
    )
  
- SET(MYSQLBINLOG_LIBRARIES
+ # The client version of log_event.cc has false positives.

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mysql/mysql-server
-    REF mysql-${VERSION}
-    SHA512 80341fe6bf6738b30721933a31c8c3f033ce8342a3a2defeb83e29219375bff274620f6f21a02ee6f4e77f0d3a858a20487436a5afd0a95ea35b0523812c52ab
+    REF "mysql-${VERSION}"
+    SHA512 f0591d263de557877a618b04871d332dc227e26c7e9b61994093dc9af29971ea6332761de5391bb8da955bd58b3b98da90722bafdbf86f36764995a70f94ae62
     HEAD_REF master
     PATCHES
         dependencies.patch

--- a/ports/libmysql/vcpkg.json
+++ b/ports/libmysql/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmysql",
-  "version": "8.0.39",
+  "version": "8.0.40",
   "description": "A MySQL client library for C development",
   "homepage": "https://github.com/mysql/mysql-server",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4813,7 +4813,7 @@
       "port-version": 0
     },
     "libmysql": {
-      "baseline": "8.0.39",
+      "baseline": "8.0.40",
       "port-version": 0
     },
     "libnice": {

--- a/versions/l-/libmysql.json
+++ b/versions/l-/libmysql.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1fcb166c50b683fcbda07bec1e7bfb7c37234525",
+      "version": "8.0.40",
+      "port-version": 0
+    },
+    {
       "git-tree": "eb4f616fe98bc02a278669124285ef829bf8abb4",
       "version": "8.0.39",
       "port-version": 0


### PR DESCRIPTION
Fixes #41718. Update `libmysql` to 8.0.40.

No feature needs to be tested, the usage test passed on `x64-windows` (header files found).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.