### PR TITLE
[aurora-au] Add link to documentation website

### DIFF
--- a/ports/aurora-au/vcpkg.json
+++ b/ports/aurora-au/vcpkg.json
@@ -2,8 +2,10 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "aurora-au",
   "version-semver": "0.3.5",
+  "port-version": 1,
   "description": "A C++14-compatible physical units library with no dependencies and a single-file delivery option. Emphasis on safety, accessibility, performance, and developer experience.",
   "homepage": "https://github.com/aurora-opensource/au",
+  "documentation": "https://aurora-opensource.github.io/au/main/",
   "license": "Apache-2.0",
   "supports": "!osx",
   "dependencies": [

--- a/versions/a-/aurora-au.json
+++ b/versions/a-/aurora-au.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "843b8ff14fe6b933b9888e9badec1595bdcec3bf",
+      "version-semver": "0.3.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "dbea0dd2b0494c189b944e96b477192d37461bb9",
       "version-semver": "0.3.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -358,7 +358,7 @@
     },
     "aurora-au": {
       "baseline": "0.3.5",
-      "port-version": 0
+      "port-version": 1
     },
     "autobahn": {
       "baseline": "20.8.1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
