### PR TITLE
Skip qt5-webengine on x86-windows and x64-windows

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -930,11 +930,14 @@ qt5-canvas3d:x64-windows-static=skip
 qt5-canvas3d:x64-windows-static-md=skip
 qt5-canvas3d:x86-windows=skip
 # Missing system libraries
-qtwayland:x64-osx=skip
-qtwayland:arm64-osx=skip
-# Missing system libraries
 qt5-x11extras:x64-osx=skip
 qt5-x11extras:arm64-osx=skip
+# Skipped to avoid exceeding the 48 hour time limit in CI
+qt5-webengine:x86-windows=skip
+qt5-webengine:x64-windows=skip
+# Missing system libraries
+qtwayland:x64-osx=skip
+qtwayland:arm64-osx=skip
 quickfix:arm-neon-android=fail
 quickfix:arm64-android=fail
 qwt-qt6:x64-osx=fail


### PR DESCRIPTION
Example: https://dev.azure.com/vcpkg/public/_build/results?buildId=109620

Azure DevOps has a hard 48 hour time limit and x86-windows and x64-windows are close to or exceeding that. qt5 is out of support from the qt foundation for OSS customers, and qt5-webengine is by far the most expensive port to build, at 2.1 hours. (The next longest is LLVM at 1.1 hours, but large portions of the registry depend on that, so we couldn't consider skipping it)

We are concurrently investigating @autoantwort 's pipelined cache upload work to help put distance to the 48 hour limit. (I finally got approval for the dependency of merging that from @ras0219-msft last week)

![Screenshot of the run above showing 48 hour runtime](https://github.com/user-attachments/assets/04a72168-8648-4091-9cd6-93d543dd78bc)
