### PR TITLE
[hdf5] update to 1.14.5

### DIFF
--- a/ports/hdf5/add-_Float16-type-on-aarch64.patch
+++ b/ports/hdf5/add-_Float16-type-on-aarch64.patch
@@ -1,10 +1,10 @@
 diff --git a/src/H5private.h b/src/H5private.h
-index 904aa9f..e745c03 100644
+index 5a201cb..9d61a5b 100644
 --- a/src/H5private.h
 +++ b/src/H5private.h
-@@ -602,7 +602,11 @@
+@@ -595,7 +595,11 @@
   */
- #ifdef H5_HAVE__FLOAT16
+ #if defined(H5_HAVE__FLOAT16) && !defined(__cplusplus)
  #if defined(__GNUC__)
 +#if defined(__aarch64__)
 +typedef __fp16 H5__Float16;

--- a/ports/hdf5/fix-zlib-szilb.patch
+++ b/ports/hdf5/fix-zlib-szilb.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeFilters.cmake b/CMakeFilters.cmake
+index a73dc34..594b161 100644
+--- a/CMakeFilters.cmake
++++ b/CMakeFilters.cmake
+@@ -106,9 +106,9 @@ if (HDF5_ENABLE_Z_LIB_SUPPORT)
+         set (H5_ZLIB_INCLUDE_DIRS ${H5_ZLIB_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIR})
+         # The FindZLIB.cmake module does not set an OUTPUT_NAME
+         # on the target. The target returned is: ZLIB::ZLIB
+-        get_filename_component (libname ${ZLIB_LIBRARIES} NAME_WLE)
+-        string (REGEX REPLACE "^lib" "" libname ${libname})
+-        set_target_properties (ZLIB::ZLIB PROPERTIES OUTPUT_NAME zlib-static)
++        # get_filename_component (libname ${ZLIB_LIBRARIES} NAME_WLE)
++        # string (REGEX REPLACE "^lib" "" libname ${libname})
++        set_target_properties (ZLIB::ZLIB PROPERTIES OUTPUT_NAME z)
+         set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ZLIB::ZLIB)
+         set (zlib_PC_LIBS_PRIVATE "${ZLIB_LIBRARIES}")
+       endif ()
+@@ -153,7 +153,13 @@ if (HDF5_ENABLE_SZIP_SUPPORT)
+     endif ()
+     set(libaec_USE_STATIC_LIBS ${HDF5_USE_LIBAEC_STATIC})
+     set(SZIP_FOUND FALSE)
+-    find_package (SZIP NAMES ${LIBAEC_PACKAGE_NAME}${HDF_PACKAGE_EXT} COMPONENTS ${LIBAEC_SEACH_TYPE})
++    # find_package (SZIP NAMES ${LIBAEC_PACKAGE_NAME}${HDF_PACKAGE_EXT} COMPONENTS ${LIBAEC_SEACH_TYPE})
++    find_package(SZIP NAMES szip REQUIRED)
++    set(SZIP_INCLUDE_DIR "")
++    set(SZIP_LIBRARIES szip-static)
++    if (TARGET szip-shared)
++      set(SZIP_LIBRARIES szip-shared)
++    endif()  
+     if (NOT SZIP_FOUND)
+       find_package (SZIP) # Legacy find
+     endif ()

--- a/ports/hdf5/pkgconfig-requires.patch
+++ b/ports/hdf5/pkgconfig-requires.patch
@@ -1,20 +1,20 @@
 diff --git a/CMakeFilters.cmake b/CMakeFilters.cmake
-index 141ab44..66b7efa 100644
+index 52d65e5..a73dc34 100644
 --- a/CMakeFilters.cmake
 +++ b/CMakeFilters.cmake
-@@ -79,6 +79,7 @@ if (HDF5_ENABLE_Z_LIB_SUPPORT)
-         set (ZLIB_INCLUDE_DIR_GEN ${ZLIB_INCLUDE_DIR})
-         set (ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIR})
-         set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${ZLIB_LIBRARIES})
+@@ -110,6 +110,7 @@ if (HDF5_ENABLE_Z_LIB_SUPPORT)
+         string (REGEX REPLACE "^lib" "" libname ${libname})
+         set_target_properties (ZLIB::ZLIB PROPERTIES OUTPUT_NAME zlib-static)
+         set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ZLIB::ZLIB)
 +        set (zlib_PC_LIBS_PRIVATE "${ZLIB_LIBRARIES}")
        endif ()
      else ()
        if (HDF5_ALLOW_EXTERNAL_SUPPORT MATCHES "GIT" OR HDF5_ALLOW_EXTERNAL_SUPPORT MATCHES "TGZ")
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b75fdd2..a2e88fd 100644
+index cf9729d..7ecec8d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -711,5 +711,8 @@ if (H5_HAVE_PARALLEL)
+@@ -779,6 +779,9 @@ if (H5_HAVE_PARALLEL)
    if (MPI_C_LINK_FLAGS)
      set (CMAKE_EXE_LINKER_FLAGS "${MPI_C_LINK_FLAGS} ${CMAKE_EXE_LINKER_FLAGS}")
    endif ()
