### PR TITLE
[vcpkg baseline][openfbx] Remove from fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -829,7 +829,6 @@ omplapp:x64-linux=skip
 # opencc/deps/rapidjson-1.1.0/rapidjson.h: Unknown machine endianess detected
 # opencc/deps/marisa-0.2.5/lib/marisa/grimoire/io/mapper.cc currently doesn't support UWP.
 opencc:x64-android=fail
-openfbx:arm-neon-android=fail
 openimageio:arm-neon-android=fail
 openimageio:arm64-android=fail
 openimageio:x64-android=fail


### PR DESCRIPTION
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=110406&view=results
`PASSING, REMOVE FROM FAIL LIST: openfbx:arm-neon-android`
Added freerdp:arm64-android=fail to ci.baseline.txt by https://github.com/microsoft/vcpkg/pull/29406. This issue is now fixed by https://github.com/microsoft/vcpkg/pull/42610.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~
