### PR TITLE
[libdwarf] Update to 0.11.1

### DIFF
--- a/ports/libdwarf/dependencies.diff
+++ b/ports/libdwarf/dependencies.diff
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c53fda5..a6dabe6 100644
+index 133523b4..0c754c6d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -186,7 +186,7 @@ endif()
- if (ENABLE_DECOMPRESSION)
+@@ -188,7 +188,7 @@ if (ENABLE_DECOMPRESSION)
+   #message(STATUS "In ENABLE_DECOMPRESSION setup: TRUE")
    # Zlib and ZSTD need to be found otherwise disable it
    if(NOT TARGET ZLIB::ZLIB)
 -    find_package(ZLIB)
@@ -11,12 +11,12 @@ index c53fda5..a6dabe6 100644
    else()
      # Presumably in this case, the target has been found externally but set this flag just in case
      set(ZLIB_FOUND TRUE)
-@@ -201,7 +201,7 @@ if (ENABLE_DECOMPRESSION)
+@@ -203,7 +203,7 @@ if (ENABLE_DECOMPRESSION)
        TARGET ZSTD::ZSTD
      )
    )
 -    find_package(zstd)
-+    find_package(zstd CONFIG REQUIRED)
++  find_package(zstd CONFIG REQUIRED)
    else()
      # Presumably in this case, the target has been found externally but set this flag just in case
      set(zstd_FOUND TRUE)

--- a/ports/libdwarf/portfile.cmake
+++ b/ports/libdwarf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO davea42/libdwarf-code
     REF "v${VERSION}"
-    SHA512 5c8e01e3a2c559515af1833c2b7626634e74bd2f3de2e3ff4fc2127ac68885af9ee339608fc274499fae7326bbe7af41bc471ba4d807145c00c6cd0010a4b1aa
+    SHA512 598237db755c595bae2c998d99ea73d7a835b802cee5feaa7c8f99521fc0bf8c7bd56131c5421c80290d2f1237f9a51b5e3fb29c483c5271c45cd9640592360f
     HEAD_REF main
     PATCHES
         include-dir.diff # avoid dwarf.h conflict with elfutils

--- a/ports/libdwarf/vcpkg.json
+++ b/ports/libdwarf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdwarf",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A library for reading DWARF2 and later DWARF.",
   "homepage": "https://github.com/davea42/libdwarf-code",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4481,7 +4481,7 @@
       "port-version": 0
     },
     "libdwarf": {
-      "baseline": "0.11.0",
+      "baseline": "0.11.1",
       "port-version": 0
     },
     "libe57": {

--- a/versions/l-/libdwarf.json
+++ b/versions/l-/libdwarf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d28beee26f54890ebb0be88b8150ec871b1f34e",
+      "version": "0.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff0cf59a7fe26e200483302657d4e878d2038d39",
       "version": "0.11.0",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

