### PR TITLE
[openblas] add default feature without-lapack and features to specify data types

### DIFF
--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -4,6 +4,12 @@ vcpkg_download_distfile(ARM64_WINDOWS_UWP_PATCH
     SHA512 808d375628499641f1134b4751c9861384b719dae14cf6bd4d9d4b09c9bfd9f8b13b2663e9fa9d09867b5b40817c26387ac659d2f6459d40a46455b2f540d018
 )
 
+vcpkg_download_distfile(LAPACK_C_SIGNATURES_PATCH
+    URLS "https://patch-diff.githubusercontent.com/raw/OpenMathLib/OpenBLAS/pull/4953.diff?full_index=1"
+    FILENAME "openblas-fix-lapack-c-ignatures.patch"
+    SHA512 542b4fdda88d861fc5bdfadadf96541f245179cb5faa9f80f045257c809718382b099258c5e93fdbb41b870f1253821589899889595219d8f8f393de1bb7d970
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenMathLib/OpenBLAS
@@ -16,6 +22,7 @@ vcpkg_from_github(
         install-tools.patch
         gcc14.patch
         ${ARM64_WINDOWS_UWP_PATCH}
+        ${LAPACK_C_SIGNATURES_PATCH}
 )
 
 find_program(GIT NAMES git git.cmd)
@@ -33,12 +40,15 @@ vcpkg_add_to_path("${SED_EXE_PATH}")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        threads        USE_THREAD
-        simplethread   USE_SIMPLE_THREADED_LEVEL3
-        "dynamic-arch" DYNAMIC_ARCH
+        threads           USE_THREAD
+        simplethread      USE_SIMPLE_THREADED_LEVEL3
+        "dynamic-arch"    DYNAMIC_ARCH
+        "without-lapack"  BUILD_WITHOUT_LAPACK
+        "build-single"    BUILD_SINGLE
+        "build-double"    BUILD_DOUBLE
+        "build-complex"   BUILD_COMPLEX
+        "build-complex16" BUILD_COMPLEX16
 )
-
-set(COMMON_OPTIONS -DBUILD_WITHOUT_LAPACK=ON)
 
 if(VCPKG_TARGET_IS_OSX)
     list(APPEND COMMON_OPTIONS -DONLY_CBLAS=1)

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openblas",
   "version": "0.3.28",
+  "port-version": 1,
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/OpenMathLib/OpenBLAS",
   "license": "BSD-3-Clause",
@@ -23,7 +24,22 @@
       "host": true
     }
   ],
+  "default-features": [
+    "without-lapack"
+  ],
   "features": {
+    "build-complex": {
+      "description": "Build single precision complex"
+    },
+    "build-complex16": {
+      "description": "Build double precision complex"
+    },
+    "build-double": {
+      "description": "Build double precision real"
+    },
+    "build-single": {
+      "description": "Build single precision real"
+    },
     "dynamic-arch": {
       "description": "Support for multiple targets in a single library",
       "supports": "!windows | mingw"
@@ -47,6 +63,9 @@
           "platform": "!windows & !uwp"
         }
       ]
+    },
+    "without-lapack": {
+      "description": "Do not build LAPACK and LAPACKE"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6590,7 +6590,7 @@
     },
     "openblas": {
       "baseline": "0.3.28",
-      "port-version": 0
+      "port-version": 1
     },
     "opencascade": {
       "baseline": "7.8.1",

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efecbf573a4ea5db6d60cfdee50bf922a60a57a4",
+      "version": "0.3.28",
+      "port-version": 1
+    },
+    {
       "git-tree": "0ea117557042e4d6a0ee7659828c44938e322ee3",
       "version": "0.3.28",
       "port-version": 0


### PR DESCRIPTION
If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

This PR adds new features to the OpenBLAS port:
* **build-single/double/complex/complex16**: By default OpenBLAS is being built for both real and complex numbers with both single and double precision. This results in longer port build times and larger binary sizes then needed if only one configuration is needed e.g. real with double precision.
Setting one or more of these new features will result in only building those configuration(s).

* **without-lapack**: OpenBLAS comes with the possibility to also build a LAPACK library which can be achieved when disabeling the corresponding CMake option which is represented by this new default feature.
OpenBLAS's LAPACK comes with manually maintained *C* sources for LAPACK generated by *f2c* from the original Fortran sources. This makes it possible to get LAPACK also on platforms that do not support Fortran e.i. **emscripten**.
So to my knowledge with this new feature it would be the only VCPKG port which supports LAPACK on emscripten (even the clapack somehow requires Fortran).