### PR TITLE
[magic-enum] update to 0.9.7

### DIFF
--- a/ports/magic-enum/portfile.cmake
+++ b/ports/magic-enum/portfile.cmake
@@ -17,8 +17,9 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/magic_enum PACKAGE_NAME magic_enum)
+vcpkg_fixup_pkgconfig()
+
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 

--- a/ports/magic-enum/portfile.cmake
+++ b/ports/magic-enum/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/magic_enum
     REF "v${VERSION}"
-    SHA512 fa3792e9c69c57e437d6325b7659cf25e6cbdda3326ffeaf0411d9838822095b15306f322ad2ebd5ec68b905ef2aed08880d2507e7d8a8559ab3c5be6c8ce99c
+    SHA512 8b61c621ff2a6981b4ff89f7df577091ffc9382d443c061db612fb61822dbf6ef8aba69ea35d1c435dcffbd7434cb4ccc5d12bbe2deba1cf0a5316c979ee6a4b
     HEAD_REF master
 )
 

--- a/ports/magic-enum/vcpkg.json
+++ b/ports/magic-enum/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "magic-enum",
-  "version": "0.9.6",
-  "port-version": 1,
+  "version": "0.9.7",
   "description": "Header-only C++17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code.",
   "homepage": "https://github.com/Neargye/magic_enum",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5697,8 +5697,8 @@
       "port-version": 0
     },
     "magic-enum": {
-      "baseline": "0.9.6",
-      "port-version": 1
+      "baseline": "0.9.7",
+      "port-version": 0
     },
     "magic-get": {
       "baseline": "2019-09-02",

--- a/versions/m-/magic-enum.json
+++ b/versions/m-/magic-enum.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1560369a5345ca1503ddc5f9b29f62f527c1ad5d",
+      "git-tree": "dd998971fdcd05406e77a56d26e798393c918740",
       "version": "0.9.7",
       "port-version": 0
     },

--- a/versions/m-/magic-enum.json
+++ b/versions/m-/magic-enum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1560369a5345ca1503ddc5f9b29f62f527c1ad5d",
+      "version": "0.9.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "165d7cfe56b22819f778749bbd7d5b0060bbb90e",
       "version": "0.9.6",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
