### PR TITLE
[libical] Update to 3.0.19

### DIFF
--- a/ports/libical/portfile.cmake
+++ b/ports/libical/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libical/libical
     REF "v${VERSION}"
-    SHA512 53ecf6c14a68d569dd11bfdeb1a072def847a14d189c6af16eab202e004350ee7d9488c6b63e9cb67889e8c2dec90643fef46aec143a915f28270d0752eaa9d5
+    SHA512 32e5cac219801b40d8691deae6efae6fdaa64ca0968a72af5b27647958d44d79626c26c4e3675cfb284c2f1039c237c61ba2dd6030e9b1ea6a9d69296424240d
 )
 
 vcpkg_find_acquire_program(PERL)
@@ -39,4 +39,4 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libical/vcpkg.json
+++ b/ports/libical/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libical",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "description": "Reference implementation of the iCalendar data type and serialization format",
   "homepage": "https://github.com/libical/libical",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4673,7 +4673,7 @@
       "port-version": 0
     },
     "libical": {
-      "baseline": "3.0.18",
+      "baseline": "3.0.19",
       "port-version": 0
     },
     "libice": {

--- a/versions/l-/libical.json
+++ b/versions/l-/libical.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d8962c7ef4bbfbdb942c83ec6af0a283b086110",
+      "version": "3.0.19",
+      "port-version": 0
+    },
+    {
       "git-tree": "4ccfb365a99b0784a89dedeedc3d78d876606afe",
       "version": "3.0.18",
       "port-version": 0


### PR DESCRIPTION
Fixes #42894

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

All features passed with following triplets:
```
x86-windows
x64-windows
```
Usage test passed on `x64-windows`.