### PR TITLE
[libjpeg-turbo] Update to version 3.1.0

### DIFF
--- a/ports/libjpeg-turbo/add-options-for-exes-docs-headers.patch
+++ b/ports/libjpeg-turbo/add-options-for-exes-docs-headers.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index ff9c9c27..d3fbad30 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -217,6 +217,12 @@ option(ENABLE_SHARED "Build shared libraries" TRUE)
+@@ -224,6 +224,12 @@ option(ENABLE_SHARED "Build shared libraries" TRUE)
  boolean_number(ENABLE_SHARED)
  option(ENABLE_STATIC "Build static libraries" TRUE)
  boolean_number(ENABLE_STATIC)
@@ -15,36 +15,36 @@ index ff9c9c27..d3fbad30 100644
  option(REQUIRE_SIMD
    "Generate a fatal error if SIMD extensions are not available for this platform (default is to fall back to a non-SIMD build)"
    FALSE)
-@@ -721,6 +727,7 @@ if(WITH_TURBOJPEG)
+@@ -734,6 +740,7 @@ if(WITH_TURBOJPEG)
          LINK_FLAGS "${TJMAPFLAG}${TJMAPFILE}")
      endif()
  
 +    if(ENABLE_EXECUTABLES)
-     add_executable(tjunittest tjunittest.c tjutil.c md5/md5.c md5/md5hl.c)
+     add_executable(tjunittest src/tjunittest.c src/tjutil.c src/md5/md5.c
+       src/md5/md5hl.c)
      target_link_libraries(tjunittest turbojpeg)
+@@ -752,9 +759,11 @@ if(WITH_TURBOJPEG)
  
-@@ -732,9 +739,11 @@ if(WITH_TURBOJPEG)
- 
-     add_executable(tjexample tjexample.c)
-     target_link_libraries(tjexample turbojpeg)
+     add_executable(tjtran src/tjtran.c)
+     target_link_libraries(tjtran turbojpeg)
 -
 +    endif()
 +    if(INSTALL_DOCS)
