### PR TITLE
[vcpkg baseline][sentencepiece] Disable optional dependency tcmalloc

### DIFF
--- a/ports/sentencepiece/portfile.cmake
+++ b/ports/sentencepiece/portfile.cmake
@@ -14,8 +14,8 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSPM_ENABLE_SHARED=OFF
+        -DSPM_ENABLE_TCMALLOC=OFF
         -DSPM_USE_BUILTIN_PROTOBUF=ON
-        -DSPM_USE_EXTERNAL_ABSL=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/sentencepiece/vcpkg.json
+++ b/ports/sentencepiece/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sentencepiece",
   "version": "0.2.0",
+  "port-version": 1,
   "description": "SentencePiece is an unsupervised text tokenizer and detokenizer mainly for Neural Network-based text generation systems where the vocabulary size is predetermined prior to the neural model training",
   "license": "Apache-2.0",
   "supports": "static",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8266,7 +8266,7 @@
     },
     "sentencepiece": {
       "baseline": "0.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sentry-native": {
       "baseline": "0.7.12",

--- a/versions/s-/sentencepiece.json
+++ b/versions/s-/sentencepiece.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b377d5e779e9eb2dc1dbf92a1ad5f55ad9e597c1",
+      "version": "0.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "60678651110bfbd252017ee568f2cb6484aaaf46",
       "version": "0.2.0",
       "port-version": 0


### PR DESCRIPTION
Fix https://dev.azure.com/vcpkg/public/_build/results?buildId=109394&view=results, `error LNK2005: _calloc_dbg already defined in tcmalloc_minimal.lib(override_functions.cc.obj)` with `gperftools[override]`

Disable the optional find library `tcmalloc` to fix.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-windows-static