### PR TITLE
[mygui] Install MyGUI PDBs

### DIFF
--- a/ports/mygui/portfile.cmake
+++ b/ports/mygui/portfile.cmake
@@ -52,6 +52,7 @@ file(REMOVE_RECURSE
 )
 
 vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
 
 if("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES FontEditor ImageEditor LayoutEditor SkinEditor AUTO_CLEAN)

--- a/ports/mygui/vcpkg.json
+++ b/ports/mygui/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mygui",
   "version": "3.4.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Fast, flexible and simple GUI",
   "homepage": "http://mygui.info",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6174,7 +6174,7 @@
     },
     "mygui": {
       "baseline": "3.4.3",
-      "port-version": 1
+      "port-version": 2
     },
     "mysql-connector-cpp": {
       "baseline": "8.0.32",

--- a/versions/m-/mygui.json
+++ b/versions/m-/mygui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cf997f9ba8195d60cc5acbaf3d754f0ca4ba6b7b",
+      "version": "3.4.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "30a391b5c1365596bafe3acb6739c67ce18c6632",
       "version": "3.4.3",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

MyGUI does have a CMake option to install PDBs, but it's set up with `cmake_dependent_option`, and looks like it would break if we set it on the command line when the other options it depended on weren't set. As that could end up desynced if the logic was copied here, it seemed more prudent to use `vcpkg_copy_pdbs`.