### PR TITLE
[libressl] Fix GitHub download URL

### DIFF
--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -5,15 +5,9 @@ endif()
 vcpkg_download_distfile(
     LIBRESSL_SOURCE_ARCHIVE
     URLS "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${PORT}-${VERSION}.tar.gz"
-         "https://github.com/libressl/portable/releases/download/v{VERSION}/${PORT}-${VERSION}.tar.gz"
+         "https://github.com/libressl/portable/releases/download/v${VERSION}/${PORT}-${VERSION}.tar.gz"
     FILENAME "${PORT}-${VERSION}.tar.gz"
     SHA512 b5ec6d1f4e3842ecb487f9a67d86db658d05cbe8cd3fcba61172affa8c65c5d0823aa244065a7233f06c669d04a5a36517c02a2d99d2f2da3c4df729ac243b37
-)
-
-vcpkg_download_distfile(WARNINGS_REMOVAL_PATCH
-    URLS https://github.com/libressl/portable/commit/1996dbc07d129cf2b1d32be384a131b9e6fa5373.diff?full_index=1
-    FILENAME Disable-additional-MSVC-warnings.patch
-    SHA512 8e32bd2b14c84a9e7106d5bc0ffc9f6bea712db2087c7b944e9b41a3a6cca0b09adcee2cff9bfd136060d539a34f7dc7d9283ec1c058028cc15410475790f4b6
 )
 
 vcpkg_extract_source_archive(
@@ -21,7 +15,6 @@ vcpkg_extract_source_archive(
     ARCHIVE "${LIBRESSL_SOURCE_ARCHIVE}"
     PATCHES
         pkgconfig.diff
-        ${WARNINGS_REMOVAL_PATCH}
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libressl/vcpkg.json
+++ b/ports/libressl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libressl",
   "version": "4.0.0",
+  "port-version": 1,
   "description": [
     "LibreSSL is a TLS/crypto stack.",
     "It was forked from OpenSSL in 2014 by the OpenBSD project, with goals of modernizing the codebase, improving security, and applying best practice development processes.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5046,7 +5046,7 @@
     },
     "libressl": {
       "baseline": "4.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "librsvg": {
       "baseline": "2.40.20",

--- a/versions/l-/libressl.json
+++ b/versions/l-/libressl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "becbc2d569c392b3f2d60027db3797b51839c53a",
+      "version": "4.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b734f8a265b1b45c5cbf6ebedf32e8aca340807f",
       "version": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
