### PR TITLE
[gumbo] Update to version 0.12.3

### DIFF
--- a/ports/gumbo/portfile.cmake
+++ b/ports/gumbo/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://codeberg.org/gumbo-parser/gumbo-parser/archive/${VERSION}.tar.gz"
     FILENAME "gumbo-${VERSION}.tar.gz"
-    SHA512  258d93c0404b7dc35e1088cded02a394b2cbd0d08f3e7d0a3e32d859c2032efcc831687c7bc749e9bddb60d4f910bab741007bed1117d486a0d3fd194e22f4e7
+    SHA512  15da29bc1b7d70a827870562462ca90fd57469d72d7a4804c59da96c5c46b3a0c50e99a08a80d6e08d2be87f55388c8848918bfbab58ac0c22df85fdc2bd35e7
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gumbo/vcpkg.json
+++ b/ports/gumbo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gumbo",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "An HTML5 parsing library in pure C99",
   "homepage": "https://codeberg.org/gumbo-parser/gumbo-parser",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3353,7 +3353,7 @@
       "port-version": 0
     },
     "gumbo": {
-      "baseline": "0.12.2",
+      "baseline": "0.12.3",
       "port-version": 0
     },
     "gz-cmake3": {
@@ -6580,10 +6580,6 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
-    "orange-math": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "omniorb": {
       "baseline": "4.3.0",
       "port-version": 3
@@ -6823,6 +6819,10 @@
     "opusfile": {
       "baseline": "0.12+20221121",
       "port-version": 1
+    },
+    "orange-math": {
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "orc": {
       "baseline": "2.0.0",

--- a/versions/g-/gumbo.json
+++ b/versions/g-/gumbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34c97da27c275c1657e50d6598c72b8aca5cb8cd",
+      "version": "0.12.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "6496c7f2e0f20c7f2c469d77e29a02877714b96b",
       "version": "0.12.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.