### PR TITLE
[xsimd] Bump to 13.1.0

### DIFF
--- a/ports/xsimd/portfile.cmake
+++ b/ports/xsimd/portfile.cmake
@@ -1,17 +1,9 @@
-vcpkg_download_distfile(
-    WIN_PATCHES
-    URLS "https://github.com/xtensor-stack/xsimd/pull/1040/commits/e8cb862e434eb1e367afb83e1a3685bccff3e566.diff?full_index=1"
-    FILENAME "xsimd-e8cb862e434eb1e367afb83e1a3685bccff3e566.patch"
-    SHA512 e584033fb79c602a19222c177d5db28f9887dd17e741844d57f2236a5749ac4c02cc0740f8011ca990602887a6ee3dd21ae0b695455c447686b1a6c8bda2e092
-)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xsimd
     REF "${VERSION}"
-    SHA512 cdc42ddad3353297cf25ea2b6b3f09967f5f388efc26241f2997979fdbbac072819ff771145bc5bfa86cb326cca84b4119e8e6e3f658407961cf203a40603a7f
+    SHA512 a446aa29364c12785b9fc600341cd21b8fcf3cff6e07f6093b5cd3669a0c26397ccd75f0504c52da7f1843e2844e8b909bebbe1e64f0f2d8355f0ee0eadf1263
     HEAD_REF master
-    PATCHES
-        "${WIN_PATCHES}"
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/xsimd/portfile.cmake
+++ b/ports/xsimd/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 

--- a/ports/xsimd/vcpkg.json
+++ b/ports/xsimd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xsimd",
-  "version": "13.0.0",
+  "version": "13.1.0",
   "port-version": 1,
   "description": "Modern, portable C++ wrappers for SIMD intrinsics",
   "homepage": "https://github.com/xtensor-stack/xsimd",

--- a/ports/xsimd/vcpkg.json
+++ b/ports/xsimd/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "xsimd",
   "version": "13.1.0",
-  "port-version": 1,
   "description": "Modern, portable C++ wrappers for SIMD intrinsics",
   "homepage": "https://github.com/xtensor-stack/xsimd",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9865,8 +9865,8 @@
       "port-version": 4
     },
     "xsimd": {
-      "baseline": "13.0.0",
-      "port-version": 1
+      "baseline": "13.1.0",
+      "port-version": 0
     },
     "xtensor": {
       "baseline": "0.25.0",

--- a/versions/x-/xsimd.json
+++ b/versions/x-/xsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f5706381f8c67dec2402d9358cdbbb383bc04ecf",
+      "version": "13.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f32923512f532dd165f1379bdb3c810b9d31d7d3",
       "version": "13.0.0",
       "port-version": 1

--- a/versions/x-/xsimd.json
+++ b/versions/x-/xsimd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f5706381f8c67dec2402d9358cdbbb383bc04ecf",
+      "git-tree": "0b77ed3d8e13fc87bade45e85ad04027ef852a00",
       "version": "13.1.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
