### PR TITLE
[basisu] update to v1.50.0

### DIFF
--- a/ports/basisu/0001-cmake.patch
+++ b/ports/basisu/0001-cmake.patch
@@ -1,0 +1,204 @@
+Remove once https://github.com/BinomialLLC/basis_universal/pull/383 merged
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8345623d..f4ed6708 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.5)
+ project(basisu)
+ option(STATIC "static linking" FALSE)
+ option(SAN "sanitize" FALSE)
++option(EXAMPLES "Build examples" TRUE)
+ 
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+ 
+@@ -174,15 +175,21 @@ add_executable(basisu basisu_tool.cpp)
+ target_link_libraries(basisu PRIVATE basisu_encoder)
+ 
+ # Create the new example executable and link against the static library
+-add_executable(examples example/example.cpp)
+-target_link_libraries(examples PRIVATE basisu_encoder)
++if(EXAMPLES)
++    add_executable(examples example/example.cpp)
++    target_link_libraries(examples PRIVATE basisu_encoder)
++endif()
+ 
+ if (ZSTD)
+     target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
+-    target_compile_definitions(examples PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
++    if(EXAMPLES)
++        target_compile_definitions(examples PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
++    endif()
+ else()
+     target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=0)
+-    target_compile_definitions(examples PRIVATE BASISD_SUPPORT_KTX2_ZSTD=0)
++    if(EXAMPLES)
++        target_compile_definitions(examples PRIVATE BASISD_SUPPORT_KTX2_ZSTD=0)
++    endif()
+ endif()
+ 
+ if (NOT MSVC)
+@@ -192,7 +199,9 @@ if (NOT MSVC)
+         set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_OPENCL=1")    
+         
+         target_include_directories(basisu PRIVATE ${OpenCL_INCLUDE_DIRS})
+-        target_include_directories(examples PRIVATE ${OpenCL_INCLUDE_DIRS})
++        if(EXAMPLES)
++            target_include_directories(examples PRIVATE ${OpenCL_INCLUDE_DIRS})
++        endif()
+ 		target_include_directories(basisu_encoder PRIVATE ${OpenCL_INCLUDE_DIRS})
+         set(BASISU_EXTRA_LIBS ${OpenCL_LIBRARIES})
+     endif()
+@@ -203,22 +212,30 @@ else()
+         set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_OPENCL=1")    
+         
+         target_include_directories(basisu PRIVATE "OpenCL")
+-        target_include_directories(examples PRIVATE "OpenCL")
++        if(EXAMPLES)
++            target_include_directories(examples PRIVATE "OpenCL")
++        endif()
+ 		target_include_directories(basisu_encoder PRIVATE "OpenCL")
+ 
+         if (BUILD_X64)
+             target_link_libraries(basisu PRIVATE "${CMAKE_SOURCE_DIR}/OpenCL/lib/OpenCL64.lib")
+-            target_link_libraries(examples PRIVATE "${CMAKE_SOURCE_DIR}/OpenCL/lib/OpenCL64.lib")
++            if(EXAMPLES)
++                target_link_libraries(examples PRIVATE "${CMAKE_SOURCE_DIR}/OpenCL/lib/OpenCL64.lib")
++            endif()
+         else()
+             target_link_libraries(basisu PRIVATE "${CMAKE_SOURCE_DIR}/OpenCL/lib/OpenCL.lib")
+-            target_link_libraries(examples PRIVATE "${CMAKE_SOURCE_DIR}/OpenCL/lib/OpenCL.lib")
++            if(EXAMPLES)
++                target_link_libraries(examples PRIVATE "${CMAKE_SOURCE_DIR}/OpenCL/lib/OpenCL.lib")
++            endif()
+         endif()
+     endif()
+ endif()    
+ 
+ if (NOT MSVC)
+     target_link_libraries(basisu PRIVATE m pthread ${BASISU_EXTRA_LIBS})
+-    target_link_libraries(examples PRIVATE m pthread ${BASISU_EXTRA_LIBS})
++    if(EXAMPLES)
++        target_link_libraries(examples PRIVATE m pthread ${BASISU_EXTRA_LIBS})
++    endif()
+ endif()
+ 
+ if (NOT EMSCRIPTEN)
+@@ -242,13 +259,15 @@ if (MSVC)
+         RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+         RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+         RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+-    )	
+-	
+-	set_target_properties(examples PROPERTIES 
+-        RUNTIME_OUTPUT_NAME "examples"
+-        RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+-        RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+-        RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+-        RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+-    )	
++    )
++
++    if(EXAMPLES)
++        set_target_properties(examples PROPERTIES
++            RUNTIME_OUTPUT_NAME "examples"
++            RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
++            RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
++            RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
++            RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
++        )
++    endif()
+ endif()
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f4ed6708..e4e7c7e6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -240,15 +240,16 @@ endif()
+ 
+ if (NOT EMSCRIPTEN)
+     if (UNIX)
+-        if (CMAKE_BUILD_TYPE STREQUAL Release)
+-            if (APPLE)
+-                add_custom_command(TARGET basisu POST_BUILD COMMAND strip -X -x ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/basisu)
+-				#message("strip command: strip -X -x ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/basisu")
+-            else()
+-                add_custom_command(TARGET basisu POST_BUILD COMMAND strip -g -X -x ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/basisu)
+-				#message("strip command: strip -g -X -x ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/basisu")
+-            endif()
++        set(STRIP_ARGS -X -x)
++        if (NOT APPLE)
++            list(APPEND STRIP_ARGS -g)
+         endif()
++        add_custom_command(
++            TARGET basisu POST_BUILD
++            DEPENDS basisu
++            COMMAND $<$<CONFIG:release>:${CMAKE_STRIP}>
++            ARGS ${STRIP_ARGS} $<TARGET_FILE:basisu>
++        )
+     endif()
+ endif()
+ 
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e4e7c7e6..46818dc4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -169,6 +169,10 @@ endif()
+ 
+ # Create the static library
+ add_library(basisu_encoder STATIC ${ENCODER_LIB_SRC_LIST})
++target_include_directories(basisu_encoder PUBLIC
++    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/transcoder>
++    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/encoder>
++    $<INSTALL_INTERFACE:include>)
+ 
+ # Create the basisu executable and link against the static library
+ add_executable(basisu basisu_tool.cpp)
+@@ -272,3 +276,31 @@ if (MSVC)
+         )
+     endif()
+ endif()
++
++# Target Installation
++install(TARGETS basisu_encoder basisu EXPORT basisu-targets)
++install(DIRECTORY "./transcoder" DESTINATION "include/basisu/"
++    FILES_MATCHING PATTERN "*.h" PATTERN "*.inc"
++)
++install(DIRECTORY "./encoder" DESTINATION "include/basisu/"
++    FILES_MATCHING PATTERN "*.h"
++)
++
++# CMake Export
++include(CMakePackageConfigHelpers)
++include(GNUInstallDirs)
++configure_package_config_file(
++    ${PROJECT_SOURCE_DIR}/basisu-config.cmake.in
++    ${PROJECT_BINARY_DIR}/basisu-config.cmake
++    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/basisu)
++export(
++    TARGETS basisu_encoder basisu
++    NAMESPACE basisu::
++    FILE ${PROJECT_BINARY_DIR}/basisu-targets.cmake)
++install(
++    FILES ${PROJECT_BINARY_DIR}/basisu-config.cmake
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/basisu)
++install(
++    EXPORT basisu-targets
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/basisu
++    NAMESPACE basisu::)
+diff --git a/basisu-config.cmake.in b/basisu-config.cmake.in
+new file mode 100644
+index 00000000..6ac330ed
+--- /dev/null
++++ b/basisu-config.cmake.in
+@@ -0,0 +1,7 @@
++@PACKAGE_INIT@
++
++if (NOT TARGET basisu::basisu_encoder)
++  include(${CMAKE_CURRENT_LIST_DIR}/basisu-targets.cmake)
++endif ()
++
++check_required_components(basisu)

