### PR TITLE
[kubazip] update to 0.3.3

### DIFF
--- a/ports/kubazip/fix_targets.patch
+++ b/ports/kubazip/fix_targets.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index cf86d70..c2bc2f9 100644
+index 804df5e..5498bb9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,6 +1,6 @@
@@ -8,7 +8,7 @@ index cf86d70..c2bc2f9 100644
 -project(zip
 +project(kubazip
    LANGUAGES C
-   VERSION "0.2.3")
+   VERSION "0.3.0")
  set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 @@ -46,11 +46,11 @@ endif()
  
@@ -24,13 +24,7 @@ index cf86d70..c2bc2f9 100644
    enable_testing()
    add_subdirectory(test)
  endif()
-@@ -69,12 +69,12 @@ if (MSVC)
- elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR
-         "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR
-         "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
--  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic")
-+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic")
- endif (MSVC)
+@@ -74,7 +74,7 @@ endif (MSVC)
  
  ####
  set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")

--- a/ports/kubazip/portfile.cmake
+++ b/ports/kubazip/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kuba--/zip
     REF "v${VERSION}"
-    SHA512 959805452f566b24ee78bc56794403733d19e86885a7f94581fca4218817a65ea4ea8b79457a452e0cc06992dc2165b3ff90360cec5f43cd8c0f934027ee9fd5
+    SHA512 dd516f2e6765e49c00063bd72b49d97bc6f1254921045269b534a801e41e0728171cbf09a73713b236f40c4cf30b5473e74579b82962004b79166b38ad6a3e0d
     HEAD_REF master
     PATCHES
         fix_targets.patch
@@ -18,4 +18,4 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/kubazip)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/UNLICENSE")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/kubazip/vcpkg.json
+++ b/ports/kubazip/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "kubazip",
-  "version": "0.2.6",
+  "version": "0.3.3",
   "description": "A portable, simple zip library written in C",
   "homepage": "https://github.com/kuba--/zip",
-  "license": "Unlicense",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4173,7 +4173,7 @@
       "port-version": 0
     },
     "kubazip": {
-      "baseline": "0.2.6",
+      "baseline": "0.3.3",
       "port-version": 0
     },
     "kubernetes": {
@@ -6580,10 +6580,6 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
-    "orange-math": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "omniorb": {
       "baseline": "4.3.0",
       "port-version": 3
@@ -6823,6 +6819,10 @@
     "opusfile": {
       "baseline": "0.12+20221121",
       "port-version": 1
+    },
+    "orange-math": {
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "orc": {
       "baseline": "2.0.0",

--- a/versions/k-/kubazip.json
+++ b/versions/k-/kubazip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f180298b3a29f98aee261face05569afcf1313e5",
+      "version": "0.3.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "a53b15054c06a67cd7ba9f19e54476893cddad72",
       "version": "0.2.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.