### PR TITLE
[calceph] update to version 4.0.3

### DIFF
--- a/ports/calceph/portfile.cmake
+++ b/ports/calceph/portfile.cmake
@@ -1,4 +1,4 @@
-set(CALCEPH_HASH 1b03bc62ab32ab56a95ca33612824a1f2104a8cca225b6cbedc656655ab4477a922053257341f36b95792f002b39cbee6a1dd2522cacdac36282aa044e121d86)
+set(CALCEPH_HASH 0130bf9f48338146eb32aba4c9ceaa2d2a2ba2dfc4812c4c27cf87da06719172e3273cce4890f76233bbe15fc13952a05c06bce6a216e4ae6ca9613c902dca33)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-${VERSION}.tar.gz"
@@ -24,6 +24,8 @@ vcpkg_copy_tools(TOOL_NAMES calceph_inspector calceph_queryposition calceph_quer
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${SOURCE_PATH}/README.rst" DESTINATION "${CURRENT_PACKAGES_DIR}/share/calceph" RENAME readme.rst)
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING_CECILL_B.LIB")

--- a/ports/calceph/vcpkg.json
+++ b/ports/calceph/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "calceph",
-  "version": "4.0.1",
+  "version": "4.0.3",
   "description": "C library to access the binary planetary ephemeris files.",
   "homepage": "https://www.imcce.fr/inpop/calceph/",
   "documentation": "https://calceph.imcce.fr/docs/latest/html/c/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1493,7 +1493,7 @@
       "port-version": 0
     },
     "calceph": {
-      "baseline": "4.0.1",
+      "baseline": "4.0.3",
       "port-version": 0
     },
     "camport3": {

--- a/versions/c-/calceph.json
+++ b/versions/c-/calceph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49026767cbf6ab4fa4dde6df55f440d3a244c5d3",
+      "version": "4.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "39ac246456a1696374698c2544fd23da60fbe918",
       "version": "4.0.1",
       "port-version": 0


### PR DESCRIPTION
- [ X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ X] SHA512s are updated for each updated download.
- [X ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ X] Only one version is added to each modified port's versions file.
