### PR TITLE
[llvm] Add feature export-symbols

### DIFF
--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_check_features(
         enable-ios COMPILER_RT_ENABLE_IOS
         enable-eh LLVM_ENABLE_EH
         enable-bindings LLVM_ENABLE_BINDINGS
+        export-symbols LLVM_EXPORT_SYMBOLS_FOR_PLUGINS
 )
 
 vcpkg_cmake_get_vars(cmake_vars_file)

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "llvm",
   "version": "18.1.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0",
@@ -189,6 +189,9 @@
       "dependencies": [
         "zstd"
       ]
+    },
+    "export-symbols": {
+      "description": "Export symbols for plugins."
     },
     "flang": {
       "description": "Include Fortran front end.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5574,7 +5574,7 @@
     },
     "llvm": {
       "baseline": "18.1.6",
-      "port-version": 1
+      "port-version": 2
     },
     "lmdb": {
       "baseline": "0.9.33",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f22f1c97f0649913c8c97c6d16d448d76e1e81b",
+      "version": "18.1.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "b175bc95eb833fee3777f727ea0d5e0519b0f1a1",
       "version": "18.1.6",
       "port-version": 1


### PR DESCRIPTION
Creating a custom LLVM-pass under windows requires LLVM_EXPORT_SYMBOLS_FOR_PLUGINS. 
This adds this as a feature to the port.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
