### PR TITLE
[libdeflate] Update to v1.23

### DIFF
--- a/ports/libdeflate/portfile.cmake
+++ b/ports/libdeflate/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ebiggers/libdeflate
     REF "v${VERSION}"
-    SHA512 ca3ec7eb3e44da13164f33e56c856dbffc4ccc7b86d995afca6a23fa3f201b766d08a047871407e14a7964dd3da843be23c316e51d981cdd98f25166092de3a9
+    SHA512 c1effb9c5ee8d65bc12ae3d0669a4a394acace13cc146300ed24a7f12a0ec058f66729e1ffbae268711bdcc4151143752ab2d56a099dd6394b2735e8e2f1b671
     HEAD_REF master
     PATCHES
         remove_wrong_c_flags_modification.diff

--- a/ports/libdeflate/vcpkg.json
+++ b/ports/libdeflate/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdeflate",
-  "version": "1.22",
+  "version": "1.23",
   "description": "libdeflate is a library for fast, whole-buffer DEFLATE-based compression and decompression.",
   "homepage": "https://github.com/ebiggers/libdeflate",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4445,7 +4445,7 @@
       "port-version": 0
     },
     "libdeflate": {
-      "baseline": "1.22",
+      "baseline": "1.23",
       "port-version": 0
     },
     "libdisasm": {

--- a/versions/l-/libdeflate.json
+++ b/versions/l-/libdeflate.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7431592dabd39fe637bebeda40110a591b125c21",
+      "version": "1.23",
+      "port-version": 0
+    },
+    {
       "git-tree": "db7abc03a06bc3b794ee65f4859a58bc6a441502",
       "version": "1.22",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.