### PR TITLE
[vcpkg baseline][openxr-loader] Fix config error

### DIFF
--- a/ports/openxr-loader/fix-config-error.patch
+++ b/ports/openxr-loader/fix-config-error.patch
@@ -1,0 +1,12 @@
+diff --git a/src/loader/OpenXRConfig.cmake.in b/src/loader/OpenXRConfig.cmake.in
+index 81b12e7..4c24771 100644
+--- a/src/loader/OpenXRConfig.cmake.in
++++ b/src/loader/OpenXRConfig.cmake.in
+@@ -6,6 +6,7 @@
+ 
+ include(CMakeFindDependencyMacro)
+ find_dependency(Threads)
++find_dependency(jsoncpp CONFIG)
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/OpenXRTargets.cmake")
+ 

--- a/ports/openxr-loader/portfile.cmake
+++ b/ports/openxr-loader/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-openxr-sdk-jsoncpp.patch
+        fix-config-error.patch
 )
 
 vcpkg_from_github(

--- a/ports/openxr-loader/vcpkg.json
+++ b/ports/openxr-loader/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openxr-loader",
   "version": "1.0.34",
+  "port-version": 1,
   "description": "A royalty-free, open standard that provides high-performance access to Augmented Reality (AR) and Virtual Reality (VR)—collectively known as XR—platforms and devices",
   "homepage": "https://github.com/KhronosGroup/OpenXR-SDK",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6790,7 +6790,7 @@
     },
     "openxr-loader": {
       "baseline": "1.0.34",
-      "port-version": 0
+      "port-version": 1
     },
     "optimus-cpp": {
       "baseline": "0.3.0",

--- a/versions/o-/openxr-loader.json
+++ b/versions/o-/openxr-loader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "444fda775f58854569eaffa1a4d336c44f94243c",
+      "version": "1.0.34",
+      "port-version": 1
+    },
+    {
       "git-tree": "7ac79e9eb86bad29f5fc6d3f6f25389df13e5b9f",
       "version": "1.0.34",
       "port-version": 0


### PR DESCRIPTION
Fix `qtquick3d` failed `Undefined _BrotliEncoderCompressStream`, https://dev.azure.com/vcpkg/public/_build/results?buildId=110038&view=results

Add function `find_dependency(jsoncpp CONFIG)` to port openxr-loader

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux