### PR TITLE
[octave] Update to 9.3.0

### DIFF
--- a/ports/octave/portfile.cmake
+++ b/ports/octave/portfile.cmake
@@ -18,7 +18,7 @@ vcpkg_add_to_path("${GPERF_EXE_PATH}")
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftpmirror.gnu.org/octave/octave-${VERSION}.tar.xz"
     FILENAME "octave-${VERSION}.tar.xz"
-    SHA512 cb1667cd6557d48ecd7ae191bc44c9b9fd4f79e7cf4bf6c917093d120c4312e9594e6dddc5287661627ac053e9f23faaec40a1286d792d859f1fefbfdb3eeb8c
+    SHA512 9550162681aee88b4bcb94c5081ed0470df0d3f7c5307b25878b94b19f1282002ba69f0c4c79877e81f61122bfba1b2671ed5007a28fbb2d755bda466a3c46d8
 )
 
 vcpkg_extract_source_archive(

--- a/ports/octave/vcpkg.json
+++ b/ports/octave/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "octave",
-  "version": "9.2.0",
-  "port-version": 1,
+  "version": "9.3.0",
   "description": "High-level interpreted language, primarily intended for numerical computations.",
   "homepage": "https://octave.org/",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6553,8 +6553,8 @@
       "port-version": 0
     },
     "octave": {
-      "baseline": "9.2.0",
-      "port-version": 1
+      "baseline": "9.3.0",
+      "port-version": 0
     },
     "octomap": {
       "baseline": "1.10.0",

--- a/versions/o-/octave.json
+++ b/versions/o-/octave.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ccc6f3902109e65f792d122b77ccd880b25c3ff8",
+      "version": "9.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "50aea0f8c6c48fa888e1b8ef0bdd611ca14a375d",
       "version": "9.2.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #42967. Update to 9.3.0.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [x] Only one version is added to each modified port's versions file.
