### PR TITLE
[Log4cxx] add features

### DIFF
--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -10,9 +10,15 @@ vcpkg_extract_source_archive(
         fix-find-package.patch
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        qt        LOG4CXX_QT_SUPPORT
+        fmt       ENABLE_FMT_LAYOUT
+)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DLOG4CXX_INSTALL_PDB=OFF # Installing pdbs failed on debug static. So, disable it and let vcpkg_copy_pdbs() do it
         -DBUILD_TESTING=OFF
 )

--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "log4cxx",
   "version": "1.2.0",
+  "port-version": 1,
   "description": "Apache log4cxx is a logging framework for C++ patterned after Apache log4j, which uses Apache Portable Runtime for most platform-specific code and should be usable on any platform supported by APR",
   "homepage": "https://logging.apache.org/log4cxx",
   "license": "Apache-2.0",

--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -17,5 +17,19 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "fmt": {
+      "description": "Include the log4cxx::FMTLayout class that uses libfmt to layout messages",
+      "dependencies": [
+        "fmt"
+      ]
+    },
+    "qt": {
+      "description": "Allow QString values in the LOG4CXX_WARN, LOG4CXX_INFO, LOG4CXX_DEBUG etc. macros",
+      "dependencies": [
+        "qt5-base"
+      ]
+    }
+  }
 }

--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -28,7 +28,10 @@
     "qt": {
       "description": "Allow QString values in the LOG4CXX_WARN, LOG4CXX_INFO, LOG4CXX_DEBUG etc. macros",
       "dependencies": [
-        "qt5-base"
+        {
+          "name": "qt5-base",
+          "default-features": false
+        }
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5582,7 +5582,7 @@
     },
     "log4cxx": {
       "baseline": "1.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "loguru": {
       "baseline": "2.1.0",

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69b1cd84fe4dce29fda6b300bf18ebc8de1aa0de",
+      "version": "1.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d24b9474cf8ec8bca0ec3dce1f0d9e4a030836bd",
       "version": "1.2.0",
       "port-version": 0

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a70d75f5535b91760df997dc6f0b178ad5f6c600",
+      "git-tree": "4f21c375bbebfd99eacad2f14fa6fc7e6d85efc3",
       "version": "1.2.0",
       "port-version": 0
     },

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4f21c375bbebfd99eacad2f14fa6fc7e6d85efc3",
+      "git-tree": "d24b9474cf8ec8bca0ec3dce1f0d9e4a030836bd",
       "version": "1.2.0",
       "port-version": 0
     },

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d24b9474cf8ec8bca0ec3dce1f0d9e4a030836bd",
+      "git-tree": "a70d75f5535b91760df997dc6f0b178ad5f6c600",
       "version": "1.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
