### PR TITLE
[libxslt] Update to v1.1.42

### DIFF
--- a/ports/libxslt/fix-gcrypt-deps.patch
+++ b/ports/libxslt/fix-gcrypt-deps.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6dc6501..d36a049 100644
+index fb352475..4113fbff 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -317,7 +317,9 @@ target_include_directories(
+@@ -319,7 +319,9 @@ target_include_directories(
  
  if(LIBXSLT_WITH_CRYPTO AND NOT WIN32)
  	target_link_libraries(LibExslt PRIVATE Gcrypt::Gcrypt)
@@ -12,9 +12,9 @@ index 6dc6501..d36a049 100644
 +	string(APPEND EXSLT_PRIVATE_REQUIRES " libgcrypt")
  endif()
  
- target_link_libraries(LibExslt PUBLIC LibXslt LibXml2::LibXml2)
+ if(UNIX)
 diff --git a/FindGcrypt.cmake b/FindGcrypt.cmake
-index 781113d..a78fa84 100644
+index 781113d5..6f680beb 100644
 --- a/FindGcrypt.cmake
 +++ b/FindGcrypt.cmake
 @@ -1,3 +1,20 @@
@@ -38,7 +38,7 @@ index 781113d..a78fa84 100644
  include(FindPackageHandleStandardArgs)
  include(SelectLibraryConfigurations)
  
-@@ -38,3 +53,4 @@ if(GCRYPT_FOUND AND NOT TARGET Gcrypt::Gcrypt)
+@@ -38,3 +55,4 @@ if(GCRYPT_FOUND AND NOT TARGET Gcrypt::Gcrypt)
  		INTERFACE_INCLUDE_DIRECTORIES "${GCRYPT_INCLUDE_DIRS}"
  	)
  endif()

--- a/ports/libxslt/libexslt-pkgconfig.patch
+++ b/ports/libxslt/libexslt-pkgconfig.patch
@@ -1,5 +1,5 @@
 diff --git a/libexslt.pc.in b/libexslt.pc.in
-index 1d60563..50089e8 100644
+index f448bb83..791bcdda 100644
 --- a/libexslt.pc.in
 +++ b/libexslt.pc.in
 @@ -7,7 +7,8 @@ includedir=@includedir@
@@ -9,6 +9,6 @@ index 1d60563..50089e8 100644
 -Requires: libxml-2.0, libxslt
 +Requires: libxslt
 +Requires.private: @EXSLT_PRIVATE_REQUIRES@
- Cflags: @EXSLT_INCLUDEDIR@
+ Cflags: @EXSLT_INCLUDEDIR@ @LIBEXSLT_CFLAGS@
  Libs: @EXSLT_LIBDIR@ -lexslt
  Libs.private: @EXSLT_PRIVATE_LIBS@

--- a/ports/libxslt/msvc-no-suffix.patch
+++ b/ports/libxslt/msvc-no-suffix.patch
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d8679fb..6dc6501 100644
+index fb352475..a4bb094e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -244,7 +249,7 @@ set_target_properties(
- 	VERSION ${PROJECT_VERSION}
+@@ -247,7 +247,7 @@ set_target_properties(
+ 	SOVERSION ${LIBXSLT_MAJOR_VERSION}
  )
  
 -if(MSVC)
@@ -11,8 +11,8 @@ index d8679fb..6dc6501 100644
  	if(BUILD_SHARED_LIBS)
  		set_target_properties(
  			LibXslt
-@@ -327,7 +332,7 @@ set_target_properties(
- 	VERSION ${LIBEXSLT_VERSION}
+@@ -340,7 +340,7 @@ set_target_properties(
+ 	SOVERSION ${LIBEXSLT_MAJOR_VERSION}
  )
  
 -if(MSVC)

--- a/ports/libxslt/python3.patch
+++ b/ports/libxslt/python3.patch
@@ -1,10 +1,10 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d8679fb..6dc6501 100644
+index fb352475..75bd44a5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -35,6 +35,11 @@ if(LIBXSLT_WITH_PYTHON)
+@@ -63,6 +63,11 @@ if(LIBXSLT_WITH_PYTHON)
  	check_symbol_exists(F_GETFL fcntl.h HAVE_F_GETFL)
- 	if(HAVE_UNISTD_H AND HAVE_F_GETFL)
+ 	if(WIN32 OR (HAVE_UNISTD_H AND HAVE_F_GETFL))
  		find_package(Python COMPONENTS Interpreter Development REQUIRED)
 +	elseif(1)
 +		find_package(Python3 COMPONENTS Interpreter Development REQUIRED)

--- a/ports/libxslt/skip-install-docs.patch
+++ b/ports/libxslt/skip-install-docs.patch
@@ -1,15 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6dc6501..d36a049 100644
+index fb352475..23fe90f6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -432,10 +434,12 @@ if(LIBXSLT_WITH_PYTHON)
+@@ -474,12 +474,14 @@ if(LIBXSLT_WITH_PYTHON)
  	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libxslt.py DESTINATION ${LIBXSLT_PYTHON_INSTALL_DIR} COMPONENT runtime)
  endif()
  
 +if(VCPKG_INSTALL_DOCS)
  install(FILES libexslt/libexslt.3 DESTINATION ${CMAKE_INSTALL_MANDIR}/man3 COMPONENT documentation)
  install(FILES libxslt/libxslt.3 DESTINATION ${CMAKE_INSTALL_MANDIR}/man3 COMPONENT documentation)
- install(FILES doc/xsltproc.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT documentation)
+ if(LIBXSLT_WITH_PROGRAMS)
+ 	install(FILES doc/xsltproc.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT documentation)
+ endif()
  install(DIRECTORY doc/ DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/libxslt COMPONENT documentation PATTERN Makefile.* EXCLUDE)
 +endif()
  

--- a/ports/libxslt/vcpkg.json
+++ b/ports/libxslt/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxslt",
-  "version": "1.1.37",
-  "port-version": 4,
+  "version": "1.1.42",
   "description": "Libxslt is a XSLT library implemented in C for XSLT 1.0 and most of EXSLT",
   "homepage": "https://github.com/GNOME/libxslt",
   "license": null,
@@ -21,7 +20,7 @@
     }
   ],
   "default-features": [
-    "default-features"
+    "thread"
   ],
   "features": {
     "crypto": {
@@ -31,16 +30,22 @@
         "libgcrypt"
       ]
     },
-    "default-features": {
-      "description": "default features for the current platform"
-    },
     "plugins": {
       "description": "(deprecated)",
       "supports": "!static"
     },
+    "profiler": {
+      "description": "Build with profiling support"
+    },
     "python": {
       "description": "Builds with python support",
       "supports": "!windows"
+    },
+    "thread": {
+      "description": "Enable multi-threading support"
+    },
+    "tools": {
+      "description": "Build the utilities"
     }
   }
 }

