### PR TITLE
Add license information for a set of ports

### DIFF
--- a/ports/double-conversion/vcpkg.json
+++ b/ports/double-conversion/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "double-conversion",
   "version": "3.3.0",
+  "port-version": 1,
   "description": "Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles.",
   "homepage": "https://github.com/google/double-conversion",
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/glew/vcpkg.json
+++ b/ports/glew/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "glew",
   "version": "2.2.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.",
   "homepage": "https://github.com/nigels-com/glew",
+  "license": "MIT AND BSD-3-Clause",
   "supports": "!android",
   "dependencies": [
     "opengl",

--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "jasper",
   "version": "4.2.4",
+  "port-version": 1,
   "description": "Open source implementation of the JPEG-2000 Part-1 standard",
   "homepage": "https://github.com/jasper-software/jasper",
-  "license": null,
+  "license": "JasPer-2.0",
   "dependencies": [
     "libjpeg-turbo",
     {

--- a/ports/libb2/vcpkg.json
+++ b/ports/libb2/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "libb2",
   "version": "0.98.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "C library providing BLAKE2b, BLAKE2s, BLAKE2bp, BLAKE2sp",
   "homepage": "https://github.com/BLAKE2/libb2",
+  "license": "CC0-1.0",
   "supports": "!windows"
 }

--- a/ports/libiconv/vcpkg.json
+++ b/ports/libiconv/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "libiconv",
   "version": "1.17",
-  "port-version": 4,
+  "port-version": 5,
   "description": "GNU Unicode text conversion",
   "homepage": "https://www.gnu.org/software/libiconv/",
-  "license": null
+  "license": "LGPL-2.1-only"
 }

--- a/ports/libmount/vcpkg.json
+++ b/ports/libmount/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libmount",
   "version": "2.40",
+  "port-version": 1,
   "description": "Block device identification library from util-linux",
   "homepage": "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/about/",
-  "license": null,
+  "license": "LGPL-2.1-or-later",
   "supports": "linux",
   "features": {
     "nls": {

--- a/ports/libxext/vcpkg.json
+++ b/ports/libxext/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libxext",
   "version": "1.3.4",
+  "port-version": 1,
   "description": "Xlib-based library for common extensions to the X11 protocol",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxext",
-  "license": null,
+  "license": "MIT",
   "dependencies": [
     "libx11",
     "xorg-macros",

--- a/ports/libxfixes/vcpkg.json
+++ b/ports/libxfixes/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libxfixes",
   "version": "6.0.0",
+  "port-version": 1,
   "description": "Xlib-based library for the XFIXES Extension",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxfixes",
-  "license": null,
+  "license": "MIT",
   "dependencies": [
     "libx11",
     "xorg-macros",

--- a/ports/libxi/vcpkg.json
+++ b/ports/libxi/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libxi",
   "version": "1.8",
+  "port-version": 1,
   "description": "Xlib library for the X Input Extension",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxi",
-  "license": null,
+  "license": "MIT",
   "dependencies": [
     "libxext",
     "libxfixes"

--- a/ports/libxtst/vcpkg.json
+++ b/ports/libxtst/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libxtst",
   "version": "1.2.4",
+  "port-version": 1,
   "description": "Xlib-based library for XTEST & RECORD extensions",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxtst",
-  "license": null,
+  "license": "X11",
   "dependencies": [
     "libx11",
     "libxext",

--- a/ports/libxv/vcpkg.json
+++ b/ports/libxv/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libxv",
   "version": "1.0.11",
+  "port-version": 1,
   "description": "Xlib-based library for the X Video (Xv) extension to the X Window System",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxv",
-  "license": null,
+  "license": "MIT",
   "dependencies": [
     "bzip2",
     "libx11",

--- a/ports/snappy/vcpkg.json
+++ b/ports/snappy/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "snappy",
   "version": "1.2.1",
+  "port-version": 1,
   "description": "A fast compressor/decompressor.",
   "homepage": "https://github.com/google/snappy",
-  "license": null,
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/xorg-macros/vcpkg.json
+++ b/ports/xorg-macros/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "xorg-macros",
   "version": "1.19.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "X.org macros utilities.",
   "homepage": "https://xcb.freedesktop.org/",
-  "license": null,
+  "license": "MIT",
   "supports": "!uwp"
 }

--- a/ports/xtrans/vcpkg.json
+++ b/ports/xtrans/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "xtrans",
   "version": "1.4.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "xtrans - X Network Transport layer shared code",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxtrans",
-  "license": null,
+  "license": "MIT-open-group",
   "dependencies": [
     "xorg-macros"
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2394,7 +2394,7 @@
     },
     "double-conversion": {
       "baseline": "3.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "dp-thread-pool": {
       "baseline": "0.6.2",
@@ -3146,7 +3146,7 @@
     },
     "glew": {
       "baseline": "2.2.0",
-      "port-version": 4
+      "port-version": 5
     },
     "glfw3": {
       "baseline": "3.4",
@@ -3826,7 +3826,7 @@
     },
     "jasper": {
       "baseline": "4.2.4",
-      "port-version": 0
+      "port-version": 1
     },
     "jbig2dec": {
       "baseline": "0.20",
@@ -4334,7 +4334,7 @@
     },
     "libb2": {
       "baseline": "0.98.1",
-      "port-version": 6
+      "port-version": 7
     },
     "libbacktrace": {
       "baseline": "2023-11-30",
@@ -4674,7 +4674,7 @@
     },
     "libiconv": {
       "baseline": "1.17",
-      "port-version": 4
+      "port-version": 5
     },
     "libics": {
       "baseline": "1.6.8",
@@ -4834,7 +4834,7 @@
     },
     "libmount": {
       "baseline": "2.40",
-      "port-version": 0
+      "port-version": 1
     },
     "libmpeg2": {
       "baseline": "0.5.1",
@@ -5394,11 +5394,11 @@
     },
     "libxext": {
       "baseline": "1.3.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libxfixes": {
       "baseline": "6.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libxfont": {
       "baseline": "2.0.5",
@@ -5410,7 +5410,7 @@
     },
     "libxi": {
       "baseline": "1.8",
-      "port-version": 0
+      "port-version": 1
     },
     "libxinerama": {
       "baseline": "1.1.4",
@@ -5482,11 +5482,11 @@
     },
     "libxtst": {
       "baseline": "1.2.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libxv": {
       "baseline": "1.0.11",
-      "port-version": 0
+      "port-version": 1
     },
     "libxxf86vm": {
       "baseline": "1.1.5",
@@ -8462,7 +8462,7 @@
     },
     "snappy": {
       "baseline": "1.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "snitch": {
       "baseline": "1.2.5",
@@ -9826,7 +9826,7 @@
     },
     "xorg-macros": {
       "baseline": "1.19.3",
-      "port-version": 1
+      "port-version": 2
     },
     "xorstr": {
       "baseline": "2021-11-20",
@@ -9874,7 +9874,7 @@
     },
     "xtrans": {
       "baseline": "1.4.0",
-      "port-version": 2
+      "port-version": 3
     },
     "xxhash": {
       "baseline": "0.8.2",

--- a/versions/d-/double-conversion.json
+++ b/versions/d-/double-conversion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ed91f5ced7e173782bcdc4750fec25418b58a453",
+      "version": "3.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "63037e8b38231f15de1dddb0593eebfb0bf32496",
       "version": "3.3.0",
       "port-version": 0

--- a/versions/g-/glew.json
+++ b/versions/g-/glew.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b60d028ed4479025dc10c75b5235579b66b48842",
+      "version": "2.2.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "bf42d73479dcd0f239b71dbed4d0d3af22efb294",
       "version": "2.2.0",
       "port-version": 4

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "813f339b3ecd201c70d1ba74b7b6ac95d68eadec",
+      "version": "4.2.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "c444456c1460b3d3272973ae701982f3cbd4c720",
       "version": "4.2.4",
       "port-version": 0

--- a/versions/l-/libb2.json
+++ b/versions/l-/libb2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9896ad99845ee89e0c66392b725695c2460d05ef",
+      "version": "0.98.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "7c113e12089453e4e2cf2bbf67ad1f0b80a133a8",
       "version": "0.98.1",
       "port-version": 6

--- a/versions/l-/libiconv.json
+++ b/versions/l-/libiconv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49f2c500ff59e9b1d6d9bf6c26d538ab5982baf3",
+      "version": "1.17",
+      "port-version": 5
+    },
+    {
       "git-tree": "6549f7452c383df31d471692b339f985d0000a88",
       "version": "1.17",
       "port-version": 4

--- a/versions/l-/libmount.json
+++ b/versions/l-/libmount.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05e14858e12a17183904bb1c32910c71f4fa04dd",
+      "version": "2.40",
+      "port-version": 1
+    },
+    {
       "git-tree": "e78ea57cae347c42d9b7cdc4d65c521f229e0ed4",
       "version": "2.40",
       "port-version": 0

--- a/versions/l-/libxext.json
+++ b/versions/l-/libxext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35b5f15da630619b28ac2ceb155323a1267d89bd",
+      "version": "1.3.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "e67774822086eb3d56334159f5aad5579643b5d3",
       "version": "1.3.4",
       "port-version": 0

--- a/versions/l-/libxfixes.json
+++ b/versions/l-/libxfixes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9eebc6112f395100d009fb9e0d9330487a0ca195",
+      "version": "6.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1f0262e8d5145c540a26a4740b62c84794244586",
       "version": "6.0.0",
       "port-version": 0

--- a/versions/l-/libxi.json
+++ b/versions/l-/libxi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b506a5b6a67baf352aa16299c5f2c2ac9836796e",
+      "version": "1.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "af8e343976780e89ba9aca93f5dafcf3e0dcfecf",
       "version": "1.8",
       "port-version": 0

--- a/versions/l-/libxtst.json
+++ b/versions/l-/libxtst.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b41facf5784bd24e7186b8f56d8207562aeff525",
+      "version": "1.2.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "8b2a80b040031d2b2c9952e885bc68884f13c099",
       "version": "1.2.4",
       "port-version": 0

--- a/versions/l-/libxv.json
+++ b/versions/l-/libxv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "260e791daa97dc2ddbfd6566a291eb1aedb2b659",
+      "version": "1.0.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "4a73c70d6f2f7092d8ddbba6c9a6ada0a8806080",
       "version": "1.0.11",
       "port-version": 0

--- a/versions/s-/snappy.json
+++ b/versions/s-/snappy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "572d378dc5c264a9d80bb977507bd18c7478dc95",
+      "version": "1.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "9672ae749ed648326f88d504ae03872883a526e4",
       "version": "1.2.1",
       "port-version": 0

--- a/versions/x-/xorg-macros.json
+++ b/versions/x-/xorg-macros.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "befbb5356a92edec8099ba945aa023033a8adc51",
+      "version": "1.19.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "766525189c81d40661731faecc566fb96d66fcc4",
       "version": "1.19.3",
       "port-version": 1

--- a/versions/x-/xtrans.json
+++ b/versions/x-/xtrans.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aade9d0eb253deb47d809425c6aa2d6334387b08",
+      "version": "1.4.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "f7f94e9ba7b242ac5b0f38e38fc6b32ac63c3024",
       "version": "1.4.0",
       "port-version": 2


### PR DESCRIPTION
See:

- https://github.com/google/double-conversion/blob/master/LICENSE
- http://glew.sourceforge.net/mesa.txt
- https://github.com/jasper-software/jasper/blob/master/LICENSE.txt
- https://github.com/BLAKE2/libb2/blob/master/COPYING
- https://github.com/microsoft/vcpkg/blob/master/ports/libiconv/portfile.cmake#L56
- https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/tree/libmount/COPYING
- https://gitlab.freedesktop.org/xorg/lib/libxext/-/blob/master/COPYING
- https://gitlab.freedesktop.org/xorg/lib/libxfixes/-/blob/master/COPYING
- https://gitlab.freedesktop.org/xorg/lib/libxi/-/blob/master/COPYING
- https://gitlab.freedesktop.org/xorg/lib/libxtst/-/blob/master/COPYING
- https://gitlab.freedesktop.org/xorg/lib/libxv/-/blob/master/COPYING
- https://github.com/google/snappy/blob/main/COPYING
- https://gitlab.freedesktop.org/xorg/util/macros/-/blob/master/COPYING
- https://gitlab.freedesktop.org/xorg/lib/libxtrans/-/blob/master/COPYING

Tasks:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. - NOT APPLICABLE
- [x] The "supports" clause reflects platforms that may be fixed by this new version. - NOT APPLICABLE
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. - NOT APPLICABLE
- [x] Any patches that are no longer applied are deleted from the port's directory. - NOT APPLICABLE
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

