### PR TITLE
[vcpkg baseline][scripts/ci.baseline.txt] Remove from fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -965,9 +965,6 @@ rapidstring:x64-windows=fail
 rapidstring:x64-windows-static=fail
 rapidstring:x64-windows-static-md=fail
 rapidstring:x86-windows=fail
-# ALooper_pollAll no longer available
-raylib:arm64-android=fail
-raylib:x64-android=fail
 # file conflicts with rbdl
 rbdl-orb:x86-windows=skip
 rbdl-orb:x64-windows=skip
@@ -1017,10 +1014,6 @@ sciter:x86-windows=skip
 sdl1:arm-neon-android=fail
 sdl1:arm64-android=fail
 sdl1:x64-android=fail
-sentencepiece:arm-neon-android=fail
-sentencepiece:arm64-android=fail
-sentencepiece:x64-android=fail
-sentencepiece:x64-windows-static-md=fail
 septag-sx:x64-android=fail
 sfml:arm-neon-android=fail
 sfml:arm64-android=fail


### PR DESCRIPTION
See https://dev.azure.com/vcpkg/public/_build/results?buildId=109536&view=results

Remove passed entries from fail list:

```properties
# ALooper_pollAll no longer available
raylib:arm64-android=fail
raylib:x64-android=fail

sentencepiece:arm-neon-android=fail
sentencepiece:arm64-android=fail
sentencepiece:x64-android=fail
sentencepiece:x64-windows-static-md=fail
```