### PR TITLE
[pipewire] update to 1.2.7

### DIFF
--- a/ports/pipewire/portfile.cmake
+++ b/ports/pipewire/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pipewire/pipewire
     REF "${VERSION}"
-    SHA512 8f444695a3ec4c03fa1a9735d0c08031631b565ff8fbee0edcbbbdf87330da632eb87ba92a9071cbfa2d9ed96705002e63ae7c48277fc45a0a3b793fff39819a
+    SHA512 a921bcc56626a90b4195f98cb47934d1e4eeda9d2fb76ea93ef49b56bf2b080ec711d93dfd47833bcdbc9c4623bad16c93f00828d214439aee06ab9a31f21ffd
     HEAD_REF master # branch name
 )
 

--- a/ports/pipewire/vcpkg.json
+++ b/ports/pipewire/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pipewire",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Low-latency audio/video router and processor. This port only builds the client library, not the server.",
   "homepage": "https://pipewire.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7013,7 +7013,7 @@
       "port-version": 2
     },
     "pipewire": {
-      "baseline": "1.2.6",
+      "baseline": "1.2.7",
       "port-version": 0
     },
     "pistache": {

--- a/versions/p-/pipewire.json
+++ b/versions/p-/pipewire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "924e36a9b292a0c9dbedc7e16b645ec3af8710b6",
+      "version": "1.2.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "9cd946c560c5fb45927e429d3e879aab1868335f",
       "version": "1.2.6",
       "port-version": 0


### PR DESCRIPTION
Fixes #42557
Update port pipewire to the latest version 1.2.7.
No feature need to test.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.