### PR TITLE
[calceph] update to version 4.0.4

### DIFF
--- a/ports/calceph/portfile.cmake
+++ b/ports/calceph/portfile.cmake
@@ -1,4 +1,4 @@
-set(CALCEPH_HASH 0130bf9f48338146eb32aba4c9ceaa2d2a2ba2dfc4812c4c27cf87da06719172e3273cce4890f76233bbe15fc13952a05c06bce6a216e4ae6ca9613c902dca33)
+set(CALCEPH_HASH 81cddae9fa0d06758dbbb5fae486bd64eb087dc2ebf2d7b17fa89b6689b86e0e84d1412e6852e980ebed00a4c84a3b1b4ac00b89021f6d0bb2f370a98a6dad25)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-${VERSION}.tar.gz"

--- a/ports/calceph/vcpkg.json
+++ b/ports/calceph/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "calceph",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "C library to access the binary planetary ephemeris files.",
   "homepage": "https://www.imcce.fr/inpop/calceph/",
   "documentation": "https://calceph.imcce.fr/docs/latest/html/c/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1493,7 +1493,7 @@
       "port-version": 0
     },
     "calceph": {
-      "baseline": "4.0.3",
+      "baseline": "4.0.4",
       "port-version": 0
     },
     "camport3": {

--- a/versions/c-/calceph.json
+++ b/versions/c-/calceph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08d3667453a109eb1030f613e946d0fbdf64e1ad",
+      "version": "4.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "49026767cbf6ab4fa4dde6df55f440d3a244c5d3",
       "version": "4.0.3",
       "port-version": 0


### PR DESCRIPTION

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
