### PR TITLE
[ecm] Update to 6.7.0

### DIFF
--- a/ports/ecm/portfile.cmake
+++ b/ports/ecm/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/extra-cmake-modules
     REF "v${VERSION}"
-    SHA512 30f9e4d606f88c8d0e2be8f0fbba47ae25cf6e1c9716d50fc2f7845e5527d6cb4a34dfca8ec4356e8e74ce936ae252edf833b2bc545a4c85a894103dd27d8c89
+    SHA512 d62091185c26c4eec83f7b2e06468c3c3691ae0e71f4d60aafaf32be262677affc686a4e54159f487005854bdf46c4c3a2214775daf850039b733ad02edc3936
     HEAD_REF master
     PATCHES
         fix_generateqmltypes.patch # https://invent.kde.org/frameworks/extra-cmake-modules/-/merge_requests/201

--- a/ports/ecm/vcpkg.json
+++ b/ports/ecm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ecm",
-  "version": "6.4.0",
+  "version": "6.7.0",
   "description": "Extra CMake Modules (ECM), extra modules and scripts for CMake",
   "homepage": "https://github.com/KDE/extra-cmake-modules",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2493,7 +2493,7 @@
       "port-version": 0
     },
     "ecm": {
-      "baseline": "6.4.0",
+      "baseline": "6.7.0",
       "port-version": 0
     },
     "ecos": {

--- a/versions/e-/ecm.json
+++ b/versions/e-/ecm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5709bdab7668ace236f37659923062c27aae0988",
+      "version": "6.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "106274dc3cc918d9af50f69fd273e248c7fd352e",
       "version": "6.4.0",
       "port-version": 0


### PR DESCRIPTION
Update `ecm` to 6.7.0. No need to test feature and usage.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.