### PR TITLE
[libxml2] Update to v2.13.5

### DIFF
--- a/ports/librsvg/fix-libxml2-2.13.5.patch
+++ b/ports/librsvg/fix-libxml2-2.13.5.patch
@@ -1,0 +1,13 @@
+diff --git a/rsvg-css.c b/rsvg-css.c
+index 5b359a206..4f59281b6 100644
+--- a/rsvg-css.c
++++ b/rsvg-css.c
+@@ -839,7 +839,7 @@ rsvg_css_parse_overflow (const char *str, gboolean * inherit)
+ }
+ 
+ static void
+-rsvg_xml_noerror (void *data, xmlErrorPtr error)
++rsvg_xml_noerror (void *data, const xmlError *error)
+ {
+ }
+ 

--- a/ports/librsvg/portfile.cmake
+++ b/ports/librsvg/portfile.cmake
@@ -5,12 +5,14 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://download.gnome.org/sources/librsvg/${MAJOR_MINOR}/librsvg-${VERSION}.tar.xz"
          "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/librsvg/${MAJOR_MINOR}/librsvg-${VERSION}.tar.xz"
     FILENAME "librsvg-${VERSION}.tar.xz"
-    SHA512 cdd8224deb4c3786e29f48ed02c32ed9dff5cb15aba574a5ef845801ad3669cfcc3eedb9d359c22213dc7a29de24c363248825adad5877c40abf73b3688ff12f
+    SHA512 db0563d8e0edaae642a6b2bcd239cf54191495058ac8c7ff614ebaf88c0e30bd58dbcd41f58d82a9d5ed200ced45fc5bae22f2ed3cf3826e9348a497009e1280
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+    PATCHES
+        fix-libxml2-2.13.5.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" "${CMAKE_CURRENT_LIST_DIR}/config.h.linux" DESTINATION "${SOURCE_PATH}")

--- a/ports/librsvg/vcpkg.json
+++ b/ports/librsvg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "librsvg",
-  "version": "2.40.20",
-  "port-version": 11,
+  "version": "2.40.21",
   "description": "A small library to render Scalable Vector Graphics (SVG)",
   "homepage": "https://gitlab.gnome.org/GNOME/librsvg",
   "license": "LGPL-2.0-or-later",

