### PR TITLE
[many ports 3] Include `<chrono>` for `system_clock` and `high_resolution_clock`

### DIFF
--- a/ports/omplapp/add-include-chrono.patch
+++ b/ports/omplapp/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/ompl/src/ompl/util/src/RandomNumbers.cpp b/ompl/src/ompl/util/src/RandomNumbers.cpp
+index fe30070..048b42d 100644
+--- a/ompl/src/ompl/util/src/RandomNumbers.cpp
++++ b/ompl/src/ompl/util/src/RandomNumbers.cpp
+@@ -37,6 +37,7 @@
+ #include "ompl/util/RandomNumbers.h"
+ #include "ompl/util/Exception.h"
+ #include "ompl/util/Console.h"
++#include <chrono>
+ #include <mutex>
+ #include <memory>
+ #include <boost/math/constants/constants.hpp>

--- a/ports/omplapp/portfile.cmake
+++ b/ports/omplapp/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_extract_source_archive(
     PATCHES
         fix_dependency.patch
         ${STATIC_PATCH}
+		add-include-chrono.patch #https://github.com/ompl/ompl/pull/1201
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -80,4 +81,4 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/omplapp/portfile.cmake
+++ b/ports/omplapp/portfile.cmake
@@ -19,7 +19,7 @@ vcpkg_extract_source_archive(
     PATCHES
         fix_dependency.patch
         ${STATIC_PATCH}
-		add-include-chrono.patch #https://github.com/ompl/ompl/pull/1201
+        add-include-chrono.patch #https://github.com/ompl/ompl/pull/1201
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/omplapp/vcpkg.json
+++ b/ports/omplapp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "omplapp",
   "version": "1.5.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Use OMPL for reading meshes and performing collision checking",
   "homepage": "https://ompl.kavrakilab.org/",
   "license": null,

--- a/ports/openvino/add-include-chrono.patch
+++ b/ports/openvino/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/src/core/include/openvino/pass/manager.hpp b/src/core/include/openvino/pass/manager.hpp
+index a026957..a727942 100644
+--- a/src/core/include/openvino/pass/manager.hpp
++++ b/src/core/include/openvino/pass/manager.hpp
+@@ -4,6 +4,7 @@
+ 
+ #pragma once
+ 
++#include <chrono>
+ #include <list>
+ #include <memory>
+ #include <typeinfo>

--- a/ports/openvino/portfile.cmake
+++ b/ports/openvino/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         001-disable-tools.patch
         002-fix-onnx.patch
         003-protobuf.patch
+		add-include-chrono.patch #https://github.com/openvinotoolkit/openvino/pull/27782
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/openvino/portfile.cmake
+++ b/ports/openvino/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
         001-disable-tools.patch
         002-fix-onnx.patch
         003-protobuf.patch
-		add-include-chrono.patch #https://github.com/openvinotoolkit/openvino/pull/27782
+        add-include-chrono.patch #https://github.com/openvinotoolkit/openvino/pull/27782
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/openvino/vcpkg.json
+++ b/ports/openvino/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openvino",
   "version": "2024.4.0",
-  "port-version": 4,
+  "port-version": 5,
   "maintainers": "OpenVINO Developers <openvino@intel.com>",
   "summary": "This is a port for Open Visual Inference And Optimization toolkit for AI inference",
   "description": [

--- a/ports/realsense2/add-include-chrono.patch
+++ b/ports/realsense2/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/src/platform/uvc-device.h b/src/platform/uvc-device.h
+index 48bd19e..b626799 100644
+--- a/src/platform/uvc-device.h
++++ b/src/platform/uvc-device.h
+@@ -15,6 +15,7 @@
+ #include <functional>
+ #include <memory>
+ #include <set>
++#include <chrono>
+ #include <thread>
+ #include <algorithm>  // find
+ 

--- a/ports/realsense2/portfile.cmake
+++ b/ports/realsense2/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         fix_openni2.patch
         fix-nlohmann_json.patch
         fix-android-prefix-path.patch
+		add-include-chrono.patch #https://github.com/IntelRealSense/librealsense/pull/13537
 )
 
 file(COPY "${SOURCE_PATH}/src/win7/drivers/IntelRealSense_D400_series_win7.inf" DESTINATION "${SOURCE_PATH}")

--- a/ports/realsense2/portfile.cmake
+++ b/ports/realsense2/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
         fix_openni2.patch
         fix-nlohmann_json.patch
         fix-android-prefix-path.patch
-		add-include-chrono.patch #https://github.com/IntelRealSense/librealsense/pull/13537
+        add-include-chrono.patch #https://github.com/IntelRealSense/librealsense/pull/13537
 )
 
 file(COPY "${SOURCE_PATH}/src/win7/drivers/IntelRealSense_D400_series_win7.inf" DESTINATION "${SOURCE_PATH}")

--- a/ports/realsense2/vcpkg.json
+++ b/ports/realsense2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "realsense2",
   "version": "2.56.2",
+  "port-version": 1,
   "description": "Intel® RealSense™ SDK 2.0 is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).",
   "homepage": "https://github.com/IntelRealSense/librealsense",
   "license": "Apache-2.0",

--- a/ports/wampcc/add-include-chrono.patch
+++ b/ports/wampcc/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/include/wampcc/protocol.h b/include/wampcc/protocol.h
+index e863768..3c86033 100644
+--- a/include/wampcc/protocol.h
++++ b/include/wampcc/protocol.h
+@@ -11,6 +11,7 @@
+ #include "wampcc/types.h"
+ 
+ #include <vector>
++#include <chrono>
+ #include <cstddef>
+ #include <memory>
+ #include <stdexcept>

--- a/ports/wampcc/portfile.cmake
+++ b/ports/wampcc/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         gcc-11.patch # https://github.com/darrenjs/wampcc/commit/d1a8c6dcabcc32e9d9774f306555e9080d871c2f
+		add-include-chrono.patch #https://github.com/darrenjs/wampcc/pull/85
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -33,7 +34,7 @@ if("utils" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES admin AUTO_CLEAN)
 endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/wampcc/portfile.cmake
+++ b/ports/wampcc/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         gcc-11.patch # https://github.com/darrenjs/wampcc/commit/d1a8c6dcabcc32e9d9774f306555e9080d871c2f
-		add-include-chrono.patch #https://github.com/darrenjs/wampcc/pull/85
+        add-include-chrono.patch #https://github.com/darrenjs/wampcc/pull/85
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/wampcc/vcpkg.json
+++ b/ports/wampcc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wampcc",
   "version-date": "2019-09-04",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Wampcc is C++ library that implements the Web Application Messaging Protocol (WAMP) protocol.",
   "license": "MIT",
   "supports": "!(windows & arm64)",

--- a/ports/zlmediakit/add-include-chrono.patch
+++ b/ports/zlmediakit/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/src/Util/util.cpp b/src/Util/util.cpp
+index 1da99cc..943a107 100644
+--- a/src/Util/util.cpp
++++ b/src/Util/util.cpp
+@@ -9,6 +9,7 @@
+  */
+ 
+ #include <cassert>
++#include <chrono>
+ #include <cstdio>
+ #include <cstdlib>
+ #include <cstring>

--- a/ports/zlmediakit/portfile.cmake
+++ b/ports/zlmediakit/portfile.cmake
@@ -15,8 +15,8 @@ vcpkg_from_github(
     REF 46231014e2a7ec1903d4a37e96222481ecc779d8
     SHA512 2a0b834f072fbc64edc84f408050e2c992f8d59f2480c67a372cace17d49f21eb2f40587288481acc42118e94a5b7863043982680c3f56bdde3863f97ca69356
     HEAD_REF master
-	PATCHES
-		add-include-chrono.patch #https://github.com/ZLMediaKit/ZLToolKit/pull/258
+    PATCHES
+        add-include-chrono.patch #https://github.com/ZLMediaKit/ZLToolKit/pull/258
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdpart/ZLToolKit")

--- a/ports/zlmediakit/portfile.cmake
+++ b/ports/zlmediakit/portfile.cmake
@@ -15,6 +15,8 @@ vcpkg_from_github(
     REF 46231014e2a7ec1903d4a37e96222481ecc779d8
     SHA512 2a0b834f072fbc64edc84f408050e2c992f8d59f2480c67a372cace17d49f21eb2f40587288481acc42118e94a5b7863043982680c3f56bdde3863f97ca69356
     HEAD_REF master
+	PATCHES
+		add-include-chrono.patch #https://github.com/ZLMediaKit/ZLToolKit/pull/258
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdpart/ZLToolKit")

--- a/ports/zlmediakit/vcpkg.json
+++ b/ports/zlmediakit/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zlmediakit",
   "version-date": "2024-09-29",
+  "port-version": 1,
   "description": "A high-performance carrier-grade streaming media service framework based on C++11.",
   "homepage": "https://github.com/ZLMediaKit/ZLMediaKit",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6582,7 +6582,7 @@
     },
     "omplapp": {
       "baseline": "1.5.1",
-      "port-version": 5
+      "port-version": 6
     },
     "onednn": {
       "baseline": "3.5.3",
@@ -6778,7 +6778,7 @@
     },
     "openvino": {
       "baseline": "2024.4.0",
-      "port-version": 4
+      "port-version": 5
     },
     "openvpn3": {
       "baseline": "3.10",
@@ -7882,7 +7882,7 @@
     },
     "realsense2": {
       "baseline": "2.56.2",
-      "port-version": 0
+      "port-version": 1
     },
     "recast": {
       "baseline": "deprecated",
@@ -9582,7 +9582,7 @@
     },
     "wampcc": {
       "baseline": "2019-09-04",
-      "port-version": 5
+      "port-version": 6
     },
     "wangle": {
       "baseline": "2024.11.18.00",
@@ -9986,7 +9986,7 @@
     },
     "zlmediakit": {
       "baseline": "2024-09-29",
-      "port-version": 0
+      "port-version": 1
     },
     "zoe": {
       "baseline": "3.5",

--- a/versions/o-/omplapp.json
+++ b/versions/o-/omplapp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f76baf82011c969085462b2f2ab145f2c198eff8",
+      "version": "1.5.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "8c7e3d29552841ecf363e9f222c6bc554be4b91e",
       "version": "1.5.1",
       "port-version": 5

--- a/versions/o-/omplapp.json
+++ b/versions/o-/omplapp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f76baf82011c969085462b2f2ab145f2c198eff8",
+      "git-tree": "64c31b2e2d99254b1ee40c212404d98f4ea90b8e",
       "version": "1.5.1",
       "port-version": 6
     },

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2da38cb22309b537f0a508c25aba07a4100af7b",
+      "version": "2024.4.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "04f4c58adc2db11be31f2d4427c6eeb62bbe0dd2",
       "version": "2024.4.0",
       "port-version": 4

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e2da38cb22309b537f0a508c25aba07a4100af7b",
+      "git-tree": "d3497e79615424c72514c072b5f7deb876f35718",
       "version": "2024.4.0",
       "port-version": 5
     },

--- a/versions/r-/realsense2.json
+++ b/versions/r-/realsense2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d49805e4385c163afd9b3cf7a801a1f6521bd0c0",
+      "git-tree": "3f099d34f5d5bf7b0354e667018c0caae7966229",
       "version": "2.56.2",
       "port-version": 1
     },

