### PR TITLE
[msquic] Allow windows build without openssl

### DIFF
--- a/ports/msquic/portfile.cmake
+++ b/ports/msquic/portfile.cmake
@@ -17,16 +17,20 @@ vcpkg_from_github(
         exports-for-msh3.diff
 )
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH OPENSSL_SOURCE_PATH
-    REPO quictls/openssl
-    REF openssl-3.1.7-quic1
-    SHA512 230f48a4ef20bfd492b512bd53816a7129d70849afc1426e9ce813273c01884d5474552ecaede05231ca354403f25e2325c972c9c7950ae66dae310800bd19e7
-    HEAD_REF openssl-3.1.7+quic
-)
-if(NOT EXISTS "${QUIC_SOURCE_PATH}/submodules/openssl3/Configure")
-    file(REMOVE_RECURSE "${QUIC_SOURCE_PATH}/submodules/openssl3")
-    file(RENAME "${OPENSSL_SOURCE_PATH}" "${QUIC_SOURCE_PATH}/submodules/openssl3")
+set(QUIC_TLS "schannel")
+if("0-rtt" IN_LIST FEATURES)
+    set(QUIC_TLS "openssl3")
+    vcpkg_from_github(
+        OUT_SOURCE_PATH OPENSSL_SOURCE_PATH
+        REPO quictls/openssl
+        REF openssl-3.1.7-quic1
+        SHA512 230f48a4ef20bfd492b512bd53816a7129d70849afc1426e9ce813273c01884d5474552ecaede05231ca354403f25e2325c972c9c7950ae66dae310800bd19e7
+        HEAD_REF openssl-3.1.7+quic
+    )
+    if(NOT EXISTS "${QUIC_SOURCE_PATH}/submodules/openssl3/Configure")
+        file(REMOVE_RECURSE "${QUIC_SOURCE_PATH}/submodules/openssl3")
+        file(RENAME "${OPENSSL_SOURCE_PATH}" "${QUIC_SOURCE_PATH}/submodules/openssl3")
+    endif()
 endif()
 
 vcpkg_from_github(
@@ -69,7 +73,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${QUIC_SOURCE_PATH}"
     OPTIONS
         -DQUIC_SOURCE_LINK=OFF
-        -DQUIC_TLS=openssl3
+        -DQUIC_TLS=${QUIC_TLS}
         -DQUIC_USE_SYSTEM_LIBCRYPTO=OFF
         -DQUIC_BUILD_PERF=OFF
         -DQUIC_BUILD_TEST=OFF

--- a/ports/msquic/vcpkg.json
+++ b/ports/msquic/vcpkg.json
@@ -1,11 +1,19 @@
 {
   "name": "msquic",
   "version": "2.4.7",
+  "port-version": 1,
   "description": "Cross-platform, C implementation of the IETF QUIC protocol",
   "homepage": "https://github.com/microsoft/msquic",
   "license": "MIT",
   "supports": "!mingw & !(static & staticcrt)",
   "dependencies": [
+    {
+      "name": "msquic",
+      "features": [
+        "0-rtt"
+      ],
+      "platform": "!windows"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -14,5 +22,14 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "0-rtt": {
+      "description": [
+        "Enable 0-RTT connection support.",
+        "This feature requires the use of (a fork of) OpenSSL 3 also on Windows."
+      ],
+      "license": "Apache-2.0"
+    }
+  }
 }

--- a/scripts/test_ports/vcpkg-ci-msh3/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-msh3/vcpkg.json
@@ -5,6 +5,13 @@
   "dependencies": [
     "msh3",
     {
+      "name": "msquic",
+      "features": [
+        "0-rtt"
+      ],
+      "platform": "windows & !static"
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6186,7 +6186,7 @@
     },
     "msquic": {
       "baseline": "2.4.7",
-      "port-version": 0
+      "port-version": 1
     },
     "mstch": {
       "baseline": "1.0.2",

--- a/versions/m-/msquic.json
+++ b/versions/m-/msquic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e727b0b7e3bf5761f161c5f7ca8f24272a3f7f2",
+      "version": "2.4.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "04855f9144f78f05b623916dc4d7310fdf8b5d29",
       "version": "2.4.7",
       "port-version": 0


### PR DESCRIPTION
Upstream's default TLS for Windows is schannel. However, OpenSSL is required for the 0-RTT capability. 
Other platforms do always need OpenSSL, so they implicitly come with that feature.

The vcpkg-ci-msh3 test port is used to ensure that both configurations are tested also for Windows.