### PR TITLE
[libheif] disable testing

### DIFF
--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DWITH_EXAMPLES=OFF
         -DWITH_DAV1D=OFF
+        -DBUILD_TESTING=OFF
         ${FEATURE_OPTIONS}
 )
 vcpkg_cmake_install()

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libheif",
   "version": "1.19.5",
+  "port-version": 1,
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4654,7 +4654,7 @@
     },
     "libheif": {
       "baseline": "1.19.5",
-      "port-version": 0
+      "port-version": 1
     },
     "libhsplasma": {
       "baseline": "2024-03-07",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b714664a4550bae5edc9fbe655f0ce057ac9e67e",
+      "version": "1.19.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "68dd9fbb12027f868c747c3e204a00a2fca872a2",
       "version": "1.19.5",
       "port-version": 0


### PR DESCRIPTION
For https://github.com/microsoft/vcpkg/issues/42499.

Disable testing.
All feature tested on the following triplets:
- x64-windows
- x64-windows-static
- x86-windows

Usage tested on x64-windows.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
