### PR TITLE
[sleef] Update to version 3.7

### DIFF
--- a/ports/libtorch/fix-sleef.patch
+++ b/ports/libtorch/fix-sleef.patch
@@ -20,3 +20,65 @@ index f3281d3cb..c8b6ed30e 100644
  
    set(CMAKE_C_FLAGS_DEBUG ${OLD_CMAKE_C_FLAGS_DEBUG})
    set(CMAKE_CXX_FLAGS ${OLD_CMAKE_CXX_FLAGS})
+diff --git a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+index f3281d3cb..c8b6ed30e 100644
+--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
++++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+@@ -21,6 +21,17 @@ inline namespace CPU_CAPABILITY {
+ 
+ #if defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
+ 
++#ifndef SLEEF_CONST
++#if (defined(__GNUC__) || defined(__CLANG__)) && !defined(__INTEL_COMPILER)
++#define SLEEF_CONST const
++#else
++#define SLEEF_CONST
++#endif
++#define SLEEF_CONST_OLD SLEEF_CONST
++#else
++#define SLEEF_CONST_OLD
++#endif
++
+ // bfloat16 conversion
+ static inline void cvtbf16_fp32(const __m128i& a, __m256& o) {
+   o = _mm256_castsi256_ps(_mm256_slli_epi32(_mm256_cvtepu16_epi32(a), 16));
+@@ -266,7 +277,7 @@ public:
+     }
+     return b;
+   }
+-  Vectorized<T> map(const __m256 (*const vop)(__m256)) const {
++  Vectorized<T> map(SLEEF_CONST __m256 (*SLEEF_CONST_OLD vop)(__m256)) const {
+     __m256 lo, hi;
+     cvt_to_fp32<T>(values, lo, hi);
+     const auto o1 = vop(lo);
+     diff --git a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+index f3281d3cb..c8b6ed30e 100644
+--- a/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
++++ b/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
+@@ -18,6 +18,17 @@ inline namespace CPU_CAPABILITY {
+ 
+ #if defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
+ 
++#ifndef SLEEF_CONST
++#if (defined(__GNUC__) || defined(__CLANG__)) && !defined(__INTEL_COMPILER)
++#define SLEEF_CONST const
++#else
++#define SLEEF_CONST
++#endif
++#define SLEEF_CONST_OLD SLEEF_CONST
++#else
++#define SLEEF_CONST_OLD
++#endif
++
+ // bfloat16 conversion
+ static inline void cvtbf16_fp32(const __m256i& a, __m512& o) {
+   o = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(a), 16));
+@@ -345,7 +356,7 @@ public:
+   }
+   #pragma clang diagnostic push
+   #pragma clang diagnostic ignored "-Wignored-qualifiers"
+-  Vectorized<T> map(const __m512 (*const vop)(__m512)) const {
++  Vectorized<T> map(SLEEF_CONST __m512 (*SLEEF_CONST_OLD vop)(__m512)) const {
+     __m512 lo, hi;
+     cvt_to_fp32<T>(values, lo, hi);
+     const auto o1 = vop(lo);

--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtorch",
   "version": "2.1.2",
-  "port-version": 8,
+  "port-version": 9,
   "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
   "homepage": "https://pytorch.org/",
   "license": null,

--- a/ports/sleef/portfile.cmake
+++ b/ports/sleef/portfile.cmake
@@ -1,22 +1,24 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO shibatch/sleef
-    REF 3.5.1
-    SHA512 e8e4e5028db52998c6b82bd462622c08d670e4e85273327f1c3bdbd900827dd7793b217c2876ca1229b6f672493bb96f40140e14366390cccea0e6780689e128
+    REF ${VERSION}
+    SHA512 0f42c4132523f87c9e214bd9eb965e77b84c80e9a63588ed854796fccd2b9affb849a74e5f95f7b0161ba6281ca7ff509d510b42950dc38a6b8175cf6745ab07
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBUILD_LIBM=ON
-        -DBUILD_DFT=ON
-        -DBUILD_QUAD=ON
-        -DBUILD_GNUABI_LIBS=${VCPKG_TARGET_IS_LINUX}
-        -DBUILD_TESTS=OFF
-        -DBUILD_INLINE_HEADERS=OFF
+        -DSLEEF_BUILD_LIBM=ON
+        -DSLEEF_BUILD_DFT=ON
+        -DSLEEF_BUILD_QUAD=ON
+        -DSLEEF_BUILD_GNUABI_LIBS=${VCPKG_TARGET_IS_LINUX}
+        -DSLEEF_BUILD_TESTS=OFF
+        -DSLEEF_BUILD_INLINE_HEADERS=OFF
 )
+
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sleef)
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 

--- a/ports/sleef/vcpkg.json
+++ b/ports/sleef/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sleef",
-  "version": "3.5.1",
-  "port-version": 4,
+  "version": "3.7",
   "description": "SIMD Library for Evaluating Elementary Functions, vectorized libm and DFT",
   "homepage": "https://sleef.org/",
   "license": "BSL-1.0",
@@ -9,6 +8,10 @@
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5242,7 +5242,7 @@
     },
     "libtorch": {
       "baseline": "2.1.2",
-      "port-version": 8
+      "port-version": 9
     },
     "libtorrent": {
       "baseline": "2.0.10",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8449,8 +8449,8 @@
       "port-version": 2
     },
     "sleef": {
-      "baseline": "3.5.1",
-      "port-version": 4
+      "baseline": "3.7",
+      "port-version": 0
     },
     "sleepy-discord": {
       "baseline": "2022-02-05",

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a4d67bf0f603494ff7ce3e51587513a1df295fe",
+      "version": "2.1.2",
+      "port-version": 9
+    },
+    {
       "git-tree": "d6c80d406232a0bfd3360a40132a69d9f70b972c",
       "version": "2.1.2",
       "port-version": 8

--- a/versions/s-/sleef.json
+++ b/versions/s-/sleef.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dcb27d5e3d26cfdbbd2d27bf9d71b0f3b7a0578a",
+      "version": "3.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "12afaa5146f51bf2912339befaafd1776e10442a",
       "version": "3.5.1",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.