### PR TITLE
[protobuf] Update to 5.28.3

### DIFF
--- a/ports/libprotobuf-mutator/portfile.cmake
+++ b/ports/libprotobuf-mutator/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         protobuf-cmake.patch
+        werror.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATIC_RUNTIME)

--- a/ports/libprotobuf-mutator/vcpkg.json
+++ b/ports/libprotobuf-mutator/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libprotobuf-mutator",
   "version": "1.3",
+  "port-version": 1,
   "description": "Library for structured fuzzing with protobuffers.",
   "dependencies": [
     "liblzma",

--- a/ports/libprotobuf-mutator/werror.patch
+++ b/ports/libprotobuf-mutator/werror.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2e4b78e..4541d17 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -84,7 +84,7 @@ unset(CMAKE_REQUIRED_FLAGS)
+ check_cxx_compiler_flag(-Wstring-conversion LIB_PROTO_MUTATOR_HAS_WSTRING_CONVERSION)
+ 
+ if (NOT MSVC)
+-  set(EXTRA_FLAGS "-fno-exceptions -Werror -Wall")
++  set(EXTRA_FLAGS "-fno-exceptions")
+   if (LIB_PROTO_MUTATOR_HAS_WSTRING_CONVERSION)
+     set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wstring-conversion")
+   endif()

--- a/ports/openvino/003-protobuf.patch
+++ b/ports/openvino/003-protobuf.patch
@@ -1,3 +1,27 @@
+diff --git a/src/frontends/onnx/frontend/src/frontend.cpp b/src/frontends/onnx/frontend/src/frontend.cpp
+index d4b83fee20..28272a1eda 100644
+--- a/src/frontends/onnx/frontend/src/frontend.cpp
++++ b/src/frontends/onnx/frontend/src/frontend.cpp
+@@ -2,6 +2,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ //
+ 
++#include <google/protobuf/runtime_version.h>
+ #include <google/protobuf/port_def.inc>
+ #if PROTOBUF_VERSION >= 4022000  // protobuf 4.22
+ #    define OV_PROTOBUF_ABSL_IS_USED
+diff --git a/src/frontends/paddle/src/frontend.cpp b/src/frontends/paddle/src/frontend.cpp
+index c6febe0843..5d4789ccb6 100644
+--- a/src/frontends/paddle/src/frontend.cpp
++++ b/src/frontends/paddle/src/frontend.cpp
+@@ -4,6 +4,7 @@
+ 
+ #include "openvino/frontend/paddle/frontend.hpp"
+ 
++#include <google/protobuf/runtime_version.h>
+ #include <google/protobuf/port_def.inc>
+ #if PROTOBUF_VERSION >= 4022000  // protobuf 4.22
+ #    define OV_PROTOBUF_ABSL_IS_USED
 diff --git a/thirdparty/dependencies.cmake b/thirdparty/dependencies.cmake
 index 9d7b16aeb8..af47fb99ee 100644
 --- a/thirdparty/dependencies.cmake

--- a/ports/openvino/vcpkg.json
+++ b/ports/openvino/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openvino",
   "version": "2024.4.0",
-  "port-version": 3,
+  "port-version": 4,
   "maintainers": "OpenVINO Developers <openvino@intel.com>",
   "summary": "This is a port for Open Visual Inference And Optimization toolkit for AI inference",
   "description": [

--- a/ports/protobuf/fix-arm64-msvc.patch
+++ b/ports/protobuf/fix-arm64-msvc.patch
@@ -1,8 +1,8 @@
 diff --git a/src/google/protobuf/parse_context.h b/src/google/protobuf/parse_context.h
-index 9292d517f..a1fa35066 100644
+index d40e71c1d..22ed8212d 100644
 --- a/src/google/protobuf/parse_context.h
 +++ b/src/google/protobuf/parse_context.h
-@@ -619,7 +619,7 @@ inline const char* VarintParseSlow(const char* p, uint32_t res, uint64_t* out) {
+@@ -635,7 +635,7 @@ inline const char* VarintParseSlow(const char* p, uint32_t res, uint64_t* out) {
    return tmp.first;
  }
  
@@ -11,7 +11,7 @@ index 9292d517f..a1fa35066 100644
  // Generally, speaking, the ARM-optimized Varint decode algorithm is to extract
  // and concatenate all potentially valid data bits, compute the actual length
  // of the Varint, and mask off the data bits which are not actually part of the
-@@ -850,7 +850,7 @@ static const char* VarintParseSlowArm(const char* p, uint64_t* out,
+@@ -866,7 +866,7 @@ static const char* VarintParseSlowArm(const char* p, uint64_t* out,
  // The caller must ensure that p points to at least 10 valid bytes.
  template <typename T>
  PROTOBUF_NODISCARD const char* VarintParse(const char* p, T* out) {

--- a/ports/protobuf/fix-default-proto-file-path.patch
+++ b/ports/protobuf/fix-default-proto-file-path.patch
@@ -1,8 +1,8 @@
 diff --git a/src/google/protobuf/compiler/command_line_interface.cc b/src/google/protobuf/compiler/command_line_interface.cc
-index f9e9666..d453a4c 100644
+index cd95c8b41..d4825180d 100644
 --- a/src/google/protobuf/compiler/command_line_interface.cc
 +++ b/src/google/protobuf/compiler/command_line_interface.cc
-@@ -280,12 +280,15 @@ void AddDefaultProtoPaths(
+@@ -272,12 +272,15 @@ void AddDefaultProtoPaths(
      paths->emplace_back("", std::move(include_path));
      return;
    }

--- a/ports/protobuf/fix-install-dirs.patch
+++ b/ports/protobuf/fix-install-dirs.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 540c12253..320aaf72d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,6 +13,7 @@ endif()
+ 
+ # Project
+ project(protobuf C CXX)
++include(GNUInstallDirs)
+ 
+ if(protobuf_DEPRECATED_CMAKE_SUBDIRECTORY_USAGE)
+   if(CMAKE_PROJECT_NAME STREQUAL "protobuf")

--- a/ports/protobuf/fix-static-build.patch
+++ b/ports/protobuf/fix-static-build.patch
@@ -1,21 +1,21 @@
 diff --git a/cmake/install.cmake b/cmake/install.cmake
-index 52914a8ea..e7c22ddb6 100644
+index 65765ca29..f5ad69102 100644
 --- a/cmake/install.cmake
 +++ b/cmake/install.cmake
-@@ -49,7 +49,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
-   install(TARGETS protoc EXPORT protobuf-targets
-     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc
-     BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
--  if (UNIX AND NOT APPLE)
-+  if (UNIX AND NOT APPLE AND NOT protobuf_MSVC_STATIC_RUNTIME)
-     set_property(TARGET protoc
-       PROPERTY INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
-   elseif (APPLE)
-@@ -68,7 +68,6 @@ set(protobuf_HEADERS
+@@ -61,7 +61,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
+     endforeach ()
+   endif ()
+   foreach (binary IN LISTS _protobuf_binaries)
+-    if (UNIX AND NOT APPLE)
++    if (UNIX AND NOT APPLE AND NOT protobuf_MSVC_STATIC_RUNTIME)
+       set_property(TARGET ${binary}
+         PROPERTY INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+     elseif (APPLE)
+@@ -81,7 +81,6 @@ set(protobuf_HEADERS
    ${cpp_features_proto_proto_srcs}
    ${descriptor_proto_proto_srcs}
    ${plugin_proto_proto_srcs}
 -  ${java_features_proto_proto_srcs}
  )
- foreach(_header ${protobuf_HEADERS})
-   string(FIND ${_header} "${protobuf_SOURCE_DIR}/src" _find_src)
+ if (protobuf_BUILD_LIBUPB)
+   list(APPEND protobuf_HEADERS ${libupb_hdrs})

--- a/ports/protobuf/fix-utf8-range.patch
+++ b/ports/protobuf/fix-utf8-range.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4137ce2e9..f1289e08a 100644
+index 15065d874..540c12253 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -294,6 +294,7 @@ endif (protobuf_BUILD_TESTS)
+@@ -302,6 +302,7 @@ endif (protobuf_BUILD_TESTS)
  include(${protobuf_SOURCE_DIR}/cmake/abseil-cpp.cmake)
  
  if (protobuf_BUILD_PROTOBUF_BINARIES)
@@ -11,20 +11,20 @@ index 4137ce2e9..f1289e08a 100644
    include(${protobuf_SOURCE_DIR}/cmake/libprotobuf-lite.cmake)
    if (NOT DEFINED protobuf_LIB_PROTOBUF_LITE)
 diff --git a/cmake/libprotobuf-lite.cmake b/cmake/libprotobuf-lite.cmake
-index f343458cf..f4b1e0faa 100644
+index 9aa81fb88..699c92ddd 100644
 --- a/cmake/libprotobuf-lite.cmake
 +++ b/cmake/libprotobuf-lite.cmake
-@@ -42,4 +42,4 @@ set_target_properties(libprotobuf-lite PROPERTIES
+@@ -46,4 +46,4 @@ set_target_properties(libprotobuf-lite PROPERTIES
  )
  add_library(protobuf::libprotobuf-lite ALIAS libprotobuf-lite)
  
 -target_link_libraries(libprotobuf-lite PRIVATE utf8_validity)
 +target_link_libraries(libprotobuf-lite PRIVATE utf8_range::utf8_validity)
 diff --git a/cmake/libprotobuf.cmake b/cmake/libprotobuf.cmake
-index 422754a1a..fa9956685 100644
+index 11c09b1bc..33ebac7cc 100644
 --- a/cmake/libprotobuf.cmake
 +++ b/cmake/libprotobuf.cmake
-@@ -45,4 +45,4 @@ set_target_properties(libprotobuf PROPERTIES
+@@ -48,4 +48,4 @@ set_target_properties(libprotobuf PROPERTIES
  )
  add_library(protobuf::libprotobuf ALIAS libprotobuf)
  

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -2,13 +2,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512 ce3eeb6d12c42157787bf97d265f34ac8e8af31070a2717b4c783e9158b6d7fbb5f239585fc38128a658315842cf7b6802cb9a80f4f391505bf806952e009da5
+    SHA512 a188d109f317c0cff1d57c3d81b307ff46db816774af2eb4edc39b136725bb3ed70fafbcffcdf9465f6f948a1e7dfc0175f75b17acd414e5ae543939a510688a
     HEAD_REF master
     PATCHES
         fix-static-build.patch
         fix-default-proto-file-path.patch
         fix-utf8-range.patch
         fix-arm64-msvc.patch
+        fix-install-dirs.patch
 )
 
 string(COMPARE EQUAL "${TARGET_TRIPLET}" "${HOST_TRIPLET}" protobuf_BUILD_PROTOC_BINARIES)
@@ -55,6 +56,7 @@ vcpkg_cmake_configure(
         -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
         -Dprotobuf_BUILD_LIBPROTOC=${protobuf_BUILD_LIBPROTOC}
         -Dprotobuf_ABSL_PROVIDER=package
+        -Dprotobuf_BUILD_LIBUPB=OFF
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protobuf",
-  "version": "5.26.1",
+  "version": "5.28.3",
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7213,7 +7213,7 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "5.26.1",
+      "baseline": "5.28.3",
       "port-version": 0
     },
     "protobuf-c": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4990,7 +4990,7 @@
     },
     "libprotobuf-mutator": {
       "baseline": "1.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libproxy": {
       "baseline": "0.4.18",
@@ -6770,7 +6770,7 @@
     },
     "openvino": {
       "baseline": "2024.4.0",
-      "port-version": 3
+      "port-version": 4
     },
     "openvpn3": {
       "baseline": "3.10",

--- a/versions/l-/libprotobuf-mutator.json
+++ b/versions/l-/libprotobuf-mutator.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc95e42e22d75f8ea9e2dc619583fbf8e5e9406a",
+      "version": "1.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "65fd72758c5a494660dc7633ecc5c69ead65cb04",
       "version": "1.3",
       "port-version": 0

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04f4c58adc2db11be31f2d4427c6eeb62bbe0dd2",
+      "version": "2024.4.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "bc53df5155c98997642b3213a096fb8c664be49c",
       "version": "2024.4.0",
       "port-version": 3

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "255021688a2d0cb1df1211ccf3b7a52a7f97be76",
+      "version": "5.28.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "f518549cd75b0c7c421b855f73f425fa13ba606a",
       "version": "5.26.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/39515


Tested `libprotobuf-mutator` and `mysql-connector-cpp` in the `x64-windows-static` triplet. Also tested `grpc` in `x64-windows-release`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



