### PR TITLE
[Luau] Add new port to luau

### DIFF
--- a/ports/luau/cmake-config-export.patch
+++ b/ports/luau/cmake-config-export.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 51fa919e..8231c1e3 100644
+index 51fa919e..d25cca2d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -65,30 +65,30 @@ add_library(Luau.VM.Internals INTERFACE)
@@ -48,7 +48,30 @@ index 51fa919e..8231c1e3 100644
  target_link_libraries(Luau.VM PUBLIC Luau.Common)
  
  target_include_directories(isocline PUBLIC extern/isocline/include)
-@@ -287,3 +287,54 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.EqSat Luau.Cod
+@@ -182,22 +182,6 @@ if(MSVC AND LUAU_BUILD_CLI)
+     set_target_properties(Luau.Repl.CLI PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
+ endif()
+ 
+-# embed .natvis inside the library debug information
+-if(MSVC)
+-    target_link_options(Luau.Ast INTERFACE /NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/tools/natvis/Ast.natvis)
+-    target_link_options(Luau.Analysis INTERFACE /NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/tools/natvis/Analysis.natvis)
+-    target_link_options(Luau.CodeGen INTERFACE /NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/tools/natvis/CodeGen.natvis)
+-    target_link_options(Luau.VM INTERFACE /NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/tools/natvis/VM.natvis)
+-endif()
+-
+-# make .natvis visible inside the solution
+-if(MSVC_IDE)
+-    target_sources(Luau.Ast PRIVATE tools/natvis/Ast.natvis)
+-    target_sources(Luau.Analysis PRIVATE tools/natvis/Analysis.natvis)
+-    target_sources(Luau.CodeGen PRIVATE tools/natvis/CodeGen.natvis)
+-    target_sources(Luau.VM PRIVATE tools/natvis/VM.natvis)
+-endif()
+-
+ # On Windows and Android threads are provided, on Linux/Mac/iOS we use pthreads
+ add_library(osthreads INTERFACE)
+ if(CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin|iOS")
+@@ -287,3 +271,54 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.EqSat Luau.Cod
          endif()
      endif()
  endforeach()

--- a/ports/luau/cmake-config-export.patch
+++ b/ports/luau/cmake-config-export.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 51fa919e..9cf8754a 100644
+index 51fa919e..9854f32c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -65,30 +65,30 @@ add_library(Luau.VM.Internals INTERFACE)
@@ -123,7 +123,7 @@ index 51fa919e..9cf8754a 100644
 +
 +install(
 +    EXPORT unofficial-luau-targets
-+    NAMESPACE unofficial-luau::
++    NAMESPACE unofficial::luau::
 +    DESTINATION "${CMAKE_INSTALL_DATADIR}/unofficial-luau"
 +)
 \ No newline at end of file

--- a/ports/luau/cmake-config-export.patch
+++ b/ports/luau/cmake-config-export.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 51fa919e..d25cca2d 100644
+index 51fa919e..9cf8754a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -65,30 +65,30 @@ add_library(Luau.VM.Internals INTERFACE)
@@ -81,20 +81,20 @@ index 51fa919e..d25cca2d 100644
 +include(CMakePackageConfigHelpers)
 +
 +write_basic_package_version_file(
-+  ${CMAKE_CURRENT_BINARY_DIR}/luau-config-version.cmake
++  ${CMAKE_CURRENT_BINARY_DIR}/unofficial-luau-config-version.cmake
 +  VERSION "${VERSION}"
 +  COMPATIBILITY AnyNewerVersion
 +)
 +
 +install(FILES
-+  ${CMAKE_CURRENT_BINARY_DIR}/luau-config-version.cmake
-+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/luau-config.cmake
-+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/luau
++  ${CMAKE_CURRENT_BINARY_DIR}/unofficial-luau-config-version.cmake
++  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/unofficial-luau-config.cmake
++  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unofficial-luau
 +)
 +
 +install(
 +  TARGETS Luau.Common Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.VM Luau.CLI.lib Luau.EqSat
-+  EXPORT luau-targets
++  EXPORT unofficial-luau-targets
 +  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 +  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 +  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -103,7 +103,7 @@ index 51fa919e..d25cca2d 100644
 +if (LUAU_BUILD_CLI)
 +    install(
 +        TARGETS Luau.Repl.CLI
-+        EXPORT luau-targets
++        EXPORT unofficial-luau-targets
 +        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 +    )
 +endif()
@@ -122,16 +122,16 @@ index 51fa919e..d25cca2d 100644
 +)
 +
 +install(
-+    EXPORT luau-targets
-+    NAMESPACE luau::
-+    DESTINATION "${CMAKE_INSTALL_DATADIR}/luau"
++    EXPORT unofficial-luau-targets
++    NAMESPACE unofficial-luau::
++    DESTINATION "${CMAKE_INSTALL_DATADIR}/unofficial-luau"
 +)
 \ No newline at end of file
-diff --git a/cmake/luau-config.cmake b/cmake/luau-config.cmake
+diff --git a/cmake/unofficial-luau-config.cmake b/cmake/unofficial-luau-config.cmake
 new file mode 100644
-index 00000000..fd681158
+index 00000000..2680ef31
 --- /dev/null
-+++ b/cmake/luau-config.cmake
++++ b/cmake/unofficial-luau-config.cmake
 @@ -0,0 +1 @@
-+include(${CMAKE_CURRENT_LIST_DIR}/luau-targets.cmake)
++include(${CMAKE_CURRENT_LIST_DIR}/unofficial-luau-targets.cmake)
 \ No newline at end of file

--- a/ports/luau/cmake-config-export.patch
+++ b/ports/luau/cmake-config-export.patch
@@ -1,0 +1,114 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 51fa919e..8231c1e3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -65,30 +65,30 @@ add_library(Luau.VM.Internals INTERFACE)
+ 
+ include(Sources.cmake)
+ 
+-target_include_directories(Luau.Common INTERFACE Common/include)
++target_include_directories(Luau.Common INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Common/include> $<INSTALL_INTERFACE:include/luau>)
+ 
+ target_compile_features(Luau.CLI.lib PUBLIC cxx_std_17)
+ target_link_libraries(Luau.CLI.lib PRIVATE Luau.Common)
+ 
+ target_compile_features(Luau.Ast PUBLIC cxx_std_17)
+-target_include_directories(Luau.Ast PUBLIC Ast/include)
++target_include_directories(Luau.Ast PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Ast/include> $<INSTALL_INTERFACE:include/luau>)
+ target_link_libraries(Luau.Ast PUBLIC Luau.Common Luau.CLI.lib)
+ 
+ target_compile_features(Luau.Compiler PUBLIC cxx_std_17)
+-target_include_directories(Luau.Compiler PUBLIC Compiler/include)
++target_include_directories(Luau.Compiler PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Compiler/include> $<INSTALL_INTERFACE:include/luau>)
+ target_link_libraries(Luau.Compiler PUBLIC Luau.Ast)
+ 
+ target_compile_features(Luau.Config PUBLIC cxx_std_17)
+-target_include_directories(Luau.Config PUBLIC Config/include)
++target_include_directories(Luau.Config PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Config/include> $<INSTALL_INTERFACE:include/luau>)
+ target_link_libraries(Luau.Config PUBLIC Luau.Ast)
+ 
+ target_compile_features(Luau.Analysis PUBLIC cxx_std_17)
+-target_include_directories(Luau.Analysis PUBLIC Analysis/include)
++target_include_directories(Luau.Analysis PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Analysis/include> $<INSTALL_INTERFACE:include/luau>)
+ target_link_libraries(Luau.Analysis PUBLIC Luau.Ast Luau.EqSat Luau.Config)
+ target_link_libraries(Luau.Analysis PRIVATE Luau.Compiler Luau.VM)
+ 
+ target_compile_features(Luau.EqSat PUBLIC cxx_std_17)
+-target_include_directories(Luau.EqSat PUBLIC EqSat/include)
++target_include_directories(Luau.EqSat PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/EqSat/include> $<INSTALL_INTERFACE:include/luau>)
+ target_link_libraries(Luau.EqSat PUBLIC Luau.Common)
+ 
+ target_compile_features(Luau.CodeGen PRIVATE cxx_std_17)
+@@ -97,7 +97,7 @@ target_link_libraries(Luau.CodeGen PRIVATE Luau.VM Luau.VM.Internals) # Code gen
+ target_link_libraries(Luau.CodeGen PUBLIC Luau.Common)
+ 
+ target_compile_features(Luau.VM PRIVATE cxx_std_11)
+-target_include_directories(Luau.VM PUBLIC VM/include)
++target_include_directories(Luau.VM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/VM/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ target_link_libraries(Luau.VM PUBLIC Luau.Common)
+ 
+ target_include_directories(isocline PUBLIC extern/isocline/include)
+@@ -287,3 +287,54 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.EqSat Luau.Cod
+         endif()
+     endif()
+ endforeach()
++
++# luau package
++include(GNUInstallDirs)
++include(CMakePackageConfigHelpers)
++
++write_basic_package_version_file(
++  ${CMAKE_CURRENT_BINARY_DIR}/luau-config-version.cmake
++  VERSION "${VERSION}"
++  COMPATIBILITY AnyNewerVersion
++)
++
++install(FILES
++  ${CMAKE_CURRENT_BINARY_DIR}/luau-config-version.cmake
++  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/luau-config.cmake
++  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/luau
++)
++
++install(
++  TARGETS Luau.Common Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.VM Luau.CLI.lib Luau.EqSat
++  EXPORT luau-targets
++  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++)
++
++if (LUAU_BUILD_CLI)
++    install(
++        TARGETS Luau.Repl.CLI
++        EXPORT luau-targets
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++    )
++endif()
++
++install(
++    DIRECTORY "${CMAKE_SOURCE_DIR}/Common/include/"
++    DIRECTORY "${CMAKE_SOURCE_DIR}/Ast/include/"
++    DIRECTORY "${CMAKE_SOURCE_DIR}/Compiler/include/"
++    DIRECTORY "${CMAKE_SOURCE_DIR}/Config/include/"
++    DIRECTORY "${CMAKE_SOURCE_DIR}/Analysis/include/"
++    DIRECTORY "${CMAKE_SOURCE_DIR}/VM/include/"
++    DIRECTORY "${CMAKE_SOURCE_DIR}/VM/src/"
++    DESTINATION "include/luau"
++    FILES_MATCHING
++    PATTERN "*.h"
++)
++
++install(
++    EXPORT luau-targets
++    NAMESPACE luau::
++    DESTINATION "${CMAKE_INSTALL_DATADIR}/luau"
++)
+\ No newline at end of file
+diff --git a/cmake/luau-config.cmake b/cmake/luau-config.cmake
+new file mode 100644
+index 00000000..fd681158
+--- /dev/null
++++ b/cmake/luau-config.cmake
+@@ -0,0 +1 @@
++include(${CMAKE_CURRENT_LIST_DIR}/luau-targets.cmake)
+\ No newline at end of file

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -1,0 +1,39 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO luau-lang/luau
+    REF ${VERSION}
+    SHA512 a3be52f7958d364693c0bc2541b08082852917b53a80cc4fbdde3167c9068b269f8476882592eafac4c4d674ed6d51ba25a52eaa3b2b6d4dce4603f6aad73f6b
+    HEAD_REF master
+    PATCHES
+        cmake-config-export.patch
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tool LUAU_BUILD_CLI
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DVERSION=${VERSION}
+        ${FEATURE_OPTIONS}
+    OPTIONS_DEBUG
+        -DLUAU_BUILD_CLI=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "luau")
+
+if("tool" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES luau AUTO_CLEAN)
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -27,7 +27,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME "luau")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "unofficial-luau")
 
 if("tool" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES luau AUTO_CLEAN)

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,0 +1,22 @@
+{
+    "name": "luau",
+    "version": "0.651",
+    "homepage": "https://github.com/luau-lang/luau",
+    "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
+    "license": "MIT",
+    "dependencies": [
+      {
+        "name" : "vcpkg-cmake",
+        "host" : true
+      },
+      {
+        "name" : "vcpkg-cmake-config",
+        "host" : true
+      }
+    ],
+    "features": {
+        "tool": {
+          "description": "Builds luau executable"
+        }
+      }
+  }

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,22 +1,22 @@
 {
-    "name": "luau",
-    "version": "0.651",
-    "homepage": "https://github.com/luau-lang/luau",
-    "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
-    "license": "MIT",
-    "dependencies": [
-      {
-        "name" : "vcpkg-cmake",
-        "host" : true
-      },
-      {
-        "name" : "vcpkg-cmake-config",
-        "host" : true
-      }
-    ],
-    "features": {
-        "tool": {
-          "description": "Builds luau executable"
-        }
-      }
+  "name": "luau",
+  "version": "0.651",
+  "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
+  "homepage": "https://github.com/luau-lang/luau",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tool": {
+      "description": "Builds luau executable"
+    }
   }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5652,6 +5652,10 @@
       "baseline": "3.1.0",
       "port-version": 1
     },
