### PR TITLE
[sese] Workaround to download from correct codeload.github URL

### DIFF
--- a/ports/sese/portfile.cmake
+++ b/ports/sese/portfile.cmake
@@ -19,13 +19,16 @@ vcpkg_download_distfile(PATCH_FIX_ENV_STATEMENT
     FILENAME libsese-sese-2.3.0-59fa66d24996eceddc2c406b043687cd13a741dd.patch  
 )
 
-vcpkg_from_github(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO libsese/sese
-        REF "refs/tags/${VERSION}"
-        SHA512 a1008c351ea3e8745d629bdcceb4a6d089ae5a84137bbd49b8abbbb271032ddf279e9b20f155181b6a7d3d8cb17c2ec2f1b7a12464fb0cac8402628e473966cb
-        PATCHES
-            ${PATCH_FIX_ENV_STATEMENT}
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://codeload.github.com/libsese/sese/tar.gz/refs/tags/${VERSION}"
+    FILENAME "libsese-sese-${VERSION}.tar.gz"
+    SHA512 a1008c351ea3e8745d629bdcceb4a6d089ae5a84137bbd49b8abbbb271032ddf279e9b20f155181b6a7d3d8cb17c2ec2f1b7a12464fb0cac8402628e473966cb
+)
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        ${PATCH_FIX_ENV_STATEMENT}
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/sese/vcpkg.json
+++ b/ports/sese/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sese",
   "version": "2.3.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A cross-platform framework for basic components.",
   "homepage": "https://github.com/libsese/sese",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8306,7 +8306,7 @@
     },
     "sese": {
       "baseline": "2.3.0",
-      "port-version": 2
+      "port-version": 3
     },
     "sf2cute": {
       "baseline": "0.2.0",

--- a/versions/s-/sese.json
+++ b/versions/s-/sese.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be70e059961e69ee44059ba3dddb318a688cb6ad",
+      "version": "2.3.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "c900b599e710379fa35b84583c0d278cedd1f247",
       "version": "2.3.0",
       "port-version": 2


### PR DESCRIPTION
See https://github.com/microsoft/vcpkg/pull/42407#issuecomment-2505924420

GitHub assets download with ambiguous tag redirect to the wrong URL

Assets: https://github.com/libsese/sese/archive/refs/tags/2.3.0.tar.gz
Wrong: https://codeload.github.com/libsese/sese/tar.gz/2.3.0/tags/2.3.0
Expect: https://codeload.github.com/libsese/sese/tar.gz/refs/tags/2.3.0

So, download directly from correct URL as workaround.

Note, the link REF is part of directory in archive, if download from commit URL, the file hash will be different. And as a redirect URL, it might change in the future. This issue is tracked by comment above.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

With no assets cache, the port installation tests pass with the following triplets:

* x64-windows
* x64-linux