### PR TITLE
[nanojsonc] Bump to 1.1.0

### DIFF
--- a/ports/nanojsonc/portfile.cmake
+++ b/ports/nanojsonc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-source-patterns/nanojsonc
         REF "${VERSION}"
-        SHA512 306fce8f90c1e5b9031f3f2b1cec5430722477425766fc05e430cceb03bb85188f2c451c0c7d34aed49b506e6a2cd835e419792362f992acbafc0b099fbe4b5e
+        SHA512 4cb73a0dc42bc6dbc106ed7bf7d22dbbadf3d92d2055d4b96990b62822978c09e580a87ca1666cf0b915b994fada6a1f6b803eb98d8da6b021a0a2c410d538ff
         HEAD_REF main
 )
 

--- a/ports/nanojsonc/vcpkg.json
+++ b/ports/nanojsonc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanojsonc",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "maintainers": "Saad Shams",
   "description": "Event-Driven JSON Parser for C",
   "homepage": "https://github.com/open-source-patterns/nanojsonc",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6257,7 +6257,7 @@
       "port-version": 5
     },
     "nanojsonc": {
-      "baseline": "1.0.0",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "nanomsg": {

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "102c65ad71dc556dd82d4af6d83efd96ee316311",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7680709fd527db1cc26d47f8897c0669cacbfb0f",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
