### PR TITLE
[sqlite3] Provide official target SQLite::SQLite3

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -74,16 +74,18 @@ if(NOT SQLITE3_SKIP_TOOLS)
     )
 endif()
 
+set_target_properties(sqlite3 PROPERTIES EXPORT_NAME SQLite3)
+
 install(
     TARGETS sqlite3
-    EXPORT unofficial-sqlite3-targets
+    EXPORT sqlite3-targets
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
 )
 
 install(FILES sqlite3.h sqlite3ext.h sqlite3-vcpkg-config.h DESTINATION include CONFIGURATIONS Release)
-install(EXPORT unofficial-sqlite3-targets NAMESPACE unofficial::sqlite3:: FILE unofficial-sqlite3-targets.cmake DESTINATION share/unofficial-sqlite3)
+install(EXPORT sqlite3-targets NAMESPACE SQLite:: DESTINATION share/sqlite3)
 
 configure_file(sqlite3.pc.in sqlite3.pc @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sqlite3.pc" DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -94,6 +94,8 @@ configure_file(
     @ONLY
 )
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-sqlite3-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}")
+
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -80,7 +80,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT} CONFIG_PATH share/unofficial-${PORT})
+vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
@@ -90,7 +90,7 @@ endif()
 
 configure_file(
     "${CMAKE_CURRENT_LIST_DIR}/sqlite3-config.in.cmake"
-    "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-sqlite3-config.cmake"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake"
     @ONLY
 )
 

--- a/ports/sqlite3/sqlite3-config.in.cmake
+++ b/ports/sqlite3/sqlite3-config.in.cmake
@@ -4,4 +4,30 @@ if(NOT WIN32)
     find_dependency(Threads)
 endif()
 
-include(${CMAKE_CURRENT_LIST_DIR}/unofficial-sqlite3-targets.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/sqlite3-targets.cmake)
+
+# Refer to https://gitlab.kitware.com/cmake/cmake/-/blob/v3.30.0/Modules/FindSQLite3.cmake.
+cmake_policy(PUSH)
+if(POLICY CMP0159)
+    cmake_policy(SET CMP0159 NEW) # file(STRINGS) with REGEX updates CMAKE_MATCH_<n>
+endif()
+
+get_target_property(SQLite3_INCLUDE_DIRS SQLite::SQLite3 INTERFACE_INCLUDE_DIRECTORIES)
+set(SQLite3_LIBRARIES SQLite::SQLite3)
+
+# Look for the necessary header
+find_path(SQLite3_INCLUDE_DIR NAMES sqlite3.h
+    HINTS ${SQLite3_INCLUDE_DIRS}
+)
+mark_as_advanced(SQLite3_INCLUDE_DIR)
+# Extract version information from the header file
+if(SQLite3_INCLUDE_DIR)
+    file(STRINGS ${SQLite3_INCLUDE_DIR}/sqlite3.h _ver_line
+        REGEX "^#define SQLITE_VERSION  *\"[0-9]+\\.[0-9]+\\.[0-9]+\""
+        LIMIT_COUNT 1)
+    string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+"
+        SQLite3_VERSION "${_ver_line}")
+    unset(_ver_line)
+endif()
+
+cmake_policy(POP)

--- a/ports/sqlite3/unofficial-sqlite3-config.cmake
+++ b/ports/sqlite3/unofficial-sqlite3-config.cmake
@@ -1,0 +1,5 @@
+include(${CMAKE_CURRENT_LIST_DIR}/../sqlite3/sqlite3-config.cmake)
+
+if(NOT TARGET unofficial::sqlite3::sqlite3 AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+    add_library(unofficial::sqlite3::sqlite3 ALIAS SQLite::SQLite3)
+endif()

--- a/ports/sqlite3/usage
+++ b/ports/sqlite3/usage
@@ -1,5 +1,5 @@
 sqlite3 provides pkgconfig bindings.
 sqlite3 provides CMake targets:
 
-    find_package(unofficial-sqlite3 CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE unofficial::sqlite3::sqlite3)
+    find_package(SQLite3 REQUIRED)
+    target_link_libraries(main PRIVATE SQLite::SQLite3)

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlite3",
   "version": "3.47.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://sqlite.org/",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8606,7 +8606,7 @@
     },
     "sqlite3": {
       "baseline": "3.47.0",
-      "port-version": 2
+      "port-version": 3
     },
     "sqlitecpp": {
       "baseline": "3.3.2",

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aef36cdb692a3196df0a1dae2093bfdff0065d82",
+      "version": "3.47.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "543d6067a10a7ab97a4893997afaee4d34230a27",
       "version": "3.47.0",
       "port-version": 2

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "aef36cdb692a3196df0a1dae2093bfdff0065d82",
+      "git-tree": "137c177530aa08c9fff3431844d5f4948c8d3438",
       "version": "3.47.0",
       "port-version": 3
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #31659.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
