### PR TITLE
[skia] update to m131

### DIFF
--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -3,15 +3,15 @@ include("${CMAKE_CURRENT_LIST_DIR}/skia-functions.cmake")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/skia
-    REF "501e9efaa2fc929ec67c44da6dbaf9335264b559"
-    SHA512 978af9894d23d7b97d95d402bbf6c0c1401d63990361aae80166b620b0aa06d9dc2c75537850ff4c2df539735b4a12713cb29840613a15cbbff68590c48c4fac
+    REF "94631d9b9a10697325589e1642af63a0137cac94"
+    SHA512 c866b79229851e20af97d314ffefbaa921e00a815b9be7e67946490879a4ac9c0d32e18e5a441414df1bea18547c621c845b356ce759fcf7047d36aebf253b64
     PATCHES
         disable-msvc-env-setup.patch
         # disable-dev-test.patch
-        skia-include-string.patch
+        # skia-include-string.patch
         bentleyottmann-build.patch
         graphite.patch
-        vulkan-headers.patch
+        # vulkan-headers.patch
         pdfsubsetfont-uwp.diff
 )
 
@@ -32,12 +32,12 @@ declare_external_from_git(d3d12allocator
 )
 declare_external_from_git(dawn
     URL "https://dawn.googlesource.com/dawn.git"
-    REF "db1fa936ad0a58846f179c81cdf60f55267099b9"
+    REF "f3c7cc5c580eb743829c78bb77df0c1e8f6a6ce3"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(dng_sdk
     URL "https://android.googlesource.com/platform/external/dng_sdk.git"
-    REF "679499cc9b92cfb0ae1dccbfd7e97ce719d23576"
+    REF "c8d0c9b1d16bfda56f15165d39e0ffa360a11123"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(jinja2
@@ -62,12 +62,12 @@ declare_external_from_git(spirv-cross
 )
 declare_external_from_git(spirv-headers
     URL "https://github.com/KhronosGroup/SPIRV-Headers.git"
-    REF "1b75a4ae0b4289014b4c369301dc925c366f78a6"
+    REF "50bc4debdc3eec5045edbeb8ce164090e29b91f3"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(spirv-tools
     URL "https://github.com/KhronosGroup/SPIRV-Tools.git"
-    REF "87fcbaf1bc8346469e178711eff27cfd20aa1960"
+    REF "42b315c15b1ff941b46bb3949c105e5386be8717"
     LICENSE_FILE LICENSE
 )
 declare_external_from_git(wuffs

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "skia",
-  "version": "129",
-  "port-version": 2,
+  "version": "131",
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8381,8 +8381,8 @@
       "port-version": 0
     },
     "skia": {
-      "baseline": "129",
-      "port-version": 2
+      "baseline": "131",
+      "port-version": 0
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a0a752d35fcc9bddbb8963a8cb63374cd0df9c8d",
+      "version": "131",
+      "port-version": 0
+    },
+    {
       "git-tree": "942c0f5227b85eb96fad153a7b57c12debb33b4c",
       "version": "129",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.