--- a/ports/libxml2/disable-docs.patch
+++ b/ports/libxml2/disable-docs.patch
@@ -1,20 +1,22 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f922d5ab..70466bc7 100644
+index f99fd368..38dcd377 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -599,15 +599,5 @@ if(LIBXML2_WITH_PYTHON)
+@@ -586,17 +586,6 @@ if(LIBXML2_WITH_PYTHON)
+     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libxml2.py DESTINATION ${LIBXML2_PYTHON_INSTALL_DIR} COMPONENT runtime)
  endif()
  
 -install(FILES doc/xml2-config.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT documentation)
 -install(FILES doc/xmlcatalog.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT documentation)
 -install(FILES doc/xmllint.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT documentation)
 -install(DIRECTORY doc/ DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT documentation
--	PATTERN "Makefile.*" EXCLUDE
--	PATTERN "*.1" EXCLUDE
--	PATTERN "*.py" EXCLUDE
--	PATTERN "*.res" EXCLUDE
--	PATTERN "*.xml" EXCLUDE
--	PATTERN "*.xsl" EXCLUDE)
- 
+-    PATTERN "Makefile.*" EXCLUDE
+-    PATTERN "*.1" EXCLUDE
+-    PATTERN "*.py" EXCLUDE
+-    PATTERN "*.res" EXCLUDE
+-    PATTERN "*.xml" EXCLUDE
+-    PATTERN "*.xsl" EXCLUDE)
+-
  configure_package_config_file(
- 	libxml2-config.cmake.cmake.in libxml2-config.cmake
+     libxml2-config.cmake.cmake.in libxml2-config.cmake
+     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxml2-${PROJECT_VERSION}

--- a/ports/libxml2/fix_cmakelist.patch
+++ b/ports/libxml2/fix_cmakelist.patch
@@ -1,90 +1,34 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9701bdc..39e96ee 100644
+index f99fd368..3246a42c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -393,15 +393,15 @@ endif()
- if(LIBXML2_WITH_ICU)
- 	target_link_libraries(LibXml2 PRIVATE ICU::data ICU::i18n ICU::uc)
- 	if(WIN32)
--		set(ICU_LIBS "-licudt -licuin -licuuc")
-+		set(ICU_LIBS "icu-i18n")
- 	else()
--		set(ICU_LIBS "-licudata -licui18n -licuuc")
-+		set(ICU_LIBS "icu-i18n")
- 	endif()
- endif()
- 
- if(LIBXML2_WITH_LZMA)
- 	target_link_libraries(LibXml2 PRIVATE LibLZMA::LibLZMA)
--	set(LZMA_LIBS "-llzma")
-+	set(LZMA_LIBS "liblzma")
- endif()
- 
- if(LIBXML2_WITH_THREADS)
-@@ -411,7 +411,7 @@ endif()
- 
- if(LIBXML2_WITH_ZLIB)
- 	target_link_libraries(LibXml2 PRIVATE ZLIB::ZLIB)
--	set(Z_LIBS "-lz")
-+	set(Z_LIBS "zlib")
- endif()
- 
- set_target_properties(
-@@ -425,23 +425,9 @@ set_target_properties(
-         SOVERSION ${LIBXML_MAJOR_VERSION}
+@@ -438,7 +438,7 @@ set_target_properties(
+     SOVERSION ${LIBXML_MAJOR_VERSION}
  )
  
-+set(XML_LIB_NAME xml2)
- if(MSVC)
--	if(BUILD_SHARED_LIBS)
--		set_target_properties(
--			LibXml2
--			PROPERTIES
--			DEBUG_POSTFIX d
--		)
--	else()
--		set_target_properties(
--			LibXml2
--			PROPERTIES
--			DEBUG_POSTFIX sd
--			MINSIZEREL_POSTFIX s
--			RELEASE_POSTFIX s
--			RELWITHDEBINFO_POSTFIX s
--		)
--	endif()
-+	set(XML_LIB_NAME libxml2)
- endif()
+-if(MSVC)
++if(0)
+     if(BUILD_SHARED_LIBS)
+         set_target_properties(
+             LibXml2
+@@ -653,7 +653,11 @@ list(JOIN XML_PRIVATE_LIBS " " XML_PRIVATE_LIBS)
  
- install(FILES ${LIBXML2_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libxml2/libxml COMPONENT development)
-@@ -586,7 +572,7 @@ endif()
- write_basic_package_version_file(
- 	${CMAKE_CURRENT_BINARY_DIR}/libxml2-config-version.cmake
- 	VERSION ${PROJECT_VERSION}
--	COMPATIBILITY ExactVersion
-+	COMPATIBILITY SameMajorVersion
- )
+ set(XML_INCLUDEDIR "-I\${includedir}/libxml2")
+ set(XML_LIBDIR "-L\${libdir}")
++if(NOT MSVC)
+ set(XML_LIBS "-lxml2")
++else()
++set(XML_LIBS "-llibxml2")
++endif()
  
- install(
-@@ -635,7 +621,7 @@ set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+ if(BUILD_SHARED_LIBS)
+     set(XML_PC_PRIVATE ".private")
+@@ -679,7 +683,7 @@ set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
  configure_file(libxml-2.0.pc.in libxml-2.0.pc @ONLY)
  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libxml-2.0.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT development)
  
 -if(WIN32)
 +if(1)
- 	set(prefix "\$(cd \"\$(dirname \"\$0\")\"; pwd -P)/..")
+     set(prefix "\$(cd \"\$(dirname \"\$0\")\"; pwd -P)/..")
  endif()
  configure_file(xml2-config.in xml2-config @ONLY)
-diff --git a/libxml-2.0.pc.in b/libxml-2.0.pc.in
-index 88e3963b..0d1706c9 100644
---- a/libxml-2.0.pc.in
-+++ b/libxml-2.0.pc.in
-@@ -8,6 +8,7 @@ Name: libXML
- Version: @VERSION@
- Description: libXML library version2.
- Requires:
--Libs: -L${libdir} @XML_LIBS@
--Libs.private: @XML_PRIVATE_LIBS@ @LIBS@
-+Requires.private: @ICU_LIBS@ @Z_LIBS@ @LZMA_LIBS@
-+Libs: -L${libdir} -l@XML_LIB_NAME@
-+Libs.private: @THREAD_LIBS@ @ICONV_LIBS@ @LIBM@ @WINSOCK_LIBS@ @LIBS@
- Cflags: @XML_INCLUDEDIR@ @XML_CFLAGS@

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -1,13 +1,26 @@
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.gnome.org/
+vcpkg_download_distfile(FIX_COMPATIBILITY_PATCH
+    URLS https://github.com/GNOME/libxml2/commit/b347a008a745778630a9eb4fbd29694f3c135bfa.diff?full_index=1
+    FILENAME Fix-compatibility-in-package-version-file.patch
+    SHA512 7f5e5f53444c12924b0fefdf3013fa4dab76fb17f552dd827628739a6e65c9817ae7182e1817cea2317e2fc9b8a200ecce4f8cb5661a2614c0548a5b3e508b66
+)
+
+vcpkg_download_distfile(ADD_MISSING_BCRYPT_PATCH
+    URLS https://github.com/GNOME/libxml2/commit/fe1ee0f25f43e33a9981fd6fe7b0483a8c8b5e8d.diff?full_index=1
+    FILENAME Add-missing-Bcrypt-link.patch
+    SHA512 22bc2fe4c365a2c9991508484daa3d884ff91803df48b3847f71b2283e240ef3ce4fdc1d230932d837ff94dc02fc53e76e2e5a1c956ef037caacb13d8f9b3982
+)
+
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/libxml2
     REF "v${VERSION}"
-    SHA512 3f2de446657bf3c23c92358ce8946f59253b9fcc09577b59eecaffdbd97e051659855c79f4882ee9f8841dd194b6bd5de2a8017691473b505e905b9dde6a1bc9
+    SHA512 dfe0529dd2fbb7dc9e79505b9c6ff7f29979fa4392d534c1b8859fa9934c2e7d4da3429265d718292056809a58080af32b130263625cdeb358123774c27da7c6
     HEAD_REF master
     PATCHES
         disable-docs.patch
         fix_cmakelist.patch
+        ${FIX_COMPATIBILITY_PATCH}
+        ${ADD_MISSING_BCRYPT_PATCH}
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -21,6 +34,9 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "tools" LIBXML2_WITH_PROGRAMS
         "icu"  LIBXML2_WITH_ICU
 )
+
+vcpkg_find_acquire_program(PKGCONFIG)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -31,7 +47,6 @@ vcpkg_cmake_configure(
         -DLIBXML2_WITH_CATALOG=ON
         -DLIBXML2_WITH_DEBUG=ON
         -DLIBXML2_WITH_ISO8859X=ON
-        -DLIBXML2_WITH_MEM_DEBUG=OFF
         -DLIBXML2_WITH_MODULES=ON
         -DLIBXML2_WITH_OUTPUT=ON
         -DLIBXML2_WITH_PATTERN=ON
@@ -50,6 +65,7 @@ vcpkg_cmake_configure(
         -DLIBXML2_WITH_XINCLUDE=ON
         -DLIBXML2_WITH_XPATH=ON
         -DLIBXML2_WITH_XPTR=ON
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
 )
 
 vcpkg_cmake_install()

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxml2",
-  "version": "2.11.9",
-  "port-version": 1,
+  "version": "2.13.5",
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5057,8 +5057,8 @@
       "port-version": 1
     },
     "librsvg": {
-      "baseline": "2.40.20",
-      "port-version": 11
+      "baseline": "2.40.21",
+      "port-version": 0
     },
     "librsync": {
       "baseline": "2.3.4",
@@ -5437,8 +5437,8 @@
       "port-version": 1
     },
     "libxml2": {
-      "baseline": "2.11.9",
-      "port-version": 1
+      "baseline": "2.13.5",
+      "port-version": 0
     },
     "libxmlmm": {
       "baseline": "0.6.0",

--- a/versions/l-/librsvg.json
+++ b/versions/l-/librsvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13a61a8e2a4e6ca73d71dfbe8a6e0b366d2300f8",
+      "version": "2.40.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "c1f96a053c524889c293f4db10c0e43ec0951ca8",
       "version": "2.40.20",
       "port-version": 11

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f61ea0a7f998b892dc7eb51f6366867bef1d5353",
+      "version": "2.13.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "f3adf0002b5de8cfba4850a6953762ad8ebdfe78",
       "version": "2.11.9",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
