### PR TITLE
[aravis] add new port (+add to OpenCV 4 as optional feature)

### DIFF
--- a/ports/aravis/portfile.cmake
+++ b/ports/aravis/portfile.cmake
@@ -1,0 +1,70 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO AravisProject/aravis
+    REF "${VERSION}"
+    SHA512 3a71228fdd3d2fc6926b4efc99f268130ad4c460a8d8573d7cfa9bc0833355e88e5fc8900302eb8b891a1cc1a7f4b8753a295e5fe10d9653b32258ab62ed2113
+    HEAD_REF main
+)
+
+set(OPTIONS "")
+set(OPTIONS_RELEASE "")
+if("usb" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dusb=enabled)
+else()
+    list(APPEND OPTIONS -Dusb=disabled)
+endif()
+if("packet-socket" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dpacket-socket=enabled)
+else()
+    list(APPEND OPTIONS -Dpacket-socket=disabled)
+endif()
+if("fast-heartbeat" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dfast-heartbeat=true)
+else()
+    list(APPEND OPTIONS -Dfast-heartbeat=false)
+endif()
+if("introspection" IN_LIST FEATURES)
+    list(APPEND OPTIONS_RELEASE -Dintrospection=enabled)
+else()
+    list(APPEND OPTIONS_RELEASE -Dintrospection=disabled)
+endif()
+
+set(GLIB_TOOLS_DIR "${CURRENT_HOST_INSTALLED_DIR}/tools/glib")
+set(GIR_TOOLS_DIR "${CURRENT_HOST_INSTALLED_DIR}/tools/gobject-introspection")
+if(CMAKE_HOST_WIN32 AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(GIR_TOOLS_DIR "${CURRENT_INSTALLED_DIR}/tools/gobject-introspection")
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH
+        "${SOURCE_PATH}"
+    OPTIONS
+        ${OPTIONS}
+        -Dviewer=disabled
+        -Dgst-plugin=disabled
+    OPTIONS_RELEASE
+        ${OPTIONS_RELEASE}
+    OPTIONS_DEBUG
+        -Dintrospection=disabled
+    ADDITIONAL_BINARIES
+        "glib-mkenums='${GLIB_TOOLS_DIR}/glib-mkenums'"
+        "glib-compile-resources='${GLIB_TOOLS_DIR}/glib-compile-resources${VCPKG_HOST_EXECUTABLE_SUFFIX}'"
+        "g-ir-compiler='${GIR_TOOLS_DIR}/g-ir-compiler${VCPKG_HOST_EXECUTABLE_SUFFIX}'"
+        "g-ir-scanner='${GIR_TOOLS_DIR}/g-ir-scanner'"
+)
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_tools(
+    AUTO_CLEAN
+    TOOL_NAMES
+        arv-camera-test-0.8
+        arv-fake-gv-camera-0.8
+        arv-test-0.8
+        arv-tool-0.8
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/aravis/vcpkg.json
+++ b/ports/aravis/vcpkg.json
@@ -1,0 +1,43 @@
+{
+  "name": "aravis",
+  "version": "0.8.34",
+  "description": " A vision library for genicam based cameras.",
+  "homepage": "https://github.com/AravisProject/aravis",
+  "license": "LGPL-2.0-or-later",
+  "dependencies": [
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    "libxml2",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    },
+    "zlib"
+  ],
+  "default-features": [
+    "usb"
+  ],
+  "features": {
+    "fast-heartbeat": {
+      "description": "Enable faster heartbeat rate"
+    },
+    "introspection": {
+      "description": "Build introspection data",
+      "dependencies": [
+        "gobject-introspection"
+      ]
+    },
+    "packet-socket": {
+      "description": "Enable packet socket support"
+    },
+    "usb": {
+      "description": "Enable USB support",
+      "dependencies": [
+        "libusb"
+      ]
+    }
+  }
+}

--- a/ports/opencv/vcpkg.json
+++ b/ports/opencv/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv",
   "version": "4.10.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",
