### PR TITLE
[qtbase] fix macdeployqt for symlinks

### DIFF
--- a/ports/qtbase/macdeployqt-symlinks.patch
+++ b/ports/qtbase/macdeployqt-symlinks.patch
@@ -1,0 +1,33 @@
+diff --git a/src/tools/macdeployqt/shared/shared.cpp b/src/tools/macdeployqt/shared/shared.cpp
+index 6ff269b..caffd44 100644
+--- a/src/tools/macdeployqt/shared/shared.cpp
++++ b/src/tools/macdeployqt/shared/shared.cpp
+@@ -1,4 +1,5 @@
+ // Copyright (C) 2016 The Qt Company Ltd.
++
+ // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR GPL-3.0-only WITH Qt-GPL-exception-1.0
+ #include <QCoreApplication>
+ #include <QString>
+@@ -85,7 +86,21 @@
+         }
+     }
+ 
+-    if (QFile::copy(from, to)) {
++    QFileInfo fromFileInfo(from);
++
++    if (fromFileInfo.isSymLink()) {
++        const QString fromSymLinkTarget = fromFileInfo.absoluteDir().relativeFilePath(fromFileInfo.symLinkTarget());
++        if (QFile::link(fromSymLinkTarget, to)) {
++            return copyFilePrintStatus(fromFileInfo.absoluteDir().absoluteFilePath(fromSymLinkTarget), QFileInfo(to).absoluteDir().absoluteFilePath(fromSymLinkTarget));
++        }
++        else {
++            LogError() << "symlink copy failed from" << from;
++            LogError() << " to" << to;
++            return false;
++        }
++
++    }
++    else if (QFile::copy(from, to)) {
+         QFile dest(to);
+         dest.setPermissions(dest.permissions() | QFile::WriteOwner | QFile::WriteUser);
+         LogNormal() << " copied:" << from;

--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -22,6 +22,7 @@ set(${PORT}_PATCHES
         fix-host-aliasing.patch
         fix_deploy_windows.patch
         fix-link-lib-discovery.patch
+        macdeployqt-symlinks.patch
 )
  
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.8.1",
+  "port-version": 1,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7566,7 +7566,7 @@
     },
     "qtbase": {
       "baseline": "6.8.1",
-      "port-version": 0
+      "port-version": 1
     },
     "qtcharts": {
       "baseline": "6.8.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aca356b06f62fc44f51769ef5418230a385e3c7f",
+      "version": "6.8.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "15eabae75af5ff861ffa692ff8072aca9af30fad",
       "version": "6.8.1",
       "port-version": 0


### PR DESCRIPTION
When building for `*-osx-dynamic`, symlinks to handle version suffix are created for the shared libs. Macdeployqt does not preserve the symlinks, which results in multiple copies of the same library causing crashes.
See https://bugreports.qt.io/browse/QTBUG-126612

This pull requests fixes macdeployqt to preserve symlinks

Upstream PR https://codereview.qt-project.org/c/qt/qtbase/+/570829