### PR TITLE
[opencv4] Fix feature openexr compilation error

### DIFF
--- a/ports/opencv4/0020-miss-openexr.patch
+++ b/ports/opencv4/0020-miss-openexr.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d6bc6de..61b7a02 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -831,6 +831,9 @@ include(cmake/OpenCVFindLibsPerf.cmake)
+ include(cmake/OpenCVFindLAPACK.cmake)
+ include(cmake/OpenCVFindProtobuf.cmake)
+ include(cmake/OpenCVDetectFlatbuffers.cmake)
++if(WITH_OPENEXR)
++  include(cmake/OpenCVFindOpenEXR.cmake)
++endif()
+ if(WITH_TIMVX)
+   include(cmake/OpenCVFindTIMVX.cmake)
+ endif()

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_from_github(
       0015-fix-freetype.patch
       0017-fix-flatbuffers.patch
       0019-opencl-kernel.patch
+	  0020-miss-openexr.patch
 )
 # Disallow accidental build of vendored copies
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/openexr")

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -22,7 +22,7 @@ vcpkg_from_github(
       0015-fix-freetype.patch
       0017-fix-flatbuffers.patch
       0019-opencl-kernel.patch
-	  0020-miss-openexr.patch
+      0020-miss-openexr.patch
 )
 # Disallow accidental build of vendored copies
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/openexr")

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.10.0",
+  "port-version": 1,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6666,7 +6666,7 @@
     },
     "opencv4": {
       "baseline": "4.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "917087e985cff05c5740b15bc705f342d2b5b601",
+      "git-tree": "6ba67264448ce7a60b8e109db62270331e657e38",
       "version": "4.10.0",
       "port-version": 1
     },

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "917087e985cff05c5740b15bc705f342d2b5b601",
+      "version": "4.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "89c7baedc6a4590a76c9a04cfe65b5a23c53800c",
       "version": "4.10.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/42221
Add the search method of openexr and fix the following problems.
```
E:\vcpkg\buildtrees\opencv4\src\4.10.0-d9ca17150b\modules\imgcodecs\src\grfmt_exr.hpp(52): fatal error C1083: Cannot open include file: 'ImfChromaticities.h': No such file or directory
E:\vcpkg\buildtrees\opencv4\src\4.10.0-d9ca17150b\modules\imgcodecs\src\grfmt_exr.cpp(62): fatal error C1083: Cannot open include file: 'ImfFrameBuffer.h': No such file or directory
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

The feature openexr and usage test passed with x64-windows triplet.