### PR TITLE
[vcpkg] Simplify cmake invokation in bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -211,14 +211,14 @@ else
     rm -rf "$baseBuildDir"
     mkdir -p "$buildDir"
     vcpkgExtractTar "$tarballPath" "$srcBaseDir"
-    cmakeConfigOptions="-DCMAKE_BUILD_TYPE=Release -G 'Ninja' -DVCPKG_DEVELOPMENT_WARNINGS=OFF"
 
     if [ "${VCPKG_MAX_CONCURRENCY}" != "" ] ; then
-        cmakeConfigOptions=" $cmakeConfigOptions '-DCMAKE_JOB_POOL_COMPILE:STRING=compile' '-DCMAKE_JOB_POOL_LINK:STRING=link' '-DCMAKE_JOB_POOLS:STRING=compile=$VCPKG_MAX_CONCURRENCY;link=$VCPKG_MAX_CONCURRENCY' "
+        cmake -S "${srcDir}" -B "${buildDir}" --preset "bootstrap.sh parallel build" || exit 1
+    else
+        cmake -S "${srcDir}" -B "${buildDir}" --preset "bootstrap.sh" || exit 1
     fi
 
-    (cd "$buildDir" && eval cmake "$srcDir" $cmakeConfigOptions) || exit 1
-    (cd "$buildDir" && cmake --build .) || exit 1
+    cmake --build "${buildDir}" || exit 1
 
     rm -rf "$vcpkgRootDir/vcpkg"
     cp "$buildDir/vcpkg" "$vcpkgRootDir/"


### PR DESCRIPTION
There's a [string escaping madness in bootstrap.sh's cmake invokation around line 217, making the script difficult to maintain.

I broke it before in PR https://github.com/microsoft/vcpkg/pull/36828 which went into master undetected as it "worked over here" (tm) and isn't executed by the CI, but appearently it wouldn't work on arch linux' bash, resulting in PR https://github.com/microsoft/vcpkg/pull/37047 .

https://github.com/microsoft/vcpkg-tool/pull/1380 introduces a CMake Preset that can take over the cmake CLI variable setup.

This commit replaces the nested string composition by it's cmake-preset counterpart.

Fixes #41996.