### PR TITLE
[qmex] Add new port

### DIFF
--- a/ports/qmex/portfile.cmake
+++ b/ports/qmex/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO huangqinjin/QMEX
+    REF 8a061d68991362aa74ebbceeb5406032a0515536
+    SHA512 bc4d13c1487291f541381e6e6baf83e4d723576d17441b0c9d206ec0bacfc33c5f6bd9ff98bb265823426110390f228b9c8ccc8f69c3842c83c6e039bfb02074
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools BUILD_TOOLS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DBUILD_TESTING=OFF
+    OPTIONS_DEBUG
+        -DBUILD_TOOLS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
+vcpkg_copy_pdbs(BUILD_PATHS "${CURRENT_PACKAGES_DIR}/bin/*.exe")
+
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES qmex-cli AUTO_CLEAN)
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE_1_0.txt")

--- a/ports/qmex/vcpkg.json
+++ b/ports/qmex/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "qmex",
+  "version-date": "2024-10-31",
+  "description": "QMEX - Query & Map & Evaluation & eXecution for Tabular Data",
+  "homepage": "https://github.com/huangqinjin/QMEX",
+  "license": "BSL-1.0",
+  "dependencies": [
+    "lua",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tools": {
+      "description": "QMEX cli tools"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7300,6 +7300,10 @@
       "baseline": "8.0.2",
       "port-version": 5
     },
+    "qmex": {
+      "baseline": "2024-10-31",
+      "port-version": 0
+    },
     "qnnpack": {
       "baseline": "2021-02-26",
       "port-version": 3

--- a/versions/q-/qmex.json
+++ b/versions/q-/qmex.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b5fa4eb05382aad62fad36c2c6ae5e961cc0a6c6",
+      "version-date": "2024-10-31",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


