### PR TITLE
[many ports 1] Include `<chrono>` for `system_clock` and `high_resolution_clock`

### DIFF
--- a/ports/concurrencpp/add-include-chrono.patch
+++ b/ports/concurrencpp/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/include/concurrencpp/results/impl/shared_result_state.h b/include/concurrencpp/results/impl/shared_result_state.h
+index 6c96f4b..1433e74 100644
+--- a/include/concurrencpp/results/impl/shared_result_state.h
++++ b/include/concurrencpp/results/impl/shared_result_state.h
+@@ -5,6 +5,7 @@
+ #include "concurrencpp/results/impl/result_state.h"
+ 
+ #include <atomic>
++#include <chrono>
+ #include <semaphore>
+ 
+ #include <cassert>

--- a/ports/concurrencpp/portfile.cmake
+++ b/ports/concurrencpp/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
   PATCHES
     fix-include-path.patch
     add-include-string.patch
+    add-include-chrono.patch # https://github.com/David-Haim/concurrencpp/pull/170
 )
 
 vcpkg_cmake_configure(

--- a/ports/concurrencpp/vcpkg.json
+++ b/ports/concurrencpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "concurrencpp",
   "version": "0.1.7",
-  "port-version": 1,
+  "port-version": 2,
   "description": "concurrencpp is a tasking library for C++ allowing developers to write highly concurrent applications easily and safely by using tasks, executors and coroutines.",
   "homepage": "https://github.com/David-Haim/concurrencpp/",
   "license": "MIT",

--- a/ports/iceoryx/add-include-chrono.patch
+++ b/ports/iceoryx/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/iceoryx_hoofs/platform/win/source/time.cpp b/iceoryx_hoofs/platform/win/source/time.cpp
+index 4c2ab2d..4a7074b 100644
+--- a/iceoryx_hoofs/platform/win/source/time.cpp
++++ b/iceoryx_hoofs/platform/win/source/time.cpp
+@@ -16,6 +16,7 @@
+ // SPDX-License-Identifier: Apache-2.0
+ 
+ #include "iceoryx_hoofs/platform/time.hpp"
++#include <chrono>
+ 
+ static std::chrono::nanoseconds getNanoSeconds(const timespec& value)
+ {

--- a/ports/iceoryx/portfile.cmake
+++ b/ports/iceoryx/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         acl.patch
+        add-include-chrono.patch # https://github.com/eclipse-iceoryx/iceoryx/pull/2378
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/iceoryx/vcpkg.json
+++ b/ports/iceoryx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "iceoryx",
   "version": "2.0.6",
+  "port-version": 1,
   "description": "True zero-copy inter-process-communication",
   "homepage": "https://iceoryx.io",
   "license": "Apache-2.0",

--- a/ports/nrf-ble-driver/add-include-chrono.patch
+++ b/ports/nrf-ble-driver/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/src/common/transport/serialization_transport.cpp b/src/common/transport/serialization_transport.cpp
+index f916961..5ab0f3a 100644
+--- a/src/common/transport/serialization_transport.cpp
++++ b/src/common/transport/serialization_transport.cpp
+@@ -43,6 +43,7 @@
+ 
+ #include "ble_common.h"
+ 
++#include <chrono>
+ #include <iterator>
+ #include <memory>
+ #include <sstream>

--- a/ports/nrf-ble-driver/portfile.cmake
+++ b/ports/nrf-ble-driver/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
         001-arm64-support.patch
         support-arm64-osx.diff # from https://github.com/NordicSemiconductor/pc-ble-driver/pull/271
         gcc-11.2.0-compilation.patch # from https://github.com/NordicSemiconductor/pc-ble-driver/pull/272
+        add-include-chrono.patch
 )
 
 # Ensure that git is found within CMakeLists.txt by appending vcpkg's git executable dirpath to $PATH.

--- a/ports/nrf-ble-driver/vcpkg.json
+++ b/ports/nrf-ble-driver/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nrf-ble-driver",
   "version": "4.1.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "BLE driver is a library for Bluetooth Low Energy communication using Nordic Semiconductor development kits.",
   "homepage": "https://github.com/NordicSemiconductor/pc-ble-driver",
   "license": "BSD-3-Clause",

--- a/ports/nsync/add-include-chrono.patch
+++ b/ports/nsync/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/platform/c++11/platform.h b/platform/c++11/platform.h
+index 2c80e0b..1468fab 100644
+--- a/platform/c++11/platform.h
++++ b/platform/c++11/platform.h
+@@ -16,6 +16,7 @@
+ #define NSYNC_PLATFORM_CPP11_PLATFORM_H_
+ 
+ /* These C header files are in "C compatibility headers" in C++11. */
++#include <chrono>
+ #include <string.h>
+ #include <errno.h>
+ #include <stdlib.h>

--- a/ports/nsync/portfile.cmake
+++ b/ports/nsync/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-install.patch
+        add-include-chrono.patch # https://github.com/google/nsync/pull/25
 )
 
 vcpkg_cmake_configure(
@@ -25,4 +26,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/nsync/vcpkg.json
+++ b/ports/nsync/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nsync",
   "version": "1.29.2",
+  "port-version": 1,
   "description": "nsync is a C library that exports various synchronization primitives, such as mutexes",
   "homepage": "https://github.com/google/nsync",
   "license": "Apache-2.0",

--- a/ports/ogdf/add-include-chrono.patch
+++ b/ports/ogdf/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/src/ogdf/cluster/HananiTutteCPlanarity.cpp b/src/ogdf/cluster/HananiTutteCPlanarity.cpp
+index 2cec55b..ac2672e 100644
+--- a/src/ogdf/cluster/HananiTutteCPlanarity.cpp
++++ b/src/ogdf/cluster/HananiTutteCPlanarity.cpp
+@@ -37,6 +37,7 @@
+ #include <ogdf/basic/extended_graph_alg.h>
+ #include <ogdf/cluster/CconnectClusterPlanar.h>
+ #include <ogdf/cluster/ClusterPlanarity.h>
++#include <chrono>
+ #include <unordered_map>
+ #include <map>
+ 

--- a/ports/ogdf/portfile.cmake
+++ b/ports/ogdf/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 214105da97863e1d0a066157e5cc573b65b433a9
     SHA512 8ab9f266fef224ce600cec418d5de56761714fbaa2d509ba89d55700c1d27d02a5fc93fab8eb8e10325a42c7d2fa8e251e2a18ece9a9565e215bf39672bff92d
     HEAD_REF master
+    PATCHES 
+        add-include-chrono.patch # https://github.com/ogdf/ogdf/pull/254
 )
 
 vcpkg_cmake_configure(
@@ -20,6 +22,6 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/OGDF)
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/minisat/doc" "${CURRENT_PACKAGES_DIR}/include/ogdf/lib/minisat/doc")

