### PR TITLE
[libarchive ] Fix fix build on iOS

### DIFF
--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -22,6 +22,10 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         lzma    ENABLE_LZMA
         lzma    CMAKE_REQUIRE_FIND_PACKAGE_LibLZMA
         lzo     ENABLE_LZO
+        tools   ENABLE_TAR
+        tools   ENABLE_CPIO
+        tools   ENABLE_CAT
+        tools   ENABLE_UNZIP
         zstd    ENABLE_ZSTD
 )
 # Default crypto backend is OpenSSL, but it is ignored for DARWIN

--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -22,10 +22,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         lzma    ENABLE_LZMA
         lzma    CMAKE_REQUIRE_FIND_PACKAGE_LibLZMA
         lzo     ENABLE_LZO
-        tools   ENABLE_TAR
-        tools   ENABLE_CPIO
-        tools   ENABLE_CAT
-        tools   ENABLE_UNZIP
         zstd    ENABLE_ZSTD
 )
 # Default crypto backend is OpenSSL, but it is ignored for DARWIN
@@ -60,6 +56,7 @@ vcpkg_cmake_configure(
         -DENABLE_EXPAT=OFF
         -DENABLE_LibGCC=OFF
         -DENABLE_CNG=OFF
+        -DENABLE_UNZIP=OFF
         -DENABLE_TAR=OFF
         -DENABLE_CPIO=OFF
         -DENABLE_CAT=OFF

--- a/ports/libarchive/vcpkg.json
+++ b/ports/libarchive/vcpkg.json
@@ -19,10 +19,6 @@
     "libxml2",
     "lz4",
     "lzma",
-    {
-      "name": "tools",
-      "platform": "!ios"
-    },
     "zstd"
   ],
   "features": {
@@ -68,9 +64,6 @@
       "dependencies": [
         "lzo"
       ]
-    },
-    "tools": {
-      "description": "Tools support"
     },
     "zstd": {
       "description": "Zstd support",

--- a/ports/libarchive/vcpkg.json
+++ b/ports/libarchive/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libarchive",
   "version": "3.7.7",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Library for reading and writing streaming archives",
   "homepage": "https://www.libarchive.org",
   "license": null,
@@ -19,6 +19,10 @@
     "libxml2",
     "lz4",
     "lzma",
+    {
+      "name": "tools",
+      "platform": "!ios"
+    },
     "zstd"
   ],
   "features": {
@@ -64,6 +68,9 @@
       "dependencies": [
         "lzo"
       ]
+    },
+    "tools": {
+      "description": "Tools support"
     },
     "zstd": {
       "description": "Zstd support",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4290,7 +4290,7 @@
     },
     "libarchive": {
       "baseline": "3.7.7",
-      "port-version": 1
+      "port-version": 2
     },
     "libass": {
       "baseline": "0.17.3",

--- a/versions/l-/libarchive.json
+++ b/versions/l-/libarchive.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "83ff102e61f8f807171af3019e5f95edc9a9633d",
+      "git-tree": "273f56c8b692d2fb25364dd5b117f22449578ffe",
       "version": "3.7.7",
       "port-version": 2
     },

--- a/versions/l-/libarchive.json
+++ b/versions/l-/libarchive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "83ff102e61f8f807171af3019e5f95edc9a9633d",
+      "version": "3.7.7",
+      "port-version": 2
+    },
+    {
       "git-tree": "b77dc1277af32b25c44e58cc233a034fa6659110",
       "version": "3.7.7",
       "port-version": 1


### PR DESCRIPTION
This pull request fixes libarchive building on iOS by setting `ENABLE_UNZIP=OFF`.

The PR is a companion to https://github.com/microsoft/vcpkg/pull/41896 . With both of the PRs in, we can build gdal on iOS with rar and 7z archived datasets support.