### PR TITLE
[fastor] Update to 0.6.4

### DIFF
--- a/ports/fastor/portfile.cmake
+++ b/ports/fastor/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO romeric/Fastor
-    REF 76152e2fded7f014af969089e7d2ca966cef4d3b
-    SHA512 e2c4a267f592a7fbb92a54f7bf774a709b2a6d4a7bd3d338a20c455299a30d8352bfc6dd6c71eafa21ac70331ac0f4a86b176a56577699b82fde6f536429fb39
+    REF "V${VERSION}"
+    SHA512 6f636cf93b6fcd3fed83c4c7e4d0e762c2ca03368cc5fa38805913173a35b5919a030190744edc90e13ba4e463f1be742b1aa97b849cc48e93d9bcb6b635774a
     HEAD_REF master
 )
 
@@ -17,5 +17,5 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 

--- a/ports/fastor/vcpkg.json
+++ b/ports/fastor/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fastor",
-  "version-date": "2021-11-22",
-  "port-version": 1,
+  "version": "0.6.4",
   "description": "a high performance tensor library for modern C++",
   "homepage": "https://github.com/romeric/Fastor",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2705,8 +2705,8 @@
       "port-version": 2
     },
     "fastor": {
-      "baseline": "2021-11-22",
-      "port-version": 1
+      "baseline": "0.6.4",
+      "port-version": 0
     },
     "faudio": {
       "baseline": "24.09",

--- a/versions/f-/fastor.json
+++ b/versions/f-/fastor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ead9de02797b1c0330cc52b54ec8a5670a2020c",
+      "version": "0.6.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "8e3101dc9482791ede896790efa2116909642320",
       "version-date": "2021-11-22",
       "port-version": 1


### PR DESCRIPTION
Update `fastor` to 0.6.4. No feature needs to be tested, the usage test passed on x64-windows(header files found).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
