### PR TITLE
[cthash] new port

### DIFF
--- a/ports/cthash/portfile.cmake
+++ b/ports/cthash/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO hanickadot/cthash
+    REF cb62928766c9623bf86072e412220d59a65407d4
+    SHA512 9ce214eff8772fcbdeac147ffdb7dadb8755bf101ed8b5fd5961ed57bfe314392dc42d40699ad1ff41d823cc132488ae936b2cb17615a1ce6740cba655e89498
+    HEAD_REF main
+)
+
+file(INSTALL "${SOURCE_PATH}/include/cthash" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cthash/vcpkg.json
+++ b/ports/cthash/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "cthash",
+  "version-date": "2024-11-16",
+  "description": "constexpr implementation of SHA-2 and SHA-3 family of hashes",
+  "homepage": "https://github.com/hanickadot/cthash",
+  "license": "Apache-2.0"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2100,6 +2100,10 @@
       "baseline": "2020-09-14",
       "port-version": 5
     },
+    "cthash": {
+      "baseline": "2024-11-16",
+      "port-version": 0
+    },
     "ctp": {
       "baseline": "6.6.1_P1_20210406_se",
       "port-version": 4

--- a/versions/c-/cthash.json
+++ b/versions/c-/cthash.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ce03bfc8d7ae54abc955c37df336d6bffc3b5def",
+      "version-date": "2024-11-16",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
I haven't used the upstream cmake build system because it does not provide install rules and the lib is header only. 