### PR TITLE
[clipp] Update vcpkg.json to add homepage URL

### DIFF
--- a/ports/clipp/vcpkg.json
+++ b/ports/clipp/vcpkg.json
@@ -3,6 +3,7 @@
   "version-date": "2019-04-30",
   "port-version": 2,
   "description": "command line interfaces for modern C++",
+  "homepage": "https://github.com/muellan/clipp",
   "license": "MIT",
   "dependencies": [
     {


### PR DESCRIPTION
Homepage url found by looking at where the code is downloaded in the portfile.cmake.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [N/A] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [N/A] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [N/A] Only one version is added to each modified port's versions file.
