### PR TITLE
[vcpkg baseline][libgpg-error] Remove from fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -545,9 +545,6 @@ libgnutls:x64-android=fail
 # Fails to build due to incompatible delcaration of select in macOS 14.2
 libgo:x64-osx=fail
 libgo:x64-android=fail
-libgpg-error:arm-neon-android=fail
-libgpg-error:arm64-android=fail
-libgpg-error:x64-android=fail
 # Missing system libraries on linux to run/prepare autoconf
 libgxps:arm-neon-android=fail
 libgxps:arm64-android=fail


### PR DESCRIPTION
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=111085&view=results
```
PASSING, REMOVE FROM FAIL LIST: libgpg-error:arm-neon-android
PASSING, REMOVE FROM FAIL LIST: libgpg-error:arm64-android
PASSING, REMOVE FROM FAIL LIST: libgpg-error:x64-android
```
Added in https://github.com/microsoft/vcpkg/pull/42960, fixed by https://github.com/microsoft/vcpkg/pull/42984, so remove them from `ci.baseline.txt`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [ ] ~~Only one version is added to each modified port's versions file.~~

