### PR TITLE
[opencv2] Use DEBUG_POSTFIX in pkgconfig files

### DIFF
--- a/ports/opencv2/0021-pkgconfig-suffix.patch
+++ b/ports/opencv2/0021-pkgconfig-suffix.patch
@@ -1,0 +1,15 @@
+--- a/cmake/OpenCVGenPkgconfig.cmake
++++ b/cmake/OpenCVGenPkgconfig.cmake
+@@ -54,6 +54,12 @@ foreach(CVLib ${OpenCV_LIB_COMPONENTS})
+     set(libname "${CVLib}")
+   endif()
+ 
++  string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type)
++  get_target_property(libsuffix ${CVLib} ${build_type}_POSTFIX)
++  if(libsuffix)
++    string(APPEND libname "${libsuffix}")
++  endif()
++
+   set(libpath "\${exec_prefix}/${OPENCV_LIB_INSTALL_PATH}")
+   list(APPEND OpenCV_LIB_COMPONENTS_ "-L${libpath}")
+   list(APPEND OpenCV_LIB_COMPONENTS_ "-l${libname}")

--- a/ports/opencv2/portfile.cmake
+++ b/ports/opencv2/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
       0007-fix-config.patch
       0019-fix-openexr.patch
       0020-missing-include.patch
+      0021-pkgconfig-suffix.patch
 )
 # Disallow accidental build of vendored copies
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/openexr")

--- a/ports/opencv2/vcpkg.json
+++ b/ports/opencv2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv2",
   "version": "2.4.13.7",
-  "port-version": 21,
+  "port-version": 22,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6638,7 +6638,7 @@
     },
     "opencv2": {
       "baseline": "2.4.13.7",
-      "port-version": 21
+      "port-version": 22
     },
     "opencv3": {
       "baseline": "3.4.18",

--- a/versions/o-/opencv2.json
+++ b/versions/o-/opencv2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "185c7b075159f3fae48b84163c487c6bfcd56c5a",
+      "version": "2.4.13.7",
+      "port-version": 22
+    },
+    {
       "git-tree": "5e1c99f5f3fe591f1d87befd960c994dab246dcc",
       "version": "2.4.13.7",
       "port-version": 21


### PR DESCRIPTION
Fixes #41962

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
