### PR TITLE
[armadillo] Update to 14.0.3

### DIFF
--- a/ports/armadillo/portfile.cmake
+++ b/ports/armadillo/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO arma
     FILENAME "armadillo-${VERSION}.tar.xz"
-    SHA512 567ed608098258749cf133022810c9296985ddd9d4dcce4eb00a938cbe8e767774d96cd030ba8c719e62895913e294b17299e4e8c064103b1f6f051021ee9e57
+    SHA512 55ee45be41ca240783edfd61f647401b0a32826850be82f5e957873c18de0dce87fc39d35e5f6363475ed912c3b1d08ff31151f25378d262d840aa6f15163ac8
     PATCHES
         cmake-config.patch
         dependencies.patch

--- a/ports/armadillo/vcpkg.json
+++ b/ports/armadillo/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "armadillo",
-  "version": "12.8.4",
-  "port-version": 2,
+  "version": "14.0.3",
   "description": "Armadillo is a high quality linear algebra library (matrix maths) for the C++ language, aiming towards a good balance between speed and ease of use",
   "homepage": "https://arma.sourceforge.net/",
   "license": "Apache-2.0",

--- a/versions/a-/armadillo.json
+++ b/versions/a-/armadillo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03e566acea662b5629f125afdb2a2b96fa486ae5",
+      "version": "14.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "fd4e4c985c16061bf656f3bb01fe020c22f67d02",
       "version": "12.8.4",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -233,8 +233,8 @@
       "port-version": 0
     },
     "armadillo": {
-      "baseline": "12.8.4",
-      "port-version": 2
+      "baseline": "14.0.3",
+      "port-version": 0
     },
     "arpack-ng": {
       "baseline": "3.9.1",


### PR DESCRIPTION
Resolves #41319

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux