### PR TITLE
[vcpkg baseline][deniskovalchuk-libftp] Disable parallel configure

### DIFF
--- a/ports/deniskovalchuk-libftp/portfile.cmake
+++ b/ports/deniskovalchuk-libftp/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
         SOURCE_PATH "${SOURCE_PATH}"
+        DISABLE_PARALLEL_CONFIGURE # generating export header in source dir
         OPTIONS
             -DLIBFTP_BUILD_TEST=OFF
             -DLIBFTP_BUILD_EXAMPLE=OFF

--- a/ports/deniskovalchuk-libftp/vcpkg.json
+++ b/ports/deniskovalchuk-libftp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "deniskovalchuk-libftp",
   "version": "1.4.0",
+  "port-version": 1,
   "maintainers": "Denis Kovalchuk <denis.kovalchuk.main@gmail.com>",
   "description": "A cross-platform FTP/FTPS client library based on Boost.Asio.",
   "homepage": "https://github.com/deniskovalchuk/libftp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2286,7 +2286,7 @@
     },
     "deniskovalchuk-libftp": {
       "baseline": "1.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "detours": {
       "baseline": "4.0.1",

--- a/versions/d-/deniskovalchuk-libftp.json
+++ b/versions/d-/deniskovalchuk-libftp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "924cd332a49b232bf29e9da835f13fec4567182a",
+      "version": "1.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b8ea0a5f92ba4b9e24a459711f55c2bb2de0343a",
       "version": "1.4.0",
       "port-version": 0


### PR DESCRIPTION
https://dev.azure.com/vcpkg/public/_build/results?buildId=110140&view=logs&j=f1a99d27-903c-5ce5-ab6b-a2a85be7b723&t=3d4837a4-bf80-5754-7acb-3d75317102c8

CC @deniskovalchuk You could stage the generated export header into the binary dir. (Avoid writing to the source dir in non-maintainer builds.)