### PR TITLE
[gtk] Update to 4.16.3

### DIFF
--- a/ports/gtk/portfile.cmake
+++ b/ports/gtk/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/gtk
     REF ${VERSION}
-    SHA512 ccb78098f202b2d099908a1b92087697cfa8f5969ba0221d4e8ed3decb6cf2ec7ea3b3d1ae450b4e12e7aff640333de06333c53930f15ba6cc201b37cebb1838
+    SHA512 2e2d3135ebf8cb176a4e5e6f1faa26ae9ea5c3e2441e2c820372a76b78e641f207257600d6a207aa05883e04f29fac1452673bffa0395789b8e482cc6b204673
     HEAD_REF master # branch name
     PATCHES
         0001-build.patch
@@ -95,7 +95,8 @@ set(TOOL_NAMES gtk4-builder-tool
                gtk4-path-tool
                gtk4-query-settings
                gtk4-rendernode-tool
-               gtk4-update-icon-cache)
+               gtk4-update-icon-cache
+               gtk4-image-tool)
 if(VCPKG_TARGET_IS_LINUX)
     list(APPEND TOOL_NAMES gtk4-launch)
 endif()

--- a/ports/gtk/vcpkg.json
+++ b/ports/gtk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gtk",
-  "version": "4.14.0",
-  "port-version": 1,
+  "version": "4.16.3",
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3297,8 +3297,8 @@
       "port-version": 0
     },
     "gtk": {
-      "baseline": "4.14.0",
-      "port-version": 1
+      "baseline": "4.16.3",
+      "port-version": 0
     },
     "gtk3": {
       "baseline": "3.24.38",
@@ -4186,7 +4186,7 @@
     },
     "launch-darkly-server": {
       "baseline": "2.9.3",
-      "port-version": 0 
+      "port-version": 0
     },
     "lazy-importer": {
       "baseline": "2023-08-03",

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a4e9da51abf1cb20ea97337705551e22d6f531f",
+      "version": "4.16.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a2c53b5715720e68051e3d26bfa56a83b6c8de0",
       "version": "4.14.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Usage passed on `x64-windows`.
```
  # GTK Graphical UI Library
  gtk4-win32

  # GTK Graphical UI Library
  gtk4
```