+    "luau": {
+        "baseline": "0.651",
+        "port-version": 0
+    },
     "luminoengine": {
       "baseline": "0.10.1",
       "port-version": 1

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -3,7 +3,7 @@
         {
             "version": "0.651",
             "port-version": 0,
-            "git-tree": "ea1bcb7db02b46fd51b187ba76532c766f23e9cb"
+            "git-tree": "a23f8560e6018c863faca47bcdaef7511609a466"
         }
     ]
 }

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,0 +1,9 @@
+{
+    "versions": [
+        {
+            "version": "0.651",
+            "port-version": 0,
+            "git-tree": "e8a14d5b095aedfe2071a9ffd3f0a90b90ff2627"
+        }
+    ]
+}

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -3,7 +3,7 @@
         {
             "version": "0.651",
             "port-version": 0,
-            "git-tree": "d2659a9d95140fe63073a421d3d4b0f9e90b0628"
+            "git-tree": "ea1bcb7db02b46fd51b187ba76532c766f23e9cb"
         }
     ]
 }

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -3,7 +3,7 @@
         {
             "version": "0.651",
             "port-version": 0,
-            "git-tree": "a23f8560e6018c863faca47bcdaef7511609a466"
+            "git-tree": "e5b08b966d05df7229b83ff5f46fb3d4f1ed34b1"
         }
     ]
 }

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -3,7 +3,7 @@
         {
             "version": "0.651",
             "port-version": 0,
-            "git-tree": "e5b08b966d05df7229b83ff5f46fb3d4f1ed34b1"
+            "git-tree": "b24888fd538d5e53526c0a7b6f37646f9aec0556"
         }
     ]
 }

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -3,7 +3,7 @@
         {
             "version": "0.651",
             "port-version": 0,
-            "git-tree": "e8a14d5b095aedfe2071a9ffd3f0a90b90ff2627"
+            "git-tree": "d2659a9d95140fe63073a421d3d4b0f9e90b0628"
         }
     ]
 }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

