### PR TITLE
[lely-core] new port

### DIFF
--- a/ports/lely-core/portfile.cmake
+++ b/ports/lely-core/portfile.cmake
@@ -1,0 +1,28 @@
+if(VCPKG_TARGET_IS_LINUX)
+    message("${PORT} currently requires the following tools and libraries from the system package manager:\n    autoconf\n    automake\n    libtool\n    \nThese can be installed on Ubuntu systems via apt-get install autoconf automake libtool")
+endif()
+
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.com/
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lely_industries/lely-core
+    REF "v${VERSION}"
+    SHA512 0beab1b5cbc987065c230c8dd5ac2aa16971712478ecb6ad25b3018fc80016f59305e87423fedca8561af5eba782107b418162cc03c568c559417747a64f8a46
+    HEAD_REF master
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS 
+        "--disable-cython"
+        "--disable-python"
+        "--disable-unit-tests"
+        "--disable-tools"
+)
+vcpkg_install_make()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/lely-core/vcpkg.json
+++ b/ports/lely-core/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "lely-core",
+  "version": "2.3.5",
+  "description": "The Lely core libraries are a collection of C and C++ libraries and tools, providing hih-performance I/O and sensor/actuator control for robotics and IoT applications",
+  "homepage": "https://gitlab.com/lely_industries/lely-core",
+  "license": "Apache-2.0",
+  "supports": "linux"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4232,6 +4232,10 @@
       "baseline": "0.2.2",
       "port-version": 2
     },
+    "lely-core": {
+      "baseline": "2.3.5",
+      "port-version": 0
+    },
     "lemon": {
       "baseline": "0",
       "port-version": 2
@@ -6580,10 +6584,6 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
-    "orange-math": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "omniorb": {
       "baseline": "4.3.0",
       "port-version": 3
@@ -6823,6 +6823,10 @@
     "opusfile": {
       "baseline": "0.12+20221121",
       "port-version": 1
+    },
+    "orange-math": {
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "orc": {
       "baseline": "2.0.0",

--- a/versions/l-/lely-core.json
+++ b/versions/l-/lely-core.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f00153462416f845a4e57dac1a8092aba70336be",
+      "version": "2.3.5",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
