### PR TITLE
[webui] Add new port

### DIFF
--- a/ports/webui/CMakeLists.txt
+++ b/ports/webui/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Project name
+project(WebUILibrary)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 11)
+
+# Variables for library names, source files, etc.
+set(WEBUI_OUT_LIB_NAME "webui-2")
+
+# Conditional compilation for TLS
+option(WEBUI_USE_TLS "Enable TLS support" OFF)
+if(WEBUI_USE_TLS)
+  find_package(OpenSSL REQUIRED)
+endif()
+
+# Source files (already filled)
+set(SOURCE_FILES
+    src/civetweb/civetweb.c
+    src/webui.c
+)
+
+add_library(webui ${SOURCE_FILES})
+target_include_directories(webui PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+set_target_properties(webui PROPERTIES
+    OUTPUT_NAME ${WEBUI_OUT_LIB_NAME}
+    PREFIX "")
+if(WEBUI_USE_TLS)
+  target_compile_definitions(webui PUBLIC WEBUI_TLS WEBUI_TLS NO_SSL_DL OPENSSL_API_1_1)
+  target_link_libraries(webui PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+else()
+  target_compile_definitions(webui PUBLIC NO_SSL)
+endif()
+
+install(FILES include/webui.h include/webui.hpp DESTINATION include)
+
+# Install targets
+install(TARGETS webui
+    EXPORT unofficial-webui
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib)
+
+install(EXPORT unofficial-webui
+    FILE unofficial-webui-config.cmake
+    NAMESPACE unofficial::webui::
+    DESTINATION share/unofficial-webui
+)

--- a/ports/webui/CMakeLists.txt
+++ b/ports/webui/CMakeLists.txt
@@ -13,6 +13,7 @@ set(WEBUI_OUT_LIB_NAME "webui-2")
 option(WEBUI_USE_TLS "Enable TLS support" OFF)
 if(WEBUI_USE_TLS)
   find_package(OpenSSL REQUIRED)
+  set(WEBUI_OUT_LIB_NAME "webui-2-secure")
 endif()
 
 # Source files (already filled)
@@ -23,15 +24,19 @@ set(SOURCE_FILES
 
 add_library(webui ${SOURCE_FILES})
 target_include_directories(webui PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
-set_target_properties(webui PROPERTIES
-    OUTPUT_NAME ${WEBUI_OUT_LIB_NAME}
-    PREFIX "")
+target_compile_definitions(webui PUBLIC NDEBUG NO_CACHING NO_CGI USE_WEBSOCKET)
+if(BUILD_SHARED_LIBS AND WIN32)
+  target_compile_definitions(webui PRIVATE CIVETWEB_DLL_EXPORTS PUBLIC CIVETWEB_DLL_IMPORTS)
+endif()
 if(WEBUI_USE_TLS)
   target_compile_definitions(webui PUBLIC WEBUI_TLS WEBUI_TLS NO_SSL_DL OPENSSL_API_1_1)
   target_link_libraries(webui PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 else()
   target_compile_definitions(webui PUBLIC NO_SSL)
 endif()
+set_target_properties(webui PROPERTIES
+    OUTPUT_NAME ${WEBUI_OUT_LIB_NAME}
+    PREFIX "")
 
 install(FILES include/webui.h include/webui.hpp DESTINATION include)
 

--- a/ports/webui/portfile.cmake
+++ b/ports/webui/portfile.cmake
@@ -1,0 +1,24 @@
+#vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO webui-dev/webui
+    REF "${VERSION}"
+    SHA512 de4392c04d39cac1216354099e52173bb8fb0dd3724e4afa03d79ded4c73e7868c8cf55a451e576ad0665c0c647b9cfb5e7a01c75269a761afd48a23d2efa4eb
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tls   WEBUI_USE_TLS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/webui/portfile.cmake
+++ b/ports/webui/portfile.cmake
@@ -1,5 +1,3 @@
-#vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webui-dev/webui

--- a/ports/webui/portfile.cmake
+++ b/ports/webui/portfile.cmake
@@ -4,9 +4,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webui-dev/webui
     REF "${VERSION}"
-    SHA512 de4392c04d39cac1216354099e52173bb8fb0dd3724e4afa03d79ded4c73e7868c8cf55a451e576ad0665c0c647b9cfb5e7a01c75269a761afd48a23d2efa4eb
+    SHA512 b82321195d0684c11380691ec07e359b348c7a73c649f3f55c45e2748051b7fdd17925bdc96dc32824eb8fde74bf54bb7d778ac5384c1bb47c7841586fe54033
     HEAD_REF master
 )
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
@@ -20,5 +22,9 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-webui)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/webui/vcpkg.json
+++ b/ports/webui/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "webui",
-  "version": "2.5.0-beta.2",
+  "version": "2.4.2",
   "description": "Use any web browser or WebView as GUI, with your preferred language in the backend and modern web technologies in the frontend, all in a lightweight portable library.",
   "homepage": "https://github.com/webui-dev/webui",
   "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ],

--- a/ports/webui/vcpkg.json
+++ b/ports/webui/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Use any web browser or WebView as GUI, with your preferred language in the backend and modern web technologies in the frontend, all in a lightweight portable library.",
   "homepage": "https://github.com/webui-dev/webui",
   "license": "MIT",
-  "supports": "!uwp",
+  "supports": "!uwp & !(arm & android)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/webui/vcpkg.json
+++ b/ports/webui/vcpkg.json
@@ -18,9 +18,7 @@
     "tls": {
       "description": "Enable TLS support",
       "dependencies": [
-        {
-          "name": "openssl"
-        }
+        "openssl"
       ]
     }
   }

--- a/ports/webui/vcpkg.json
+++ b/ports/webui/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Use any web browser or WebView as GUI, with your preferred language in the backend and modern web technologies in the frontend, all in a lightweight portable library.",
   "homepage": "https://github.com/webui-dev/webui",
   "license": "MIT",
-  "supports": "!uwp & !(arm & android)",
+  "supports": "!uwp & !(arm32 & android)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/webui/vcpkg.json
+++ b/ports/webui/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "webui",
+  "version": "2.5.0-beta.2",
+  "description": "Use any web browser or WebView as GUI, with your preferred language in the backend and modern web technologies in the frontend, all in a lightweight portable library.",
+  "homepage": "https://github.com/webui-dev/webui",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "features": {
+    "tls": {
+      "description": "Enable TLS support",
+      "dependencies": [
+        {
+          "name": "openssl"
+        }
+      ]
+    }
+  }
+}

--- a/ports/webui/vcpkg.json
+++ b/ports/webui/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Use any web browser or WebView as GUI, with your preferred language in the backend and modern web technologies in the frontend, all in a lightweight portable library.",
   "homepage": "https://github.com/webui-dev/webui",
   "license": "MIT",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9644,6 +9644,10 @@
       "baseline": "1.0.5",
       "port-version": 1
     },
+    "webui": {
+      "baseline": "2.4.2",
+      "port-version": 0
+    },
     "webview2": {
       "baseline": "1.0.2277.86",
       "port-version": 0

--- a/versions/w-/webui.json
+++ b/versions/w-/webui.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6bf631702c3289b82c61b623b0ae69fed50071fa",
+      "version": "2.4.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/w-/webui.json
+++ b/versions/w-/webui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4668516ce79a556853c98c3bb0af2de20011224d",
+      "git-tree": "ecb4ddbc58fde612c9aeb6003f11c057460eb4c3",
       "version": "2.4.2",
       "port-version": 0
     }

--- a/versions/w-/webui.json
+++ b/versions/w-/webui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6bf631702c3289b82c61b623b0ae69fed50071fa",
+      "git-tree": "4668516ce79a556853c98c3bb0af2de20011224d",
       "version": "2.4.2",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

CMakeLists is based on the official nmake and make configurations.

Fixes https://github.com/microsoft/vcpkg/issues/35821