### PR TITLE
[libftp] Update to 1.4.0

### DIFF
--- a/ports/deniskovalchuk-libftp/portfile.cmake
+++ b/ports/deniskovalchuk-libftp/portfile.cmake
@@ -1,7 +1,3 @@
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-endif()
-
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO deniskovalchuk/libftp

--- a/ports/deniskovalchuk-libftp/portfile.cmake
+++ b/ports/deniskovalchuk-libftp/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO deniskovalchuk/libftp
         REF "v${VERSION}"
-        SHA512 7765c35884e1e4560e39018b15f441abac687afcb06942b0350ef21df8bf27d40283011397ce4a9e9125772bb9752180c225429b274fd6374e1a521ac2744b2e
+        SHA512 017c809c19e32b0ddb3b4d7f5cc4cb5cc0f27a4c2be0640ddf115d869f9dbfa4b7cc77845193fed9058885bb38d33f0cff436c18c35e9611ca4f299afefe3b9d
         HEAD_REF master
 )
 

--- a/ports/deniskovalchuk-libftp/vcpkg.json
+++ b/ports/deniskovalchuk-libftp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "deniskovalchuk-libftp",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "maintainers": "Denis Kovalchuk <denis.kovalchuk.main@gmail.com>",
   "description": "A cross-platform FTP/FTPS client library based on Boost.Asio.",
   "homepage": "https://github.com/deniskovalchuk/libftp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2285,7 +2285,7 @@
       "port-version": 0
     },
     "deniskovalchuk-libftp": {
-      "baseline": "1.3.0",
+      "baseline": "1.4.0",
       "port-version": 0
     },
     "detours": {

--- a/versions/d-/deniskovalchuk-libftp.json
+++ b/versions/d-/deniskovalchuk-libftp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a7dceaab1b395fd2166e23a70e5d8a94b60d1947",
+      "git-tree": "b8ea0a5f92ba4b9e24a459711f55c2bb2de0343a",
       "version": "1.4.0",
       "port-version": 0
     },

--- a/versions/d-/deniskovalchuk-libftp.json
+++ b/versions/d-/deniskovalchuk-libftp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7dceaab1b395fd2166e23a70e5d8a94b60d1947",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ec17b648e643d563b6f916c0d8026fb646cfb2fe",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.