### PR TITLE
[sdl2] Fix could not find found library alsa

### DIFF
--- a/ports/sdl2/alsa-dep-fix.patch
+++ b/ports/sdl2/alsa-dep-fix.patch
@@ -2,13 +2,12 @@ diff --git a/SDL2Config.cmake.in b/SDL2Config.cmake.in
 index cc8bcf26d..ead829767 100644
 --- a/SDL2Config.cmake.in
 +++ b/SDL2Config.cmake.in
-@@ -35,7 +35,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/sdlfind.cmake")
+@@ -35,7 +35,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/sdlfind.cmake")
  
  set(SDL_ALSA @SDL_ALSA@)
  set(SDL_ALSA_SHARED @SDL_ALSA_SHARED@)
 -if(SDL_ALSA AND NOT SDL_ALSA_SHARED AND TARGET SDL2::SDL2-static)
 +if(SDL_ALSA)
-+  set(CMAKE_REQUIRE_FIND_PACKAGE_ALSA 1)
    sdlFindALSA()
  endif()
  unset(SDL_ALSA)

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl2",
   "version": "2.30.10",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8234,7 +8234,7 @@
     },
     "sdl2": {
       "baseline": "2.30.10",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52c67d447613dba08aff29bd9ee48376cf168f04",
+      "version": "2.30.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "c34f21447296be501bab81979e8d0698264b48c3",
       "version": "2.30.10",
       "port-version": 0


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/42929, error with `Could NOT find ALSA (missing: ALSA_LIBRARY) (found version "1.2.13")`

Remove `set(CMAKE_REQUIRE_FIND_PACKAGE_ALSA 1)`.

### Checklist

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

### Test

The installation `vcpkg install sdl2[alsa] imgui[sdl2-binding,sdl2-renderer-binding]` tests pass with the following triplets:

* x64-linux