### PR TITLE
[lilv] Fix dependencies, tools

### DIFF
--- a/ports/lilv/portfile.cmake
+++ b/ports/lilv/portfile.cmake
@@ -7,15 +7,34 @@ vcpkg_from_gitlab(
     HEAD_REF master
 )
 
+set(options "")
+if("tools" IN_LIST FEATURES)
+    list(APPEND options -Dtools=enabled)
+else()
+    list(APPEND options -Dtools=disabled)
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${options}
+        -Dbindings_cpp=enabled
+        -Dbindings_py=disabled
+        -Ddocs=disabled
         -Dtests=disabled
 )
 
 vcpkg_install_meson()
-vcpkg_copy_tools(TOOL_NAMES lv2info lv2ls AUTO_CLEAN)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
+
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES lv2apply lv2bench lv2info lv2ls AUTO_CLEAN)
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/etc"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/lilv/vcpkg.json
+++ b/ports/lilv/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "lilv",
   "version": "0.24.24",
+  "port-version": 1,
   "description": "Lilv is a C library for simple use of LV2 plugins in applications.",
   "homepage": "https://drobilla.net/software/lilv",
   "license": "ISC",
@@ -13,6 +14,16 @@
     {
       "name": "vcpkg-tool-meson",
       "host": true
+    },
+    "zix"
+  ],
+  "features": {
+    "tools": {
+      "description": "Build tools",
+      "supports": "!windows",
+      "dependencies": [
+        "libsndfile"
+      ]
     }
-  ]
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5546,7 +5546,7 @@
     },
     "lilv": {
       "baseline": "0.24.24",
-      "port-version": 0
+      "port-version": 1
     },
     "linalg": {
       "baseline": "2.2",

--- a/versions/l-/lilv.json
+++ b/versions/l-/lilv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d111881ad652319d2d57242779612581dff3b2e",
+      "version": "0.24.24",
+      "port-version": 1
+    },
+    {
       "git-tree": "350900cd2f7b77c0b2cfc8d033fe98dc4f092ee7",
       "version": "0.24.24",
       "port-version": 0


### PR DESCRIPTION
Fixes installation order problem noticed in #42750, introduced by #42537.
Tools broken for windows, https://github.com/lv2/lilv/issues/64.
New features `tools` tested on x64-linux.