### PR TITLE
[llvm] Include `<chrono>` for `system_clock` and `now`

### DIFF
--- a/ports/llvm/add-include-chrono.patch
+++ b/ports/llvm/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/lldb/tools/lldb-dap/ProgressEvent.h b/lldb/tools/lldb-dap/ProgressEvent.h
+index dac2197..72317b8 100644
+--- a/lldb/tools/lldb-dap/ProgressEvent.h
++++ b/lldb/tools/lldb-dap/ProgressEvent.h
+@@ -7,6 +7,7 @@
+ //===----------------------------------------------------------------------===//
+ 
+ #include <atomic>
++#include <chrono>
+ #include <mutex>
+ #include <optional>
+ #include <queue>

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
         75711.patch # [clang] Add intrin0.h header to mimic intrin0.h used by MSVC STL for clang-cl #75711
         79694.patch # [SEH] Ignore EH pad check for internal intrinsics #79694
         82407.patch # [Clang][Sema] Fix incorrect rejection default construction of union with nontrivial member #82407
+        add-include-chrono.patch # https://github.com/llvm/llvm-project/pull/118059
 )
 
 vcpkg_check_features(

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "llvm",
   "version": "18.1.6",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5582,7 +5582,7 @@
     },
     "llvm": {
       "baseline": "18.1.6",
-      "port-version": 2
+      "port-version": 3
     },
     "lmdb": {
       "baseline": "0.9.33",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4037972c311903335c3cca2fbb4683570f309ff9",
+      "version": "18.1.6",
+      "port-version": 3
+    },
+    {
       "git-tree": "8f22f1c97f0649913c8c97c6d16d448d76e1e81b",
       "version": "18.1.6",
       "port-version": 2


### PR DESCRIPTION
Due to there are new changes merged by microsoft/STL#5105, so port `llvm` need to include `<chrono>` by patching to fix the following error for feature `llvm[lldb]`:
```
D:\b\llvm\src\org-18.1.6-e754cb1d0b.clean\lldb\tools\lldb-dap\ProgressEvent.h(79): error C2039: 'system_clock': is not a member of 'std::chrono'
D:\b\llvm\src\org-18.1.6-e754cb1d0b.clean\lldb\tools\lldb-dap\ProgressEvent.cpp(134): error C3083: 'system_clock': the symbol to the left of a '::' must be a type
D:\b\llvm\src\org-18.1.6-e754cb1d0b.clean\lldb\tools\lldb-dap\ProgressEvent.cpp(134): error C2039: 'now': is not a member of 'std::chrono'
```
I have submitted relevant PRs upstream https://github.com/llvm/llvm-project/pull/118059.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.