### PR TITLE
[libxml2] Config policy same major version

### DIFF
--- a/ports/libxml2/fix_cmakelist.patch
+++ b/ports/libxml2/fix_cmakelist.patch
@@ -75,7 +75,7 @@ index 9701bdc..39e96ee 100644
  	${CMAKE_CURRENT_BINARY_DIR}/libxml2-config-version.cmake
  	VERSION ${PROJECT_VERSION}
 -	COMPATIBILITY ExactVersion
-+	COMPATIBILITY SameMinorVersion
++	COMPATIBILITY SameMajorVersion
  )
  
  install(

--- a/ports/libxml2/fix_cmakelist.patch
+++ b/ports/libxml2/fix_cmakelist.patch
@@ -56,21 +56,7 @@ index 9701bdc..39e96ee 100644
  endif()
  
  install(FILES ${LIBXML2_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libxml2/libxml COMPONENT development)
-@@ -574,30 +560,30 @@ endif()
- 
- configure_package_config_file(
- 	libxml2-config.cmake.cmake.in libxml2-config.cmake
--	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxml2-${PROJECT_VERSION}
-+	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxml2
- )
- 
- install(
- 	FILES ${CMAKE_CURRENT_BINARY_DIR}/libxml2-config.cmake
--	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxml2-${PROJECT_VERSION}
-+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxml2
- 	COMPONENT development
- )
- 
+@@ -586,7 +572,7 @@ endif()
  write_basic_package_version_file(
  	${CMAKE_CURRENT_BINARY_DIR}/libxml2-config-version.cmake
  	VERSION ${PROJECT_VERSION}
@@ -79,30 +65,15 @@ index 9701bdc..39e96ee 100644
  )
  
  install(
- 	FILES ${CMAKE_CURRENT_BINARY_DIR}/libxml2-config-version.cmake
--	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxml2-${PROJECT_VERSION}
-+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxml2
- 	COMPONENT development
- )
- 
- install(
- 	EXPORT LibXml2
--	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxml2-${PROJECT_VERSION}
-+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxml2
- 	NAMESPACE LibXml2::
- 	FILE libxml2-export.cmake
- 	COMPONENT development
-@@ -635,9 +621,7 @@ set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+@@ -635,7 +621,7 @@ set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
  configure_file(libxml-2.0.pc.in libxml-2.0.pc @ONLY)
  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libxml-2.0.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT development)
  
 -if(WIN32)
--	set(prefix "\$(cd \"\$(dirname \"\$0\")\"; pwd -P)/..")
--endif()
-+set(prefix "\$(cd \"\$(dirname \"\$0\")\"; pwd -P)/..")
++if(1)
+ 	set(prefix "\$(cd \"\$(dirname \"\$0\")\"; pwd -P)/..")
+ endif()
  configure_file(xml2-config.in xml2-config @ONLY)
- install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/xml2-config DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT development)
-
 diff --git a/libxml-2.0.pc.in b/libxml-2.0.pc.in
 index 88e3963b..0d1706c9 100644
 --- a/libxml-2.0.pc.in

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -54,7 +54,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libxml2")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libxml2-${VERSION}")
 vcpkg_fixup_pkgconfig()
 
 vcpkg_copy_pdbs()

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libxml2",
   "version": "2.11.9",
+  "port-version": 1,
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5430,7 +5430,7 @@
     },
     "libxml2": {
       "baseline": "2.11.9",
-      "port-version": 0
+      "port-version": 1
     },
     "libxmlmm": {
       "baseline": "0.6.0",

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3adf0002b5de8cfba4850a6953762ad8ebdfe78",
+      "version": "2.11.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "9adc435281d53b3906a7cc7394dfe340edeb1c51",
       "version": "2.11.9",
       "port-version": 0


### PR DESCRIPTION
and replace some patching with fixup.

Adopts https://gitlab.gnome.org/GNOME/libxml2/-/commit/2ef1beb38b2d98b40f5b8b3430a45e5944688386.
Fixes #42315.