### PR TITLE
[vcpkg baseline][sdl3] Improve port

### DIFF
--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -39,18 +39,16 @@ vcpkg_cmake_configure(
         -DSDL_LIBC=ON
         -DSDL_TEST_LIBRARY=OFF
         -DSDL_TESTS=OFF
-        # Speficying the revision skips the need to use git to determine a version
-        -DSDL_REVISION=SDL-${VERSION}
+        -DSDL_INSTALL_CMAKEDIR_ROOT=share/${PORT}
+        # Specifying the revision skips the need to use git to determine a version
+        -DSDL_REVISION=vcpkg
+        -DCMAKE_DISABLE_FIND_PACKAGE_LibUSB=1
     MAYBE_UNUSED_VARIABLES
         SDL_FORCE_STATIC_VCRT
 )
 
 vcpkg_cmake_install()
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
-else()
-    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/SDL3)
-endif()
+vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
@@ -61,4 +59,6 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt"
+    COMMENT "Some configurations may use code licensed under the MIT and Apache-2.0 licenses."
+)

--- a/ports/sdl3/usage
+++ b/ports/sdl3/usage
@@ -1,4 +1,4 @@
 sdl3 provides CMake targets:
 
-    find_package(SDL3 CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE SDL3::SDL3)
+  find_package(SDL3 CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE SDL3::SDL3)

--- a/ports/sdl3/vcpkg.json
+++ b/ports/sdl3/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "sdl3",
   "version": "3.1.6-preview",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
-  "license": "Zlib",
+  "license": "Zlib AND MIT AND Apache-2.0",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8218,7 +8218,7 @@
     },
     "sdl3": {
       "baseline": "3.1.6-preview",
-      "port-version": 0
+      "port-version": 1
     },
     "seacas": {
       "baseline": "2022-11-22",

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fc1dd65862da2cf2770e2540136da1f89b493cda",
+      "version": "3.1.6-preview",
+      "port-version": 1
+    },
+    {
       "git-tree": "13a8f95b66218cead5be81f83a049a7d4cc266f8",
       "version": "3.1.6-preview",
       "port-version": 0


### PR DESCRIPTION
Don't pick libusb. Fixes installation order problem (blocking #42045).
Elaborate license info.
Cleanup.