### PR TITLE
[arpack-ng] Export Fortran symbols

### DIFF
--- a/ports/arpack-ng/portfile.cmake
+++ b/ports/arpack-ng/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_cmake_configure(
         -DICBEXMM=OFF
         -DEXAMPLES=OFF
         -DTESTS=OFF
+        -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/arpack-ng/vcpkg.json
+++ b/ports/arpack-ng/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "arpack-ng",
   "version": "3.9.1",
+  "port-version": 1,
   "description": "ARPACK-NG is a collection of Fortran77 subroutines designed to solve large scale eigenvalue problems.",
   "homepage": "https://github.com/opencollab/arpack-ng",
   "license": "BSD-3-Clause",

--- a/versions/a-/arpack-ng.json
+++ b/versions/a-/arpack-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "278c6c66052d39f6df0519440ea599b13125116e",
+      "version": "3.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "7dd6a7103d3c8f2b5377921d2edc2b29d330a531",
       "version": "3.9.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -238,7 +238,7 @@
     },
     "arpack-ng": {
       "baseline": "3.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "arrayfire": {
       "baseline": "3.8.0",


### PR DESCRIPTION
Fortran library no problem with exporting all symbols. This patch mainly applies for the case that a proper native Fortran compiler is used on windows. 
There is a def file but patching that correctly into the CMake build is more complicated.