### PR TITLE
[cuda-api-wrappers] Updated version from 0.7.1 to 0.8.0

### DIFF
--- a/ports/cuda-api-wrappers/portfile.cmake
+++ b/ports/cuda-api-wrappers/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eyalroz/cuda-api-wrappers
     REF "v${VERSION}"
-    SHA512 5281557d05faa95f25a509a03d331ecf60b881cfbe0d80f560a9a1be1957d5b3b7a9afa99e1ffb35175f30b357fea3103058665f56bcecea55df9efa23179619
+    SHA512 14df77c3d613500e57f223fb692b04ea89c6b6b4ba9ecc1b58059e1b2970acaa8986cb55f3f090d305a3fe6136a83d2a8cf0bb88e02be691456fcef1b1867ef9
     HEAD_REF master
 )
 

--- a/ports/cuda-api-wrappers/usage
+++ b/ports/cuda-api-wrappers/usage
@@ -1,4 +1,4 @@
 cuda-api-wrappers provides CMake targets:
 
   find_package(cuda-api-wrappers CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE cuda-api-wrappers::rtc cuda-api-wrappers::nvtx cuda-api-wrappers::runtime-and-driver)
+  target_link_libraries(main PRIVATE cuda-api-wrappers::rtc cuda-api-wrappers::nvtx cuda-api-wrappers::runtime-and-driver cuda-api-wrappers::fatbin)

--- a/ports/cuda-api-wrappers/vcpkg.json
+++ b/ports/cuda-api-wrappers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cuda-api-wrappers",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Header-only library of integrated wrappers around the core parts of NVIDIA's CUDA execution ecosystem",
   "homepage": "https://github.com/eyalroz/cuda-api-wrappers",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2125,7 +2125,7 @@
       "port-version": 13
     },
     "cuda-api-wrappers": {
-      "baseline": "0.7.1",
+      "baseline": "0.8.0",
       "port-version": 0
     },
     "cudnn": {

--- a/versions/c-/cuda-api-wrappers.json
+++ b/versions/c-/cuda-api-wrappers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11274aecf51310841c0165bc3d3b6c77525dd38e",
+      "version": "0.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e1c89070ea5d1eb68494361a8e3c88fa4a15de77",
       "version": "0.7.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Note: In this version, targets are added which have a `_static` suffix (e.g. `cuda-api-wrappers::rtc_static` in addition to `cuda-api-wrappers::rtc`). As this is a header-only library, nothing gets built anyway - neither dynamic-dependency or static-dependency; the meaning of these is a choice of which NVIDIA library versions to depend on, in a client project when _it_ builds.