### PR TITLE
[libmariadb] Fix ambiguous cmake call

### DIFF
--- a/ports/libmariadb/cmake-ambiguous-keyword.diff
+++ b/ports/libmariadb/cmake-ambiguous-keyword.diff
@@ -1,0 +1,19 @@
+diff --git a/cmake/plugins.cmake b/cmake/plugins.cmake
+index de5c12c..f433859 100644
+--- a/cmake/plugins.cmake
++++ b/cmake/plugins.cmake
+@@ -15,11 +15,14 @@ FUNCTION(REGISTER_PLUGIN)
+   SET(one_value_keywords TARGET DISABLED TYPE DEFAULT)
+   SET(multi_value_keywords CONFIGURATIONS SOURCES LIBRARIES INCLUDES COMPILE_OPTIONS)
+ 
++  # https://github.com/microsoft/vcpkg/issues/41719
++  string(REPLACE ";DEFAULT;DEFAULT;" ";vcpkg_value_DEFAULT;DEFAULT;" ARGN "${ARGN}")
+   cmake_parse_arguments(CC_PLUGIN
+                         "${options}"
+                         "${one_value_keywords}"
+                         "${multi_value_keywords}"
+                         ${ARGN})
++  string(REPLACE "vcpkg_value_DEFAULT" "DEFAULT" CC_PLUGIN_CONFIGURATIONS "${CC_PLUGIN_CONFIGURATIONS}")
+ 
+   # overwrite default if it was specified with cmake option
+   string(TOUPPER ${CC_PLUGIN_TARGET} cc_plugin)

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
     SHA512 396ce2a36937d49ec96eb239312118c736f46383d2906b7142d9695e795f310af28255d8827cc98ad76ae4e6d5a22faf1188b7dd286791e3c85f22c96d0114b3
     HEAD_REF 3.4
     PATCHES
+        cmake-ambiguous-keyword.diff
         compiler-flags.diff
         dependencies.diff
         disable-mariadb_config.diff

--- a/ports/libmariadb/vcpkg.json
+++ b/ports/libmariadb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmariadb",
   "version-semver": "3.4.1",
+  "port-version": 1,
   "description": "MariaDB Connector/C is used to connect C/C++ applications to MariaDB and MySQL databases",
   "homepage": "https://github.com/mariadb-corporation/mariadb-connector-c",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4758,7 +4758,7 @@
     },
     "libmariadb": {
       "baseline": "3.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libmaxminddb": {
       "baseline": "1.11.0",

--- a/versions/l-/libmariadb.json
+++ b/versions/l-/libmariadb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a0ded7227a50f4a953d3b81be2f63b5db3c21a4",
+      "version-semver": "3.4.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "052df42a61bbe15831197f9adbafcf4da7f6fcc6",
       "version-semver": "3.4.1",
       "port-version": 0


### PR DESCRIPTION
Tentative patch for https://github.com/microsoft/vcpkg/issues/41719. Not for upstream. Not needed before CMake 3.31. Subject to resolution of https://gitlab.kitware.com/cmake/cmake/-/issues/26397.