### PR TITLE
[libmediainfo] update to 24.11

### DIFF
--- a/ports/libmediainfo/portfile.cmake
+++ b/ports/libmediainfo/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MediaArea/MediaInfoLib
     REF "v${MEDIAINFO_VERSION}"
-    SHA512 179b71638d519a90f5ac0737c9f676dcc72eb89a4566d48f6bce98bc6d91c38bf55a204d9a0ddbced8a7c9019ef31edbef488f9d23a3d49aad6b20d7fb27aff6
+    SHA512 51b940f577aa88d24d00dcf00cc90dfb7e8fb38e19c96517bea59ffb92877b7c8af9dcc0d93e152c707ce06725958e43dd8f64b85f099140fc8f536cea5b21b5
     HEAD_REF master
     PATCHES
         msvc-arm.diff

--- a/ports/libmediainfo/vcpkg.json
+++ b/ports/libmediainfo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmediainfo",
-  "version": "24.6",
+  "version": "24.11",
   "description": "Get most relevant technical and tag data from video and audio files",
   "homepage": "https://github.com/MediaArea/MediaInfoLib",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4773,7 +4773,7 @@
       "port-version": 0
     },
     "libmediainfo": {
-      "baseline": "24.6",
+      "baseline": "24.11",
       "port-version": 0
     },
     "libmesh": {

--- a/versions/l-/libmediainfo.json
+++ b/versions/l-/libmediainfo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "294f2cfc21bf3881eeb3ce4c968998aa6db6adfb",
+      "version": "24.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "3f1131145a40572e714a0289ed63f6183863a31d",
       "version": "24.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
