### PR TITLE
[vcpkg-tool-meson] fix #41869

### DIFF
--- a/ports/vcpkg-tool-meson/vcpkg.json
+++ b/ports/vcpkg-tool-meson/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vcpkg-tool-meson",
   "version": "1.6.0",
+  "port-version": 1,
   "description": "Meson build system",
   "homepage": "https://github.com/mesonbuild/meson",
   "license": "Apache-2.0",

--- a/ports/vcpkg-tool-meson/vcpkg_install_meson.cmake
+++ b/ports/vcpkg-tool-meson/vcpkg_install_meson.cmake
@@ -1,5 +1,10 @@
 function(vcpkg_install_meson)
-    cmake_parse_arguments(PARSE_ARGV 0 arg "ADD_BIN_TO_PATH" "" "")
+    # EXPORTED_PYTHON_HOME is the name of variable which hold the PYTHONHOME configured by vcpkg_configu_meson.
+    # if not set, default to "VCPKG_PYTHON3_DIR", if set as empty string, means not set PYTHONHOME env variable.
+    cmake_parse_arguments(PARSE_ARGV 0 arg "ADD_BIN_TO_PATH" "EXPORTED_PYTHON_HOME" "")
+    if(NOT DEFINED arg_EXPORTED_PYTHON_HOME)
+        set(arg_EXPORTED_PYTHON_HOME "VCPKG_PYTHON3_DIR")
+    endif()
 
     vcpkg_find_acquire_program(NINJA)
     unset(ENV{DESTDIR}) # installation directory was already specified with '--prefix' option
@@ -29,6 +34,10 @@ function(vcpkg_install_meson)
             else()
                 vcpkg_add_to_path(PREPEND "${CURRENT_INSTALLED_DIR}/bin")
             endif()
+        endif()
+        if(NOT arg_EXPORTED_PYTHON_HOME STREQUAL "" AND DEFINED ${arg_EXPORTED_PYTHON_HOME})
+            # arg_EXPORTED_PYTHON_HOME is defined by vcpkg_configure_meson to hold the python home.
+            set(ENV{PYTHONHOME} "${${arg_EXPORTED_PYTHON_HOME}}")
         endif()
         vcpkg_execute_required_process(
             COMMAND "${NINJA}" install -v

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4186,7 +4186,7 @@
     },
     "launch-darkly-server": {
       "baseline": "2.9.3",
-      "port-version": 0 
+      "port-version": 0
     },
     "lazy-importer": {
       "baseline": "2023-08-03",
@@ -9354,7 +9354,7 @@
     },
     "vcpkg-tool-meson": {
       "baseline": "1.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vcpkg-tool-mozbuild": {
       "baseline": "4.0.2",

--- a/versions/v-/vcpkg-tool-meson.json
+++ b/versions/v-/vcpkg-tool-meson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b58085cbbd55d3914a8518f23be1596ae7155936",
+      "version": "1.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ba86563d438bbe6692c2b13df4235755ba135cbc",
       "version": "1.6.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

Only fixes ports built with meson, not other ports that use python directly. adding a python._pyd file will also fix this issue. However, python._pyd will completely overwrite sys.path and ignore all relevant environment variables, which may cause new bugs
