### PR TITLE
[DO NOT MERGE] analyzing prior regression

### DIFF
--- a/scripts/cmake/vcpkg_extract_archive.cmake
+++ b/scripts/cmake/vcpkg_extract_archive.cmake
@@ -21,6 +21,12 @@ function(vcpkg_extract_archive)
 
     file(MAKE_DIRECTORY "${arg_DESTINATION}")
 
+ # Trying to see if this triggers a build for anyone using vcpkg_find_acquire(CLANG)
+get_filename_component(filename "${arg_ARCHIVE}" NAME)
+if("${filename}" STREQUAL "LLVM-15.0.6-win32.exe" OR "${filename}" STREQUAL "LLVM-15.0.6-win64.exe")
+    message(FATAL_ERROR "Explicit failure: vcpkg_extract_archive detected the specific file ${filename}")
+endif()
+
     cmake_path(GET arg_ARCHIVE EXTENSION archive_extension)
     string(TOLOWER "${archive_extension}" archive_extension)
     if("${archive_extension}" MATCHES [[\.msi$]])


### PR DESCRIPTION
A prior [PR](https://github.com/microsoft/vcpkg/pull/41604) silently broke the `gmp` port and necessitated a revert. The reason being that the `gmp` port calls `vcpkg_find_acquire(CLANG)` which downloads LLVM as a `.7z.exe`. The problem was that the asset was not a real 7z archive so when the tool tried to extract it -> 💥

The question is why didn't our CI catch this regression?

This PR purposely tries to break `vcpkg_find_acquire(CLANG)` to see if it triggers a build for `gmp` or any other port that calls `vcpkg_find_acquire(CLANG)`

If it doesn't build `gmp` it means there is a gap in our CI that we need to address. 