### PR TITLE
Bot: Normalize line endings

### DIFF
--- a/.github/workflows/check_issues.yml
+++ b/.github/workflows/check_issues.yml
@@ -20,6 +20,7 @@ jobs:
               repo: context.repo.repo
             };
             let issue = await github.rest.issues.get(issue_query)
+            let issue_body = issue.data.body.replaceAll("\r\n", "\n");
             let commentLabelClose = async (comment, label) => {
               await github.rest.issues.removeAllLabels(issue_query);
               await github.rest.issues.setLabels({...issue_query, labels: [label]});
@@ -29,7 +30,7 @@ jobs:
 
             // missing-windows-sdk-issue
             let reg = /RC Pass 1: command "rc .*" failed \(exit code 0\) with the following output:/;
-            if (reg.test(issue.data.body)){
+            if (reg.test(issue_body)){
               let body = "Thanks for posting this issue. Please make sure you have the following installed.\n" +
                          "- Visual Studio Desktop development with C++.\n" +
                          "- Windows 10 SDK or Windows 11 SDK.";
@@ -38,41 +39,41 @@ jobs:
 
             // msys2 download fails => old vcpkg version
             reg = /error: https:\/\/repo\.msys2\.org\/.*: failed: status code 404/;
-            if (reg.test(issue.data.body)){
+            if (reg.test(issue_body)){
               let body = "Try updating your vcpkg version via `git pull` to resolve this issue. MSYS2 downloads are removed from the upstream servers from time to time, so using an up-to-date vcpkg version is necessary."
               return await commentLabelClose(body, "category:question");
             }
 
             // Issue text is: Copy issue body from .../issue_body.md
             reg = /^Copy issue body from .*issue_body.md$/;
-            if (reg.test(issue.data.body)){
+            if (reg.test(issue_body)){
               let body = "Please see #30604 for how to report a build failure."
               return await commentLabelClose(body, "requires:more-information");
             }
 
             // Issue to short like #36592 or #36668
-            reg = /^error: building.* BUILD_FAILED\r\nElapsed time.*\r\nPlease ensure.*(\r\nThen check .*\r\n.*)?$/;
-            if (reg.test(issue.data.body)){
+            reg = /^error: building.* BUILD_FAILED\nElapsed time.*\nPlease ensure.*(\nThen check .*\n.*)?$/;
+            if (reg.test(issue_body)){
               let body = "Please see #30604 for how to report a build failure."
               return await commentLabelClose(body, "requires:more-information");
             }
 
             // pkg-config/ not found issues like #36011
-            reg = /CMake Error at scripts\/cmake\/vcpkg_find_acquire_program.*\r\n(.*Please install it via your package manager:[\s\S]+)Call Stack/;
-            match = issue.data.body.match(reg)
+            reg = /CMake Error at scripts\/cmake\/vcpkg_find_acquire_program.*\n(.*Please install it via your package manager:[\s\S]+)Call Stack/;
+            match = issue_body.match(reg)
             if (match){
               let body = "From the log:\n```\n" + match[1] + "```\n"
               return await commentLabelClose(body, "category:question");
             }
 
             // MSVC internal compiler error like #36628
-            if (issue.data.body.indexOf("fatal error C1001: Internal compiler error") !== -1){
+            if (issue_body.indexOf("fatal error C1001: Internal compiler error") !== -1){
               let body = "The build failed due to an internal compiler error. Please update your compiler or revert to an old version."
               return await commentLabelClose(body, "category:question");
             }
 
             // configure: error: 'autoconf-archive' is missing like #37013
-            if (issue.data.body.indexOf("configure: error: 'autoconf-archive' is missing") !== -1){
+            if (issue_body.indexOf("configure: error: 'autoconf-archive' is missing") !== -1){
               let body = "Please install `autoconf-archive` via `brew install autoconf-archive` (macos) or `sudo apt-get install autoconf-archive` (linux)"
               return await commentLabelClose(body, "category:question");
             }


### PR DESCRIPTION
I wondered why https://github.com/microsoft/vcpkg/issues/41821 was not closed by the bot. [It seems](https://github.com/autoantwort/vcpkg/actions/runs/11552227056/job/32150870531#step:2:78) that the issue body contains `\r\n` when created via the ui and only `\n` when created via the cli. So lets first normalize to `\n` and remove `\r` from the regex expressions. 