### PR TITLE
[mongo-c-driver,libbson] update to 1.29.0

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 08ebc8a4ebe3249fe74ebe564b6e0ce965b8601eb6d76d4b667e80e135a5cc390a03d198e2c18cfb9816c09be53ac769dccd6aea35c4ab317f4d2b964d0176fd
+    SHA512 7fe1319c0d845bfd0e59f59d5fe27869372e490f512f44c38657cb5f94bec48886919f2ccfeb09864d6359710b9b885d3ec12f7ab7e7c6429fa54b285df5e67f
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/mongo-c-driver/disable-dynamic-when-static.patch
+++ b/ports/mongo-c-driver/disable-dynamic-when-static.patch
@@ -1,25 +1,27 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1fe4c76..96be699 100644
+index 3a40f52..d080479 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -354,11 +354,9 @@ if (USE_SYSTEM_LIBBSON)
+@@ -358,11 +358,11 @@ if (USE_SYSTEM_LIBBSON)
  
     set (USING_SYSTEM_BSON TRUE)
     if (NOT TARGET mongo::bson_shared)
 -           message (FATAL_ERROR "System libbson built without shared library target")
++
     endif ()
     set (BSON_LIBRARIES mongo::bson_shared)
     if (NOT TARGET mongo::bson_static)
 -           message (FATAL_ERROR "System libbson built without static library target")
