### PR TITLE
[tomsolver] Add new port

### DIFF
--- a/ports/tomsolver/portfile.cmake
+++ b/ports/tomsolver/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tomwillow/tomsolver
+    REF "${VERSION}"
+    SHA512 332301dc8df2756818e709655f726193dd424fb04fba2e18b4264fa078120a6da9cc6a164c930a440439b1b34f7f6a8afc9263db5e8c16e6cd99391296ab0296
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tomsolver/vcpkg.json
+++ b/ports/tomsolver/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "tomsolver",
+  "version": "1.0.0",
+  "description": "Simplest, Well-tested, Non-linear equations solver library.",
+  "homepage": "https://github.com/tomwillow/tomsolver",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9080,6 +9080,10 @@
       "baseline": "3.4.0",
       "port-version": 0
     },
+    "tomsolver": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "torch-th": {
       "baseline": "2019-04-19",
       "port-version": 4

--- a/versions/t-/tomsolver.json
+++ b/versions/t-/tomsolver.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ca6ebeda0ee3996867907f8948cb722480696a04",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
