### PR TITLE
[kdreports] new port

### DIFF
--- a/ports/kdreports/fix-cmake-config.patch
+++ b/ports/kdreports/fix-cmake-config.patch
@@ -1,0 +1,19 @@
+diff --git a/src/KDReportsConfig.cmake.in b/src/KDReportsConfig.cmake.in
+index fa26517..49b9054 100644
+--- a/src/KDReportsConfig.cmake.in
++++ b/src/KDReportsConfig.cmake.in
+@@ -9,10 +9,10 @@
+ 
+ include(CMakeFindDependencyMacro)
+ 
+-find_dependency(Qt@Qt_VERSION_MAJOR@Core @QT_MIN_VERSION@)
+-find_dependency(Qt@Qt_VERSION_MAJOR@Widgets @QT_MIN_VERSION@)
+-find_dependency(Qt@Qt_VERSION_MAJOR@PrintSupport @QT_MIN_VERSION@)
+-find_dependency(Qt@Qt_VERSION_MAJOR@Xml @QT_MIN_VERSION@)
++find_dependency(Qt@QT_VERSION_MAJOR@Core @QT_MIN_VERSION@)
++find_dependency(Qt@QT_VERSION_MAJOR@Widgets @QT_MIN_VERSION@)
++find_dependency(Qt@QT_VERSION_MAJOR@PrintSupport @QT_MIN_VERSION@)
++find_dependency(Qt@QT_VERSION_MAJOR@Xml @QT_MIN_VERSION@)
+ 
+ if (@KDChart_FOUND@)
+     find_dependency(KDChart)

--- a/ports/kdreports/fix-license-text.patch
+++ b/ports/kdreports/fix-license-text.patch
@@ -1,0 +1,10 @@
+diff --git a/LICENSE.txt b/LICENSE.txt
+index 110b884..db69306 100644
+--- a/LICENSE.txt
++++ b/LICENSE.txt
+@@ -3,4 +3,4 @@ License
+ The KD Reports Software is © 2007 Klarälvdalens Datakonsult AB (KDAB),
+ and is available under the terms of the MIT license.
+ 
+-See the full license text in the LICENSES folder.
++See the full license text provided below in this file.

--- a/ports/kdreports/portfile.cmake
+++ b/ports/kdreports/portfile.cmake
@@ -1,0 +1,39 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDAB/KDReports
+    REF "kdreports-${VERSION}"
+    SHA512 f9b3785d71c68d032a0e1420ba3adae517994d257a02df69aaffcff4a8909b24d081c91b4cc9e1cc00311768f92e63b9288a99cfaac8422ebd1cae7321b3edbb
+    HEAD_REF master
+    PATCHES
+        "fix-cmake-config.patch"
+        "fix-license-text.patch"
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" KDReports_STATIC)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DKDReports_QT6=ON
+        -DKDReports_STATIC=${KDReports_STATIC}
+        -DKDReports_TESTS=OFF
+        -DKDReports_EXAMPLES=OFF
+        -DKDReports_DOCS=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_KDChart-qt6=ON
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME KDReports-qt6 CONFIG_PATH lib/cmake/KDReports-qt6)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.txt"
+        "${SOURCE_PATH}/LICENSES/BSD-3-Clause.txt"
+        "${SOURCE_PATH}/LICENSES/MIT.txt"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/kdreports/usage
+++ b/ports/kdreports/usage
@@ -1,0 +1,4 @@
+kdreports provides CMake targets:
+
+  find_package(KDReports-qt6 CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE KDReports::kdreports)

--- a/ports/kdreports/vcpkg.json
+++ b/ports/kdreports/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "kdreports",
+  "version": "2.3.0",
+  "description": "KD Reports is a Qt tool that lets you easily create printable reports by providing all of the necessary features for a variety of applications.",
+  "homepage": "https://github.com/KDAB/KDReports",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "widgets"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3948,6 +3948,10 @@
       "baseline": "2.1.0",
       "port-version": 1
     },
+    "kdreports": {
+      "baseline": "2.3.0",
+      "port-version": 0
+    },
     "kdsingleapplication": {
       "baseline": "1.1.0",
       "port-version": 0

--- a/versions/k-/kdreports.json
+++ b/versions/k-/kdreports.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "48775584d32659e830bfd206d7e9fd9256d3a802",
+      "version": "2.3.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
