### PR TITLE
[sdl3-image] Add new port sdl3-image

### DIFF
--- a/ports/sdl3-image/cmake-sdl3.patch
+++ b/ports/sdl3-image/cmake-sdl3.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/SDL3_imageConfig.cmake.in b/cmake/SDL3_imageConfig.cmake.in
+index db72fd70..d942a698 100644
+--- a/cmake/SDL3_imageConfig.cmake.in
++++ b/cmake/SDL3_imageConfig.cmake.in
+@@ -43,6 +43,8 @@ set(SDLIMAGE_BACKEND_WIC       @SDLIMAGE_BACKEND_WIC@)
+ 
+ set(SDLIMAGE_SDL3_REQUIRED_VERSION  @SDL_REQUIRED_VERSION@)
+ 
++find_package(SDL3 CONFIG REQUIRED)
++
+ set(SDL3_image_SDL3_image-shared_FOUND FALSE)
+ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL3_image-shared-targets.cmake")
+     include("${CMAKE_CURRENT_LIST_DIR}/SDL3_image-shared-targets.cmake")

--- a/ports/sdl3-image/portfile.cmake
+++ b/ports/sdl3-image/portfile.cmake
@@ -1,0 +1,55 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libsdl-org/SDL_image
+    REF "preview-${VERSION}"
+    SHA512 e139fd9474213757f473ca96cb7df78e6b122ac1a0f8b88e66d28955b8ee0390f83ee14dfe4f188aa4ba14b812c5522ce366e61a00609a3079930d68d8233921
+    HEAD_REF main
+    PATCHES
+        cmake-sdl3.patch
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        libjpeg-turbo SDLIMAGE_JPG
+        libwebp       SDLIMAGE_WEBP
+        tiff          SDLIMAGE_TIF
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DSDLIMAGE_BACKEND_IMAGEIO=OFF
+        -DSDLIMAGE_BACKEND_STB=OFF
+        -DSDLIMAGE_DEPS_SHARED=OFF
+        -DSDLIMAGE_SAMPLES=OFF
+        -DSDLIMAGE_VENDORED=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
+    vcpkg_cmake_config_fixup(PACKAGE_NAME SDL3_image CONFIG_PATH cmake)
+elseif(EXISTS "${CURRENT_PACKAGES_DIR}/SDL3_image.framework/Resources")
+    vcpkg_cmake_config_fixup(PACKAGE_NAME SDL3_image CONFIG_PATH SDL3_image.framework/Resources)
+else()
+    vcpkg_cmake_config_fixup(PACKAGE_NAME SDL3_image CONFIG_PATH lib/cmake/SDL3_image)
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+if(NOT VCPKG_TARGET_IS_LINUX AND NOT VCPKG_TARGET_IS_ANDROID AND NOT VCPKG_BUILD_TYPE)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/SDL3-image.pc" "-lSDL3_image" "-lSDL3_imaged")
+endif()
+
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/SDL3_image.framework"
+    "${CURRENT_PACKAGES_DIR}/debug/SDL3_image.framework"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/sdl3-image/usage
+++ b/ports/sdl3-image/usage
@@ -1,0 +1,9 @@
+sdl3-image provides CMake targets:
+
+  find_package(SDL3_image CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SDL3_image::SDL3_image-shared>,SDL3_image::SDL3_image-shared,SDL3_image-static>)
+
+sdl3-image provides pkg-config modules:
+
+  # image loading library for Simple DirectMedia Layer
+  sdl3-image

--- a/ports/sdl3-image/vcpkg.json
+++ b/ports/sdl3-image/vcpkg.json
@@ -1,0 +1,45 @@
+{
+  "name": "sdl3-image",
+  "version": "3.1.0",
+  "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
+  "homepage": "https://github.com/libsdl-org/SDL_image",
+  "license": "Zlib",
+  "dependencies": [
+    "libpng",
+    {
+      "name": "sdl3",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "libjpeg-turbo": {
+      "description": "Support for JPEG image format",
+      "dependencies": [
+        "libjpeg-turbo"
+      ]
+    },
+    "libwebp": {
+      "description": "Support for WEBP image format.",
+      "dependencies": [
+        "libwebp"
+      ]
+    },
+    "tiff": {
+      "description": "Support for TIFF image format",
+      "dependencies": [
+        {
+          "name": "tiff",
+          "default-features": false
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8276,6 +8276,10 @@
       "baseline": "3.1.8-preview",
       "port-version": 0
     },
+    "sdl3-image": {
+      "baseline": "3.1.0",
+      "port-version": 0
+    },
     "seacas": {
       "baseline": "2022-11-22",
       "port-version": 8

--- a/versions/s-/sdl3-image.json
+++ b/versions/s-/sdl3-image.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e5c443cbdf6896a4989f1a0a6034be21c3fc43c0",
+      "version": "3.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add `SDL3-image` port. There already is an `SDL3` port, but none for the relevant components (mixer, ttf, image). Used the [latest 3.x release tag](https://github.com/libsdl-org/SDL_image/releases/tag/preview-3.1.0) (`preview-3.1.0`)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
