### PR TITLE
[libwebp] update to 1.5.0

### DIFF
--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/libwebp
     REF "v${VERSION}"
-    SHA512 666b53fb33fa7895bf9dc83ca24e09865cf7fba7ae88b77f15a2ce11d94e84d5a6b8a084f0d8cad6c2a6eb8868ea7268f7efd2f6886148bbb58b7a3522957cde
+    SHA512 a922cb84e147f1aeaaac9ff4c6000ebad067a9a4b74d94c25d6c9181f487dfd6d8c7966ac1d239f4fad65cc07ad3d5c82ee9ab4adfa4b125d231056781632548
     HEAD_REF master
     PATCHES
         0002-cmake-config.patch

--- a/ports/libwebp/vcpkg.json
+++ b/ports/libwebp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libwebp",
-  "version": "1.4.0",
-  "port-version": 1,
+  "version": "1.5.0",
   "description": "WebP codec: library to encode and decode images in WebP format",
   "homepage": "https://github.com/webmproject/libwebp",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5353,8 +5353,8 @@
       "port-version": 1
     },
     "libwebp": {
-      "baseline": "1.4.0",
-      "port-version": 1
+      "baseline": "1.5.0",
+      "port-version": 0
     },
     "libwebsockets": {
       "baseline": "4.3.3",

--- a/versions/l-/libwebp.json
+++ b/versions/l-/libwebp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "785bb5f8a86b4f67c4186cdb2c7ee09d344dcfff",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9d0c00119dd6ec04488b4e0c926aa3ae73b95847",
       "version": "1.4.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43033
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.