++
     endif ()
     set (BSON_STATIC_LIBRARIES mongo::bson_static)
  endif ()
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index 74c541f..737e566 100644
+index fcab819..be0bfb2 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -826,7 +826,7 @@ set (
-    "${SOURCE_DIR}/src/uthash"
+@@ -889,7 +889,7 @@ set (
+    "${mongo-c-driver_SOURCE_DIR}/src/uthash"
  )
  
 -if (ENABLE_SHARED)
@@ -27,7 +29,7 @@ index 74c541f..737e566 100644
     add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
     if(WIN32)
        # Add resource-definition script for Windows shared library (.dll).
-@@ -902,7 +902,7 @@ if (ENABLE_SHARED)
+@@ -966,7 +966,7 @@ if (ENABLE_SHARED)
                 RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
     endif () # ENABLE_SHM_COUNTERS
  
@@ -36,7 +38,7 @@ index 74c541f..737e566 100644
  
  if (MONGOC_ENABLE_STATIC_BUILD)
     add_library (mongoc_static STATIC ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
-@@ -1272,7 +1272,7 @@ if (MONGOC_ENABLE_STATIC_INSTALL)
+@@ -1364,7 +1364,7 @@ if (MONGOC_ENABLE_STATIC_INSTALL)
     list (APPEND TARGETS_TO_INSTALL mongoc_static)
  endif ()
  
@@ -45,7 +47,7 @@ index 74c541f..737e566 100644
     list (APPEND TARGETS_TO_INSTALL mongoc_shared)
  endif ()
  
-@@ -1327,6 +1327,7 @@ endif()
+@@ -1419,6 +1419,7 @@ endif()
  set_property(TARGET ${TARGETS_TO_INSTALL} APPEND PROPERTY pkg_config_INCLUDE_DIRECTORIES "${MONGOC_HEADER_INSTALL_DIR}")
  
  # Deprecated alias for libmongoc-1.0.pc, see CDRIVER-2086.
@@ -53,7 +55,7 @@ index 74c541f..737e566 100644
  if (MONGOC_ENABLE_SSL)
     configure_file (
        ${CMAKE_CURRENT_SOURCE_DIR}/src/libmongoc-ssl-1.0.pc.in
-@@ -1337,6 +1338,7 @@ if (MONGOC_ENABLE_SSL)
+@@ -1429,6 +1430,7 @@ if (MONGOC_ENABLE_SSL)
        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
     )
  endif ()

--- a/ports/mongo-c-driver/fix-mingw.patch
+++ b/ports/mongo-c-driver/fix-mingw.patch
@@ -1,8 +1,8 @@
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index 847e073..5338bea 100644
+index be0bfb2..6e295d6 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -189,7 +189,7 @@ endfunction()
+@@ -206,7 +206,7 @@ endfunction()
  # Per-backend link libs/options:
  set(SecureTransport/LINK_LIBRARIES "-framework CoreFoundation" "-framework Security")
  set(SecureTransport/pkg_config_LIBS -framework Corefoundation -framework Security)
@@ -11,7 +11,7 @@ index 847e073..5338bea 100644
  set(SecureChannel/pkg_config_LIBS ${SecureChannel/LINK_LIBRARIES})
  set(LibreSSL/LINK_LIBRARIES LibreSSL::TLS LibreSSL::Crypto)
  set(LibreSSL/pkg_config_LIBS -ltls -lcrypto)
-@@ -340,7 +340,7 @@ function(_use_sasl libname)
+@@ -357,7 +357,7 @@ function(_use_sasl libname)
     target_link_libraries(_mongoc-dependencies INTERFACE _mongoc-sasl_backend)
     install(TARGETS _mongoc-sasl_backend EXPORT mongoc-targets)
     if(libname STREQUAL "SSPI")
@@ -21,7 +21,7 @@ index 847e073..5338bea 100644
     elseif(libname STREQUAL "CYRUS")
        find_package(SASL2 2.0 REQUIRED)
 diff --git a/src/libmongoc/src/mongoc/mongoc-client.c b/src/libmongoc/src/mongoc/mongoc-client.c
-index 15517e6..00cd017 100644
+index 80f15f8..28a0742 100644
 --- a/src/libmongoc/src/mongoc/mongoc-client.c
 +++ b/src/libmongoc/src/mongoc/mongoc-client.c
 @@ -18,8 +18,8 @@
@@ -36,7 +36,7 @@ index 15517e6..00cd017 100644
  #else
  #if defined(MONGOC_HAVE_RES_NSEARCH) || defined(MONGOC_HAVE_RES_SEARCH)
 diff --git a/src/libmongoc/src/mongoc/mongoc-socket.c b/src/libmongoc/src/mongoc/mongoc-socket.c
-index a77d805..15d39b4 100644
+index e417d7d..cccabf5 100644
 --- a/src/libmongoc/src/mongoc/mongoc-socket.c
 +++ b/src/libmongoc/src/mongoc/mongoc-socket.c
 @@ -25,7 +25,7 @@
@@ -47,9 +47,9 @@ index a77d805..15d39b4 100644
 +#include <mstcpip.h>
  #include <process.h>
  #endif
- 
+ #include <common-cmp-private.h>
 diff --git a/src/libmongoc/src/mongoc/mongoc-sspi-private.h b/src/libmongoc/src/mongoc/mongoc-sspi-private.h
-index 60996fc..3745eff 100644
+index a2df035..a1ade8a 100644
 --- a/src/libmongoc/src/mongoc/mongoc-sspi-private.h
 +++ b/src/libmongoc/src/mongoc/mongoc-sspi-private.h
 @@ -28,7 +28,7 @@ BSON_BEGIN_DECLS

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 08ebc8a4ebe3249fe74ebe564b6e0ce965b8601eb6d76d4b667e80e135a5cc390a03d198e2c18cfb9816c09be53ac769dccd6aea35c4ab317f4d2b964d0176fd
+    SHA512 7fe1319c0d845bfd0e59f59d5fe27869372e490f512f44c38657cb5f94bec48886919f2ccfeb09864d6359710b9b885d3ec12f7ab7e7c6429fa54b285df5e67f
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4325,7 +4325,7 @@
       "port-version": 4
     },
     "libbson": {
-      "baseline": "1.28.1",
+      "baseline": "1.29.0",
       "port-version": 0
     },
     "libcaer": {
@@ -6005,7 +6005,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.28.1",
+      "baseline": "1.29.0",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26a9d88eae332f1e4fa42bc3f85d81997214459a",
+      "version": "1.29.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "faf528e27ca98d05419b5a1b2638533148d19eb2",
       "version": "1.28.1",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efed020d2a1dbbfaaba8550ba154d30c79b58d33",
+      "version": "1.29.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "79cc46a3281584b2c34acf830aa2d1935481d381",
       "version": "1.28.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/41994.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All feature test passed with x64-windows triplet.
