### PR TITLE
[vcpkg baseline][openimageio] Disable optional dependency jxl

### DIFF
--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -53,6 +53,7 @@ vcpkg_cmake_configure(
         -DUSE_OpenVDB=OFF
         -DUSE_PTEX=OFF
         -DUSE_TBB=OFF
+        -DUSE_JXL=OFF
         -DLINKSTATIC=OFF # LINKSTATIC breaks library lookup
         -DBUILD_MISSING_FMT=OFF
         -DINTERNALIZE_FMT=OFF  # carry fmt's msvc utf8 usage requirements

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openimageio",
   "version": "3.0.0.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6702,7 +6702,7 @@
     },
     "openimageio": {
       "baseline": "3.0.0.3",
-      "port-version": 1
+      "port-version": 2
     },
     "openjpeg": {
       "baseline": "2.5.2",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6d167570fb49971bccad7de36cee042da0a44b2",
+      "version": "3.0.0.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "22b11b52b97211a4cb04fce6c5518fd2b33f3529",
       "version": "3.0.0.3",
       "port-version": 1


### PR DESCRIPTION
Fix `openimageio` failed `Undefined _BrotliEncoderCompressStream`, https://dev.azure.com/vcpkg/public/_build/results?buildId=109536&view=results

Disabling the undeclared optional library `jxl` to fix.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* arm64-osx
* x64-linux