### PR TITLE
[libepoxy] build static library while linking to CRT dynamically

### DIFF
--- a/ports/libepoxy/portfile.cmake
+++ b/ports/libepoxy/portfile.cmake
@@ -1,5 +1,5 @@
 if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+    vcpkg_check_linkage(ONLY_DYNAMIC_CRT)
 endif()
 
 if (VCPKG_TARGET_IS_LINUX)

--- a/ports/libepoxy/vcpkg.json
+++ b/ports/libepoxy/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libepoxy",
   "version": "1.5.10",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Epoxy is a library for handling OpenGL function pointer management for you",
   "homepage": "https://github.com/anholt/libepoxy",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4478,7 +4478,7 @@
     },
     "libepoxy": {
       "baseline": "1.5.10",
-      "port-version": 2
+      "port-version": 3
     },
     "liberasurecode": {
       "baseline": "1.6.4",

--- a/versions/l-/libepoxy.json
+++ b/versions/l-/libepoxy.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "858f3ccbc10b37db743623024cbac0e488f64c29",
+      "git-tree": "78488441bd28dcd6c1712e1b8add79bb8d3fb4c7",
       "version": "1.5.10",
       "port-version": 3
     },

--- a/versions/l-/libepoxy.json
+++ b/versions/l-/libepoxy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "858f3ccbc10b37db743623024cbac0e488f64c29",
+      "version": "1.5.10",
+      "port-version": 3
+    },
+    {
       "git-tree": "df7389605ff392a312b77b633ca658167c14221a",
       "version": "1.5.10",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
