### PR TITLE
[yasm] Repaired the PDB file that was overwritten due to having the same name

### DIFF
--- a/ports/yasm/fix-overlay-pdb.patch
+++ b/ports/yasm/fix-overlay-pdb.patch
@@ -1,32 +1,12 @@
 diff --git a/frontends/yasm/CMakeLists.txt b/frontends/yasm/CMakeLists.txt
-index b11d7f8..ef423f5 100644
+index b11d7f8..b8306b1 100644
 --- a/frontends/yasm/CMakeLists.txt
 +++ b/frontends/yasm/CMakeLists.txt
-@@ -13,22 +13,22 @@ ADD_CUSTOM_COMMAND(
- SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
- 
- IF(BUILD_SHARED_LIBS)
--    ADD_EXECUTABLE(yasm
-+    ADD_EXECUTABLE(yasm-tool
-         yasm.c
-         yasm-options.c
+@@ -19,6 +19,7 @@ IF(BUILD_SHARED_LIBS)
          yasm-plugin.c
          )
--    TARGET_LINK_LIBRARIES(yasm libyasm ${LIBDL})
-+    TARGET_LINK_LIBRARIES(yasm-tool libyasm ${LIBDL})
+     TARGET_LINK_LIBRARIES(yasm libyasm ${LIBDL})
++    set_target_properties(yasm PROPERTIES PDB_NAME "yasm-tool")
  ELSE(BUILD_SHARED_LIBS)
--    ADD_EXECUTABLE(yasm
-+    ADD_EXECUTABLE(yasm-tool
+     ADD_EXECUTABLE(yasm
          yasm.c
-         yasm-options.c
-         )
--    TARGET_LINK_LIBRARIES(yasm yasmstd libyasm)
-+    TARGET_LINK_LIBRARIES(yasm-tool yasmstd libyasm)
- ENDIF(BUILD_SHARED_LIBS)
- 
- SET_SOURCE_FILES_PROPERTIES(yasm.c PROPERTIES
-     OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/license.c
-     )
- 
--INSTALL(TARGETS yasm RUNTIME DESTINATION bin)
-+INSTALL(TARGETS yasm-tool RUNTIME DESTINATION bin)

--- a/ports/yasm/fix-overlay-pdb.patch
+++ b/ports/yasm/fix-overlay-pdb.patch
@@ -1,0 +1,32 @@
+diff --git a/frontends/yasm/CMakeLists.txt b/frontends/yasm/CMakeLists.txt
+index b11d7f8..ef423f5 100644
+--- a/frontends/yasm/CMakeLists.txt
++++ b/frontends/yasm/CMakeLists.txt
+@@ -13,22 +13,22 @@ ADD_CUSTOM_COMMAND(
+ SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+ 
+ IF(BUILD_SHARED_LIBS)
+-    ADD_EXECUTABLE(yasm
++    ADD_EXECUTABLE(yasm-tool
+         yasm.c
+         yasm-options.c
+         yasm-plugin.c
+         )
+-    TARGET_LINK_LIBRARIES(yasm libyasm ${LIBDL})
++    TARGET_LINK_LIBRARIES(yasm-tool libyasm ${LIBDL})
+ ELSE(BUILD_SHARED_LIBS)
+-    ADD_EXECUTABLE(yasm
++    ADD_EXECUTABLE(yasm-tool
+         yasm.c
+         yasm-options.c
+         )
+-    TARGET_LINK_LIBRARIES(yasm yasmstd libyasm)
++    TARGET_LINK_LIBRARIES(yasm-tool yasmstd libyasm)
+ ENDIF(BUILD_SHARED_LIBS)
+ 
+ SET_SOURCE_FILES_PROPERTIES(yasm.c PROPERTIES
+     OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/license.c
+     )
+ 
+-INSTALL(TARGETS yasm RUNTIME DESTINATION bin)
++INSTALL(TARGETS yasm-tool RUNTIME DESTINATION bin)

--- a/ports/yasm/portfile.cmake
+++ b/ports/yasm/portfile.cmake
@@ -48,12 +48,11 @@ if (BUILD_TOOLS)
     if (NOT VCPKG_CROSSCOMPILING)
         list(APPEND EXTRA_BUILD_TOOLS re2c genmacro genperf genversion)
     endif()
-    vcpkg_copy_tools(TOOL_NAMES vsyasm yasm-tool ytasm ${EXTRA_BUILD_TOOLS} AUTO_CLEAN)
+    vcpkg_copy_tools(TOOL_NAMES vsyasm yasm ytasm ${EXTRA_BUILD_TOOLS} AUTO_CLEAN)
     if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
         file(COPY "${CURRENT_PACKAGES_DIR}/bin/yasmstd${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
             DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
     endif()
-    file(RENAME "${CURRENT_PACKAGES_DIR}/tools/${PORT}/yasm-tool${VCPKG_HOST_EXECUTABLE_SUFFIX}" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/yasm${VCPKG_HOST_EXECUTABLE_SUFFIX}")
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)

--- a/ports/yasm/portfile.cmake
+++ b/ports/yasm/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         add-feature-tools.patch
         fix-arm-cross-build.patch
+        fix-overlay-pdb.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -47,11 +48,12 @@ if (BUILD_TOOLS)
     if (NOT VCPKG_CROSSCOMPILING)
         list(APPEND EXTRA_BUILD_TOOLS re2c genmacro genperf genversion)
     endif()
-    vcpkg_copy_tools(TOOL_NAMES vsyasm yasm ytasm ${EXTRA_BUILD_TOOLS} AUTO_CLEAN)
+    vcpkg_copy_tools(TOOL_NAMES vsyasm yasm-tool ytasm ${EXTRA_BUILD_TOOLS} AUTO_CLEAN)
     if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
         file(COPY "${CURRENT_PACKAGES_DIR}/bin/yasmstd${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
             DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
     endif()
+    file(RENAME "${CURRENT_PACKAGES_DIR}/tools/${PORT}/yasm-tool${VCPKG_HOST_EXECUTABLE_SUFFIX}" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/yasm${VCPKG_HOST_EXECUTABLE_SUFFIX}")
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)

--- a/ports/yasm/vcpkg.json
+++ b/ports/yasm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "yasm",
   "version": "1.3.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Yasm is a complete rewrite of the NASM assembler under the new BSD License.",
   "homepage": "https://github.com/yasm/yasm",
   "license": "BSD-2-Clause OR BSD-3-Clause OR Artistic-1.0 OR GPL-2.0-only OR LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9906,7 +9906,7 @@
     },
     "yasm": {
       "baseline": "1.3.0",
-      "port-version": 5
+      "port-version": 6
     },
     "yasm-tool": {
       "baseline": "2021-12-14",

--- a/versions/y-/yasm.json
+++ b/versions/y-/yasm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2b274b3e956b70f76c52f6318cdd949ba314d537",
+      "git-tree": "cd30518fa90953d3fa7cc1c0096bf628d2b457be",
       "version": "1.3.0",
       "port-version": 6
     },

--- a/versions/y-/yasm.json
+++ b/versions/y-/yasm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b274b3e956b70f76c52f6318cdd949ba314d537",
+      "version": "1.3.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "e9ad958de17f5b7661720dc322cff96b2dff8355",
       "version": "1.3.0",
       "port-version": 5


### PR DESCRIPTION
Due to the name of tool `yasm` is same with lib `yasm`, so the matched pdb file of `yasm.dll` was overwritten by tool `yasm`, use `PDB_NAME` to fix this issue.
The related build warning of `yasm`:
```
CMake Warning at scripts/cmake/vcpkg_copy_pdbs.cmake:44 (message):
  Could not find a matching pdb file for:

      F:/vcpkg/packages/yasm_x64-windows/bin/yasm.dll
      F:/vcpkg/packages/yasm_x64-windows/debug/bin/yasm.dll

Call Stack (most recent call first):
  ports/yasm/portfile.cmake:43 (vcpkg_copy_pdbs)
  scripts/ports.cmake:196 (include)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
