### PR TITLE
[gz-common5] Add include <chrono> for system_clock

### DIFF
--- a/ports/gz-common5/003-include-chrono.patch
+++ b/ports/gz-common5/003-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/events/include/gz/common/Event.hh b/events/include/gz/common/Event.hh
+index a86c3ac07..936417d74 100644
+--- a/events/include/gz/common/Event.hh
++++ b/events/include/gz/common/Event.hh
+@@ -18,6 +18,7 @@
+ #define GZ_COMMON_EVENT_HH_
+ 
+ #include <atomic>
++#include <chrono>
+ #include <functional>
+ #include <list>
+ #include <map>

--- a/ports/gz-common5/portfile.cmake
+++ b/ports/gz-common5/portfile.cmake
@@ -11,6 +11,7 @@ ignition_modular_library(
       "-DPKG_CONFIG_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf/pkgconf${VCPKG_HOST_EXECUTABLE_SUFFIX}"
    PATCHES
       gz_remotery_vis.patch
+      003-include-chrono.patch
 )
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/gz-common5-graphics/gz-common5-graphics-config.cmake" "find_package(GTS "

--- a/ports/gz-common5/vcpkg.json
+++ b/ports/gz-common5/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gz-common5",
   "version": "5.4.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Common libraries for robotics applications",
   "homepage": "https://ignitionrobotics.org/libs/common",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3370,7 +3370,7 @@
     },
     "gz-common5": {
       "baseline": "5.4.1",
-      "port-version": 2
+      "port-version": 3
     },
     "gz-fuel-tools8": {
       "baseline": "8.1.0",

--- a/versions/g-/gz-common5.json
+++ b/versions/g-/gz-common5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41a407bcf716c1a34f71478a24e9c481f15c255e",
+      "version": "5.4.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "379bf372ab20a993390aaf8c34be3292e43c2ec8",
       "version": "5.4.1",
       "port-version": 2


### PR DESCRIPTION
An issue revealed in https://github.com/microsoft/STL/pull/5105, that can be fixed by including `<chrono>`.

```log
include\gz\common5\gz/common/Event.hh(89): error C2039: 'system_clock': is not a member of 'std::chrono'
```

Submit upstream https://github.com/gazebosim/gz-common/pull/655

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-windows