### PR TITLE
[or-tools] adds or-tools as new port

### DIFF
--- a/ports/or-tools/disable-build-of-executables.patch
+++ b/ports/or-tools/disable-build-of-executables.patch
@@ -1,7 +1,8 @@
 diff --git a/ortools/linear_solver/CMakeLists.txt b/ortools/linear_solver/CMakeLists.txt
---- a/ortools/linear_solver/CMakeLists.txt	(revision ed94162b910fa58896db99191378d3b71a5313af)
-+++ b/ortools/linear_solver/CMakeLists.txt	(date 1733304142696)
-@@ -49,6 +49,7 @@
+index 74d20df48b..e03a83120c 100644
+--- a/ortools/linear_solver/CMakeLists.txt
++++ b/ortools/linear_solver/CMakeLists.txt
+@@ -49,6 +49,7 @@ target_link_libraries(${NAME} PRIVATE
  #add_library(${PROJECT_NAMESPACE}::linear_solver ALIAS ${NAME})
  
  # solve
@@ -9,7 +10,7 @@ diff --git a/ortools/linear_solver/CMakeLists.txt b/ortools/linear_solver/CMakeL
  add_executable(solve)
  target_sources(solve PRIVATE "solve.cc")
  target_include_directories(solve PRIVATE
-@@ -73,6 +74,7 @@
+@@ -73,6 +74,7 @@ endif()
  install(TARGETS solve
    EXPORT ${PROJECT_NAME}Targets
    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -17,26 +18,11 @@ diff --git a/ortools/linear_solver/CMakeLists.txt b/ortools/linear_solver/CMakeL
  
  if(BUILD_TESTING)
    if (APPLE)
-diff --git a/ortools/sat/CMakeLists.txt b/ortools/sat/CMakeLists.txt
---- a/ortools/sat/CMakeLists.txt	(revision ed94162b910fa58896db99191378d3b71a5313af)
-+++ b/ortools/sat/CMakeLists.txt	(date 1733303962623)
-@@ -40,6 +40,7 @@
- #add_library(${PROJECT_NAMESPACE}::sat ALIAS ${NAME})
-
- # Sat Runner
-+#[[
- add_executable(sat_runner)
- target_sources(sat_runner PRIVATE "sat_runner.cc")
- target_include_directories(sat_runner PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-@@ -59,3 +60,4 @@
- endif()
-
- install(TARGETS sat_runner)
-+]]
 diff --git a/ortools/packing/CMakeLists.txt b/ortools/packing/CMakeLists.txt
---- a/ortools/packing/CMakeLists.txt	(revision ed94162b910fa58896db99191378d3b71a5313af)
-+++ b/ortools/packing/CMakeLists.txt	(date 1733304078524)
-@@ -32,6 +32,7 @@
+index 857750dff3..24f1ab8427 100644
+--- a/ortools/packing/CMakeLists.txt
++++ b/ortools/packing/CMakeLists.txt
+@@ -32,6 +32,7 @@ target_link_libraries(${NAME} PRIVATE
  #add_library(${PROJECT_NAMESPACE}::packing ALIAS ${NAME})
  
  # Vector Bin Packing
@@ -44,9 +30,25 @@ diff --git a/ortools/packing/CMakeLists.txt b/ortools/packing/CMakeLists.txt
  add_executable(vector_bin_packing)
  target_sources(vector_bin_packing PRIVATE "vector_bin_packing_main.cc")
  target_include_directories(vector_bin_packing PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-@@ -57,3 +58,4 @@
+@@ -57,3 +58,4 @@ if(BUILD_TESTING)
  endif()
  
  install(TARGETS vector_bin_packing)
 +]]
-\ No newline at end of file
+diff --git a/ortools/sat/CMakeLists.txt b/ortools/sat/CMakeLists.txt
+index 027aa46c6f..b700aa0414 100644
+--- a/ortools/sat/CMakeLists.txt
++++ b/ortools/sat/CMakeLists.txt
+@@ -40,6 +40,7 @@ target_link_libraries(${NAME} PRIVATE
+ #add_library(${PROJECT_NAMESPACE}::sat ALIAS ${NAME})
+ 
+ # Sat Runner
++#[[
+ add_executable(sat_runner)
+ target_sources(sat_runner PRIVATE "sat_runner.cc")
+ target_include_directories(sat_runner PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+@@ -59,3 +60,4 @@ elseif(UNIX)
+ endif()
+ 
+ install(TARGETS sat_runner)
++]]

--- a/ports/or-tools/disable-build-of-executables.patch
+++ b/ports/or-tools/disable-build-of-executables.patch
@@ -1,0 +1,52 @@
+diff --git a/ortools/linear_solver/CMakeLists.txt b/ortools/linear_solver/CMakeLists.txt
+--- a/ortools/linear_solver/CMakeLists.txt	(revision ed94162b910fa58896db99191378d3b71a5313af)
++++ b/ortools/linear_solver/CMakeLists.txt	(date 1733304142696)
+@@ -49,6 +49,7 @@
+ #add_library(${PROJECT_NAMESPACE}::linear_solver ALIAS ${NAME})
+ 
+ # solve
++#[[
+ add_executable(solve)
+ target_sources(solve PRIVATE "solve.cc")
+ target_include_directories(solve PRIVATE
+@@ -73,6 +74,7 @@
+ install(TARGETS solve
+   EXPORT ${PROJECT_NAME}Targets
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++]]
+ 
+ if(BUILD_TESTING)
+   if (APPLE)
+diff --git a/ortools/sat/CMakeLists.txt b/ortools/sat/CMakeLists.txt
+--- a/ortools/sat/CMakeLists.txt	(revision ed94162b910fa58896db99191378d3b71a5313af)
++++ b/ortools/sat/CMakeLists.txt	(date 1733303962623)
+@@ -40,6 +40,7 @@
+ #add_library(${PROJECT_NAMESPACE}::sat ALIAS ${NAME})
+
+ # Sat Runner
++#[[
+ add_executable(sat_runner)
+ target_sources(sat_runner PRIVATE "sat_runner.cc")
+ target_include_directories(sat_runner PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+@@ -59,3 +60,4 @@
+ endif()
+
+ install(TARGETS sat_runner)
++]]
+diff --git a/ortools/packing/CMakeLists.txt b/ortools/packing/CMakeLists.txt
+--- a/ortools/packing/CMakeLists.txt	(revision ed94162b910fa58896db99191378d3b71a5313af)
++++ b/ortools/packing/CMakeLists.txt	(date 1733304078524)
+@@ -32,6 +32,7 @@
+ #add_library(${PROJECT_NAMESPACE}::packing ALIAS ${NAME})
+ 
+ # Vector Bin Packing
++#[[
+ add_executable(vector_bin_packing)
+ target_sources(vector_bin_packing PRIVATE "vector_bin_packing_main.cc")
+ target_include_directories(vector_bin_packing PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+@@ -57,3 +58,4 @@
+ endif()
+ 
+ install(TARGETS vector_bin_packing)
++]]
+\ No newline at end of file

