### PR TITLE
[igraph] update to 0.10.15

### DIFF
--- a/ports/igraph/portfile.cmake
+++ b/ports/igraph/portfile.cmake
@@ -4,9 +4,9 @@
 #  - The release tarball contains pre-generated parser sources, which eliminates the dependency on bison/flex.
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/igraph/igraph/releases/download/0.10.13/igraph-0.10.13.tar.gz"
-    FILENAME "igraph-0.10.13.tar.gz"
-    SHA512 2b6f5b219713c12114066c1a2a5a60d79665b77b27900c9cb06ab80e86088e96ef64a941fb4615e86833e60dfe7d9d4e13d850205391721e27acc6cc498da2fd
+    URLS "https://github.com/igraph/igraph/releases/download/0.10.15/igraph-0.10.15.tar.gz"
+    FILENAME "igraph-0.10.15.tar.gz"
+    SHA512 bf9f0f2f62618cf037bdbbf2e126d27ec4e45edfb65efcf26df3fc1fb71a3e1f05a8b9a62f972650d96daa1e7bd3f2a084fe39bbca42e808cc737165514276e0
 )
 
 vcpkg_extract_source_archive(

--- a/ports/igraph/vcpkg.json
+++ b/ports/igraph/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "igraph",
-  "version": "0.10.13",
+  "version": "0.10.15",
   "description": "igraph is a C library for network analysis and graph theory, with an emphasis on efficiency portability and ease of use.",
   "homepage": "https://igraph.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3657,7 +3657,7 @@
       "port-version": 0
     },
     "igraph": {
-      "baseline": "0.10.13",
+      "baseline": "0.10.15",
       "port-version": 0
     },
     "iir1": {

--- a/versions/i-/igraph.json
+++ b/versions/i-/igraph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8d7f26d7f84453184d67529391c51effd999e85",
+      "version": "0.10.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "42ba83fca57e6096a63886deb6f68d6e1e96c2ff",
       "version": "0.10.13",
       "port-version": 0


### PR DESCRIPTION
Unchecked boxes below do not apply.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

