### PR TITLE
add immuds port

### DIFF
--- a/ports/immuds/CONTROL
+++ b/ports/immuds/CONTROL
@@ -1,0 +1,3 @@
+Source: immuds
+Version: 1.0.0
+Description: A simple C++ header-only library for immutable data structures.

--- a/ports/immuds/portfile.cmake
+++ b/ports/immuds/portfile.cmake
@@ -1,0 +1,9 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO vlad-dobrescu/ImmuDS
+    REF v1.0.0
+    SHA512 a85fe1229f9c6e3f45e81e940dc4255a65192c5a0f4ed1b067f540cc97c863c4e0f261aee0d8e3784d1b30c198040423998540bfb4b9eb3a9864e31b9f5a9ace
+)
+
+file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+


### PR DESCRIPTION
This PR adds a new port: `immuds`, a header-only immutable data structures library.

<!-- If this PR adds a new port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed library includes a "copyright" file that matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

---

### Notes

- `immuds` is a header-only library, so no linking is required. It provides immutable data structures for C++ developers.
- The library is compatible with all major platforms supported by `vcpkg` and has no optional dependencies.

### Available Headers

The library provides the following immutable data structure implementations:

- `immutable/Stack.h`: A stack implementation that returns new instances upon modification.
- `immutable/PriorityQueue.h`: A priority queue implementation.
- `immutable/Queue.h`: A queue implementation.
- `immutable/Set.h`: A set implementation.
- `immutable/HashMap.h`: A hash map implementation.

---

### Usage Instructions

After installing via `vcpkg`:
```bash
./vcpkg install immuds
```

To use it in your CMake project, follow these steps:

1. Include the `vcpkg` toolchain in your project configuration:
   ```cmake
   set(CMAKE_TOOLCHAIN_FILE "/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake")
   ```

2. Find and include the `immuds` headers:
   ```cmake
   find_path(IMMUDS_INCLUDE_DIRS "immutable/HashMap.h")
   target_include_directories(main PRIVATE ${IMMUDS_INCLUDE_DIRS})
   ```

3. Write a C++ program that uses the library:
   ```cpp
   #include <immutable/HashMap.h>

   int main() {
 
        immutable::Stack<int> stack;
        stack = stack.push(3);
        stack = stack.push(11);
        std::cout<<stack.top();
        stack = stack.pop();
       return 0;
   }
   ```
