### PR TITLE
[cpp-kana] Add new port

### DIFF
--- a/ports/cpp-kana/portfile.cmake
+++ b/ports/cpp-kana/portfile.cmake
@@ -19,5 +19,9 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
+endif ()
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/cpp-kana/portfile.cmake
+++ b/ports/cpp-kana/portfile.cmake
@@ -1,27 +1,23 @@
 vcpkg_from_github(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO wolfgitpr/cpp-kana
-        REF "${VERSION}"
-        SHA512 b1e992f7172f080f74612e515713c3fd74d15d25d088923b834563c6ee06155bb0b073a39a480e82cb6d87c4066b10e65d45f913e26975ece88bf1f4d24dcc2b
-        HEAD_REF main
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wolfgitpr/cpp-kana
+    REF "${VERSION}"
+    SHA512 b1e992f7172f080f74612e515713c3fd74d15d25d088923b834563c6ee06155bb0b073a39a480e82cb6d87c4066b10e65d45f913e26975ece88bf1f4d24dcc2b
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
         -DCPP_KANA_BUILD_STATIC=FALSE
         -DCPP_KANA_BUILD_TESTS=FALSE
 )
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT} CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
-endif()
-
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/cpp-kana/portfile.cmake
+++ b/ports/cpp-kana/portfile.cmake
@@ -28,9 +28,5 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
-endif ()
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/cpp-kana/portfile.cmake
+++ b/ports/cpp-kana/portfile.cmake
@@ -6,21 +6,14 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    vcpkg_cmake_configure(
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CPP_KANA_BUILD_STATIC)
+
+vcpkg_cmake_configure(
         SOURCE_PATH "${SOURCE_PATH}"
         OPTIONS
-            -DCPP_KANA_BUILD_STATIC=TRUE
-            -DCPP_KANA_BUILD_TESTS=FALSE
-    )
-elseif (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    vcpkg_cmake_configure(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
-            -DCPP_KANA_BUILD_STATIC=FALSE
-            -DCPP_KANA_BUILD_TESTS=FALSE
-    )
-endif()
+        -DCPP_KANA_BUILD_STATIC=${CPP_KANA_BUILD_STATIC}
+        -DCPP_KANA_BUILD_TESTS=FALSE
+)
 
 vcpkg_cmake_install()
 

--- a/ports/cpp-kana/portfile.cmake
+++ b/ports/cpp-kana/portfile.cmake
@@ -9,8 +9,8 @@ vcpkg_from_github(
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CPP_KANA_BUILD_STATIC)
 
 vcpkg_cmake_configure(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
         -DCPP_KANA_BUILD_STATIC=${CPP_KANA_BUILD_STATIC}
         -DCPP_KANA_BUILD_TESTS=FALSE
 )

--- a/ports/cpp-kana/portfile.cmake
+++ b/ports/cpp-kana/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO wolfgitpr/cpp-kana
+        REF "${VERSION}"
+        SHA512 b1e992f7172f080f74612e515713c3fd74d15d25d088923b834563c6ee06155bb0b073a39a480e82cb6d87c4066b10e65d45f913e26975ece88bf1f4d24dcc2b
+        HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+        -DCPP_KANA_BUILD_STATIC=FALSE
+        -DCPP_KANA_BUILD_TESTS=FALSE
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT} CONFIG_PATH lib/cmake/${PORT})
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
+endif()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/cpp-kana/portfile.cmake
+++ b/ports/cpp-kana/portfile.cmake
@@ -6,12 +6,21 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DCPP_KANA_BUILD_STATIC=FALSE
-        -DCPP_KANA_BUILD_TESTS=FALSE
-)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+            -DCPP_KANA_BUILD_STATIC=TRUE
+            -DCPP_KANA_BUILD_TESTS=FALSE
+    )
+elseif (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+            -DCPP_KANA_BUILD_STATIC=FALSE
+            -DCPP_KANA_BUILD_TESTS=FALSE
+    )
+endif()
 
 vcpkg_cmake_install()
 

--- a/ports/cpp-kana/usage
+++ b/ports/cpp-kana/usage
@@ -1,0 +1,4 @@
+cpp-kana provides CMake targets:
+
+find_package(cpp-kana CONFIG REQUIRED)
+target_link_libraries(main PRIVATE cpp-kana::cpp-kana)

--- a/ports/cpp-kana/usage
+++ b/ports/cpp-kana/usage
@@ -1,4 +1,4 @@
 cpp-kana provides CMake targets:
 
-find_package(cpp-kana CONFIG REQUIRED)
-target_link_libraries(main PRIVATE cpp-kana::cpp-kana)
+  find_package(cpp-kana CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE cpp-kana::cpp-kana)

--- a/ports/cpp-kana/vcpkg.json
+++ b/ports/cpp-kana/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "cpp-kana",
+  "version": "1.0.0",
+  "homepage": "https://github.com/wolfgitpr/cpp-kana",
+  "description": "A lightweight library for converting Japanese kana to romaji and vice versa.",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/cpp-kana/vcpkg.json
+++ b/ports/cpp-kana/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "cpp-kana",
   "version": "1.0.0",
-  "homepage": "https://github.com/wolfgitpr/cpp-kana",
   "description": "A lightweight library for converting Japanese kana to romaji and vice versa.",
+  "homepage": "https://github.com/wolfgitpr/cpp-kana",
   "license": "Apache-2.0",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1912,6 +1912,10 @@
       "baseline": "2022-08-27",
       "port-version": 1
     },
+    "cpp-kana": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "cpp-netlib": {
       "baseline": "0.13.0",
       "port-version": 9

--- a/versions/c-/cpp-kana.json
+++ b/versions/c-/cpp-kana.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b06e248630897fcb1a137ec0da074917c26975e6",
+      "git-tree": "d6073cf169a88525234ef873cb21b236c73feca9",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/c-/cpp-kana.json
+++ b/versions/c-/cpp-kana.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d6073cf169a88525234ef873cb21b236c73feca9",
+      "git-tree": "d3fad821868122c31e65a8f085edd08ebcefa1cb",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/c-/cpp-kana.json
+++ b/versions/c-/cpp-kana.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d3fad821868122c31e65a8f085edd08ebcefa1cb",
+      "git-tree": "6eda2f3f76b28b4454d608f8407dda45a548c099",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/c-/cpp-kana.json
+++ b/versions/c-/cpp-kana.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e3d7c570c24d52780d8691697e605a3dfe84afb6",
+      "git-tree": "3c40e472b035db22e89f35a71853e0cab277e1a1",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/c-/cpp-kana.json
+++ b/versions/c-/cpp-kana.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3c40e472b035db22e89f35a71853e0cab277e1a1",
+      "git-tree": "b06e248630897fcb1a137ec0da074917c26975e6",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/c-/cpp-kana.json
+++ b/versions/c-/cpp-kana.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e3d7c570c24d52780d8691697e605a3dfe84afb6",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
