### PR TITLE
[protobuf] update to the latest release (v5.29.1)

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512  6cb70c9a93cfc784632b78836d685d78260680a81559df11d94d32d1c62f0794747a16bba215ad09a4e40396deebe964dbe0b21605b1f4eb026c7f0e8f9f7ed8
+    SHA512 18b49716ac15800f4ed970a2b2dc3235299933e1ab34edbffd0c1eeabd1ade37b3ea50d90b9a814211aa83ee7a335d9dae1763a088f8899ff64341911d3678c1
     HEAD_REF master
     PATCHES
         fix-static-build.patch

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protobuf",
-  "version": "5.29.0",
+  "version": "5.29.1",
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7221,7 +7221,7 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "5.29.0",
+      "baseline": "5.29.1",
       "port-version": 0
     },
     "protobuf-c": {

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a08737d5c463e22ccf3fa7533122ab763c70e2b2",
+      "version": "5.29.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8d7ae72e8a78bdc3bda1d3c02fffd99241844800",
       "version": "5.29.0",
       "port-version": 0


### PR DESCRIPTION
Updates protobuf to the latest release (v5.29.1)

Tested locally (on x64-linux) with:

```
./vcpkg remove protobuf && ./vcpkg install 'protobuf'
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
