### PR TITLE
[opentelemetry-cpp] Don't prefer CMake config

### DIFF
--- a/ports/opentelemetry-cpp/cmake-quirks.diff
+++ b/ports/opentelemetry-cpp/cmake-quirks.diff
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fd41fa7..cde4566 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,7 +24,6 @@ project(opentelemetry-cpp)
+ mark_as_advanced(CMAKE_TOOLCHAIN_FILE)
+ 
+ # Prefer cmake CONFIG to auto resolve dependencies.
+-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+ 
+ # Don't use customized cmake modules if vcpkg is used to resolve dependence.
+ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+@@ -96,7 +95,6 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+ endif()
+ 
+ if(VCPKG_CHAINLOAD_TOOLCHAIN_FILE)
+-  include("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}")
+ endif()
+ 
+ option(WITH_ABI_VERSION_1 "ABI version 1" ON)

--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     SHA512 c89c4f7a73c11c020f8ea1cb836ccd222456f899ede8e81a1fd0024e0a88f17c44a66bada8ed3010b0d03ac052475edb34b855aeafcff50975d24c8859463d68
     HEAD_REF main
     PATCHES
+        cmake-quirks.diff
         # Missing find_dependency for Abseil
         add-missing-find-dependency.patch
 )

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.17.0",
+  "port-version": 1,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6722,7 +6722,7 @@
     },
     "opentelemetry-cpp": {
       "baseline": "1.17.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opentelemetry-cpp-contrib-version": {
       "baseline": "2024-06-17",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "676c68ab244c1b790041e5ae63dd72f794deb5d9",
+      "version-semver": "1.17.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f1c52bb415c2c2e19b33e37dc85a2747720ae033",
       "version-semver": "1.17.0",
       "port-version": 0


### PR DESCRIPTION
Avoid picking broken (OpenSSL) or external (ZLIB) config.