### PR TITLE
[dcmtk] Update to 3.6.9

### DIFF
--- a/ports/dcmtk/dependencies.diff
+++ b/ports/dcmtk/dependencies.diff
@@ -1,5 +1,5 @@
 diff --git a/CMake/3rdparty.cmake b/CMake/3rdparty.cmake
-index c355922..33ddc73 100644
+index 510027c..e5b0fea 100644
 --- a/CMake/3rdparty.cmake
 +++ b/CMake/3rdparty.cmake
 @@ -1,3 +1,11 @@
@@ -14,16 +14,7 @@ index c355922..33ddc73 100644
  set(USE_FIND_PACKAGE_DOCS "Control whether libraries are searched via CMake's find_package() mechanism or a Windows specific fallback")
  # Advanced user (eg. vcpkg) may want to override this:
  if(NOT DEFINED DCMTK_USE_FIND_PACKAGE_WIN_DEFAULT)
-@@ -42,7 +50,7 @@ if(DCMTK_USE_FIND_PACKAGE)
-         message(STATUS "Info: DCMTK TIFF support will be enabled")
-         include_directories(${TIFF_INCLUDE_DIR} ${JPEG_INCLUDE_DIR})
-       endif()
--      set(LIBTIFF_LIBS ${TIFF_LIBRARY} ${TIFF_EXTRA_LIBS_STATIC} ${JPEG_LIBRARY})
-+      set(LIBTIFF_LIBS ${TIFF_LIBRARIES})
-     endif()
-   endif()
- 
-@@ -57,7 +65,7 @@ if(DCMTK_USE_FIND_PACKAGE)
+@@ -58,7 +66,7 @@ if(DCMTK_USE_FIND_PACKAGE)
        message(STATUS "Info: DCMTK PNG support will be enabled")
        set(WITH_LIBPNG 1)
        include_directories(${PNG_INCLUDE_DIR})
@@ -32,7 +23,7 @@ index c355922..33ddc73 100644
      endif()
    endif()
  
-@@ -102,7 +110,7 @@ if(DCMTK_USE_FIND_PACKAGE)
+@@ -103,7 +111,7 @@ if(DCMTK_USE_FIND_PACKAGE)
      else()
        message(STATUS "Info: DCMTK XML support will be enabled")
        set(WITH_LIBXML 1)
@@ -41,7 +32,7 @@ index c355922..33ddc73 100644
        set(LIBXML_LIBS ${LIBXML2_LIBRARIES} ${LIBXML2_EXTRA_LIBS_STATIC})
      endif()
    endif()
-@@ -140,7 +148,10 @@ if(DCMTK_USE_FIND_PACKAGE)
+@@ -141,7 +149,10 @@ if(DCMTK_USE_FIND_PACKAGE)
    # Find libiconv
    if(DCMTK_WITH_ICONV)
      find_package(Iconv QUIET)

--- a/ports/dcmtk/dependencies.diff
+++ b/ports/dcmtk/dependencies.diff
@@ -1,5 +1,5 @@
 diff --git a/CMake/3rdparty.cmake b/CMake/3rdparty.cmake
-index 510027c..e5b0fea 100644
+index 510027c..9f3a5da 100644
 --- a/CMake/3rdparty.cmake
 +++ b/CMake/3rdparty.cmake
 @@ -1,3 +1,11 @@
@@ -14,6 +14,15 @@ index 510027c..e5b0fea 100644
  set(USE_FIND_PACKAGE_DOCS "Control whether libraries are searched via CMake's find_package() mechanism or a Windows specific fallback")
  # Advanced user (eg. vcpkg) may want to override this:
  if(NOT DEFINED DCMTK_USE_FIND_PACKAGE_WIN_DEFAULT)
+@@ -42,7 +50,7 @@ if(DCMTK_USE_FIND_PACKAGE)
+       else()
+         message(STATUS "Info: DCMTK TIFF support will be enabled")
+         include_directories(${TIFF_INCLUDE_DIR} ${JPEG_INCLUDE_DIR})
+-        set(LIBTIFF_LIBS ${TIFF_LIBRARIES} ${TIFF_EXTRA_LIBS_STATIC} ${JPEG_LIBRARIES})
++        set(LIBTIFF_LIBS ${TIFF_LIBRARIES})
+       endif()
+     endif()
+   endif()
 @@ -58,7 +66,7 @@ if(DCMTK_USE_FIND_PACKAGE)
        message(STATUS "Info: DCMTK PNG support will be enabled")
        set(WITH_LIBPNG 1)

