### PR TITLE
[utf8-range] update to 5.29.1 

### DIFF
--- a/ports/utf8-range/portfile.cmake
+++ b/ports/utf8-range/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512 a188d109f317c0cff1d57c3d81b307ff46db816774af2eb4edc39b136725bb3ed70fafbcffcdf9465f6f948a1e7dfc0175f75b17acd414e5ae543939a510688a
+    SHA512 18b49716ac15800f4ed970a2b2dc3235299933e1ab34edbffd0c1eeabd1ade37b3ea50d90b9a814211aa83ee7a335d9dae1763a088f8899ff64341911d3678c1
     HEAD_REF main
     PATCHES
         fix-cmake.patch

--- a/ports/utf8-range/vcpkg.json
+++ b/ports/utf8-range/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "utf8-range",
-  "version": "5.28.3",
+  "version": "5.29.1",
   "description": "Fast UTF-8 validation with Range algorithm (NEON+SSE4+AVX2)",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9277,7 +9277,7 @@
       "port-version": 4
     },
     "utf8-range": {
-      "baseline": "5.28.3",
+      "baseline": "5.29.1",
       "port-version": 0
     },
     "utf8h": {

--- a/versions/u-/utf8-range.json
+++ b/versions/u-/utf8-range.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09bb6fc16a60acee3536d8e7febd6fcca82a67ac",
+      "version": "5.29.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3fca368158ad02ea861065c11c195ca58d94206f",
       "version": "5.28.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #42747
Update port utf8-range to the latest version 5.29.1.
No feature need to test.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
