### PR TITLE
[dataframe]: Upgrading C++ DataFrame to version 3.4.0

### DIFF
--- a/ports/dataframe/portfile.cmake
+++ b/ports/dataframe/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hosseinmoein/DataFrame
     REF "${VERSION}"
-    SHA512 0586c114091dcc030d25a16dfe5f8bc9eeaedd1f8d7be6ceeb14538fd848fab45515367de0bb095b8a91b4570111a76c37ffe1cb406b136afef2dcf0fd977ac7
+    SHA512 5aaefb55014118dc3aef9bbf03048dec787073fd4bad165dd12ec54c2eeb29f1489c7df62de09f15d046988154d971315cecddb1ea7ff959bfe2ac13e8310813
     HEAD_REF master
 )
 vcpkg_cmake_configure(

--- a/ports/dataframe/vcpkg.json
+++ b/ports/dataframe/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dataframe",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "C++ DataFrame for statistical, Financial, and ML analysis -- in modern C++ using native types and contiguous memory storage",
   "homepage": "https://github.com/hosseinmoein/DataFrame",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2209,7 +2209,7 @@
       "port-version": 3
     },
     "dataframe": {
-      "baseline": "3.3.0",
+      "baseline": "3.4.0",
       "port-version": 0
     },
     "date": {

--- a/versions/d-/dataframe.json
+++ b/versions/d-/dataframe.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a962ca141fcfcab2e7d40a4c705283503cc1eb33",
+      "git-tree": "4e088553d67ede463b836a8e33290c6aa287df30",
       "version": "3.4.0",
       "port-version": 0
     },

--- a/versions/d-/dataframe.json
+++ b/versions/d-/dataframe.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "git-tree": "a962ca141fcfcab2e7d40a4c705283503cc1eb33",
+      "version": "3.4.0",
+      "port-version": 0
+    },
+    {
+      "git-tree": "a962ca141fcfcab2e7d40a4c705283503cc1eb33",
       "version": "3.3.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
