### PR TITLE
[folly] change FastFloat dependency to config

### DIFF
--- a/ports/folly/fix-deps.patch
+++ b/ports/folly/fix-deps.patch
@@ -1,8 +1,8 @@
 diff --git a/CMake/folly-config.cmake.in b/CMake/folly-config.cmake.in
-index 0b96f0a10..ce7ce6b3f 100644
+index 0b96f0a..34f5b53 100644
 --- a/CMake/folly-config.cmake.in
 +++ b/CMake/folly-config.cmake.in
-@@ -29,10 +29,30 @@ endif()
+@@ -29,10 +29,31 @@ endif()
  set(FOLLY_LIBRARIES Folly::folly)
  
  # Find folly's dependencies
@@ -12,6 +12,7 @@ index 0b96f0a10..ce7ce6b3f 100644
 +find_dependency(glog CONFIG)
 +find_dependency(gflags CONFIG)
 +find_dependency(Libevent CONFIG)
++find_dependency(FastFloat CONFIG)
 +if (NOT @CMAKE_DISABLE_FIND_PACKAGE_Zstd@)
 +    find_dependency(zstd CONFIG)
 +endif()
@@ -36,7 +37,7 @@ index 0b96f0a10..ce7ce6b3f 100644
      context
      filesystem
 diff --git a/CMake/folly-deps.cmake b/CMake/folly-deps.cmake
-index d51f11128..776102d4d 100644
+index 6ce4c67..4b7814b 100644
 --- a/CMake/folly-deps.cmake
 +++ b/CMake/folly-deps.cmake
 @@ -35,7 +35,7 @@ else()
@@ -59,10 +60,10 @@ index d51f11128..776102d4d 100644
 -find_package(DoubleConversion MODULE REQUIRED)
 -list(APPEND FOLLY_LINK_LIBRARIES ${DOUBLE_CONVERSION_LIBRARY})
 -list(APPEND FOLLY_INCLUDE_DIRECTORIES ${DOUBLE_CONVERSION_INCLUDE_DIR})
- 
- find_package(FastFloat MODULE REQUIRED)
- list(APPEND FOLLY_INCLUDE_DIRECTORIES ${FASTFLOAT_INCLUDE_DIR})
- 
+-
+-find_package(FastFloat MODULE REQUIRED)
+-list(APPEND FOLLY_INCLUDE_DIRECTORIES ${FASTFLOAT_INCLUDE_DIR})
+-
 -find_package(Gflags MODULE)
 -set(FOLLY_HAVE_LIBGFLAGS ${LIBGFLAGS_FOUND})
 -if(LIBGFLAGS_FOUND)
@@ -71,26 +72,19 @@ index d51f11128..776102d4d 100644
 -  set(FOLLY_LIBGFLAGS_LIBRARY ${LIBGFLAGS_LIBRARY})
 -  set(FOLLY_LIBGFLAGS_INCLUDE ${LIBGFLAGS_INCLUDE_DIR})
 -endif()
-+find_package(double-conversion CONFIG REQUIRED)
-+list(APPEND FOLLY_LINK_LIBRARIES double-conversion::double-conversion)
  
 -find_package(Glog MODULE)
 -set(FOLLY_HAVE_LIBGLOG ${GLOG_FOUND})
 -list(APPEND FOLLY_LINK_LIBRARIES ${GLOG_LIBRARY})
 -list(APPEND FOLLY_INCLUDE_DIRECTORIES ${GLOG_INCLUDE_DIR})
-+find_package(glog CONFIG REQUIRED)
-+set(FOLLY_HAVE_LIBGLOG 1)
-+list(APPEND FOLLY_LINK_LIBRARIES glog::glog)
++find_package(FastFloat CONFIG REQUIRED)
++list(APPEND FOLLY_LINK_LIBRARIES FastFloat::fast_float)
  
 -find_package(LibEvent MODULE REQUIRED)
 -list(APPEND FOLLY_LINK_LIBRARIES ${LIBEVENT_LIB})
 -list(APPEND FOLLY_INCLUDE_DIRECTORIES ${LIBEVENT_INCLUDE_DIR})
