### PR TITLE
[otl] update hash for 4.0.478 download

### DIFF
--- a/ports/otl/portfile.cmake
+++ b/ports/otl/portfile.cmake
@@ -3,7 +3,7 @@ set(OTL_VERSION 40478)
 vcpkg_download_distfile(ARCHIVE
     URLS "http://otl.sourceforge.net/otlv4_${OTL_VERSION}.zip"
     FILENAME "otlv4_${OTL_VERSION}.zip"
-    SHA512 1b36aff8e18bded3bade20b63191d9fcd77a9e7abfdfd6c4f79da9a7cc205a21a741d088c453ef1fb8dedf161a320378bdfa9c0ff7a7d79916b6bef8f4268b6d
+    SHA512 dcc2289a31150ae59568a04156ad2e260fb925708404c34e05f0e5ba7b955792ab947566b19e4996ee0a1e19b2f6c18674344c73e908f8f5e71fe3e65817908e
 )
 
 vcpkg_extract_source_archive(

--- a/ports/otl/vcpkg.json
+++ b/ports/otl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "otl",
   "version": "4.0.478",
+  "port-version": 1,
   "description": "Oracle, Odbc and DB2-CLI Template Library",
   "homepage": "http://otl.sourceforge.net/",
   "license": "ISC"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6838,7 +6838,7 @@
     },
     "otl": {
       "baseline": "4.0.478",
-      "port-version": 0
+      "port-version": 1
     },
     "outcome": {
       "baseline": "2.2.9",

--- a/versions/o-/otl.json
+++ b/versions/o-/otl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3a913a0f858f637c9d573d97548ec1b6afef574a",
+      "version": "4.0.478",
+      "port-version": 1
+    },
+    {
       "git-tree": "62f8921579ec50d2d505df1f6141c7704d54cb39",
       "version": "4.0.478",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.