### PR TITLE
[7zip] restore missing sources and fix compilation on android

### DIFF
--- a/ports/7zip/CMakeLists.txt
+++ b/ports/7zip/CMakeLists.txt
@@ -179,6 +179,16 @@ target_sources(7zip PRIVATE
     CPP/7zip/Common/UniqBlocks.cpp
     CPP/7zip/Common/VirtThread.cpp
 
+    CPP/Windows/FileDir.cpp
+    CPP/Windows/FileFind.cpp
+    CPP/Windows/FileIO.cpp
+    CPP/Windows/FileName.cpp
+    CPP/Windows/PropVariant.cpp
+    CPP/Windows/PropVariantUtils.cpp
+    CPP/Windows/Synchronization.cpp
+    CPP/Windows/System.cpp
+    CPP/Windows/TimeUtils.cpp
+
     CPP/7zip/Archive/ApmHandler.cpp
     CPP/7zip/Archive/ArHandler.cpp
     CPP/7zip/Archive/ArjHandler.cpp
@@ -299,20 +309,6 @@ target_sources(7zip PRIVATE
     CPP/7zip/Archive/Archive2.def
     C/Util/LzmaLib/LzmaLib.def
 )
-
-if(WIN32)
-    target_sources(7zip PRIVATE
-        CPP/Windows/FileDir.cpp
-        CPP/Windows/FileFind.cpp
-        CPP/Windows/FileIO.cpp
-        CPP/Windows/FileName.cpp
-        CPP/Windows/PropVariant.cpp
-        CPP/Windows/PropVariantUtils.cpp
-        CPP/Windows/Synchronization.cpp
-        CPP/Windows/System.cpp
-        CPP/Windows/TimeUtils.cpp
-    )
-endif()
 
 # 7zCrcOpt
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/7zip/fix_timespec_get_broken_on_android.patch
+++ b/ports/7zip/fix_timespec_get_broken_on_android.patch
@@ -1,0 +1,13 @@
+diff --git a/CPP/Windows/TimeUtils.cpp b/CPP/Windows/TimeUtils.cpp
+index bbd79ba..8df3ea3 100644
+--- a/CPP/Windows/TimeUtils.cpp
++++ b/CPP/Windows/TimeUtils.cpp
+@@ -259,7 +259,7 @@ bool GetSecondsSince1601(unsigned year, unsigned month, unsigned day,
+       Minix 3.1.8, AIX 7.1, HP-UX 11.31, IRIX 6.5, Solaris 11.3,
+       Cygwin 2.9, mingw, MSVC 14, Android 9.0.
+ */
+-#if defined(TIME_UTC)
++#if defined(TIME_UTC) && (!defined(__ANDROID__) || __ANDROID_API__ < 18)
+ #define ZIP7_USE_timespec_get
+ // #pragma message("ZIP7_USE_timespec_get")
+ #elif defined(CLOCK_REALTIME)

--- a/ports/7zip/fix_timespec_get_broken_on_android.patch
+++ b/ports/7zip/fix_timespec_get_broken_on_android.patch
@@ -7,7 +7,7 @@ index bbd79ba..8df3ea3 100644
        Cygwin 2.9, mingw, MSVC 14, Android 9.0.
  */
 -#if defined(TIME_UTC)
-+#if defined(TIME_UTC) && (!defined(__ANDROID__) || __ANDROID_API__ < 18)
++#if defined(TIME_UTC) && (!defined(__ANDROID__) || __ANDROID_API__ >= 29)
  #define ZIP7_USE_timespec_get
  // #pragma message("ZIP7_USE_timespec_get")
  #elif defined(CLOCK_REALTIME)

--- a/ports/7zip/portfile.cmake
+++ b/ports/7zip/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 dc0241ed96907965445550912d1171fe32230a52997b089558a4cc73a662fc6a17940db8dcb0794b805268964899d9e5a48ddb444e92b56fd243bbaa17c20a1c
     HEAD_REF main
+    PATCHES
+        fix_timespec_get_broken_on_android.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/7zip/portfile.cmake
+++ b/ports/7zip/portfile.cmake
@@ -9,9 +9,6 @@ vcpkg_from_github(
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/7zip-config.cmake.in" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_cmake_get_vars(cmake_vars_file)
-include("${cmake_vars_file}")
-
 if(VCPKG_TARGET_IS_ANDROID)
     message(STATUS "Disable TIME_UTC on android")
     vcpkg_replace_string("${SOURCE_PATH}/CPP/Windows/TimeUtils.cpp"

--- a/ports/7zip/portfile.cmake
+++ b/ports/7zip/portfile.cmake
@@ -9,6 +9,17 @@ vcpkg_from_github(
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/7zip-config.cmake.in" DESTINATION "${SOURCE_PATH}")
 
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+
+if(VCPKG_TARGET_IS_ANDROID)
+    message(STATUS "Disable TIME_UTC on android")
+    vcpkg_replace_string("${SOURCE_PATH}/CPP/Windows/TimeUtils.cpp"
+        [[if defined(TIME_UTC)]]
+        [[if defined(TIME_UTC) && !defined(__ANDROID__)]]
+    )
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )

--- a/ports/7zip/portfile.cmake
+++ b/ports/7zip/portfile.cmake
@@ -9,14 +9,6 @@ vcpkg_from_github(
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/7zip-config.cmake.in" DESTINATION "${SOURCE_PATH}")
 
-if(VCPKG_TARGET_IS_ANDROID)
-    message(STATUS "Disable TIME_UTC on android")
-    vcpkg_replace_string("${SOURCE_PATH}/CPP/Windows/TimeUtils.cpp"
-        [[if defined(TIME_UTC)]]
-        [[if defined(TIME_UTC) && !defined(__ANDROID__)]]
-    )
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )

--- a/ports/7zip/vcpkg.json
+++ b/ports/7zip/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "7zip",
   "version-string": "24.09",
+  "port-version": 1,
   "description": "Library for archiving file with a high compression ratio.",
   "homepage": "https://www.7-zip.org",
   "license": "LGPL-2.1-or-later",

--- a/ports/7zip/vcpkg.json
+++ b/ports/7zip/vcpkg.json
@@ -14,10 +14,6 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-get-vars",
-      "host": true
     }
   ]
 }

--- a/ports/7zip/vcpkg.json
+++ b/ports/7zip/vcpkg.json
@@ -14,6 +14,10 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
     }
   ]
 }

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5ad1af60bfd9198f2f12a029c3e54b3f615cb439",
+      "git-tree": "68564a79f07645b24c9267fef692229c7a888559",
       "version-string": "24.09",
       "port-version": 1
     },

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e45c7adcc2c515eb76c4729d44e4d2d271535774",
+      "git-tree": "8ed8294e7f88b2298a05eef56cdd6f8361aa1509",
       "version-string": "24.09",
       "port-version": 1
     },

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e45c7adcc2c515eb76c4729d44e4d2d271535774",
+      "version-string": "24.09",
+      "port-version": 1
+    },
+    {
       "git-tree": "29a42acc927078e1dc58fbbf354d1c59e01d0a03",
       "version-string": "24.09",
       "port-version": 0

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8ed8294e7f88b2298a05eef56cdd6f8361aa1509",
+      "git-tree": "5ad1af60bfd9198f2f12a029c3e54b3f615cb439",
       "version-string": "24.09",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6,7 +6,7 @@
     },
     "7zip": {
       "baseline": "24.09",
-      "port-version": 0
+      "port-version": 1
     },
     "ableton": {
       "baseline": "3.0.6",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

Fixes #42910 

References #41721, #41743