--- a/ports/xcb/vcpkg.json
+++ b/ports/xcb/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "xcb",
   "version": "1.14",
-  "port-version": 2,
+  "port-version": 3,
   "description": "C interface to the X Window System protocol, which replaces the traditional Xlib interface.",
   "homepage": "https://xcb.freedesktop.org/",
   "license": "X11-distribute-modifications-variant",
@@ -11,7 +11,11 @@
     "libxdmcp",
     {
       "name": "libxslt",
-      "host": true
+      "host": true,
+      "default-features": false,
+      "features": [
+        "tools"
+      ]
     },
     "pthread",
     "pthread-stubs",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5481,8 +5481,8 @@
       "port-version": 0
     },
     "libxslt": {
-      "baseline": "1.1.37",
-      "port-version": 4
+      "baseline": "1.1.42",
+      "port-version": 0
     },
     "libxt": {
       "baseline": "1.3.0",
@@ -9778,7 +9778,7 @@
     },
     "xcb": {
       "baseline": "1.14",
-      "port-version": 2
+      "port-version": 3
     },
     "xcb-image": {
       "baseline": "0.4.1",

--- a/versions/l-/libxslt.json
+++ b/versions/l-/libxslt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8bd8a88f0bf38f7e3b7dda75aa505d413a496836",
+      "version": "1.1.42",
+      "port-version": 0
+    },
+    {
       "git-tree": "75b0e06db8a91635c6383e8d7be0f96222aa3cbd",
       "version": "1.1.37",
       "port-version": 4

--- a/versions/x-/xcb.json
+++ b/versions/x-/xcb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c22c4b92b4143d3aeb4d3ecbe82d9c03ca7acece",
+      "version": "1.14",
+      "port-version": 3
+    },
+    {
       "git-tree": "409e8b6e371d2541c6330d13034e44bcaa4e10e8",
       "version": "1.14",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.