### PR TITLE
[test] [mysql-connector-cpp] Ci baseline error repro

### DIFF
--- a/ports/mysql-connector-cpp/vcpkg.json
+++ b/ports/mysql-connector-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mysql-connector-cpp",
   "version": "9.1.0",
+  "port-version": 1,
   "description": "This is a release of MySQL Connector/C++, the C++ interface for communicating with MySQL servers.",
   "homepage": "https://github.com/mysql/mysql-connector-cpp",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6214,7 +6214,7 @@
     },
     "mysql-connector-cpp": {
       "baseline": "9.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nameof": {
       "baseline": "0.10.4",

--- a/versions/m-/mysql-connector-cpp.json
+++ b/versions/m-/mysql-connector-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad87f2b13ee0650c1b13230d9960b315a2933bc9",
+      "version": "9.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "54ee1f8995fb28c0666bdcc6e98c8adfe272cef0",
       "version": "9.1.0",
       "port-version": 0


### PR DESCRIPTION

Repro error:
````
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(166,5): error MSB3073: The command "setlocal [D:\b\mysql-connector-cpp\x86-windows-dbg\connector.vcxproj]

````