### PR TITLE
[rapidfuzz] update to 3.1.1

### DIFF
--- a/ports/rapidfuzz/portfile.cmake
+++ b/ports/rapidfuzz/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO maxbachmann/rapidfuzz-cpp
     REF "v${VERSION}"
-    SHA512 4e0a7e28a54612fb11eb331449aa4fdfde1fbd2bf59b295f9eb68903cd647a639fa04d71aa7a8c88ddb7be6646cd3d0f1f5400eb53644b0ae96590037e74f771
+    SHA512 204ee06c1e51b786f0a2efd32a1c2467c3bff2738e8258e6e8fe44b5569afe7c665af1051fdd05dcc98704f3045f5bd2afcba5dba3fc0b34e2facf8944478b48
     HEAD_REF master
 )
 

--- a/ports/rapidfuzz/vcpkg.json
+++ b/ports/rapidfuzz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rapidfuzz",
-  "version": "3.0.5",
+  "version": "3.1.1",
   "description": "Rapid fuzzy string matching library for C++17 using the Levenshtein Distance.",
   "homepage": "https://github.com/maxbachmann/rapidfuzz-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7793,7 +7793,7 @@
       "port-version": 0
     },
     "rapidfuzz": {
-      "baseline": "3.0.5",
+      "baseline": "3.1.1",
       "port-version": 0
     },
     "rapidhash": {

--- a/versions/r-/rapidfuzz.json
+++ b/versions/r-/rapidfuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69d16c2c7b6ebe829a69d291ae8894237c183405",
+      "version": "3.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "77721c6b7e406690a3f73db1cf0b96f4dc72b1b6",
       "version": "3.0.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.