### PR TITLE
[qt5-location] Fix missing header file issue

### DIFF
--- a/ports/qt5-location/missing-include.patch
+++ b/ports/qt5-location/missing-include.patch
@@ -10,3 +10,52 @@ index c7dc8b3..0fb25b8 100644
  namespace mbgl {
  namespace util {
  
+diff --git a/src/3rdparty/mapbox-gl-native/deps/rapidjson/1.1.0/include/rapidjson/document.h b/src/3rdparty/mapbox-gl-native/deps/rapidjson/1.1.0/include/rapidjson/document.h
+index e3e20df..ad362a6 100644
+--- a/src/3rdparty/mapbox-gl-native/deps/rapidjson/1.1.0/include/rapidjson/document.h
++++ b/src/3rdparty/mapbox-gl-native/deps/rapidjson/1.1.0/include/rapidjson/document.h
+@@ -322,7 +322,7 @@ struct GenericStringRef {
+     operator const Ch *() const { return s; }
+ 
+     const Ch* const s; //!< plain CharType pointer
+-    const SizeType length; //!< length of the string (excluding the trailing NULL terminator)
++    SizeType length; //!< length of the string (excluding the trailing NULL terminator)
+ 
+ private:
+     //! Disallow construction from non-const array
+diff --git a/src/3rdparty/mapbox-gl-native/include/mbgl/util/geometry.hpp b/src/3rdparty/mapbox-gl-native/include/mbgl/util/geometry.hpp
+index a28c59a..c20b125 100644
+--- a/src/3rdparty/mapbox-gl-native/include/mbgl/util/geometry.hpp
++++ b/src/3rdparty/mapbox-gl-native/include/mbgl/util/geometry.hpp
+@@ -3,6 +3,7 @@
+ #include <mapbox/geometry/geometry.hpp>
+ #include <mapbox/geometry/point_arithmetic.hpp>
+ #include <mapbox/geometry/for_each_point.hpp>
++#include <cstdint>
+ 
+ namespace mbgl {
+ 
+diff --git a/src/3rdparty/mapbox-gl-native/include/mbgl/util/string.hpp b/src/3rdparty/mapbox-gl-native/include/mbgl/util/string.hpp
+index 13498cc..5a5e0b6 100644
+--- a/src/3rdparty/mapbox-gl-native/include/mbgl/util/string.hpp
++++ b/src/3rdparty/mapbox-gl-native/include/mbgl/util/string.hpp
+@@ -5,6 +5,7 @@
+ #include <cassert>
+ #include <cstdlib>
+ #include <exception>
++#include <cstdint>
+ 
+ // Polyfill needed by Qt when building for Android with GCC
+ #if defined(__ANDROID__) && defined(__GLIBCXX__)
+diff --git a/src/3rdparty/mapbox-gl-native/src/mbgl/gl/stencil_mode.hpp b/src/3rdparty/mapbox-gl-native/src/mbgl/gl/stencil_mode.hpp
+index bc959c9..7e67cf0 100644
+--- a/src/3rdparty/mapbox-gl-native/src/mbgl/gl/stencil_mode.hpp
++++ b/src/3rdparty/mapbox-gl-native/src/mbgl/gl/stencil_mode.hpp
+@@ -1,6 +1,7 @@
+ #pragma once
+ 
+ #include <mbgl/util/variant.hpp>
++#include <cstdint>
+ 
+ namespace mbgl {
+ namespace gl {

--- a/ports/qt5-location/vcpkg.json
+++ b/ports/qt5-location/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-location",
   "version": "5.15.16",
+  "port-version": 1,
   "description": "The Qt Location API helps you create viable mapping solutions using the data available from some of the popular location services.",
   "license": null,
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7430,7 +7430,7 @@
     },
     "qt5-location": {
       "baseline": "5.15.16",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-macextras": {
       "baseline": "5.15.16",

--- a/versions/q-/qt5-location.json
+++ b/versions/q-/qt5-location.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bbcdddf4665c2009231e2015106fe5471e1d3dfa",
+      "version": "5.15.16",
+      "port-version": 1
+    },
+    {
       "git-tree": "bd04e516a9dd43e1089611fe978f1fdf7103e839",
       "version": "5.15.16",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/42641
Fixed the issue that length cannot be assigned due to const.
```
/mnt/vcpkg/buildtrees/qt5-location/src/5.15.16-1d3cdeca51/src/3rdparty/mapbox-gl-native/deps/rapidjson/1.1.0/include/rapidjson/document.h:319:82: error: assignment of read-only member ‘rapidjson::GenericStringRef<CharType>::length’
  319 |     GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test passed with x64-linux triplet.