### PR TITLE
[openimageio] Update to v3.0.1.0

### DIFF
--- a/ports/openimageio/fix-openexr-target-missing.patch
+++ b/ports/openimageio/fix-openexr-target-missing.patch
@@ -1,13 +1,13 @@
 diff --git a/src/cmake/Config.cmake.in b/src/cmake/Config.cmake.in
-index 9ee9c9d..6b9e7c2 100644
+index 2620994b3..c9cbe7290 100644
 --- a/src/cmake/Config.cmake.in
 +++ b/src/cmake/Config.cmake.in
-@@ -31,6 +31,8 @@ endif()
+@@ -10,6 +10,8 @@ include(CMakeFindDependencyMacro)
  if (NOT @OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH@ AND NOT OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH)
      find_dependency(Imath @Imath_VERSION@
                      HINTS @Imath_DIR@)
 +    find_dependency(OpenEXR @OpenEXR_VERSION@
 +                        HINTS @OpenEXR_DIR@)
  endif ()
-
+ 
  if (NOT @fmt_LOCAL_BUILD@ AND NOT @OIIO_INTERNALIZE_FMT@)

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -1,8 +1,14 @@
+vcpkg_download_distfile(FIX_LIBRAW_BUILD_PATCH
+    URLS https://github.com/AcademySoftwareFoundation/OpenImageIO/commit/904df59ab74d0c89c1c9eea7d5ef0ecfe0620b2c.diff?full_index=1
+    FILENAME AcademySoftwareFoundation-OpenImageIO-libraw-build.patch
+    SHA512 0c3bb7bf76c8fd3e1e9408373cced3e8f1e189df268cef27c7ca7244ab6e15be8b96759505238aafd63061f683b0c552d7d710bf8ab49edb0de0d2aff8ceb8fc
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/OpenImageIO
     REF "v${VERSION}"
-    SHA512 16d357fc6f75d39b1c9265edb45fe78dd2ea67a094885174a0a2bdd39ad19f8f69c16a7aaacac82a106a295e08e311d0315daafcb5641c24f644a52e66aaf667
+    SHA512 8639b32ea3bd4d9188b346144721006cb93e09035ac6ec64636f1df97a26775b4dc53491b991aac943053824e2c2d52209a9a580a470d6450f2d55006554d87a
     HEAD_REF master
     PATCHES
         fix-dependencies.patch
@@ -10,6 +16,7 @@ vcpkg_from_github(
         imath-version-guard.patch
         fix-openimageio_include_dir.patch
         fix-openexr-target-missing.patch
+        ${FIX_LIBRAW_BUILD_PATCH}
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/ext")
@@ -24,6 +31,7 @@ file(REMOVE
     "${SOURCE_PATH}/src/cmake/modules/FindWebP.cmake"
     "${SOURCE_PATH}/src/cmake/modules/Findfmt.cmake"
     "${SOURCE_PATH}/src/cmake/modules/FindTBB.cmake"
+    "${SOURCE_PATH}/src/cmake/modules/FindJXL.cmake"
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -33,6 +41,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         ffmpeg      USE_FFMPEG
         freetype    USE_FREETYPE
         gif         USE_GIF
+        jpegxl      USE_JXL
         opencv      USE_OPENCV
         openjpeg    USE_OPENJPEG
         webp        USE_WEBP
@@ -53,7 +62,6 @@ vcpkg_cmake_configure(
         -DUSE_OpenVDB=OFF
         -DUSE_PTEX=OFF
         -DUSE_TBB=OFF
-        -DUSE_JXL=OFF
         -DLINKSTATIC=OFF # LINKSTATIC breaks library lookup
         -DBUILD_MISSING_FMT=OFF
         -DINTERNALIZE_FMT=OFF  # carry fmt's msvc utf8 usage requirements

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openimageio",
-  "version": "3.0.0.3",
-  "port-version": 2,
+  "version": "3.0.1.0",
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",
@@ -49,6 +48,12 @@
       "description": "Enable giflib support for openimageio",
       "dependencies": [
         "giflib"
+      ]
+    },
+    "jpegxl": {
+      "description": "Enable JPEG XL codec",
+      "dependencies": [
+        "libjxl"
       ]
     },
     "libheif": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6705,8 +6705,8 @@
       "port-version": 4
     },
     "openimageio": {
-      "baseline": "3.0.0.3",
-      "port-version": 2
+      "baseline": "3.0.1.0",
+      "port-version": 0
     },
     "openjpeg": {
       "baseline": "2.5.2",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e944cfc15c3d5a1ca39466a141c8a6c26153a3a",
+      "version": "3.0.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d6d167570fb49971bccad7de36cee042da0a44b2",
       "version": "3.0.0.3",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
