### PR TITLE
[cpp-pinyin] Add new port

### DIFF
--- a/ports/cpp-pinyin/portfile.cmake
+++ b/ports/cpp-pinyin/portfile.cmake
@@ -20,5 +20,9 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT} CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
+endif()
+
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/cpp-pinyin/portfile.cmake
+++ b/ports/cpp-pinyin/portfile.cmake
@@ -1,14 +1,14 @@
 vcpkg_from_github(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO wolfgitpr/cpp-pinyin
-        REF  "${VERSION}"
-        SHA512 cdd78cdc493ab352bfd7c5adfb4642bc587fb26f65b4d81a07e7c89c377222a30730f3e800f028106b66cbc35e32709c1a0e470e9737b6ee9718e3ce9da8137a
-        HEAD_REF main
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wolfgitpr/cpp-pinyin
+    REF  "${VERSION}"
+    SHA512 cdd78cdc493ab352bfd7c5adfb4642bc587fb26f65b4d81a07e7c89c377222a30730f3e800f028106b66cbc35e32709c1a0e470e9737b6ee9718e3ce9da8137a
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
         -DCPP_PINYIN_BUILD_STATIC=FALSE
         -DCPP_PINYIN_BUILD_TESTS=FALSE
         -DVCPKG_DICT_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}
@@ -16,7 +16,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT} CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
@@ -24,5 +24,5 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
 endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/cpp-pinyin/portfile.cmake
+++ b/ports/cpp-pinyin/portfile.cmake
@@ -6,23 +6,29 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DCPP_PINYIN_BUILD_STATIC=FALSE
-        -DCPP_PINYIN_BUILD_TESTS=FALSE
-        -DVCPKG_DICT_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}
-)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+            -DCPP_PINYIN_BUILD_STATIC=TRUE
+            -DCPP_PINYIN_BUILD_TESTS=FALSE
+            -DVCPKG_DICT_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}
+    )
+elseif (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+            -DCPP_PINYIN_BUILD_STATIC=FALSE
+            -DCPP_PINYIN_BUILD_TESTS=FALSE
+            -DVCPKG_DICT_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}
+    )
+endif()
 
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
-endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/cpp-pinyin/portfile.cmake
+++ b/ports/cpp-pinyin/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO wolfgitpr/cpp-pinyin
+        REF  "${VERSION}"
+        SHA512 cdd78cdc493ab352bfd7c5adfb4642bc587fb26f65b4d81a07e7c89c377222a30730f3e800f028106b66cbc35e32709c1a0e470e9737b6ee9718e3ce9da8137a
+        HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+        -DCPP_PINYIN_BUILD_STATIC=FALSE
+        -DCPP_PINYIN_BUILD_TESTS=FALSE
+        -DVCPKG_DICT_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT} CONFIG_PATH lib/cmake/${PORT})
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/cpp-pinyin/portfile.cmake
+++ b/ports/cpp-pinyin/portfile.cmake
@@ -6,23 +6,15 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    vcpkg_cmake_configure(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
-            -DCPP_PINYIN_BUILD_STATIC=TRUE
-            -DCPP_PINYIN_BUILD_TESTS=FALSE
-            -DVCPKG_DICT_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}
-    )
-elseif (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    vcpkg_cmake_configure(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
-            -DCPP_PINYIN_BUILD_STATIC=FALSE
-            -DCPP_PINYIN_BUILD_TESTS=FALSE
-            -DVCPKG_DICT_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}
-    )
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CPP_PINYIN_BUILD_STATIC)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCPP_PINYIN_BUILD_STATIC=${CPP_PINYIN_BUILD_STATIC}
+        -DCPP_PINYIN_BUILD_TESTS=FALSE
+        "-DVCPKG_DICT_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
 
 vcpkg_cmake_install()
 

--- a/ports/cpp-pinyin/usage
+++ b/ports/cpp-pinyin/usage
@@ -1,16 +1,16 @@
 cpp-pinyin provides CMake targets:
 
-find_package(cpp-pinyin CONFIG REQUIRED)
-target_link_libraries(main PRIVATE cpp-pinyin::cpp-pinyin)
+    find_package(cpp-pinyin CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE cpp-pinyin::cpp-pinyin)
 
-To use the library, you need to copy the dictionary files to the binary directory.
+    To use the library, you need to copy the dictionary files to the binary directory.
 
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/cpp-pinyin/dict
-    $<TARGET_FILE_DIR:${PROJECT_NAME}>/dict
-)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/cpp-pinyin/dict
+        $<TARGET_FILE_DIR:${PROJECT_NAME}>/dict
+    )
 
