### PR TITLE
[vcpkg baseline][otl] update hash for 4.0.476 download

### DIFF
--- a/ports/otl/portfile.cmake
+++ b/ports/otl/portfile.cmake
@@ -2,8 +2,8 @@ set(OTL_VERSION 40476)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "http://otl.sourceforge.net/otlv4_${OTL_VERSION}.zip"
-    FILENAME "otlv4_${OTL_VERSION}-9485a0fe15a7-1.zip"
-    SHA512 ef43695b4c97d953bd997ba2381ae37ae067efb99a14479e93f502e3ad5d651829a9712bd14698c8663f733114861f6e2ae2277ed0967fad1ac2a068825a9e38
+    FILENAME "otlv4_${OTL_VERSION}-9485a0fe15a7-2.zip"
+    SHA512 adb84bc6bc29de01b41d63a59174a7d35bde8124dc602d0687abbb308c5d5471869fe9afc90fb80e4c1acbe94e5b92c6ef7058e89aed60fe4519c82826d2aeb5
 )
 
 vcpkg_extract_source_archive(

--- a/ports/otl/vcpkg.json
+++ b/ports/otl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "otl",
   "version": "4.0.476",
+  "port-version": 1,
   "description": "Oracle, Odbc and DB2-CLI Template Library",
   "homepage": "http://otl.sourceforge.net/",
   "license": "ISC"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6814,7 +6814,7 @@
     },
     "otl": {
       "baseline": "4.0.476",
-      "port-version": 0
+      "port-version": 1
     },
     "outcome": {
       "baseline": "2.2.9",

--- a/versions/o-/otl.json
+++ b/versions/o-/otl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6e971fcfc7eff67d88d2db91b2a949045107ddd",
+      "version": "4.0.476",
+      "port-version": 1
+    },
+    {
       "git-tree": "065115c4c16167e62e04d0e3aad6b7d0e66b8a65",
       "version": "4.0.476",
       "port-version": 0


### PR DESCRIPTION
<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

<!-- END OF PORT UPDATE CHECKLIST (delete this line) -->
