### PR TITLE
[kdstatemachineeditor] new port

### DIFF
--- a/ports/kdstatemachineeditor/portfile.cmake
+++ b/ports/kdstatemachineeditor/portfile.cmake
@@ -1,0 +1,43 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDAB/KDStateMachineEditor
+    REF v${VERSION}
+    SHA512 dedd7166f434689cd5acf4ee3172169d3f77182269d3187f0a7a12966467dd5c7733e3ff64cd1fd03b0f3866c2aafa37cc3f2d7b8a3f4a5d8a7592da039de7af
+    HEAD_REF master
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" VCPKG_BUILD_SHARED_LIBS)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DKDSME_QT6=ON
+        -DKDSME_INTERNAL_GRAPHVIZ=OFF
+        -DKDSME_DOCS=OFF
+        -DKDSME_EXAMPLES=OFF
+        -DBUILD_TESTING=OFF
+        -DBUILD_SHARED_LIBS=${VCPKG_BUILD_SHARED_LIBS}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME KDSME-qt6 CONFIG_PATH lib/cmake/KDSME-qt6)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.txt"
+        "${SOURCE_PATH}/LICENSES/BSD-3-Clause.txt"
+        "${SOURCE_PATH}/LICENSES/GPL-3.0-or-later.txt"
+        "${SOURCE_PATH}/LICENSES/LicenseRef-CISST.txt"
+        "${SOURCE_PATH}/LICENSES/LicenseRef-Qt-Commercial.txt"
+        "${SOURCE_PATH}/LICENSES/GPL-3.0-only.txt"
+        "${SOURCE_PATH}/LICENSES/LGPL-2.1-only.txt"
+        "${SOURCE_PATH}/LICENSES/LicenseRef-KDAB-KDStateMachineEditor.txt"
+        "${SOURCE_PATH}/LICENSES/MIT.txt"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/kdstatemachineeditor/usage
+++ b/ports/kdstatemachineeditor/usage
@@ -1,0 +1,11 @@
+kdstatemachineeditor provides CMake targets:
+
+  find_package(KDSME-qt6 CONFIG REQUIRED)
+  # Core library
+  target_link_libraries(main PRIVATE KDSME::Core)
+  # View library
+  target_link_libraries(main PRIVATE KDSME::View)
+  # Debug interface client library
+  target_link_libraries(main PRIVATE KDSME::DebugInterfaceClient)
+  # Debug interface server library
+  target_link_libraries(main PRIVATE KDSME::DebugInterfaceSource)

--- a/ports/kdstatemachineeditor/vcpkg.json
+++ b/ports/kdstatemachineeditor/vcpkg.json
@@ -1,0 +1,30 @@
+{
+  "name": "kdstatemachineeditor",
+  "version": "2.0.0",
+  "description": "KDStateMachineEditor is a library for visualizing and editing state charts.",
+  "homepage": "https://github.com/KDAB/KDStateMachineEditor",
+  "license": "LGPL-2.1-only",
+  "dependencies": [
+    "graphviz",
+    "qt5compat",
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "testlib",
+        "widgets"
+      ]
+    },
+    "qtdeclarative",
+    "qtremoteobjects",
+    "qtscxml",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3956,6 +3956,10 @@
       "baseline": "2.2.0",
       "port-version": 0
     },
+    "kdstatemachineeditor": {
+      "baseline": "2.0.0",
+      "port-version": 0
+    },
     "kealib": {
       "baseline": "1.6.0",
       "port-version": 0

--- a/versions/k-/kdstatemachineeditor.json
+++ b/versions/k-/kdstatemachineeditor.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "698e2dfa9c5950117cc66ad7a800d692d8c9a99e",
+      "version": "2.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