-To generate your own dictionary files, you can use the pinyin-makedict tool provided by cpp-pinyin.
+    To generate your own dictionary files, you can use the pinyin-makedict tool provided by cpp-pinyin.
 
-https://github.com/wolfgitpr/pinyin-makedict
+    https://github.com/wolfgitpr/pinyin-makedict

--- a/ports/cpp-pinyin/usage
+++ b/ports/cpp-pinyin/usage
@@ -1,16 +1,12 @@
 cpp-pinyin provides CMake targets:
 
-    find_package(cpp-pinyin CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE cpp-pinyin::cpp-pinyin)
+  find_package(cpp-pinyin CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE cpp-pinyin::cpp-pinyin)
 
-    To use the library, you need to copy the dictionary files to the binary directory.
+To use the library, you need to copy the dictionary files to the binary directory.
 
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/cpp-pinyin/dict
-        $<TARGET_FILE_DIR:${PROJECT_NAME}>/dict
-    )
-
-    To generate your own dictionary files, you can use the pinyin-makedict tool provided by cpp-pinyin.
-
-    https://github.com/wolfgitpr/pinyin-makedict
+  add_custom_command(TARGET main POST_BUILD
+      COMMAND "${CMAKE_COMMAND}" -E copy_directory
+        "${cpp-pinyin_DIR}/dict"
+        "$<TARGET_FILE_DIR:main>/dict"
+  )

--- a/ports/cpp-pinyin/usage
+++ b/ports/cpp-pinyin/usage
@@ -1,0 +1,16 @@
+cpp-pinyin provides CMake targets:
+
+find_package(cpp-pinyin CONFIG REQUIRED)
+target_link_libraries(main PRIVATE cpp-pinyin::cpp-pinyin)
+
+To use the library, you need to copy the dictionary files to the binary directory.
+
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/cpp-pinyin/dict
+    $<TARGET_FILE_DIR:${PROJECT_NAME}>/dict
+)
+
+To generate your own dictionary files, you can use the pinyin-makedict tool provided by cpp-pinyin.
+
+https://github.com/wolfgitpr/pinyin-makedict

--- a/ports/cpp-pinyin/vcpkg.json
+++ b/ports/cpp-pinyin/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "cpp-pinyin",
+  "version": "1.0.0",
+  "homepage": "https://github.com/wolfgitpr/cpp-pinyin",
+  "description": "A lightweight Chinese/Cantonese to Pinyin library.",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/cpp-pinyin/vcpkg.json
+++ b/ports/cpp-pinyin/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "cpp-pinyin",
   "version": "1.0.0",
-  "homepage": "https://github.com/wolfgitpr/cpp-pinyin",
   "description": "A lightweight Chinese/Cantonese to Pinyin library.",
+  "homepage": "https://github.com/wolfgitpr/cpp-pinyin",
   "license": "Apache-2.0",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1920,6 +1920,10 @@
       "baseline": "1.9.0",
       "port-version": 0
     },
+    "cpp-pinyin": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "cpp-redis": {
       "baseline": "4.3.1",
       "port-version": 5

--- a/versions/c-/cpp-pinyin.json
+++ b/versions/c-/cpp-pinyin.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "65ed5e970724ce8a265398fe39f3a346f7a06d52",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/cpp-pinyin.json
+++ b/versions/c-/cpp-pinyin.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "65ed5e970724ce8a265398fe39f3a346f7a06d52",
+      "git-tree": "01820c37c425c0c99bd1d32ba8b26fe115661cb2",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/c-/cpp-pinyin.json
+++ b/versions/c-/cpp-pinyin.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "01820c37c425c0c99bd1d32ba8b26fe115661cb2",
+      "git-tree": "c4bab2c85575f31dcd749b2fdf2b49eb9ad57a3e",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/c-/cpp-pinyin.json
+++ b/versions/c-/cpp-pinyin.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c4bab2c85575f31dcd749b2fdf2b49eb9ad57a3e",
+      "git-tree": "63bc214f34d1acbbbdcd3a8307b1020d70b2e653",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/c-/cpp-pinyin.json
+++ b/versions/c-/cpp-pinyin.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "63bc214f34d1acbbbdcd3a8307b1020d70b2e653",
+      "git-tree": "f3a4b0cc31a8acaecebdee019de6f0a07b45037a",
       "version": "1.0.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
