### PR TITLE
[libodb-sqlite] Fix path typo

### DIFF
--- a/ports/libodb-sqlite/CMakeLists.txt
+++ b/ports/libodb-sqlite/CMakeLists.txt
@@ -47,7 +47,7 @@ if(LIBODB_INSTALL_HEADERS)
     )
     install(
         FILES config.unix.h.in
-        DESTINATION include/odb/sqlite/detail
+        DESTINATION include/odb/sqlite/details
         COMPONENT sqlite
         RENAME config.h
     )

--- a/ports/libodb-sqlite/vcpkg.json
+++ b/ports/libodb-sqlite/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libodb-sqlite",
   "version": "2.4.0",
-  "port-version": 12,
+  "port-version": 13,
   "description": "Sqlite support for the ODB ORM library",
   "homepage": "https://www.codesynthesis.com/products/odb/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4882,7 +4882,7 @@
     },
     "libodb-sqlite": {
       "baseline": "2.4.0",
-      "port-version": 12
+      "port-version": 13
     },
     "libofx": {
       "baseline": "0.10.9",

--- a/versions/l-/libodb-sqlite.json
+++ b/versions/l-/libodb-sqlite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "853c419533939b4d0c0c2a2f0047165e66348c30",
+      "version": "2.4.0",
+      "port-version": 13
+    },
+    {
       "git-tree": "02dc624090eb462a27ba05eb1f0851911c724d95",
       "version": "2.4.0",
       "port-version": 12


### PR DESCRIPTION
This PR updates an existing port.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.