### PR TITLE
[tinyexr] Bump to 1.0.9

### DIFF
--- a/ports/tinyexr/fixtargets.patch
+++ b/ports/tinyexr/fixtargets.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6d03e7e..be416f5 100644
+index b7f97b0..2afd0e0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -7,6 +7,20 @@ set(SAMPLE_TARGET "test_tinyexr")
@@ -40,13 +40,13 @@ index 6d03e7e..be416f5 100644
 @@ -43,7 +54,7 @@ target_link_libraries(${BUILD_TARGET} ${TINYEXR_EXT_LIBRARIES} ${CMAKE_DL_LIBS})
  
  # Increase warning level for clang.
- IF (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
--  set_source_files_properties(${TINYEXR_SOURCES} PROPERTIES COMPILE_FLAGS "-Weverything -Werror -Wno-padded -Wno-c++98-compat-pedantic -Wno-documentation -Wno-unused-member-function")
-+  set_source_files_properties(${TINYEXR_SOURCES} PROPERTIES COMPILE_FLAGS "-Weverything -Wno-padded -Wno-c++98-compat-pedantic -Wno-documentation -Wno-unused-member-function")
- ENDIF ()
- 
- if (TINYEXR_BUILD_SAMPLE)
-@@ -72,3 +83,32 @@ if (TINYEXR_BUILD_SAMPLE)
+ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT MSVC)
+-  set(CLANG_COMPILE_FLAGS "-Weverything -Werror -Wno-padded -Wno-c++98-compat-pedantic -Wno-documentation -Wno-unused-member-function")
++  set(CLANG_COMPILE_FLAGS "-Weverything -Wno-padded -Wno-c++98-compat-pedantic -Wno-documentation -Wno-unused-member-function")
+   if (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 16)
+     set(CLANG_COMPILE_FLAGS "${CLANG_COMPILE_FLAGS} -Wno-unsafe-buffer-usage")
+   endif()
+@@ -76,3 +87,32 @@ if (TINYEXR_BUILD_SAMPLE)
    endif(WIN32)
  
  endif (TINYEXR_BUILD_SAMPLE)

--- a/ports/tinyexr/portfile.cmake
+++ b/ports/tinyexr/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO syoyo/tinyexr
     REF "v${VERSION}"
-    SHA512 583404c77009ec88d75accf006f90ee8972d2205bbae41e460d2cbb9a54d9382735a82eba0657fcc5f4e8b3b0fadd51449cec440529570e75c307eb7f0fcc8fb
+    SHA512 19187cbd703c7a2f9e5322a123453cbd56d2b842d1e8f026831d405e9356b8f2a7fde5a2c6b601ee3a28f0a00293d635245b8b70bf03375cce56b5b816d5d54a
     HEAD_REF master
     PATCHES
         fixtargets.patch

--- a/ports/tinyexr/vcpkg.json
+++ b/ports/tinyexr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyexr",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Library to load and save OpenEXR(.exr) images",
   "homepage": "https://github.com/syoyo/tinyexr",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6580,10 +6580,6 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
-    "orange-math": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "omniorb": {
       "baseline": "4.3.0",
       "port-version": 3
@@ -6823,6 +6819,10 @@
     "opusfile": {
       "baseline": "0.12+20221121",
       "port-version": 1
+    },
+    "orange-math": {
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "orc": {
       "baseline": "2.0.0",
@@ -8993,7 +8993,7 @@
       "port-version": 2
     },
     "tinyexr": {
-      "baseline": "1.0.8",
+      "baseline": "1.0.9",
       "port-version": 0
     },
     "tinyfiledialogs": {

--- a/versions/t-/tinyexr.json
+++ b/versions/t-/tinyexr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d2b22b1785f27ed281bc1d3da4e3853e0c4846f5",
+      "version": "1.0.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "8912e0ebb371923d28ba6a2cc8ab5ecd47957e51",
       "version": "1.0.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