-     add_custom_target(tjdoc COMMAND doxygen -s doxygen.config
-       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+     add_custom_target(tjdoc COMMAND doxygen -s ../doc/doxygen.config
+       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src)
 +    endif()
    endif()
  
    if(ENABLE_STATIC)
-@@ -755,6 +764,7 @@ if(WITH_TURBOJPEG)
+@@ -776,6 +785,7 @@ if(WITH_TURBOJPEG)
        set_target_properties(turbojpeg-static PROPERTIES OUTPUT_NAME turbojpeg)
      endif()
  
 +    if(ENABLE_EXECUTABLES)
-     add_executable(tjunittest-static tjunittest.c tjutil.c md5/md5.c
-       md5/md5hl.c)
+     add_executable(tjunittest-static src/tjunittest.c src/tjutil.c
+       src/md5/md5.c src/md5/md5hl.c)
      target_link_libraries(tjunittest-static turbojpeg-static)
-@@ -764,6 +774,7 @@ if(WITH_TURBOJPEG)
+@@ -785,6 +795,7 @@ if(WITH_TURBOJPEG)
      if(UNIX)
        target_link_libraries(tjbench-static m)
      endif()
@@ -52,58 +52,58 @@ index ff9c9c27..d3fbad30 100644
    endif()
  endif()
  
-@@ -782,13 +793,15 @@ if(ENABLE_STATIC)
-   add_library(cjpeg16-static OBJECT rdgif.c rdppm.c)
+@@ -803,12 +814,14 @@ if(ENABLE_STATIC)
+   add_library(cjpeg16-static OBJECT src/rdppm.c)
    set_property(TARGET cjpeg16-static PROPERTY COMPILE_FLAGS
      "-DBITS_IN_JSAMPLE=16 -DGIF_SUPPORTED -DPPM_SUPPORTED")
 +  if(ENABLE_EXECUTABLES)
-   add_executable(cjpeg-static cjpeg.c cdjpeg.c rdbmp.c rdgif.c rdppm.c
-     rdswitch.c rdtarga.c $<TARGET_OBJECTS:cjpeg12-static>
+   add_executable(cjpeg-static src/cjpeg.c src/cdjpeg.c src/rdbmp.c src/rdgif.c
+     src/rdppm.c src/rdswitch.c src/rdtarga.c $<TARGET_OBJECTS:cjpeg12-static>
      $<TARGET_OBJECTS:cjpeg16-static>)
    set_property(TARGET cjpeg-static PROPERTY COMPILE_FLAGS
      ${CDJPEG_COMPILE_FLAGS})
    target_link_libraries(cjpeg-static jpeg-static)
--
 +  endif()
-+  
+ 
    # Compile a separate version of these source files with 12-bit and 16-bit
    # data precision.
-   add_library(djpeg12-static OBJECT rdcolmap.c wrgif.c wrppm.c)
-@@ -797,6 +810,7 @@ if(ENABLE_STATIC)
-   add_library(djpeg16-static OBJECT wrppm.c)
+@@ -818,6 +831,7 @@ if(ENABLE_STATIC)
+   add_library(djpeg16-static OBJECT src/wrppm.c)
    set_property(TARGET djpeg16-static PROPERTY COMPILE_FLAGS
      "-DBITS_IN_JSAMPLE=16 -DPPM_SUPPORTED")
 +  if(ENABLE_EXECUTABLES)
-   add_executable(djpeg-static djpeg.c cdjpeg.c rdcolmap.c rdswitch.c wrbmp.c
-     wrgif.c wrppm.c wrtarga.c $<TARGET_OBJECTS:djpeg12-static>
-     $<TARGET_OBJECTS:djpeg16-static>)
-@@ -810,11 +824,14 @@ if(ENABLE_STATIC)
+   add_executable(djpeg-static src/djpeg.c src/cdjpeg.c src/rdcolmap.c
+     src/rdswitch.c src/wrbmp.c src/wrgif.c src/wrppm.c src/wrtarga.c
+     $<TARGET_OBJECTS:djpeg12-static> $<TARGET_OBJECTS:djpeg16-static>)
+@@ -832,11 +846,14 @@ if(ENABLE_STATIC)
  
-   add_executable(example-static example.c)
+   add_executable(example-static src/example.c)
    target_link_libraries(example-static jpeg-static)
 +  endif()
  endif()
  
 +if(ENABLE_EXECUTABLES)
- add_executable(rdjpgcom rdjpgcom.c)
+ add_executable(rdjpgcom src/rdjpgcom.c)
  
- add_executable(wrjpgcom wrjpgcom.c)
+ add_executable(wrjpgcom src/wrjpgcom.c)
 +endif()
  
  
  ###############################################################################
-@@ -1730,8 +1747,10 @@ if(WITH_TURBOJPEG)
+@@ -1971,9 +1988,11 @@ if(WITH_TURBOJPEG)
+       INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib
        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib
-       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin)
+-      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin)
++      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin)      
 +    if(ENABLE_EXECUTABLES)
      install(TARGETS tjbench
        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin)
 +    endif()
-     if(NOT CMAKE_VERSION VERSION_LESS "3.1" AND MSVC AND
+     if(NOT CMAKE_VERSION VERSION_LESS "3.1" AND MSVC_LIKE AND
        CMAKE_C_LINKER_SUPPORTS_PDB)
        install(FILES "$<TARGET_PDB_FILE:turbojpeg>"
-@@ -1742,7 +1761,7 @@ if(WITH_TURBOJPEG)
+@@ -1984,7 +2003,7 @@ if(WITH_TURBOJPEG)
      install(TARGETS turbojpeg-static EXPORT ${CMAKE_PROJECT_NAME}Targets
        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib)
@@ -112,12 +112,12 @@ index ff9c9c27..d3fbad30 100644
        if(GENERATOR_IS_MULTI_CONFIG)
          set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
        else()
-@@ -1752,15 +1771,17 @@ if(WITH_TURBOJPEG)
+@@ -1994,15 +2013,17 @@ if(WITH_TURBOJPEG)
          DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin RENAME tjbench${EXE})
      endif()
    endif()
 +  if(INSTALL_HEADERS)
-   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/turbojpeg.h
+   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/turbojpeg.h
      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT include)
 +  endif()
  endif()
