### PR TITLE
[libremidi] add readerwriterqueue dependency on linux

### DIFF
--- a/ports/libremidi/vcpkg.json
+++ b/ports/libremidi/vcpkg.json
@@ -1,12 +1,17 @@
 {
   "name": "libremidi",
   "version": "4.5.0",
+  "port-version": 1,
   "description": "A modern C++ MIDI real-time & file I/O library",
   "homepage": "https://github.com/jcelerier/libremidi",
   "license": "BSD-2-Clause",
   "dependencies": [
     {
       "name": "alsa",
+      "platform": "linux"
+    },
+    {
+      "name": "readerwriterqueue",
       "platform": "linux"
     },
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5054,7 +5054,7 @@
     },
     "libremidi": {
       "baseline": "4.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libressl": {
       "baseline": "4.0.0",

--- a/versions/l-/libremidi.json
+++ b/versions/l-/libremidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9f7f74d1c8742a224f1bd79011ac5fee7a0247b",
+      "version": "4.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "355e1ad8bb5377cfbc28e346d2666d94adf0eb4b",
       "version": "4.5.0",
       "port-version": 0


### PR DESCRIPTION
Add readerwriterqueue dependency on linux.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
