### PR TITLE
 [matio] Merge mat73 and hdf5 features with mat73 name

### DIFF
--- a/ports/matio/portfile.cmake
+++ b/ports/matio/portfile.cmake
@@ -11,10 +11,10 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        hdf5            MATIO_WITH_HDF5
+        mat73           MATIO_WITH_HDF5
+        mat73           MATIO_MAT73
         zlib            MATIO_WITH_ZLIB
         extended-sparse MATIO_EXTENDED_SPARSE
-        mat73           MATIO_MAT73
         pic             MATIO_PIC
 )
 

--- a/ports/matio/vcpkg.json
+++ b/ports/matio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "matio",
   "version": "1.5.27",
+  "port-version": 1,
   "description": "MATLAB MAT File I/O Library",
   "homepage": "https://github.com/tbeu/matio",
   "license": "BSD-2-Clause",
@@ -11,15 +12,15 @@
     }
   ],
   "default-features": [
-    "hdf5",
+    "mat73",
     "zlib"
   ],
   "features": {
     "extended-sparse": {
       "description": "Enable extended sparse matrix data types not supported in MATLAB"
     },
-    "hdf5": {
-      "description": "Check for HDF5 library",
+    "mat73": {
+      "description": "Enable support for version 7.3 MAT files using the HDF5 library",
       "dependencies": [
         {
           "name": "hdf5",
@@ -30,18 +31,6 @@
           "default-features": false,
           "features": [
             "zlib"
-          ]
-        }
-      ]
-    },
-    "mat73": {
-      "description": "Enable support for version 7.3 MAT files",
-      "dependencies": [
-        {
-          "name": "matio",
-          "default-features": false,
-          "features": [
-            "hdf5"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5802,7 +5802,7 @@
     },
     "matio": {
       "baseline": "1.5.27",
-      "port-version": 0
+      "port-version": 1
     },
     "matplotlib-cpp": {
       "baseline": "2020-08-27",

--- a/versions/m-/matio.json
+++ b/versions/m-/matio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5365545edb3db0730c490d4b03dcb84e8f7839dd",
+      "version": "1.5.27",
+      "port-version": 1
+    },
+    {
       "git-tree": "d841cddf1c82ca09a7f7b465219e6d5fd32b9db4",
       "version": "1.5.27",
       "port-version": 0


### PR DESCRIPTION
This is just a proposal, but I thought it was easier to discuss with a concrete change proposal rather than a issue.

`matio` enables the `hdf5` feature by default, while the `mat73` feature is disabled by default. I think this may be misleading, as the `hdf5` features does nothing  at the code level unless `mat73` is also enabled. As enabling `mat73` does not add any additional dependency to the build, to fix the problem I think we can just add `mat73` to the default features of the `matio` vcpkg port.

For reference:
* https://github.com/tbeu/matio/blob/v1.5.27/README#L78-L82
* https://github.com/tbeu/matio/blob/v1.5.27/cmake/options.cmake#L12
* https://github.com/tbeu/matio/blob/v1.5.27/src/matio_private.h#L75

See https://github.com/ami-iit/matio-cpp/issues/84 for an example of confusion that this PR want to fix.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


