### PR TITLE
[hdf5] Fix link library error

### DIFF
--- a/ports/hdf5/fix-dep.patch
+++ b/ports/hdf5/fix-dep.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeFilters.cmake b/CMakeFilters.cmake
+index f2dae77..3a532c9 100644
+--- a/CMakeFilters.cmake
++++ b/CMakeFilters.cmake
+@@ -70,7 +70,7 @@ option (HDF5_ENABLE_Z_LIB_SUPPORT "Enable Zlib Filters" ON)
+ if (HDF5_ENABLE_Z_LIB_SUPPORT)
+   if (NOT H5_ZLIB_HEADER)
+     if (NOT ZLIB_USE_EXTERNAL)
+-      find_package (ZLIB NAMES ${ZLIB_PACKAGE_NAME}${HDF_PACKAGE_EXT} COMPONENTS static shared)
++      find_package(ZLIB REQUIRED)
+       if (NOT ZLIB_FOUND)
+         find_package (ZLIB) # Legacy find
+       endif ()
+@@ -78,7 +78,7 @@ if (HDF5_ENABLE_Z_LIB_SUPPORT)
+         set (H5_ZLIB_HEADER "zlib.h")
+         set (ZLIB_INCLUDE_DIR_GEN ${ZLIB_INCLUDE_DIR})
+         set (ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIR})
+-        set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${ZLIB_LIBRARIES})
++        set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ZLIB::ZLIB)
+         set (zlib_PC_LIBS_PRIVATE "${ZLIB_LIBRARIES}")
+       endif ()
+     else ()
+@@ -118,12 +118,13 @@ if (HDF5_ENABLE_SZIP_SUPPORT)
+   if (NOT SZIP_USE_EXTERNAL)
+     set(SZIP_FOUND FALSE)
+     set(libaec_USE_STATIC_LIBS ${USE_LIBAEC_STATIC})
+-    find_package (libaec 1.0.5 CONFIG)
++    find_package(libaec CONFIG REQUIRED)
+     if (SZIP_FOUND)
+       set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${SZIP_LIBRARIES})
+     endif ()
+     if (NOT SZIP_FOUND)
+-      find_package (SZIP NAMES ${LIBAEC_PACKAGE_NAME}${HDF_PACKAGE_EXT} COMPONENTS static shared)
++      find_package(libaec CONFIG REQUIRED)
++      set (LINK_COMP_LIBS ${LINK_COMP_LIBS} libaec::sz libaec::aec libaec::sz_shared libaec::aec_shared)
+       if (NOT SZIP_FOUND)
+         find_package (SZIP) # Legacy find
+       endif ()

--- a/ports/hdf5/fix-dep.patch
+++ b/ports/hdf5/fix-dep.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeFilters.cmake b/CMakeFilters.cmake
-index f2dae77..3a532c9 100644
+index f2dae77..1a69a10 100644
 --- a/CMakeFilters.cmake
 +++ b/CMakeFilters.cmake
 @@ -70,7 +70,7 @@ option (HDF5_ENABLE_Z_LIB_SUPPORT "Enable Zlib Filters" ON)
@@ -20,7 +20,7 @@ index f2dae77..3a532c9 100644
          set (zlib_PC_LIBS_PRIVATE "${ZLIB_LIBRARIES}")
        endif ()
      else ()
-@@ -118,12 +118,13 @@ if (HDF5_ENABLE_SZIP_SUPPORT)
+@@ -118,13 +118,17 @@ if (HDF5_ENABLE_SZIP_SUPPORT)
    if (NOT SZIP_USE_EXTERNAL)
      set(SZIP_FOUND FALSE)
      set(libaec_USE_STATIC_LIBS ${USE_LIBAEC_STATIC})
@@ -31,8 +31,13 @@ index f2dae77..3a532c9 100644
      endif ()
      if (NOT SZIP_FOUND)
 -      find_package (SZIP NAMES ${LIBAEC_PACKAGE_NAME}${HDF_PACKAGE_EXT} COMPONENTS static shared)
-+      find_package(libaec CONFIG REQUIRED)
-+      set (LINK_COMP_LIBS ${LINK_COMP_LIBS} libaec::sz libaec::aec libaec::sz_shared libaec::aec_shared)
-       if (NOT SZIP_FOUND)
+-      if (NOT SZIP_FOUND)
++	  if(BUILD_SHARED_LIBS)
++        set (LINK_COMP_LIBS ${LINK_COMP_LIBS} libaec::sz_shared libaec::aec_shared)
++	  else()
++	    set (LINK_COMP_LIBS ${LINK_COMP_LIBS} libaec::sz libaec::aec)
++	  endif()
++      if (NOT libaec_FOUND)
          find_package (SZIP) # Legacy find
        endif ()
+     endif ()

--- a/ports/hdf5/fix-dep.patch
+++ b/ports/hdf5/fix-dep.patch
@@ -41,3 +41,15 @@ index f2dae77..1a69a10 100644
          find_package (SZIP) # Legacy find
        endif ()
      endif ()
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 9d04c21..db2417a 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1191,7 +1191,6 @@ endforeach ()
+ # Assuming they don't
+ foreach (libs ${LINK_COMP_LIBS})
+ #  set (_PKG_CONFIG_REQUIRES_PRIVATE "${_PKG_CONFIG_REQUIRES_PRIVATE} -l${libs}")
+-  #set (_PKG_CONFIG_LIBS_PRIVATE "${_PKG_CONFIG_LIBS_PRIVATE} -l${libs}")
+ endforeach ()
+ 
+ if (BUILD_STATIC_LIBS)