--- a/ports/ogdf/vcpkg.json
+++ b/ports/ogdf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ogdf",
   "version-date": "2022-06-30",
+  "port-version": 1,
   "description": "Open Graph Drawing Framework",
   "homepage": "https://github.com/ogdf/ogdf",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1838,7 +1838,7 @@
     },
     "concurrencpp": {
       "baseline": "0.1.7",
-      "port-version": 1
+      "port-version": 2
     },
     "concurrentqueue": {
       "baseline": "1.0.4",
@@ -3578,7 +3578,7 @@
     },
     "iceoryx": {
       "baseline": "2.0.6",
-      "port-version": 0
+      "port-version": 1
     },
     "icu": {
       "baseline": "74.2",
@@ -6422,7 +6422,7 @@
     },
     "nrf-ble-driver": {
       "baseline": "4.1.4",
-      "port-version": 1
+      "port-version": 2
     },
     "nspr": {
       "baseline": "4.35",
@@ -6434,7 +6434,7 @@
     },
     "nsync": {
       "baseline": "1.29.2",
-      "port-version": 0
+      "port-version": 1
     },
     "nt-wrapper": {
       "baseline": "2019-08-10",
@@ -6558,7 +6558,7 @@
     },
     "ogdf": {
       "baseline": "2022-06-30",
-      "port-version": 0
+      "port-version": 1
     },
     "ogre": {
       "baseline": "14.3.1",

--- a/versions/c-/concurrencpp.json
+++ b/versions/c-/concurrencpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46298cd69835358c8776d28900b669f39254cfb8",
+      "version": "0.1.7",
+      "port-version": 2
+    },
+    {
       "git-tree": "07b69be3721571f0f15bc80442fd735cf1f87b70",
       "version": "0.1.7",
       "port-version": 1

--- a/versions/i-/iceoryx.json
+++ b/versions/i-/iceoryx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc0edf5362f2ad323fbc30d0610971e5fb376b2b",
+      "version": "2.0.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "8018622ded2c8e174b5ef1da63008580b414ad93",
       "version": "2.0.6",
       "port-version": 0

--- a/versions/n-/nrf-ble-driver.json
+++ b/versions/n-/nrf-ble-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17eafc8f3a6edf7a947cf816f47c28e4ad9f5038",
+      "version": "4.1.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "4eaac577bc7f0f8d3bf2cc6281f96d848937ccaa",
       "version": "4.1.4",
       "port-version": 1

--- a/versions/n-/nsync.json
+++ b/versions/n-/nsync.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9338d6f959bf9fabd1bd4d428ab049c48d281587",
+      "version": "1.29.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "04b2d31e465f427424f48323cec0c1f2aa51cbc8",
       "version": "1.29.2",
       "port-version": 0

--- a/versions/o-/ogdf.json
+++ b/versions/o-/ogdf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efd41698d7e242a8e995803b50da10d687485976",
+      "version-date": "2022-06-30",
+      "port-version": 1
+    },
+    {
       "git-tree": "59450d8dd4543482cace9a1a59ca8f46883e85b2",
       "version-date": "2022-06-30",
       "port-version": 0


### PR DESCRIPTION
 Due to there are new changes merged by microsoft/STL#5105, so ports `concurrencpp` `iceoryx` `nrf-ble-driver` `nsync` and `ogdf` need to include `<chrono>` by patching to fix the following error:
```
error C2039: 'system_clock': is not a member of 'std::chrono'
error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
```
The upstream of `nrf-ble-driver` released a deprecation notice https://github.com/NordicSemiconductor/pc-ble-driver/pull/279 in April this year. Now it is not possible to raise questions or PRs upstream.

The other ports have submitted relevant PRs upstream. The list is as follows:
https://github.com/David-Haim/concurrencpp/pull/170
https://github.com/eclipse-iceoryx/iceoryx/pull/2378
https://github.com/google/nsync/pull/25
https://github.com/ogdf/ogdf/pull/254

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
