### PR TITLE
[cppgraphqlgen] Expose clientgen/schemagen features

### DIFF
--- a/ports/cppgraphqlgen/portfile.cmake
+++ b/ports/cppgraphqlgen/portfile.cmake
@@ -17,7 +17,9 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        clientgen   GRAPHQL_BUILD_CLIENTGEN
         rapidjson   GRAPHQL_USE_RAPIDJSON
+        schemagen   GRAPHQL_BUILD_SCHEMAGEN
 )
 
 vcpkg_cmake_configure(
@@ -40,9 +42,19 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup()
 
-vcpkg_copy_tools(
-    TOOL_NAMES schemagen clientgen
-    SEARCH_DIR ${CURRENT_PACKAGES_DIR}/tools/cppgraphqlgen)
+set(tools "")
+if ("clientgen" IN_LIST FEATURES)
+    list(APPEND tools clientgen)
+endif()
+if ("schemagen" IN_LIST FEATURES)
+    list(APPEND tools schemagen)
+endif()
+list(LENGTH tools num_tools)
+if (num_tools GREATER 0)
+    vcpkg_copy_tools(
+        TOOL_NAMES ${tools}
+        SEARCH_DIR ${CURRENT_PACKAGES_DIR}/tools/cppgraphqlgen)
+endif()
 
 vcpkg_copy_pdbs()
 

--- a/ports/cppgraphqlgen/vcpkg.json
+++ b/ports/cppgraphqlgen/vcpkg.json
@@ -17,9 +17,7 @@
     }
   ],
   "default-features": [
-    "clientgen",
-    "rapidjson",
-    "schemagen"
+    "rapidjson"
   ],
   "features": {
     "clientgen": {

--- a/ports/cppgraphqlgen/vcpkg.json
+++ b/ports/cppgraphqlgen/vcpkg.json
@@ -1,12 +1,11 @@
 {
   "name": "cppgraphqlgen",
   "version": "4.5.7",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++ GraphQL schema service generator",
   "homepage": "https://github.com/microsoft/cppgraphqlgen",
   "license": "MIT",
   "dependencies": [
-    "boost-program-options",
     "pegtl",
     {
       "name": "vcpkg-cmake",
@@ -18,13 +17,27 @@
     }
   ],
   "default-features": [
-    "rapidjson"
+    "clientgen",
+    "rapidjson",
+    "schemagen"
   ],
   "features": {
+    "clientgen": {
+      "description": "Build the clientgen CLI tool.",
+      "dependencies": [
+        "boost-program-options"
+      ]
+    },
     "rapidjson": {
       "description": "Build the graphqljson library with RapidJSON.",
       "dependencies": [
         "rapidjson"
+      ]
+    },
+    "schemagen": {
+      "description": "Build the schemagen CLI tool.",
+      "dependencies": [
+        "boost-program-options"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1966,7 +1966,7 @@
     },
     "cppgraphqlgen": {
       "baseline": "4.5.7",
-      "port-version": 1
+      "port-version": 2
     },
     "cppitertools": {
       "baseline": "2.1",

--- a/versions/c-/cppgraphqlgen.json
+++ b/versions/c-/cppgraphqlgen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a7cbb853116994c618ead340b1c78e1dbf0137b3",
+      "git-tree": "3ad7f8b9f23c95604d6fe6cd0710af8a4ea99176",
       "version": "4.5.7",
       "port-version": 2
     },

--- a/versions/c-/cppgraphqlgen.json
+++ b/versions/c-/cppgraphqlgen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7cbb853116994c618ead340b1c78e1dbf0137b3",
+      "version": "4.5.7",
+      "port-version": 2
+    },
+    {
       "git-tree": "6fa915d7e50edceda898664f00c7860694433fab",
       "version": "4.5.7",
       "port-version": 1


### PR DESCRIPTION
Disabling both of these allows building a version of the library which does not depend on boost. The clientgen/schemagen CLI tools are generally only required in development environments and CI. Thus it may be preferable to link against a boostless cppgraphqlgen when building for release.

Default behaviour for vcpkg users who do not disable default-features when installing cppgraphqlgen remains unchanged.

The flags in question can be found here - https://github.com/microsoft/cppgraphqlgen/blob/681b0e1942521d4dd7806a4badfce9aa703f6dcf/CMakeLists.txt#L37. In testing this works as expected when building both with and without the default feature list. However, I am not very familiar with CMake et al, so please let me know if there are any issues with my implementation.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.