### PR TITLE
[bit7z] compile option without warnings as errors

### DIFF
--- a/ports/bit7z/fix_compile_options.patch
+++ b/ports/bit7z/fix_compile_options.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/CompilerOptions.cmake b/cmake/CompilerOptions.cmake
+index 1cdb84f..fd9346f 100644
+--- a/cmake/CompilerOptions.cmake
++++ b/cmake/CompilerOptions.cmake
+@@ -70,7 +70,7 @@ if( MSVC )
+         endforeach()
+     endif()
+ else()
+-    target_compile_options( ${LIB_TARGET} PRIVATE -Wall -Wextra -Werror -Wconversion -Wsign-conversion )
++    target_compile_options( ${LIB_TARGET} PRIVATE -Wall -Wextra -Wconversion -Wsign-conversion )
+ endif()
+
+ # Extra warning flags for Clang

--- a/ports/bit7z/portfile.cmake
+++ b/ports/bit7z/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
       fix_install.patch
       fix_dependency.patch
+      fix_compile_options.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-bit7z-config.cmake.in" DESTINATION "${SOURCE_PATH}")

--- a/ports/bit7z/vcpkg.json
+++ b/ports/bit7z/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "bit7z",
   "version": "4.0.9",
+  "port-version": 1,
   "description": "A C++ static library offering a clean and simple interface to the 7-zip shared libraries.",
   "homepage": "https://github.com/rikyoz/bit7z",
   "license": "MPL-2.0",

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -6,7 +6,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "2fd28238d813d9da923a209393c821209972ca57",
+      "git-tree": "88073b4adf36aa5b939b9565ec299084e3162e8b",
       "version": "4.0.9",
       "port-version": 0
     },

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "88073b4adf36aa5b939b9565ec299084e3162e8b",
+      "git-tree": "761234aa0ad3687fccc86bf939350659f9d137d6",
+      "version": "4.0.9",
+      "port-version": 1
+    },
+    {
+      "git-tree": "2fd28238d813d9da923a209393c821209972ca57",
       "version": "4.0.9",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -658,7 +658,7 @@
     },
     "bit7z": {
       "baseline": "4.0.9",
-      "port-version": 0
+      "port-version": 1
     },
     "bitmagic": {
       "baseline": "7.13.4",


### PR DESCRIPTION
Fixes #43003 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
