### PR TITLE
[directxmath] Fix to support MSBuild usage

### DIFF
--- a/ports/directxmath/include-path-fix.patch
+++ b/ports/directxmath/include-path-fix.patch
@@ -1,0 +1,43 @@
+From 994441ebfa63fe1440bf430c99b5ba3eaba02c66 Mon Sep 17 00:00:00 2001
+From: Chuck Walbourn <chuckw@microsoft.com>
+Date: Tue, 26 Nov 2024 17:44:02 -0800
+Subject: [PATCH] CMake update to avoid directxmath subdir for include
+
+---
+ CMakeLists.txt | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d10adc1..7041f14 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,7 +30,7 @@ add_library(${PROJECT_NAME} INTERFACE)
+ 
+ target_include_directories(${PROJECT_NAME} INTERFACE
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Inc>
+-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/directxmath>)
++  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ 
+ target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+ 
+@@ -61,7 +61,7 @@ install(EXPORT ${PROJECT_NAME}-targets
+   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME})
+ 
+ install(FILES ${LIBRARY_HEADERS}
+-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/directxmath)
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ 
+ install(FILES
+     ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}-config.cmake
+@@ -71,7 +71,7 @@ install(FILES
+ # Create pkg-config file
+ include(build/JoinPaths.cmake)
+ # from: https://github.com/jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files
+-join_paths(DIRECTXMATH_INCLUDEDIR_FOR_PKG_CONFIG "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}/directxmath")
++join_paths(DIRECTXMATH_INCLUDEDIR_FOR_PKG_CONFIG "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+ join_paths(DIRECTXMATH_LIBDIR_FOR_PKG_CONFIG "\${prefix}"     "${CMAKE_INSTALL_LIBDIR}")
+ 
+ configure_file(
+-- 
+2.47.0.vfs.0.3
+

--- a/ports/directxmath/portfile.cmake
+++ b/ports/directxmath/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF oct2024
     SHA512 501a3c8b51cd6d3d4fbcc511c2c37f1d0511bd84d546d5254c2bc81238c11242b9d62c7a153ee110dc9d96a0c7d2544428d8de832c943b680b0cb09d8e3760f2
     HEAD_REF main
+    PATCHES include-path-fix.patch
 )
 
 vcpkg_cmake_configure(
@@ -27,7 +28,7 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
 
     file(INSTALL
       ${DOWNLOADS}/sal.h
-      DESTINATION ${CURRENT_PACKAGES_DIR}/include/directxmath)
+      DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/directxmath/vcpkg.json
+++ b/ports/directxmath/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxmath",
-  "version-date": "2024-10-15",
+  "version-date": "2024-12-02",
   "description": "DirectXMath SIMD C++ math library",
   "homepage": "https://github.com/Microsoft/DirectXMath",
   "documentation": "https://docs.microsoft.com/windows/win32/dxmath/directxmath-portal",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2321,7 +2321,7 @@
       "port-version": 0
     },
     "directxmath": {
-      "baseline": "2024-10-15",
+      "baseline": "2024-12-02",
       "port-version": 0
     },
     "directxmesh": {

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf54dfb76f186cf9b58dfe7d06150667ec54babc",
+      "version-date": "2024-12-02",
+      "port-version": 0
+    },
+    {
       "git-tree": "b842f51d9302c1c46491b4481947be89005c3936",
       "version-date": "2024-10-15",
       "port-version": 0


### PR DESCRIPTION
The port was installing the headers to `include\directxmath` which worked fine for CMake scenarios. For MSBuild, however, this would require changing all the source to use ``#include <directxmath\DirectXMath.h>``.

This patch just installs it to `include` so no client code changes are needed for MSBuild+VCPKG compared t CMake+VCPKG. This change was also made upstream to will be included in future updates as well.