### PR TITLE
[thrift] Bump to 0.21.0

### DIFF
--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/thrift
     REF "v${VERSION}"
-    SHA512 5e4ee9870b30fe5ba484d39781c435716f7f3903793dc8aae96594ca813b1a5a73363b84719038ca8fa3ab8ef0a419a28410d936ff7b3bbadf36fc085a6883ae
+    SHA512 39566b7ecae7ae159822ee1c2c03a7af9ba6e228c3bbecea4079bdbd2332b42f03f79af08303a2685d04723f996d230cf95e5afc4d2a3880158a80429e21c190
     HEAD_REF master
     PATCHES
       "correct-paths.patch"

--- a/ports/thrift/vcpkg.json
+++ b/ports/thrift/vcpkg.json
@@ -10,6 +10,7 @@
     "boost-range",
     "boost-scope-exit",
     "boost-smart-ptr",
+    "boost-uuid",
     "libevent",
     "openssl",
     {

--- a/ports/thrift/vcpkg.json
+++ b/ports/thrift/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "thrift",
-  "version": "0.20.0",
-  "port-version": 1,
+  "version": "0.21.0",
   "description": "Apache Thrift is a software project spanning a variety of programming languages and use cases. Our goal is to make reliable, performant communication and data serialization across languages as efficient and seamless as possible.",
   "homepage": "https://github.com/apache/thrift",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6580,10 +6580,6 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
-    "orange-math": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "omniorb": {
       "baseline": "4.3.0",
       "port-version": 3
@@ -6823,6 +6819,10 @@
     "opusfile": {
       "baseline": "0.12+20221121",
       "port-version": 1
+    },
+    "orange-math": {
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "orc": {
       "baseline": "2.0.0",
@@ -8937,8 +8937,8 @@
       "port-version": 3
     },
     "thrift": {
-      "baseline": "0.20.0",
-      "port-version": 1
+      "baseline": "0.21.0",
+      "port-version": 0
     },
     "tidy-html5": {
       "baseline": "5.8.0",

--- a/versions/t-/thrift.json
+++ b/versions/t-/thrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "79207b69ed9c144d3f037664d50e2e6fbd8d4752",
+      "version": "0.21.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "13757a6b05741cf3c9c39e3a1dcc5e5cd685e025",
       "version": "0.20.0",
       "port-version": 1

--- a/versions/t-/thrift.json
+++ b/versions/t-/thrift.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "79207b69ed9c144d3f037664d50e2e6fbd8d4752",
+      "git-tree": "715b9d757e886ab578d7f006132f980616a036b0",
       "version": "0.21.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
