### PR TITLE
[kdsingleapplication] new port

### DIFF
--- a/ports/kdsingleapplication/portfile.cmake
+++ b/ports/kdsingleapplication/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDAB/KDSingleApplication
+    REF "v${VERSION}"
+    SHA512 12540e70014f04b20529d19bc41bf089580c8a82e407511979017020d3f1d96c60112b208d5abe1e6c4e90ed65d3b0ca9dc2f09f20c8b580c3b8a17ae9a84ae0
+    HEAD_REF master
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" KDSingleApplication_STATIC)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DKDSingleApplication_QT6=ON
+        -DKDSingleApplication_STATIC=${KDSingleApplication_STATIC}
+        -DKDSingleApplication_TESTS=OFF
+        -DKDSingleApplication_EXAMPLES=OFF
+        -DKDSingleApplication_DOCS=OFF
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME KDSingleApplication-qt6 CONFIG_PATH lib/cmake/KDSingleApplication-qt6)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+file(
+    COPY
+        "${SOURCE_PATH}/LICENSES/BSD-3-Clause.txt"
+        "${SOURCE_PATH}/LICENSES/MIT.txt"
+    DESTINATION
+        "${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSES/"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/kdsingleapplication/usage
+++ b/ports/kdsingleapplication/usage
@@ -1,0 +1,4 @@
+kdsingleapplication provides CMake targets:
+
+  find_package(KDSingleApplication-qt6 CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE KDAB::kdsingleapplication)

--- a/ports/kdsingleapplication/vcpkg.json
+++ b/ports/kdsingleapplication/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "kdsingleapplication",
+  "version": "1.1.0",
+  "description": "KDSingleApplication is a helper class for single-instance policy applications.",
+  "homepage": "https://github.com/KDAB/KDSingleApplication",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "network",
+        "widgets"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3952,6 +3952,10 @@
       "baseline": "2.1.0",
       "port-version": 1
     },
+    "kdsingleapplication": {
+      "baseline": "1.1.0",
+      "port-version": 0
+    },
     "kdsoap": {
       "baseline": "2.2.0",
       "port-version": 0

--- a/versions/k-/kdsingleapplication.json
+++ b/versions/k-/kdsingleapplication.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "97d5185143331c6d5e9f744d6aa0164436ae4e6d",
+      "version": "1.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
