### PR TITLE
[curl] wolfssl and openssl features can install alongside

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -44,14 +44,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         websockets  CURL_DISABLE_WEBSOCKETS
 )
 
-# Add warning on build failuer when using wolfssl and openssl features togther.
-if("openssl" IN_LIST FEATURES AND "wolfssl" IN_LIST FEATURES)
-    message(WARNING "Adding OpenSSL and WolfSSL simultaneously will result in a build failure. \
-                     Please remove one of these features from your build process.\
-                     If you are using OpenSSL version 1.1, you may disregard this warning."
-    )
-endif()
-
 set(OPTIONS "")
 
 if("sectransp" IN_LIST FEATURES)

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "curl",
   "version": "8.11.0",
+  "port-version": 1,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",

--- a/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-curl/vcpkg.json
@@ -33,7 +33,8 @@
         "gsasl",
         "mbedtls",
         "openssl",
-        "psl"
+        "psl",
+        "wolfssl"
       ],
       "platform": "!uwp"
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2134,7 +2134,7 @@
     },
     "curl": {
       "baseline": "8.11.0",
-      "port-version": 0
+      "port-version": 1
     },
     "curlcpp": {
       "baseline": "3.1",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ef1763f3cbe570d6378632c9b5793479c37fb07",
+      "version": "8.11.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c7272ca5021fc2b6a404911e1c0055fa08992463",
       "version": "8.11.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
