### PR TITLE
libfreenect2 uses a dual apache/gpl license

### DIFF
--- a/ports/libfreenect2/vcpkg.json
+++ b/ports/libfreenect2/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "libfreenect2",
   "version": "0.2.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Open source drivers for the Kinect for Windows v2 device",
   "homepage": "https://github.com/OpenKinect/libfreenect2",
-  "license": "GPL-2.0-only",
+  "license": "GPL-2.0-only OR Apache-2.0",
   "supports": "!xbox",
   "dependencies": [
     "libjpeg-turbo",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4566,7 +4566,7 @@
     },
     "libfreenect2": {
       "baseline": "0.2.1",
-      "port-version": 1
+      "port-version": 2
     },
     "libfs": {
       "baseline": "1.0.9",

--- a/versions/l-/libfreenect2.json
+++ b/versions/l-/libfreenect2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69f6ddad233507911805c1c313b5030d6c771baa",
+      "version": "0.2.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "41b1ddb75208930631ff81c5a19a86c7f0308791",
       "version": "0.2.1",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.