### PR TITLE
[ngspice] update to 43

### DIFF
--- a/ports/ngspice/portfile.cmake
+++ b/ports/ngspice/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_sourceforge(
     REPO ngspice/ng-spice-rework
     REF ${VERSION}
     FILENAME "ngspice-${VERSION}.tar.gz"
-    SHA512 fb0960cc9fcde1871fad82571cacebb1f5cce09ee3297cc938a24b88173ed102a2cb3f246599cdfbde7275e45e3d551edd0368e3ba6e79c592937c4cc466325e
+    SHA512 ad938e6ea8f9874c04d1033599bf39d3728e763fbd42ba77bd036b6c00271600695b3656f3f34547c39153382f55e7d7d5d6cb732f272d149cdbe21988c0d636
     PATCHES
         use-winbison-sharedspice.patch
         use-winbison-vngspice.patch

--- a/ports/ngspice/remove-post-build.patch
+++ b/ports/ngspice/remove-post-build.patch
@@ -121,11 +121,11 @@ index 14773c8..178aa73 100644
      </PostBuildEvent>
    </ItemDefinitionGroup>
 diff --git a/visualc/vngspice.vcxproj b/visualc/vngspice.vcxproj
-index 7b6ac0b..7190c1e 100644
+index 8d1825a..b623b99 100644
 --- a/visualc/vngspice.vcxproj
 +++ b/visualc/vngspice.vcxproj
-@@ -242,7 +242,7 @@
-       <LargeAddressAware>true</LargeAddressAware>
+@@ -244,7 +244,7 @@
+       <AdditionalLibraryDirectories>KLU/Debug/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
      </Link>
      <PostBuildEvent>
 -      <Command>make-install-vngspiced.bat $(OutDir)</Command>
@@ -133,7 +133,7 @@ index 7b6ac0b..7190c1e 100644
      </PostBuildEvent>
      <Manifest>
        <AdditionalManifestFiles>$(ProjectDir)ngspice-x86.exe.manifest</AdditionalManifestFiles>
-@@ -293,7 +293,6 @@
+@@ -297,7 +297,6 @@
      </Link>
      <PostBuildEvent>
        <Command>
@@ -141,7 +141,7 @@ index 7b6ac0b..7190c1e 100644
        </Command>
      </PostBuildEvent>
      <Manifest>
-@@ -342,7 +341,6 @@
+@@ -348,7 +347,6 @@
      </Link>
      <PostBuildEvent>
        <Command>
@@ -149,7 +149,7 @@ index 7b6ac0b..7190c1e 100644
        </Command>
      </PostBuildEvent>
      <Manifest>
-@@ -399,7 +397,6 @@
+@@ -407,7 +405,6 @@
      </Link>
      <PostBuildEvent>
        <Command>
@@ -157,8 +157,8 @@ index 7b6ac0b..7190c1e 100644
        </Command>
      </PostBuildEvent>
      <Manifest>
-@@ -444,7 +441,7 @@
-       <LargeAddressAware>true</LargeAddressAware>
+@@ -454,7 +451,7 @@
+       <AdditionalLibraryDirectories>KLU/Debug/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
      </Link>
      <PostBuildEvent>
 -      <Command>make-install-vngspiced.bat $(OutDir)</Command>
@@ -166,8 +166,8 @@ index 7b6ac0b..7190c1e 100644
      </PostBuildEvent>
      <Manifest>
        <AdditionalManifestFiles>$(ProjectDir)ngspice-x86.exe.manifest</AdditionalManifestFiles>
-@@ -494,7 +491,7 @@
-       <LargeAddressAware>true</LargeAddressAware>
+@@ -506,7 +503,7 @@
+       <AdditionalLibraryDirectories>KLU/Release/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
      </Link>
      <PostBuildEvent>
 -      <Command>make-install-vngspice.bat $(OutDir)</Command>
@@ -175,7 +175,7 @@ index 7b6ac0b..7190c1e 100644
      </PostBuildEvent>
      <Manifest>
        <AdditionalManifestFiles>$(ProjectDir)ngspice-x86.exe.manifest</AdditionalManifestFiles>
-@@ -542,7 +539,6 @@
+@@ -556,7 +553,6 @@
      </Link>
      <PostBuildEvent>
        <Command>
@@ -183,7 +183,7 @@ index 7b6ac0b..7190c1e 100644
        </Command>
      </PostBuildEvent>
      <Manifest>
-@@ -597,7 +593,6 @@
+@@ -613,7 +609,6 @@
      </Link>
      <PostBuildEvent>
        <Command>
@@ -191,8 +191,8 @@ index 7b6ac0b..7190c1e 100644
        </Command>
      </PostBuildEvent>
      <Manifest>
-@@ -649,7 +644,7 @@
-       <LargeAddressAware>true</LargeAddressAware>
+@@ -666,7 +661,7 @@
+       <AdditionalLibraryDirectories>KLU/Release/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
      </Link>
      <PostBuildEvent>
 -      <Command>make-install-vngspice.bat $(OutDir)</Command>
@@ -200,7 +200,7 @@ index 7b6ac0b..7190c1e 100644
      </PostBuildEvent>
      <Manifest>
        <AdditionalManifestFiles>$(ProjectDir)ngspice-x86.exe.manifest</AdditionalManifestFiles>
-@@ -706,7 +701,6 @@
+@@ -726,7 +721,6 @@
      </Link>
      <PostBuildEvent>
        <Command>
@@ -208,8 +208,8 @@ index 7b6ac0b..7190c1e 100644
        </Command>
      </PostBuildEvent>
      <Manifest>
-@@ -758,7 +752,7 @@
-       <LargeAddressAware>true</LargeAddressAware>
+@@ -779,7 +773,7 @@
+       <AdditionalLibraryDirectories>KLU/Release/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
      </Link>
      <PostBuildEvent>
 -      <Command>make-install-vngspice.bat $(OutDir)</Command>
@@ -217,7 +217,7 @@ index 7b6ac0b..7190c1e 100644
      </PostBuildEvent>
      <Manifest>
        <AdditionalManifestFiles>$(ProjectDir)ngspice-x86.exe.manifest</AdditionalManifestFiles>
-@@ -813,7 +807,6 @@
+@@ -837,7 +831,6 @@
      </Link>
      <PostBuildEvent>
        <Command>
@@ -225,6 +225,5 @@ index 7b6ac0b..7190c1e 100644
        </Command>
      </PostBuildEvent>
      <Manifest>
--- 
 2.32.0.windows.2
 

--- a/ports/ngspice/vcpkg.json
+++ b/ports/ngspice/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ngspice",
-  "version": "41",
+  "version": "43",
   "description": "Ngspice is a mixed-level/mixed-signal electronic circuit simulator. It is a successor of the latest stable release of Berkeley SPICE",
   "homepage": "http://ngspice.sourceforge.net/",
   "license": "CC-BY-SA-4.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6373,7 +6373,7 @@
       "port-version": 0
     },
     "ngspice": {
-      "baseline": "41",
+      "baseline": "43",
       "port-version": 0
     },
     "ngtcp2": {

--- a/versions/n-/ngspice.json
+++ b/versions/n-/ngspice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc84ae98077ea1e141d23ae193adef7896cdc8e8",
+      "version": "43",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae82af35f1dfb0ac52968de34d29a7de809cf575",
       "version": "41",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/42974

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.