### PR TITLE
[grpc] Update to 1.68.1

### DIFF
--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO grpc/grpc
     REF "v${VERSION}"
-    SHA512 498ddf8b5da5d2419aa778ee6b35f00e34339a3ba167887380d015d4a3b8b0fa457bfce6d13870621100b1f45d18d88f732bef90fbdcf55a58f0da0a16ad9759
+    SHA512 cfb88a1290e2ee46fbd5f2b50b9c066ac174b1077170088c3b1a30bd37e66c6ca5254d2b951329a3991ac2b4320d12a50b1464babffbfc3bcf4eab670a449fd1
     HEAD_REF master
     PATCHES
         00001-fix-uwp.patch

--- a/ports/grpc/vcpkg.json
+++ b/ports/grpc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc",
-  "version-semver": "1.68.0",
+  "version-semver": "1.68.1",
   "description": "gRPC is a modern, open source, high-performance remote procedure call (RPC) framework that can run anywhere. gRPC enables client and server applications to communicate transparently, and simplifies the building of connected systems.",
   "homepage": "https://github.com/grpc/grpc",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3285,7 +3285,7 @@
       "port-version": 0
     },
     "grpc": {
-      "baseline": "1.68.0",
+      "baseline": "1.68.1",
       "port-version": 0
     },
     "grppi": {

--- a/versions/g-/grpc.json
+++ b/versions/g-/grpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d93112a282fcf3073db2495fba3dff723bbe0a4e",
+      "version-semver": "1.68.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0cd4312a39e794cf750e3e14a380e0901c40709d",
       "version-semver": "1.68.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #42408
Usage test passed on `x64-windows`.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.