### PR TITLE
[sfml] update to 2.6.2

### DIFF
--- a/ports/sfml/fix-dep-openal.patch
+++ b/ports/sfml/fix-dep-openal.patch
@@ -1,0 +1,28 @@
+diff --git a/cmake/SFMLConfigDependencies.cmake.in b/cmake/SFMLConfigDependencies.cmake.in
+index ef96827..864b32e 100644
+--- a/cmake/SFMLConfigDependencies.cmake.in
++++ b/cmake/SFMLConfigDependencies.cmake.in
+@@ -75,6 +75,8 @@ if(SFML_STATIC_LIBRARIES)
+     # sfml-audio
+     list(FIND SFML_FIND_COMPONENTS "audio" FIND_SFML_AUDIO_COMPONENT_INDEX)
+     if(FIND_SFML_AUDIO_COMPONENT_INDEX GREATER -1)
++        find_dependency(OpenAL)
++        set(OpenAL_LIB OpenAL::OpenAL)
+         sfml_bind_dependency(TARGET OpenAL FRIENDLY_NAME "OpenAL" SEARCH_NAMES "OpenAL" "openal" "openal32")
+         if (NOT FIND_SFML_OS_IOS)
+             sfml_bind_dependency(TARGET VORBIS FRIENDLY_NAME "VorbisFile" SEARCH_NAMES "vorbisfile")
+diff --git a/src/SFML/Audio/CMakeLists.txt b/src/SFML/Audio/CMakeLists.txt
+index 8158365..3ebaf90 100644
+--- a/src/SFML/Audio/CMakeLists.txt
++++ b/src/SFML/Audio/CMakeLists.txt
+@@ -68,7 +68,9 @@ elseif(SFML_OS_ANDROID)
+ endif()
+ 
+ # find external libraries
+-find_package(OpenAL REQUIRED)
++find_package(OpenAL CONFIG REQUIRED)
++set(OpenAL_LIB OpenAL::OpenAL)
++sfml_find_package(OpenAL LINK OpenAL_LIB)
+ sfml_find_package(VORBIS INCLUDE "VORBIS_INCLUDE_DIRS" LINK "VORBIS_LIBRARIES")
+ sfml_find_package(FLAC INCLUDE "FLAC_INCLUDE_DIR" LINK "FLAC_LIBRARY")
+ 

--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO SFML/SFML
     REF "${VERSION}"
     HEAD_REF master
-    SHA512 b376d3b00277ed60d107fe1268c210749b3aafcee618a8f924b181a9b476e92b9cb9baddecf70a8913b5910c471d53ea0260a876ad7b2db2b98b944d9f508714
+    SHA512 d8a8bee3aa9acda4609104c2a9d4a2512e4be6d6e85fd4b24c287c03f60cfb888e669e61bfac4113dae35f0c3492559b65b3453baf38766d8c0223d9ab77aada
     PATCHES
         fix-dependencies.patch
 )
@@ -32,6 +32,9 @@ vcpkg_cmake_configure(
         -DSFML_GENERATE_PDB=OFF
         -DSFML_WARNINGS_AS_ERRORS=OFF #Remove in the next version
         ${FEATURE_OPTIONS}
+	MAYBE_UNUSED_VARIABLES
+	    SFML_MISC_INSTALL_PREFIX
+        SFML_WARNINGS_AS_ERRORS   
 )
 
 vcpkg_cmake_install()

--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     SHA512 d8a8bee3aa9acda4609104c2a9d4a2512e4be6d6e85fd4b24c287c03f60cfb888e669e61bfac4113dae35f0c3492559b65b3453baf38766d8c0223d9ab77aada
     PATCHES
         fix-dependencies.patch
+        fix-dep-openal.patch
 )
 
 # The embedded FindFreetype doesn't properly handle debug libraries

--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -33,9 +33,9 @@ vcpkg_cmake_configure(
         -DSFML_GENERATE_PDB=OFF
         -DSFML_WARNINGS_AS_ERRORS=OFF #Remove in the next version
         ${FEATURE_OPTIONS}
-	MAYBE_UNUSED_VARIABLES
-	    SFML_MISC_INSTALL_PREFIX
-            SFML_WARNINGS_AS_ERRORS   
+    MAYBE_UNUSED_VARIABLES
+        SFML_MISC_INSTALL_PREFIX
+        SFML_WARNINGS_AS_ERRORS
 )
 
 vcpkg_cmake_install()

--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -35,7 +35,7 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
 	MAYBE_UNUSED_VARIABLES
 	    SFML_MISC_INSTALL_PREFIX
-        SFML_WARNINGS_AS_ERRORS   
+            SFML_WARNINGS_AS_ERRORS   
 )
 
 vcpkg_cmake_install()

--- a/ports/sfml/vcpkg.json
+++ b/ports/sfml/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sfml",
-  "version": "2.6.1",
-  "port-version": 1,
+  "version": "2.6.2",
   "description": "Simple and fast multimedia library",
   "homepage": "https://github.com/SFML/SFML",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8289,8 +8289,8 @@
       "port-version": 6
     },
     "sfml": {
-      "baseline": "2.6.1",
-      "port-version": 1
+      "baseline": "2.6.2",
+      "port-version": 0
     },
     "sfsexp": {
       "baseline": "1.4.1",

--- a/versions/s-/sfml.json
+++ b/versions/s-/sfml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca45cc07122e95c4b23906ed24fca24ec2c0c719",
+      "version": "2.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "4c609b9803b2a442437fac0e707f18df8544810a",
       "version": "2.6.1",
       "port-version": 1

--- a/versions/s-/sfml.json
+++ b/versions/s-/sfml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bf19b7b3a0a35ae7dc620ded349be15be29052f0",
+      "git-tree": "16580cf264c6a8933fb657e425a5866568d4c394",
       "version": "2.6.2",
       "port-version": 0
     },

--- a/versions/s-/sfml.json
+++ b/versions/s-/sfml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ca45cc07122e95c4b23906ed24fca24ec2c0c719",
+      "git-tree": "bf19b7b3a0a35ae7dc620ded349be15be29052f0",
       "version": "2.6.2",
       "port-version": 0
     },


### PR DESCRIPTION
Updated port based on [comments](https://github.com/microsoft/vcpkg/pull/35118#issuecomment-2469326811).
Fix openal not being found when statically compiled.
```
Error		CMake Error at E:/vcpkg/installed/x64-windows-static/share/sfml/SFMLConfigDependencies.cmake:42 (set_property):
  set_property could not find TARGET OpenAL.  Perhaps it has not yet been
  created.		E:/vcpkg/installed/x64-windows-static/share/sfml/SFMLConfigDependencies.cmake	42
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test passed with x64-windows triplet.