### PR TITLE
[nanoprintf] Bump to 0.5.3

### DIFF
--- a/ports/nanoprintf/portfile.cmake
+++ b/ports/nanoprintf/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO charlesnicholson/nanoprintf
     REF "v${VERSION}"
-    SHA512 a82da24fcd176c385c8c2d1666416bcbafc3bf3e1b9e1365c8ffd7a0158485c7af6b0dbf7cd0821a7af55238784cd682a0f22fe37527b91ea3f3eaa702c61c46
+    SHA512 4b0dffdbb0dc98b5e48b6f0d1d8a39407899a1601a47a4688879c6d47398c65bbe11ae4a06f70ee66d5c600ca0fad859cd11359be906181c722479555ec05ae1
     HEAD_REF master
 )
 

--- a/ports/nanoprintf/vcpkg.json
+++ b/ports/nanoprintf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoprintf",
-  "version": "0.3.4",
+  "version": "0.5.3",
   "description": "A tiny embeddable printf replacement written in C99",
   "homepage": "https://github.com/charlesnicholson/nanoprintf"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6269,7 +6269,7 @@
       "port-version": 0
     },
     "nanoprintf": {
-      "baseline": "0.3.4",
+      "baseline": "0.5.3",
       "port-version": 0
     },
     "nanorange": {
@@ -6580,10 +6580,6 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
-    "orange-math": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "omniorb": {
       "baseline": "4.3.0",
       "port-version": 3
@@ -6823,6 +6819,10 @@
     "opusfile": {
       "baseline": "0.12+20221121",
       "port-version": 1
+    },
+    "orange-math": {
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "orc": {
       "baseline": "2.0.0",

--- a/versions/n-/nanoprintf.json
+++ b/versions/n-/nanoprintf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d7428d888aabcb615d9a06f699611d0cb9227fc6",
+      "version": "0.5.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "88e688e729a34f99b0ec4185786fb67fb9fda107",
       "version": "0.3.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
