### PR TITLE
[poco] Update version to 1.14.0

### DIFF
--- a/ports/poco/0001-static-pcre.patch
+++ b/ports/poco/0001-static-pcre.patch
@@ -1,10 +1,10 @@
 diff --git a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
-index f504bc1..226dadb 100644
+index 5898d22..d8df9dc 100644
 --- a/Foundation/CMakeLists.txt
 +++ b/Foundation/CMakeLists.txt
-@@ -109,6 +109,23 @@ set_target_properties(Foundation
+@@ -101,6 +101,23 @@ set_target_properties(Foundation
  if(POCO_UNBUNDLED)
- 	target_link_libraries(Foundation PUBLIC Pcre2::Pcre2 ZLIB::ZLIB)
+ 	target_link_libraries(Foundation PUBLIC Pcre2::Pcre2 ZLIB::ZLIB Utf8Proc::Utf8Proc)
  	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED)
 +	add_definitions(
 +		-D_pcre2_utf8_table1=_poco_pcre2_utf8_table1
@@ -23,6 +23,6 @@ index f504bc1..226dadb 100644
 +		-D_pcre2_utt_names_8=_poco_pcre2_utt_names_8
 +		-D_pcre2_utt_size_8=_poco_pcre2_utt_size_8
 +	)
+ else()
+ 	target_compile_definitions(Foundation PUBLIC UTF8PROC_STATIC)
  endif(POCO_UNBUNDLED)
- 
- target_include_directories(Foundation

--- a/ports/poco/0003-fix-dependency.patch
+++ b/ports/poco/0003-fix-dependency.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c552091..8842c76 100644
+index 861c27c..d2701ce 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -90,8 +90,6 @@ option(FORCE_OPENSSL "Force usage of OpenSSL even under windows" OFF)
+@@ -80,8 +80,6 @@ option(ENABLE_NETSSL_WIN "Enable NetSSL Windows" OFF)
  
  if(ENABLE_CRYPTO OR ENABLE_NETSSL OR ENABLE_JWT)
  	find_package(OpenSSL REQUIRED)
@@ -11,7 +11,7 @@ index c552091..8842c76 100644
  endif()
  
  if(OPENSSL_FOUND)
-@@ -121,24 +119,19 @@ else()
+@@ -111,24 +109,19 @@ else()
  	option(ENABLE_APACHECONNECTOR "Enable ApacheConnector" OFF)
  endif()
  
@@ -44,7 +44,7 @@ index c552091..8842c76 100644
  endif()
  
  if(PostgreSQL_FOUND)
-@@ -223,6 +216,9 @@ include(DefinePlatformSpecifc)
+@@ -260,6 +253,9 @@ include(DefinePlatformSpecific)
  # Collect the built libraries and include dirs, the will be used to create the PocoConfig.cmake file
  set(Poco_COMPONENTS "")
  
@@ -54,7 +54,7 @@ index c552091..8842c76 100644
  if(ENABLE_TESTS)
  	add_subdirectory(CppUnit)
  	set(ENABLE_XML ON CACHE BOOL "Enable XML" FORCE)
-@@ -351,8 +347,11 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/Prometheus AND ENABLE_PROMETHEUS)
+@@ -392,8 +388,11 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/Prometheus AND ENABLE_PROMETHEUS)
  	list(APPEND Poco_COMPONENTS "Prometheus")
  endif()
  
@@ -68,27 +68,11 @@ index c552091..8842c76 100644
  	list(APPEND Poco_COMPONENTS "PDF")
  endif()
  
-@@ -492,15 +491,6 @@ install(
- 		Devel
- )
- 
--if(POCO_UNBUNDLED)
--	install(FILES cmake/FindPCRE2.cmake
--			DESTINATION "${PocoConfigPackageLocation}")
--	install(FILES cmake/V39/FindEXPAT.cmake
--			DESTINATION "${PocoConfigPackageLocation}/V39")
--	install(FILES cmake/V313/FindSQLite3.cmake
--			DESTINATION "${PocoConfigPackageLocation}/V313")
--endif()
--
- message(STATUS "CMake ${CMAKE_VERSION} successfully configured ${PROJECT_NAME} using ${CMAKE_GENERATOR} generator")
- message(STATUS "${PROJECT_NAME} package version: ${PROJECT_VERSION}")
- if(BUILD_SHARED_LIBS)
 diff --git a/Data/CMakeLists.txt b/Data/CMakeLists.txt
