### PR TITLE
[reflectcpp] Updated to reflectcpp 0.16.0; added support for various formats in the form of features

### DIFF
--- a/ports/reflectcpp/portfile.cmake
+++ b/ports/reflectcpp/portfile.cmake
@@ -14,10 +14,8 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" REFLECTCPP_BUILD_SHARE
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         bson                REFLECTCPP_BSON
-        cbor                REFLECTCPP_CBOR
         flexbuffers         REFLECTCPP_FLEXBUFFERS
         msgpack             REFLECTCPP_MSGPACK
-        toml                REFLECTCPP_TOML
         ubjson              REFLECTCPP_UBJSON
         xml                 REFLECTCPP_XML
         yaml                REFLECTCPP_YAML

--- a/ports/reflectcpp/portfile.cmake
+++ b/ports/reflectcpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO getml/reflect-cpp
     REF "v${VERSION}"
-    SHA512 755f1474f3c58a950c6db010eeea388a11cf1caca66fbb75b1e03c86794fb3a9c6fa1509e0e78401d31055f43bcaddcd138da06d54e1e3507b2ea08d3a2d05b1
+    SHA512 9c5034e6d964a1ae817cb14e4cd0d19ccb69e703affd8c070105ace63f2f0f59079ae450c1de7a19d3e35faf471dcd5e4bbd56cd3f0594f23059dfc45f622ac0 
     HEAD_REF main
 )
 
@@ -10,6 +10,18 @@ if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" REFLECTCPP_BUILD_SHARED)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        bson                REFLECTCPP_BSON
+        cbor                REFLECTCPP_CBOR
+        flexbuffers         REFLECTCPP_FLEXBUFFERS
+        msgpack             REFLECTCPP_MSGPACK
+        toml                REFLECTCPP_TOML
+        ubjson              REFLECTCPP_UBJSON
+        xml                 REFLECTCPP_XML
+        yaml                REFLECTCPP_YAML
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/reflectcpp/vcpkg.json
+++ b/ports/reflectcpp/vcpkg.json
@@ -32,15 +32,6 @@
         }
       ]
     },
-    "cbor": {
-      "description": "Support for the CBOR format",
-      "dependencies": [
-        {
-          "name": "tinycbor",
-          "version>=": "0.6.0"
-        }
-      ]
-    },
     "flexbuffers": {
       "description": "Support for the flexbuffers format (part of flatbuffers)",
       "dependencies": [
@@ -56,15 +47,6 @@
         {
           "name": "msgpack-c",
           "version>=": "6.0.0"
-        }
-      ]
-    },
-    "toml": {
-      "description": "Support for the TOML format",
-      "dependencies": [
-        {
-          "name": "tomlplusplus",
-          "version>=": "3.4.0"
         }
       ]
     },

