### PR TITLE
[libmodplug] Fix build failure with clang-19

### DIFF
--- a/ports/libmodplug/portfile.cmake
+++ b/ports/libmodplug/portfile.cmake
@@ -17,13 +17,7 @@ vcpkg_from_github(
         005-fix-install-paths.patch # https://github.com/Konstanty/libmodplug/pull/61
 )
 
-set(EXTRA_OPTIONS "")
-
-if(VCPKG_TARGET_IS_EMSCRIPTEN)
-    list(APPEND EXTRA_OPTIONS "-DCMAKE_CXX_STANDARD=11")
-elseif(VCPKG_TARGET_IS_ANDROID)
-    list(APPEND EXTRA_OPTIONS "-DCMAKE_CXX_STANDARD=11")
-endif()
+set(EXTRA_OPTIONS "-DCMAKE_CXX_STANDARD=11")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libmodplug/vcpkg.json
+++ b/ports/libmodplug/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmodplug",
   "version": "0.8.9.0",
-  "port-version": 13,
+  "port-version": 14,
   "description": "The ModPlug mod file playing library.",
   "homepage": "https://github.com/Konstanty/libmodplug",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4798,7 +4798,7 @@
     },
     "libmodplug": {
       "baseline": "0.8.9.0",
-      "port-version": 13
+      "port-version": 14
     },
     "libmorton": {
       "baseline": "0.2.12",

--- a/versions/l-/libmodplug.json
+++ b/versions/l-/libmodplug.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff73830b584f9c52036cfa1d31b12cf936beabe8",
+      "version": "0.8.9.0",
+      "port-version": 14
+    },
+    {
       "git-tree": "c8e3d0af1af8bb778f772c0a8d59a3c99ec663c1",
       "version": "0.8.9.0",
       "port-version": 13

--- a/versions/l-/libmodplug.json
+++ b/versions/l-/libmodplug.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "24e042bf1e6d517ef9bbb83229c541d3e1cdaf3c",
+      "git-tree": "c8e3d0af1af8bb778f772c0a8d59a3c99ec663c1",
       "version": "0.8.9.0",
       "port-version": 13
     },

--- a/versions/l-/libmodplug.json
+++ b/versions/l-/libmodplug.json
@@ -6,7 +6,7 @@
       "port-version": 14
     },
     {
-      "git-tree": "c8e3d0af1af8bb778f772c0a8d59a3c99ec663c1",
+      "git-tree": "24e042bf1e6d517ef9bbb83229c541d3e1cdaf3c",
       "version": "0.8.9.0",
       "port-version": 13
     },


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