-index 0772af6..ec82d76 100644
+index 95e5019..d7bd537 100644
 --- a/Data/CMakeLists.txt
 +++ b/Data/CMakeLists.txt
-@@ -45,7 +45,7 @@ else(ENABLE_DATA_SQLITE)
+@@ -73,7 +73,7 @@ else(ENABLE_DATA_SQLITE)
  	message(STATUS "SQLite Support Disabled")
  endif()
  
@@ -98,7 +82,7 @@ index 0772af6..ec82d76 100644
  	add_subdirectory(MySQL)
  else()
 diff --git a/Data/MySQL/CMakeLists.txt b/Data/MySQL/CMakeLists.txt
-index ce411cf..5a30b7c 100644
+index 0ea8701..3c8a426 100644
 --- a/Data/MySQL/CMakeLists.txt
 +++ b/Data/MySQL/CMakeLists.txt
 @@ -21,7 +21,7 @@ set_target_properties(DataMySQL
@@ -124,7 +108,7 @@ index 2386590..81b2c8e 100644
  #endif
  
 diff --git a/Data/SQLite/CMakeLists.txt b/Data/SQLite/CMakeLists.txt
-index 3a176d7..d8055cb 100644
+index 7141112..0c73beb 100644
 --- a/Data/SQLite/CMakeLists.txt
 +++ b/Data/SQLite/CMakeLists.txt
 @@ -7,7 +7,7 @@ file(GLOB_RECURSE HDRS_G "include/*.h")
@@ -136,7 +120,7 @@ index 3a176d7..d8055cb 100644
  else()
  	# sqlite3
  	POCO_SOURCES(SQLITE_SRCS sqlite3
-@@ -43,7 +43,7 @@ target_include_directories(DataSQLite
+@@ -39,7 +39,7 @@ target_include_directories(DataSQLite
  )
  
  if(POCO_UNBUNDLED)
@@ -146,7 +130,7 @@ index 3a176d7..d8055cb 100644
  		POCO_UNBUNDLED
  		SQLITE_THREADSAFE=1
 diff --git a/XML/CMakeLists.txt b/XML/CMakeLists.txt
-index 123657a..9856c55 100644
+index cf66250..89e6c8f 100644
 --- a/XML/CMakeLists.txt
 +++ b/XML/CMakeLists.txt
 @@ -20,7 +20,7 @@ endif()

--- a/ports/poco/0004-fix-feature-sqlite3.patch
+++ b/ports/poco/0004-fix-feature-sqlite3.patch
@@ -1,25 +1,3 @@
-diff --git a/Data/SQLite/CMakeLists.txt b/Data/SQLite/CMakeLists.txt
-index 0c73beb..a4030bb 100644
---- a/Data/SQLite/CMakeLists.txt
-+++ b/Data/SQLite/CMakeLists.txt
-@@ -6,7 +6,7 @@ POCO_SOURCES_AUTO(SQLITE_SRCS ${SRCS_G})
- file(GLOB_RECURSE HDRS_G "include/*.h")
- POCO_HEADERS_AUTO(SQLITE_SRCS ${HDRS_G})
- 
--if(POCO_UNBUNDLED)
-+if(ENABLE_DATA_SQLITE)
- 	find_package(unofficial-sqlite3 CONFIG REQUIRED)
- else()
- 	# sqlite3
-@@ -38,7 +38,7 @@ target_include_directories(DataSQLite
- 	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
- )
- 
--if(POCO_UNBUNDLED)
-+if(ENABLE_DATA_SQLITE)
- 	target_link_libraries(DataSQLite PUBLIC unofficial::sqlite3::sqlite3)
- 	target_compile_definitions(DataSQLite PUBLIC
- 		POCO_UNBUNDLED
 diff --git a/Data/SQLite/cmake/PocoDataSQLiteConfig.cmake b/Data/SQLite/cmake/PocoDataSQLiteConfig.cmake
 index 5478bab..c5d6d6d 100644
 --- a/Data/SQLite/cmake/PocoDataSQLiteConfig.cmake

--- a/ports/poco/0004-fix-feature-sqlite3.patch
+++ b/ports/poco/0004-fix-feature-sqlite3.patch
@@ -1,3 +1,25 @@
+diff --git a/Data/SQLite/CMakeLists.txt b/Data/SQLite/CMakeLists.txt
+index 0c73beb..a4030bb 100644
+--- a/Data/SQLite/CMakeLists.txt
++++ b/Data/SQLite/CMakeLists.txt
+@@ -6,7 +6,7 @@ POCO_SOURCES_AUTO(SQLITE_SRCS ${SRCS_G})
+ file(GLOB_RECURSE HDRS_G "include/*.h")
+ POCO_HEADERS_AUTO(SQLITE_SRCS ${HDRS_G})
+ 
+-if(POCO_UNBUNDLED)
++if(ENABLE_DATA_SQLITE)
+ 	find_package(unofficial-sqlite3 CONFIG REQUIRED)
+ else()
+ 	# sqlite3
+@@ -38,7 +38,7 @@ target_include_directories(DataSQLite
+ 	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
+ )
+ 
+-if(POCO_UNBUNDLED)
++if(ENABLE_DATA_SQLITE)
+ 	target_link_libraries(DataSQLite PUBLIC unofficial::sqlite3::sqlite3)
+ 	target_compile_definitions(DataSQLite PUBLIC
+ 		POCO_UNBUNDLED
 diff --git a/Data/SQLite/cmake/PocoDataSQLiteConfig.cmake b/Data/SQLite/cmake/PocoDataSQLiteConfig.cmake
 index 5478bab..c5d6d6d 100644
 --- a/Data/SQLite/cmake/PocoDataSQLiteConfig.cmake

--- a/ports/poco/0005-fix-error-c3861.patch
+++ b/ports/poco/0005-fix-error-c3861.patch
@@ -1,7 +1,7 @@
-diff --git a/XML/include/Poco/XML/ParserEngine.h b/XML/include/Poco/XML/ParserEngine.h
-index e0c8455..363654c 100644
---- a/XML/include/Poco/XML/ParserEngine.h
-+++ b/XML/include/Poco/XML/ParserEngine.h
+diff --git a/XML/src/ParserEngine.h b/XML/src/ParserEngine.h
+index f74b553..c638778 100644
+--- a/XML/src/ParserEngine.h
++++ b/XML/src/ParserEngine.h
 @@ -19,6 +19,7 @@
  
  #include "Poco/XML/XML.h"
@@ -9,4 +9,4 @@ index e0c8455..363654c 100644
 +#include <expat_config.h>
  #include <expat.h>
  #else
- #include "Poco/XML/expat.h"
+ #include "expat.h"

--- a/ports/poco/0007-find-pcre2.patch
+++ b/ports/poco/0007-find-pcre2.patch
@@ -26,3 +26,55 @@ index d8df9dc..fe2b000 100644
  	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED)
  	add_definitions(
  		-D_pcre2_utf8_table1=_poco_pcre2_utf8_table1
+diff --git a/cmake/FindPCRE2.cmake b/cmake/FindPCRE2.cmake
+index e730f32..6e10df2 100644
+--- a/cmake/FindPCRE2.cmake
++++ b/cmake/FindPCRE2.cmake
+@@ -54,7 +54,7 @@ Hints
+ include(FindPackageHandleStandardArgs)
+ 
+ find_package(PkgConfig QUIET)
+-pkg_check_modules(PC_PCRE2 QUIET pcre2)
++pkg_check_modules(PC_PCRE2 QUIET libpcre2-8)
+ 
+ find_path(PCRE2_INCLUDE_DIR
+   NAMES pcre2.h
+@@ -66,8 +66,8 @@ find_path(PCRE2_INCLUDE_DIR
+   DOC "Specify the include directory containing pcre2.h"
+ )
+ 
+-find_library(PCRE2_LIBRARY
+-  NAMES pcre2-8
++find_library(PCRE2_LIBRARY_DEBUG
++  NAMES pcre2-8d pcre2-8-staticd
+   HINTS
+         ${PCRE2_ROOT_DIR}/lib
+         ${PCRE2_ROOT_LIBRARY_DIRS}
+@@ -76,6 +76,19 @@ find_library(PCRE2_LIBRARY
+   DOC "Specify the lib directory containing pcre2"
+ )
+ 
++find_library(PCRE2_LIBRARY_RELEASE
++  NAMES pcre2-8 pcre2-8-static
++  HINTS
++        ${PCRE2_ROOT_DIR}/lib
++        ${PCRE2_ROOT_LIBRARY_DIRS}
++  PATHS
++        ${PC_PCRE2_LIBRARY_DIRS}
++  DOC "Specify the lib directory containing pcre2"
++)
++
++include(SelectLibraryConfigurations)
++select_library_configurations(PCRE2)
++
+ set(PCRE2_VERSION ${PC_PCRE2_VERSION})
+ 
+ find_package_handle_standard_args(PCRE2
+@@ -87,7 +100,6 @@ find_package_handle_standard_args(PCRE2
+ )
+ 
+ if(PCRE2_FOUND)
+-  set(PCRE2_LIBRARIES ${PCRE2_LIBRARY})
+   set(PCRE2_INCLUDE_DIRS ${PCRE2_INCLUDE_DIR})
+   set(PCRE2_DEFINITIONS ${PC_PCRE2_CFLAGS_OTHER})
+ endif()

--- a/ports/poco/0007-find-pcre2.patch
+++ b/ports/poco/0007-find-pcre2.patch
@@ -1,29 +1,15 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8842c76..b887168 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -491,6 +491,11 @@ install(
- 		Devel
- )
- 
-+if(POCO_UNBUNDLED)
-+	install(FILES cmake/FindPCRE2.cmake
-+			DESTINATION "${PocoConfigPackageLocation}")
-+endif()
-+
- message(STATUS "CMake ${CMAKE_VERSION} successfully configured ${PROJECT_NAME} using ${CMAKE_GENERATOR} generator")
- message(STATUS "${PROJECT_NAME} package version: ${PROJECT_VERSION}")
- if(BUILD_SHARED_LIBS)
 diff --git a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
-index 226dadb..a3765a7 100644
+index d8df9dc..fe2b000 100644
 --- a/Foundation/CMakeLists.txt
 +++ b/Foundation/CMakeLists.txt
-@@ -35,8 +35,11 @@ POCO_MESSAGES(SRCS Logging src/pocomsg.mc)
+@@ -27,9 +27,12 @@ POCO_MESSAGES(SRCS Logging src/pocomsg.mc)
  # If POCO_UNBUNDLED is enabled we try to find the required packages
  # The configuration will fail if the packages are not found
  if(POCO_UNBUNDLED)
 -	find_package(PCRE2 REQUIRED)
  	find_package(ZLIB REQUIRED)
+-	find_package(Utf8Proc REQUIRED)
++	find_package(unofficial-utf8proc CONFIG REQUIRED)
 +	include(SelectLibraryConfigurations)
 +	find_library(PCRE2_LIBRARY_DEBUG NAMES pcre2-8d pcre2-8-staticd HINTS ${INSTALLED_LIB_PATH})
 +	find_library(PCRE2_LIBRARY_RELEASE NAMES pcre2-8 pcre2-8-static HINTS ${INSTALLED_LIB_PATH})
@@ -31,64 +17,12 @@ index 226dadb..a3765a7 100644
  
  	#HACK: Unicode.cpp requires functions from these files. The can't be taken from the library
  	POCO_SOURCES(SRCS RegExp
-@@ -107,7 +110,7 @@ set_target_properties(Foundation
+@@ -99,7 +102,7 @@ set_target_properties(Foundation
  )
  
  if(POCO_UNBUNDLED)
--	target_link_libraries(Foundation PUBLIC Pcre2::Pcre2 ZLIB::ZLIB)
-+	target_link_libraries(Foundation PUBLIC ${PCRE2_LIBRARY} ZLIB::ZLIB)
+-	target_link_libraries(Foundation PUBLIC Pcre2::Pcre2 ZLIB::ZLIB Utf8Proc::Utf8Proc)
++	target_link_libraries(Foundation PUBLIC ${PCRE2_LIBRARY} ZLIB::ZLIB utf8proc)
  	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED)
  	add_definitions(
  		-D_pcre2_utf8_table1=_poco_pcre2_utf8_table1
-diff --git a/cmake/FindPCRE2.cmake b/cmake/FindPCRE2.cmake
-index e730f32..6e10df2 100644
---- a/cmake/FindPCRE2.cmake
-+++ b/cmake/FindPCRE2.cmake
-@@ -54,7 +54,7 @@ Hints
- include(FindPackageHandleStandardArgs)
- 
- find_package(PkgConfig QUIET)
--pkg_check_modules(PC_PCRE2 QUIET pcre2)
-+pkg_check_modules(PC_PCRE2 QUIET libpcre2-8)
- 
- find_path(PCRE2_INCLUDE_DIR
-   NAMES pcre2.h
-@@ -66,8 +66,8 @@ find_path(PCRE2_INCLUDE_DIR
-   DOC "Specify the include directory containing pcre2.h"
- )
- 
--find_library(PCRE2_LIBRARY
--  NAMES pcre2-8
-+find_library(PCRE2_LIBRARY_DEBUG
-+  NAMES pcre2-8d pcre2-8-staticd
-   HINTS
-         ${PCRE2_ROOT_DIR}/lib
-         ${PCRE2_ROOT_LIBRARY_DIRS}
-@@ -76,6 +76,19 @@ find_library(PCRE2_LIBRARY
-   DOC "Specify the lib directory containing pcre2"
- )
- 
-+find_library(PCRE2_LIBRARY_RELEASE
-+  NAMES pcre2-8 pcre2-8-static
-+  HINTS
-+        ${PCRE2_ROOT_DIR}/lib
-+        ${PCRE2_ROOT_LIBRARY_DIRS}
-+  PATHS
-+        ${PC_PCRE2_LIBRARY_DIRS}
-+  DOC "Specify the lib directory containing pcre2"
-+)
-+
-+include(SelectLibraryConfigurations)
-+select_library_configurations(PCRE2)
-+
- set(PCRE2_VERSION ${PC_PCRE2_VERSION})
- 
- find_package_handle_standard_args(PCRE2
-@@ -87,7 +100,6 @@ find_package_handle_standard_args(PCRE2
- )
- 
- if(PCRE2_FOUND)
--  set(PCRE2_LIBRARIES ${PCRE2_LIBRARY})
-   set(PCRE2_INCLUDE_DIRS ${PCRE2_INCLUDE_DIR})
-   set(PCRE2_DEFINITIONS ${PC_PCRE2_CFLAGS_OTHER})
- endif()

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -9,12 +9,13 @@ vcpkg_from_github(
         0001-static-pcre.patch
         # Add the support of arm64-windows
         0002-arm64-pcre.patch
-        0003-fix-dependency.patch 
+        0003-fix-dependency.patch
+        0004-fix-feature-sqlite3.patch
         0005-fix-error-c3861.patch
         0007-find-pcre2.patch
         # MSYS2 repo was used as a source. Thanks MSYS2 team: https://github.com/msys2/MINGW-packages/blob/6e7fba42b7f50e1111b7c0ef50048832243b0ac4/mingw-w64-poco/001-fix-build-on-mingw.patch
         0008-fix-mingw-compilation.patch
-        0004-fix-feature-sqlite3.patch
+
 )
 
 file(REMOVE "${SOURCE_PATH}/Foundation/src/pcre2.h")

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -15,7 +15,6 @@ vcpkg_from_github(
         0007-find-pcre2.patch
         # MSYS2 repo was used as a source. Thanks MSYS2 team: https://github.com/msys2/MINGW-packages/blob/6e7fba42b7f50e1111b7c0ef50048832243b0ac4/mingw-w64-poco/001-fix-build-on-mingw.patch
         0008-fix-mingw-compilation.patch
-
 )
 
 file(REMOVE "${SOURCE_PATH}/Foundation/src/pcre2.h")

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -34,7 +34,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         crypto      ENABLE_CRYPTO
         netssl      ENABLE_NETSSL
         pdf         ENABLE_PDF
-        sqlite3     ENABLE_DATA_SQLITE
         postgresql  ENABLE_DATA_POSTGRESQL
 )
 

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -9,12 +9,12 @@ vcpkg_from_github(
         0001-static-pcre.patch
         # Add the support of arm64-windows
         0002-arm64-pcre.patch
-        0003-fix-dependency.patch
-        0004-fix-feature-sqlite3.patch
+        0003-fix-dependency.patch 
         0005-fix-error-c3861.patch
         0007-find-pcre2.patch
         # MSYS2 repo was used as a source. Thanks MSYS2 team: https://github.com/msys2/MINGW-packages/blob/6e7fba42b7f50e1111b7c0ef50048832243b0ac4/mingw-w64-poco/001-fix-build-on-mingw.patch
         0008-fix-mingw-compilation.patch
+        0004-fix-feature-sqlite3.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/Foundation/src/pcre2.h")

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pocoproject/poco
     REF "poco-${VERSION}-release"
-    SHA512 084064fb462c9e7993d069ebdf395802af900ed92c5b294465a2c246162bb86caa3505985de329e8110d3e9fb3bc39ae9536d523843729d4ed5ce00c35289d92
+    SHA512 4475a0ede5d06e4ce9537295fec92fa39b8fd5635d1cfb38498be4f707bc62b4a8b57672d2a15b557114e4115cc45480d27d0c856b7bd982eeec7adad9ff2582
     HEAD_REF devel
     PATCHES
         # Fix embedded copy of pcre in static linking mode

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -9,6 +9,7 @@
     "expat",
     "pcre2",
     "utf8proc",
+    "sqlite3",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -63,12 +64,6 @@
       "description": "PostgreSQL support for POCO",
       "dependencies": [
         "libpqxx"
-      ]
-    },
-    "sqlite3": {
-      "description": "Sqlite3 support for POCO",
-      "dependencies": [
-        "sqlite3"
       ]
     }
   }

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "poco",
-  "version": "1.13.3",
-  "port-version": 1,
+  "version": "1.14.0",
   "description": "Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.",
   "homepage": "https://github.com/pocoproject/poco",
   "license": "BSL-1.0",
@@ -9,6 +8,7 @@
   "dependencies": [
     "expat",
     "pcre2",
+    "utf8proc",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -8,8 +8,8 @@
   "dependencies": [
     "expat",
     "pcre2",
-    "utf8proc",
     "sqlite3",
+    "utf8proc",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7113,8 +7113,8 @@
       "port-version": 1
     },
     "poco": {
-      "baseline": "1.13.3",
-      "port-version": 1
+      "baseline": "1.14.0",
+      "port-version": 0
     },
     "podofo": {
       "baseline": "0.10.4",

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d1752c000626dc0f9d4e13e7e15116ca287c47b2",
+      "git-tree": "0484f3cc3309e72934353b83384c3f84e5000bd9",
       "version": "1.14.0",
       "port-version": 0
     },

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "085b543c3113c579017f49b2474cb5d8da56e521",
+      "git-tree": "95d7ba01cbd1af97dee1713bbe873fe31c18f03d",
       "version": "1.14.0",
       "port-version": 0
     },

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "534545da005288c187a601074e74229e9ae00575",
+      "git-tree": "d1752c000626dc0f9d4e13e7e15116ca287c47b2",
       "version": "1.14.0",
       "port-version": 0
     },

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "534545da005288c187a601074e74229e9ae00575",
+      "version": "1.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "431894de75b90a806a64bcb289b6ad81d5c98a4c",
       "version": "1.13.3",
       "port-version": 1

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "95d7ba01cbd1af97dee1713bbe873fe31c18f03d",
+      "git-tree": "a430ad2f694fb8af957b599850f63786485f98a2",
       "version": "1.14.0",
       "port-version": 0
     },

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0484f3cc3309e72934353b83384c3f84e5000bd9",
+      "git-tree": "085b543c3113c579017f49b2474cb5d8da56e521",
       "version": "1.14.0",
       "port-version": 0
     },


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/42653

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
