### PR TITLE
[vcpkg_find_acquire_program(NASM).cmake] Update to version 2.16.03

### DIFF
--- a/scripts/cmake/vcpkg_find_acquire_program(NASM).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(NASM).cmake
@@ -1,14 +1,13 @@
 set(program_name nasm)
-set(program_version 2.16.01)
+set(program_version 2.16.03)
 set(brew_package_name "nasm")
 set(apt_package_name "nasm")
 if(CMAKE_HOST_WIN32)
     set(download_urls
         "https://www.nasm.us/pub/nasm/releasebuilds/${program_version}/win64/nasm-${program_version}-win64.zip"
-        "https://gstreamer.freedesktop.org/src/mirror/nasm-${program_version}-win64.zip"
         "https://vcpkg.github.io/assets/nasm/nasm-${program_version}-win64.zip"
     )
     set(download_filename "nasm-${program_version}-win64.zip")
-    set(download_sha512 ce4d02f530dc3376b4513f219bbcec128ee5bebd8a5c332599b48d8071f803d1538d7258fec7c2e9b4d725b8d7314cea2696289d0493017eb13bfe70e5cb5062)
+    set(download_sha512 22869ceb70ea0e6597fe06abe205b5d5dd66b41fe54dda73d338c488ba6ef13a39158f25b357616bf578752bb112869ef26ad897eb29352e85cf1ecc61a7c07a)
     set(paths_to_search "${DOWNLOADS}/tools/nasm/nasm-${program_version}")
 endif()


### PR DESCRIPTION
- Updated version 2.16.03
- Updated SHA512 checksum for the new source archive
- Remove the mirror host -> https://gstreamer.freedesktop.org/src/mirror/

On my individual machine, version 2.16.01 of NASM encounters the following error:
```
crypto\modes\aes-gcm-avx512.asm:126983: error: expecting ] at end of memory operand
NMAKE : fatal error U1077: ��"D:\workspace\ServerEngine\dependencies\vcpkg\downloads\tools\nasm\nasm-2.16.01\nasm.exe"  -Ox -f win64 -DNEAR -g -o crypto\modes\libcrypto-shlib-aes-gcm-avx512.obj "crypto\modes\aes-gcm-avx512.asm"��: ���ش��롰0x1��
Stop.
NMAKE : fatal error U1077: ��"D:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.34433\bin\Hostx64\x64\nmake.exe" /LU                 _build_libs��: ���ش��롰0x2��
Stop.
```