### PR TITLE
[opencv4] Add include <chrono> for system_clock

### DIFF
--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -1,5 +1,11 @@
 set(USE_QT_VERSION "6")
 
+vcpkg_download_distfile(PATCH_ADD_INCLUDE_CHRONO
+    URLS https://github.com/opencv/opencv/commit/96d6395a6dccb9554bc2f83105f87ebd071d37fa.patch?full_index=1
+    SHA512 d385b5386a19e4a0b3e78d5423baac4d132d25581d9336f084db819b9f68a6bc1ac23968a901891ac5023ab2fe4fa4513d7c70e5170e72cb57710d51b50e67a1
+    FILENAME opencv4-4.11.0-include-chrono.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO opencv/opencv
@@ -23,6 +29,7 @@ vcpkg_from_github(
       0017-fix-flatbuffers.patch
       0019-opencl-kernel.patch
       0020-miss-openexr.patch
+      "${PATCH_ADD_INCLUDE_CHRONO}"
 )
 # Disallow accidental build of vendored copies
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/openexr")

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.10.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6682,7 +6682,7 @@
     },
     "opencv4": {
       "baseline": "4.10.0",
-      "port-version": 2
+      "port-version": 3
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b252c88917d365d1df72e1eba286537f11b0350b",
+      "version": "4.10.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "c493a7ea4c35003983be050429d12e2a51ee8fed",
       "version": "4.10.0",
       "port-version": 2


### PR DESCRIPTION
An issue revealed in https://github.com/microsoft/STL/pull/5105, that can be fixed by including `<chrono>`.

```log
modules\gapi\src\streaming\gstreamer\gstreamersource.cpp(234): error C2039: 'system_clock': is not a member of 'std::chrono'
```

Submit upstream https://github.com/opencv/opencv/pull/26668, backport https://github.com/opencv/opencv/commit/96d6395a6dccb9554bc2f83105f87ebd071d37fa to fix.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port feature `opencv4[ade,calib3d,contrib,core,cuda,cudnn,default-features,dnn,dnn-cuda,dshow,eigen,ffmpeg,freetype,fs,gapi,gdcm,gstreamer,highgui,intrinsics,ipp,jasper,jpeg,nonfree,opencl,opengl,openjpeg,openmp,ovis,png,python,qt,quirc,sfm,tbb,thread,tiff,vtk,vulkan,webp,win32ui]` installation tests pass with the triplet `x64-windows`.