### PR TITLE
[muparser] update to 2.3.5

### DIFF
--- a/ports/muparser/portfile.cmake
+++ b/ports/muparser/portfile.cmake
@@ -1,16 +1,20 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beltoforion/muparser
-    REF 59e0ce1e0d35d42713af67788f19797945d81364 # v2.3.4
-    SHA512 4d0261b9c155b2697ce7222d87ff19be781919e93154bf69455ce36432f66abe2a1ea80a59f7526990f7859f78259014ef56702aa5c7db2ac8c28c8e9491e1f5 
+    REF "v${VERSION}"
+    SHA512 48610dd112b5c8e1ea7615e29c9f9ca185091392b651794de039c14edfad4c62a6ae1d087393fdfd8d03a99f94a6e71275b86ddc8027234d322030bc7c25223e 
     HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        openmp    ENABLE_OPENMP
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
         -DENABLE_SAMPLES=OFF
-        -DENABLE_OPENMP=OFF
         -DENABLE_WIDE_CHAR=OFF
 )
 
@@ -19,9 +23,6 @@ vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/muparser")
 vcpkg_fixup_pkgconfig()
-
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/muParserDef.h" "#if defined(_UNICODE)" "#if 0")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/muParserDLL.h" "#ifndef _UNICODE" "#if 1")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/muParserFixes.h" "#ifndef MUPARSER_STATIC" "#if 0")

--- a/ports/muparser/vcpkg.json
+++ b/ports/muparser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "muparser",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Fast math parser library",
   "homepage": "https://github.com/beltoforion/muparser",
   "license": "BSD-2-Clause",
@@ -14,5 +14,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "openmp": {
+      "description": "Enable OpenMP for multithreading"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6205,7 +6205,7 @@
       "port-version": 5
     },
     "muparser": {
-      "baseline": "2.3.4",
+      "baseline": "2.3.5",
       "port-version": 0
     },
     "murmur3": {

--- a/versions/m-/muparser.json
+++ b/versions/m-/muparser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cbb068f60126bf3db24e867abb1b6daad94fdb0f",
+      "version": "2.3.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "7a10458552dd11fbd4d72ff5e978f5f55a82e2f3",
       "version": "2.3.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.