--- a/ports/reflectcpp/vcpkg.json
+++ b/ports/reflectcpp/vcpkg.json
@@ -23,77 +23,77 @@
     }
   ],
   "features": {
-    "bson": { 
-        "description": "Support for the BSON format", 
-        "dependencies": [
-            {
-              "name": "libbson",
-              "version>=": "1.25.1"
-            }
-        ]
+    "bson": {
+      "description": "Support for the BSON format",
+      "dependencies": [
+        {
+          "name": "libbson",
+          "version>=": "1.25.1"
+        }
+      ]
     },
-    "cbor": { 
-        "description": "Support for the CBOR format", 
-        "dependencies": [
-            {
-              "name": "tinycbor",
-              "version>=": "0.6.0"
-            }
-        ]
+    "cbor": {
+      "description": "Support for the CBOR format",
+      "dependencies": [
+        {
+          "name": "tinycbor",
+          "version>=": "0.6.0"
+        }
+      ]
     },
-    "flexbuffers": { 
-        "description": "Support for the flexbuffers format (part of flatbuffers)", 
-        "dependencies": [
-           {
-                "name": "flatbuffers",
-                "version>=": "23.5.26#1"
-           }
-        ]
+    "flexbuffers": {
+      "description": "Support for the flexbuffers format (part of flatbuffers)",
+      "dependencies": [
+        {
+          "name": "flatbuffers",
+          "version>=": "23.5.26#1"
+        }
+      ]
     },
-    "msgpack": { 
-        "description": "Support for the msgpack format", 
-        "dependencies": [
-            {
-              "name": "msgpack-c",
-              "version>=": "6.0.0"
-            }
-        ]
+    "msgpack": {
+      "description": "Support for the msgpack format",
+      "dependencies": [
+        {
+          "name": "msgpack-c",
+          "version>=": "6.0.0"
+        }
+      ]
     },
-    "toml": { 
-        "description": "Support for the TOML format", 
-        "dependencies": [
-            {
-              "name": "tomlplusplus",
-              "version>=": "3.4.0"
-            }
-        ]
+    "toml": {
+      "description": "Support for the TOML format",
+      "dependencies": [
+        {
+          "name": "tomlplusplus",
+          "version>=": "3.4.0"
+        }
+      ]
     },
-    "ubjson": { 
-        "description": "Support for the UBJSON format", 
-        "dependencies": [
-            {
-              "name": "jsoncons",
-              "version>=": "0.176.0"
-            }
-        ]
+    "ubjson": {
+      "description": "Support for the UBJSON format",
+      "dependencies": [
+        {
+          "name": "jsoncons",
+          "version>=": "0.176.0"
+        }
+      ]
     },
-    "xml": { 
-        "description": "Support for the XML format", 
-        "dependencies": [
-            {
-              "name": "pugixml",
-              "version>=": "1.14"
-            }
-        ]
+    "xml": {
+      "description": "Support for the XML format",
+      "dependencies": [
+        {
+          "name": "pugixml",
+          "version>=": "1.14"
+        }
+      ]
     },
-    "yaml": { 
-        "description": "Support for the YAML format", 
-        "dependencies": [
-            {
-              "name": "yaml-cpp",
-              "version>=": "0.8.0#1"
-            }
-        ]
+    "yaml": {
+      "description": "Support for the YAML format",
+      "dependencies": [
+        {
+          "name": "yaml-cpp",
+          "version>=": "0.8.0#1"
+        }
+      ]
     }
   }
 }

--- a/ports/reflectcpp/vcpkg.json
+++ b/ports/reflectcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectcpp",
-  "version": "0.13.0",
+  "version": "0.16.0",
   "description": "A C++ library for serialization and deserialization using reflection.",
   "homepage": "https://github.com/getml/reflect-cpp/",
   "license": "MIT",
@@ -19,7 +19,81 @@
     },
     {
       "name": "yyjson",
-      "version>=": "0.9.0"
+      "version>=": "0.10.0"
     }
-  ]
+  ],
+  "features": {
+    "bson": { 
+        "description": "Support for the BSON format", 
+        "dependencies": [
+            {
+              "name": "libbson",
+              "version>=": "1.25.1"
+            }
+        ]
+    },
+    "cbor": { 
+        "description": "Support for the CBOR format", 
+        "dependencies": [
+            {
+              "name": "tinycbor",
+              "version>=": "0.6.0"
+            }
+        ]
+    },
+    "flexbuffers": { 
+        "description": "Support for the flexbuffers format (part of flatbuffers)", 
+        "dependencies": [
+           {
+                "name": "flatbuffers",
+                "version>=": "23.5.26#1"
+           }
+        ]
+    },
+    "msgpack": { 
+        "description": "Support for the msgpack format", 
+        "dependencies": [
+            {
+              "name": "msgpack-c",
+              "version>=": "6.0.0"
+            }
+        ]
+    },
+    "toml": { 
+        "description": "Support for the TOML format", 
+        "dependencies": [
+            {
+              "name": "tomlplusplus",
+              "version>=": "3.4.0"
+            }
+        ]
+    },
+    "ubjson": { 
+        "description": "Support for the UBJSON format", 
+        "dependencies": [
+            {
+              "name": "jsoncons",
+              "version>=": "0.176.0"
+            }
+        ]
+    },
+    "xml": { 
+        "description": "Support for the XML format", 
+        "dependencies": [
+            {
+              "name": "pugixml",
+              "version>=": "1.14"
+            }
+        ]
+    },
+    "yaml": { 
+        "description": "Support for the YAML format", 
+        "dependencies": [
+            {
+              "name": "yaml-cpp",
+              "version>=": "0.8.0#1"
+            }
+        ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7905,7 +7905,7 @@
       "port-version": 0
     },
     "reflectcpp": {
-      "baseline": "0.13.0",
+      "baseline": "0.16.0",
       "port-version": 0
     },
     "refprop-headers": {

--- a/versions/r-/reflectcpp.json
+++ b/versions/r-/reflectcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "390a3fcc66d92ccdf0f16fa86837f7d8bd5b7e2a",
+      "version": "0.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "08d112d4bab3b16cfb10d1af5876dd192448be15",
       "version": "0.13.0",
       "port-version": 0

--- a/versions/r-/reflectcpp.json
+++ b/versions/r-/reflectcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "390a3fcc66d92ccdf0f16fa86837f7d8bd5b7e2a",
+      "git-tree": "2d577f7925bfa71cbded3d56697961c0e325938d",
       "version": "0.16.0",
       "port-version": 0
     },

--- a/versions/r-/reflectcpp.json
+++ b/versions/r-/reflectcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2d577f7925bfa71cbded3d56697961c0e325938d",
+      "git-tree": "18558577ba05cafc84ff2d0e89eb712297411da9",
       "version": "0.16.0",
       "port-version": 0
     },


### PR DESCRIPTION
If this PR updates an existing port, please uncomment and fill out this checklist:

- [x ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ x] SHA512s are updated for each updated download.
- [ x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ x] Any patches that are no longer applied are deleted from the port's directory.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Only one version is added to each modified port's versions file.

