### PR TITLE
[zfp] Update to 1.0.1

### DIFF
--- a/ports/zfp/portfile.cmake
+++ b/ports/zfp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO LLNL/zfp
-    REF f39af72648a2aeb88e9b2cca8c64f51b493ad5f4 #1.0.0
-    SHA512 943c147a5170defe8e40c6b5ffc736dcc5a4fd33ab5b3e71aab9194821d68e4b6d093f11c76532ae011cbee44c861b04feb01e36789a9858b10ebfa808416e92
+    REF "${VERSION}"
+    SHA512 5bbd98ed2f98e75c654afa863cab3023abb2eeb8f203f9049c75d5dbdf4b364cfb5c8378e10e6aaeaf13242315ad4949b06619810a67b3adaed095b7e8a48d5a
     HEAD_REF master
 )
 
@@ -39,4 +39,4 @@ endif()
 
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/zfp/vcpkg.json
+++ b/ports/zfp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "zfp",
-  "version": "1.0.0",
-  "port-version": 2,
+  "version": "1.0.1",
   "description": "Zfp is an open source C/C++ library for compressed numerical arrays that support high throughput read and write random access. zfp also supports streaming compression of integer and floating-point data, e.g., for applications that read and write large data sets to and from disk. zfp is primarily written in C and C++ but also includes Python and Fortran bindings.",
   "homepage": "https://github.com/LLNL/zfp",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9977,8 +9977,8 @@
       "port-version": 2
     },
     "zfp": {
-      "baseline": "1.0.0",
-      "port-version": 2
+      "baseline": "1.0.1",
+      "port-version": 0
     },
     "zimpl": {
       "baseline": "3.6.1",

--- a/versions/z-/zfp.json
+++ b/versions/z-/zfp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "25e02beed507eb4dab6ed9efc9acfbfbe2dc9f6f",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "560a885ed95ebb2e7477dfe4e68d5abe7f122fca",
       "version": "1.0.0",
       "port-version": 2


### PR DESCRIPTION
Update `zfp` to 1.0.1.

All features are tested successfully in the following triplet:
```
x86-windows
x64-windows
x64-windows-static
```
The usage test passed on `x64-windows` (header files found).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
