### PR TITLE
[libxml2] Update feature set

### DIFF
--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -26,15 +26,44 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        "c14n" LIBXML2_WITH_C14N
+        "catalog" LIBXML2_WITH_CATALOG
         "ftp" LIBXML2_WITH_FTP
+        "html" LIBXML2_WITH_HTML
         "http" LIBXML2_WITH_HTTP
         "iconv" LIBXML2_WITH_ICONV
+        "icu"  LIBXML2_WITH_ICU
+        "iso8859x" LIBXML2_WITH_ISO8859X
         "legacy" LIBXML2_WITH_LEGACY
         "lzma" LIBXML2_WITH_LZMA
-        "zlib" LIBXML2_WITH_ZLIB
+        "plugins" LIBXML2_WITH_MODULES
+        "output" LIBXML2_WITH_OUTPUT
+        "pattern" LIBXML2_WITH_PATTERN
         "tools" LIBXML2_WITH_PROGRAMS
-        "icu"  LIBXML2_WITH_ICU
+        "push" LIBXML2_WITH_PUSH
+        "python" LIBXML2_WITH_PYTHON
+        "reader" LIBXML2_WITH_READER
+        "regex" LIBXML2_WITH_REGEXPS
+        "sax1" LIBXML2_WITH_SAX1
+        "schemas" LIBXML2_WITH_SCHEMAS
+        "schematron" LIBXML2_WITH_SCHEMATRON
+        "thread" LIBXML2_WITH_THREADS
+        "thread-alloc" LIBXML2_WITH_THREAD_ALLOC
+        "thread-local-storage" LIBXML2_WITH_TLS
+        "validation" LIBXML2_WITH_VALID
+        "writer" LIBXML2_WITH_WRITER
+        "xinclude" LIBXML2_WITH_XINCLUDE
+        "xpath" LIBXML2_WITH_XPATH
+        "xptr" LIBXML2_WITH_XPTR
+        "xptr-locs" LIBXML2_WITH_XPTR_LOCS
+        "zlib" LIBXML2_WITH_ZLIB
 )
+if("python" IN_LIST FEATURES)
+    vcpkg_find_acquire_program(PYTHON3)
+    list(APPEND FEATURE_OPTIONS "-DPython_EXECUTABLE=${PYTHON3}")
+    list(APPEND FEATURE_OPTIONS_RELEASE "-DLIBXML2_PYTHON_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib/site-packages")
+    list(APPEND FEATURE_OPTIONS_DEBUG "-DLIBXML2_PYTHON_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib/site-packages")
+endif()
 
 vcpkg_find_acquire_program(PKGCONFIG)
 
@@ -43,30 +72,14 @@ vcpkg_cmake_configure(
     OPTIONS
         ${FEATURE_OPTIONS}
         -DLIBXML2_WITH_TESTS=OFF
-        -DLIBXML2_WITH_HTML=ON
-        -DLIBXML2_WITH_C14N=ON
-        -DLIBXML2_WITH_CATALOG=ON
-        -DLIBXML2_WITH_DEBUG=ON
-        -DLIBXML2_WITH_ISO8859X=ON
-        -DLIBXML2_WITH_MODULES=ON
-        -DLIBXML2_WITH_OUTPUT=ON
-        -DLIBXML2_WITH_PATTERN=ON
-        -DLIBXML2_WITH_PUSH=ON
-        -DLIBXML2_WITH_PYTHON=OFF
-        -DLIBXML2_WITH_READER=ON
-        -DLIBXML2_WITH_REGEXPS=ON
-        -DLIBXML2_WITH_SAX1=ON
-        -DLIBXML2_WITH_SCHEMAS=ON
-        -DLIBXML2_WITH_SCHEMATRON=ON
-        -DLIBXML2_WITH_THREADS=ON
-        -DLIBXML2_WITH_THREAD_ALLOC=OFF
         -DLIBXML2_WITH_TREE=ON
-        -DLIBXML2_WITH_VALID=ON
-        -DLIBXML2_WITH_WRITER=ON
-        -DLIBXML2_WITH_XINCLUDE=ON
-        -DLIBXML2_WITH_XPATH=ON
-        -DLIBXML2_WITH_XPTR=ON
         "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+    OPTIONS_RELEASE
+        ${FEATURE_OPTIONS_RELEASE}
+        -DLIBXML2_WITH_DEBUG:BOOL=OFF
+    OPTIONS_DEBUG
+        ${FEATURE_OPTIONS_DEBUG}
+        -DLIBXML2_WITH_DEBUG:BOOL=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libxml2",
   "version": "2.13.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
   "license": "MIT",
@@ -16,14 +16,39 @@
     }
   ],
   "default-features": [
+    "c14n",
+    "catalog",
+    "html",
     "iconv",
-    "lzma",
-    "zlib"
+    "iso8859x",
+    "output",
+    "pattern",
+    "push",
+    "reader",
+    "regex",
+    "sax1",
+    "schemas",
+    "schematron",
+    "thread",
+    "validation",
+    "writer",
+    "xinclude",
+    "xpath",
+    "xptr"
   ],
   "features": {
+    "c14n": {
+      "description": "Add the Canonicalization support"
+    },
+    "catalog": {
+      "description": "Add the Catalog support"
+    },
     "ftp": {
       "description": "Add the FTP support",
       "supports": "!uwp"
+    },
+    "html": {
+      "description": "Add the HTML support"
     },
     "http": {
       "description": "Add the HTTP support",
@@ -41,6 +66,9 @@
         "icu"
       ]
     },
