### PR TITLE
Enabled using bootstrap.sh from any msys2 bash env.

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -36,9 +36,8 @@ do
     fi
 done
 
-# Enable using this entry point on windows from git bash by redirecting to the .bat file.
-unixName=$(uname -s | sed 's/MINGW.*_NT.*/MINGW_NT/')
-if [ "$unixName" = "MINGW_NT" ]; then
+# Enable using this entry point on Windows from an msys2 bash env. (e.g., git bash) by redirecting to the .bat file.
+if [[ "$(uname -s)" =~ (MINGW|MSYS).*_NT ]]; then
     if [ "$vcpkgDisableMetrics" = "ON" ]; then
         args="-disableMetrics"
     else

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -37,7 +37,8 @@ do
 done
 
 # Enable using this entry point on Windows from an msys2 bash env. (e.g., git bash) by redirecting to the .bat file.
-if [[ "$(uname -s)" =~ (MINGW|MSYS).*_NT ]]; then
+unixKernelName=$(uname -s | sed -E 's/(CYGWIN|MINGW|MSYS).*_NT.*/\1_NT/')
+if [ "$unixKernelName" = CYGWIN_NT ] || [ "$unixKernelName" = MINGW_NT ] || [ "$unixKernelName" = MSYS_NT ]; then
     if [ "$vcpkgDisableMetrics" = "ON" ]; then
         args="-disableMetrics"
     else

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -36,7 +36,7 @@ do
     fi
 done
 
-# Enable using this entry point on Windows from an msys2 bash env. (e.g., git bash) by redirecting to the .bat file.
+# Enable using this entry point on Windows from an msys2 or cygwin bash env. (e.g., git bash) by redirecting to the .bat file.
 unixKernelName=$(uname -s | sed -E 's/(CYGWIN|MINGW|MSYS).*_NT.*/\1_NT/')
 if [ "$unixKernelName" = CYGWIN_NT ] || [ "$unixKernelName" = MINGW_NT ] || [ "$unixKernelName" = MSYS_NT ]; then
     if [ "$vcpkgDisableMetrics" = "ON" ]; then


### PR DESCRIPTION
When using the default/root msys2 environment MSYS, `uname -s` reports the OS kernel name as being "MSYS_NT".

Also checked other [msys2 environments](https://www.msys2.org/docs/environments/) by setting MSYSTEM env. var. to CLANG64, UCRT64 - in addition to MSYS and MINGW64:

* kernel name is MINGW64_NT when MSYSTEM=MINGW64
* kernel name is MINGW32_NT when MSYSTEM=MINGW32
* kernel name is MINGW64_NT when MSYSTEM=CLANG64
* kernel name is MINGW64_NT when MSYSTEM=UCRT64
* kernel name is MSYS_NT when MSYSTEM=MSYS
