### PR TITLE
[angle] Add export unofficial targets include

### DIFF
--- a/ports/angle/cmake-buildsystem/CMakeLists.txt
+++ b/ports/angle/cmake-buildsystem/CMakeLists.txt
@@ -414,6 +414,7 @@ set(_possibleTargets EGL GLESv2 ANGLE)
 foreach(_target IN LISTS _possibleTargets)
     if(TARGET ${_target})
         list(APPEND _installableTargets "${_target}")
+        target_include_directories(${_target} INTERFACE $<INSTALL_INTERFACE:include>)
     endif()
 endforeach()
 

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_5414",
-  "port-version": 9,
+  "port-version": 10,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "025eefba308651be2ae69502477d1201dfdf04ea",
+      "version-string": "chromium_5414",
+      "port-version": 10
+    },
+    {
       "git-tree": "b0e6049d392ece97ba5be00c7c3e4410aa78d3f0",
       "version-string": "chromium_5414",
       "port-version": 9

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -134,7 +134,7 @@
     },
     "angle": {
       "baseline": "chromium_5414",
-      "port-version": 9
+      "port-version": 10
     },
     "ankurvdev-embedresource": {
       "baseline": "0.0.11",


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/42324, no `INTERFACE_INCLUDE_DIRECTORIES`.

Add `$<INSTALL_INTERFACE:include>` to fix.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port usage tests pass with the following triplets:

* x64-windows