### PR TITLE
[qwtw] Include <chrono> for `chrono_literals`

### DIFF
--- a/ports/qwtw/add-include-chrono.patch
+++ b/ports/qwtw/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/qwtw/qwtest2.cpp b/qwtw/qwtest2.cpp
+index 97af0cc..470f6cd 100644
+--- a/qwtw/qwtest2.cpp
++++ b/qwtw/qwtest2.cpp
+@@ -7,6 +7,7 @@
+ #include <iostream>
+ #include <math.h>
+ #include <conio.h>
++#include <chrono>
+ 
+ #include <iomanip>
+ #include <locale>

--- a/ports/qwtw/portfile.cmake
+++ b/ports/qwtw/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
    REF 7d6e7c95437cbc7d5d123fc1ccf0d6a3c4e419e6 # v3.1.0
    SHA512 de5abf26d0975b9f0ed88e10cd4d5b4d12e25cce8c87ab6a18d8e7064697de6fc8da83e118b5a4e2819c09e2dbbfd20daeecc6a42748c019c6699666276d075a
    HEAD_REF master
+   PATCHES
+        add-include-chrono.patch
 )
 
 vcpkg_cmake_configure(
@@ -12,4 +14,4 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/qwtw/vcpkg.json
+++ b/ports/qwtw/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qwtw",
   "version": "3.1.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "qwt-based 2D plotting library",
   "homepage": "https://github.com/ig-or/qwtw",
   "supports": "windows & x64 & !static",
@@ -21,10 +21,6 @@
     "qwt",
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7766,7 +7766,7 @@
     },
     "qwtw": {
       "baseline": "3.1.0",
-      "port-version": 3
+      "port-version": 4
     },
     "rabit": {
       "baseline": "0.1",

--- a/versions/q-/qwtw.json
+++ b/versions/q-/qwtw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22ef5b72a4e1c73a37012ed27045397771848a86",
+      "version": "3.1.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "48138fbfb30a40a3a78cd2ecd61ed0d3fc9e24ea",
       "version": "3.1.0",
       "port-version": 3


### PR DESCRIPTION
Due to there are new changes merged by https://github.com/microsoft/STL/pull/5105, so ports `qwtw` need to include `<chrono>` by patching to fix the following error:
```
error C2039: 'chrono_literals': is not a member of 'std'
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
