### PR TITLE
 [ryml] Update to latest version

### DIFF
--- a/ports/ryml/cmake-fix.patch
+++ b/ports/ryml/cmake-fix.patch
@@ -18,7 +18,7 @@ index d18407c..db19e0b 100644
          ryml.natvis
      SOURCE_ROOT ${RYML_SRC_DIR}
      INC_DIRS
-+    	 $<BUILD_INTERFACE:${C4CORE_INCLUDE_DIR}>
++        $<BUILD_INTERFACE:${C4CORE_INCLUDE_DIR}>
          $<BUILD_INTERFACE:${RYML_SRC_DIR}>
          $<INSTALL_INTERFACE:include>
 -    LIBS c4core

--- a/ports/ryml/cmake-fix.patch
+++ b/ports/ryml/cmake-fix.patch
@@ -2,21 +2,23 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index d18407c..db19e0b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -21,8 +21,7 @@ option(RYML_DBG "Enable (very verbose) ryml debug prints." OFF)
+@@ -27,10 +27,7 @@ option(RYML_DBG "Enable (very verbose) ryml debug prints." OFF)
  
  #-------------------------------------------------------
  
 -c4_require_subproject(c4core INCORPORATE
--    SUBDIRECTORY ${RYML_EXT_DIR}/c4core)
+-    SUBDIRECTORY ${RYML_EXT_DIR}/c4core
+-    OVERRIDE C4CORE_INSTALL ${RYML_INSTALL}
+-)
 +find_package(c4core CONFIG REQUIRED)
  
  c4_add_library(ryml
      SOURCES
-@@ -54,10 +53,10 @@ c4_add_library(ryml
+@@ -74,10 +74,10 @@ c4_add_library(ryml
          ryml.natvis
      SOURCE_ROOT ${RYML_SRC_DIR}
      INC_DIRS
-+    $<BUILD_INTERFACE:${C4CORE_INCLUDE_DIR}>
++    	 $<BUILD_INTERFACE:${C4CORE_INCLUDE_DIR}>
          $<BUILD_INTERFACE:${RYML_SRC_DIR}>
          $<INSTALL_INTERFACE:include>
 -    LIBS c4core

--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -33,7 +33,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         def-callbacks RYML_DEFAULT_CALLBACKS
         dbg           RYML_DBG
-		git  		  GIT
 )
 
 vcpkg_cmake_configure(

--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -5,19 +5,19 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/rapidyaml
     REF "v${VERSION}"
-    SHA512 861f1d2c39c5c8d455e8d40e3ecadd828b948c5dea2bcb88ba92686ca77b9a7d69ab2d94407732eab574e4e3c7b319d0f1b31250b18fb513310847192623a2f7
+    SHA512 2ff14776498dc8a55cb257c38fbea5b1a1fc5c4c09ade5b10c45cb4afcaf0cc587674723bedf38fd04b3179a18ba7357a929484b154474d658d597d0f9ee8d2e
     HEAD_REF master
     PATCHES cmake-fix.patch
 )
 
-set(CM_COMMIT_HASH fe41e86552046c3df9ba73a40bf3d755df028c1e)
+set(CM_COMMIT_HASH 08b1e26dbe7346ce3c7aeafe350d0962ae86a278)
 
 # Get cmake scripts for rapidyaml
 vcpkg_download_distfile(
     CMAKE_ARCHIVE
     URLS "https://github.com/biojppm/cmake/archive/${CM_COMMIT_HASH}.zip"
     FILENAME "cmake-${CM_COMMIT_HASH}.zip"
-    SHA512 7292f9856d9c41581f2731e73fdf08880e0f4353b757da38a13ec89b62c5c8cb52b9efc1a9ff77336efa0b6809727c17649e607d8ecacc965a9b2a7a49925237
+    SHA512 587e50f766e7702acbdbccdad1549ced83cdf340803a6a20995aaba8e6a9b375e928c068fbc3c4fd0611ee1ef908a082417e365e8e61e46e67e5ff802a648572
 )
 
 vcpkg_extract_source_archive(
@@ -33,6 +33,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         def-callbacks RYML_DEFAULT_CALLBACKS
         dbg           RYML_DBG
+		git  		  GIT
 )
 
 vcpkg_cmake_configure(

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ryml",
-  "version": "0.5.0",
-  "port-version": 1,
+  "version": "0.7.2",
   "description": "Rapid YAML library",
   "homepage": "https://github.com/biojppm/rapidyaml",
   "license": "MIT",
@@ -20,14 +19,15 @@
     }
   ],
   "default-features": [
-    "def-callbacks"
+    "def-callbacks",
+	"standalone"
   ],
   "features": {
-    "dbg": {
-      "description": "Enable (very verbose) ryml debug prints."
-    },
     "def-callbacks": {
       "description": "Enable ryml's default implementation of callbacks: allocate(), free(), error()"
-    }
+    },
+	"standalone" : {
+		"description": "Enable compilation of opting-in targets from ryml in standalone."
+	}
   }
 }

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,5 +1,10 @@
 {
   "versions": [
+	{
+      "git-tree": "40e7d3584e3ecdcd88bb3f30778895176a37d298",
+      "version": "0.7.2",
+      "port-version": 0
+    },
     {
       "git-tree": "c8ceae82ba08f1a242ec0b15f80424db37e4847c",
       "version": "0.5.0",

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
 	{
-      "git-tree": "40e7d3584e3ecdcd88bb3f30778895176a37d298",
+      "git-tree": "74c7ba1e6951c3fb87af39a7d74af39fc76ce8d1",
       "version": "0.7.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.