### PR TITLE
[bitmagic] fixed clang compilation issues

### DIFF
--- a/ports/bitmagic/fix-clang.patch
+++ b/ports/bitmagic/fix-clang.patch
@@ -1,0 +1,22 @@
+diff --git a/src/bm.h b/src/bm.h
+index 547b108..0c59785 100644
+--- a/src/bm.h
++++ b/src/bm.h
+@@ -523,7 +523,7 @@ public:
+         {
+             bvect_ = ii.bvect_;
+             if (!buf_)
+-                buf_ = bvect_->allocate_tempblock();
++                buf_ = (value_type*) bvect_->blockman_.get_allocator().alloc_bit_block();
+             buf_size_ = ii.buf_size_;
+             ::memcpy(buf_, ii.buf_, buf_size_ * sizeof(*buf_));
+             sorted_ = ii.sorted_;
+@@ -534,7 +534,7 @@ public:
+         {
+             bvect_ = ii.bvect_;
+             if (buf_)
+-                bvect_->free_tempblock(buf_);
++                bvect_->blockman_.get_allocator().free_bit_block((bm::word_t*)buf_);
+             buf_ = ii.buf_; ii.buf_ = 0;
+             buf_size_ = ii.buf_size_;
+             sorted_ = ii.sorted_;

--- a/ports/bitmagic/portfile.cmake
+++ b/ports/bitmagic/portfile.cmake
@@ -5,9 +5,10 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 d034f66b8631d09cb0be11b96f5f12dea416ef2cfca42ed7f0865aeb65102a4951821805ec65bee793541ce1a665e5d11ba4bedb0d79956c0eee6c856afb29b2
     HEAD_REF master
-
+    PATCHES
+        fix-clang.patch #https://github.com/tlk00/BitMagic/commit/fab01f43eca266bf56efb1aca659773c911a83fb
 )
 
 file(GLOB HEADER_LIST "${SOURCE_PATH}/src/*.h")
 file(INSTALL ${HEADER_LIST} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/bitmagic/vcpkg.json
+++ b/ports/bitmagic/vcpkg.json
@@ -1,6 +1,8 @@
 {
   "name": "bitmagic",
   "version": "7.13.4",
+  "port-version": 1,
   "description": "Algorithms and tools for Algebra of Sets for information retrieval, indexing of databases, scientific algorithms, ranking, clustering, unsupervised machine learning and signal processing.",
-  "homepage": "http://bitmagic.io"
+  "homepage": "http://bitmagic.io",
+  "license": "Apache-2.0"
 }

--- a/versions/b-/bitmagic.json
+++ b/versions/b-/bitmagic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14d510fa0efbea29992a891120f898df71dc746d",
+      "version": "7.13.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "98fb920eba690a2a64666a6a76e16af95a797ae8",
       "version": "7.13.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -662,7 +662,7 @@
     },
     "bitmagic": {
       "baseline": "7.13.4",
-      "port-version": 0
+      "port-version": 1
     },
     "bitserializer": {
       "baseline": "0.70",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/41935
No feature needs to be tested.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.