### PR TITLE
[mdl-sdk] Fix build of openimageio feature after update to OpenImageIO 3.x.

### DIFF
--- a/ports/mdl-sdk/013-openimageio-3.0.patch
+++ b/ports/mdl-sdk/013-openimageio-3.0.patch
@@ -1,0 +1,100 @@
+diff -u -r a/cmake/find/find_boost_ext.cmake b/cmake/find/find_boost_ext.cmake
+--- a/cmake/find/find_boost_ext.cmake
++++ b/cmake/find/find_boost_ext.cmake
+@@ -38,13 +38,7 @@
+     set(Boost_NO_WARN_NEW_VERSIONS ON CACHE INTERNAL "")
+     #set(Boost_DEBUG ON)
+ 
+-    if(MDL_BUILD_OPENIMAGEIO_PLUGIN OR MDL_BUILD_CORE_EXAMPLES)
+-        # OpenImageIO needs Boost::filesystem and Boost::thread.
+-        find_package(Boost COMPONENTS filesystem thread)
+-    else()
+-        # Otherwise the Boost headers are sufficient.
+-        find_package(Boost)
+-    endif()
++    find_package(Boost)
+ 
+     set(Boost_FOUND ${Boost_FOUND} CACHE INTERNAL "Dependency boost has been resolved.")
+ 
+diff -u -r a/cmake/find/find_openimageio_ext.cmake b/cmake/find/find_openimageio_ext.cmake
+--- a/cmake/find/find_openimageio_ext.cmake
++++ b/cmake/find/find_openimageio_ext.cmake
+@@ -4,19 +4,17 @@
+ 
+ function(FIND_OPENIMAGEIO_EXT)
+ 
+-    if(${CMAKE_VERSION} VERSION_LESS "3.19.0")
+-        find_package(OpenImageIO)
+-        if(OpenImageIO_FOUND)
+-            if(${OpenImageIO_VERSION} VERSION_LESS "2.4")
+-                set(OpenImageIO_FOUND OFF)
+-                message(WARNING "Found OpenImageIO version ${OpenImageIO_VERSION} is too old.")
+-            elseif(${OpenImageIO_VERSION} VERSION_GREATER_EQUAL "3.0")
+-                set(OpenImageIO_FOUND OFF)
+-                message(WARNING "Found OpenImageIO version ${OpenImageIO_VERSION} is too new.")
+-            endif()
++    # Explicit code since a version range on find_package() does not support multiple major
++    # versions.
++    find_package(OpenImageIO)
++    if(OpenImageIO_FOUND)
++        if(${OpenImageIO_VERSION} VERSION_LESS "2.4")
++            set(OpenImageIO_FOUND OFF)
++            message(WARNING "Found OpenImageIO version ${OpenImageIO_VERSION} is too old.")
++        elseif(${OpenImageIO_VERSION} VERSION_GREATER_EQUAL "4.0")
++            set(OpenImageIO_FOUND OFF)
++            message(WARNING "Found OpenImageIO version ${OpenImageIO_VERSION} is too new.")
+         endif()
+-    else()
+-        find_package(OpenImageIO 2.4...<3.0)
+     endif()
+ 
+     # See https://github.com/microsoft/vcpkg/issues/29284
+diff -u -r a/src/shaders/plugin/openimageio/openimageio_utilities.cpp b/src/shaders/plugin/openimageio/openimageio_utilities.cpp
+--- a/src/shaders/plugin/openimageio/openimageio_utilities.cpp
++++ b/src/shaders/plugin/openimageio/openimageio_utilities.cpp
+@@ -421,14 +421,22 @@
+ 
+     const char* proxytype () const override { return "nv_reader"; }
+     void close() override { m_reader.reset(); }
++#if OIIO_VERSION >= OIIO_MAKE_VERSION(3,0,0)
++    int64_t tell() const override { return m_reader->tell_absolute(); }
++#else
+     int64_t tell() override { return m_reader->tell_absolute(); }
++#endif
+     bool seek( int64_t offset) override { return m_reader->seek_absolute( offset); }
+     size_t read( void* buf, size_t size) override;
+     size_t write( const void* buf, size_t size) override;
+     size_t pread( void* buf, size_t size, int64_t offset) override;
+     size_t pwrite( const void* buf, size_t size, int64_t offset) override;
+     size_t size() const override { return m_reader->get_file_size(); }
++#if OIIO_VERSION >= OIIO_MAKE_VERSION(3,0,0)
++    void flush() override { }
++#else
+     void flush() const override { }
++#endif
+ 
+ private:
+     /// The wrapped reader.
+@@ -502,14 +510,22 @@
+ 
+     const char* proxytype () const override { return "nv_writer"; }
+     void close() override { m_writer.reset(); }
++#if OIIO_VERSION >= OIIO_MAKE_VERSION(3,0,0)
++    int64_t tell() const override { return m_writer->tell_absolute(); }
++#else
+     int64_t tell() override { return m_writer->tell_absolute(); }
++#endif
+     bool seek( int64_t offset) override { return m_writer->seek_absolute( offset); }
+     size_t read( void* buf, size_t size) override;
+     size_t write( const void* buf, size_t size) override;
+     size_t pread( void* buf, size_t size, int64_t offset) override;
+     size_t pwrite( const void* buf, size_t size, int64_t offset) override;
+     size_t size() const override { return m_writer->get_file_size(); }
++#if OIIO_VERSION >= OIIO_MAKE_VERSION(3,0,0)
++    void flush() override { m_writer->flush(); }
++#else
+     void flush() const override { m_writer->flush(); }
++#endif
+ 
+ private:
+     /// The wrapped writer.

--- a/ports/mdl-sdk/portfile.cmake
+++ b/ports/mdl-sdk/portfile.cmake
@@ -83,6 +83,7 @@ vcpkg_from_github(
     PATCHES
         008-build-static-llvm.patch
         012-remove-wrong-llvm-cxx-standard.patch
+        013-openimageio-3.0.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/mdl-sdk/vcpkg.json
+++ b/ports/mdl-sdk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mdl-sdk",
   "version": "2024.0.4",
+  "port-version": 1,
   "description": "NVIDIA Material Definition Language SDK",
   "homepage": "https://github.com/NVIDIA/MDL-SDK",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5866,7 +5866,7 @@
     },
     "mdl-sdk": {
       "baseline": "2024.0.4",
-      "port-version": 0
+      "port-version": 1
     },
     "mdns": {
       "baseline": "1.4.3",

--- a/versions/m-/mdl-sdk.json
+++ b/versions/m-/mdl-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d1412426eab60c60fc3bbfb4efda57da723cbe9c",
+      "version": "2024.0.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "089fc6e3fd51fbe06084eb0e59cbecb3b68387a3",
       "version": "2024.0.4",
       "port-version": 0


### PR DESCRIPTION
Backport upstream fixes for support of OpenImageIO 3.x to MDL SDK 2024.0.4.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.