### PR TITLE
[ucoro] add new port

### DIFF
--- a/ports/ucoro/cmake-install.patch
+++ b/ports/ucoro/cmake-install.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 663044e..6d8e460 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,8 +15,31 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+     add_compile_options(-foptimize-sibling-calls)
+ endif()
+ 
++include(GNUInstallDirs)
++
+ add_library(ucoro INTERFACE)
+-target_include_directories(ucoro INTERFACE include)
++target_include_directories(ucoro INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
++                                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++
++option(UCORO_BUILD_TESTING "Build the tests" ON)
++if (UCORO_BUILD_TESTING)
++    enable_testing()
++    add_subdirectory(tests)
++endif()
++
++install(
++    TARGETS ucoro
++    EXPORT ucoroTargets
++    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++)
++install(
++    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ucoro
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++)
++# generate config.cmake
++install(
++    EXPORT ucoroTargets
++    FILE ucoro-config.cmake
++    DESTINATION "share/ucoro"
++)
+ 
+-enable_testing()
+-add_subdirectory(tests)

--- a/ports/ucoro/cmake-install.patch
+++ b/ports/ucoro/cmake-install.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 663044e..6d8e460 100644
+index 663044e..9121cb3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -15,8 +15,31 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
@@ -18,7 +18,9 @@ index 663044e..6d8e460 100644
 +    enable_testing()
 +    add_subdirectory(tests)
 +endif()
-+
+ 
+-enable_testing()
+-add_subdirectory(tests)
 +install(
 +    TARGETS ucoro
 +    EXPORT ucoroTargets
@@ -32,8 +34,6 @@ index 663044e..6d8e460 100644
 +install(
 +    EXPORT ucoroTargets
 +    FILE ucoro-config.cmake
++    NAMESPACE ucoro::
 +    DESTINATION "share/ucoro"
 +)
- 
--enable_testing()
--add_subdirectory(tests)

--- a/ports/ucoro/portfile.cmake
+++ b/ports/ucoro/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO avplayer/ucoro
+    REF "v${VERSION}"
+    SHA512 c3436b436ef1ebb3d47a65db9603842293bdb6451bc6fb738a63d61a63b52901e223f46625d956303566dc52dfb38ffb2c6ce20016c18b444f9cb3e2e701e613
+    HEAD_REF main
+    PATCHES
+        cmake-install.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DUCORO_BUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE_1_0.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ucoro/portfile.cmake
+++ b/ports/ucoro/portfile.cmake
@@ -1,3 +1,5 @@
+set(VCPKG_BUILD_TYPE release)  # header-only
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO avplayer/ucoro
@@ -17,9 +19,5 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 vcpkg_fixup_pkgconfig()
-
-file(REMOVE_RECURSE 
-    "${CURRENT_PACKAGES_DIR}/debug"
-)
 
 file(INSTALL "${SOURCE_PATH}/LICENSE_1_0.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ucoro/portfile.cmake
+++ b/ports/ucoro/portfile.cmake
@@ -19,8 +19,7 @@ vcpkg_cmake_config_fixup()
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE 
-    "${CURRENT_PACKAGES_DIR}/debug/include"
-    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug"
 )
 
 file(INSTALL "${SOURCE_PATH}/LICENSE_1_0.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ucoro/vcpkg.json
+++ b/ports/ucoro/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "1.0",
   "description": "It is a minimized C++20 coroutine library.",
   "homepage": "https://github.com/avplayer/ucoro",
+  "license": "BSL-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/ucoro/vcpkg.json
+++ b/ports/ucoro/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "ucoro",
+  "version": "1.0",
+  "description": "It is a minimized C++20 coroutine library.",
+  "homepage": "https://github.com/avplayer/ucoro",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9204,6 +9204,10 @@
       "baseline": "0.0.8",
       "port-version": 0
     },
+    "ucoro": {
+      "baseline": "1.0",
+      "port-version": 0
+    },
     "udt": {
       "baseline": "4.11",
       "port-version": 0

--- a/versions/u-/ucoro.json
+++ b/versions/u-/ucoro.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b725fd749de02e00920707b6c8dabe1a3e491852",
+      "git-tree": "d461a5bc5382ef0d0b4cd776a861c416099ca2e9",
       "version": "1.0",
       "port-version": 0
     }

--- a/versions/u-/ucoro.json
+++ b/versions/u-/ucoro.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d461a5bc5382ef0d0b4cd776a861c416099ca2e9",
+      "git-tree": "29380e4860b67d864c58e5c7b26c763dd90b634b",
       "version": "1.0",
       "port-version": 0
     }

--- a/versions/u-/ucoro.json
+++ b/versions/u-/ucoro.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b725fd749de02e00920707b6c8dabe1a3e491852",
+      "version": "1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
