### PR TITLE
[fmt] Add feature unicode to control FMT_UNICODE

### DIFF
--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -9,9 +9,15 @@ vcpkg_from_github(
         fix-pass-utf-8-only-if-the-compiler-is-MSVC-at-build.patch # remove in next release
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+        unicode    FMT_UNICODE
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DFMT_CMAKE_DIR=share/fmt
         -DFMT_TEST=OFF
         -DFMT_DOC=OFF

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -17,7 +17,7 @@
   ],
   "features": {
     "unicode": {
-      "description": "Enable Unicode support, default value is ON"
+      "description": "Disable Unicode support."
     }
   }
 }

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fmt",
   "version": "11.0.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "{fmt} is an open-source formatting library providing a fast and safe alternative to C stdio and C++ iostreams.",
   "homepage": "https://github.com/fmtlib/fmt",
   "license": "MIT",
@@ -14,5 +14,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "unicode": {
+      "description": "Enable Unicode support, default value is ON"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2854,7 +2854,7 @@
     },
     "fmt": {
       "baseline": "11.0.2",
-      "port-version": 1
+      "port-version": 2
     },
     "folly": {
       "baseline": "2024.10.28.00",

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "aef3fe08c15db956ce3675575bb4cebf2e2701d6",
+      "git-tree": "73f60944a6c042f6990a53682a4e205314477a84",
       "version": "11.0.2",
       "port-version": 2
     },

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aef3fe08c15db956ce3675575bb4cebf2e2701d6",
+      "version": "11.0.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "07a73a7565e5de9eb42e90c16c133bdfdfebbcda",
       "version": "11.0.2",
       "port-version": 1


### PR DESCRIPTION
Fixes #41879, add a feature to control `FMT_UNICODE`, due to the default value set by upstream is ON, so add this feature to `INVERTED_FEATURES`. Someone could install this feature to disable `FMT_UNICODE`.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Feature passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```
