### PR TITLE
[log4cxx] update to 1.3.1

### DIFF
--- a/ports/log4cxx/fix-find-package.patch
+++ b/ports/log4cxx/fix-find-package.patch
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7b1c0d52..62c4fb43 100644
+index 498d0b5..22815a5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -70,7 +70,7 @@ find_package( Threads REQUIRED )
- include("${CMAKE_CURRENT_LIST_DIR}/src/cmake/FindLibFuzzer.cmake")
+@@ -67,7 +67,7 @@ find_package(APR-Util REQUIRED)
+ find_package( Threads REQUIRED )
  
  # Find expat for XML parsing
 -find_package(EXPAT REQUIRED)

--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -1,20 +1,13 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/logging/log4cxx/${VERSION}/apache-log4cxx-${VERSION}.tar.gz"
     FILENAME "apache-log4cxx-${VERSION}.tar.gz"
-    SHA512 bd481d69e29b3c8908bbc91489bf4e752e6edb147404454c0e88fd8f107d68ae5a98e220ab912692e555ca071d1cff7fb99ffa51194cfa7d070593ce6285d2b0
-)
-
-vcpkg_download_distfile(MAKE_PKG_CONFIG_SUPPORT_OPT_IN
-  URLS https://github.com/apache/logging-log4cxx/commit/4642a50c70b6cbd9b68d7e8dace9c049c8198b07.patch?full_index=1
-  SHA512 4b3628d98d233a2e68d1183a8bb2156c2f1e6f80ab50cfe75a6df799d14bc3c7ba028fbb7ff524c56530a2260be37fd9f3d089422027987b5c8c36e9978c254c
-  FILENAME Make_pkg_config_support_opt_in-4642a50c70b6cbd9b68d7e8dace9c049c8198b07.patch
+    SHA512 0956fd034fd1a98d2e48ed461578c1e85da02d176850a580195b6a60b959feaf402a2743cc84ccb5d467dd924ee46422b8a7b39d2be9ee131e4e275e65ba839c
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH ARCHIVE "${ARCHIVE}"
     PATCHES
         fix-find-package.patch
-        ${MAKE_PKG_CONFIG_SUPPORT_OPT_IN}
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -48,5 +41,4 @@ ${_contents}"
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "log4cxx",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Apache log4cxx is a logging framework for C++ patterned after Apache log4j, which uses Apache Portable Runtime for most platform-specific code and should be usable on any platform supported by APR",
   "homepage": "https://logging.apache.org/log4cxx",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5613,7 +5613,7 @@
       "port-version": 0
     },
     "log4cxx": {
-      "baseline": "1.3.0",
+      "baseline": "1.3.1",
       "port-version": 0
     },
     "loguru": {

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "699df3eeb8f994155f24dd335626fc938f7dc412",
+      "version": "1.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "fb973202e7b0a9c6060e23b92fee4b33df52204a",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #42918. Update `log4cxx` to 1.3.1.
All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```
The usage test passed on `x64-windows` (header files found).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.