### PR TITLE
[wcslib] Update to 8.4

### DIFF
--- a/ports/wcslib/portfile.cmake
+++ b/ports/wcslib/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(archive
-    URLS "http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-8.2.1.tar.bz2"
-    FILENAME "wcslib-8.2.1.tar.bz2"
-    SHA512 0d1ab63445974c2a4f425225cde197866187a9e7ae0195a33dcb33ad299018294338bc16ab4cbe6a3a27fb40aded75c60377348eaa91713d16a934cd95532c25
+    URLS "http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-${VERSION}.tar.bz2"
+    FILENAME "wcslib-${VERSION}.tar.bz2"
+    SHA512 1989f8f5788fd6d9fa102b771ad7db188b0899f716e11360516c96742f81f50755881279f90fce388451e8857f24003c85751f06aea83377e04bb5230523469f
 )
 
 vcpkg_extract_source_archive(

--- a/ports/wcslib/vcpkg.json
+++ b/ports/wcslib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wcslib",
-  "version": "8.2.1",
+  "version": "8.4",
   "description": "World Coordinate System (WCS) (Library)",
   "homepage": "https://www.atnf.csiro.au/people/mcalabre/WCS/",
   "supports": "!windows"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9613,7 +9613,7 @@
       "port-version": 1
     },
     "wcslib": {
-      "baseline": "8.2.1",
+      "baseline": "8.4",
       "port-version": 0
     },
     "websocketpp": {

--- a/versions/w-/wcslib.json
+++ b/versions/w-/wcslib.json
@@ -6,13 +6,13 @@
       "port-version": 0
     },
     {
-      "git-tree": "2e33104b54c3db79012234ded4db319a3464885b",
-      "version": "7.12",
+      "git-tree": "a68a2412a39e7458698f2e4110d8a50dc8619c96",
+      "version": "8.2.1",
       "port-version": 0
     },
     {
-      "git-tree": "a68a2412a39e7458698f2e4110d8a50dc8619c96",
-      "version": "8.2.1",
+      "git-tree": "2e33104b54c3db79012234ded4db319a3464885b",
+      "version": "7.12",
       "port-version": 0
     }
   ]

--- a/versions/w-/wcslib.json
+++ b/versions/w-/wcslib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4aabfdd25c7d79ce7cd97e339cdad70959798a39",
+      "version": "8.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "2e33104b54c3db79012234ded4db319a3464885b",
       "version": "7.12",
       "port-version": 0


### PR DESCRIPTION
Update `wcslib` to 8.4. 

No feature needs to be tested, the usage test successfully on `x64-linux`(the header files found).

Adjust the version order in the wcslib.json file to make it the same as other json files in vcpkg. The error comes from: [35213/files](https://github.com/microsoft/vcpkg/pull/35213/files#diff-6179415146eafb145ab29f790b6a0a19f228e1a970cab98d64032cd9a916c2fb).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.