### PR TITLE
[winreg] update to v6.3.2

### DIFF
--- a/ports/winreg/portfile.cmake
+++ b/ports/winreg/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GiovanniDicanio/WinReg
     REF "v${VERSION}"
-    SHA512 a242be16e7acf435ccd83f2becdcf8d07a63daae3801f92a7bfab8c13cd120a7eb83e30150c9eb8d0ef2fad56ea070e1a3a47da372ab600c7b6f586b30ce41fc
+    SHA512 174d5ff3c08825990663159e91b9150f5a792591a4ee9e7f08facde124e212456df8b52c3fb50239363a2a2b43986678fde3880ca81e19c4c51e0f2ebddfef8c
     HEAD_REF master
 )
 

--- a/ports/winreg/vcpkg.json
+++ b/ports/winreg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "winreg",
-  "version": "6.3.0",
+  "version": "6.3.2",
   "description": "High-level C++ wrapper around the Windows Registry C API.",
   "homepage": "https://github.com/GiovanniDicanio/WinReg",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9617,7 +9617,7 @@
       "port-version": 0
     },
     "winreg": {
-      "baseline": "6.3.0",
+      "baseline": "6.3.2",
       "port-version": 0
     },
     "winsock2": {

--- a/versions/w-/winreg.json
+++ b/versions/w-/winreg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74833e1a8a84195835e2baa33f409c60a81ddf28",
+      "version": "6.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "0fa2df0dae16abe346b4c7d2a5e00703456ef9c4",
       "version": "6.3.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/41991
Update `winreg` to the latest version v6.3.2.
No feature needs to be tested.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.