### PR TITLE
[imgui] Bump to 1.91.6

### DIFF
--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -5,7 +5,7 @@ if ("docking-experimental" IN_LIST FEATURES)
         OUT_SOURCE_PATH SOURCE_PATH
         REPO ocornut/imgui
         REF "v${VERSION}-docking"
-        SHA512 2864672d3b08caf3396f69affe1b83d7977d2300f571864378ebe5b4a1a1b5634e6e171c8870444b7f8947fdc681aeaf07f59b25a290c94059d36226fc7e1aad
+        SHA512 5d1849867475c24dea51254bde945e919938b4fa2aac218e35a9371d3f48d8fc486ac4e459e9a0c3d36526f18972ac3ac292581aa831ca54efb3d640c6e156b1
         HEAD_REF docking
     )
 else()
@@ -13,7 +13,7 @@ else()
         OUT_SOURCE_PATH SOURCE_PATH
         REPO ocornut/imgui
         REF "v${VERSION}"
-        SHA512 85ced14d0c4c3506caf0cff5897dc2c49521fe6de5bcadbc1107e2b63d6bd9a19f967960ba31206187fc2c830246f635e8f2b29b0b1ff522be209dd2a5349529
+        SHA512 eef35ba9f7e39ddeff3e2df0eef77d3cd8602115cb42a6fad274aecf4d5e6922c43ea4fab37908729df00a3d3e69c5000b21b46b23ed18891fb899e6b9807feb
         HEAD_REF master
     )
 endif()

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.91.5",
+  "version": "1.91.6",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3697,7 +3697,7 @@
       "port-version": 0
     },
     "imgui": {
-      "baseline": "1.91.5",
+      "baseline": "1.91.6",
       "port-version": 0
     },
     "imgui-node-editor": {
@@ -6580,10 +6580,6 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
-    "orange-math": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "omniorb": {
       "baseline": "4.3.0",
       "port-version": 3
@@ -6823,6 +6819,10 @@
     "opusfile": {
       "baseline": "0.12+20221121",
       "port-version": 1
+    },
+    "orange-math": {
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "orc": {
       "baseline": "2.0.0",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "61d143dfebf9b720272a52d1d78a3082590f948a",
+      "version": "1.91.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "1b5f147821dea003ee9d733b40bfff23e2c40f04",
       "version": "1.91.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
