### PR TITLE
[gmp] Use msys autoconf2.71

### DIFF
--- a/ports/gmp/portfile.cmake
+++ b/ports/gmp/portfile.cmake
@@ -79,9 +79,17 @@ if(VCPKG_CROSSCOMPILING)
     set(ENV{HOST_TOOLS_PREFIX} "${CURRENT_HOST_INSTALLED_DIR}/manual-tools/${PORT}")
 endif()
 
+if(VCPKG_HOST_IS_WINDOWS)
+    # dumpbin detection fails with autoconf 2.72
+    set(ENV{WANT_AUTOCONF} 2.71)
+endif()
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
+    ADDITIONAL_MSYS_PACKAGES
+        DIRECT_PACKAGES
+            "https://mirror.msys2.org/msys/x86_64/autoconf2.71-2.71-3-any.pkg.tar.zst"
+            dd312c428b2e19afd00899eb53ea4255794dea4c19d1d6dea2419cb6a54209ea2130d48abbc20af12196b9f628143436f736fbf889809c2c2291be0c69c0e306
     OPTIONS
         ${OPTIONS}
         --enable-cxx

--- a/ports/gmp/vcpkg.json
+++ b/ports/gmp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gmp",
   "version": "6.3.0",
+  "port-version": 1,
   "description": "The GNU Multiple Precision Arithmetic Library",
   "homepage": "https://gmplib.org",
   "license": "LGPL-3.0-only OR GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3182,7 +3182,7 @@
     },
     "gmp": {
       "baseline": "6.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "gmsh": {
       "baseline": "4.12.2",

--- a/versions/g-/gmp.json
+++ b/versions/g-/gmp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0634ea068717e4b97b9a9d767d70179b909657b6",
+      "version": "6.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c28d96e8dd3ed941ba550f1e9d9f7bf1f2a83ac8",
       "version": "6.3.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #41804.
Decoupled from regular msys2 updates, and without world rebuild.