### PR TITLE
[ismrmrd] Fix nodiscard warning in meta.cpp

### DIFF
--- a/ports/ismrmrd/fix-nodiscard-warning.patch
+++ b/ports/ismrmrd/fix-nodiscard-warning.patch
@@ -1,0 +1,13 @@
+diff --git a/libsrc/meta.cpp b/libsrc/meta.cpp
+index 9cc8cc9..69fce79 100644
+--- a/libsrc/meta.cpp
++++ b/libsrc/meta.cpp
+@@ -23,7 +23,7 @@ namespace ISMRMRD {
+             pugi::xml_node value = meta.child("value");
+ 
+             if (!name || !value) {
+-                std::runtime_error("Malformed metadata value");
++                throw std::runtime_error("Malformed metadata value");
+             }
+ 
+             while (value) {

--- a/ports/ismrmrd/portfile.cmake
+++ b/ports/ismrmrd/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     PATCHES
         ${WIN32_INCLUDE_STDDEF_PATCH}
         fix-depends-hdf5.patch
+        fix-nodiscard-warning.patch
 )
 
 vcpkg_cmake_configure(
@@ -47,4 +48,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin/")
 endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ismrmrd/vcpkg.json
+++ b/ports/ismrmrd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ismrmrd",
   "version": "1.14.1",
+  "port-version": 1,
   "description": "ISMRM Raw Data Format",
   "homepage": "https://github.com/ismrmrd/ismrmrd",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3786,7 +3786,7 @@
     },
     "ismrmrd": {
       "baseline": "1.14.1",
-      "port-version": 0
+      "port-version": 1
     },
     "itay-grudev-singleapplication": {
       "baseline": "3.5.1",

--- a/versions/i-/ismrmrd.json
+++ b/versions/i-/ismrmrd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e5e8f72ee1ce058b1efcac5f9e8be7bafe246fd0",
+      "version": "1.14.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "c903e7a9cc49e7395d37dc5e8587d6dd0196e65a",
       "version": "1.14.1",
       "port-version": 0


### PR DESCRIPTION
Since STL PR https://github.com/microsoft/STL/pull/5174 is merged, `ismrmrd` install failed with below error:
```
src\v1.14.1-55f6463d32.clean\libsrc\meta.cpp(26): error C2220: the following warning is treated as an error
src\v1.14.1-55f6463d32.clean\libsrc\meta.cpp(26): warning C4834: discarding return value of function with [[nodiscard]] attribute
```
For fixing this issue, I added a patch to add the `throw` keyword to the `std::runtime_error` call in `meta.cpp`.
I have submitted a PR to upstream: https://github.com/ismrmrd/ismrmrd/pull/258

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.