### PR TITLE
[ffmpeg] add implicit link libs (#42676)

### DIFF
--- a/ports/ffmpeg/FindFFMPEG.cmake.in
+++ b/ports/ffmpeg/FindFFMPEG.cmake.in
@@ -45,17 +45,17 @@ function(append_dependencies out)
     cmake_parse_arguments(PARSE_ARGV 1 "arg" "DEBUG" "NAMES" "")
     if(${arg_DEBUG})
         set(config DEBUG)
-        set(path "${CURRENT_INSTALLED_DIR}/debug/lib/")
+        set(path "${SEARCH_PATH}/debug/lib/")
     else()
         set(config RELEASE)
-        set(path "${CURRENT_INSTALLED_DIR}/lib/")
+        set(path "${SEARCH_PATH}/lib/")
     endif()
     if("${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES}" STREQUAL "")
         enable_language(CXX)
     endif()
     set(pass_through
         ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES}
-        bcrypt gdi32 mfuuid ole32 oleaut32 psapi secur32 shlwapi strmiids user32 uuid vfw32 ws2_32
+        advapi32 bcrypt crypt32 gdi32 mfuuid ole32 oleaut32 psapi secur32 shlwapi strmiids user32 uuid vfw32 ws2_32
         -pthread -pthreads pthread atomic m
     )
     cmake_policy(SET CMP0057 NEW)

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "7.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2758,7 +2758,7 @@
     },
     "ffmpeg": {
       "baseline": "7.1",
-      "port-version": 1
+      "port-version": 2
     },
     "ffnvcodec": {
       "baseline": "12.2.72.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88c48d9d8743bb6641072c4aa50e1da155c2eb50",
+      "version": "7.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "8bf6bad9b522d47e259a13d9033a825a6abd41a9",
       "version": "7.1",
       "port-version": 1


### PR DESCRIPTION
Fixes #42676.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
