### PR TITLE
[g2o] Add feature spdlog

### DIFF
--- a/ports/g2o/0003-dependency-spdlog.diff
+++ b/ports/g2o/0003-dependency-spdlog.diff
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c2b0a09b..2645ff66 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -177,7 +177,8 @@ find_package(QGLViewer)
+ option(G2O_USE_LOGGING "Try to use spdlog for logging" ON)
+ set(G2O_HAVE_LOGGING 0)
+ if (G2O_USE_LOGGING)
+-  find_package(spdlog 1.6 QUIET)
++  find_package(spdlog 1.6 REQUIRED CONFIG)
++  set(G2O_HAVE_LOGGING 1)
+   if (TARGET spdlog::spdlog OR TARGET spdlog::spdlog_header_only)
+     set(G2O_HAVE_LOGGING 1)
+     message(STATUS "Compiling with logging support")

--- a/ports/g2o/portfile.cmake
+++ b/ports/g2o/portfile.cmake
@@ -7,14 +7,21 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-absolute.patch
+        0003-dependency-spdlog.diff
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_LGPL_SHARED_LIBS)
 file(REMOVE "${SOURCE_PATH}/cmake_modules/FindBLAS.cmake")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        spdlog      G2O_USE_LOGGING
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBUILD_LGPL_SHARED_LIBS=${BUILD_LGPL_SHARED_LIBS}
         -DG2O_BUILD_EXAMPLES=OFF
         -DG2O_BUILD_APPS=OFF

--- a/ports/g2o/vcpkg.json
+++ b/ports/g2o/vcpkg.json
@@ -1,14 +1,13 @@
 {
   "name": "g2o",
   "version-date": "2024-12-14",
-  "port-version": 1,
+  "port-version": 2,
   "description": "g2o: A General Framework for Graph Optimization",
   "homepage": "https://openslam.org/g2o.html",
   "dependencies": [
     "ceres",
     "eigen3",
     "lapack",
-    "spdlog",
     "suitesparse",
     {
       "name": "vcpkg-cmake",
@@ -18,5 +17,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "spdlog": {
+      "description": "Use spdlog for logging",
+      "dependencies": [
+        "spdlog"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2986,7 +2986,7 @@
     },
     "g2o": {
       "baseline": "2024-12-14",
-      "port-version": 1
+      "port-version": 2
     },
     "g3log": {
       "baseline": "2.4",

--- a/versions/g-/g2o.json
+++ b/versions/g-/g2o.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c1f1836df83234a33a1f96cb292331f45f1650f",
+      "version-date": "2024-12-14",
+      "port-version": 2
+    },
+    {
       "git-tree": "a4cbc27e6ebb4c53963c9cff2b686ea4dc12e4d3",
       "version-date": "2024-12-14",
       "port-version": 1


### PR DESCRIPTION
Fix https://dev.azure.com/vcpkg/public/_build/results?buildId=110837&view=logs&j=f79cfdd7-47a8-597f-8f57-dc3e21a8f2ad&t=4f03addf-ef5a-50a2-71be-19894d9df4e3, `rtabmap` failed with `g2o` optional dependency `spdlog`.

Add feature `spdlog` depend on required dependency `spdlog`.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port feature `spdlog` installation tests pass with the following triplets:

* x64-linux 