### PR TITLE
[sentry-native] update to 0.7.11

### DIFF
--- a/ports/sentry-native/fix-crashpad-wer.patch
+++ b/ports/sentry-native/fix-crashpad-wer.patch
@@ -57,7 +57,7 @@ diff --git a/src/backends/sentry_backend_crashpad.cpp b/src/backends/sentry_back
 index 711dc57..4c1d473 100644
 --- a/src/backends/sentry_backend_crashpad.cpp
 +++ b/src/backends/sentry_backend_crashpad.cpp
-@@ -115,7 +115,7 @@ crashpad_backend_user_consent_changed(sentry_backend_t *backend)
+@@ -120,7 +120,7 @@ crashpad_backend_user_consent_changed(sentry_backend_t *backend)
      data->db->GetSettings()->SetUploadsEnabled(!sentry__should_skip_upload());
  }
 
@@ -66,9 +66,9 @@ index 711dc57..4c1d473 100644
  static void
  crashpad_register_wer_module(
      const sentry_path_t *absolute_handler_path, const crashpad_state_t *data)
-@@ -413,7 +413,7 @@ crashpad_backend_startup(
-         return 1;
-     }
+@@ -445,7 +445,7 @@ crashpad_backend_startup(
+         /* asynchronous_start */ false, attachments);
+     sentry_free(minidump_url);
 
 -#ifdef SENTRY_PLATFORM_WINDOWS
 +#if defined(SENTRY_PLATFORM_WINDOWS) && defined(SENTRY_TRANSPORT_CRASHPAD_USE_WER)

--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 f6fffb751bf64ae87c011d2f4046573a82e21f4163c157f65b54920cd5ba8cc7dc80a3ad03442bf6fcdc3a0e0098a05da6b27daadaedfaede85d6a914e8393f0
+    SHA512 eaa340a394ad833f37fc1db7ca226fc1eabe3a6a9628bef312edc105b3bfbdf9721e604d50d01fcbc30305fa9e384b9019de220e0b0f44e95f470358eb4e481d
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8221,7 +8221,7 @@
       "port-version": 0
     },
     "sentry-native": {
-      "baseline": "0.7.10",
+      "baseline": "0.7.11",
       "port-version": 0
     },
     "septag-dmon": {

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e752d47aea944c69d1c824a521a3d621d1ceaf1f",
+      "version": "0.7.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "7b6158b530cb70b945421376336bee4d386f6868",
       "version": "0.7.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