@@ -131,7 +131,7 @@ index ff9c9c27..d3fbad30 100644
      if(GENERATOR_IS_MULTI_CONFIG)
        set(DIR "${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}")
      else()
-@@ -1775,9 +1796,12 @@ if(ENABLE_STATIC)
+@@ -2017,9 +2038,12 @@ if(ENABLE_STATIC)
    endif()
  endif()
  
@@ -142,63 +142,65 @@ index ff9c9c27..d3fbad30 100644
  
 +if(INSTALL_DOCS)
  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.ijg
-   ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_SOURCE_DIR}/example.c
-   ${CMAKE_CURRENT_SOURCE_DIR}/tjexample.c
-@@ -1790,8 +1814,9 @@ if(WITH_JAVA)
-   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/java/TJExample.java
+   ${CMAKE_CURRENT_SOURCE_DIR}/README.md
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/example.c
+@@ -2038,8 +2062,9 @@ if(WITH_JAVA)
+     ${CMAKE_CURRENT_SOURCE_DIR}/java/TJTran.java
      DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT doc)
  endif()
 +endif()
  
 -if(UNIX OR MINGW)
 +if((UNIX OR MINGW) AND INSTALL_DOCS)
-   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cjpeg.1
-     ${CMAKE_CURRENT_SOURCE_DIR}/djpeg.1 ${CMAKE_CURRENT_SOURCE_DIR}/jpegtran.1
-     ${CMAKE_CURRENT_SOURCE_DIR}/rdjpgcom.1
-@@ -1814,11 +1839,12 @@ install(EXPORT ${CMAKE_PROJECT_NAME}Targets
+   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/cjpeg.1
+     ${CMAKE_CURRENT_SOURCE_DIR}/doc/djpeg.1
+     ${CMAKE_CURRENT_SOURCE_DIR}/doc/jpegtran.1
+@@ -2063,12 +2088,13 @@ install(EXPORT ${CMAKE_PROJECT_NAME}Targets
    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
    COMPONENT lib)
  
 +if(INSTALL_HEADERS)
  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/jconfig.h
-   ${CMAKE_CURRENT_SOURCE_DIR}/jerror.h ${CMAKE_CURRENT_SOURCE_DIR}/jmorecfg.h
-   ${CMAKE_CURRENT_SOURCE_DIR}/jpeglib.h
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/jerror.h
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/jmorecfg.h
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/jpeglib.h
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT include)
 -
 +endif()
  include(cmakescripts/BuildPackages.cmake)
  
  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmakescripts/cmake_uninstall.cmake.in"
+
 diff --git a/sharedlib/CMakeLists.txt b/sharedlib/CMakeLists.txt
 index eaed9e95..74d53696 100644
 --- a/sharedlib/CMakeLists.txt
 +++ b/sharedlib/CMakeLists.txt
