### PR TITLE
[vsg] Update the glslang minimum required version to 15

### DIFF
--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# added -DGLSLANG_MIN_VERSION=15 to sync with vcpkg version of glslang
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}" OPTIONS -DGLSLANG_MIN_VERSION=15)
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME "vsg" CONFIG_PATH "lib/cmake/vsg")

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}" OPTIONS -DGLSLANG_MIN_VERSION=15)
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME "vsg" CONFIG_PATH "lib/cmake/vsg")
 vcpkg_copy_pdbs()

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -7,7 +7,11 @@ vcpkg_from_github(
 )
 
 # added -DGLSLANG_MIN_VERSION=15 to sync with vcpkg version of glslang
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}" OPTIONS -DGLSLANG_MIN_VERSION=15)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DGLSLANG_MIN_VERSION=15
+)
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME "vsg" CONFIG_PATH "lib/cmake/vsg")
 vcpkg_copy_pdbs()

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DGLSLANG_MIN_VERSION=15
+        -DGLSLANG_MIN_VERSION=
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME "vsg" CONFIG_PATH "lib/cmake/vsg")

--- a/ports/vsg/vcpkg.json
+++ b/ports/vsg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vsg",
   "version": "1.1.7",
-  "port-version": 2,
+  "port-version": 1,
   "description": "A modern, cross platform, high performance scene graph library built upon Vulkan.",
   "homepage": "http://www.vulkanscenegraph.org/",
   "license": "MIT",

--- a/ports/vsg/vcpkg.json
+++ b/ports/vsg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vsg",
   "version": "1.1.7",
+  "port-version": 2,
   "description": "A modern, cross platform, high performance scene graph library built upon Vulkan.",
   "homepage": "http://www.vulkanscenegraph.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9490,7 +9490,7 @@
     },
     "vsg": {
       "baseline": "1.1.7",
-      "port-version": 1
+      "port-version": 0
     },
     "vsgimgui": {
       "baseline": "0.3.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9490,7 +9490,7 @@
     },
     "vsg": {
       "baseline": "1.1.7",
-      "port-version": 0
+      "port-version": 1
     },
     "vsgimgui": {
       "baseline": "0.3.0",

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "bc46fa01158df76657864f0bf67916c4ecbb0bbf",
-      "version": "1.1.7",
-      "port-version": 1
-    },
-    {
       "git-tree": "cc734f695e25c4a6641584e4f785fd95f81abf48",
       "version": "1.1.7",
       "port-version": 0

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "0c50dc080fb15d76840835caf0448969120cb52c",
-      "version": "1.1.7",
-      "port-version": 1
-    },
-    {
       "git-tree": "cc734f695e25c4a6641584e4f785fd95f81abf48",
       "version": "1.1.7",
       "port-version": 0

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ddb004a4fdb8ddd46977c2fb9909a020817d8073",
+      "version": "1.1.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "cc734f695e25c4a6641584e4f785fd95f81abf48",
       "version": "1.1.7",
       "port-version": 0

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc46fa01158df76657864f0bf67916c4ecbb0bbf",
+      "version": "1.1.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "cc734f695e25c4a6641584e4f785fd95f81abf48",
       "version": "1.1.7",
       "port-version": 0

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c50dc080fb15d76840835caf0448969120cb52c",
+      "version": "1.1.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "cc734f695e25c4a6641584e4f785fd95f81abf48",
       "version": "1.1.7",
       "port-version": 0

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ddb004a4fdb8ddd46977c2fb9909a020817d8073",
+      "git-tree": "f9710535eb6dade1a009e1a87c5332af3346baf9",
       "version": "1.1.7",
       "port-version": 1
     },


### PR DESCRIPTION
Updates the glslang minimum required version to the latest version of glslang in vcpkg (15.0.0).
Implemented by passing in an option to vcpkg_cmake_configure().
Failing to do so will prevent vsg from building with glsl compiler support, and will result in a runtime error.

Further information can be found here:
https://github.com/vsg-dev/VulkanSceneGraph/issues/1326

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
