### PR TITLE
[mysql-connector-cpp] Disable attempting to copy all dependencies into its own package.

### DIFF
--- a/ports/mysql-connector-cpp/dependencies.patch
+++ b/ports/mysql-connector-cpp/dependencies.patch
@@ -1,3 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f24eb57..ec7c53d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -469,7 +469,7 @@ endif()
+ # system-wide). Here we arrange for the OpenSSL DLLs to be copied to the build
+ # location of the connector library after building it.
+ 
+-if(WIN32 AND OPENSSL_LIB_DIR)
++if(WIN32 AND OPENSSL_LIB_DIR AND 0)
+ 
+   # Note: For simplicity we just copy any DLLs we can find at the given
+   # OpenSSL location.
 diff --git a/cdk/cmake/DepFindCompression.cmake b/cdk/cmake/DepFindCompression.cmake
 index 68f8e10..ebe7e31 100644
 --- a/cdk/cmake/DepFindCompression.cmake

--- a/ports/mysql-connector-cpp/portfile.cmake
+++ b/ports/mysql-connector-cpp/portfile.cmake
@@ -27,7 +27,6 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATIC_MSVCRT)
 # Use mysql-connector-cpp's own build process.
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    WINDOWS_USE_MSBUILD
     OPTIONS
         "-DWITH_SSL=${CURRENT_INSTALLED_DIR}"
         "-DWITH_LZ4=${CURRENT_INSTALLED_DIR}"

--- a/ports/mysql-connector-cpp/portfile.cmake
+++ b/ports/mysql-connector-cpp/portfile.cmake
@@ -24,9 +24,20 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIBS)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATIC_MSVCRT)
 
-# Use mysql-connector-cpp's own build process.
+# Preparing to merge STATIC library: connector (xapi;devapi)
+# CMake Error at cmake/libutils.cmake:297 (message):
+#   Sorry but building static connector on Windows using MSVC toolset works
+#   only with msbuild at the moment.
+# Call Stack (most recent call first):
+#   CMakeLists.txt:413 (merge_libraries)
+set(USE_MSBUILD_ARG)
+if(BUILD_STATIC)
+    set(USE_MSBUILD_ARG WINDOWS_USE_MSBUILD)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    ${USE_MSBUILD_ARG}
     OPTIONS
         "-DWITH_SSL=${CURRENT_INSTALLED_DIR}"
         "-DWITH_LZ4=${CURRENT_INSTALLED_DIR}"

--- a/ports/mysql-connector-cpp/vcpkg.json
+++ b/ports/mysql-connector-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mysql-connector-cpp",
   "version": "9.1.0",
+  "port-version": 1,
   "description": "This is a release of MySQL Connector/C++, the C++ interface for communicating with MySQL servers.",
   "homepage": "https://github.com/mysql/mysql-connector-cpp",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6214,7 +6214,7 @@
     },
     "mysql-connector-cpp": {
       "baseline": "9.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nameof": {
       "baseline": "0.10.4",

--- a/versions/m-/mysql-connector-cpp.json
+++ b/versions/m-/mysql-connector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ea3d37c8d911b70d572232b8b30bdb55717c1b86",
+      "git-tree": "a1e99552e0b1ff9e507f46cdda63911e77dba19a",
       "version": "9.1.0",
       "port-version": 1
     },

--- a/versions/m-/mysql-connector-cpp.json
+++ b/versions/m-/mysql-connector-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea3d37c8d911b70d572232b8b30bdb55717c1b86",
+      "version": "9.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "54ee1f8995fb28c0666bdcc6e98c8adfe272cef0",
       "version": "9.1.0",
       "port-version": 0


### PR DESCRIPTION
I believe this also exceeded command line length limits causing failures in CI: https://dev.azure.com/vcpkg/public/_build/results?buildId=109931&view=results
