### PR TITLE
[qtwebengine] Compilation fix for Visual Studio 17.12

### DIFF
--- a/ports/qtwebengine/msvc_17_12_compilation_fix.patch
+++ b/ports/qtwebengine/msvc_17_12_compilation_fix.patch
@@ -1,0 +1,50 @@
+diff --git a/src/3rdparty/chromium/v8/src/snapshot/embedded/embedded-data.cc b/src/3rdparty/chromium/v8/src/snapshot/embedded/embedded-data.cc
+index fb3642c95..f1ba90978 100644
+--- a/src/3rdparty/chromium/v8/src/snapshot/embedded/embedded-data.cc
++++ b/src/3rdparty/chromium/v8/src/snapshot/embedded/embedded-data.cc
+@@ -22,12 +22,12 @@ Builtin EmbeddedData::TryLookupCode(Address address) const {
+   uint32_t offset =
+       static_cast<uint32_t>(address - reinterpret_cast<Address>(RawCode()));
+ 
+-  const struct BuiltinLookupEntry* start =
++  const struct EmbeddedData::BuiltinLookupEntry* start =
+       BuiltinLookupEntry(static_cast<ReorderedBuiltinIndex>(0));
+-  const struct BuiltinLookupEntry* end = start + kTableSize;
+-  const struct BuiltinLookupEntry* desc =
++  const struct EmbeddedData::BuiltinLookupEntry* end = start + kTableSize;
++  const struct EmbeddedData::BuiltinLookupEntry* desc =
+       std::upper_bound(start, end, offset,
+-                       [](uint32_t o, const struct BuiltinLookupEntry& desc) {
++                       [](uint32_t o, const struct EmbeddedData::BuiltinLookupEntry& desc) {
+                          return o < desc.end_offset;
+                        });
+   Builtin builtin = static_cast<Builtin>(desc->builtin_id);
+@@ -237,8 +237,8 @@ EmbeddedData EmbeddedData::NewFromIsolate(Isolate* isolate) {
+   Builtins* builtins = isolate->builtins();
+ 
+   // Store instruction stream lengths and offsets.
+-  std::vector<struct LayoutDescription> layout_descriptions(kTableSize);
+-  std::vector<struct BuiltinLookupEntry> offset_descriptions(kTableSize);
++  std::vector<struct EmbeddedData::LayoutDescription> layout_descriptions(kTableSize);
++  std::vector<struct EmbeddedData::BuiltinLookupEntry> offset_descriptions(kTableSize);
+ 
+   bool saw_unsafe_builtin = false;
+   uint32_t raw_code_size = 0;
+@@ -287,7 +287,7 @@ EmbeddedData EmbeddedData::NewFromIsolate(Isolate* isolate) {
+     {
+       // We use builtin id as index in layout_descriptions.
+       const int builtin_id = static_cast<int>(builtin);
+-      struct LayoutDescription& layout_desc = layout_descriptions[builtin_id];
++      struct EmbeddedData::LayoutDescription& layout_desc = layout_descriptions[builtin_id];
+       layout_desc.instruction_offset = raw_code_size;
+       layout_desc.instruction_length = instruction_size;
+       layout_desc.metadata_offset = raw_data_size;
+@@ -298,7 +298,7 @@ EmbeddedData EmbeddedData::NewFromIsolate(Isolate* isolate) {
+ 
+     {
+       // We use embedded index as index in offset_descriptions.
+-      struct BuiltinLookupEntry& offset_desc =
++      struct EmbeddedData::BuiltinLookupEntry& offset_desc =
+           offset_descriptions[embedded_index];
+       offset_desc.end_offset = raw_code_size;
+       offset_desc.builtin_id = static_cast<uint32_t>(builtin);

--- a/ports/qtwebengine/portfile.cmake
+++ b/ports/qtwebengine/portfile.cmake
@@ -5,6 +5,7 @@ set(${PORT}_PATCHES
       "clang-cl.patch"
       "fix-error2275-2672.patch"
       "blink-include-fixes.patch"
+      "msvc_17_12_compilation_fix.patch"
 )
 
 set(TOOL_NAMES gn QtWebEngineProcess qwebengine_convert_dict webenginedriver)

--- a/ports/qtwebengine/vcpkg.json
+++ b/ports/qtwebengine/vcpkg.json
@@ -2,6 +2,7 @@
   "$comment": "x86-windows is not within the upstream support matrix of Qt6",
   "name": "qtwebengine",
   "version": "6.8.0",
+  "port-version": 1,
   "description": "Qt WebEngine provides functionality for rendering regions of dynamic web content.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7718,7 +7718,7 @@
     },
     "qtwebengine": {
       "baseline": "6.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qtwebsockets": {
       "baseline": "6.8.0",

--- a/versions/q-/qtwebengine.json
+++ b/versions/q-/qtwebengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "980b146cab16b2c22c13154cf804494caf2298f5",
+      "version": "6.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d02b034d91eeab6041f6de522eed214c5411f31f",
       "version": "6.8.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #42366

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


Note: This is my first PR here, so please verify that I did everything correctly