+    "iso8859x": {
+      "description": "Add ISO8859X support if no iconv"
+    },
     "legacy": {
       "description": "Add deprecated APIs for compatibility"
     },
@@ -50,8 +78,67 @@
         "liblzma"
       ]
     },
+    "output": {
+      "description": "Add the serialization support"
+    },
+    "pattern": {
+      "description": "Add the xmlPattern selection interface"
+    },
+    "plugins": {
+      "description": "Add the dynamic modules support",
+      "supports": "!static"
+    },
+    "push": {
+      "description": "Add the PUSH parser interfaces"
+    },
+    "python": {
+      "description": "Build Python bindings",
+      "supports": "!windows"
+    },
+    "reader": {
+      "description": "Add the xmlReader parsing interface"
+    },
+    "regex": {
+      "description": "Add Regular Expressions support"
+    },
+    "sax1": {
+      "description": "Add the older SAX1 interface"
+    },
+    "schemas": {
+      "description": "Add Relax-NG and Schemas support"
+    },
+    "schematron": {
+      "description": "Add Schematron support"
+    },
+    "thread": {
+      "description": "Add multithread support"
+    },
+    "thread-alloc": {
+      "description": "Add per-thread memory"
+    },
+    "thread-local-storage": {
+      "description": "Enable thread-local storage"
+    },
     "tools": {
       "description": "Build tools"
+    },
+    "validation": {
+      "description": "Add the DTD validation support"
+    },
+    "writer": {
+      "description": "Add the xmlWriter saving interface"
+    },
+    "xinclude": {
+      "description": "Add the XInclude support"
+    },
+    "xpath": {
+      "description": "Add the XPATH support"
+    },
+    "xptr": {
+      "description": "Add the XPointer support"
+    },
+    "xptr-locs": {
+      "description": "Add support for XPointer locations"
     },
     "zlib": {
       "description": "Use ZLib",

--- a/ports/libxslt/vcpkg.json
+++ b/ports/libxslt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libxslt",
   "version": "1.1.42",
+  "port-version": 1,
   "description": "Libxslt is a XSLT library implemented in C for XSLT 1.0 and most of EXSLT",
   "homepage": "https://github.com/GNOME/libxslt",
   "license": null,
@@ -8,7 +9,12 @@
   "dependencies": [
     {
       "name": "libxml2",
-      "default-features": false
+      "default-features": false,
+      "features": [
+        "html",
+        "output",
+        "xpath"
+      ]
     },
     {
       "name": "vcpkg-cmake",
@@ -32,7 +38,16 @@
     },
     "plugins": {
       "description": "(deprecated)",
-      "supports": "!static"
+      "supports": "!static",
+      "dependencies": [
+        {
+          "name": "libxml2",
+          "default-features": false,
+          "features": [
+            "plugins"
+          ]
+        }
+      ]
     },
     "profiler": {
       "description": "Build with profiling support"
@@ -42,7 +57,16 @@
       "supports": "!windows"
     },
     "thread": {
-      "description": "Enable multi-threading support"
+      "description": "Enable multi-threading support",
+      "dependencies": [
+        {
+          "name": "libxml2",
+          "default-features": false,
+          "features": [
+            "thread"
+          ]
+        }
+      ]
     },
     "tools": {
       "description": "Build the utilities"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5446,7 +5446,7 @@
     },
     "libxml2": {
       "baseline": "2.13.5",
-      "port-version": 1
+      "port-version": 2
     },
     "libxmlmm": {
       "baseline": "0.6.0",
@@ -5490,7 +5490,7 @@
     },
     "libxslt": {
       "baseline": "1.1.42",
-      "port-version": 0
+      "port-version": 1
     },
     "libxt": {
       "baseline": "1.3.0",

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b65d04fba2e8ae2beea02f17fbd34f33ee5a276",
+      "version": "2.13.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "42ed1437607b934471807d0a2830d23d43f22bb1",
       "version": "2.13.5",
       "port-version": 1

--- a/versions/l-/libxslt.json
+++ b/versions/l-/libxslt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3409fea122bb804ea3da767ebdf87493399ab238",
+      "version": "1.1.42",
+      "port-version": 1
+    },
+    {
       "git-tree": "8bd8a88f0bf38f7e3b7dda75aa505d413a496836",
       "version": "1.1.42",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.