### PR TITLE
[gpgmm] update port to 0.1.2 and fix warning

### DIFF
--- a/ports/gpgmm/portfile.cmake
+++ b/ports/gpgmm/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO intel/gpgmm
-  REF v0.0.4
-  SHA512 2ffc3c8299f2d10cb1c0013cd306ba45781a644fa0aa426ef1dfa616e4b53671461a376f65b7068b1ff8a4a2d1a6f9539664174eb5830ea6a760ef5e5d0fc6b0
+  REF "v${VERSION}"
+  SHA512 1e949e87110e555aa139e564a667a030150e77fd9b174f11bd3238b1fc3e7ae7ef17cc483b8afc9b0b7c346ce36564c94959454e27509c520bec18ef8396b5a1
   HEAD_REF main
 )
 
@@ -16,6 +16,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
@@ -24,7 +25,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
   file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-file(GLOB GPGMM_INCLUDE "${SOURCE_PATH}/src/include/*.h")
-file(COPY ${GPGMM_INCLUDE} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(GLOB_RECURSE GPGMM_INCLUDE "${SOURCE_PATH}/src/*.h")
+file(INSTALL ${GPGMM_INCLUDE} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/gpgmm/vcpkg.json
+++ b/ports/gpgmm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gpgmm",
-  "version": "0.0.4",
+  "version": "0.1.2",
   "description": "GPGMM is a General-Purpose GPU Memory Management library. It provides a common set of GPU memory routines optimized for GPUs. The library helps developers manage video memory by implementing the necessary functionality across components based on Vulkan or D3D12",
   "homepage": "https://github.com/intel/GPGMM/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3225,7 +3225,7 @@
       "port-version": 0
     },
     "gpgmm": {
-      "baseline": "0.0.4",
+      "baseline": "0.1.2",
       "port-version": 0
     },
     "gppanel": {

--- a/versions/g-/gpgmm.json
+++ b/versions/g-/gpgmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26588ebafae6c3d0ba1d0d8a76ea8d425ba33eaf",
+      "version": "0.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "588c2c48227d309001811deaab846ce36476c3c9",
       "version": "0.0.4",
       "port-version": 0


### PR DESCRIPTION
Update port gpgmm to the latest version 0.1.2
Fix warning:
````
-- Performing post-build validation
F:\test\vcpkg\ports\gpgmm\portfile.cmake: warning: The folder ${CURRENT_PACKAGES_DIR}/include is empty or not present. This usually means that headers are not correctly installed. If this is a CMake helper port, add set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled). If this is not a CMake helper port but this is otherwise intentional, add set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled) to suppress this message.
F:\test\vcpkg\ports\gpgmm\portfile.cmake: warning: This port installs the following CMake files in places CMake files are not expected. CMake files should be installed in ${CURRENT_PACKAGES_DIR}/share/${PORT}. To suppress this message, add set(VCPKG_POLICY_SKIP_MISPLACED_CMAKE_FILES_CHECK enabled)
F:\test\vcpkg\packages\gpgmm_x64-windows: note: the files are relative to ${CURRENT_PACKAGES_DIR} here
note: lib/cmake/gpgmm/gpgmmConfig.cmake
note: lib/cmake/gpgmm/gpgmmTargets-release.cmake
note: debug/lib/cmake/gpgmm/gpgmmConfig.cmake
note: debug/lib/cmake/gpgmm/gpgmmTargets-debug.cmake
note: debug/lib/cmake/gpgmm/gpgmmTargets.cmake
hould be merged and moved to ${CURRENT_PACKAGES_DIR}/share/${PORT}/cmake. Please use the helper function vcpkg_cmake_config_fixup() from the port vcpkg-cmake-config. To suppress this message, add set(VCPKG_POLICY_SKIP_LIB_CMAKE_MERGE_CHECK enabled)
F:\test\vcpkg\ports\gpgmm\portfile.cmake: warning: Found 3 post-build check problem(s). These are usually caused by bugs in portfile.cmake or the upstream build system. Please correct these before submitting this port to the curated registry.
Elapsed time to handle gpgmm:x64-windows: 33 s
````
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.