### PR TITLE
[libunwind,gperftools] Fix dependencies

### DIFF
--- a/ports/gperftools/libunwind.diff
+++ b/ports/gperftools/libunwind.diff
@@ -1,0 +1,30 @@
+diff --git a/configure.ac b/configure.ac
+index 65a4e24..fc0d7d6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -278,9 +278,24 @@ AM_CONDITIONAL(ENABLE_STATIC, test "$enable_static" = yes)
+ # We want to link in libunwind if it is enabled and exists.
+ UNWIND_LIBS=
+ if test "$enable_libunwind" = yes; then
++  save_CFLAGS="$CFLAGS"
++  save_LIBS="$LIBS"
++  PKG_PROG_PKG_CONFIG
++  PKG_CHECK_MODULES([PC_UNWIND],[libunwind],[
++    CFLAGS="$PC_UNWIND_CFLAGS"
++    LIBS="$PC_UNWIND_LIBS"
++  ],[
++    PC_UNWIND_CFLAGS=""
++    LIBS="-lunwind"
++  ])
+   AC_CHECK_HEADERS([libunwind.h],
+-                   [AC_CHECK_LIB(unwind, backtrace, UNWIND_LIBS=-lunwind)
++                   [AC_SEARCH_LIBS(backtrace, [], [
++                    save_CFLAGS="$CFLAGS $PC_UNWIND_CFLAGS"
++                    UNWIND_LIBS="$LIBS"
++                   ])
+                     will_use_libunwind=yes])
++  CFLAGS="$save_CFLAGS"
++  LIBS="$save_LIBS"
+ fi
+ AC_SUBST(UNWIND_LIBS)
+ 

--- a/ports/gperftools/portfile.cmake
+++ b/ports/gperftools/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF gperftools-2.10
     SHA512 4400711723be9401f519d85b3b69c026e4715473cbed48ab0573df17abdf895fb971ee969875fe5127a2e8b9aba90d858285e50c8e012384c2c36d5a76b1f0c4
     HEAD_REF master
+    PATCHES
+        libunwind.diff
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/gperftools/portfile.cmake
+++ b/ports/gperftools/portfile.cmake
@@ -56,6 +56,10 @@ else()
         set(BUILD_OPTS --enable-static --disable-shared)
     endif()
 
+    if(VCPKG_TARGET_IS_LINUX)
+        vcpkg_find_acquire_program(PKGCONFIG)
+    endif()
+
     vcpkg_configure_make(
         SOURCE_PATH ${SOURCE_PATH}
         AUTOCONFIG

--- a/ports/gperftools/vcpkg.json
+++ b/ports/gperftools/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "gperftools",
   "version": "2.10",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A set of tools for performance profiling and memory checking",
   "homepage": "https://github.com/gperftools/gperftools",
   "supports": "!(arm & windows) & !uwp & !android",
   "dependencies": [
+    {
+      "name": "libunwind",
+      "platform": "linux"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true,

--- a/ports/libunwind/liblzma.diff
+++ b/ports/libunwind/liblzma.diff
@@ -1,0 +1,30 @@
+diff --git a/configure.ac b/configure.ac
+index 82caaa7..a17b7a1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -443,9 +443,11 @@ AC_MSG_CHECKING([whether to support LZMA-compressed symbol tables])
+ AC_ARG_ENABLE(minidebuginfo,
+ AS_HELP_STRING([--enable-minidebuginfo], [Enables support for LZMA-compressed symbol tables]),, [enable_minidebuginfo=auto])
+ AC_MSG_RESULT([$enable_minidebuginfo])
++PKG_PROG_PKG_CONFIG
+ if test x$enable_minidebuginfo != xno; then
+-   AC_CHECK_LIB([lzma], [lzma_mf_is_supported],
+-   [LIBLZMA=-llzma
++   PKG_CHECK_MODULES([LZMA],[liblzma],
++   [LIBLZMA="$LZMA_LIBS"
++    CFLAGS="$CFLAGS $LZMA_CFLAGS"
+     AC_DEFINE([HAVE_LZMA], [1], [Define if you have liblzma])
+     enable_minidebuginfo=yes],
+    [if test x$enable_minidebuginfo = xyes; then
+diff --git a/src/unwind/libunwind.pc.in b/src/unwind/libunwind.pc.in
+index 9a65faf..bb351f7 100644
+--- a/src/unwind/libunwind.pc.in
++++ b/src/unwind/libunwind.pc.in
+@@ -7,5 +7,6 @@ Name: libunwind
+ Description: libunwind base library
+ Version: @VERSION@
+ Libs: -L${libdir} -lunwind
+-Libs.private: @LIBLZMA@ @LIBZ@
++Libs.private:           @LIBZ@
++Requires.private: liblzma
+ Cflags: -I${includedir}

--- a/ports/libunwind/portfile.cmake
+++ b/ports/libunwind/portfile.cmake
@@ -19,6 +19,8 @@ vcpkg_from_github(
         "${CURRENT_BUILDTREES_DIR}/src/libunwind.diff"
 )
 
+vcpkg_find_acquire_program(PKGCONFIG)
+
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG

--- a/ports/libunwind/portfile.cmake
+++ b/ports/libunwind/portfile.cmake
@@ -31,6 +31,4 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
-
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libunwind/portfile.cmake
+++ b/ports/libunwind/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
     HEAD_REF master
     SHA512 dd8332b7a2cbabb4716c01feea422f83b4a7020c1bee20551de139c3285ea0e0ceadfa4171c6f5187448c8ddc53e0ec4728697d0a985ee0c3ff4835b94f6af6f
     PATCHES
+        liblzma.diff
         "${CURRENT_BUILDTREES_DIR}/src/libunwind.diff"
 )
 
@@ -22,7 +23,9 @@ vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
     OPTIONS
+        --disable-documentation
         --disable-tests
+        --disable-zlibdebuginfo
         --enable-minidebuginfo
 )
 vcpkg_install_make()

--- a/ports/libunwind/usage
+++ b/ports/libunwind/usage
@@ -1,6 +1,0 @@
-The package libunwind can be imported via CMake FindPkgConfig module:
-
-    find_package(PkgConfig)
-    pkg_check_modules(libunwind REQUIRED IMPORTED_TARGET GLOBAL libunwind)
-    
-    target_link_libraries(main PRIVATE PkgConfig::libunwind)

--- a/ports/libunwind/vcpkg.json
+++ b/ports/libunwind/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libunwind",
   "version": "1.8.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Unix libray for portable stack unwinding",
   "homepage": "https://www.nongnu.org/libunwind",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3222,7 +3222,7 @@
     },
     "gperftools": {
       "baseline": "2.10",
-      "port-version": 1
+      "port-version": 2
     },
     "gpgme": {
       "baseline": "1.23.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5254,7 +5254,7 @@
     },
     "libunwind": {
       "baseline": "1.8.1",
-      "port-version": 2
+      "port-version": 3
     },
     "liburing": {
       "baseline": "2.7",

--- a/versions/g-/gperftools.json
+++ b/versions/g-/gperftools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "096d48f5b41ce3e4563e268a19be7b09e3dcd3e2",
+      "version": "2.10",
+      "port-version": 2
+    },
+    {
       "git-tree": "ebb8ef920067346d4633cc78ee176f7ed9bc89d4",
       "version": "2.10",
       "port-version": 1

--- a/versions/g-/gperftools.json
+++ b/versions/g-/gperftools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "096d48f5b41ce3e4563e268a19be7b09e3dcd3e2",
+      "git-tree": "9de2b6bb7a1d0a80fe402a8561161e3cac4ede19",
       "version": "2.10",
       "port-version": 2
     },

--- a/versions/l-/libunwind.json
+++ b/versions/l-/libunwind.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a9dfdcaea258403c5db349968769ed7833466ff0",
+      "git-tree": "535c5df0f63ffbfd8bb48e564758d20e2bad192c",
       "version": "1.8.1",
       "port-version": 3
     },

--- a/versions/l-/libunwind.json
+++ b/versions/l-/libunwind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9dfdcaea258403c5db349968769ed7833466ff0",
+      "version": "1.8.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "d9bd4526e93e77c007518879e00a2cc163a87d20",
       "version": "1.8.1",
       "port-version": 2


### PR DESCRIPTION
Handle libunwind's complete liblzma usage requirements via pkgconfig.
Prevent libunwind's zlib dependency (subject to installation order).
Show full auto-generated pkg-config usage for libunwind.
Fix gperftools installation order and libunwind linking bug. (Cf. https://github.com/microsoft/vcpkg/pull/41815#issuecomment-2449270562. Also blocking #41525.)