### PR TITLE
[oatpp-swagger] Feature/oatpp swagger 1.3.0 latest

### DIFF
--- a/ports/oatpp-swagger/portfile.cmake
+++ b/ports/oatpp-swagger/portfile.cmake
@@ -1,4 +1,4 @@
-set(OATPP_VERSION "1.3.0")
+set(OATPP_VERSION "1.3.0-latest")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oatpp/oatpp-swagger
     REF ${OATPP_VERSION}
-    SHA512 5b4ced90690f484ebe15c3a0be47b1b851fb7b650e70c99fddc20430724aac8eff89d8c6187df750bd2ceff0e1144336f258d740fc10cdfa67a65a2f3b00d80b
+    SHA512 a6b3fce21bef57a055c498e80afefacf7b8219fc03381c468b8555c003566bc3e1ce0672670b46e99c51e090cd7000195c7dfeb0258851c4e05bec9ee4c652b3
     HEAD_REF master
 )
 
@@ -23,8 +23,15 @@ vcpkg_cmake_configure(
         "-DOATPP_MSVC_LINK_STATIC_RUNTIME=${OATPP_MSVC_LINK_STATIC_RUNTIME}"
 )
 
+function(strip_version version output_var)
+    string(REGEX REPLACE "([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" stripped_version "${version}")
+    set(${output_var} "${stripped_version}" PARENT_SCOPE)
+endfunction()
+ 
+strip_version("${OATPP_VERSION}" OATPP_VERSION_STRIPPED)
+
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME oatpp-swagger CONFIG_PATH lib/cmake/oatpp-swagger-${OATPP_VERSION})
+vcpkg_cmake_config_fixup(PACKAGE_NAME oatpp-swagger CONFIG_PATH lib/cmake/oatpp-swagger-${OATPP_VERSION_STRIPPED})
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/oatpp-swagger/vcpkg.json
+++ b/ports/oatpp-swagger/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "oatpp-swagger",
-  "version": "1.3.0",
+  "version": "1.3.0-latest",
   "port-version": 1,
   "description": "Oat++ OpenApi (Swagger) UI submodule.",
   "homepage": "https://github.com/oatpp/oatpp-swagger",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6513,7 +6513,7 @@
       "port-version": 1
     },
     "oatpp-swagger": {
-      "baseline": "1.3.0",
+      "baseline": "1.3.0-latest",
       "port-version": 1
     },
     "oatpp-websocket": {

--- a/versions/o-/oatpp-swagger.json
+++ b/versions/o-/oatpp-swagger.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ed5251c580e2e98beb50d818bcea8ddc91419d8c",
+      "git-tree": "274d2eee807e6e1ae0b77be706c5ec644fc042a4",
       "version": "1.3.0-latest",
       "port-version": 1
     },

--- a/versions/o-/oatpp-swagger.json
+++ b/versions/o-/oatpp-swagger.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ed5251c580e2e98beb50d818bcea8ddc91419d8c",
+      "version": "1.3.0-latest",
+      "port-version": 1
+    },
+    {
       "git-tree": "b8935367b57b4203e0eba828a6b8f9cc5ebb659c",
       "version": "1.3.0",
       "port-version": 1


### PR DESCRIPTION
This adds the version oatpp-swagger `1.3.0-latest` since `1.4.0` is still not ready, and this already brings an important feature, you can set the BASE_URL for the auto generated swagger routes.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

