### PR TITLE
[mysql-connector-cpp] Fix static lib name for MSVC

### DIFF
--- a/ports/mysql-connector-cpp/depfindprotobuf.diff
+++ b/ports/mysql-connector-cpp/depfindprotobuf.diff
@@ -1,24 +1,24 @@
 diff --git a/cdk/cmake/DepFindProtobuf.cmake b/cdk/cmake/DepFindProtobuf.cmake
-index 1fc785e..d9eaecc 100644
+index 1fc785e..2ba7e99 100644
 --- a/cdk/cmake/DepFindProtobuf.cmake
 +++ b/cdk/cmake/DepFindProtobuf.cmake
-@@ -45,8 +45,6 @@
+@@ -44,9 +44,9 @@
+ #
  #
  
- if(TARGET ext::protobuf)
--  return()
+-if(TARGET ext::protobuf)
++if(COMMAND mysqlx_protobuf_generate_cpp)
+   return()
 -endif()
++elseif(0)
  
  message(STATUS "Setting up Protobuf.")
  
-@@ -65,6 +63,10 @@ add_ext_targets(protobuf
-   EXECUTABLE protoc pb_protoc
+@@ -66,6 +66,7 @@ add_ext_targets(protobuf
  )
  
-+endif()
-+if(COMMAND mysqlx_protobuf_generate_cpp)
-+  return()
-+endif()
  
++endif()
  # Standard PROTOBUF_GENERATE_CPP modified to our usage
  function(mysqlx_protobuf_generate_cpp SRCS HDRS)
+   IF(NOT ARGN)

--- a/ports/mysql-connector-cpp/lib-name-static.diff
+++ b/ports/mysql-connector-cpp/lib-name-static.diff
@@ -1,0 +1,26 @@
+diff --git a/install_layout.cmake b/install_layout.cmake
+index 4a8a511..ee091da 100644
+--- a/install_layout.cmake
++++ b/install_layout.cmake
+@@ -219,7 +219,7 @@ set(LIB_NAME_BASE "mysqlcppconnx")
+ set(LIB_NAME_STATIC "${LIB_NAME_BASE}-static")
+ 
+ if(WIN32 AND STATIC_MSVCRT)
+-  set(LIB_NAME_STATIC "${LIB_NAME}-mt")
++  set(LIB_NAME_STATIC "${LIB_NAME_STATIC}-mt")
+ endif()
+ 
+ if(BUILD_STATIC)
+diff --git a/jdbc/install_layout.cmake b/jdbc/install_layout.cmake
+index e9e15a5..a4f7dc0 100644
+--- a/jdbc/install_layout.cmake
++++ b/jdbc/install_layout.cmake
+@@ -91,7 +91,7 @@ set(LIB_NAME_BASE "mysqlcppconn")
+ set(LIB_NAME_STATIC "${LIB_NAME_BASE}-static")
+ 
+ if(WIN32 AND STATIC_MSVCRT)
+-  set(LIB_NAME_STATIC "${LIB_NAME}-mt")
++  set(LIB_NAME_STATIC "${LIB_NAME_STATIC}-mt")
+ endif()
+ 
+ if(BUILD_STATIC)

--- a/ports/mysql-connector-cpp/portfile.cmake
+++ b/ports/mysql-connector-cpp/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         depfindprotobuf.diff
         disable-telemetry.diff
         dont-preload-cache.diff
+        lib-name-static.diff
         merge-archives.diff
         save-linker-opts.diff
         export-targets.patch

--- a/ports/mysql-connector-cpp/vcpkg.json
+++ b/ports/mysql-connector-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mysql-connector-cpp",
   "version": "9.1.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "This is a release of MySQL Connector/C++, the C++ interface for communicating with MySQL servers.",
   "homepage": "https://github.com/mysql/mysql-connector-cpp",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6214,7 +6214,7 @@
     },
     "mysql-connector-cpp": {
       "baseline": "9.1.0",
-      "port-version": 2
+      "port-version": 3
     },
     "nameof": {
       "baseline": "0.10.4",

--- a/versions/m-/mysql-connector-cpp.json
+++ b/versions/m-/mysql-connector-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bdd83a314ef53b655567e07757c328eb33694315",
+      "version": "9.1.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "30acb048f76e9b63cfd210aa612d7a1bbcc447a3",
       "version": "9.1.0",
       "port-version": 2


### PR DESCRIPTION
For https://github.com/microsoft/vcpkg/issues/42581#issuecomment-2530186794.
For the new API, this was a regression in #42586. The JDBC API had the same issue. Note https://github.com/mysql/mysql-connector-cpp/pull/35/files.

Also improve the depfindprotobuf patch. We want only the command.