### PR TITLE
[libb2] Fix Windows build

### DIFF
--- a/ports/libb2/fix-msvc-cpuid.patch
+++ b/ports/libb2/fix-msvc-cpuid.patch
@@ -1,0 +1,31 @@
+diff --git a/m4/ax_gcc_x86_cpuid.m4 b/m4/ax_gcc_x86_cpuid.m4
+--- a/m4/ax_gcc_x86_cpuid.m4
++++ b/m4/ax_gcc_x86_cpuid.m4
+@@ -60,14 +60,26 @@
+ AC_DEFUN([AX_GCC_X86_CPUID],
+ [AC_REQUIRE([AC_PROG_CC])
+ AC_LANG_PUSH([C])
+ AC_CACHE_CHECK(for x86 cpuid $1 output, ax_cv_gcc_x86_cpuid_$1,
+- [AC_RUN_IFELSE([AC_LANG_PROGRAM([#include <stdio.h>], [
++ [AC_RUN_IFELSE([AC_LANG_PROGRAM([#include <stdio.h>
++#ifdef _MSC_VER
++#include <intrin.h>
++#endif], [
+      int op = $1, eax, ebx, ecx, edx;
+      FILE *f;
++#ifdef _MSC_VER
++     int out[[4]];
++     __cpuid(out, $1);
++     eax = out[[0]];
++     ebx = out[[1]];
++     ecx = out[[2]];
++     edx = out[[3]];
++#else
+       __asm__("cpuid"
+         : "=a" (eax), "=b" (ebx), "=c" (ecx), "=d" (edx)
+         : "a" (op));
++#endif
+      f = fopen("conftest_cpuid", "w"); if (!f) return 1;
+      fprintf(f, "%x:%x:%x:%x\n", eax, ebx, ecx, edx);
+      fclose(f);
+      return 0;

--- a/ports/libb2/portfile.cmake
+++ b/ports/libb2/portfile.cmake
@@ -4,11 +4,15 @@ vcpkg_from_github(
     REF 2c5142f12a2cd52f3ee0a43e50a3a76f75badf85
     SHA512 cf29cf9391ae37a978eb6618de6f856f3defa622b8f56c2d5a519ab34fd5e4d91f3bb868601a44e9c9164a2992e80dde188ccc4d1605dffbdf93687336226f8d
     HEAD_REF master
+    PATCHES
+        fix-msvc-cpuid.patch
 )
 
-set(OPTIONS)
-if(CMAKE_HOST_WIN32)
-    set(OPTIONS --disable-native) # requires cpuid
+# Ensure we can detect cpu features on {x64,x86}-windows.
+if (VCPKG_HOST_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86") AND VCPKG_CROSSCOMPILING)
+set(pre_run PRERUN_SHELL
+    "sed -i 's/cross_compiling=yes/cross_compiling=no/g' configure"
+)
 endif()
 
 vcpkg_configure_make(
@@ -16,7 +20,7 @@ vcpkg_configure_make(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         ax_cv_check_cflags___O3=no # see https://github.com/microsoft/vcpkg/pull/17912#issuecomment-840514179
-        ${OPTIONS}
+    ${pre_run}
 )
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()

--- a/ports/libb2/vcpkg.json
+++ b/ports/libb2/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "libb2",
   "version": "0.98.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "C library providing BLAKE2b, BLAKE2s, BLAKE2bp, BLAKE2sp",
   "homepage": "https://github.com/BLAKE2/libb2",
-  "supports": "!windows"
+  "supports": "!uwp"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4342,7 +4342,7 @@
     },
     "libb2": {
       "baseline": "0.98.1",
-      "port-version": 6
+      "port-version": 7
     },
     "libbacktrace": {
       "baseline": "2023-11-30",

--- a/versions/l-/libb2.json
+++ b/versions/l-/libb2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5863b65a41cefd7f6cb2357afc1d28cca4f29920",
+      "version": "0.98.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "7c113e12089453e4e2cf2bbf67ad1f0b80a133a8",
       "version": "0.98.1",
       "port-version": 6


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