--- a/ports/or-tools/disable-msvc-bundle-install.patch
+++ b/ports/or-tools/disable-msvc-bundle-install.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/cpp.cmake b/cmake/cpp.cmake
+index 6313c9c273..8ff2424183 100644
+--- a/cmake/cpp.cmake
++++ b/cmake/cpp.cmake
+@@ -520,7 +520,7 @@ configure_file(
+ ${PROJECT_SOURCE_DIR}/cmake/bundle-install.cmake.in
+ ${PROJECT_BINARY_DIR}/bundle-install.cmake
+ @ONLY)
+-install(SCRIPT ${PROJECT_BINARY_DIR}/bundle-install.cmake)
++#install(SCRIPT ${PROJECT_BINARY_DIR}/bundle-install.cmake)
+ endif()
+ 
+ install(FILES "${PROJECT_SOURCE_DIR}/LICENSE"

--- a/ports/or-tools/don't-export-compiler-options.patch
+++ b/ports/or-tools/don't-export-compiler-options.patch
@@ -1,0 +1,21 @@
+Subject: [PATCH] don't export compiler options
+---
+Index: cmake/cpp.cmake
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cmake/cpp.cmake b/cmake/cpp.cmake
+--- a/cmake/cpp.cmake	(revision a5295e034c02df2aa43a12dd7268a57da953b688)
++++ b/cmake/cpp.cmake	(date 1733934737168)
+@@ -288,8 +288,8 @@
+ target_compile_features(${PROJECT_NAME} PUBLIC
+   $<IF:$<CXX_COMPILER_ID:MSVC>,cxx_std_20,cxx_std_17>)
+ target_compile_definitions(${PROJECT_NAME} PUBLIC ${OR_TOOLS_COMPILE_DEFINITIONS})
+-target_compile_options(${PROJECT_NAME} PUBLIC ${OR_TOOLS_COMPILE_OPTIONS})
+-target_link_options(${PROJECT_NAME} INTERFACE ${OR_TOOLS_LINK_OPTIONS})
++target_compile_options(${PROJECT_NAME} PRIVATE ${OR_TOOLS_COMPILE_OPTIONS})
++#target_link_options(${PROJECT_NAME} INTERFACE ${OR_TOOLS_LINK_OPTIONS})
+ # Properties
+ if(NOT APPLE)
+   set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/ports/or-tools/fix-find-protobuf-crosscompiling.patch
+++ b/ports/or-tools/fix-find-protobuf-crosscompiling.patch
@@ -1,0 +1,23 @@
+Subject: [PATCH] fix find protobuf crosscompiling
+---
+Index: cmake/host.cmake
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cmake/host.cmake b/cmake/host.cmake
+--- a/cmake/host.cmake	(revision 998f3e467260a939cd9f7b54a36b01e4235bc625)
++++ b/cmake/host.cmake	(date 1733732824407)
+@@ -11,10 +11,10 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-if(NOT CMAKE_CROSSCOMPILING)
++#if(NOT CMAKE_CROSSCOMPILING)
+   set(PROTOC_PRG protobuf::protoc)
+   return()
+-endif()
++#endif()
+ 
+ message(STATUS "Subproject: HostTools...")
+ 

--- a/ports/or-tools/portfile.cmake
+++ b/ports/or-tools/portfile.cmake
@@ -1,10 +1,12 @@
 vcpkg_from_github(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO google/or-tools
-        REF v${VERSION}
-        SHA512 38dbdb910c32cb07fc861ffae3976db80ea3f209d3e883ebb1193860f4095448b74c947b98c200a7d3fadac9480b7e94ff13825392b17d6c2576f0c2569d9d27
-        HEAD_REF stable
-        PATCHES disable-msvc-bundle-install.patch disable-build-of-executables.patch
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/or-tools
+    REF "v${VERSION}"
+    SHA512 38dbdb910c32cb07fc861ffae3976db80ea3f209d3e883ebb1193860f4095448b74c947b98c200a7d3fadac9480b7e94ff13825392b17d6c2576f0c2569d9d27
+    HEAD_REF stable
+    PATCHES
+        disable-msvc-bundle-install.patch
+        disable-build-of-executables.patch
 )
 
 vcpkg_check_features(

--- a/ports/or-tools/portfile.cmake
+++ b/ports/or-tools/portfile.cmake
@@ -3,25 +3,27 @@ if (VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO google/or-tools
-    REF "v${VERSION}"
-    SHA512 38dbdb910c32cb07fc861ffae3976db80ea3f209d3e883ebb1193860f4095448b74c947b98c200a7d3fadac9480b7e94ff13825392b17d6c2576f0c2569d9d27
-    HEAD_REF stable
-    PATCHES
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO google/or-tools
+        REF "v${VERSION}"
+        SHA512 38dbdb910c32cb07fc861ffae3976db80ea3f209d3e883ebb1193860f4095448b74c947b98c200a7d3fadac9480b7e94ff13825392b17d6c2576f0c2569d9d27
+        HEAD_REF stable
+        PATCHES
         disable-msvc-bundle-install.patch
         disable-build-of-executables.patch
         fix-find-protobuf-crosscompiling.patch
+        don't-export-compiler-options.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
+        FEATURES
         highs USE_HIGHS
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${FEATURE_OPTIONS}
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS ${FEATURE_OPTIONS}
+        -DUSE_GUROBI=OFF
         -DUSE_SCIP=OFF
         -DUSE_COINOR=OFF
         -DBUILD_TESTING=OFF
@@ -29,7 +31,8 @@ vcpkg_cmake_configure(
         -DBUILD_SAMPLES=OFF
         -DBUILD_EXAMPLES=OFF
         -DBUILD_FLATZINC=OFF
-        -DINSTALL_DOC=OFF
+        -DBUILD_LP_PARSER=OFF
+        -DBUILD_MATH_OPT=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/or-tools/portfile.cmake
+++ b/ports/or-tools/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         REF v${VERSION}
         SHA512 38dbdb910c32cb07fc861ffae3976db80ea3f209d3e883ebb1193860f4095448b74c947b98c200a7d3fadac9480b7e94ff13825392b17d6c2576f0c2569d9d27
         HEAD_REF stable
-        PATCHES disable-msvc-bundle-install.patch
+        PATCHES disable-msvc-bundle-install.patch disable-build-of-executables.patch
 )
 
 vcpkg_check_features(
@@ -92,9 +92,4 @@ file(REMOVE_RECURSE
         "${CURRENT_PACKAGES_DIR}/include/ortools/util/csharp"
         "${CURRENT_PACKAGES_DIR}/include/ortools/util/java"
         "${CURRENT_PACKAGES_DIR}/include/ortools/util/python"
-)
-
-vcpkg_copy_tools(
-        TOOL_NAMES solve sat_runner vector_bin_packing
-        AUTO_CLEAN
 )

--- a/ports/or-tools/portfile.cmake
+++ b/ports/or-tools/portfile.cmake
@@ -23,7 +23,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 vcpkg_cmake_configure(
         SOURCE_PATH "${SOURCE_PATH}"
         OPTIONS ${FEATURE_OPTIONS}
-        -DUSE_GUROBI=OFF
         -DUSE_SCIP=OFF
         -DUSE_COINOR=OFF
         -DBUILD_TESTING=OFF
@@ -32,7 +31,6 @@ vcpkg_cmake_configure(
         -DBUILD_EXAMPLES=OFF
         -DBUILD_FLATZINC=OFF
         -DBUILD_LP_PARSER=OFF
-        -DBUILD_MATH_OPT=OFF
 )
 
 vcpkg_cmake_install()
@@ -43,6 +41,7 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 # Empty directories
 file(REMOVE_RECURSE

--- a/ports/or-tools/portfile.cmake
+++ b/ports/or-tools/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         disable-msvc-bundle-install.patch
         disable-build-of-executables.patch
+        fix-find-protobuf-crosscompiling.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/or-tools/portfile.cmake
+++ b/ports/or-tools/portfile.cmake
@@ -19,7 +19,6 @@ vcpkg_cmake_configure(
     OPTIONS ${FEATURE_OPTIONS}
         -DUSE_SCIP=OFF
         -DUSE_COINOR=OFF
-
         -DBUILD_TESTING=OFF
         -DBUILD_DEPS=OFF
         -DBUILD_SAMPLES=OFF

--- a/ports/or-tools/portfile.cmake
+++ b/ports/or-tools/portfile.cmake
@@ -15,9 +15,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 vcpkg_cmake_configure(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
-        ${FEATURE_OPTIONS}
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
         -DUSE_SCIP=OFF
         -DUSE_COINOR=OFF
 

--- a/ports/or-tools/portfile.cmake
+++ b/ports/or-tools/portfile.cmake
@@ -9,9 +9,8 @@ vcpkg_from_github(
         disable-build-of-executables.patch
 )
 
-vcpkg_check_features(
-        OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-        FEATURES
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
         highs USE_HIGHS
 )
 

--- a/ports/or-tools/portfile.cmake
+++ b/ports/or-tools/portfile.cmake
@@ -34,7 +34,7 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 # Empty directories
 file(REMOVE_RECURSE

--- a/ports/or-tools/portfile.cmake
+++ b/ports/or-tools/portfile.cmake
@@ -1,3 +1,7 @@
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/or-tools

--- a/ports/or-tools/portfile.cmake
+++ b/ports/or-tools/portfile.cmake
@@ -1,0 +1,100 @@
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO google/or-tools
+        REF v${VERSION}
+        SHA512 38dbdb910c32cb07fc861ffae3976db80ea3f209d3e883ebb1193860f4095448b74c947b98c200a7d3fadac9480b7e94ff13825392b17d6c2576f0c2569d9d27
+        HEAD_REF stable
+        PATCHES disable-msvc-bundle-install.patch
+)
+
+vcpkg_check_features(
+        OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+        FEATURES
+        highs USE_HIGHS
+)
+
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+        ${FEATURE_OPTIONS}
+        -DUSE_SCIP=OFF
+        -DUSE_COINOR=OFF
+
+        -DBUILD_TESTING=OFF
+        -DBUILD_DEPS=OFF
+        -DBUILD_SAMPLES=OFF
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_FLATZINC=OFF
+        -DINSTALL_DOC=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME ortools CONFIG_PATH "lib/cmake/ortools")
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+# Empty directories
+file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/include/ortools/algorithms/csharp"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/algorithms/java"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/algorithms/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/algorithms/samples"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/constraint_solver/csharp"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/constraint_solver/docs"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/constraint_solver/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/constraint_solver/samples"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/cpp"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/dotnet"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/flatzinc/challenge"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/flatzinc/mznlib"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/glop/samples"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/graph/csharp"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/graph/java"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/graph/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/graph/samples"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/graph/testdata"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/init/csharp"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/init/java"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/init/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/java"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/julia"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/linear_solver/csharp"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/linear_solver/java"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/linear_solver/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/linear_solver/samples"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/linear_solver/testdata"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/math_opt/core/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/math_opt/io/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/math_opt/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/math_opt/samples"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/math_opt/solver_tests/testdata"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/math_opt/tools"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/packing/testdata"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/pdlp/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/pdlp/samples"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/routing/parsers/testdata"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/routing/samples"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/routing/testdata"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/sat/colab"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/sat/csharp"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/sat/docs"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/sat/java"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/sat/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/sat/samples"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/scheduling/python"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/scheduling/testdata"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/service"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/util/csharp"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/util/java"
+        "${CURRENT_PACKAGES_DIR}/include/ortools/util/python"
+)
+
+vcpkg_copy_tools(
+        TOOL_NAMES solve sat_runner vector_bin_packing
+        AUTO_CLEAN
+)

--- a/ports/or-tools/usage
+++ b/ports/or-tools/usage
@@ -1,0 +1,4 @@
+or-tools provides CMake targets:
+
+  find_package(ortools CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE ortools::ortools)

--- a/ports/or-tools/vcpkg.json
+++ b/ports/or-tools/vcpkg.json
@@ -1,6 +1,8 @@
 {
   "name": "or-tools",
   "version": "9.11",
+  "description": "Google Optimization Tools (a.k.a., OR-Tools) is an open-source, fast and portable software suite for solving combinatorial optimization problems",
+  "homepage": "https://developers.google.com/optimization",
   "license": "Apache-2.0",
   "supports": "!(windows & static)",
   "dependencies": [

--- a/ports/or-tools/vcpkg.json
+++ b/ports/or-tools/vcpkg.json
@@ -6,7 +6,12 @@
   "license": "Apache-2.0",
   "supports": "!android",
   "dependencies": [
-    "abseil",
+    {
+      "name": "abseil",
+      "features": [
+        "cxx17"
+      ]
+    },
     "eigen3",
     "protobuf",
     {

--- a/ports/or-tools/vcpkg.json
+++ b/ports/or-tools/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Google Optimization Tools (a.k.a., OR-Tools) is an open-source, fast and portable software suite for solving combinatorial optimization problems",
   "homepage": "https://developers.google.com/optimization",
   "license": "Apache-2.0",
-  "supports": "!(windows & !static) & !android",
+  "supports": "!android",
   "dependencies": [
     {
       "name": "abseil",

--- a/ports/or-tools/vcpkg.json
+++ b/ports/or-tools/vcpkg.json
@@ -6,15 +6,9 @@
   "license": "Apache-2.0",
   "supports": "!android",
   "dependencies": [
-    {
-      "name": "abseil",
-      "features": [
-        "cxx17"
-      ]
-    },
+    "abseil",
     "eigen3",
     "protobuf",
-    "re2",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/or-tools/vcpkg.json
+++ b/ports/or-tools/vcpkg.json
@@ -14,6 +14,7 @@
     },
     "eigen3",
     "protobuf",
+    "re2",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/or-tools/vcpkg.json
+++ b/ports/or-tools/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Google Optimization Tools (a.k.a., OR-Tools) is an open-source, fast and portable software suite for solving combinatorial optimization problems",
   "homepage": "https://developers.google.com/optimization",
   "license": "Apache-2.0",
-  "supports": "!(windows & static)",
+  "supports": "!(windows & !static)",
   "dependencies": [
     {
       "name": "abseil",

--- a/ports/or-tools/vcpkg.json
+++ b/ports/or-tools/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "or-tools",
   "version": "9.11",
   "license": "Apache-2.0",
-  "supports": "(windows & static & !uwp & !arm) | linux | osx",
+  "supports": "!(windows & static)",
   "dependencies": [
     {
       "name": "abseil",

--- a/ports/or-tools/vcpkg.json
+++ b/ports/or-tools/vcpkg.json
@@ -1,0 +1,33 @@
+{
+  "name": "or-tools",
+  "version": "9.11",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "abseil",
+      "features": [
+        "cxx17"
+      ]
+    },
+    "eigen3",
+    "protobuf",
+    "re2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ],
+  "features": {
+    "highs": {
+      "description": "Enable support for HiGHS solver",
+      "dependencies": [
+        "highs"
+      ]
+    }
+  }
+}

--- a/ports/or-tools/vcpkg.json
+++ b/ports/or-tools/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "or-tools",
   "version": "9.11",
   "license": "Apache-2.0",
-  "supports": "(windows & static & !uwp) | linux | osx",
+  "supports": "(windows & static & !uwp & !arm) | linux | osx",
   "dependencies": [
     {
       "name": "abseil",

--- a/ports/or-tools/vcpkg.json
+++ b/ports/or-tools/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Google Optimization Tools (a.k.a., OR-Tools) is an open-source, fast and portable software suite for solving combinatorial optimization problems",
   "homepage": "https://developers.google.com/optimization",
   "license": "Apache-2.0",
-  "supports": "!(windows & !static)",
+  "supports": "!(windows & !static) & !android",
   "dependencies": [
     {
       "name": "abseil",

--- a/ports/or-tools/vcpkg.json
+++ b/ports/or-tools/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "or-tools",
   "version": "9.11",
   "license": "Apache-2.0",
+  "supports": "(windows & static & !uwp) | linux | osx",
   "dependencies": [
     {
       "name": "abseil",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6812,6 +6812,10 @@
       "baseline": "0.12+20221121",
       "port-version": 1
     },
+    "or-tools": {
+      "baseline": "9.11",
+      "port-version": 0
+    },
     "orc": {
       "baseline": "2.0.0",
       "port-version": 0

--- a/versions/o-/or-tools.json
+++ b/versions/o-/or-tools.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0175a5c8ee50c129afdc67b4e195a8e41878d390",
+      "version": "9.11",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/o-/or-tools.json
+++ b/versions/o-/or-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3d1c0345198fa69c7072c2cb11919f796f568164",
+      "git-tree": "19edbbceac81500af68976aad66ea335f7027385",
       "version": "9.11",
       "port-version": 0
     }

--- a/versions/o-/or-tools.json
+++ b/versions/o-/or-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a0935e48ee7ac0ac373075442af29d3fe6661be8",
+      "git-tree": "aefe953c0062864192b3e91e71629c43eeb1652c",
       "version": "9.11",
       "port-version": 0
     }

--- a/versions/o-/or-tools.json
+++ b/versions/o-/or-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a0af3e978bb5e6910a3d3c0674851bce252231d4",
+      "git-tree": "4b8da9f2be8ad21c19d500e1712b9aee05aa0148",
       "version": "9.11",
       "port-version": 0
     }

--- a/versions/o-/or-tools.json
+++ b/versions/o-/or-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "aefe953c0062864192b3e91e71629c43eeb1652c",
+      "git-tree": "a0af3e978bb5e6910a3d3c0674851bce252231d4",
       "version": "9.11",
       "port-version": 0
     }

--- a/versions/o-/or-tools.json
+++ b/versions/o-/or-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5062806a86b57b885d67b0d8857f79b2d4bb0310",
+      "git-tree": "8b663d12bdfba5f2bf568d0f185649671b31278c",
       "version": "9.11",
       "port-version": 0
     }

--- a/versions/o-/or-tools.json
+++ b/versions/o-/or-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8cf738953179a7976f9b7621f496d60cd4a44b3e",
+      "git-tree": "5062806a86b57b885d67b0d8857f79b2d4bb0310",
       "version": "9.11",
       "port-version": 0
     }

--- a/versions/o-/or-tools.json
+++ b/versions/o-/or-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c436c6e5cb265493df10c14bb95db9696d608b57",
+      "git-tree": "8cf738953179a7976f9b7621f496d60cd4a44b3e",
       "version": "9.11",
       "port-version": 0
     }

--- a/versions/o-/or-tools.json
+++ b/versions/o-/or-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4b8da9f2be8ad21c19d500e1712b9aee05aa0148",
+      "git-tree": "c436c6e5cb265493df10c14bb95db9696d608b57",
       "version": "9.11",
       "port-version": 0
     }

--- a/versions/o-/or-tools.json
+++ b/versions/o-/or-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8b663d12bdfba5f2bf568d0f185649671b31278c",
+      "git-tree": "3d1c0345198fa69c7072c2cb11919f796f568164",
       "version": "9.11",
       "port-version": 0
     }

--- a/versions/o-/or-tools.json
+++ b/versions/o-/or-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0175a5c8ee50c129afdc67b4e195a8e41878d390",
+      "git-tree": "a0935e48ee7ac0ac373075442af29d3fe6661be8",
       "version": "9.11",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

Adds Google or-tools lib as a port.
- `highs` solver is useable as an optional feature
- `coin-or` solver couldn't be added because of https://github.com/microsoft/vcpkg/issues/39342. Once this is issue is resolved `coin-or` can also be added as an optional feature

----------

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.

