### PR TITLE
[opentelemetry-cpp-contrib-version] Update port opentelemetry-cpp-contrib-version to support ubuntu 24.04

### DIFF
--- a/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
@@ -4,9 +4,9 @@ function(clone_opentelemetry_cpp_contrib CONTRIB_SOURCE_PATH)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-telemetry/opentelemetry-cpp-contrib
-        REF 93733bb2e52273474f4298d10645bf7d1157fc55
+        REF 8933841f0a7f8737f61404cf0a64acf6b079c8a5
         HEAD_REF main
-        SHA512 bfe297e313b8e960a4557dd8750c814af2f9b574dd248f8c30b452160f5b7aba53af85b2c5b87a423ea3878e8a852022e3ff3d08a983db073c68418e64f671b2
+        SHA512 1a067053d18217f204d686476ad3947a90e7b46c90f21a6bb8346da8aea14021f92dd3d80a5cb57d0990655148860f15fb2f1c20f10d48a4c711a920ab3c8f19
     )
     set(${CONTRIB_SOURCE_PATH} ${SOURCE_PATH} CACHE INTERNAL "")
 endfunction()

--- a/ports/opentelemetry-cpp-contrib-version/vcpkg.json
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp-contrib-version",
-  "version-date": "2024-06-17",
+  "version-date": "2024-11-14",
+  "port-version": 1,
   "description": "This port manages the opentelemetry-cpp-version that will be used for opentelemetry-cpp",
   "homepage": "https://github.com/open-telemetry/opentelemetry-cpp-contrib",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6753,8 +6753,8 @@
       "port-version": 1
     },
     "opentelemetry-cpp-contrib-version": {
-      "baseline": "2024-06-17",
-      "port-version": 0
+      "baseline": "2024-11-14",
+      "port-version": 1
     },
     "opentracing": {
       "baseline": "1.6.0",

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "79722d231ddd94a76e175ab81d9979685c3f5446",
+      "git-tree": "18a9845f266b0ad2932e629c327e0b93229f0008",
       "version-date": "2024-11-14",
       "port-version": 1
     },

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5206130235588a761f3f16867efff91e9ba63950",
+      "git-tree": "79722d231ddd94a76e175ab81d9979685c3f5446",
       "version-date": "2024-06-17",
       "port-version": 0
     }

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "git-tree": "79722d231ddd94a76e175ab81d9979685c3f5446",
+      "version-date": "2024-11-14",
+      "port-version": 1
+    },
+    {
+      "git-tree": "5206130235588a761f3f16867efff91e9ba63950",
       "version-date": "2024-06-17",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
