### PR TITLE
[gstreamer] Fix multiple definition of functions

### DIFF
--- a/ports/gstreamer/fix-multiple-def.patch
+++ b/ports/gstreamer/fix-multiple-def.patch
@@ -1,0 +1,35 @@
+diff --git a/subprojects/gst-plugins-bad/gst/siren/common.c b/subprojects/gst-plugins-bad/gst/siren/common.c
+index 2e07748..70f58f6 100644
+--- a/subprojects/gst-plugins-bad/gst/siren/common.c
++++ b/subprojects/gst-plugins-bad/gst/siren/common.c
+@@ -44,7 +44,7 @@ int max_bin[8] = {
+   1
+ };
+ 
+-float step_size[8] = {
++float stp_size[8] = {
+   0.3536f,
+   0.5f,
+   0.70709997f,
+@@ -87,7 +87,7 @@ siren_init (void)
+         (float) pow (10, (i - 24 + 0.5) * STEPSIZE);
+ 
+   for (i = 0; i < 8; i++)
+-    step_size_inverse[i] = (float) 1.0 / step_size[i];
++    step_size_inverse[i] = (float) 1.0 / stp_size[i];
+ 
+   siren_dct4_init ();
+   siren_rmlt_init ();
+diff --git a/subprojects/gst-plugins-bad/gst/siren/common.h b/subprojects/gst-plugins-bad/gst/siren/common.h
+index e09e533..123b888 100644
+--- a/subprojects/gst-plugins-bad/gst/siren/common.h
++++ b/subprojects/gst-plugins-bad/gst/siren/common.h
+@@ -95,7 +95,7 @@ extern int vector_dimension[8];
+ extern int number_of_vectors[8];
+ extern float dead_zone[8];
+ extern int max_bin[8];
+-extern float step_size[8];
++extern float stp_size[8];
+ extern float step_size_inverse[8];
+ 
+ 

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_from_gitlab(
         fix-bz2-windows-debug-dependency.patch
         no-downloads.patch
         ${PATCHES}
+		fix-multiple-def.patch
 )
 
 vcpkg_find_acquire_program(FLEX)

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.24.7",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3314,7 +3314,7 @@
     },
     "gstreamer": {
       "baseline": "1.24.7",
-      "port-version": 1
+      "port-version": 2
     },
     "gtest": {
       "baseline": "1.15.2",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "895e28954cc355e23abad8b4babb540f5de2db6b",
+      "version": "1.24.7",
+      "port-version": 2
+    },
+    {
       "git-tree": "018489638670c73b79e737bb3fe4d1e6452697f9",
       "version": "1.24.7",
       "port-version": 1


### PR DESCRIPTION
Fix the following error.
```
/usr/bin/ld: /mnt/vcpkg/installed/x64-linux/debug/lib/pkgconfig/../../lib/libsndfile.a(g72x.c.o): in function `step_size':
/mnt/vcpkg/buildtrees/libsndfile/src/1.2.2-fa730f3d73.clean/src/G72x/g72x.c:299: multiple definition of `step_size'; subprojects/gst-plugins-bad/gst/siren/libgstsiren.a(common.c.o):/mnt/vcpkg/buildtrees/gstreamer/x64-linux-dbg/../src/1.24.7-08ef53880b/subprojects/gst-plugins-bad/gst/siren/common.c:47: first defined here
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

The feature sndfile test passed with x64-linux and x64-windows triplets.