@@ -20,6 +20,18 @@
           "default-features": false,
           "features": [
             "ade"
+          ]
+        }
+      ]
+    },
+    "aravis": {
+      "description": "aravis",
+      "dependencies": [
+        {
+          "name": "opencv4",
+          "default-features": false,
+          "features": [
+            "aravis"
           ]
         }
       ]

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -70,6 +70,7 @@ set(ADE_DIR ${CURRENT_INSTALLED_DIR}/share/ade CACHE PATH "Path to existing ADE 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
  FEATURES
  "ade"        WITH_ADE
+ "aravis"     WITH_ARAVIS
  "calib3d"    BUILD_opencv_calib3d
  "carotene"   WITH_CAROTENE
  "contrib"    WITH_CONTRIB

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.10.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",
@@ -65,6 +65,15 @@
       "description": "graph api",
       "dependencies": [
         "ade"
+      ]
+    },
+    "aravis": {
+      "description": "aravis",
+      "dependencies": [
+        {
+          "name": "aravis",
+          "default-features": false
+        }
       ]
     },
     "calib3d": {

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -55,6 +55,10 @@ apr:arm64-android=fail
 apr:x64-android=fail
 apsi:arm-neon-android=fail
 apsi:x64-android=fail
+# needs NDK w/ API level >=24, CI currently has API level 21
+aravis:arm-neon-android=fail
+aravis:arm64-android=fail
+aravis:x64-android=fail
 # Broken with CUDA 12; needs update to 3.8.3 and https://github.com/arrayfire/arrayfire/issues/3349 fixed
 arrayfire:x64-linux=fail
 avro-c:arm-neon-android=fail

--- a/scripts/test_ports/vcpkg-ci-opencv/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-opencv/vcpkg.json
@@ -121,6 +121,14 @@
       "platform": "!uwp & !android & !(windows & (arm | arm64)) & !(osx & arm64)"
     },
     {
+      "name": "opencv",
+      "default-features": false,
+      "features": [
+        "aravis"
+      ],
+      "platform": "!android & !uwp"
+    },
+    {
       "name": "opencv2",
       "default-features": false,
       "features": [

--- a/versions/a-/aravis.json
+++ b/versions/a-/aravis.json
@@ -4,11 +4,6 @@
       "git-tree": "9de676f9a27354906fbff6a6005d11719e8f09e1",
       "version": "0.8.34",
       "port-version": 0
-    },
-    {
-      "git-tree": "f10c74a734a6136a4703c6f44528740ee9d3413e",
-      "version": "0.8.33",
-      "port-version": 0
     }
   ]
 }

--- a/versions/a-/aravis.json
+++ b/versions/a-/aravis.json
@@ -1,0 +1,14 @@
+{
+  "versions": [
+    {
+      "git-tree": "9de676f9a27354906fbff6a6005d11719e8f09e1",
+      "version": "0.8.34",
+      "port-version": 0
+    },
+    {
+      "git-tree": "f10c74a734a6136a4703c6f44528740ee9d3413e",
+      "version": "0.8.33",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6722,7 +6722,7 @@
     },
     "opencv": {
       "baseline": "4.10.0",
-      "port-version": 2
+      "port-version": 3
     },
     "opencv2": {
       "baseline": "2.4.13.7",
@@ -6734,7 +6734,7 @@
     },
     "opencv4": {
       "baseline": "4.10.0",
-      "port-version": 5
+      "port-version": 6
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -184,6 +184,10 @@
       "baseline": "0.11.0",
       "port-version": 0
     },
+    "aravis": {
+      "baseline": "0.8.34",
+      "port-version": 0
+    },
     "arb": {
       "baseline": "2.21.1",
       "port-version": 2

--- a/versions/o-/opencv.json
+++ b/versions/o-/opencv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b64f8548c2b8c03acf0f510c100785725c6e3f6f",
+      "version": "4.10.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "22a0035d6e4154c97495125f9482180d7810fe91",
       "version": "4.10.0",
       "port-version": 2

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "93ab740dda4563da56f1b89ddbd8bc9802ec6df2",
+      "version": "4.10.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "176f72c465d0770b93bc5c394d4993de54ad9c71",
       "version": "4.10.0",
       "port-version": 5


### PR DESCRIPTION
please note:
* i'm not part of the aravis maintainers (i'm just a user)
* i've tested this under Ubuntu 24.04 in WSL2 using a USB3 VISION camera through OpenCV (with the new `aravis` feature introduced in this PR) and it worked fine
* aravis currently builds a couple of binaries (`arv-camera-test-0.8`, `arv-fake-gv-camera-0.8`, `arv-test-0.8` and `arv-tool-0.8`) which cannot be disabled at the moment (except with a patch to their build system), i've reported this to upstream: https://github.com/AravisProject/aravis/issues/962. i think they currently don't hurt and it's better if this gets fixed in upstream rather than having a patch here.
* back in 2019 @cenit already once attempted to package aravis here but that PR was abandoned later: #8595

resolves #37072
resolves #3411


checklist:
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

