### PR TITLE
[pipewire] Update to 1.2.6

### DIFF
--- a/ports/pipewire/portfile.cmake
+++ b/ports/pipewire/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pipewire/pipewire
     REF "${VERSION}"
-    SHA512 5ebd27ac0fe599ebdce9f08af0926a949df01c67997b8ddfaa86975eff96f7a37e19b6ed4a62e22d1fba48893d5cd2e0e2572e8d97d016536623ec7bfe6078aa
+    SHA512 8f444695a3ec4c03fa1a9735d0c08031631b565ff8fbee0edcbbbdf87330da632eb87ba92a9071cbfa2d9ed96705002e63ae7c48277fc45a0a3b793fff39819a
     HEAD_REF master # branch name
 )
 

--- a/ports/pipewire/vcpkg.json
+++ b/ports/pipewire/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pipewire",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Low-latency audio/video router and processor. This port only builds the client library, not the server.",
   "homepage": "https://pipewire.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4186,7 +4186,7 @@
     },
     "launch-darkly-server": {
       "baseline": "2.9.3",
-      "port-version": 0 
+      "port-version": 0
     },
     "lazy-importer": {
       "baseline": "2023-08-03",
@@ -6977,7 +6977,7 @@
       "port-version": 2
     },
     "pipewire": {
-      "baseline": "1.2.5",
+      "baseline": "1.2.6",
       "port-version": 0
     },
     "pistache": {

--- a/versions/p-/pipewire.json
+++ b/versions/p-/pipewire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9cd946c560c5fb45927e429d3e879aab1868335f",
+      "version": "1.2.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "76b5ab518b516d973957b81e57aecd436ff31e08",
       "version": "1.2.5",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

