### PR TITLE
[gaussianlib] Update to 2024-11-03

### DIFF
--- a/ports/gaussianlib/portfile.cmake
+++ b/ports/gaussianlib/portfile.cmake
@@ -3,12 +3,13 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO LukasBanana/GaussianLib
-    REF 9b4a163a9a97c900b0febd93e22dc1be3faf6e20
-    SHA512 f16c3cd699e30d3fbd3ef6e80f64716d72383a1f2dc073325f785b63c2ba6edc62e2a7d360eba6a92a42bf4a2ad32accd4ce3e249ee510ff5133745b897a4f55
+    REF da580773dc65eefb4369894587864384e5e0dd7e # 2024-11-03
+    SHA512 4092c9d69c15e4aca08bde140dde2e7fa919dad4cb4f9138871efd9d23cd3d672201bc65608b8a379186e5d64b14e10852323a4a243c5ccd9911b7b9589cd927
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/include/Gauss DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+file(COPY "${SOURCE_PATH}/include/Gauss" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/gaussianlib/vcpkg.json
+++ b/ports/gaussianlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gaussianlib",
-  "version-date": "2023-02-17",
+  "version-date": "2024-11-03",
   "description": "Basic linear algebra C++ library for 2D and 3D applications",
   "homepage": "https://github.com/LukasBanana/GaussianLib"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3017,7 +3017,7 @@
       "port-version": 4
     },
     "gaussianlib": {
-      "baseline": "2023-02-17",
+      "baseline": "2024-11-03",
       "port-version": 0
     },
     "gazebo": {

--- a/versions/g-/gaussianlib.json
+++ b/versions/g-/gaussianlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "01fee04f8e319ca752ed7b3acaecbba081cd4773",
+      "version-date": "2024-11-03",
+      "port-version": 0
+    },
+    {
       "git-tree": "323865bad084941748ff0e99a25d7ef090d765f4",
       "version-date": "2023-02-17",
       "port-version": 0


### PR DESCRIPTION
Update `gaussianlib` to 2024-11-03. No feature needs to be tested, the usage test passed on x64-windows (header files found).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

