### PR TITLE
[imageinfo] Bump to 2024-12-02

### DIFF
--- a/ports/imageinfo/portfile.cmake
+++ b/ports/imageinfo/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiaozhuai/imageinfo
-    REF d010e59f25867a0ee159143f8bf116f071d993b1 # committed on 2024-08-05
-    SHA512 a30c241608d44aa296f75debc988f7a8875eafe45ea925ca9d276975512cd1de9413b95c6421d1e37a71cb3e1c65f2bed101ffdf0e83ef3a883c8443a8bffb8d
+    REF 4e772f7d7d4453028c71f90e1783c390f5d78adf # committed on 2024-12-02
+    SHA512 6ef9041a450c516ba84c5ccb4d96a2f5e27c0b45164e1db38b8df6adfeaec1725b76677955e8b2bf4d73842162cecf734ee25163af21eeeb045af48af92ba821
     HEAD_REF master
 )
 

--- a/ports/imageinfo/vcpkg.json
+++ b/ports/imageinfo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imageinfo",
-  "version-date": "2024-08-05",
+  "version-date": "2024-12-02",
   "description": "Cross platform super fast single header c++ library to get image size and format without loading/decoding. Support avif, bmp, cur, dds, gif, hdr (pic), heic (heif), icns, ico, jp2, jpeg (jpg), jpx, ktx, png, psd, qoi, tga, tiff (tif), webp ...",
   "homepage": "https://github.com/xiaozhuai/imageinfo",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3685,7 +3685,7 @@
       "port-version": 0
     },
     "imageinfo": {
-      "baseline": "2024-08-05",
+      "baseline": "2024-12-02",
       "port-version": 0
     },
     "imath": {

--- a/versions/i-/imageinfo.json
+++ b/versions/i-/imageinfo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49a738d9a75f95f74ffc75e34f6961c48aebe33d",
+      "version-date": "2024-12-02",
+      "port-version": 0
+    },
+    {
       "git-tree": "b798e4d9bc0316e2a3a267599b498be93e9ab935",
       "version-date": "2024-08-05",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
