### PR TITLE
[level-zero] v1.20.0 version

### DIFF
--- a/ports/level-zero/portfile.cmake
+++ b/ports/level-zero/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oneapi-src/level-zero
     REF "v${VERSION}"
-    SHA512 45ce777712ed4dad766a4de6808acaf2588345907c6dc039c5c2f56076b6ecbd0cdcddae6c14531f3e8b6b261b7d4f0302f82ff629f98fc62f5b03cfeb633d2d
+    SHA512 7fa4eed3b23bdbc4b1a2b4cb48e57c29c3fdf8920eda7ce2daad0bd04a72f31cdbe6722114926c1180cb07939424e6db8ce2605851ca365bfda1df3958ef1aa6
     HEAD_REF master
 )
 

--- a/ports/level-zero/vcpkg.json
+++ b/ports/level-zero/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "level-zero",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "description": "oneAPI Level Zero Specification Headers and Loader.",
   "homepage": "https://github.com/oneapi-src/level-zero",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4261,7 +4261,7 @@
       "port-version": 0
     },
     "level-zero": {
-      "baseline": "1.19.2",
+      "baseline": "1.20.0",
       "port-version": 0
     },
     "leveldb": {

--- a/versions/l-/level-zero.json
+++ b/versions/l-/level-zero.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b3504b7af61885023255d5004bfdf152aa8eda1f",
+      "version": "1.20.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "39366344839d08370272fdfa483e2502be36870f",
       "version": "1.19.2",
       "port-version": 0


### PR DESCRIPTION
Required for https://github.com/microsoft/vcpkg/pull/43053 to use vcpkg's level-zero via pkg-config