### PR TITLE
[many ports 2] Include `<chrono>` for `system_clock` and `high_resolution_clock`

### DIFF
--- a/ports/antlr4/add-include-chrono.patch
+++ b/ports/antlr4/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp b/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp
+index 9fd86d6..5220492 100644
+--- a/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp
++++ b/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp
+@@ -10,6 +10,7 @@
+ #include "support/CPPUtils.h"
+ 
+ #include "atn/ProfilingATNSimulator.h"
++#include <chrono>
+ 
+ using namespace antlr4;
+ using namespace antlr4::atn;

--- a/ports/antlr4/portfile.cmake
+++ b/ports/antlr4/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     SHA512 afd8ecab637a0e70cddf98f63c918eab2b907f87207624e20e80a79f885d6502d4ab734a602b1707969d61944410828b689ec2f8b09c15314fe991024cde1613
     PATCHES
         set-export-macro-define-as-private.patch
+        add-include-chrono.patch # https://github.com/antlr/antlr4/pull/4738
 )
 
 set(RUNTIME_PATH "${SOURCE_PATH}/runtime/Cpp")

--- a/ports/antlr4/vcpkg.json
+++ b/ports/antlr4/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "antlr4",
   "version": "4.13.2",
+  "port-version": 1,
   "description": "ANother Tool for Language Recognition",
   "homepage": "https://www.antlr.org",
   "license": "BSD-3-Clause",

--- a/ports/avisynthplus/add-include-chrono.patch
+++ b/ports/avisynthplus/add-include-chrono.patch
@@ -1,0 +1,24 @@
+diff --git a/avs_core/core/avisynth.cpp b/avs_core/core/avisynth.cpp
+index c66d39e..5bc61a3 100644
+--- a/avs_core/core/avisynth.cpp
++++ b/avs_core/core/avisynth.cpp
+@@ -45,6 +45,7 @@
+ #include "FilterConstructor.h"
+ #include "PluginManager.h"
+ #include "MappedList.h"
++#include <chrono>
+ #include <vector>
+ #include <iostream>
+ #include <fstream>
+diff --git a/avs_core/core/cache.cpp b/avs_core/core/cache.cpp
+index 76eb7cf..957e102 100644
+--- a/avs_core/core/cache.cpp
++++ b/avs_core/core/cache.cpp
+@@ -38,6 +38,7 @@
+ #include "InternalEnvironment.h"
+ #include "DeviceManager.h"
+ #include <cassert>
++#include <chrono>
+ #include <cstdio>
+ 
+ #ifdef X86_32

--- a/ports/avisynthplus/portfile.cmake
+++ b/ports/avisynthplus/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 0e0daa83e3ab729fdc35a52c60c23c9142f1229187af893d0dbbd36f88eced36f63a3e8c767a3dc825edaa5395a49a5aad726f6b61de8f6b291557eec20de426
     HEAD_REF master
+    PATCHES
+        add-include-chrono.patch # https://github.com/AviSynth/AviSynthPlus/pull/414
 )
 
 vcpkg_download_distfile(GHC_ARCHIVE
@@ -27,4 +29,4 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/distrib/gpl.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/distrib/gpl.txt")

--- a/ports/avisynthplus/vcpkg.json
+++ b/ports/avisynthplus/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "avisynthplus",
   "version": "3.7.3",
+  "port-version": 1,
   "description": "An improved version of the AviSynth frameserver, with improved features and developer friendliness",
   "homepage": "https://avs-plus.net/",
   "license": "GPL-2.0",

--- a/ports/ignition-common1/add-include-chrono.patch
+++ b/ports/ignition-common1/add-include-chrono.patch
@@ -1,0 +1,36 @@
+diff --git a/include/ignition/common/Event.hh b/include/ignition/common/Event.hh
+index 82c7e55..709f4a0 100644
+--- a/include/ignition/common/Event.hh
++++ b/include/ignition/common/Event.hh
+@@ -18,6 +18,7 @@
+ #define IGNITION_COMMON_EVENT_HH_
+ 
+ #include <atomic>
++#include <chrono>
+ #include <functional>
+ #include <list>
+ #include <map>
+diff --git a/src/Console.cc b/src/Console.cc
+index 1cc70db..d897cd6 100644
+--- a/src/Console.cc
++++ b/src/Console.cc
+@@ -14,6 +14,7 @@
+  * limitations under the License.
+  *
+  */
++#include <chrono>
+ #include <string>
+ #include <sstream>
+ 
+diff --git a/src/Util.cc b/src/Util.cc
+index 5cd6699..46e8193 100644
+--- a/src/Util.cc
++++ b/src/Util.cc
+@@ -30,6 +30,7 @@
+ #include <cstdlib>
+ #include <cstring>
+ #include <cctype>
++#include <chrono>
+ 
+ #include <ignition/common/config.hh>
+ #include <ignition/common/SystemPaths.hh>

--- a/ports/ignition-common1/portfile.cmake
+++ b/ports/ignition-common1/portfile.cmake
@@ -1,4 +1,6 @@
 ignition_modular_library(NAME common
                          VERSION "1.1.1"
                          REF ignition-common_1.1.1
-                         SHA512 3311a07fad8fdf809ff3f865de2493ec17c3dd157ee3297f283cf872090fb9e9f05b163416dca32f1bdf2bde02c9b4a9a7defc308344b747a8d113594f65f309)
+                         SHA512 3311a07fad8fdf809ff3f865de2493ec17c3dd157ee3297f283cf872090fb9e9f05b163416dca32f1bdf2bde02c9b4a9a7defc308344b747a8d113594f65f309
+                         PATCHES add-include-chrono.patch
+                         )

