### PR TITLE
[vsgxchange] Update to 1.1.4

### DIFF
--- a/ports/vsgxchange/portfile.cmake
+++ b/ports/vsgxchange/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vsg-dev/vsgXchange
     REF "v${VERSION}"
-    SHA512 b2f8c0382dee8d91a31852c29fecd946deb8c3d45dc9a80eb1fb0d7efce8ecefb099bfd2dba4b3171ddd9e7099da41dbf0b72e11ec53bf982aaf9d04afad5104
+    SHA512 a4c79092162c64f745556fa64b10fd06906526f5f7b7e22e61fc34f42d50116fe1816ff5cb0ca862f7da6a4a221818e99867e8520da4ffc2b9867ef15a01cd13
     HEAD_REF master
     PATCHES require-features.patch
 )

--- a/ports/vsgxchange/require-features.patch
+++ b/ports/vsgxchange/require-features.patch
@@ -1,65 +1,64 @@
 diff --git a/src/assimp/build_vars.cmake b/src/assimp/build_vars.cmake
-index 1e413fc..49d77d4 100644
+index 821de33..b2283fb 100644
 --- a/src/assimp/build_vars.cmake
 +++ b/src/assimp/build_vars.cmake
-@@ -1,7 +1,6 @@
+@@ -1,5 +1,7 @@
  # add assimp if available
 -find_package(assimp 5.1 QUIET)
--if(NOT assimp_FOUND)
--find_package(assimp 5.0 QUIET)
 +if (VSGXCHANGE_WITH_ASSIMP)
-+find_package(assimp REQUIRED)
- endif()
++    find_package(assimp CONFIG REQUIRED)
++endif()
  
- 
+ if(assimp_FOUND)
+     OPTION(vsgXchange_assimp "Optional Assimp support provided" ON)
 diff --git a/src/curl/build_vars.cmake b/src/curl/build_vars.cmake
-index 015b68c..a4afc8a 100644
+index 3f8206d..bdf1cd7 100644
 --- a/src/curl/build_vars.cmake
 +++ b/src/curl/build_vars.cmake
 @@ -1,5 +1,7 @@
  # add CURL if available
 -find_package(CURL)
 +if(VSGXCHANGE_WITH_CURL)
-+find_package(CURL REQUIRED)
++    find_package(CURL REQUIRED)
 +endif()
  
  if(CURL_FOUND)
      OPTION(vsgXchange_curl "Optional CURL support provided" ON)
 diff --git a/src/freetype/build_vars.cmake b/src/freetype/build_vars.cmake
-index cb63a8b..327db9e 100644
+index cb63a8b..2b2343f 100644
 --- a/src/freetype/build_vars.cmake
 +++ b/src/freetype/build_vars.cmake
 @@ -1,5 +1,7 @@
  # add freetype if available
 -find_package(Freetype)
 +if(VSGXCHANGE_WITH_FREETYPE)
-+find_package(Freetype REQUIRED)
++    find_package(Freetype REQUIRED)
 +endif()
  
  if(FREETYPE_FOUND)
      OPTION(vsgXchange_freetype "Freetype support provided" ON)
 diff --git a/src/gdal/build_vars.cmake b/src/gdal/build_vars.cmake
-index dd240b0..227c6b7 100644
+index dd240b0..cdcbdb4 100644
 --- a/src/gdal/build_vars.cmake
 +++ b/src/gdal/build_vars.cmake
 @@ -1,5 +1,7 @@
  # add GDAL if available
 -find_package(GDAL QUIET)
 +if(VSGXCHANGE_WITH_GDAL)
-+find_package(GDAL REQUIRED)
++    find_package(GDAL CONFIG REQUIRED)
 +endif()
  
  if(GDAL_FOUND)
      OPTION(vsgXchange_GDAL "GDAL support provided" ON)
 diff --git a/src/openexr/build_vars.cmake b/src/openexr/build_vars.cmake
-index c4c880a..3ab27c8 100644
+index c4c880a..6595c41 100644
 --- a/src/openexr/build_vars.cmake
 +++ b/src/openexr/build_vars.cmake
 @@ -1,5 +1,7 @@
  # add openexr if available
 -find_package(OpenEXR QUIET)
 +if(VSGXCHANGE_WITH_OPENEXR)
-+find_package(OpenEXR REQUIRED)
++    find_package(OpenEXR CONFIG REQUIRED)
 +endif()
  
  if(OpenEXR_FOUND)

--- a/ports/vsgxchange/vcpkg.json
+++ b/ports/vsgxchange/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vsgxchange",
-  "version": "1.0.5",
-  "port-version": 1,
+  "version": "1.1.4",
   "description": "Utility library for converting 3rd party images, models and fonts formats to/from VulkanSceneGraph.",
   "homepage": "https://github.com/vsg-dev/vsgXchange",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9529,8 +9529,8 @@
       "port-version": 0
     },
     "vsgxchange": {
-      "baseline": "1.0.5",
-      "port-version": 1
+      "baseline": "1.1.4",
+      "port-version": 0
     },
     "vst3sdk": {
       "baseline": "v3.7.12_build_20",

--- a/versions/v-/vsgxchange.json
+++ b/versions/v-/vsgxchange.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc9b4c901aa03cdb767383d0924c1e5318b97748",
+      "version": "1.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "73b799a8d58def43da13c3642687cabbb917c630",
       "version": "1.0.5",
       "port-version": 1


### PR DESCRIPTION
Fixes #35970. Update `vsgxchange` to 1.1.4.

All features are tested successfully in the following triplet:
```
x64-windows
x64-windows-static
arm64-osx
```
The usage test passed on `x64-windows` (header files found).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