-+find_package(gflags CONFIG)
-+if(TARGET gflags::gflags)
-+  set(FOLLY_HAVE_LIBGFLAGS 1)
-+  list(APPEND FOLLY_LINK_LIBRARIES gflags::gflags)
-+  set(FOLLY_LIBGFLAGS_LIBRARY gflags::gflags)
-+endif()
++find_package(double-conversion CONFIG REQUIRED)
++list(APPEND FOLLY_LINK_LIBRARIES double-conversion::double-conversion)
  
 -find_package(ZLIB MODULE)
 -set(FOLLY_HAVE_LIBZ ${ZLIB_FOUND})
@@ -98,6 +92,17 @@ index d51f11128..776102d4d 100644
 -  list(APPEND FOLLY_INCLUDE_DIRECTORIES ${ZLIB_INCLUDE_DIRS})
 -  list(APPEND FOLLY_LINK_LIBRARIES ${ZLIB_LIBRARIES})
 -  list(APPEND CMAKE_REQUIRED_LIBRARIES ${ZLIB_LIBRARIES})
++find_package(glog CONFIG REQUIRED)
++set(FOLLY_HAVE_LIBGLOG 1)
++list(APPEND FOLLY_LINK_LIBRARIES glog::glog)
++
++find_package(gflags CONFIG)
++if(TARGET gflags::gflags)
++  set(FOLLY_HAVE_LIBGFLAGS 1)
++  list(APPEND FOLLY_LINK_LIBRARIES gflags::gflags)
++  set(FOLLY_LIBGFLAGS_LIBRARY gflags::gflags)
++endif()
++
 +find_package(Libevent CONFIG REQUIRED)
 +list(APPEND FOLLY_LINK_LIBRARIES libevent::core libevent::extra)
 +if(NOT WIN32)
@@ -207,7 +212,7 @@ index d51f11128..776102d4d 100644
  endif()
  if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
    list(APPEND FOLLY_LINK_LIBRARIES "execinfo")
-@@ -301,11 +312,7 @@ endif()
+@@ -310,11 +321,7 @@ endif()
  
  add_library(folly_deps INTERFACE)
  

--- a/ports/folly/fix-deps.patch
+++ b/ports/folly/fix-deps.patch
@@ -37,7 +37,7 @@ index 0b96f0a..34f5b53 100644
      context
      filesystem
 diff --git a/CMake/folly-deps.cmake b/CMake/folly-deps.cmake
-index 6ce4c67..4b7814b 100644
+index 6ce4c67..701bb55 100644
 --- a/CMake/folly-deps.cmake
 +++ b/CMake/folly-deps.cmake
 @@ -35,7 +35,7 @@ else()
@@ -49,7 +49,7 @@ index 6ce4c67..4b7814b 100644
    COMPONENTS
      context
      filesystem
