### PR TITLE
[vcpkg baseline][unicorn] Remove from fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1135,7 +1135,6 @@ torch-th:x64-windows-static=fail
 tvision:arm-neon-android=fail
 tvision:arm64-android=fail
 tvision:x64-android=fail
-unicorn:x64-windows-static-md=fail
 # Proper support for a true static usd build is left as a future port improvement. It probably require fiddling with its monolithic mode.
 usd:x64-windows-static=skip
 # needs android-24


### PR DESCRIPTION
Passing on  https://dev.azure.com/vcpkg/public/_build/results?buildId=110634&view=results

`PASSING, REMOVE FROM FAIL LIST: unicorn:x64-windows-static-md`
Added unicorn:x64-windows-static-md=fail to ci.baseline.txt by https://github.com/microsoft/vcpkg/pull/31155. This issue is now fixed by https://github.com/microsoft/vcpkg/pull/42578.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~