--- a/versions/r-/realsense2.json
+++ b/versions/r-/realsense2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d49805e4385c163afd9b3cf7a801a1f6521bd0c0",
+      "version": "2.56.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "cd83d4d25a389c96970ee763fa48a48b9b419f5b",
       "version": "2.56.2",
       "port-version": 0

--- a/versions/w-/wampcc.json
+++ b/versions/w-/wampcc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "374e6b6a7f9e495f8e2699a5f78498a820f5d2c6",
+      "version-date": "2019-09-04",
+      "port-version": 6
+    },
+    {
       "git-tree": "69c3d159720746a5321085dab7b543c1c95eed85",
       "version-date": "2019-09-04",
       "port-version": 5

--- a/versions/w-/wampcc.json
+++ b/versions/w-/wampcc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "374e6b6a7f9e495f8e2699a5f78498a820f5d2c6",
+      "git-tree": "87cce5b744b64992e4a83bf9dddfc5d28abfd0ec",
       "version-date": "2019-09-04",
       "port-version": 6
     },

--- a/versions/z-/zlmediakit.json
+++ b/versions/z-/zlmediakit.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fff5f04e4aa12f0830e3f8d3e027083e8b779a42",
+      "git-tree": "5e00c8916600f9fe24ce27f677abcec334479f28",
       "version-date": "2024-09-29",
       "port-version": 1
     },

--- a/versions/z-/zlmediakit.json
+++ b/versions/z-/zlmediakit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fff5f04e4aa12f0830e3f8d3e027083e8b779a42",
+      "version-date": "2024-09-29",
+      "port-version": 1
+    },
+    {
       "git-tree": "ee4983a040a7165456de12910b16f1e24f078c32",
       "version-date": "2024-09-29",
       "port-version": 0


### PR DESCRIPTION
Due to there are new changes merged by https://github.com/microsoft/STL/pull/5105, so ports `zlmediakit` `wampcc` `realsense2` `openvino` and `omplapp` need to include `<chrono>` by patching to fix the following errors:
```
error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
```
[StephanTLavavej](https://github.com/StephanTLavavej) has already submitted a PR: https://github.com/IntelRealSense/librealsense/pull/13537 to `realsense2`'s upstream.

The other ports have submitted relevant PRs upstream. The list is as follows:
https://github.com/ZLMediaKit/ZLToolKit/pull/258
https://github.com/darrenjs/wampcc/pull/85
https://github.com/openvinotoolkit/openvino/pull/27782
https://github.com/ompl/ompl/pull/1201

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