-@@ -45,40 +45,40 @@ find_package(Boost 1.51.0 MODULE
+@@ -45,40 +45,41 @@ find_package(Boost 1.51.0 MODULE
      thread
    REQUIRED
  )
@@ -71,20 +71,37 @@ index 6ce4c67..4b7814b 100644
 -  list(APPEND FOLLY_INCLUDE_DIRECTORIES ${LIBGFLAGS_INCLUDE_DIR})
 -  set(FOLLY_LIBGFLAGS_LIBRARY ${LIBGFLAGS_LIBRARY})
 -  set(FOLLY_LIBGFLAGS_INCLUDE ${LIBGFLAGS_INCLUDE_DIR})
--endif()
++
++
++find_package(double-conversion CONFIG REQUIRED)
++list(APPEND FOLLY_LINK_LIBRARIES double-conversion::double-conversion)
++
++find_package(FastFloat CONFIG REQUIRED)
++list(APPEND FOLLY_LINK_LIBRARIES FastFloat::fast_float)
++
++find_package(gflags CONFIG)
++if(TARGET gflags::gflags)
++  set(FOLLY_HAVE_LIBGFLAGS 1)
++  list(APPEND FOLLY_LINK_LIBRARIES gflags::gflags)
++  set(FOLLY_LIBGFLAGS_LIBRARY gflags::gflags)
+ endif()
  
 -find_package(Glog MODULE)
 -set(FOLLY_HAVE_LIBGLOG ${GLOG_FOUND})
 -list(APPEND FOLLY_LINK_LIBRARIES ${GLOG_LIBRARY})
 -list(APPEND FOLLY_INCLUDE_DIRECTORIES ${GLOG_INCLUDE_DIR})
-+find_package(FastFloat CONFIG REQUIRED)
-+list(APPEND FOLLY_LINK_LIBRARIES FastFloat::fast_float)
++find_package(glog CONFIG REQUIRED)
++set(FOLLY_HAVE_LIBGLOG 1)
++list(APPEND FOLLY_LINK_LIBRARIES glog::glog)
  
 -find_package(LibEvent MODULE REQUIRED)
 -list(APPEND FOLLY_LINK_LIBRARIES ${LIBEVENT_LIB})
 -list(APPEND FOLLY_INCLUDE_DIRECTORIES ${LIBEVENT_INCLUDE_DIR})
-+find_package(double-conversion CONFIG REQUIRED)
-+list(APPEND FOLLY_LINK_LIBRARIES double-conversion::double-conversion)
++find_package(Libevent CONFIG REQUIRED)
++list(APPEND FOLLY_LINK_LIBRARIES libevent::core libevent::extra)
++if(NOT WIN32)
++  list(APPEND FOLLY_LINK_LIBRARIES libevent::pthreads)
++endif()
  
 -find_package(ZLIB MODULE)
 -set(FOLLY_HAVE_LIBZ ${ZLIB_FOUND})
@@ -92,23 +109,6 @@ index 6ce4c67..4b7814b 100644
 -  list(APPEND FOLLY_INCLUDE_DIRECTORIES ${ZLIB_INCLUDE_DIRS})
 -  list(APPEND FOLLY_LINK_LIBRARIES ${ZLIB_LIBRARIES})
 -  list(APPEND CMAKE_REQUIRED_LIBRARIES ${ZLIB_LIBRARIES})
-+find_package(glog CONFIG REQUIRED)
-+set(FOLLY_HAVE_LIBGLOG 1)
-+list(APPEND FOLLY_LINK_LIBRARIES glog::glog)
-+
-+find_package(gflags CONFIG)
-+if(TARGET gflags::gflags)
-+  set(FOLLY_HAVE_LIBGFLAGS 1)
-+  list(APPEND FOLLY_LINK_LIBRARIES gflags::gflags)
-+  set(FOLLY_LIBGFLAGS_LIBRARY gflags::gflags)
-+endif()
-+
-+find_package(Libevent CONFIG REQUIRED)
-+list(APPEND FOLLY_LINK_LIBRARIES libevent::core libevent::extra)
-+if(NOT WIN32)
-+  list(APPEND FOLLY_LINK_LIBRARIES libevent::pthreads)
-+endif()
-+
 +if (CMAKE_REQUIRE_FIND_PACKAGE_ZLIB)
 +  find_package(ZLIB MODULE REQUIRED)
 +  set(FOLLY_HAVE_LIBZ ${ZLIB_FOUND})
@@ -120,7 +120,7 @@ index 6ce4c67..4b7814b 100644
  endif()
  
  find_package(OpenSSL 1.1.1 MODULE REQUIRED)
-@@ -106,25 +106,29 @@ if (LIBLZMA_FOUND)
+@@ -106,25 +107,29 @@ if (LIBLZMA_FOUND)
    list(APPEND FOLLY_LINK_LIBRARIES ${LIBLZMA_LIBRARIES})
  endif()
  
@@ -165,7 +165,7 @@ index 6ce4c67..4b7814b 100644
  endif()
  
  find_package(LibDwarf)
-@@ -135,17 +139,24 @@ find_package(Libiberty)
+@@ -135,17 +140,24 @@ find_package(Libiberty)
  list(APPEND FOLLY_LINK_LIBRARIES ${LIBIBERTY_LIBRARIES})
  list(APPEND FOLLY_INCLUDE_DIRECTORIES ${LIBIBERTY_INCLUDE_DIRS})
  
@@ -199,7 +199,7 @@ index 6ce4c67..4b7814b 100644
  
  list(APPEND FOLLY_LINK_LIBRARIES ${CMAKE_DL_LIBS})
  list(APPEND CMAKE_REQUIRED_LIBRARIES ${CMAKE_DL_LIBS})
-@@ -156,10 +167,10 @@ if (PYTHON_EXTENSIONS)
+@@ -156,10 +168,10 @@ if (PYTHON_EXTENSIONS)
  endif ()
  
  find_package(LibUnwind)
@@ -212,7 +212,7 @@ index 6ce4c67..4b7814b 100644
  endif()
  if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
    list(APPEND FOLLY_LINK_LIBRARIES "execinfo")
-@@ -310,11 +321,7 @@ endif()
+@@ -310,11 +322,7 @@ endif()
  
  add_library(folly_deps INTERFACE)
  

--- a/ports/folly/fix-libunwind.patch
+++ b/ports/folly/fix-libunwind.patch
@@ -1,8 +1,8 @@
 diff --git a/CMake/folly-deps.cmake b/CMake/folly-deps.cmake
-index 0702380..984c749 100644
+index 701bb55..e41c128 100644
 --- a/CMake/folly-deps.cmake
 +++ b/CMake/folly-deps.cmake
-@@ -99,6 +99,13 @@ if (BZIP2_FOUND)
+@@ -100,6 +100,13 @@ if (BZIP2_FOUND)
    list(APPEND FOLLY_LINK_LIBRARIES ${BZIP2_LIBRARIES})
  endif()
  
@@ -16,7 +16,7 @@ index 0702380..984c749 100644
  find_package(LibLZMA MODULE)
  set(FOLLY_HAVE_LIBLZMA ${LIBLZMA_FOUND})
  if (LIBLZMA_FOUND)
-@@ -166,12 +173,6 @@ if (PYTHON_EXTENSIONS)
+@@ -167,12 +174,6 @@ if (PYTHON_EXTENSIONS)
    find_package(Cython 0.26 REQUIRED)
  endif ()
  

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_from_github(
         fix-libunwind.patch
 )
 
+file(REMOVE "${SOURCE_PATH}/CMake/FindFastFloat.cmake")
 file(REMOVE "${SOURCE_PATH}/CMake/FindFmt.cmake")
 file(REMOVE "${SOURCE_PATH}/CMake/FindLibsodium.cmake")
 file(REMOVE "${SOURCE_PATH}/CMake/FindZstd.cmake")

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "folly",
   "version-string": "2024.11.04.00",
+  "port-version": 1,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2870,7 +2870,7 @@
     },
     "folly": {
       "baseline": "2024.11.04.00",
-      "port-version": 0
+      "port-version": 1
     },
     "font-chef": {
       "baseline": "1.1.0",
@@ -5665,8 +5665,8 @@
       "port-version": 1
     },
     "luau": {
-        "baseline": "0.651",
-        "port-version": 0
+      "baseline": "0.651",
+      "port-version": 0
     },
     "luminoengine": {
       "baseline": "0.10.1",

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad432f2e863e0a5460e7a5267f23888893ea6f2c",
+      "version-string": "2024.11.04.00",
+      "port-version": 1
+    },
+    {
       "git-tree": "399b1bcab72dccdda31bd83e2873b9cc2cf292bf",
       "version-string": "2024.11.04.00",
       "port-version": 0

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad432f2e863e0a5460e7a5267f23888893ea6f2c",
+      "git-tree": "9ca09c920d702b4156f710daf3b17ebb439bc8ba",
       "version-string": "2024.11.04.00",
       "port-version": 1
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

