### PR TITLE
[libxml2] Drop ftp

### DIFF
--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -26,7 +26,6 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        "ftp" LIBXML2_WITH_FTP
         "http" LIBXML2_WITH_HTTP
         "iconv" LIBXML2_WITH_ICONV
         "legacy" LIBXML2_WITH_LEGACY

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libxml2",
   "version": "2.13.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
   "license": "MIT",
@@ -21,10 +21,6 @@
     "zlib"
   ],
   "features": {
-    "ftp": {
-      "description": "Add the FTP support",
-      "supports": "!uwp"
-    },
     "http": {
       "description": "Add the HTTP support",
       "supports": "!uwp"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5442,7 +5442,7 @@
     },
     "libxml2": {
       "baseline": "2.13.5",
-      "port-version": 1
+      "port-version": 2
     },
     "libxmlmm": {
       "baseline": "0.6.0",

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2bb3f4003bc2666a38974d2e829001820269ad9c",
+      "version": "2.13.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "42ed1437607b934471807d0a2830d23d43f22bb1",
       "version": "2.13.5",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Upstream removed ftp support. See https://gitlab.gnome.org/GNOME/libxml2/-/commit/dba1ed85a320c36807ee09f44d09fd30852b9370
