### PR TITLE
[tbb] fix mingw compilation

### DIFF
--- a/ports/tbb/fix-mingw-compilation.patch
+++ b/ports/tbb/fix-mingw-compilation.patch
@@ -1,0 +1,49 @@
+diff --git a/cmake/compilers/Clang.cmake b/cmake/compilers/Clang.cmake
+index dcd66634..c8f67d4a 100644
+--- a/cmake/compilers/Clang.cmake
++++ b/cmake/compilers/Clang.cmake
+@@ -66,7 +66,7 @@ endif()
+ set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -Wformat -Wformat-security -Werror=format-security -fPIC $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:-fstack-protector-strong>)
+ 
+ # -z switch is not supported on MacOS
+-if (NOT APPLE)
++if (NOT APPLE AND NOT MINGW)
+     set(TBB_LIB_LINK_FLAGS ${TBB_LIB_LINK_FLAGS} -Wl,-z,relro,-z,now)
+ endif()
+ 
+diff --git a/cmake/compilers/GNU.cmake b/cmake/compilers/GNU.cmake
+index cf6d8bdb..8f4dbc7f 100644
+--- a/cmake/compilers/GNU.cmake
++++ b/cmake/compilers/GNU.cmake
+@@ -36,6 +36,10 @@ if (NOT CMAKE_GENERATOR MATCHES "Ninja" AND NOT CMAKE_CXX_DEPENDS_USE_COMPILER)
+ endif()
+ 
+ 
++if(MINGW)
++  set(_tbb_gnu_asm_major_version "2")
++  set(_tbb_gnu_asm_minor_version "43")
++else()
+ # Binutils < 2.31.1 do not support the tpause instruction. When compiling with
+ # a modern version of GCC (supporting it) but relying on an outdated assembler,
+ # will result in an error reporting "no such instruction: tpause".
+@@ -61,6 +65,7 @@ unset(ASSEMBLER_VERSION_LINE_OUT)
+ unset(ASSEMBLER_VERSION_LINE_ERR)
+ unset(ASSEMBLER_VERSION_LINE)
+ message(TRACE "Extracted GNU assembler version: major=${_tbb_gnu_asm_major_version} minor=${_tbb_gnu_asm_minor_version}")
++endif()
+ 
+ math(EXPR _tbb_gnu_asm_version_number  "${_tbb_gnu_asm_major_version} * 1000 + ${_tbb_gnu_asm_minor_version}")
+ set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} "-D__TBB_GNU_ASM_VERSION=${_tbb_gnu_asm_version_number}")
+diff --git a/include/oneapi/tbb/profiling.h b/include/oneapi/tbb/profiling.h
+index 412b5a35..fccaba5f 100644
+--- a/include/oneapi/tbb/profiling.h
++++ b/include/oneapi/tbb/profiling.h
+@@ -132,7 +132,7 @@ namespace d1 {
+         r1::call_itt_notify(static_cast<int>(t), ptr);
+     }
+ 
+-#if (_WIN32||_WIN64) && !__MINGW32__
++#if (_WIN32||_WIN64)
+     inline void itt_set_sync_name(void* obj, const wchar_t* name) {
+         r1::itt_set_sync_name(obj, name);
+     }

--- a/ports/tbb/portfile.cmake
+++ b/ports/tbb/portfile.cmake
@@ -7,6 +7,9 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 c87b84964b2c323f61895a532968dfa6413a774c177cffbf6e798a07e74e8da5d449144875771df0a1b02657eeb2a7ae4d41c6c432dbf7ea50e3d5a9ea9f8cd3
     HEAD_REF master
+    PATCHES
+        # MSYS2 repo was used as a source. Thanks MSYS2 team: https://github.com/msys2/MINGW-packages/blob/fd6b60e652298d7535c5918126213faa7c8b176d/mingw-w64-tbb
+        fix-mingw-compilation.patch
 )
 
 vcpkg_check_features(

--- a/ports/tbb/vcpkg.json
+++ b/ports/tbb/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "tbb",
   "version": "2022.0.0",
+  "port-version": 1,
   "description": "Intel's Threading Building Blocks.",
   "homepage": "https://github.com/oneapi-src/oneTBB",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8838,7 +8838,7 @@
     },
     "tbb": {
       "baseline": "2022.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tcb-span": {
       "baseline": "2022-06-15",

--- a/versions/t-/tbb.json
+++ b/versions/t-/tbb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d7b1a76cc51e454e91aa6ac242ef944a0763041d",
+      "version": "2022.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1190d84d0e84ec7100662a4c35cd6a27ce532864",
       "version": "2022.0.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #42046
Fixes #40683

This could also mean a fix for ports that depend on TBB and support MinGW __(if the build failure is caused by TBB)__. However I couldn't find a matching issue in the repository or on the issues page.  
I wanted to add the numbers of these issues to help.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Thanks for making life easier with this great package manager :) .