### PR TITLE
[gmime] Enable library to be built and used in linux

### DIFF
--- a/ports/gmime/config-linux.h
+++ b/ports/gmime/config-linux.h
@@ -1,0 +1,7 @@
+#define HAVE_GETHOSTNAME 1
+#define HAVE_GETADDRINFO 1
+#define HAVE_NETDB_H 1
+#define LIBIDN 1
+#define HAVE_FSYNC 1
+
+#define ssize_t intptr_t

--- a/ports/gmime/portfile.cmake
+++ b/ports/gmime/portfile.cmake
@@ -18,9 +18,15 @@ vcpkg_extract_source_archive(
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 # We can use file supplied with original sources
-configure_file("${SOURCE_PATH}/build/vs2017/unistd.h" "${SOURCE_PATH}" COPYONLY)
-configure_file("${SOURCE_PATH}/build/vs2017/config.h" "${SOURCE_PATH}" COPYONLY)
-configure_file("${SOURCE_PATH}/build/vs2017/gmime.def" "${SOURCE_PATH}" COPYONLY)
+if(VCPKG_TARGET_IS_WINDOWS)
+    configure_file("${SOURCE_PATH}/build/vs2017/unistd.h" "${SOURCE_PATH}" COPYONLY)
+    configure_file("${SOURCE_PATH}/build/vs2017/config.h" "${SOURCE_PATH}" COPYONLY)
+    configure_file("${SOURCE_PATH}/build/vs2017/gmime.def" "${SOURCE_PATH}" COPYONLY)
+else()
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/config-linux.h "${SOURCE_PATH}/config.h" COPYONLY)
+endif()
+
+
 vcpkg_find_acquire_program(PKGCONFIG)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/gmime/vcpkg.json
+++ b/ports/gmime/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gmime",
   "version": "3.2.6",
-  "port-version": 6,
+  "port-version": 7,
   "description": "GMime is a C/C++ library which may be used for the creation and parsing of messages using the Multipurpose Internet Mail Extension (MIME).",
   "homepage": "https://developer.gnome.org/gmime/",
   "license": "LGPL-2.1-or-later",

--- a/ports/gmime/vcpkg.json
+++ b/ports/gmime/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "GMime is a C/C++ library which may be used for the creation and parsing of messages using the Multipurpose Internet Mail Extension (MIME).",
   "homepage": "https://developer.gnome.org/gmime/",
   "license": "LGPL-2.1-or-later",
-  "supports": "windows & !xbox",
+  "supports": "(linux & x64) | (windows & !xbox)",
   "dependencies": [
     "glib",
     "libiconv",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3194,7 +3194,7 @@
     },
     "gmime": {
       "baseline": "3.2.6",
-      "port-version": 6
+      "port-version": 7
     },
     "gmmlib": {
       "baseline": "22.5.2",

--- a/versions/g-/gmime.json
+++ b/versions/g-/gmime.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eff4c5cfc721a3f1e23cf22c5fd7fc0cad6c4f1d",
+      "version": "3.2.6",
+      "port-version": 7
+    },
+    {
       "git-tree": "93e8b6f02474e1edb7e99db85020d864ee071ce0",
       "version": "3.2.6",
       "port-version": 6


### PR DESCRIPTION
This patch updates the port to enable the library to be built and used in Linux. Only the x64 platform has been tested.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [X] Only one version is added to each modified port's versions file.

