### PR TITLE
[aliyun-oss-cpp-sdk] Do not use OpenSSL CMake config

### DIFF
--- a/ports/aliyun-oss-cpp-sdk/0001-dependency-and-targets.patch
+++ b/ports/aliyun-oss-cpp-sdk/0001-dependency-and-targets.patch
@@ -9,7 +9,7 @@ index ea0d8d6..2a853a0 100644
 -	include(FindCURL)
 -	include(FindOpenSSL)
 +	find_package(CURL CONFIG REQUIRED)
-+	find_package(OpenSSL CONFIG REQUIRED)
++	find_package(OpenSSL REQUIRED)
  
  	if(NOT CURL_FOUND)
  		message(FATAL_ERROR "Could not find curl")

--- a/ports/aliyun-oss-cpp-sdk/vcpkg.json
+++ b/ports/aliyun-oss-cpp-sdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "aliyun-oss-cpp-sdk",
   "version": "1.10.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Alibaba Cloud Object Storage Service (OSS) is a cloud storage service provided by Alibaba Cloud, featuring massive capacity, security, a low cost, and high reliability.",
   "homepage": "https://github.com/aliyun/aliyun-oss-cpp-sdk",
   "license": "Apache-2.0",

--- a/versions/a-/aliyun-oss-cpp-sdk.json
+++ b/versions/a-/aliyun-oss-cpp-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0911047ac61bf556c75c153d23ab0169990a4f77",
+      "version": "1.10.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "ca0c99c6cdc51c43705f89baf7ee8a4e61b25fe2",
       "version": "1.10.0",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -82,7 +82,7 @@
     },
     "aliyun-oss-cpp-sdk": {
       "baseline": "1.10.0",
-      "port-version": 2
+      "port-version": 3
     },
     "allegro5": {
       "baseline": "5.2.9.1",


### PR DESCRIPTION
OpenSSL CMake config is release-only.