### PR TITLE
[lapack-reference] expose the lapacke option of lapack-reference

### DIFF
--- a/ports/lapack-reference/portfile.cmake
+++ b/ports/lapack-reference/portfile.cmake
@@ -1,8 +1,6 @@
 #TODO: Features to add:
 # USE_XBLAS??? extended precision blas. needs xblas
-# LAPACKE should be its own PORT
 # USE_OPTIMIZED_LAPACK (Probably not what we want. Does a find_package(LAPACK): probably for LAPACKE only builds _> own port?)
-# LAPACKE Builds LAPACKE
 # LAPACKE_WITH_TMG Build LAPACKE with tmglib routines
 if(EXISTS "${CURRENT_INSTALLED_DIR}/share/clapack/copyright")
     message(FATAL_ERROR "Can't build ${PORT} if clapack is installed. Please remove clapack:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
@@ -56,6 +54,11 @@ if(VCPKG_USE_INTERNAL_Fortran)
     endif()
 endif()
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS options
+    FEATURES
+        lapacke    LAPACKE
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -63,6 +66,7 @@ vcpkg_cmake_configure(
         "-DCMAKE_REQUIRE_FIND_PACKAGE_BLAS=${USE_OPTIMIZED_BLAS}"
         "-DCBLAS=${CBLAS}"
         "-DTEST_FORTRAN_COMPILER=OFF"
+        ${options}
         ${FORTRAN_CMAKE}
     MAYBE_UNUSED_VARIABLES
         CMAKE_REQUIRE_FIND_PACKAGE_BLAS

--- a/ports/lapack-reference/vcpkg.json
+++ b/ports/lapack-reference/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lapack-reference",
   "version": "3.11.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "LAPACK - Linear Algebra PACKage",
   "homepage": "https://netlib.org/lapack/",
   "license": "BSD-3-Clause-Open-MPI",
@@ -38,6 +38,9 @@
     },
     "cblas": {
       "description": "Builds CBLAS"
+    },
+    "lapacke": {
+      "description": "Build the LAPACKE C Interface to LAPACK"
     },
     "noblas": {
       "description": "Use external optimized BLAS",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4178,7 +4178,7 @@
     },
     "lapack-reference": {
       "baseline": "3.11.0",
-      "port-version": 6
+      "port-version": 7
     },
     "lastools": {
       "baseline": "2.0.3",

--- a/versions/l-/lapack-reference.json
+++ b/versions/l-/lapack-reference.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e87cc54fe20ae5272c037df3387aa6b1fdcdedb",
+      "version": "3.11.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "c6447c2a6f70504bfbf20f2e649bcc17a6ce67de",
       "version": "3.11.0",
       "port-version": 6


### PR DESCRIPTION
This adds the missing `lapacke` CMake option of `lapack-reference` so that vcpkg follows the upstream options. 

[Reference-LAPACK/lapack@1573c82/CMakeLists.txt#L344](https://github.com/Reference-LAPACK/lapack/blob/1573c8275433f137107f02bb48017c2165e3ce96/CMakeLists.txt#L344)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.