### PR TITLE
[lzokay] update to the latest for newer compilers

### DIFF
--- a/ports/lzokay/portfile.cmake
+++ b/ports/lzokay/portfile.cmake
@@ -2,9 +2,9 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO jackoalan/lzokay
-    REF 546a9695271e8a8b4711383f828172754fd825f2
-    SHA512 b4e96183ea52dc5ba0d88b4b9b27baa2c3e2c540b1bfd50cf7a3c2569337fbe9d73dd9939cb456d5f7459df8e10d84677d40ee33f7d524f0f5f8a723d7a70583
+    REPO AxioDL/lzokay
+    REF db2df1fcbebc2ed06c10f727f72567d40f06a2be
+    SHA512 0e0c597cb74985ef2fc3329392dadf87c0ffc84287cdb2f04e6a70d2e74dcc79732de18872ff05d0906fac2d53749c3db6f2ccd32b906f5a8b81310810eae8eb
     HEAD_REF master
 )
 

--- a/ports/lzokay/vcpkg.json
+++ b/ports/lzokay/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lzokay",
   "version-date": "2020-07-30",
-  "port-version": 2,
+  "port-version": 3,
   "description": "lzokay – MIT licensed C++ implementation of LZO compression/decompression algorithm",
   "homepage": "https://github.com/jackoalan/lzokay",
   "dependencies": [

--- a/ports/lzokay/vcpkg.json
+++ b/ports/lzokay/vcpkg.json
@@ -3,7 +3,7 @@
   "version-date": "2020-07-30",
   "port-version": 3,
   "description": "lzokay – MIT licensed C++ implementation of LZO compression/decompression algorithm",
-  "homepage": "https://github.com/jackoalan/lzokay",
+  "homepage": "https://github.com/AxioDL/lzokay",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/lzokay/vcpkg.json
+++ b/ports/lzokay/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "lzokay",
-  "version-date": "2020-07-30",
-  "port-version": 3,
+  "version-date": "2023-10-22",
   "description": "lzokay – MIT licensed C++ implementation of LZO compression/decompression algorithm",
   "homepage": "https://github.com/AxioDL/lzokay",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5706,7 +5706,7 @@
     },
     "lzokay": {
       "baseline": "2020-07-30",
-      "port-version": 2
+      "port-version": 3
     },
     "maddy": {
       "baseline": "1.3.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5705,8 +5705,8 @@
       "port-version": 9
     },
     "lzokay": {
-      "baseline": "2020-07-30",
-      "port-version": 3
+      "baseline": "2023-10-22",
+      "port-version": 0
     },
     "maddy": {
       "baseline": "1.3.0",

--- a/versions/l-/lzokay.json
+++ b/versions/l-/lzokay.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c4d0313157374f5e0b71b94f0432223f75accfd3",
+      "git-tree": "489181d9c70f9d80f622ce33000a652329d723dc",
       "version-date": "2023-10-22",
       "port-version": 0
     },

--- a/versions/l-/lzokay.json
+++ b/versions/l-/lzokay.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "8d04e6eee122ebca45dc5b9dfc0f1aed4357d310",
-      "version-date": "2020-07-30",
-      "port-version": 3
-    },
-    {
       "git-tree": "2a04a58317804702e2dc099904e39a58fb148d25",
       "version-date": "2020-07-30",
       "port-version": 2

--- a/versions/l-/lzokay.json
+++ b/versions/l-/lzokay.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c4d0313157374f5e0b71b94f0432223f75accfd3",
+      "version-date": "2023-10-22",
+      "port-version": 0
+    },
+    {
       "git-tree": "8d04e6eee122ebca45dc5b9dfc0f1aed4357d310",
       "version-date": "2020-07-30",
       "port-version": 3

--- a/versions/l-/lzokay.json
+++ b/versions/l-/lzokay.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d04e6eee122ebca45dc5b9dfc0f1aed4357d310",
+      "version-date": "2020-07-30",
+      "port-version": 3
+    },
+    {
       "git-tree": "2a04a58317804702e2dc099904e39a58fb148d25",
       "version-date": "2020-07-30",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

It's my first time to make a PR to vcpkg. If you find any mistakes, please let me know!