### PR TITLE
[ruapu] Add new port

### DIFF
--- a/ports/ruapu/portfile.cmake
+++ b/ports/ruapu/portfile.cmake
@@ -1,0 +1,14 @@
+# header-only library
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nihui/ruapu
+    REF "${VERSION}"
+    SHA512 efc74fde9e08637a5a888cfcbca000c1e7fe8095be5e59415c54c535cc2be496a4efe8aa66aac5dfbb1ae3385ba7762eb8bfd83ddbdf21720c7561707c287e45
+    HEAD_REF master
+)
+
+file(COPY "${SOURCE_PATH}/ruapu.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ruapu/vcpkg.json
+++ b/ports/ruapu/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "ruapu",
+  "version": "0.1.0",
+  "description": "Detect CPU features with single-file",
+  "homepage": "https://github.com/nihui/ruapu",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8088,6 +8088,10 @@
       "baseline": "0.9.6+20210811",
       "port-version": 1
     },
+    "ruapu": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "rubberband": {
       "baseline": "4.0.0",
       "port-version": 0

--- a/versions/r-/ruapu.json
+++ b/versions/r-/ruapu.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7a70de92d2e605300b4cb147b32a11db159d6db7",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
