### PR TITLE
[deniskovalchuk-libftp] Update to 1.4.1

### DIFF
--- a/ports/deniskovalchuk-libftp/portfile.cmake
+++ b/ports/deniskovalchuk-libftp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO deniskovalchuk/libftp
         REF "v${VERSION}"
-        SHA512 017c809c19e32b0ddb3b4d7f5cc4cb5cc0f27a4c2be0640ddf115d869f9dbfa4b7cc77845193fed9058885bb38d33f0cff436c18c35e9611ca4f299afefe3b9d
+        SHA512 c0fe6f174d0bcb200f7b3a933671f5b6ab63599ba9c7a4cadd2219866d246c0ab11bb9c9bfdfe6bf9adfebb9132c2378c7912cb7cb80489e29c05c9710e839c3
         HEAD_REF master
 )
 

--- a/ports/deniskovalchuk-libftp/vcpkg.json
+++ b/ports/deniskovalchuk-libftp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "deniskovalchuk-libftp",
-  "version": "1.4.0",
-  "port-version": 1,
+  "version": "1.4.1",
   "maintainers": "Denis Kovalchuk <denis.kovalchuk.main@gmail.com>",
   "description": "A cross-platform FTP/FTPS client library based on Boost.Asio.",
   "homepage": "https://github.com/deniskovalchuk/libftp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2277,8 +2277,8 @@
       "port-version": 0
     },
     "deniskovalchuk-libftp": {
-      "baseline": "1.4.0",
-      "port-version": 1
+      "baseline": "1.4.1",
+      "port-version": 0
     },
     "detours": {
       "baseline": "4.0.1",

--- a/versions/d-/deniskovalchuk-libftp.json
+++ b/versions/d-/deniskovalchuk-libftp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2dc10866ab80c071876660752ac03872f0488f00",
+      "version": "1.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "924cd332a49b232bf29e9da835f13fec4567182a",
       "version": "1.4.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.