### PR TITLE
[thor] Pin SFML version to SFML 2

### DIFF
--- a/ports/thor/vcpkg.json
+++ b/ports/thor/vcpkg.json
@@ -1,15 +1,24 @@
 {
   "name": "thor",
-  "version-date": "2022-04-16",
+  "version-date": "2022-04-17",
   "description": "Extends the multimedia library SFML with higher-level features",
   "homepage": "https://bromeon.ch/libraries/thor/",
   "license": "Zlib",
   "dependencies": [
     "aurora",
-    "sfml",
+    {
+      "name": "sfml",
+      "version>=": "2.5.0"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
+    }
+  ],
+  "overrides": [
+    {
+      "name": "sfml",
+      "version": "2.6.2"
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8933,7 +8933,7 @@
       "port-version": 2
     },
     "thor": {
-      "baseline": "2022-04-16",
+      "baseline": "2022-04-17",
       "port-version": 0
     },
     "thorvg": {

--- a/versions/t-/thor.json
+++ b/versions/t-/thor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c50c35f9cf935e8ca3d31a7802a2fab98b77ffe4",
+      "version-date": "2022-04-17",
+      "port-version": 0
+    },
+    {
       "git-tree": "52c5298a73cdd120b4138b72dd84085cf18f53c1",
       "version-date": "2022-04-16",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

[Thor](https://github.com/Bromeon/Thor) has been archived and won't be receiving any updates, as such the SFML version should be pinned to >=2.5

This is currently causing issues when trying to update SFML to SFML 3, see #42913 

To be honest I don't know if I understood the [versioning pinning](https://devblogs.microsoft.com/cppblog/take-control-of-your-vcpkg-dependencies-with-versioning-support/) correctly, so feel free to leave any review comments.