### PR TITLE
[live555] Update version to 2024.10.24

### DIFF
--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://live555.com/liveMedia/public/live.2024.09.29.tar.gz"
-    FILENAME "live.2024.09.29.tar.gz"
-    SHA512 af2d6585729b3254e0ffabd6f73d40806bffb71ddfa8e0a6ad103318fe0177fb1cfdd062e042e3be68a5e437619f5569fbe7272d02bd922f28d0ce2c33082712
+    URLS "http://live555.com/liveMedia/public/live.2024.10.24.tar.gz"
+    FILENAME "live.2024.10.24.tar.gz"
+    SHA512 59c36211317dd99d459f454a007a180ad33fdd568974c107caddcbb436f9b9c63fc05858d76bedb7f71b5f43e6850d484a973fd5f9d4acc68fb2b4d0e0de3835
 )
 
 vcpkg_extract_source_archive(

--- a/ports/live555/vcpkg.json
+++ b/ports/live555/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "live555",
-  "version-date": "2024-09-29",
+  "version-date": "2024-10-24",
   "description": "A complete RTSP server application",
   "homepage": "http://www.live555.com/liveMedia",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5521,7 +5521,7 @@
       "port-version": 0
     },
     "live555": {
-      "baseline": "2024-09-29",
+      "baseline": "2024-10-24",
       "port-version": 0
     },
     "llfio": {

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96a8593eb30850e7fa7aad8412e0206620ce3c3b",
+      "version-date": "2024-10-24",
+      "port-version": 0
+    },
+    {
       "git-tree": "0d484d25a359fcfc9d02375aad4ad97ece05bfcd",
       "version-date": "2024-09-29",
       "port-version": 0


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/41763

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
