### PR TITLE
[vtk-dicom] Fix cmake path

### DIFF
--- a/ports/vtk-dicom/portfile.cmake
+++ b/ports/vtk-dicom/portfile.cmake
@@ -37,7 +37,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/dicom-0.8)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/dicom-0.8 PACKAGE_NAME dicom)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/vtk-dicom/portfile.cmake
+++ b/ports/vtk-dicom/portfile.cmake
@@ -37,7 +37,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/dicom-0.8)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/vtk-dicom/vcpkg.json
+++ b/ports/vtk-dicom/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vtk-dicom",
   "version": "0.8.16",
+  "port-version": 1,
   "description": "DICOM for VTK",
   "homepage": "https://github.com/dgobbi/vtk-dicom",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9454,7 +9454,7 @@
     },
     "vtk-dicom": {
       "baseline": "0.8.16",
-      "port-version": 0
+      "port-version": 1
     },
     "vtk-m": {
       "baseline": "2.1.0",

--- a/versions/v-/vtk-dicom.json
+++ b/versions/v-/vtk-dicom.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e980a37a30cde85f924b9778c25f7209ae6944f4",
+      "git-tree": "73df27ee23b96ebb4d9caad96c39f567f99ceb6f",
       "version": "0.8.16",
       "port-version": 1
     },

--- a/versions/v-/vtk-dicom.json
+++ b/versions/v-/vtk-dicom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e980a37a30cde85f924b9778c25f7209ae6944f4",
+      "version": "0.8.16",
+      "port-version": 1
+    },
+    {
       "git-tree": "17092f6f2038b2c29c0fba0e21efcf5521bc64fa",
       "version": "0.8.16",
       "port-version": 0


### PR DESCRIPTION
Fixes #12813
Install *.cmake to the correct path.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.