### PR TITLE
[behaviortree-cpp] Update behaviortree.cpp port from 4.3.7 to 4.6.2

### DIFF
--- a/ports/behaviortree-cpp/portfile.cmake
+++ b/ports/behaviortree-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BehaviorTree/BehaviorTree.CPP
     REF ${VERSION}
-    SHA512 3dbe048b276dbb3c79f85bfae0ae5da4657088d08ef9b7b0674fac1fb4daf8fb3cf7e3ab774b71d363af6cd8ac7ed315b4dd6d3318a38aa0532e6e0d43e6fa37
+    SHA512 f3ebbf21a93839b66b3b9d5091906b62c7a7f121f2c296cfdd7be4563924e695ea7464b8ab947ee95039242b3ea0cfe1572a2fd0ae826ab2bbeebd820631f716
     HEAD_REF master
     PATCHES
         fix-x86_build.patch

--- a/ports/behaviortree-cpp/portfile.cmake
+++ b/ports/behaviortree-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BehaviorTree/BehaviorTree.CPP
     REF ${VERSION}
-    SHA512 f2ee647c734e39e50f92405c5dc9fd2876602ff074a86416959fbf6548e37130d35f312cafb084ca4a40da7ee81386502a75ad839ce99a2859c30ff187820fdf
+    SHA512 3dbe048b276dbb3c79f85bfae0ae5da4657088d08ef9b7b0674fac1fb4daf8fb3cf7e3ab774b71d363af6cd8ac7ed315b4dd6d3318a38aa0532e6e0d43e6fa37
     HEAD_REF master
     PATCHES
         fix-x86_build.patch

--- a/ports/behaviortree-cpp/vcpkg.json
+++ b/ports/behaviortree-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "behaviortree-cpp",
-  "version": "4.3.7",
+  "version": "4.6.2",
   "description": "Behavior Trees Library in C++.",
   "homepage": "https://www.behaviortree.dev",
   "supports": "!uwp",

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b0373040f95b84572ece1ac3ac0f694efb68a59",
+      "version": "4.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "4cacd1d5f1a465b3ca9d23ebb0b9b4626a26db63",
       "version": "4.3.7",
       "port-version": 0

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7b0373040f95b84572ece1ac3ac0f694efb68a59",
+      "git-tree": "758978e4f79ff1f27bbf31698e476f451cc9410c",
       "version": "4.6.2",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -589,7 +589,7 @@
       "port-version": 2
     },
     "behaviortree-cpp": {
-      "baseline": "4.3.7",
+      "baseline": "4.6.2",
       "port-version": 0
     },
     "benchmark": {


### PR DESCRIPTION
If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Re-installed and tested locally