### PR TITLE
[modern-cpp-kafka] Update to v2024.07.03

### DIFF
--- a/ports/modern-cpp-kafka/portfile.cmake
+++ b/ports/modern-cpp-kafka/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO morganstanley/modern-cpp-kafka
     REF "v${VERSION}"
-    SHA512 5071ba4aeb80d94fd078df054e3a36249e2e433bda2af4c26686cd5b0615d622cfd964c7193d075cc549a572cfa5b11bc4bbab9e00de7c80ea2bbf4a9d797201
+    SHA512 a6a921cc5037baaa0632fed350b4b5a3d5d47116397ae2638f9121997dbf7842d6406a889833ae551d738cd1bb189c5cec152b14f59644aec38ac9b6b5883a0b
     HEAD_REF main
 )
 

--- a/ports/modern-cpp-kafka/vcpkg.json
+++ b/ports/modern-cpp-kafka/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-cpp-kafka",
-  "version-string": "2023.03.07",
+  "version-string": "2024.07.03",
   "description": "A C++ API for Kafka clients (i.e. KafkaProducer, KafkaConsumer, AdminClient)",
   "homepage": "https://github.com/morganstanley/modern-cpp-kafka",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5997,7 +5997,7 @@
       "port-version": 6
     },
     "modern-cpp-kafka": {
-      "baseline": "2023.03.07",
+      "baseline": "2024.07.03",
       "port-version": 0
     },
     "modp-base64": {

--- a/versions/m-/modern-cpp-kafka.json
+++ b/versions/m-/modern-cpp-kafka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e842bd7d2edef40a83e26606ea4b75784c1c7bb",
+      "version-string": "2024.07.03",
+      "port-version": 0
+    },
+    {
       "git-tree": "2da384edebac3371ee02b0a1d06606e93add35d5",
       "version-string": "2023.03.07",
       "port-version": 0


### PR DESCRIPTION
Resolves #41573

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-windows