### PR TITLE
[kdsingleapplication] Fix copyright file

### DIFF
--- a/ports/kdsingleapplication/fix-license-text.patch
+++ b/ports/kdsingleapplication/fix-license-text.patch
@@ -1,0 +1,12 @@
+diff --git a/LICENSE.txt b/LICENSE.txt
+index 12ee586..ac0144d 100644
+--- a/LICENSE.txt
++++ b/LICENSE.txt
+@@ -1,6 +1,6 @@
+ KDSingleApplication is (C) 2019-2023, Klarälvdalens Datakonsult AB,
+ and is available under the terms of the MIT license.
+ 
+-See the full license text in the LICENSES folder.
++See the full license text provided below in this file.
+ 
+ Contact KDAB at <info@kdab.com> to inquire about commercial licensing.

--- a/ports/kdsingleapplication/portfile.cmake
+++ b/ports/kdsingleapplication/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 12540e70014f04b20529d19bc41bf089580c8a82e407511979017020d3f1d96c60112b208d5abe1e6c4e90ed65d3b0ca9dc2f09f20c8b580c3b8a17ae9a84ae0
     HEAD_REF master
+    PATCHES "fix-license-text.patch"
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" KDSingleApplication_STATIC)
@@ -25,13 +26,11 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
-file(
-    COPY
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.txt"
         "${SOURCE_PATH}/LICENSES/BSD-3-Clause.txt"
         "${SOURCE_PATH}/LICENSES/MIT.txt"
-    DESTINATION
-        "${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSES/"
 )
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/kdsingleapplication/vcpkg.json
+++ b/ports/kdsingleapplication/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kdsingleapplication",
   "version": "1.1.0",
+  "port-version": 1,
   "description": "KDSingleApplication is a helper class for single-instance policy applications.",
   "homepage": "https://github.com/KDAB/KDSingleApplication",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3950,7 +3950,7 @@
     },
     "kdsingleapplication": {
       "baseline": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kdsoap": {
       "baseline": "2.2.0",

--- a/versions/k-/kdsingleapplication.json
+++ b/versions/k-/kdsingleapplication.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ee7be30605e7b02d718073e03de51bcbba9e9ad",
+      "version": "1.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "97d5185143331c6d5e9f744d6aa0164436ae4e6d",
       "version": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
Update the port copyright file in the same way as it was done in #42671 for kdsoap

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
