### PR TITLE
[DiscordCoreAPI] to v2.0.8 and [Jsonifier] to v0.9.98

### DIFF
--- a/ports/discordcoreapi/portfile.cmake
+++ b/ports/discordcoreapi/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RealTimeChris/DiscordCoreAPI
     REF "v${VERSION}"
-    SHA512 344e960491e17e9626f6ab4a42f28fe59842c0c15cf32ef2508e850099105667c651feaa6dd642207413fbeac43283310fe2b9a98a2ebfd4a49716da43e5cade
+    SHA512 d977ed7d8805f0b110450d3baf0256eae11ecc25947496c657a9c9b17aa9222db92435f28ebd924c166927e4714b3e9ae388f64836175cc96b78b08315031ede
     HEAD_REF main
 )
 
@@ -23,8 +23,6 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    # Due to CMake/DCADetectArchitecture.cmake invoking a sub-CMake and using the source tree as the target
-    DISABLE_PARALLEL_CONFIGURE
 )
 
 vcpkg_cmake_install()

--- a/ports/discordcoreapi/vcpkg.json
+++ b/ports/discordcoreapi/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "discordcoreapi",
-  "version": "2.0.7",
-  "port-version": 1,
+  "version": "2.0.8",
   "description": "A Discord bot library written in C++ using custom asynchronous coroutines.",
   "homepage": "https://discordcoreapi.com",
   "license": "MIT",

--- a/ports/jsonifier/portfile.cmake
+++ b/ports/jsonifier/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO realtimechris/jsonifier
     REF "v${VERSION}"
-    SHA512 6168378a117850297fcda78853a0babd0ce7e0ca21b3e8c276acb7e75e04d85ed8909061a62e3324c309fe9e31bc59d89ea06e47853b50481843273e95172ab8
+    SHA512 d6465426218429a1597fa66b2d8cb912bce00831d663be7b8ea406267537dd6f455c1b99c3c8551dd8165a75d9dbe42fefedbad5979eb45d01e0286f08daad96
     HEAD_REF main
 )
 
@@ -10,8 +10,6 @@ set(VCPKG_BUILD_TYPE release) # header-only
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    # Due to CMake/JsonifierDetectArchitecture.cmake invoking a sub-CMake and using the source tree as the target
-    DISABLE_PARALLEL_CONFIGURE
 )
 
 vcpkg_cmake_install()

--- a/ports/jsonifier/vcpkg.json
+++ b/ports/jsonifier/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "jsonifier",
-  "version": "0.9.97",
-  "port-version": 1,
+  "version": "0.9.98",
   "description": "A few classes for parsing and serializing json - very rapidly.",
   "homepage": "https://github.com/realtimechris/jsonifier",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2357,8 +2357,8 @@
       "port-version": 4
     },
     "discordcoreapi": {
-      "baseline": "2.0.7",
-      "port-version": 1
+      "baseline": "2.0.8",
+      "port-version": 0
     },
     "discount": {
       "baseline": "3.0.0d",
@@ -3909,8 +3909,8 @@
       "port-version": 0
     },
     "jsonifier": {
-      "baseline": "0.9.97",
-      "port-version": 1
+      "baseline": "0.9.98",
+      "port-version": 0
     },
     "jsonnet": {
       "baseline": "0.20.0",

--- a/versions/d-/discordcoreapi.json
+++ b/versions/d-/discordcoreapi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27e0ce86a5c8ede0c9f6c3586bb53ec3d15dfd9f",
+      "version": "2.0.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "1371e3f72145af807a144e3fadb1daf58c0b7cdd",
       "version": "2.0.7",
       "port-version": 1

--- a/versions/j-/jsonifier.json
+++ b/versions/j-/jsonifier.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c74184d63d1f960f3abc909d45469b454b30c9f",
+      "version": "0.9.98",
+      "port-version": 0
+    },
+    {
       "git-tree": "5d654c9f844e2a31fdefed0d5e628d241e6451f6",
       "version": "0.9.97",
       "port-version": 1


### PR DESCRIPTION
DiscordCoreAPI Changes:
* Updated to keep in track with Jsonifier dependency.
* Removed the compile-time CPU architecture script.

Jsonifier Changes:
- Removed dependence upon a compile-time script for CPU architecture selection.
- Implemented partial reading/writing.
- Added newly optimized float parsing algorithm.
- Added a new tuple implementation to significantly reduce compile time.

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
