### PR TITLE
[vcpkg] Nix-shell package pkgconfig reanamed to pkg-config

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,7 +14,7 @@
       libxkbcommon.dev
       m4
       ninja
-      pkgconfig
+      pkg-config
       zip
       zstd.dev
     ] ++ pkgs.lib.optionals withX11 [


### PR DESCRIPTION
Fixes #41986
Rename pkgconfig to pkg-config fix error:
````
nix-shell
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'vcpkg-shell-env'
         whose name attribute is located at /nix/store/dhsv8dalz1nm031xd6l8i085cmd0sv7q-nixpkgs/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:336:7

       … while evaluating attribute 'shellHook' of derivation 'vcpkg-shell-env'

         at /nix/store/dhsv8dalz1nm031xd6l8i085cmd0sv7q-nixpkgs/nixpkgs/pkgs/build-support/build-fhsenv-bubblewrap/default.nix:279:7:

          278|     env = runCommandLocal "${name}-shell-env" {
          279|       shellHook = bwrapCmd {};
             |       ^
          280|     } ''

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: 'pkgconfig' has been renamed to/replaced by 'pkg-config'
````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [ ] ~~Only one version is added to each modified port's versions file.~~