--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -88,13 +88,13 @@ vcpkg_fixup_pkgconfig()
 
 if ("tools" IN_LIST FEATURES)
     set(_tools
-	    dcm2cda
+        dcm2cda
         cda2dcm
-		dcm2img
+        dcm2img
         dcm2json
         dcm2pdf
         dcm2pnm
-        dcm2xml		
+        dcm2xml
         dcmcjpeg
         dcmcjpls
         dcmconv

--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -41,7 +41,6 @@ endif()
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         "iconv"   DCMTK_WITH_ICONV
-        "icu"     DCMTK_WITH_ICU
         "openssl" DCMTK_WITH_OPENSSL
         "png"     DCMTK_WITH_PNG
         "tiff"    DCMTK_WITH_TIFF

--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DCMTK/dcmtk
-    REF 59f75a8b50e50ae1bb1ff12098040c6327500740 # DCMTK-3.6.8
-    SHA512 2719e2163d57339a81f079c8c28d4e9e3ee6b1b85bc3db5b94a2279e3dd9881ab619d432d64984e6371569866d7aa4f01bf8b41841b773bcd60bbb8ad2118cac
+    REF "DCMTK-${VERSION}"
+    SHA512 fcb222182ea653304a1c49db31899a8b08d881916f90d3d35bfab2896aa11473232ac0c0f2195e4d478a6188d3b2c5f54d5172f29c42688c5d05f9bf738ca775
     HEAD_REF master
     PATCHES
         dcmtk.patch
@@ -89,33 +89,30 @@ vcpkg_fixup_pkgconfig()
 
 if ("tools" IN_LIST FEATURES)
     set(_tools
+	    dcm2cda
         cda2dcm
+		dcm2img
         dcm2json
         dcm2pdf
         dcm2pnm
-        dcm2xml
+        dcm2xml		
         dcmcjpeg
         dcmcjpls
         dcmconv
         dcmcrle
-        dcmdata_tests
         dcmdjpeg
         dcmdjpls
         dcmdrle
         dcmdspfn
         dcmdump
-        dcmect_tests
-        dcmfg_tests
         dcmftest
         dcmgpdir
         dcmicmp
-        dcmiod_tests
         dcmj2pnm
         dcml2pnm
         dcmmkcrv
         dcmmkdir
         dcmmklut
-        dcmnet_tests
         dcmodify
         dcmp2pgm
         dcmprscp
@@ -130,17 +127,12 @@ if ("tools" IN_LIST FEATURES)
         dcmqrti
         dcmquant
         dcmrecv
-        dcmrt_tests
         dcmscale
-        dcmseg_tests
         dcmsend
         dcmsign
-        dcmsr_tests
-        dcmtls_tests
         dcod2lum
         dconvlum
         drtdump
-        drttest
         dsr2html
         dsr2xml
         dsrdump
@@ -151,18 +143,13 @@ if ("tools" IN_LIST FEATURES)
         img2dcm
         mkcsmapper
         mkesdb
-        mkreport
         movescu
-        msgserv
-        oficonv_tests
-        ofstd_tests
         pdf2dcm
         stl2dcm
         storescp
         storescu
         termscu
         wlmscpfs
-        wltest
         xml2dcm
         xml2dsr
     )
@@ -180,4 +167,5 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dcmtk/config/osconfig.h"
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/${PORT}/doc-${VERSION}/COPYRIGHT" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")
+

--- a/ports/dcmtk/vcpkg.json
+++ b/ports/dcmtk/vcpkg.json
@@ -29,12 +29,6 @@
         "libiconv"
       ]
     },
-    "icu": {
-      "description": "Enable ICU support",
-      "dependencies": [
-        "icu"
-      ]
-    },
     "openssl": {
       "description": "Enable OpenSSL",
       "dependencies": [

--- a/ports/dcmtk/vcpkg.json
+++ b/ports/dcmtk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dcmtk",
-  "version": "3.6.8",
-  "port-version": 9,
+  "version": "3.6.9",
   "description": "This DICOM ToolKit (DCMTK) package consists of source code, documentation and installation instructions for a set of software libraries and applications implementing part of the DICOM/MEDICOM Standard.",
   "homepage": "https://github.com/DCMTK/dcmtk",
   "license": null,

--- a/scripts/test_ports/vcpkg-ci-dcmtk/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-dcmtk/vcpkg.json
@@ -9,7 +9,6 @@
       "name": "dcmtk",
       "features": [
         "iconv",
-        "icu",
         "openssl",
         "tiff",
         "tools",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2269,8 +2269,8 @@
       "port-version": 5
     },
     "dcmtk": {
-      "baseline": "3.6.8",
-      "port-version": 9
+      "baseline": "3.6.9",
+      "port-version": 0
     },
     "debug-assert": {
       "baseline": "1.3.4",

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e11bf2ea7dbb0d06f88e2dc9774ef8cc4834c21f",
+      "git-tree": "9adca2e85e93d23b6e6aa2cf8b5d932a306e1c7f",
       "version": "3.6.9",
       "port-version": 0
     },

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9adca2e85e93d23b6e6aa2cf8b5d932a306e1c7f",
+      "git-tree": "7ebfbdae104c5b87bbb6280f8304be4bf7e87ebb",
       "version": "3.6.9",
       "port-version": 0
     },

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "90c27d541ea5332188c1a3597d346dd44eb5f86c",
+      "version": "3.6.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "49f23c4ed5cbf8ff7b8dea4ef9fd66539b765c2a",
       "version": "3.6.8",
       "port-version": 9

--- a/versions/d-/dcmtk.json
+++ b/versions/d-/dcmtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "90c27d541ea5332188c1a3597d346dd44eb5f86c",
+      "git-tree": "e11bf2ea7dbb0d06f88e2dc9774ef8cc4834c21f",
       "version": "3.6.9",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/42654

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features and usage test passed with x64-windows triplet.