### PR TITLE
[winsparkle] update to 0.8.3

### DIFF
--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/vslavik/winsparkle/releases/download/v0.8.3/WinSparkle-0.8.3.zip"
-    FILENAME "winsparkle-083.zip"
+    URLS "https://github.com/vslavik/winsparkle/releases/download/v${VERSION}/WinSparkle-${VERSION}.zip"
+    FILENAME "winsparkle-v${VERSION}.zip"
     SHA512 5ed99a73541f5a590f20ff1e7953284ca00da15df388319b3a96e87c69bb99aaeb5d5eb5e814a6245cf2e4389e0eb5a53ff8657d3eb0717e35f8fe526be911dc
 )
 

--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/vslavik/winsparkle/releases/download/v0.8.1/WinSparkle-0.8.1.zip"
-    FILENAME "winsparkle-081.zip"
-    SHA512 05588793272618ca13fe884620f1ed421276b011a906f15c92f4879b1787c71b175ae1a170b80fe2adfdb7669eac90c38fac929a9bcf382388983f9aea25ba9c
+    URLS "https://github.com/vslavik/winsparkle/releases/download/v0.8.3/WinSparkle-0.8.3.zip"
+    FILENAME "winsparkle-083.zip"
+    SHA512 5ed99a73541f5a590f20ff1e7953284ca00da15df388319b3a96e87c69bb99aaeb5d5eb5e814a6245cf2e4389e0eb5a53ff8657d3eb0717e35f8fe526be911dc
 )
 
 vcpkg_extract_source_archive(

--- a/ports/winsparkle/vcpkg.json
+++ b/ports/winsparkle/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "winsparkle",
-  "version": "0.8.1",
+  "version": "0.8.3",
   "description": "WinSparkle is an easy-to-use software update library for Windows developers.",
   "homepage": "https://winsparkle.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9677,7 +9677,7 @@
       "port-version": 5
     },
     "winsparkle": {
-      "baseline": "0.8.1",
+      "baseline": "0.8.3",
       "port-version": 0
     },
     "wintoast": {

--- a/versions/w-/winsparkle.json
+++ b/versions/w-/winsparkle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e733dd2d130ccfabf21486e2cef4a937119d077",
+      "version": "0.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "033cf81cd03bc5533ddb7e57d65f704db078ba44",
       "version": "0.8.1",
       "port-version": 0

--- a/versions/w-/winsparkle.json
+++ b/versions/w-/winsparkle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1e733dd2d130ccfabf21486e2cef4a937119d077",
+      "git-tree": "d1defb75e4741ef2b57c225fe729abca3974a0b5",
       "version": "0.8.3",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.