### PR TITLE
[spdlog] use '/utf-8' only when compiler is msvc

### DIFF
--- a/ports/spdlog/fix-msvc-utf8.patch
+++ b/ports/spdlog/fix-msvc-utf8.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c5bc7b8..2fcdfff 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -274,8 +274,8 @@ if(MSVC)
+     target_compile_options(spdlog PRIVATE "/Zc:__cplusplus")
+     target_compile_options(spdlog_header_only INTERFACE "/Zc:__cplusplus")
+     if(SPDLOG_MSVC_UTF8)
+-	    target_compile_options(spdlog PUBLIC "/utf-8")
+-	    target_compile_options(spdlog_header_only INTERFACE "/utf-8")    
++	    target_compile_options(spdlog PUBLIC $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/utf-8>)
++	    target_compile_options(spdlog_header_only INTERFACE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/utf-8>)    
+      endif()
+ endif()
+ 

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 3dd98409f4625ae4d46ef5f59a2fc22a6e151a13dba9d37433363e5d84eab7cca73b379eeb637d8f9b1f0f5a42221c0cc9a2a70414dc2b6af6a162e19fba0647
     HEAD_REF v1.x
+    PATCHES
+        fix-msvc-utf8.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/spdlog/vcpkg.json
+++ b/ports/spdlog/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "spdlog",
   "version-semver": "1.15.0",
+  "port-version": 1,
   "description": "Very fast, header-only/compiled, C++ logging library.",
   "homepage": "https://github.com/gabime/spdlog",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8578,7 +8578,7 @@
     },
     "spdlog": {
       "baseline": "1.15.0",
-      "port-version": 0
+      "port-version": 1
     },
     "spectra": {
       "baseline": "1.0.1",

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "72b3738962d622e47073cf4a0dc0e6ddd29d1544",
+      "version-semver": "1.15.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6595ef6c86cf6618cede07b4e1bc8b4d6b098b45",
       "version-semver": "1.15.0",
       "port-version": 0


### PR DESCRIPTION
this pr is same as https://github.com/microsoft/vcpkg/pull/40944, and should fix https://github.com/microsoft/vcpkg/issues/42132

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
