### PR TITLE
[vcpkg baseline][g2o] Update to 2024-12-14

### DIFF
--- a/ports/g2o/fix-absolute.patch
+++ b/ports/g2o/fix-absolute.patch
@@ -1,22 +1,22 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c3b6ab5..f050970 100644
+index c2b0a09..8c62d5a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -485,7 +485,8 @@ set(G2O_HAVE_CHOLMOD ${CHOLMOD_FOUND})
+@@ -492,7 +492,8 @@ set(G2O_HAVE_CHOLMOD ${CHOLMOD_FOUND})
  set(G2O_HAVE_CSPARSE ${G2O_USE_CSPARSE})
  set(G2O_SHARED_LIBS ${BUILD_SHARED_LIBS})
  set(G2O_LGPL_SHARED_LIBS ${BUILD_LGPL_SHARED_LIBS})
 -set(G2O_CXX_COMPILER "${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER}")
 +cmake_path(GET CMAKE_CXX_COMPILER FILENAME cxx_compiler)
 +set(G2O_CXX_COMPILER "${CMAKE_CXX_COMPILER_ID} ${cxx_compiler}")
-
+ 
  # Generate cmake configuration scripts
  set(G2O_GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
-@@ -496,7 +496,6 @@ set(G2O_PROJECT_CONFIG "${G2O_GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
+@@ -501,7 +502,6 @@ set(G2O_PROJECT_CONFIG "${G2O_GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
  set(G2O_TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
  set(G2O_CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
  set(G2O_NAMESPACE "${PROJECT_NAME}::")
 -set(G2O_SRC_DIR "${PROJECT_SOURCE_DIR}")
- set(G2O_VERSION 1.0.0)
-
+ 
  include(CMakePackageConfigHelpers)
+ WRITE_BASIC_PACKAGE_VERSION_FILE(

--- a/ports/g2o/portfile.cmake
+++ b/ports/g2o/portfile.cmake
@@ -2,8 +2,8 @@ string(REPLACE "-" "" GIT_TAG "${VERSION}_git")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RainerKuemmerle/g2o
-    REF "${GIT_TAG}"
-    SHA512 626b4d286b564ca6714957d0caf41cf5387ecbc7100299c1a1134fa4a11a340f6e6e0796fa5ff16229032a1e1e384bc03e7d2c118be39d6d51a20d9f2774a98d
+    REF eec325a1da1273e87bc97887d49e70570f28570c
+    SHA512 22d3d546fbc92bff4767b66dcc9a001b5ed0cac0787874dda8712140aa03004b0312f702ea7d61c5fdcfa0bb00654c873f8b99899cd9e2b89667d8d99667d5cd
     HEAD_REF master
     PATCHES
         fix-absolute.patch

--- a/ports/g2o/vcpkg.json
+++ b/ports/g2o/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "g2o",
-  "version-date": "2023-08-06",
-  "port-version": 1,
+  "version-date": "2024-12-14",
   "description": "g2o: A General Framework for Graph Optimization",
   "homepage": "https://openslam.org/g2o.html",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2989,8 +2989,8 @@
       "port-version": 2
     },
     "g2o": {
-      "baseline": "2023-08-06",
-      "port-version": 1
+      "baseline": "2024-12-14",
+      "port-version": 0
     },
     "g3log": {
       "baseline": "2.4",

--- a/versions/g-/g2o.json
+++ b/versions/g-/g2o.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e3c374b6033493e361f78bd082cbbaea6d5790a8",
+      "version-date": "2024-12-14",
+      "port-version": 0
+    },
+    {
       "git-tree": "6de83a9660c1f5b6e922a56140584c1dbdaa1643",
       "version-date": "2023-08-06",
       "port-version": 1


### PR DESCRIPTION
Update to the latest version to fix the following issues.
```
D:\b\g2o\src\230806_git-93792713b9.clean\g2o\core\optimizable_graph.cpp(483): error C2039: 'join': is not a member of 'fmt'
D:\installed\x86-windows\include\fmt/ostream.h(25): note: see declaration of 'fmt'
D:\b\g2o\src\230806_git-93792713b9.clean\g2o\core\optimizable_graph.cpp(483): error C3861: 'join': identifier not found
D:\b\g2o\src\230806_git-93792713b9.clean\g2o\core\optimizable_graph.cpp(483): error C2672: 'spdlog::logger::error': no matching overloaded function found
D:\installed\x86-windows\include\spdlog/logger.h(252): note: could be 'void spdlog::logger::error(const T &)'
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test passed with x64-windows triplet.