### PR TITLE
[allegro5] Add Minimp3 support

### DIFF
--- a/ports/allegro5/minimp3-fix.patch
+++ b/ports/allegro5/minimp3-fix.patch
@@ -1,0 +1,17 @@
+diff --git a/addons/acodec/CMakeLists.txt b/addons/acodec/CMakeLists.txt
+index 6906a99..7896989 100644
+--- a/addons/acodec/CMakeLists.txt
++++ b/addons/acodec/CMakeLists.txt
+@@ -394,9 +394,10 @@ acodec_summary(" - Opus" SUPPORT_OPUS)
+ # MP3
+ #
+ if(WANT_MP3)
+-    find_package(MiniMP3)
++    find_path(MINIMP3_INCLUDE_DIRS "minimp3/minimp3.h")
++    set(MINIMP3_FOUND true)
+     if(MINIMP3_FOUND)
+-        include_directories(SYSTEM ${MINIMP3_INCLUDE_DIRS})
++        include_directories(SYSTEM ${MINIMP3_INCLUDE_DIRS}/minimp3)
+         set(ALLEGRO_CFG_ACODEC_MP3 1)
+         list(APPEND ACODEC_SOURCES mp3.c)
+     endif(MINIMP3_FOUND)

--- a/ports/allegro5/portfile.cmake
+++ b/ports/allegro5/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         do-not-copy-pdbs-to-lib.patch
         msvc-arm64-atomic.patch
+        minimp3-fix.patch
 )
 
 if(VCPKG_TARGET_IS_ANDROID AND NOT ENV{ANDROID_HOME})
@@ -43,7 +44,7 @@ vcpkg_cmake_configure(
         -DWANT_GLES3=ON
         -DWANT_IMAGE_FREEIMAGE=OFF
         -DWANT_MODAUDIO=OFF # Not available on vcpkg right now
-        -DWANT_MP3=OFF
+        -DWANT_MP3=ON
         -DWANT_OPENSL=OFF # Not yet available on vcpkg
         -DWANT_POPUP_EXAMPLES=OFF
         -DWANT_TESTS=OFF

--- a/ports/allegro5/vcpkg.json
+++ b/ports/allegro5/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "allegro5",
-  "version": "5.2.9.1",
+  "version": "5.2.9.2",
   "description": "Allegro is a cross-platform library mainly aimed at video game and multimedia programming. It handles common, low-level tasks such as creating windows, accepting user input, loading data, drawing images, playing sounds, etc. and generally abstracting away the underlying platform. However, Allegro is not a game engine: you are free to design and structure your program as you like.",
   "homepage": "https://liballeg.org/",
   "license": "BSD-3-Clause AND Zlib",
@@ -24,6 +24,7 @@
       "name": "libwebp",
       "default-features": false
     },
+    "minimp3",
     "openal-soft",
     "opus",
     "opusfile",
@@ -36,8 +37,7 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "zlib",
-    "minimp3"
+    "zlib"
   ],
   "default-features": [
     {

--- a/ports/allegro5/vcpkg.json
+++ b/ports/allegro5/vcpkg.json
@@ -36,7 +36,8 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "zlib"
+    "zlib",
+    "minimp3"
   ],
   "default-features": [
     {

--- a/versions/a-/allegro5.json
+++ b/versions/a-/allegro5.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b851ab5c1343656dd3d5dff7e0e206c1c5c1feaa",
+      "git-tree": "c375db21b3bfa0c14dec1832be9fc687f6b28426",
       "version": "5.2.9.2",
       "port-version": 0
     },

--- a/versions/a-/allegro5.json
+++ b/versions/a-/allegro5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b851ab5c1343656dd3d5dff7e0e206c1c5c1feaa",
+      "version": "5.2.9.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1162ff1bdc43ad43036a30af2ca8214eeea566d9",
       "version": "5.2.9.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -85,7 +85,7 @@
       "port-version": 3
     },
     "allegro5": {
-      "baseline": "5.2.9.1",
+      "baseline": "5.2.9.2",
       "port-version": 0
     },
     "alpaca": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
