### PR TITLE
[libassuan] Update to 3.0.1

### DIFF
--- a/ports/libassuan/cross-tools.patch
+++ b/ports/libassuan/cross-tools.patch
@@ -1,5 +1,5 @@
 diff --git a/src/Makefile.am b/src/Makefile.am
-index 6b9a46d..5156865 100644
+index 61e1958..22bf8fe 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
 @@ -19,6 +19,13 @@
@@ -16,7 +16,23 @@ index 6b9a46d..5156865 100644
  pkgconfigdir = $(libdir)/pkgconfig
  pkgconfig_DATA = libassuan.pc
  
-@@ -152,6 +159,6 @@ mkheader: mkheader.c Makefile
+@@ -27,11 +34,11 @@ EXTRA_DIST = libassuan-config.in libassuan.m4 libassuan.vers \
+              libassuan.pc.in
+ AM_CPPFLAGS = -I..
+ 
+-if USE_GPGRT_CONFIG
+-noinst_SCRIPTS = libassuan-config
+-else
++# if USE_GPGRT_CONFIG
++# noinst_SCRIPTS = libassuan-config
++# else
+ bin_SCRIPTS = libassuan-config
+-endif
++# endif
+ m4datadir = $(datadir)/aclocal
+ m4data_DATA = libassuan.m4
+ lib_LTLIBRARIES = libassuan.la
+@@ -134,6 +141,6 @@ mkheader$(EXEEXT_FOR_BUILD): mkheader.c Makefile
  	$(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) \
            $(LDFLAGS_FOR_BUILD) -I. -I$(srcdir) -o $@ $(srcdir)/mkheader.c
  

--- a/ports/libassuan/portfile.cmake
+++ b/ports/libassuan/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/libassuan/libassuan-${VERSION}.tar.bz2"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libassuan/libassuan-${VERSION}.tar.bz2"
     FILENAME "libassuan-${VERSION}.tar.bz2"
-    SHA512 ca33bd0325bbebccb63b6a84cc0aa5c85b25c6275a68df83aeb3f3729b2cd38220198a941c3479bd461f16b7ddb6b558c0664697ca3153c7fb430544303d773f
+    SHA512 6914a02c20053bae0fc4c29c5c40655f1cec711983d57fa85e46df34e90b10e33d31256dd50ae7c7faa8d8d750a529bf9072da0cda3bdd77ebfedbc0e26e5e16
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH
@@ -52,4 +52,4 @@ if(NOT VCPKG_CROSSCOMPILING)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(INSTALL "${SOURCE_PATH}/COPYING.LIB" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.LIB")

--- a/ports/libassuan/vcpkg.json
+++ b/ports/libassuan/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libassuan",
-  "version": "2.5.7",
+  "version": "3.0.1",
   "description": "A library implementing the so-called Assuan protocol",
   "homepage": "https://gnupg.org/software/libassuan/index.html",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4293,7 +4293,7 @@
       "port-version": 0
     },
     "libassuan": {
-      "baseline": "2.5.7",
+      "baseline": "3.0.1",
       "port-version": 0
     },
     "libatomic-ops": {

--- a/versions/l-/libassuan.json
+++ b/versions/l-/libassuan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a1726114440f66f64b11c7e53db751f4683f323",
+      "version": "3.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9f619f927aa36d89e928f02b815690fe87164ff9",
       "version": "2.5.7",
       "port-version": 0


### PR DESCRIPTION
Update `libassuan` to 3.0.1, the following usage passed on `x64-linux`.
```
libassuan provides pkg-config modules:

  # IPC library for the GnuPG components
  libassuan
```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
