### PR TITLE
[mygui] Support dynamic linking for MyGUI

### DIFF
--- a/ports/mygui/platform-lib-static.patch
+++ b/ports/mygui/platform-lib-static.patch
@@ -1,0 +1,91 @@
+diff --git a/Platforms/DirectX/DirectXPlatform/CMakeLists.txt b/Platforms/DirectX/DirectXPlatform/CMakeLists.txt
+index 169a2afe4..2ea45af2b 100644
+--- a/Platforms/DirectX/DirectXPlatform/CMakeLists.txt
++++ b/Platforms/DirectX/DirectXPlatform/CMakeLists.txt
+@@ -9,7 +9,7 @@ include_directories(
+ 
+ include(${PROJECTNAME}.list)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt b/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt
+index 251fcdbe3..16d4f33a5 100644
+--- a/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt
++++ b/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt
+@@ -9,7 +9,7 @@ include_directories(
+ 
+ include(${PROJECTNAME}.list)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/Dummy/DummyPlatform/CMakeLists.txt b/Platforms/Dummy/DummyPlatform/CMakeLists.txt
+index 1055694f2..625391132 100644
+--- a/Platforms/Dummy/DummyPlatform/CMakeLists.txt
++++ b/Platforms/Dummy/DummyPlatform/CMakeLists.txt
+@@ -8,7 +8,7 @@ include_directories(
+ 
+ include(${PROJECTNAME}.list)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/Ogre/OgrePlatform/CMakeLists.txt b/Platforms/Ogre/OgrePlatform/CMakeLists.txt
+index a151abcf8..23f8a2373 100644
+--- a/Platforms/Ogre/OgrePlatform/CMakeLists.txt
++++ b/Platforms/Ogre/OgrePlatform/CMakeLists.txt
+@@ -8,7 +8,7 @@ include_directories(
+ 
+ include(${PROJECTNAME}.list)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt b/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
+index 0d58d3d71..78eaf0267 100644
+--- a/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
++++ b/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
+@@ -19,7 +19,7 @@ if (NOT MYGUI_USE_SYSTEM_GLEW)
+ endif ()
+ add_definitions(-DGL_GLEXT_PROTOTYPES)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt b/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt
+index 27d96da3e..4dcee1601 100644
+--- a/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt
++++ b/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt
+@@ -19,7 +19,7 @@ if (NOT MYGUI_USE_SYSTEM_GLEW)
+ endif ()
+ add_definitions(-DGL_GLEXT_PROTOTYPES)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt b/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt
+index bd6d9657b..ad31fc158 100644
+--- a/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt
++++ b/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt
+@@ -9,7 +9,7 @@ include_directories(
+ 
+ include(${PROJECTNAME}.list)
+ add_definitions(-DGL_GLEXT_PROTOTYPES)
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 

--- a/ports/mygui/platform-lib-static.patch
+++ b/ports/mygui/platform-lib-static.patch
@@ -89,3 +89,31 @@ index bd6d9657b..ad31fc158 100644
  
  add_dependencies(${PROJECTNAME} MyGUIEngine)
  
+From 32e39f8de4b750ed5d2332ee18846f23b7e98df5 Mon Sep 17 00:00:00 2001
+From: AnyOldName3 <krizdjali@gmail.com>
+Date: Tue, 29 Oct 2024 14:53:52 +0000
+Subject: [PATCH] Explicitly mark another library as static
+
+I've also figured out why this problem wasn't obvious.
+It only happens when someone's used the CMake-standard BUILD_SHARED_LIBS option, which controls the default behaviour for add_library.
+When MyGUI is built as a standalone project, this won't be set (unless someone's done it manually) so it's fine.
+When MyGUI is built as part of a larger project (e.g. package manager like vcpkg or CPM, or as a nested project with FetchContent), it's likely to have been set by something else.
+
+It might be a good idea to pick the default value of MYGUI_STATIC to match BUILD_SHARED_LIBS if it's set, but I've not done that in this PR.
+---
+ Common/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Common/CMakeLists.txt b/Common/CMakeLists.txt
+index e97507019..87a16290f 100644
+--- a/Common/CMakeLists.txt
++++ b/Common/CMakeLists.txt
+@@ -99,7 +99,7 @@ SOURCE_GROUP("Base" FILES
+ 	Input/SDL/ResourceSDLPointer.cpp
+ )
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ mygui_set_platform_name(${MYGUI_RENDERSYSTEM})
+ add_dependencies(${PROJECTNAME} MyGUI.${MYGUI_PLATFORM_NAME}Platform)

--- a/ports/mygui/portfile.cmake
+++ b/ports/mygui/portfile.cmake
@@ -1,7 +1,3 @@
-# MyGUI supports compiling itself as a DLL,
-# but it seems platform-related stuff doesn't support dynamic linkage
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MyGUI/mygui
@@ -14,6 +10,7 @@ vcpkg_from_github(
         opengl.patch
         sdl2-static.patch
         fix-tools-lnk2005.patch
+        platform-lib-static.patch
 )
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "wasm32")
@@ -30,10 +27,12 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         tools MYGUI_BUILD_TOOLS
 )
 
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" MYGUI_STATIC)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DMYGUI_STATIC=TRUE
+        -DMYGUI_STATIC=${MYGUI_STATIC}
         -DMYGUI_BUILD_DEMOS=FALSE
         -DMYGUI_BUILD_PLUGINS=TRUE
         -DMYGUI_BUILD_UNITTESTS=FALSE

--- a/ports/mygui/portfile.cmake
+++ b/ports/mygui/portfile.cmake
@@ -51,6 +51,7 @@ file(REMOVE_RECURSE
 )
 
 vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
 
 if("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES FontEditor ImageEditor LayoutEditor SkinEditor AUTO_CLEAN)

--- a/ports/mygui/vcpkg.json
+++ b/ports/mygui/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mygui",
   "version": "3.4.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Fast, flexible and simple GUI",
   "homepage": "http://mygui.info",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6174,7 +6174,7 @@
     },
     "mygui": {
       "baseline": "3.4.3",
-      "port-version": 1
+      "port-version": 2
     },
     "mysql-connector-cpp": {
       "baseline": "8.0.32",

--- a/versions/m-/mygui.json
+++ b/versions/m-/mygui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d523dab2ea87eebd9e08c623add8a6ac9e3f76a0",
+      "git-tree": "7efdf991088c6e26ca97c11bb8ef00c94d690a9b",
       "version": "3.4.3",
       "port-version": 2
     },

--- a/versions/m-/mygui.json
+++ b/versions/m-/mygui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d523dab2ea87eebd9e08c623add8a6ac9e3f76a0",
+      "version": "3.4.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "30a391b5c1365596bafe3acb6739c67ce18c6632",
       "version": "3.4.3",
       "port-version": 1


### PR DESCRIPTION
The new patch was accepted upstream as https://github.com/MyGUI/mygui/pull/270, but as other lines have changed in one of the affected files, we need a bespoke patch to work with the 3.4.3 release.

Intended to supersede https://github.com/microsoft/vcpkg/pull/41800 as that PR isn't useful without the other changes this one makes.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.