### PR TITLE
[Do not merge] Test migration to Actions demonstration PR

### DIFF
--- a/.github/workflows/test_modified_ports.yml
+++ b/.github/workflows/test_modified_ports.yml
@@ -1,3 +1,4 @@
+# This is an edit to demonstrate that PRs are working
 name: Test Modified Ports
 on:
   push:


### PR DESCRIPTION
We are looking to move everything to Actions to:

* Address compliance burden the vcpkg team currently has to keep dev.azure.com/vcpkg alive.
* Make it so that GitHub contributors don't need to click 5 times to get their build failure logs.
* Make it easier to generate console output that makes for a better PR experience for contributors in the future.

Known limitations:

* GitHub Actions has no equivalent to the test run telemetry originally contributed by @dg0yt .
* GitHub Actions makes temporary edits to test e.g. a subset of triplets more difficult.