### PR TITLE
[libxcrypt] crypt-bcrypt.c: Fix Werror=strict-overflow with GCC 4.8.5

### DIFF
--- a/ports/libxcrypt/portfile.cmake
+++ b/ports/libxcrypt/portfile.cmake
@@ -15,11 +15,19 @@ if(NOT LIBTOOL_BIN)
     message(FATAL_ERROR "${PORT} requires libtool from the system package manager (example: \"sudo apt install libtool\")")
 endif()
 
+vcpkg_download_distfile(PATCH_FIX_ERROR_STRICT_OVERFLOW
+    URLS https://github.com/besser82/libxcrypt/commit/7fc153170ea6c2938c0392794778de7ec995f8f9.patch?full_index=1
+    SHA512 55f4709c52f6d0a29f159348821c06e3f5df0fae83f487b7a52ce61cd3f6a3a0f48023159fb7029d0a5a3decee36ac6a429cc91e23a83996a3265d681fa11929
+    FILENAME besser82-libxcrypt-7fc153170ea6c2938c0392794778de7ec995f8f9.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO besser82/libxcrypt
     REF "v${VERSION}"
     SHA512 61e5e393654f37775457474d4170098314879ee79963d423c1c461e80dc5dc74f0c161dd8754f016ce96109167be6c580ad23994fa1d2c38c54b96e602f3aece
+    PATCHES
+        "${PATCH_FIX_ERROR_STRICT_OVERFLOW}"
 )
 
 vcpkg_configure_make(

--- a/ports/libxcrypt/vcpkg.json
+++ b/ports/libxcrypt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libxcrypt",
   "version": "4.4.36",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libxcrypt is a modern library for one-way hashing of passwords. On Linux-based systems, by default libxcrypt will be binary backward compatible with the libcrypt.so.1 shipped as part of the GNU C Library.",
   "homepage": "https://github.com/besser82/libxcrypt",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5382,7 +5382,7 @@
     },
     "libxcrypt": {
       "baseline": "4.4.36",
-      "port-version": 1
+      "port-version": 2
     },
     "libxcvt": {
       "baseline": "0.1.2",

--- a/versions/l-/libxcrypt.json
+++ b/versions/l-/libxcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "825ff0426ce377f1e386f7effd1f3dfb5e218a64",
+      "version": "4.4.36",
+      "port-version": 2
+    },
+    {
       "git-tree": "89d7de97e87cb0eb10479d47ec43e1cc732b2734",
       "version": "4.4.36",
       "port-version": 1


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/42978, error with `Werror=strict-overflow`

Submit upstream https://github.com/besser82/libxcrypt/pull/197, backport https://github.com/besser82/libxcrypt/commit/7fc153170ea6c2938c0392794778de7ec995f8f9 to fix.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux (GNU 4.8.5 and GNU 14.2.0)