### PR TITLE
[libavif] Remove incorrect CMake config

### DIFF
--- a/ports/libavif/portfile.cmake
+++ b/ports/libavif/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO AOMediaCodec/libavif
     REF "v${VERSION}"
     SHA512 ba72b8d02b098f361643a073361fccafd22eaac14e46dd06378d5e7acd9853538c5d166473e1de0b020de62dac25be83e42bd57ba51f675d11e2ddf155fbfa21
-    HEAD_REF master
+    HEAD_REF main
     PATCHES
         disable-source-utf8.patch
 )
@@ -19,6 +19,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DAVIF_BUILD_APPS=OFF
         -DAVIF_BUILD_TESTS=OFF
+        -DAVIF_BUILD_EXAMPLES=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_libsharpyuv=ON
         ${FEATURE_OPTIONS}
 )
@@ -32,6 +33,8 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 # Fix pkg-config files
 vcpkg_fixup_pkgconfig()
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
 
 # Remove duplicate files
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/libavif/usage
+++ b/ports/libavif/usage
@@ -1,0 +1,4 @@
+libavif provides pkg-config modules:
+
+    # Library for encoding and decoding .avif files
+    libavif

--- a/ports/libavif/vcpkg.json
+++ b/ports/libavif/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libavif",
   "version-semver": "1.1.1",
+  "port-version": 1,
   "description": "Library for encoding and decoding AVIF files",
   "homepage": "https://github.com/AOMediaCodec/libavif",
   "license": "BSD-2-Clause AND Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4330,7 +4330,7 @@
     },
     "libavif": {
       "baseline": "1.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libb2": {
       "baseline": "0.98.1",

--- a/versions/l-/libavif.json
+++ b/versions/l-/libavif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "306ec45371bf5ee5e23a6a73a995fecfce122d33",
+      "version-semver": "1.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "ad9d36286110339f45b585a1bbb330273c04edad",
       "version-semver": "1.1.1",
       "port-version": 0


### PR DESCRIPTION
Related #42112, error with `fatal error: 'avif/avif.h' file not found` that target `iavif` lost `INTERFACE_INCLUDE_DIRECTORIES` for static build.

Upstream CMake config file does not work since features (dependencies) added https://github.com/microsoft/vcpkg/commit/927bc12e31148b0d44ae9d174b96c20e3bcf08eb. Adding transitive dependencies cannot be fixed it, so remove it from usage prompt.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port usage tests pass with the following triplets:

* x64-windows
* x64-windows-static