### PR TITLE
[scotch] Add ptscotch support

### DIFF
--- a/ports/scotch/portfile.cmake
+++ b/ports/scotch/portfile.cmake
@@ -25,10 +25,14 @@ if(VCPKG_TARGET_IS_WINDOWS)
     string(APPEND VCPKG_CXX_FLAGS   " -DGRAPHMATCHNOTHREAD")
 endif()
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        ptscotch    BUILD_PTSCOTCH # Requires MPI
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DBUILD_PTSCOTCH=OFF # Requires MPI
+    OPTIONS ${FEATURE_OPTIONS}
         -DBUILD_LIBESMUMPS=OFF
         -DBUILD_LIBSCOTCHMETIS=OFF
         -DTHREADS=ON
@@ -44,6 +48,10 @@ vcpkg_copy_tools(TOOL_NAMES
     mord mtst
     AUTO_CLEAN
     )
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/doc/CeCILL-C_V1-en.txt")

--- a/ports/scotch/portfile.cmake
+++ b/ports/scotch/portfile.cmake
@@ -27,7 +27,7 @@ endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        ptscotch    BUILD_PTSCOTCH # Requires MPI
+        ptscotch    BUILD_PTSCOTCH
 )
 
 vcpkg_cmake_configure(

--- a/ports/scotch/portfile.cmake
+++ b/ports/scotch/portfile.cmake
@@ -49,8 +49,8 @@ vcpkg_copy_tools(TOOL_NAMES
     AUTO_CLEAN
     )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
+if ("ptscotch" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES dggath dgmap dgord dgscat dgtst AUTO_CLEAN)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/scotch/vcpkg.json
+++ b/ports/scotch/vcpkg.json
@@ -22,7 +22,10 @@
   ],
   "features": {
     "ptscotch": {
-      "description": "Build PT-Scotch"
+      "description": "Build PT-Scotch",
+      "dependencies": [
+        "mpi"
+      ]
     }
   }
 }

--- a/ports/scotch/vcpkg.json
+++ b/ports/scotch/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "scotch",
   "version": "7.0.5",
+  "port-version": 1,
   "description": "Scotch: a software package for graph and mesh/hypergraph partitioning, graph clustering, and sparse matrix ordering",
   "homepage": "https://gitlab.inria.fr/scotch/scotch",
   "license": null,
@@ -18,5 +19,10 @@
       "host": true
     },
     "zlib"
-  ]
+  ],
+  "features": {
+    "ptscotch": {
+      "description": "Build PT-Scotch"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8166,7 +8166,7 @@
     },
     "scotch": {
       "baseline": "7.0.5",
-      "port-version": 0
+      "port-version": 1
     },
     "scottt-debugbreak": {
       "baseline": "1.0",

--- a/versions/s-/scotch.json
+++ b/versions/s-/scotch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ddb8b17152bd20089569803ba8a8cdcee0d52b3e",
+      "git-tree": "5c7c99870a9ad20059cbd1a527f1ff8e7e4bf387",
       "version": "7.0.5",
       "port-version": 1
     },

--- a/versions/s-/scotch.json
+++ b/versions/s-/scotch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5c7c99870a9ad20059cbd1a527f1ff8e7e4bf387",
+      "git-tree": "ac6bd42f55d0f52fc7dd0ab144ea4c058e663b92",
       "version": "7.0.5",
       "port-version": 1
     },

--- a/versions/s-/scotch.json
+++ b/versions/s-/scotch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ddb8b17152bd20089569803ba8a8cdcee0d52b3e",
+      "version": "7.0.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "6894afdfdbdbe1e142bb42d4d0894ecc37bca0ab",
       "version": "7.0.5",
       "port-version": 0


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vcpkg/issues/41266,

All feature tested pass on the following triplets:
- x64-windows
- x64-windows-static
- x86-windows
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.