### PR TITLE
[poco] Fix mingw compilation

### DIFF
--- a/ports/poco/0008-fix-mingw-compilation.patch
+++ b/ports/poco/0008-fix-mingw-compilation.patch
@@ -1,0 +1,38 @@
+diff --git a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
+index 41ba99936..b3986690f 100644
+--- a/Foundation/CMakeLists.txt
++++ b/Foundation/CMakeLists.txt
+@@ -189,7 +189,6 @@ if(MINGW)
+ 			_WIN32
+ 			MINGW32
+ 			WINVER=0x500
+-			ODBCVER=0x0300
+ 			POCO_THREAD_STACK_SIZE
+ 	)
+ endif()
+diff --git a/Foundation/include/Poco/Platform.h b/Foundation/include/Poco/Platform.h
+index 7a4e7e2fb..8caa6de06 100644
+--- a/Foundation/include/Poco/Platform.h
++++ b/Foundation/include/Poco/Platform.h
+@@ -244,6 +244,9 @@
+ #define POCO_NO_FPENVIRONMENT
+ #endif
+ 
++#if defined (__MINGW32__) || defined (__MINGW64__)
++	#define POCO_COMPILER_MINGW
++#endif
+ 
+ #if defined(__clang__)
+ 	#define POCO_COMPILER_CLANG
+@@ -253,11 +256,6 @@
+ #elif defined (__GNUC__)
+ 	#define POCO_COMPILER_GCC
+ 	#define POCO_HAVE_CXXABI_H
+-	#if defined (__MINGW32__) || defined (__MINGW64__)
+-		#define POCO_COMPILER_MINGW
+-	#endif
+-#elif defined (__MINGW32__) || defined (__MINGW64__)
+-	#define POCO_COMPILER_MINGW
+ #elif defined (__INTEL_COMPILER) || defined(__ICC) || defined(__ECC) || defined(__ICL)
+ 	#define POCO_COMPILER_INTEL
+ #elif defined (__SUNPRO_CC)

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -13,6 +13,8 @@ vcpkg_from_github(
         0004-fix-feature-sqlite3.patch
         0005-fix-error-c3861.patch
         0007-find-pcre2.patch
+        # MSYS2 repo was used as a source. Thanks MSYS2 team: https://github.com/msys2/MINGW-packages/blob/6e7fba42b7f50e1111b7c0ef50048832243b0ac4/mingw-w64-poco/001-fix-build-on-mingw.patch
+        0008-fix-mingw-compilation.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/Foundation/src/pcre2.h")

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "poco",
   "version": "1.13.3",
+  "port-version": 1,
   "description": "Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.",
   "homepage": "https://github.com/pocoproject/poco",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7106,7 +7106,7 @@
     },
     "poco": {
       "baseline": "1.13.3",
-      "port-version": 0
+      "port-version": 1
     },
     "podofo": {
       "baseline": "0.10.4",

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "431894de75b90a806a64bcb289b6ad81d5c98a4c",
+      "version": "1.13.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "161e940e8c25d09dd731462771d84cbe78743643",
       "version": "1.13.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #38873  
Fixes #39797  

The development has been tested with `x64-mingw-static` and `x86-mingw-static` and no issues have been observed.  

Due to the more patches in this port, I have scoped the patch specifically to this triplet, as it seemed more appropriate. This approach should not cause any issues for other triplets.