### PR TITLE
[capnproto] Support Windows on ARM64.

### DIFF
--- a/ports/capnproto/portfile.cmake
+++ b/ports/capnproto/portfile.cmake
@@ -10,6 +10,12 @@ vcpkg_from_github(
         undef-KJ_USE_EPOLL-for-ANDROID_PLATFORM-23.patch
 )
 
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    # In ARM64 it fails without /bigobj
+    set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} /bigobj")
+    set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} /bigobj")
+endif()
+
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         "openssl" OPENSSL_FEATURE

--- a/ports/capnproto/vcpkg.json
+++ b/ports/capnproto/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "capnproto",
   "version": "1.0.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Data interchange format and capability-based RPC system",
   "homepage": "https://capnproto.org/",
   "license": "MIT",
-  "supports": "!windows | (!uwp & !arm)",
+  "supports": "!windows | (!uwp & !arm32)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1506,7 +1506,7 @@
     },
     "capnproto": {
       "baseline": "1.0.2",
-      "port-version": 1
+      "port-version": 2
     },
     "capstone": {
       "baseline": "5.0.3",

--- a/versions/c-/capnproto.json
+++ b/versions/c-/capnproto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34d3e2f7eaa026d154cec3576cffefe6aec1cda1",
+      "version": "1.0.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "38a65f51f26928a3ea7bed90ada2ec4081091a6b",
       "version": "1.0.2",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.