### PR TITLE
[python3] Fix venvlauncher patch

### DIFF
--- a/ports/python3/0015-dont-use-WINDOWS-def.patch
+++ b/ports/python3/0015-dont-use-WINDOWS-def.patch
@@ -1,13 +1,9 @@
-diff --git a/PC/launcher.c b/PC/launcher.c
-index 734e75333..7124927cf 100644
 --- a/PC/launcher.c
 +++ b/PC/launcher.c
-@@ -2015,7 +2015,7 @@ installed, use -0 for available pythons", &p[1]);
-     return rc;
- }
- 
--#if defined(_WINDOWS)
-+#if !defined(_CONSOLE) // _WINDOWS is defined by the vcpkg toolchain
- 
- int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
-                    LPWSTR lpstrCmd, int nShow)
+@@ -1,3 +1,6 @@
++#if defined(_CONSOLE)
++#undef _WINDOWS
++#endif
+ /*
+  * Copyright (C) 2011-2013 Vinay Sajip.
+  * Licensed to PSF under a contributor agreement.

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "python3",
   "version": "3.11.10",
+  "port-version": 1,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7310,7 +7310,7 @@
     },
     "python3": {
       "baseline": "3.11.10",
-      "port-version": 0
+      "port-version": 1
     },
     "qca": {
       "baseline": "2.3.7",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb875e2bc4bc24f25891d298de7b7358411d044b",
+      "version": "3.11.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "62c1ff180dae6af1ba4aff966bd87f9683c6d8f1",
       "version": "3.11.10",
       "port-version": 0


### PR DESCRIPTION
This is not the only place where `_WINDOWS` is checked. Instead of patching all of them, just undefine it if `_CONSOLE` is defined.
Without this, `venvlauncher` behaves like `venvwlauncher`

Fixes the issue described in https://github.com/microsoft/vcpkg/pull/40784#issuecomment-2502034604