### PR TITLE
[mlpack] Bump to 4.5.1

### DIFF
--- a/ports/mlpack/portfile.cmake
+++ b/ports/mlpack/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mlpack/mlpack
     REF "${VERSION}"
-    SHA512 fd1612a2689e7e54bcbebb0b9da7d20aa6fe2fce395d544d476136d8de7f63a638bbbbab1bc2d00991649bcdf66ee6493ffdeed28c42121f98c82ee208c35947
+    SHA512 2be9c3b8e2874ebbf9e39ade1d65774e1d7d08eea1427d592ef9f49f6a35a1441585749e043e058cbcb8f5e7eae4cf589b0f4931c59ae6c0fed74c32bac0f4b3
     HEAD_REF master
 )
 

--- a/ports/mlpack/vcpkg.json
+++ b/ports/mlpack/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mlpack",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "mlpack is an intuitive, fast, and flexible header-only C++ machine learning library with bindings to other languages.",
   "homepage": "https://github.com/mlpack/mlpack",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6013,7 +6013,7 @@
       "port-version": 0
     },
     "mlpack": {
-      "baseline": "4.5.0",
+      "baseline": "4.5.1",
       "port-version": 0
     },
     "mman": {

--- a/versions/m-/mlpack.json
+++ b/versions/m-/mlpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "159e1840b52507ad8dc7349370e853f68225414d",
+      "version": "4.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8467e71cd0c010cc0e0831c2111cef62124e592a",
       "version": "4.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
