### PR TITLE
[libmupdf] Update to 1.24.11

### DIFF
--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ArtifexSoftware/mupdf
     REF "${VERSION}"
-    SHA512 b3a3e9ba000d920641647b936c01bf88d6df4f3cd5635240fc50402e7ed1663015deb5de09f51c698181cb33ea4c76441a5bdbace81d6e472275afd02d0f84d7
+    SHA512 d8b6d643b12c9cdf91bf292c8d43a0086eb614a87344d12bbac04e74fc5a333dc699cd37c7715e73f2bee00a233e9b80a1942b879a51275aa865aa12c6fa6b0d
     HEAD_REF master
     PATCHES
         dont-generate-extract-3rd-party-things.patch

--- a/ports/libmupdf/vcpkg.json
+++ b/ports/libmupdf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmupdf",
-  "version": "1.24.10",
+  "version": "1.24.11",
   "description": "a lightweight PDF, XPS, and E-book library",
   "homepage": "https://github.com/ArtifexSoftware/mupdf",
   "license": "AGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4845,7 +4845,7 @@
       "port-version": 0
     },
     "libmupdf": {
-      "baseline": "1.24.10",
+      "baseline": "1.24.11",
       "port-version": 0
     },
     "libmysofa": {

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f76ab7716730acd4fdfdc16d23a19099fed8bc2a",
+      "version": "1.24.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "dc4b20674350d09f28dfe7af3c520f16fc06e25a",
       "version": "1.24.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Feature `libmupdf[ocr]` passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```