### PR TITLE
[gumbo] update to 0.12.2 and switch homepage

### DIFF
--- a/ports/gumbo/portfile.cmake
+++ b/ports/gumbo/portfile.cmake
@@ -1,11 +1,15 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH
-  REPO google/gumbo-parser
-  REF v0.10.1
-  SHA512  bb1fb55cd07076ab6a9f38dc14db50397dbdca9a04ace4895dfba8b8cbc09038a96e26070c09c75fa929ada2e815affe233c1e2ecd8afe2aba6201647cf277d1
-  HEAD_REF master
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://codeberg.org/gumbo-parser/gumbo-parser/archive/${VERSION}.tar.gz"
+    FILENAME "gumbo-${VERSION}.tar.gz"
+    SHA512  258d93c0404b7dc35e1088cded02a394b2cbd0d08f3e7d0a3e32d859c2032efcc831687c7bc749e9bddb60d4f910bab741007bed1117d486a0d3fd194e22f4e7
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    SOURCE_BASE "${VERSION}"
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
@@ -25,4 +29,4 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/gumbo" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/doc/COPYING")

--- a/ports/gumbo/vcpkg.json
+++ b/ports/gumbo/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "gumbo",
-  "version": "0.10.1",
-  "port-version": 6,
+  "version": "0.12.2",
   "description": "An HTML5 parsing library in pure C99",
-  "homepage": "https://github.com/google/gumbo-parser",
+  "homepage": "https://codeberg.org/gumbo-parser/gumbo-parser",
   "license": "Apache-2.0",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3357,8 +3357,8 @@
       "port-version": 0
     },
     "gumbo": {
-      "baseline": "0.10.1",
-      "port-version": 6
+      "baseline": "0.12.2",
+      "port-version": 0
     },
     "gz-cmake3": {
       "baseline": "3.4.1",

--- a/versions/g-/gumbo.json
+++ b/versions/g-/gumbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6496c7f2e0f20c7f2c469d77e29a02877714b96b",
+      "version": "0.12.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "b0b57c7286bdadcc64d0e4b2f5b5aca951bb1749",
       "version": "0.10.1",
       "port-version": 6


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/42704.
No feature needs to test.
Usage tested on `x64-windows`.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.