-@@ -88,12 +88,13 @@ set_property(TARGET cjpeg12 PROPERTY COMPILE_FLAGS
- add_library(cjpeg16 OBJECT ../rdgif.c ../rdppm.c)
+@@ -94,12 +94,13 @@ set_property(TARGET cjpeg12 PROPERTY COMPILE_FLAGS
+ add_library(cjpeg16 OBJECT ../src/rdppm.c)
  set_property(TARGET cjpeg16 PROPERTY COMPILE_FLAGS
    "-DBITS_IN_JSAMPLE=16 -DGIF_SUPPORTED -DPPM_SUPPORTED")
 +if(ENABLE_EXECUTABLES)
- add_executable(cjpeg ../cjpeg.c ../cdjpeg.c ../rdbmp.c ../rdgif.c ../rdppm.c
-   ../rdswitch.c ../rdtarga.c $<TARGET_OBJECTS:cjpeg12>
-   $<TARGET_OBJECTS:cjpeg16>)
+ add_executable(cjpeg ../src/cjpeg.c ../src/cdjpeg.c ../src/rdbmp.c
+   ../src/rdgif.c ../src/rdppm.c ../src/rdswitch.c ../src/rdtarga.c
+   $<TARGET_OBJECTS:cjpeg12> $<TARGET_OBJECTS:cjpeg16>)
  set_property(TARGET cjpeg PROPERTY COMPILE_FLAGS ${CDJPEG_COMPILE_FLAGS})
  target_link_libraries(cjpeg jpeg)
 -
 +endif()
  # Compile a separate version of these source files with 12-bit and 16-bit data
  # precision.
- add_library(djpeg12 OBJECT ../rdcolmap.c ../wrgif.c ../wrppm.c)
-@@ -102,6 +103,7 @@ set_property(TARGET djpeg12 PROPERTY COMPILE_FLAGS
- add_library(djpeg16 OBJECT ../wrppm.c)
+ add_library(djpeg12 OBJECT ../src/rdcolmap.c ../src/wrgif.c ../src/wrppm.c)
+@@ -108,6 +109,7 @@ set_property(TARGET djpeg12 PROPERTY COMPILE_FLAGS
+ add_library(djpeg16 OBJECT ../src/wrppm.c)
  set_property(TARGET djpeg16 PROPERTY COMPILE_FLAGS
    "-DBITS_IN_JSAMPLE=16 -DPPM_SUPPORTED")
 +if(ENABLE_EXECUTABLES)
- add_executable(djpeg ../djpeg.c ../cdjpeg.c ../rdcolmap.c ../rdswitch.c
-   ../wrbmp.c ../wrgif.c ../wrppm.c ../wrtarga.c $<TARGET_OBJECTS:djpeg12>
-   $<TARGET_OBJECTS:djpeg16>)
-@@ -117,14 +119,16 @@ target_link_libraries(example jpeg)
+ add_executable(djpeg ../src/djpeg.c ../src/cdjpeg.c ../src/rdcolmap.c
+   ../src/rdswitch.c ../src/wrbmp.c ../src/wrgif.c ../src/wrppm.c
+   ../src/wrtarga.c $<TARGET_OBJECTS:djpeg12> $<TARGET_OBJECTS:djpeg16>)
+@@ -124,14 +126,16 @@ target_link_libraries(example jpeg)
  
- add_executable(jcstest ../jcstest.c)
+ add_executable(jcstest ../src/jcstest.c)
  target_link_libraries(jcstest jpeg)
 -
 +endif()
@@ -211,6 +213,6 @@ index eaed9e95..74d53696 100644
  install(TARGETS cjpeg djpeg jpegtran
    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin)
 +endif()
- if(NOT CMAKE_VERSION VERSION_LESS "3.1" AND MSVC AND
+ if(NOT CMAKE_VERSION VERSION_LESS "3.1" AND MSVC_LIKE AND
    CMAKE_C_LINKER_SUPPORTS_PDB)
    install(FILES "$<TARGET_PDB_FILE:jpeg>"

--- a/ports/libjpeg-turbo/portfile.cmake
+++ b/ports/libjpeg-turbo/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libjpeg-turbo/libjpeg-turbo
     REF "${VERSION}"
-    SHA512 f43e1b6b9d048e29e381796c71e1c34a04c0f1c52c1f462db9f9930cfc75d69a50861be2570a6a4adc26a4183b6601300fd9d5553c06bc042f0d32fc1e408ed9
+    SHA512 5712d318e222f1ffcd2f748b0f2c32b3859253a4ed4e13ae134f4445e0ca06efc258c7653b6924b39815ae078f6a9177e098c89684d2c886161a0a4118122e8d
     HEAD_REF master
     PATCHES
         add-options-for-exes-docs-headers.patch

--- a/ports/libjpeg-turbo/vcpkg.json
+++ b/ports/libjpeg-turbo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libjpeg-turbo",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "description": "libjpeg-turbo is a JPEG image codec that uses SIMD instructions (MMX, SSE2, NEON, AltiVec) to accelerate baseline JPEG compression and decompression on x86, x86-64, ARM, and PowerPC systems.",
   "homepage": "https://github.com/libjpeg-turbo/libjpeg-turbo",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4717,7 +4717,7 @@
       "port-version": 2
     },
     "libjpeg-turbo": {
-      "baseline": "3.0.4",
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "libjuice": {

--- a/versions/l-/libjpeg-turbo.json
+++ b/versions/l-/libjpeg-turbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8286a6351f59be7eed5e924d32c3a419d0612ee9",
+      "version": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fbedc8ef954f9951c7d169c9bac3f9534b4b2c77",
       "version": "3.0.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.