### PR TITLE
[recycle] Bump to 7.0.0

### DIFF
--- a/ports/recycle/portfile.cmake
+++ b/ports/recycle/portfile.cmake
@@ -1,10 +1,8 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO steinwurf/recycle
     REF "${VERSION}"
-    SHA512 7fff2d8d8da0613d330d58b0f82fafd7fc20b78ac2588ba9743dc8033f130acaf29b37f4c2c02f8b39fc8d5b352f589c6e8398420161124a7143ca4ca6521512
+    SHA512 c30cd3d388eeeea6a3db344e0e448878686c4a7bc106260c7de9d1eeb3477435eb1783bca09151356ba51200ecf14182891f97a38943959032c54b17ea0abac3
 )
 
 vcpkg_cmake_configure(

--- a/ports/recycle/vcpkg.json
+++ b/ports/recycle/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "recycle",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Simple resource pool for recycling resources in C++",
   "homepage": "https://github.com/steinwurf/recycle",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7901,7 +7901,7 @@
       "port-version": 1
     },
     "recycle": {
-      "baseline": "6.0.0",
+      "baseline": "7.0.0",
       "port-version": 0
     },
     "redis-plus-plus": {

--- a/versions/r-/recycle.json
+++ b/versions/r-/recycle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "342b8bf7460c684c89e390b02194bcad6ef7eb64",
+      "version": "7.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0fe3fb2e4ec2870ca2a01029cc4e40c3992572cb",
       "version": "6.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
