### PR TITLE
[gdal] Add libarchive support

### DIFF
--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_replace_string("${SOURCE_PATH}/ogr/ogrsf_frmts/flatgeobuf/flatbuffers/base
 # "core" is used for a dependency which must be enabled to avoid vendored lib.
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        archive          GDAL_USE_ARCHIVE
         cfitsio          GDAL_USE_CFITSIO
         curl             GDAL_USE_CURL
         expat            GDAL_USE_EXPAT

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.9.3",
+  "port-version": 1,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,
@@ -41,6 +42,12 @@
     "default-features"
   ],
   "features": {
+    "archive": {
+      "description": "Enable libarchive support",
+      "dependencies": [
+        "libarchive"
+      ]
+    },
     "aws-ec2-windows": {
       "description": "Optimized detection of AWS EC2 Windows hosts",
       "dependencies": [

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -45,7 +45,10 @@
     "archive": {
       "description": "Enable libarchive support",
       "dependencies": [
-        "libarchive"
+        {
+          "name": "libarchive",
+          "default-features": false
+        }
       ]
     },
     "aws-ec2-windows": {

--- a/scripts/test_ports/vcpkg-ci-gdal/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-gdal/vcpkg.json
@@ -8,6 +8,7 @@
     {
       "name": "gdal",
       "features": [
+        "archive",
         "freexl"
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3026,7 +3026,7 @@
     },
     "gdal": {
       "baseline": "3.9.3",
-      "port-version": 0
+      "port-version": 1
     },
     "gdcm": {
       "baseline": "3.0.24",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eec5cae5afa08d1e0798973a0e190c1b2462de49",
+      "version-semver": "3.9.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "f5682e9626c47a26f37e7578c3df847ddc3fe11c",
       "version-semver": "3.9.3",
       "port-version": 0

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eec5cae5afa08d1e0798973a0e190c1b2462de49",
+      "git-tree": "48387632dca0060dca76a899ebb693e2799d3d39",
       "version-semver": "3.9.3",
       "port-version": 1
     },


### PR DESCRIPTION
This PR adds a new "archive' feature to the gdal port to enable support for /vsirar/ and /vsi7z/ archived datasets. Since the libarchive dependency is already a port here, it was ridiculously easy to implement :)