### PR TITLE
Fix for VcpkgPlatformTarget default fails for ARM, ARM64, ARM64EC

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -53,8 +53,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(VcpkgPlatformTarget)' == ''">
-    <VcpkgPlatformTarget>$(Platform)</VcpkgPlatformTarget>
-    <VcpkgPlatformTarget Condition="'$(Platform)' == 'Win32'">x86</VcpkgPlatformTarget>
+    <VcpkgPlatformTarget>$(Platform.ToLower())</VcpkgPlatformTarget>
+    <VcpkgPlatformTarget Condition="'$(Platform)' == 'win32'">x86</VcpkgPlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -54,7 +54,7 @@
 
   <PropertyGroup Condition="'$(VcpkgPlatformTarget)' == ''">
     <VcpkgPlatformTarget>$(Platform.ToLower())</VcpkgPlatformTarget>
-    <VcpkgPlatformTarget Condition="'$(Platform)' == 'win32'">x86</VcpkgPlatformTarget>
+    <VcpkgPlatformTarget Condition="'$(VcpkgPlatformTarget)' == 'win32'">x86</VcpkgPlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The logic to set `VcpkgPlatformTarget` to a default triplet based on the MSBuild VC++ Platform value fails for ARM, ARM64, ARM64, etc. with the following error:

```
##[error]EXEC(0,0): Error : Invalid triplet name. Triplet names are all lowercase alphanumeric+hyphens.
```