--- a/ports/hdf5/fix-dep.patch
+++ b/ports/hdf5/fix-dep.patch
@@ -42,14 +42,14 @@ index f2dae77..1a69a10 100644
        endif ()
      endif ()
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 9d04c21..db2417a 100644
+index 122b02f..db2417a 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -1191,7 +1191,6 @@ endforeach ()
  # Assuming they don't
  foreach (libs ${LINK_COMP_LIBS})
  #  set (_PKG_CONFIG_REQUIRES_PRIVATE "${_PKG_CONFIG_REQUIRES_PRIVATE} -l${libs}")
--  #set (_PKG_CONFIG_LIBS_PRIVATE "${_PKG_CONFIG_LIBS_PRIVATE} -l${libs}")
+-  set (_PKG_CONFIG_LIBS_PRIVATE "${_PKG_CONFIG_LIBS_PRIVATE} -l${libs}")
  endforeach ()
  
  if (BUILD_STATIC_LIBS)

--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         hdf5_config.patch
         add-_Float16-type-on-aarch64.patch
         pkgconfig-requires.patch
+        fix-dep.patch
 )
 
 set(ALLOW_UNSUPPORTED OFF)

--- a/ports/hdf5/vcpkg.json
+++ b/ports/hdf5/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hdf5",
   "version": "1.14.4.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "HDF5 is a data model, library, and file format for storing and managing data",
   "homepage": "https://www.hdfgroup.org/downloads/hdf5/",
   "license": "BSD-3-Clause",

--- a/ports/libaec/fix-config.patch
+++ b/ports/libaec/fix-config.patch
@@ -1,0 +1,23 @@
+diff --git a/cmake/libaec-config.cmake.in b/cmake/libaec-config.cmake.in
+index 2fffad9..35ce668 100644
+--- a/cmake/libaec-config.cmake.in
++++ b/cmake/libaec-config.cmake.in
+@@ -24,17 +24,4 @@
+ #   libaec::aec    - The AEC library.
+ #   libaec::sz     - The SZIP compatible version of the AEC library.
+ 
+-find_path(libaec_INCLUDE_DIR NAMES libaec.h DOC "AEC include directory")
+-find_path(SZIP_INCLUDE_DIR NAMES szlib.h DOC "SZIP include directory")
+-if (libaec_USE_STATIC_LIBS)
+-  if (MSVC)
+-    find_library(libaec_LIBRARY NAMES aec-static.lib DOC "AEC library")
+-    find_library(SZIP_LIBRARY NAMES szip-static.lib DOC "SZIP compatible version of the AEC library")
+-  else ()
+-    find_library(libaec_LIBRARY NAMES libaec.a DOC "AEC library")
+-    find_library(SZIP_LIBRARY NAMES libsz.a DOC "SZIP compatible version of the AEC library")
+-  endif ()
+-else ()
+-  find_library(libaec_LIBRARY NAMES aec DOC "AEC library")
+-  find_library(SZIP_LIBRARY NAMES sz szip DOC "SZIP compatible version of the AEC library")
+-endif ()
++include("${CMAKE_CURRENT_LIST_DIR}/libaec-targets.cmake")

--- a/ports/libaec/portfile.cmake
+++ b/ports/libaec/portfile.cmake
@@ -6,7 +6,9 @@ vcpkg_from_gitlab(
     SHA512 6f317d08ad7d003bc6664da147321eb87c924978f32bd28780a8ebf015e251019046b0cb16b78e776cd1957a7701215667f64686efb8e5c6bae7c08528cede56
     PATCHES
         cmake-config.patch
-        static-shared.patch)
+        static-shared.patch
+		fix-config.patch
+)
 
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" AEC_BUILD_SHARED)
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "static" AEC_BUILD_STATIC)

--- a/ports/libaec/vcpkg.json
+++ b/ports/libaec/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libaec",
   "version": "1.1.3",
+  "port-version": 1,
   "description": "Adaptive Entropy Coding library",
   "homepage": "https://gitlab.dkrz.de/k202009/libaec",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3466,7 +3466,7 @@
     },
     "hdf5": {
       "baseline": "1.14.4.3",
-      "port-version": 3
+      "port-version": 4
     },
     "hdr-histogram": {
       "baseline": "0.11.8",
@@ -4290,7 +4290,7 @@
     },
     "libaec": {
       "baseline": "1.1.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libaes-siv": {
       "baseline": "2020-10-15",

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d7309c2ae862cb78659a770c68e9a15dc534a36d",
+      "git-tree": "fe6a979bf1f989e89256a0b56fddcbb62c9a4ae4",
       "version": "1.14.4.3",
       "port-version": 4
     },

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d7309c2ae862cb78659a770c68e9a15dc534a36d",
+      "version": "1.14.4.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "865f6593cb402e937d842ad41cda9e5aa06b0230",
       "version": "1.14.4.3",
       "port-version": 3

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "660a1377ba50619b2a61540baf275133e43088c0",
+      "git-tree": "405a8dad707a9b432c9dc1965a932f43fe7c133d",
       "version": "1.14.4.3",
       "port-version": 4
     },

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fe6a979bf1f989e89256a0b56fddcbb62c9a4ae4",
+      "git-tree": "660a1377ba50619b2a61540baf275133e43088c0",
       "version": "1.14.4.3",
       "port-version": 4
     },

--- a/versions/l-/libaec.json
+++ b/versions/l-/libaec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f9614321d306f68a051d179d0a28c62614c5368",
+      "version": "1.1.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "cd65575e04e977bc93d95a711349279d554d5920",
       "version": "1.1.3",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/42436

Fix the way hdf5 finds zlib and szip.
Fix the error that libaec exported config cannot be used.

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

Usage test passed with x64-windows triplet.