@@ -23,11 +23,12 @@ index b75fdd2..a2e88fd 100644
 +  endif()
  endif ()
  
+ # Determine whether to build the HDF5 Subfiling VFD
 diff --git a/config/cmake/HDFMacros.cmake b/config/cmake/HDFMacros.cmake
-index 1af513b47..05d56ccce 100644
+index 3be3e6a..177a51e 100644
 --- a/config/cmake/HDFMacros.cmake
 +++ b/config/cmake/HDFMacros.cmake
-@@ -425,7 +425,7 @@ macro (HDF_DIR_PATHS package_prefix)
+@@ -483,7 +483,7 @@ macro (HDF_DIR_PATHS package_prefix)
    endif ()
  
    #set the default debug suffix for all library targets
@@ -37,10 +38,10 @@ index 1af513b47..05d56ccce 100644
        set (CMAKE_DEBUG_POSTFIX "_D")
      else ()
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index b3c2226..ea80d60 100644
+index 9224cc0..6f09256 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -1321,6 +1321,16 @@ foreach (libs ${LINK_LIBS} ${LINK_COMP_LIBS})
+@@ -1213,6 +1213,16 @@ if (BUILD_SHARED_LIBS)
  endif ()
  
  set (_PKG_CONFIG_REQUIRES)

--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -5,12 +5,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  HDFGroup/hdf5
     REF "${hdf5_ref}"
-    SHA512 77849b644f5312eae5a3f2fe45666d9df95cc21b092207dae01ca7d019e428255d75fe0c27538e4101eabf2030927a73ceaec8e1471c72b51fed5370810f9a35
+    SHA512 cf5e681e549c1e60546c7a6539a4f92f2e56468360e2ee697f92b171d168d3e6bd7746f77207c2c7676bf1ade5ccdaab6e35ca93144e3e5c14fdd20567a663ab
     HEAD_REF develop
     PATCHES
         hdf5_config.patch
         add-_Float16-type-on-aarch64.patch
         pkgconfig-requires.patch
+        fix-zlib-szilb.patch
 )
 
 set(ALLOW_UNSUPPORTED OFF)
@@ -72,6 +73,7 @@ vcpkg_cmake_configure(
         -DHDF_PACKAGE_NAMESPACE:STRING=hdf5::
         -DHDF5_MSVC_NAMING_CONVENTION=OFF
         -DALLOW_UNSUPPORTED=${ALLOW_UNSUPPORTED}
+        -DHDF5_ENABLE_SZIP_SUPPORT=OFF
     OPTIONS_RELEASE
         -DCMAKE_DEBUG_POSTFIX= # For lib name in pkgconfig files
 )

--- a/ports/hdf5/vcpkg.json
+++ b/ports/hdf5/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "hdf5",
-  "version": "1.14.4.3",
-  "port-version": 3,
+  "version": "1.14.5",
   "description": "HDF5 is a data model, library, and file format for storing and managing data",
   "homepage": "https://www.hdfgroup.org/downloads/hdf5/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3465,8 +3465,8 @@
       "port-version": 1
     },
     "hdf5": {
-      "baseline": "1.14.4.3",
-      "port-version": 3
+      "baseline": "1.14.5",
+      "port-version": 0
     },
     "hdr-histogram": {
       "baseline": "0.11.8",

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dfedcf57efc49357424452b45cdfb5163081fead",
+      "version": "1.14.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "865f6593cb402e937d842ad41cda9e5aa06b0230",
       "version": "1.14.4.3",
       "port-version": 3


### PR DESCRIPTION
Update to 1.14.5. For https://github.com/HDFGroup/hdf5/issues/5157.

Add patch to fix build error: see https://github.com/HDFGroup/hdf5/issues/5026.
```
CMake Error at CMakeFilters.cmake:109 (get_filename_component):
  get_filename_component unknown component
  D:/a/h5py/h5py/zlib-msvc-x64/build/native/lib_release/zlib.lib
```
All features are tested on the following triplets:

- x64-windows
- x64-windows-static
- x86-windows

Usage tested on `x64-windows`.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
