### PR TITLE
[winpixevent] Added new port for DX12 PIX event headers

### DIFF
--- a/ports/winpixevent/portfile.cmake
+++ b/ports/winpixevent/portfile.cmake
@@ -1,0 +1,41 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/WinPixEventRuntime/${VERSION}"
+    FILENAME "winpixevent.${VERSION}.zip"
+    SHA512 1ae497fe84760d42176ba0f0c6e6e975f7c1ba3be1799fb1416810ea37244f5506098f7454a9831855ae76a2becff48aed9c3dca8934048124c88bd86eeb149f
+)
+
+vcpkg_extract_source_archive(
+    PACKAGE_PATH
+    ARCHIVE ${ARCHIVE}
+    NO_REMOVE_ONE_LEVEL
+)
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(PIX_ARCH ARM64)
+else()
+    set(PIX_ARCH x64)
+endif()
+
+file(GLOB HEADER_FILES "${PACKAGE_PATH}/include/WinPixEventRuntime/*.h")
+file(INSTALL ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+if(VCPKG_TARGET_IS_UWP)
+    set(WINPIXEVENTRUNTIME WinPixEventRuntime_UAP)
+else()
+    set(WINPIXEVENTRUNTIME WinPixEventRuntime)
+endif()
+
+file(INSTALL "${PACKAGE_PATH}/bin/${PIX_ARCH}/${WINPIXEVENTRUNTIME}.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+file(INSTALL "${PACKAGE_PATH}/bin/${PIX_ARCH}/${WINPIXEVENTRUNTIME}.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+
+file(INSTALL "${PACKAGE_PATH}/bin/${PIX_ARCH}/${WINPIXEVENTRUNTIME}.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+file(INSTALL "${PACKAGE_PATH}/bin/${PIX_ARCH}/${WINPIXEVENTRUNTIME}.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/winpixevent-config.cmake.in"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake"
+    @ONLY)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${PACKAGE_PATH}/license.txt")

--- a/ports/winpixevent/usage
+++ b/ports/winpixevent/usage
@@ -1,0 +1,4 @@
+The WinPixEventRuntime redistributable package provides CMake targets:
+
+    find_package(winpixevent CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Microsoft::WinPixEventRuntime)

--- a/ports/winpixevent/vcpkg.json
+++ b/ports/winpixevent/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "winpixevent",
+  "version": "1.0.240308001",
+  "description": "Allows applications to be instrumented with marker events, for use with Microsoft PIX.",
+  "homepage": "https://devblogs.microsoft.com/pix/",
+  "documentation": "https://devblogs.microsoft.com/pix/documentation/",
+  "license": "MIT",
+  "supports": "windows & (x64 | arm64) & !staticcrt & !xbox"
+}

--- a/ports/winpixevent/winpixevent-config.cmake.in
+++ b/ports/winpixevent/winpixevent-config.cmake.in
@@ -1,0 +1,11 @@
+get_filename_component(_wpix_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(_wpix_root "${_wpix_root}" PATH)
+
+add_library(Microsoft::WinPixEventRuntime SHARED IMPORTED)
+set_target_properties(Microsoft::WinPixEventRuntime PROPERTIES
+  IMPORTED_LOCATION                    "${_wpix_root}/bin/@WINPIXEVENTRUNTIME@.dll"
+  IMPORTED_IMPLIB                      "${_wpix_root}/lib/@WINPIXEVENTRUNTIME@.lib"
+  INTERFACE_INCLUDE_DIRECTORIES        "${_wpix_root}/include"
+  IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+
+unset(_wpix_root)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9696,6 +9696,10 @@
       "baseline": "4.1.3",
       "port-version": 12
     },
+    "winpixevent": {
+      "baseline": "1.0.240308001",
+      "port-version": 0
+    },
     "winpty": {
       "baseline": "0.4.3",
       "port-version": 0

--- a/versions/w-/winpixevent.json
+++ b/versions/w-/winpixevent.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b46fd3eca929d7e0b09c0ffaa5d9af2e9477755c",
+      "version": "1.0.240308001",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
The DirectX 12 version of PIX uses a specific set of headers/libs/DLLs to do event mark-up. This adds an adapter port for the NuGet package that ships these headers.

> These supersede the existing `pix.h` files in the Windows SDK which were only used by the legacy Visual Studio Graphics Diagnostics (VGSD) legacy version of PIX for Direct3D 11.