### PR TITLE
[protopuf] Update to v3.0.0

### DIFF
--- a/ports/protopuf/portfile.cmake
+++ b/ports/protopuf/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PragmaTwice/protopuf
-    REF v2.2.1
-    SHA512 f7cf0df90178f2582ba50f6fb8518b4a005dbad7d0fb1fea8f0b2d80a3df18d251b0c795583a121aab246acf245a46ecf374597447b7b61777e48c5bfafed5f2
+    REF "v${VERSION}"
+    SHA512 c74bd2bc6090fb1b09d697ff1c082028cb3bacbe7f18bb93afe8b323f8f140a3b6d1c79ac41d54cd06eb1132d97ddc61e1dd6c2e658368ac08f80c414eb779fd
     HEAD_REF master
 )
 

--- a/ports/protopuf/vcpkg.json
+++ b/ports/protopuf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protopuf",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "description": "A little, highly templated, and protobuf-compatible serialization/deserialization library written in C++20",
   "homepage": "https://github.com/PragmaTwice/protopuf",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7229,7 +7229,7 @@
       "port-version": 0
     },
     "protopuf": {
-      "baseline": "2.2.1",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "protozero": {

--- a/versions/p-/protopuf.json
+++ b/versions/p-/protopuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "81d04541581f77d3e71387de058cd91052486489",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fce43fe70999efa77083824e66e61251e0df3219",
       "version": "2.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.