### PR TITLE
[libpopt] Suppress implicit-function-declaration

### DIFF
--- a/ports/libpopt/CMakeLists.txt
+++ b/ports/libpopt/CMakeLists.txt
@@ -52,6 +52,8 @@ include_directories(${CMAKE_BINARY_DIR})
 add_library(popt ${SOURCES})
 if (MSVC)
     target_compile_options(popt PRIVATE /wd4996)
+else()
+    target_compile_options(popt PRIVATE -Wno-error=implicit-function-declaration)
 endif()
 
 install(TARGETS popt

--- a/ports/libpopt/vcpkg.json
+++ b/ports/libpopt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libpopt",
   "version": "1.16",
-  "port-version": 17,
+  "port-version": 18,
   "description": "Library for parsing command line parameters",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4990,7 +4990,7 @@
     },
     "libpopt": {
       "baseline": "1.16",
-      "port-version": 17
+      "port-version": 18
     },
     "libpq": {
       "baseline": "16.4",

--- a/versions/l-/libpopt.json
+++ b/versions/l-/libpopt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a2e2e626497005de88c4a6b1f8a1ff327386f271",
+      "version": "1.16",
+      "port-version": 18
+    },
+    {
       "git-tree": "2f73cf4ebdadeac639e83a83e2acc8766ed597c3",
       "version": "1.16",
       "port-version": 17


### PR DESCRIPTION
Fix #42659, error with `poptconfig.c:108:9: error: implicit declaration of function ‘glob_pattern_p’ [-Wimplicit-function-declaration]` on Ubuntu 24.

Repro with GCC 14, suppress it to fix.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux