### PR TITLE
[bddisasm] Bump to 2.2.0

### DIFF
--- a/ports/bddisasm/portfile.cmake
+++ b/ports/bddisasm/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bitdefender/bddisasm
     REF "v${VERSION}"
-    SHA512 254aa303f5957327de85715cc05c8bcf33f27bd18ad90959a74b2d817ee393d672878d66c83de63c9ec1e6d65df7ae2657e3a585ead24dbc093a035a7daeea4a
+    SHA512 5c1b8b8b9a29db76ce6197674e662fdc526e89372a84f7fac8e74cf4cc53bfab8d55c096cdb3f344fcfaa6a4d54a5bef79e8f1cf9131e497636072523b2cf3ec
     HEAD_REF master
 )
 

--- a/ports/bddisasm/vcpkg.json
+++ b/ports/bddisasm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bddisasm",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "maintainers": "Cristi Anichitei <ianichitei@bitdefender.com>",
   "description": "bddisasm is a fast, lightweight, x86/x64 instruction decoder and emulator.",
   "homepage": "https://github.com/bitdefender/bddisasm",

--- a/versions/b-/bddisasm.json
+++ b/versions/b-/bddisasm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "67bc59a4afc477abcc19ae1d0dcc5c4e4884aea6",
+      "version": "2.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f7a110ba4cae651ef869f470e1165ab60e903aeb",
       "version": "2.1.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -573,7 +573,7 @@
       "port-version": 3
     },
     "bddisasm": {
-      "baseline": "2.1.5",
+      "baseline": "2.2.0",
       "port-version": 0
     },
     "bde": {
@@ -6580,10 +6580,6 @@
       "baseline": "1.5.1",
       "port-version": 1
     },
-    "orange-math": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "omniorb": {
       "baseline": "4.3.0",
       "port-version": 3
@@ -6823,6 +6819,10 @@
     "opusfile": {
       "baseline": "0.12+20221121",
       "port-version": 1
+    },
+    "orange-math": {
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "orc": {
       "baseline": "2.0.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
