### PR TITLE
[comms] Update to 5.2.7

### DIFF
--- a/ports/comms/portfile.cmake
+++ b/ports/comms/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO commschamp/comms
-    REF v4.0
-    SHA512 ec83bef647dd6c32e6ba98ce51970c48befaa2b0ff9c26f538fb0ce72e46da14cd592a0c652af5f9f10906f7058ff623dcf13ac4b81c96c0aea1fd8a31551bb7
+    REF "v${VERSION}"
+    SHA512 838b4c90a2c9c6374f0755a694057f60b53898dfdd100d16b0e81d308f6a62f3af9e680307b1782290d71c7c0d067fdf5af364e58f30907246b0fcad962e4ce8
     HEAD_REF master
 )
 
@@ -12,7 +12,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DCC_COMMS_BUILD_UNIT_TESTS=OFF
         -DBUILD_TESTING=OFF
-        -DCC_WARN_AS_ERR=OFF
+        -DCC_COMMS_WARN_AS_ERR=OFF
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME LibComms CONFIG_PATH lib/LibComms/cmake)
@@ -21,5 +21,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)

--- a/ports/comms/vcpkg.json
+++ b/ports/comms/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "comms",
-  "version-semver": "4.0.0",
+  "version": "5.2.7",
   "description": "COMMS is the C++(11) headers only, platform independent library, which makes the implementation of a communication protocol to be an easy and relatively quick process.",
   "homepage": "https://commschamp.github.io/",
   "documentation": "https://github.com/commschamp/comms",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1817,7 +1817,7 @@
       "port-version": 0
     },
     "comms": {
-      "baseline": "4.0.0",
+      "baseline": "5.2.7",
       "port-version": 0
     },
     "comms-ublox": {

--- a/versions/c-/comms.json
+++ b/versions/c-/comms.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e9e4735a43786c44da7658392215c5d339c0d33c",
+      "version": "5.2.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "3a9bdbc7d61f9494ad2853f702a19699dae74a70",
       "version-semver": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Usage passed on `x64-windows`.