### PR TITLE
[libheif] Fix compilation errors using gcc8

### DIFF
--- a/ports/libheif/fix-gcc8.patch
+++ b/ports/libheif/fix-gcc8.patch
@@ -1,0 +1,33 @@
+diff --git a/libheif/bitstream.cc b/libheif/bitstream.cc
+index 9063718..f459fcc 100644
+--- a/libheif/bitstream.cc
++++ b/libheif/bitstream.cc
+@@ -25,6 +25,12 @@
+ #include <cassert>
+ #include <bit>
+ 
++#if ((defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && !defined(__PGI)) && __GNUC__ < 9) || (defined(__clang__) && __clang_major__ < 10)
++#include <type_traits>
++#else
++#include <bit>
++#endif
++
+ #define MAX_UVLC_LEADING_ZEROS 20
+ 
+ #define AVOID_FUZZER_FALSE_POSITIVE 0
+diff --git a/libheif/codecs/uncompressed/decoder_abstract.cc b/libheif/codecs/uncompressed/decoder_abstract.cc
+index bbe4692..3c9aacd 100644
+--- a/libheif/codecs/uncompressed/decoder_abstract.cc
++++ b/libheif/codecs/uncompressed/decoder_abstract.cc
+@@ -35,6 +35,11 @@
+ #include "unc_codec.h"
+ #include "decoder_abstract.h"
+ 
++#if ((defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && !defined(__PGI)) && __GNUC__ < 9) || (defined(__clang__) && __clang_major__ < 10)
++#include <type_traits>
++#else
++#include <bit>
++#endif
+ 
+ AbstractDecoder::AbstractDecoder(uint32_t width, uint32_t height, const std::shared_ptr<Box_cmpd> cmpd, const std::shared_ptr<Box_uncC> uncC) :
+     m_width(width),

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         gdk-pixbuf.patch
+        fix-gcc8.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libheif",
   "version": "1.19.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4658,7 +4658,7 @@
     },
     "libheif": {
       "baseline": "1.19.5",
-      "port-version": 1
+      "port-version": 2
     },
     "libhsplasma": {
       "baseline": "2024-03-07",
@@ -6580,10 +6580,6 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
-    "orange-math": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "omniorb": {
       "baseline": "4.3.0",
       "port-version": 3
@@ -6823,6 +6819,10 @@
     "opusfile": {
       "baseline": "0.12+20221121",
       "port-version": 1
+    },
+    "orange-math": {
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "orc": {
       "baseline": "2.0.0",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ecd6b2d082b2b4c294587aaabb0c53b7e1d87f5c",
+      "version": "1.19.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "b714664a4550bae5edc9fbe655f0ce057ac9e67e",
       "version": "1.19.5",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/42833

Fixed using upstream [patch](https://github.com/strukturag/libheif/commit/81cc81ae5145349d9ac42baecf3278f65c3d414d).

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Compile test pass with following triplets:
```
x64-linux
x64-windows
```