### PR TITLE
Fix avro cpp compilation under linux

### DIFF
--- a/ports/avro-cpp/fix-std32_t.patch
+++ b/ports/avro-cpp/fix-std32_t.patch
@@ -1,0 +1,12 @@
+diff --git a/lang/c++/include/avro/LogicalType.hh b/lang/c++/include/avro/LogicalType.hh
+index b2a7d0294..7b113b3aa 100644
+--- a/lang/c++/include/avro/LogicalType.hh
++++ b/lang/c++/include/avro/LogicalType.hh
+@@ -22,6 +22,7 @@
+ #include <iostream>
+ 
+ #include "Config.hh"
++#include <cstdint>
+ 
+ namespace avro {
+ 

--- a/ports/avro-cpp/portfile.cmake
+++ b/ports/avro-cpp/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-cmake.patch
         fix-fmt.patch
+        fix-std32_t.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/avro-cpp/vcpkg.json
+++ b/ports/avro-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "avro-cpp",
   "version": "1.12.0",
+  "port-version": 2,
   "description": "Apache Avro is a data serialization system",
   "homepage": "https://github.com/apache/avro",
   "license": "Apache-2.0",

--- a/versions/a-/avro-cpp.json
+++ b/versions/a-/avro-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ef85ccd3feb1c611ad245ab1ead9796b09b1bc9",
+      "version": "1.12.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "d177503c9c4f90f723a50e01156fbb79b479237d",
       "version": "1.12.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -382,7 +382,7 @@
     },
     "avro-cpp": {
       "baseline": "1.12.0",
-      "port-version": 0
+      "port-version": 2
     },
     "awlib": {
       "baseline": "2024-04-06",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

