### PR TITLE
[gameinput] Add port to use Microsoft.GameInput from nuget.org

### DIFF
--- a/ports/gameinput/gameinput-config.cmake.in
+++ b/ports/gameinput/gameinput-config.cmake.in
@@ -1,22 +1,12 @@
-
 get_filename_component(_gameinput_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
 get_filename_component(_gameinput_root "${_gameinput_root}" PATH)
 
 set(_gameinput_root_lib "${_gameinput_root}/lib/gameinput.lib")
-if (EXISTS "${_gameinput_root_lib}")
 
-   add_library(Microsoft::GameInput INTERFACE)
-   set_target_properties(Microsoft::GameInput PROPERTIES
-      INTERFACE_LINK_LIBRARIES      "${_gameinput_root_lib}"
-      INTERFACE_INCLUDE_DIRECTORIES "${_gameinput_root}/include")
-
-   set(gameinput_FOUND TRUE)
-
-else()
-
-    set(gameinput_FOUND FALSE)
-
-endif()
+add_library(Microsoft::GameInput INTERFACE IMPORTED)
+set_target_properties(Microsoft::GameInput PROPERTIES
+   INTERFACE_LINK_LIBRARIES      "${_gameinput_root_lib}"
+   INTERFACE_INCLUDE_DIRECTORIES "${_gameinput_root}/include")
 
 unset(_gameinput_root_lib)
 unset(_gameinput_root)

--- a/ports/gameinput/gameinput-config.cmake.in
+++ b/ports/gameinput/gameinput-config.cmake.in
@@ -1,0 +1,22 @@
+
+get_filename_component(_gameinput_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(_gameinput_root "${_gameinput_root}" PATH)
+
+set(_gameinput_root_lib "${_gameinput_root}/lib/gameinput.lib")
+if (EXISTS "${_gameinput_root_lib}")
+
+   add_library(Microsoft::GameInput INTERFACE)
+   set_target_properties(Microsoft::GameInput PROPERTIES
+      INTERFACE_LINK_LIBRARIES      "${_gameinput_root_lib}"
+      INTERFACE_INCLUDE_DIRECTORIES "${_gameinput_root}/include")
+
+   set(gameinput_FOUND TRUE)
+
+else()
+
+    set(gameinput_FOUND FALSE)
+
+endif()
+
+unset(_gameinput_root_lib)
+unset(_gameinput_root)

--- a/ports/gameinput/portfile.cmake
+++ b/ports/gameinput/portfile.cmake
@@ -1,24 +1,69 @@
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.nuget.org/api/v2/package/Microsoft.GameInput/${VERSION}"
-    FILENAME "gameinput.${VERSION}.zip"
-    SHA512 4ad0e8a2ff14e498632557c64cdcd967c6b166b405b2c60427578a5f8b32b925184a1c74bce95a7a73a129e61edddbec030c4abe4ada287a2ce9ae50178cdcea
-)
+if(VCPKG_TARGET_IS_XBOX)
 
-vcpkg_extract_source_archive(
-    PACKAGE_PATH
-    ARCHIVE ${ARCHIVE}
-    NO_REMOVE_ONE_LEVEL
-)
+    cmake_path(SET GRDKLatest "$ENV{GRDKLatest}")
+    cmake_path(SET GXDKLatest "$ENV{GXDKLatest}")
 
-file(INSTALL "${PACKAGE_PATH}/native/include/gameinput.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-file(INSTALL "${PACKAGE_PATH}/native/lib/${VCPKG_TARGET_ARCHITECTURE}/gameinput.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
-file(INSTALL "${PACKAGE_PATH}/native/lib/${VCPKG_TARGET_ARCHITECTURE}/gameinput.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+    find_file(GAMEINPUT_H
+      NAMES GameInput.h
+      PATHS "${GRDKLatest}/gameKit/Include"
+            "${GXDKLatest}/gameKit/Include"
+      NO_DEFAULT_PATH
+    )
 
-file(INSTALL "${PACKAGE_PATH}/redist/GameInputRedist.msi" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+    find_library(GAMEINPUT_LIB
+      NAMES GameInput.lib
+      PATHS "${GRDKLatest}/gameKit/Lib/amd64"
+            "${GXDKLatest}/gameKit/Lib/amd64"
+      NO_DEFAULT_PATH
+    )
+
+    if(NOT (GAMEINPUT_H AND GAMEINPUT_LIB))
+        message(FATAL_ERROR "Ensure you have installed the Microsoft GDK with Xbox Extensions installed. See https://aka.ms/gdkx.")
+    endif()
+
+    # Output user-friendly status message for installed edition.
+    if(${GXDKLatest} MATCHES ".*/([0-9][0-9])([0-9][0-9])([0-9][0-9])/.*")
+    set(_months "null" "January" "February" "March" "April" "May" "June" "July" "August" "September" "October" "November" "December")
+    list(GET _months ${CMAKE_MATCH_2} month)
+    set(update "")
+    if(${CMAKE_MATCH_3} GREATER 0)
+        set(update " Update ${CMAKE_MATCH_3}")
+    endif()
+    message(STATUS "Found the Microsoft GDK with Xbox Extensions (${month} 20${CMAKE_MATCH_1}${update})")
+    endif()
+
+    file(INSTALL ${GAMEINPUT_H} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(INSTALL ${GAMEINPUT_LIB} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(INSTALL ${GAMEINPUT_LIB} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+
+    set(VCPKG_POLICY_SKIP_COPYRIGHT_CHECK enabled)
+
+else()
+
+    vcpkg_download_distfile(ARCHIVE
+        URLS "https://www.nuget.org/api/v2/package/Microsoft.GameInput/${VERSION}"
+        FILENAME "gameinput.${VERSION}.zip"
+        SHA512 4ad0e8a2ff14e498632557c64cdcd967c6b166b405b2c60427578a5f8b32b925184a1c74bce95a7a73a129e61edddbec030c4abe4ada287a2ce9ae50178cdcea
+    )
+
+    vcpkg_extract_source_archive(
+        PACKAGE_PATH
+        ARCHIVE ${ARCHIVE}
+        NO_REMOVE_ONE_LEVEL
+    )
+
+    file(INSTALL "${PACKAGE_PATH}/native/include/gameinput.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(INSTALL "${PACKAGE_PATH}/native/lib/${VCPKG_TARGET_ARCHITECTURE}/gameinput.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(INSTALL "${PACKAGE_PATH}/native/lib/${VCPKG_TARGET_ARCHITECTURE}/gameinput.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+
+    file(INSTALL "${PACKAGE_PATH}/redist/GameInputRedist.msi" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+
+    vcpkg_install_copyright(FILE_LIST "${PACKAGE_PATH}/LICENSE.txt")
+
+endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/gameinput-config.cmake.in"
     "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake"
-    @ONLY)
+    COPYONLY)
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-vcpkg_install_copyright(FILE_LIST "${PACKAGE_PATH}/LICENSE.txt")

--- a/ports/gameinput/portfile.cmake
+++ b/ports/gameinput/portfile.cmake
@@ -14,8 +14,13 @@ vcpkg_extract_source_archive(
 
 file(INSTALL "${PACKAGE_PATH}/native/include/gameinput.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 file(INSTALL "${PACKAGE_PATH}/native/lib/${VCPKG_TARGET_ARCHITECTURE}/gameinput.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+file(INSTALL "${PACKAGE_PATH}/native/lib/${VCPKG_TARGET_ARCHITECTURE}/gameinput.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+
+file(INSTALL "${PACKAGE_PATH}/redist/GameInputRedist.msi" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/gameinput-config.cmake.in"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake"
+    @ONLY)
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${PACKAGE_PATH}/LICENSE.txt")
-
-configure_file("${CMAKE_CURRENT_LIST_DIR}/gameinput-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake" COPYONLY)

--- a/ports/gameinput/portfile.cmake
+++ b/ports/gameinput/portfile.cmake
@@ -1,0 +1,21 @@
+set(NUGET_VERSION 0.2303.22621.3038)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.GameInput/${NUGET_VERSION}"
+    FILENAME "gameinput.${NUGET_VERSION}.zip"
+    SHA512 4ad0e8a2ff14e498632557c64cdcd967c6b166b405b2c60427578a5f8b32b925184a1c74bce95a7a73a129e61edddbec030c4abe4ada287a2ce9ae50178cdcea
+)
+
+vcpkg_extract_source_archive(
+    PACKAGE_PATH
+    ARCHIVE ${ARCHIVE}
+    NO_REMOVE_ONE_LEVEL
+)
+
+file(INSTALL "${PACKAGE_PATH}/native/include/gameinput.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(INSTALL "${PACKAGE_PATH}/native/lib/${VCPKG_TARGET_ARCHITECTURE}/gameinput.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${PACKAGE_PATH}/LICENSE.txt")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/gameinput-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake" COPYONLY)

--- a/ports/gameinput/portfile.cmake
+++ b/ports/gameinput/portfile.cmake
@@ -1,8 +1,6 @@
-set(NUGET_VERSION 0.2303.22621.3038)
-
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.nuget.org/api/v2/package/Microsoft.GameInput/${NUGET_VERSION}"
-    FILENAME "gameinput.${NUGET_VERSION}.zip"
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.GameInput/${VERSION}"
+    FILENAME "gameinput.${VERSION}.zip"
     SHA512 4ad0e8a2ff14e498632557c64cdcd967c6b166b405b2c60427578a5f8b32b925184a1c74bce95a7a73a129e61edddbec030c4abe4ada287a2ce9ae50178cdcea
 )
 

--- a/ports/gameinput/usage
+++ b/ports/gameinput/usage
@@ -1,0 +1,4 @@
+The GameInput package provides CMake targets:
+
+    find_package(gameinput CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Microsoft::GameInput)

--- a/ports/gameinput/usage
+++ b/ports/gameinput/usage
@@ -3,4 +3,4 @@ The GameInput package provides CMake targets:
     find_package(gameinput CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Microsoft::GameInput)
 
-Note that the GameInputRedist.msi must be installed on the target system.
+Note that the GameInputRedist.msi must be installed on the target system for Windows.

--- a/ports/gameinput/usage
+++ b/ports/gameinput/usage
@@ -2,3 +2,5 @@ The GameInput package provides CMake targets:
 
     find_package(gameinput CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Microsoft::GameInput)
+
+Note that the GameInputRedist.msi must be installed on the target system.

--- a/ports/gameinput/vcpkg.json
+++ b/ports/gameinput/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "gameinput",
+  "version-date": "2024-04-29",
+  "description": "GameInput",
+  "homepage": "https://aka.ms/gameinput",
+  "license": null,
+  "supports": "windows & x64 & !uwp & !xbox"
+}

--- a/ports/gameinput/vcpkg.json
+++ b/ports/gameinput/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "gameinput",
-  "version-date": "2024-04-29",
+  "version": "0.2303.22621.3038",
   "description": "GameInput",
   "homepage": "https://aka.ms/gameinput",
   "license": null,
-  "supports": "windows & x64 & !uwp & !xbox"
+  "supports": "windows & x64 & !uwp"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2985,7 +2985,7 @@
       "port-version": 0
     },
     "gameinput": {
-      "baseline": "2024-04-29",
+      "baseline": "0.2303.22621.3038",
       "port-version": 0
     },
     "gamenetworkingsockets": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2984,6 +2984,10 @@
       "baseline": "1.2.0",
       "port-version": 0
     },
+    "gameinput": {
+      "baseline": "2024-04-29",
+      "port-version": 0
+    },
     "gamenetworkingsockets": {
       "baseline": "1.4.1",
       "port-version": 1

--- a/versions/g-/gameinput.json
+++ b/versions/g-/gameinput.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e7d6fa50789cf12d229031f6952ad8a87cf70770",
+      "version-date": "2024-04-29",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/g-/gameinput.json
+++ b/versions/g-/gameinput.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "e7d6fa50789cf12d229031f6952ad8a87cf70770",
-      "version-date": "2024-04-29",
+      "git-tree": "b71fb62174fb92b8fe4fa6a87311d202349bee72",
+      "version": "0.2303.22621.3038",
       "port-version": 0
     }
   ]


### PR DESCRIPTION
The GameInput API is available as a NuGet package. This adds a new port recipe to use it.

If using the *xbox* triplets, GameInput from an installed Microsoft GDKX is used instead of the NuGet package which is intended for PC.

> The next release of *directxtk* and *directxtk12* will consume this port.