### PR TITLE
[libmysql] Add prompt to install system libraries

### DIFF
--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -22,6 +22,13 @@ if (third_party)
     file(REMOVE_RECURSE ${third_party})
 endif()
 
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+  message("libmysql currently requires the following programs from the system package manager:
+  libtirpc-dev
+On Ubuntu derivatives:
+    sudo apt install libtirpc-dev
+")
+
 #Skip the version check for Visual Studio
 set(FORCE_UNSUPPORTED_COMPILER "")
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/libmysql/vcpkg.json
+++ b/ports/libmysql/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmysql",
   "version": "8.0.40",
+  "port-version": 1,
   "description": "A MySQL client library for C development",
   "homepage": "https://github.com/mysql/mysql-server",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4858,7 +4858,7 @@
     },
     "libmysql": {
       "baseline": "8.0.40",
-      "port-version": 0
+      "port-version": 1
     },
     "libnice": {
       "baseline": "0.1.22",

--- a/versions/l-/libmysql.json
+++ b/versions/l-/libmysql.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca48d9ee3ec01572228eb9e89f4aeb0fe28f8eaa",
+      "version": "8.0.40",
+      "port-version": 1
+    },
+    {
       "git-tree": "1fcb166c50b683fcbda07bec1e7bfb7c37234525",
       "version": "8.0.40",
       "port-version": 0


### PR DESCRIPTION
Fix the following error:
```
CMake Warning at cmake/rpc.cmake:41 (MESSAGE):
  Cannot find RPC development libraries.  You need to install the required
  packages:

    Debian/Ubuntu:              apt install libtirpc-dev
    RedHat/Fedora/Oracle Linux: yum install libtirpc-devel
    SuSE:                       zypper install glibc-devel

Call Stack (most recent call first):
  cmake/rpc.cmake:107 (WARN_MISSING_SYSTEM_TIRPC)
  CMakeLists.txt:2070 (MYSQL_CHECK_RPC)


CMake Error at cmake/rpc.cmake:108 (MESSAGE):
  Could not find rpc/rpc.h in /usr/include or /usr/include/tirpc
Call Stack (most recent call first):
  CMakeLists.txt:2070 (MYSQL_CHECK_RPC)
```

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

Compile and usage test pass with x64-linux triplet.
