### PR TITLE
[ezc3d] Update to 1.5.11

### DIFF
--- a/ports/ezc3d/portfile.cmake
+++ b/ports/ezc3d/portfile.cmake
@@ -2,15 +2,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pyomeca/ezc3d
     REF "Release_${VERSION}"
-    SHA512 8e3a03c2d588ac1f8ed3d0988b90f7560f2c0b36c05f5bf9b6f029a5f4c6e4ab49d7153ef7a9bbbdb018c719a92d1da08a6af259ba95972bf8fd60766d4a480e
+    SHA512 343b4c6a03ff6cdf01e4443929a05eb15c14ed50d77f3a4e7783ace118f628e16873c8cd41ac58ecc2f29bf1ee6dd58851d45e5d64e2afc0d283c8c0a4eca576
     HEAD_REF dev
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-Dezc3d_BIN_FOLDER=bin"
-        "-Dezc3d_LIB_FOLDER=lib"
         -DBUILD_EXAMPLE=OFF
 )
 vcpkg_cmake_install()
@@ -20,4 +18,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/ezc3d")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ezc3d/vcpkg.json
+++ b/ports/ezc3d/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ezc3d",
-  "version": "1.5.7",
+  "version": "1.5.11",
   "description": "C3D reader/writer",
   "homepage": "https://github.com/pyomeca/ezc3d",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2625,7 +2625,7 @@
       "port-version": 2
     },
     "ezc3d": {
-      "baseline": "1.5.7",
+      "baseline": "1.5.11",
       "port-version": 0
     },
     "ezfoundation": {
@@ -4186,7 +4186,7 @@
     },
     "launch-darkly-server": {
       "baseline": "2.9.3",
-      "port-version": 0 
+      "port-version": 0
     },
     "lazy-importer": {
       "baseline": "2023-08-03",

--- a/versions/e-/ezc3d.json
+++ b/versions/e-/ezc3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2ee306dd52280b69694135241fa41b4b491eb32",
+      "version": "1.5.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "1331eec1377ca1e720afdd9c3cf2660c49b58084",
       "version": "1.5.7",
       "port-version": 0


### PR DESCRIPTION
Update `ezc3d` to 1.5.11. No feature needs to be tested, the usage test passed on `x64-windows` (header files found).

Remove outdated options `ezc3d_BIN_FOLDER` and `ezc3d_LIB_FOLDER`. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.