### PR TITLE
[stringzilla] Bump to 3.11.2

### DIFF
--- a/ports/stringzilla/portfile.cmake
+++ b/ports/stringzilla/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/StringZilla
     REF "v${VERSION}"
-    SHA512 a97ed147be78164b01e61ff4aeae8efb8eba23204edf48ed7701786cbc85b8c6d09f1802aa3cf0f65ca140bdccb4e8c3518a56b2b910466fc8d040f2b0293716
+    SHA512 7f1f3c0df25232cc688bdbed966a4ef6a6050dcf43d1b38b11723051c728e0244e889a8eefc8bdf5dca144c847c924a35fe4512c02f219d9d5430eed46d3f684
     HEAD_REF master
 )
 

--- a/ports/stringzilla/vcpkg.json
+++ b/ports/stringzilla/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "name": "stringzilla",
-  "version": "3.10.5",
+  "version": "3.11.2",
   "description": "StringZilla is the GodZilla of string libraries, using SIMD and SWAR to accelerate string operations on modern CPUs.",
   "homepage": "https://github.com/ashvardanian/StringZilla",
-  "license": "Apache-2.0",
-  "supports": "!x86"
+  "license": "Apache-2.0"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6580,10 +6580,6 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
-    "orange-math": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "omniorb": {
       "baseline": "4.3.0",
       "port-version": 3
@@ -6823,6 +6819,10 @@
     "opusfile": {
       "baseline": "0.12+20221121",
       "port-version": 1
+    },
+    "orange-math": {
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "orc": {
       "baseline": "2.0.0",
@@ -8765,7 +8765,7 @@
       "port-version": 1
     },
     "stringzilla": {
-      "baseline": "3.10.5",
+      "baseline": "3.11.2",
       "port-version": 0
     },
     "strong-type": {

--- a/versions/s-/stringzilla.json
+++ b/versions/s-/stringzilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44759b36165dad1d7e3830ea05394bc7e3b41107",
+      "version": "3.11.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "19c1fcc087b436864ea6093cd182a5df96dcd408",
       "version": "3.10.5",
       "port-version": 0

--- a/versions/s-/stringzilla.json
+++ b/versions/s-/stringzilla.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "44759b36165dad1d7e3830ea05394bc7e3b41107",
+      "git-tree": "80deb7c3d14c69c599962518556c3932f636183e",
       "version": "3.11.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