--- a/ports/basisu/portfile.cmake
+++ b/ports/basisu/portfile.cmake
@@ -1,24 +1,28 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BinomialLLC/basis_universal
-    REF "${VERSION}"
-    SHA512 7f7dd62741b4a3e13050233a2ed751e6108cde9eab7b05ea5882ded6ab49fe181cc30e795cf73f8fa625a71e77ae891fda5ea84e20b632b1397844d6539715b3
+    REF "v1_50_0_2"
+    SHA512 845077e9c88a3610b4845bbf4856a2141d678751eb2b5eba26bb4cbbaa0199ad4eae6a37dee485bfcac9d583ee6dca983f300fb7e2b86dfbc9824b5059e11345
     HEAD_REF master
+    PATCHES
+        # Remove once https://github.com/BinomialLLC/basis_universal/pull/383 merged
+        0001-cmake.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBUILD_TESTS=OFF
+        -DEXAMPLES=OFF
 )
 
 vcpkg_cmake_install()
-
 vcpkg_copy_pdbs()
 
 vcpkg_copy_tools(TOOL_NAMES "basisu" AUTO_CLEAN)
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
-# Remove unnecessary files
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME basisu CONFIG_PATH lib/cmake/basisu)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/basisu/vcpkg.json
+++ b/ports/basisu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "basisu",
-  "version": "1.16.4",
+  "version": "1.50.0",
   "description": "Basis Universal is a supercompressed GPU texture and video compression format that outputs a highly compressed intermediate file format (.basis) that can be quickly transcoded to a wide variety of GPU texture compression formats.",
   "homepage": "https://github.com/BinomialLLC/basis_universal",
   "license": "Apache-2.0",
@@ -9,6 +9,10 @@
     "lodepng",
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/b-/basisu.json
+++ b/versions/b-/basisu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d73fe30c22b77d2059f07330ae9cb13e0dd2809",
+      "version": "1.50.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d355537e7392dad769a0c435f2a2cedf310b322c",
       "version": "1.16.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -565,7 +565,7 @@
       "port-version": 0
     },
     "basisu": {
-      "baseline": "1.16.4",
+      "baseline": "1.50.0",
       "port-version": 0
     },
     "bcg729": {


### PR DESCRIPTION

Patches upstreamd here: https://github.com/BinomialLLC/basis_universal/pull/383

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
