### PR TITLE
[bgfx] update to 1.128.8808-482

### DIFF
--- a/ports/bgfx/portfile.cmake
+++ b/ports/bgfx/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_download_distfile(
   ARCHIVE_FILE
   URLS https://github.com/bkaradzic/bgfx.cmake/releases/download/v${VERSION}/bgfx.cmake.v${VERSION}.tar.gz
   FILENAME bgfx.cmake.v${VERSION}.tar.gz
-  SHA512 227caf8b7cee5fe84c078a473c25e636e3cb32ae4b252cdb193f0cef069cfc32f9eb6ef52f96d5e547a3bd20360e5f09147c0c8ba5f3b20541a0082171fda076
+  SHA512 879ffef9623238b5e4ff88ac1bd655203adf76f4232f8e36f9a7ba5d0baab11ef80fdc7b3fea110e54d22f284106d51e12bf468459d82dc50a177555b4e4ada9
 )
 
 vcpkg_extract_source_archive(

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bgfx",
-  "version": "1.128.8786-481",
+  "version": "1.128.8808-482",
   "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
   "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
   "homepage": "https://bkaradzic.github.io/bgfx/overview.html",

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "38419e14182a560fb1b84d51f88e68af9174e90c",
+      "version": "1.128.8808-482",
+      "port-version": 0
+    },
+    {
       "git-tree": "059b5b641de1b56edd27101a5d0ce1093cceaa5a",
       "version": "1.128.8786-481",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -637,7 +637,7 @@
       "port-version": 0
     },
     "bgfx": {
-      "baseline": "1.128.8786-481",
+      "baseline": "1.128.8808-482",
       "port-version": 0
     },
     "bigint": {
@@ -4186,7 +4186,7 @@
     },
     "launch-darkly-server": {
       "baseline": "2.9.3",
-      "port-version": 0 
+      "port-version": 0
     },
     "lazy-importer": {
       "baseline": "2023-08-03",


### PR DESCRIPTION
Update `bgfx` to the latest version v1.128.8808-482.
Feature test passed with x64-windows triplet.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.