### PR TITLE
[ginkgo] Update to 1.9.0

### DIFF
--- a/ports/ginkgo/portfile.cmake
+++ b/ports/ginkgo/portfile.cmake
@@ -6,8 +6,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ginkgo-project/ginkgo
     REF "v${VERSION}"
-    SHA512 9d121a5eec9f5d17d1bd4b8924ebb32985a68e8087addc7385b619e365ed260a40ab73eb7a8a16f46a590d3162a78c9311ff41dd3dc74a9117a61e0445d96c52
-    HEAD_REF master
+    SHA512 9a52534cf19f908f776ed54b43791e621a9bd5da1fec93a4f035cf4535ddb0ce9cb9e6623ee57c631c76012b4f3ed5066ec731dc3ecac722f6b5d705ec7fd4c7
+    HEAD_REF main
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -15,6 +15,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     openmp    GINKGO_BUILD_OMP
     cuda      GINKGO_BUILD_CUDA
     mpi       GINKGO_BUILD_MPI
+    half      GINKGO_ENABLE_HALF
 )
 
 vcpkg_cmake_configure(

--- a/ports/ginkgo/vcpkg.json
+++ b/ports/ginkgo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ginkgo",
-  "version-semver": "1.8.0",
+  "version-semver": "1.9.0",
   "description": "Ginkgo is a high-performance linear algebra library for manycore systems, with a focus on sparse solution of linear systems.",
   "homepage": "https://github.com/ginkgo-project/ginkgo",
   "license": "BSD-3-Clause",
@@ -21,6 +21,10 @@
       "dependencies": [
         "cuda"
       ]
+    },
+    "half": {
+      "description": "Enable half precision in Ginkgo",
+      "supports": "!windows"
     },
     "mpi": {
       "description": "Build the distributed MPI backend of Ginkgo",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3121,7 +3121,7 @@
       "port-version": 0
     },
     "ginkgo": {
-      "baseline": "1.8.0",
+      "baseline": "1.9.0",
       "port-version": 0
     },
     "gklib": {

--- a/versions/g-/ginkgo.json
+++ b/versions/g-/ginkgo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d81808841501e44042f617b9982a117d9a2d0f99",
+      "git-tree": "b0886c7ed93e3c417747633a5a32b2d1898af447",
       "version-semver": "1.9.0",
       "port-version": 0
     },

--- a/versions/g-/ginkgo.json
+++ b/versions/g-/ginkgo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d81808841501e44042f617b9982a117d9a2d0f99",
+      "version-semver": "1.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f40f0d719c04549720682c6481f5e4f8996aeae4",
       "version-semver": "1.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

cc @upsj 
