### PR TITLE
[LIEF] update to 0.16.1

### DIFF
--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lief-project/LIEF
     REF ${VERSION}
-    SHA512 0
+    SHA512 776d26bc5d8ec7bca823d1c0fc821b0efc2411976901e1fca0ffecbc64591798e9e21a483c1637e9877bdd921dc463ffaef4eeb6a76d9dd8463c97c5f50834d4
     HEAD_REF master
     PATCHES
         fix-cmakelists.patch

--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -1,21 +1,13 @@
-vcpkg_download_distfile(
-    FIX_FMT_V11_JOIN_LINUX_INCLUDE_MEMORY_PATCH
-    URLS https://github.com/lief-project/LIEF/commit/41166332a2435fdb7d2bdc5c73f9ff9b442c5459.patch?full_index=1
-    FILENAME fix-fmt-v11-join-linux-include-memory-41166332a2435fdb7d2bdc5c73f9ff9b442c5459.patch
-    SHA512 14d5f7380352bd340c16447905b8185dbd2d977c8ba245e01d982fe7fbbdffb71004b9d4fdd732bc13e71a11aa3f46a4822cdeb2277e2cec6b841492d0de5606
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lief-project/LIEF
     REF ${VERSION}
-    SHA512 7df75fab6c7023e37a6a4d27fac8dcb4200e0235625fc5952bb23cedb2e582a37fb67ee471c1ae953c0b205fd9cca5538a835f65ef80a771f72dc7ff68000ed9
+    SHA512 0
     HEAD_REF master
     PATCHES
         fix-cmakelists.patch
         fix-liefconfig-cmake-in.patch
         fix-vcpkg-includes.patch
-        "${FIX_FMT_V11_JOIN_LINUX_INCLUDE_MEMORY_PATCH}"
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/third-party")

--- a/ports/lief/vcpkg.json
+++ b/ports/lief/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lief",
-  "version-semver": "0.16.0",
+  "version-semver": "0.16.1",
   "description": "LIEF - Library to Instrument Executable Formats",
   "homepage": "https://lief.quarkslab.com",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5533,7 +5533,7 @@
       "port-version": 0
     },
     "lief": {
-      "baseline": "0.16.0",
+      "baseline": "0.16.1",
       "port-version": 0
     },
     "lightgbm": {

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9414cb09fdab9f362b873d73c46a8ad7136f9b4c",
+      "version-semver": "0.16.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "fafe51c4db1abe4b79e44013592db1c89945740d",
       "version-semver": "0.16.0",
       "port-version": 0

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9414cb09fdab9f362b873d73c46a8ad7136f9b4c",
+      "git-tree": "daa3916496b152d323bfe3116aaa239e24f62f4f",
       "version-semver": "0.16.1",
       "port-version": 0
     },

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "daa3916496b152d323bfe3116aaa239e24f62f4f",
+      "git-tree": "c93d7992ef9c457a2e320a5f10df9e1dfae1407d",
       "version-semver": "0.16.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


