### PR TITLE
[joltphysics] Add debug build compile definitions features

### DIFF
--- a/ports/joltphysics/portfile.cmake
+++ b/ports/joltphysics/portfile.cmake
@@ -10,6 +10,12 @@ vcpkg_from_github(
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" USE_STATIC_CRT)
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        debugrenderer       DEBUG_RENDERER_IN_DEBUG_AND_RELEASE
+        profiler            PROFILER_IN_DEBUG_AND_RELEASE
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/Build"
     OPTIONS
@@ -23,8 +29,7 @@ vcpkg_cmake_configure(
         -DUSE_STATIC_MSVC_RUNTIME_LIBRARY=${USE_STATIC_CRT}
         -DENABLE_ALL_WARNINGS=OFF
         -DOVERRIDE_CXX_FLAGS=OFF
-        -DDEBUG_RENDERER_IN_DEBUG_AND_RELEASE=OFF
-        -DPROFILER_IN_DEBUG_AND_RELEASE=OFF
+        ${FEATURE_OPTIONS}
     OPTIONS_RELEASE
         -DGENERATE_DEBUG_SYMBOLS=OFF
 )

--- a/ports/joltphysics/vcpkg.json
+++ b/ports/joltphysics/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "joltphysics",
   "version": "5.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A multi core friendly rigid body physics and collision detection library suitable for games and VR applications",
   "homepage": "https://github.com/jrouwe/JoltPhysics",
   "license": "MIT",
@@ -14,5 +14,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "debugrenderer": {
+      "description": "Enable debug renderer in Debug and Release builds"
+    },
+    "profiler": {
+      "description": "Enable the profiler in Debug and Release builds"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3838,7 +3838,7 @@
     },
     "joltphysics": {
       "baseline": "5.1.0",
-      "port-version": 1
+      "port-version": 2
     },
     "josuttis-jthread": {
       "baseline": "2020-07-21",
@@ -4186,7 +4186,7 @@
     },
     "launch-darkly-server": {
       "baseline": "2.9.3",
-      "port-version": 0 
+      "port-version": 0
     },
     "lazy-importer": {
       "baseline": "2023-08-03",

--- a/versions/j-/joltphysics.json
+++ b/versions/j-/joltphysics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77fc93156891bade6362a38c0cc5619fce1b6b2b",
+      "version": "5.1.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "be4e60601ee3a8e15476ee5f583a1102e0d53f51",
       "version": "5.1.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #39999, add new features to control `DEBUG_RENDERER_IN_DEBUG_AND_RELEASE` and `PROFILER_IN_DEBUG_AND_RELEASE`.

All features passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```
Usage test passed on `x64-windows`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.