### PR TITLE
[openfbx] Miniz dep was removed in latest version and replaced by libdeflate

### DIFF
--- a/ports/openfbx/CMakeLists.txt
+++ b/ports/openfbx/CMakeLists.txt
@@ -6,10 +6,10 @@ set(CMAKE_CXX_STANDARD 11)
 
 include(GNUInstallDirs)
 
-find_package(miniz REQUIRED)
+find_package(libdeflate REQUIRED)
 
 add_library(openfbx src/ofbx.cpp)
-target_link_libraries(openfbx PRIVATE miniz::miniz)
+target_link_libraries(openfbx PRIVATE libdeflate::libdeflate)
 
 target_include_directories(openfbx
         PUBLIC

--- a/ports/openfbx/CMakeLists.txt
+++ b/ports/openfbx/CMakeLists.txt
@@ -9,7 +9,8 @@ include(GNUInstallDirs)
 find_package(libdeflate REQUIRED)
 
 add_library(openfbx src/ofbx.cpp)
-target_link_libraries(openfbx PRIVATE libdeflate::libdeflate)
+target_link_libraries(openfbx PRIVATE $<IF:$<TARGET_EXISTS:libdeflate::libdeflate_shared>,libdeflate::libdeflate_shared,libdeflate::libdeflate_static>)
+
 
 target_include_directories(openfbx
         PUBLIC

--- a/ports/openfbx/unofficial-openfbxConfig.cmake.in
+++ b/ports/openfbx/unofficial-openfbxConfig.cmake.in
@@ -1,8 +1,8 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(miniz)
+find_dependency(libdeflate)
 
 include("${CMAKE_CURRENT_LIST_DIR}/unofficial-openfbxTargets.cmake")
 
-check_required_components(miniz)
+check_required_components(libdeflate)

--- a/ports/openfbx/vcpkg.json
+++ b/ports/openfbx/vcpkg.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/nem0/OpenFBX",
   "license": "MIT",
   "dependencies": [
-    "miniz",
+    "libdeflate",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/openfbx/vcpkg.json
+++ b/ports/openfbx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openfbx",
   "version-date": "2024-05-08",
-  "port-version": "20240508#2",
+  "port-version": "2",
   "description": "Lightweight open source FBX importer",
   "homepage": "https://github.com/nem0/OpenFBX",
   "license": "MIT",

--- a/ports/openfbx/vcpkg.json
+++ b/ports/openfbx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openfbx",
   "version-date": "2024-05-08",
-  "port-version": "2",
+  "port-version": "1",
   "description": "Lightweight open source FBX importer",
   "homepage": "https://github.com/nem0/OpenFBX",
   "license": "MIT",

--- a/ports/openfbx/vcpkg.json
+++ b/ports/openfbx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openfbx",
   "version-date": "2024-05-08",
-  "port-version": "1",
+  "port-version": 1,
   "description": "Lightweight open source FBX importer",
   "homepage": "https://github.com/nem0/OpenFBX",
   "license": "MIT",

--- a/ports/openfbx/vcpkg.json
+++ b/ports/openfbx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openfbx",
   "version-date": "2024-05-08",
+  "port-version": "2024-05-08#2",
   "description": "Lightweight open source FBX importer",
   "homepage": "https://github.com/nem0/OpenFBX",
   "license": "MIT",

--- a/ports/openfbx/vcpkg.json
+++ b/ports/openfbx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openfbx",
   "version-date": "2024-05-08",
-  "port-version": "2024-05-08#2",
+  "port-version": "20240508#2",
   "description": "Lightweight open source FBX importer",
   "homepage": "https://github.com/nem0/OpenFBX",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6686,7 +6686,7 @@
     },
     "openfbx": {
       "baseline": "2024-05-08",
-      "port-version": 0
+      "port-version": 1
     },
     "openfx": {
       "baseline": "1.4",

--- a/versions/o-/openfbx.json
+++ b/versions/o-/openfbx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0044aa1e6ff32e6287babe258cab76c7f7bf8bf7",
+      "git-tree": "91f58df63150443bd8e644f319361162031b88c7",
       "version-date": "2024-05-08",
       "port-version": 1
     },

--- a/versions/o-/openfbx.json
+++ b/versions/o-/openfbx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0044aa1e6ff32e6287babe258cab76c7f7bf8bf7",
+      "version-date": "2024-05-08",
+      "port-version": 1
+    },
+    {
       "git-tree": "a8cefcba9bae878776bff95c9f078ffa58d5f15a",
       "version-date": "2024-05-08",
       "port-version": 0


### PR DESCRIPTION
Miniz dep was removed in latest version and replaced by libdeflate.
So latest version vcpkg package is not working because it still have miniz as dependency instead of libdeflate now.
I have to fix the port version 2024-05-08.