### PR TITLE
[tgui] Update version to 1.7.0

### DIFF
--- a/ports/tgui/portfile.cmake
+++ b/ports/tgui/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO texus/TGUI
     REF "v${VERSION}"
-    SHA512 a117c1c23b6811370f58069b3d6a7fb73930455f7d456ffd53e2abd161d637968cecca653d42ea8a055d53f8af8c5e10f66528e2bb5091e04a28ceb3b774d7ff
+    SHA512 24aa59b5eb225987247384dfdfc8bdce1d755cc7daeda6fdff9046eea77a0f2e686d5b03d24cbbd20e7d6d90ae809eae90467a2b1d923de1e2ecf668e28bcff4
     HEAD_REF 1.x
     PATCHES
         devendor-stb.patch

--- a/ports/tgui/vcpkg.json
+++ b/ports/tgui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tgui",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "TGUI is an easy to use, cross-platform, C++ GUI for SFML.",
   "homepage": "https://tgui.eu",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8917,7 +8917,7 @@
       "port-version": 4
     },
     "tgui": {
-      "baseline": "1.6.1",
+      "baseline": "1.7.0",
       "port-version": 0
     },
     "think-cell-range": {

--- a/versions/t-/tgui.json
+++ b/versions/t-/tgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a228fc0e38252f9fc749e1962462f703c43b348e",
+      "version": "1.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7f9e5c089cb674e9ea51e4ee9a572e924d93d7dd",
       "version": "1.6.1",
       "port-version": 0


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/42999

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