--- a/ports/ignition-common1/vcpkg.json
+++ b/ports/ignition-common1/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ignition-common1",
   "version": "1.1.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Deprecated: Use ignition-common3. Common libraries for robotics applications",
   "license": null,
   "supports": "windows",

--- a/ports/ompl/0004_include_chrono.patch
+++ b/ports/ompl/0004_include_chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/src/ompl/util/src/RandomNumbers.cpp b/src/ompl/util/src/RandomNumbers.cpp
+index fe30070..048b42d 100644
+--- a/src/ompl/util/src/RandomNumbers.cpp
++++ b/src/ompl/util/src/RandomNumbers.cpp
+@@ -37,6 +37,7 @@
+ #include "ompl/util/RandomNumbers.h"
+ #include "ompl/util/Exception.h"
+ #include "ompl/util/Console.h"
++#include <chrono>
+ #include <mutex>
+ #include <memory>
+ #include <boost/math/constants/constants.hpp>

--- a/ports/ompl/portfile.cmake
+++ b/ports/ompl/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         0001_Export_targets.patch
         0002_Fix_config.patch
         0003_fix_dep.patch
+        0004_include_chrono.patch # https://github.com/ompl/ompl/pull/1201
 )
 
 # Based on selected features different files get downloaded, so use the following command instead of patch.

--- a/ports/ompl/vcpkg.json
+++ b/ports/ompl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ompl",
   "version": "1.6.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The Open Motion Planning Library, consists of many state-of-the-art sampling-based motion planning algorithms",
   "homepage": "https://ompl.kavrakilab.org/",
   "dependencies": [

--- a/versions/a-/antlr4.json
+++ b/versions/a-/antlr4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "419f0511764db2cbdf8f8c5c3aad4f984f1c8fe5",
+      "version": "4.13.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "f2803934714fc26ec4ef9d6df467e05b0f6c1096",
       "version": "4.13.2",
       "port-version": 0

--- a/versions/a-/avisynthplus.json
+++ b/versions/a-/avisynthplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02aec32ec997a98d60fe28b529bc2ad132d4b5c7",
+      "version": "3.7.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "d6a5198252f84212548934db0f73184919283928",
       "version": "3.7.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -146,7 +146,7 @@
     },
     "antlr4": {
       "baseline": "4.13.2",
-      "port-version": 0
+      "port-version": 1
     },
     "any-lite": {
       "baseline": "0.4.0",
@@ -374,7 +374,7 @@
     },
     "avisynthplus": {
       "baseline": "3.7.3",
-      "port-version": 0
+      "port-version": 1
     },
     "avro-c": {
       "baseline": "1.11.3",
@@ -3614,7 +3614,7 @@
     },
     "ignition-common1": {
       "baseline": "1.1.1",
-      "port-version": 4
+      "port-version": 5
     },
     "ignition-common3": {
       "baseline": "3.16.0",
@@ -6578,7 +6578,7 @@
     },
     "ompl": {
       "baseline": "1.6.0",
-      "port-version": 2
+      "port-version": 3
     },
     "omplapp": {
       "baseline": "1.5.1",

--- a/versions/i-/ignition-common1.json
+++ b/versions/i-/ignition-common1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00134cd3245b61790b8249239317ef7928943cba",
+      "version": "1.1.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "c41c38488af45c9721e56792886250ef144bc050",
       "version": "1.1.1",
       "port-version": 4

--- a/versions/o-/ompl.json
+++ b/versions/o-/ompl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff05634f7ee0c70e57c5990ec909e49114542f19",
+      "version": "1.6.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "af59be72a074fcdfbfaf6500afca3442e0a2648b",
       "version": "1.6.0",
       "port-version": 2


### PR DESCRIPTION
Due to there are new changes merged by microsoft/STL#5105, so ports `antlr4` `avisynthplus` `ignition-common1` and `ompl` need to include `<chrono>` by patching to fix the following error:
```
error C2039: 'system_clock': is not a member of 'std::chrono'
error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
error C2653: 'high_resolution_clock': is not a class or namespace name
```
The master of `ignition-common1` has been added `<chrono>`.
The other ports have submitted relevant PRs upstream. The list is as follows:
https://github.com/antlr/antlr4/pull/4738
https://github.com/AviSynth/AviSynthPlus/pull/414
https://github.com/ompl/ompl/pull/1201

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.