### PR TITLE
[itpp] Fix runtime errors

### DIFF
--- a/ports/itpp/fix-build.patch
+++ b/ports/itpp/fix-build.patch
@@ -1,0 +1,14 @@
+diff --git a/itpp/base/mat.cpp b/itpp/base/mat.cpp
+index 9f2a20e..11b0a58 100644
+--- a/itpp/base/mat.cpp
++++ b/itpp/base/mat.cpp
+@@ -173,8 +173,7 @@ cmat operator*(const cmat &m1, const cmat &m2)
+ template<>
+ mat operator*(const mat &m1, const mat &m2)
+ {
+-  it_assert_debug(m1.rows() == m2.cols(),
+-                  "Mat<>::operator*(): Wrong sizes");
++  it_assert_debug(m1.cols() == m2.rows(), "cmat::operator*(): Wrong sizes");
+   mat r(m1.rows(), m2.cols());
+   double *tr = r._data();
+   const double *t1;

--- a/ports/itpp/portfile.cmake
+++ b/ports/itpp/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_sourceforge(
         fix-uwp.patch
         fix-linux.patch
         rename-version.patch
-		fix-build.patch
+        fix-build.patch
 )
 file(RENAME "${SOURCE_PATH}/VERSION" "${SOURCE_PATH}/VERSION.txt")
 

--- a/ports/itpp/portfile.cmake
+++ b/ports/itpp/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_sourceforge(
         fix-uwp.patch
         fix-linux.patch
         rename-version.patch
+		fix-build.patch
 )
 file(RENAME "${SOURCE_PATH}/VERSION" "${SOURCE_PATH}/VERSION.txt")
 
@@ -33,6 +34,6 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 vcpkg_fixup_pkgconfig()

--- a/ports/itpp/vcpkg.json
+++ b/ports/itpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "itpp",
   "version-semver": "4.3.1",
-  "port-version": 11,
+  "port-version": 12,
   "description": "IT++ is a C++ library of mathematical, signal processing and communication classes and functions. Its main use is in simulation of communication systems and for performing research in the area of communications.",
   "homepage": "http://itpp.sourceforge.net",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3798,7 +3798,7 @@
     },
     "itpp": {
       "baseline": "4.3.1",
-      "port-version": 11
+      "port-version": 12
     },
     "itsy-bitsy": {
       "baseline": "2022-08-02",
@@ -6580,10 +6580,6 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
-    "orange-math": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "omniorb": {
       "baseline": "4.3.0",
       "port-version": 3
@@ -6823,6 +6819,10 @@
     "opusfile": {
       "baseline": "0.12+20221121",
       "port-version": 1
+    },
+    "orange-math": {
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "orc": {
       "baseline": "2.0.0",

--- a/versions/i-/itpp.json
+++ b/versions/i-/itpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c08ca0916e36ffc36b592b15b0d6ddd737a14ae6",
+      "git-tree": "90c2b246877a97ce4ee4b4f5b7aa55714ac715fd",
       "version-semver": "4.3.1",
       "port-version": 12
     },

--- a/versions/i-/itpp.json
+++ b/versions/i-/itpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c08ca0916e36ffc36b592b15b0d6ddd737a14ae6",
+      "version-semver": "4.3.1",
+      "port-version": 12
+    },
+    {
       "git-tree": "deb799807d61211af72ccc732eea3950b2d52b4c",
       "version-semver": "4.3.1",
       "port-version": 11


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/42855
```
./test
*** Assertion failed in /mnt/vcpkg/buildtrees/itpp/src/itpp-4-85e4b0a512.clean/itpp/base/mat.cpp on line 176:
Mat<>::operator*(): Wrong sizes (m1.rows() == m2.cols())
Aborted (core dumped)
```
Fix runtime errors using upstream code.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test passed with x64-linux triplet.