### PR TITLE
[eigen3] Update warning suppression to latest.

### DIFF
--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_gitlab(
     PATCHES
         remove_configure_checks.patch # This removes unnecessary configure checks. Eigen3 just installs headers not anything more.
         fix-vectorized-reductions-half.patch # Remove this patch in the next update
+        update-warning-suppression-to-latest.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/eigen3/update-warning-suppression-to-latest.patch
+++ b/ports/eigen3/update-warning-suppression-to-latest.patch
@@ -1,0 +1,140 @@
+From 193e24dca1338ad692a65c47c90eb3fb3f342a0c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Antonio=20S=C3=A1nchez?= <cantonios@google.com>
+Date: Mon, 21 Mar 2022 15:56:03 +0000
+Subject: [PATCH] Update warning suppression to latest.
+
+---
+ Eigen/src/Core/util/DisableStupidWarnings.h | 91 ++++++++++++++-------
+ 1 file changed, 61 insertions(+), 30 deletions(-)
+ mode change 100755 => 100644 Eigen/src/Core/util/DisableStupidWarnings.h
+
+diff --git a/Eigen/src/Core/util/DisableStupidWarnings.h b/Eigen/src/Core/util/DisableStupidWarnings.h
+old mode 100755
+new mode 100644
+index fe0cfec0b..75056592d
+--- a/Eigen/src/Core/util/DisableStupidWarnings.h
++++ b/Eigen/src/Core/util/DisableStupidWarnings.h
+@@ -1,7 +1,7 @@
+ #ifndef EIGEN_WARNINGS_DISABLED
+ #define EIGEN_WARNINGS_DISABLED
+ 
+-#ifdef _MSC_VER
++#if defined(_MSC_VER)
+   // 4100 - unreferenced formal parameter (occurred e.g. in aligned_allocator::destroy(pointer p))
+   // 4101 - unreferenced local variable
+   // 4181 - qualifier applied to reference type ignored
+@@ -35,25 +35,28 @@
+   #pragma warning disable 2196 279 1684 2259
+ 
+ #elif defined __clang__
+-  // -Wconstant-logical-operand - warning: use of logical && with constant operand; switch to bitwise & or remove constant
+-  //     this is really a stupid warning as it warns on compile-time expressions involving enums
+   #ifndef EIGEN_PERMANENTLY_DISABLE_STUPID_WARNINGS
+     #pragma clang diagnostic push
+   #endif
+-  #pragma clang diagnostic ignored "-Wconstant-logical-operand"
+-  #if __clang_major__ >= 3 && __clang_minor__ >= 5
+-    #pragma clang diagnostic ignored "-Wabsolute-value"
+-  #endif
+-  #if __clang_major__ >= 10
+-    #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
+-  #endif
+-  #if ( defined(__ALTIVEC__) || defined(__VSX__) ) && __cplusplus < 201103L
+-    // warning: generic selections are a C11-specific feature
+-    // ignoring warnings thrown at vec_ctf in Altivec/PacketMath.h
+-    #pragma clang diagnostic ignored "-Wc11-extensions"
++  #if defined(__has_warning)
++    // -Wconstant-logical-operand - warning: use of logical && with constant operand; switch to bitwise & or remove constant
++    //     this is really a stupid warning as it warns on compile-time expressions involving enums
++    #if __has_warning("-Wconstant-logical-operand")
++      #pragma clang diagnostic ignored "-Wconstant-logical-operand"
++    #endif
++    #if __has_warning("-Wimplicit-int-float-conversion")
++      #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
++    #endif
++    #if ( defined(__ALTIVEC__) || defined(__VSX__) ) && __cplusplus < 201103L
++      // warning: generic selections are a C11-specific feature
++      // ignoring warnings thrown at vec_ctf in Altivec/PacketMath.h
++      #if __has_warning("-Wc11-extensions")
++        #pragma clang diagnostic ignored "-Wc11-extensions"
++      #endif
++    #endif
+   #endif
+ 
+-#elif defined __GNUC__
++#elif defined __GNUC__ && !defined(__FUJITSU)
+ 
+   #if (!defined(EIGEN_PERMANENTLY_DISABLE_STUPID_WARNINGS)) &&  (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+     #pragma GCC diagnostic push
+@@ -74,25 +77,53 @@
+ #endif
+ 
+ #if defined __NVCC__
+-  #pragma diag_suppress boolean_controlling_expr_is_constant
++  // MSVC 14.16 (required by CUDA 9.*) does not support the _Pragma keyword, so
++  // we instead use Microsoft's __pragma extension.
++  #if defined _MSC_VER
++    #define EIGEN_MAKE_PRAGMA(X) __pragma(#X)
++  #else
++    #define EIGEN_MAKE_PRAGMA(X) _Pragma(#X)
++  #endif
++  #if defined __NVCC_DIAG_PRAGMA_SUPPORT__
++    #define EIGEN_NV_DIAG_SUPPRESS(X) EIGEN_MAKE_PRAGMA(nv_diag_suppress X)
++  #else
++    #define EIGEN_NV_DIAG_SUPPRESS(X) EIGEN_MAKE_PRAGMA(diag_suppress X)
++  #endif
++
++  EIGEN_NV_DIAG_SUPPRESS(boolean_controlling_expr_is_constant)
+   // Disable the "statement is unreachable" message
+-  #pragma diag_suppress code_is_unreachable
++  EIGEN_NV_DIAG_SUPPRESS(code_is_unreachable)
+   // Disable the "dynamic initialization in unreachable code" message
+-  #pragma diag_suppress initialization_not_reachable
++  EIGEN_NV_DIAG_SUPPRESS(initialization_not_reachable)
+   // Disable the "invalid error number" message that we get with older versions of nvcc
+-  #pragma diag_suppress 1222
++  EIGEN_NV_DIAG_SUPPRESS(1222)
+   // Disable the "calling a __host__ function from a __host__ __device__ function is not allowed" messages (yes, there are many of them and they seem to change with every version of the compiler)
+-  #pragma diag_suppress 2527
+-  #pragma diag_suppress 2529
+-  #pragma diag_suppress 2651
+-  #pragma diag_suppress 2653
+-  #pragma diag_suppress 2668
+-  #pragma diag_suppress 2669
+-  #pragma diag_suppress 2670
+-  #pragma diag_suppress 2671
+-  #pragma diag_suppress 2735
+-  #pragma diag_suppress 2737
+-  #pragma diag_suppress 2739
++  EIGEN_NV_DIAG_SUPPRESS(2527)
++  EIGEN_NV_DIAG_SUPPRESS(2529)
++  EIGEN_NV_DIAG_SUPPRESS(2651)
++  EIGEN_NV_DIAG_SUPPRESS(2653)
++  EIGEN_NV_DIAG_SUPPRESS(2668)
++  EIGEN_NV_DIAG_SUPPRESS(2669)
++  EIGEN_NV_DIAG_SUPPRESS(2670)
++  EIGEN_NV_DIAG_SUPPRESS(2671)
++  EIGEN_NV_DIAG_SUPPRESS(2735)
++  EIGEN_NV_DIAG_SUPPRESS(2737)
++  EIGEN_NV_DIAG_SUPPRESS(2739)
++  EIGEN_NV_DIAG_SUPPRESS(2885)
++  EIGEN_NV_DIAG_SUPPRESS(2888)
++  EIGEN_NV_DIAG_SUPPRESS(2976)
++  EIGEN_NV_DIAG_SUPPRESS(2979)
++  EIGEN_NV_DIAG_SUPPRESS(20011)
++  EIGEN_NV_DIAG_SUPPRESS(20014)
++  // Disable the "// __device__ annotation is ignored on a function(...) that is
++  //              explicitly defaulted on its first declaration" message.
++  // The __device__ annotation seems to actually be needed in some cases,
++  // otherwise resulting in kernel runtime errors.
++  EIGEN_NV_DIAG_SUPPRESS(2886)
++  EIGEN_NV_DIAG_SUPPRESS(2977)
++  EIGEN_NV_DIAG_SUPPRESS(20012)
++  #undef EIGEN_NV_DIAG_SUPPRESS
++  #undef EIGEN_MAKE_PRAGMA
+ #endif
+ 
+ #else
+-- 
+2.37.0.windows.1
+

--- a/ports/eigen3/vcpkg.json
+++ b/ports/eigen3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "eigen3",
   "version": "3.4.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.",
   "homepage": "http://eigen.tuxfamily.org",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2554,7 +2554,7 @@
     },
     "eigen3": {
       "baseline": "3.4.0",
-      "port-version": 4
+      "port-version": 5
     },
     "elements": {
       "baseline": "2024-09-12",

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9b547a9e3dc5b847f5ecab763fdea9728107a16",
+      "version": "3.4.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "17249b310c689b0722c3ee825780a8e24c7d73a2",
       "version": "3.4.0",
       "port-version": 4


### PR DESCRIPTION
apply this commit:  https://gitlab.com/libeigen/eigen/-/merge_requests/927

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

