### PR TITLE
[libleidenalg] update version to 0.11.1

### DIFF
--- a/ports/libleidenalg/portfile.cmake
+++ b/ports/libleidenalg/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vtraag/libleidenalg
     REF "${VERSION}"
-    SHA512 a3077592b68cb6fd9bc24127898a64576982b608ff3c123e8b1c7ea1b8da2dfb302123fba64cbf93c16b9310ab42199ddc8de5efa5b6606dd49ee47f074f7f2f
+    SHA512 254b5454086683af3655c7e0e18cca8c24ceb899e0614940ab84a50fb2eea57d1b6409eb19a92976758b4d3066c86b643512356eb38d33311c80ff701381c433
     HEAD_REF main
 )
 
@@ -10,7 +10,7 @@ vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/libleidenalg/vcpkg.json
+++ b/ports/libleidenalg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libleidenalg",
-  "version": "0.10.0",
-  "port-version": 1,
+  "version": "0.11.1",
   "maintainers": "Andrew Robbins <andrew@robbinsa.me>",
   "description": "Leiden is a general algorithm for methods of community detection in large networks.",
   "homepage": "https://github.com/vtraag/libleidenalg",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4713,8 +4713,8 @@
       "port-version": 2
     },
     "libleidenalg": {
-      "baseline": "0.10.0",
-      "port-version": 1
+      "baseline": "0.11.1",
+      "port-version": 0
     },
     "liblemon": {
       "baseline": "2019-06-13",

--- a/versions/l-/libleidenalg.json
+++ b/versions/l-/libleidenalg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "823c09a7bf91a6c9da357016c0d4a919b519d625",
+      "version": "0.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "54e658de6b5148a82e4f7ef8e56e5d56db8deedb",
       "version": "0.10.0",
       "port-version": 1


### PR DESCRIPTION
Update `libleidenalg` version to `0.11.1`.

No feature need to test.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
