### PR TITLE
[fastlz] Update to 2024-08-02

### DIFF
--- a/ports/fastlz/portfile.cmake
+++ b/ports/fastlz/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ariya/FastLZ
-    REF c3bdfad9e0094d0fb15c12cd300e647c13dc85f9 #2021-5-10
-    SHA512 cb1c7e365e955f4cabfcb0bebf9cb57e88e81183fc0bec0713a88acee6bc3aeb31cdf8fa0b56b4b7c63f220ab7b50c299b13df15912a3b4a01ec70dd2a9513f7
+    REF b1342dabcf5257ab303743c9332fe75e9147a011 #2024-08-02
+    SHA512 a9c440c60e0d4fd9535a5438f3227e626c27ccd26cdcc9787c0dda5011b980c12ef46c7ddd2f197f6cc3bcef39755341d34214be9a508871ee3e1a24631a87b5
     HEAD_REF master
 )
 
@@ -19,4 +19,4 @@ vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.MIT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.MIT")

--- a/ports/fastlz/vcpkg.json
+++ b/ports/fastlz/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fastlz",
-  "version-date": "2021-05-10",
-  "port-version": 2,
+  "version-date": "2024-08-02",
   "description": "A lightning-fast lossless compression library",
   "homepage": "https://github.com/ariya/FastLZ",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2701,8 +2701,8 @@
       "port-version": 0
     },
     "fastlz": {
-      "baseline": "2021-05-10",
-      "port-version": 2
+      "baseline": "2024-08-02",
+      "port-version": 0
     },
     "fastor": {
       "baseline": "2021-11-22",

--- a/versions/f-/fastlz.json
+++ b/versions/f-/fastlz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a8f1e974f444b848e63429a21677172189e1836",
+      "version-date": "2024-08-02",
+      "port-version": 0
+    },
+    {
       "git-tree": "c0b4a47d599f386343ef30714e7ad2757c07e969",
       "version-date": "2021-05-10",
       "port-version": 2


### PR DESCRIPTION
Update `fastlz` to 2024-08-02. No feature needs to be tested.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
