### PR TITLE
[vlpp] Update to 1.2.10.2

### DIFF
--- a/ports/vlpp/portfile.cmake
+++ b/ports/vlpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vczh-libraries/Release
-    REF "1.12.10.1"
-    SHA512 8884709c919e7536b89da2cc9905a2d71260668f9ce63fa3d4f13c5cc58dd2fade481e738d756fde4c0bc3c5eb9c79db5609b03953838dfb3b964d3463b75432
+    REF "${VERSION}"
+    SHA512 327f62a03e45f90cdf84a973b097b0e7643848fe771919044c1b83635e74b26439fe96fb413d100b33ce030a013a0cb84b34597ca69de2478a4c773ba9b2ccf2
     HEAD_REF master
     PATCHES 
         fix-tool-build.patch

--- a/ports/vlpp/vcpkg.json
+++ b/ports/vlpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vlpp",
-  "version": "1.2.10.1",
+  "version": "1.2.10.2",
   "maintainers": "vczh",
   "description": "Common C++ construction, including string operation / generic container / linq / General-LR parser generator / multithreading / reflection for C++ / etc",
   "homepage": "https://github.com/vczh-libraries/Release",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5665,8 +5665,8 @@
       "port-version": 1
     },
     "luau": {
-        "baseline": "0.651",
-        "port-version": 0
+      "baseline": "0.651",
+      "port-version": 0
     },
     "luminoengine": {
       "baseline": "0.10.1",
@@ -9465,7 +9465,7 @@
       "port-version": 4
     },
     "vlpp": {
-      "baseline": "1.2.10.1",
+      "baseline": "1.2.10.2",
       "port-version": 0
     },
     "volk": {

--- a/versions/v-/vlpp.json
+++ b/versions/v-/vlpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05db8dfa678ad7f39d99d7a73d35df6e8dbf684c",
+      "version": "1.2.10.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e1b6401de0adad14cac063543dc34e7eb048beb7",
       "version": "1.2.10.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test passed with x64-windows triplet.