### PR TITLE
[halide] Update version to 18.0.0

### DIFF
--- a/ports/halide/portfile.cmake
+++ b/ports/halide/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO halide/Halide
-    REF 8864e8ac1c0bb460f0034e9c46f7f944afad3a19 # unreleased version with LLVM 18 support
+    REF "${VERSION}"
     SHA512 286cbef25b5cc0f5095cbc80a2fd1cacf369948c58c14406ac6bcc28a7a37c81417d601975083f03670e22276a1886b8801bdc91aa6fe80049a276a1c8fd08b9
     HEAD_REF main
 )

--- a/ports/halide/vcpkg.json
+++ b/ports/halide/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "halide",
-  "version": "17.0.1",
-  "port-version": 1,
+  "version": "18.0.0",
   "description": "Halide is a programming language designed to make it easier to write high-performance image and array processing code on modern machines.",
   "homepage": "https://github.com/halide/Halide",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3409,8 +3409,8 @@
       "port-version": 0
     },
     "halide": {
-      "baseline": "17.0.1",
-      "port-version": 1
+      "baseline": "18.0.0",
+      "port-version": 0
     },
     "happly": {
       "baseline": "2021-03-19",
@@ -4186,7 +4186,7 @@
     },
     "launch-darkly-server": {
       "baseline": "2.9.3",
-      "port-version": 0 
+      "port-version": 0
     },
     "lazy-importer": {
       "baseline": "2023-08-03",

--- a/versions/h-/halide.json
+++ b/versions/h-/halide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef0d66c94e06585d576e942fbd63e7a32bfa7e54",
+      "version": "18.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cdced195e1ecb05af078e7d0ba4ba58106397330",
       "version": "17.0.1",
       "port-version": 1


### PR DESCRIPTION
Update port halide to the latest version 18.0.0

All features are tested successfully in the following triplet:
````
x86-windows
x64-windows
x64-windows-static
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.