### PR TITLE
[avcpp] Add support for Windows shared libraries

### DIFF
--- a/ports/avcpp/portfile.cmake
+++ b/ports/avcpp/portfile.cmake
@@ -1,8 +1,3 @@
-if(VCPKG_TARGET_IS_WINDOWS)
-    # avcpp doesn't export any symbols
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO h4tr3d/avcpp
@@ -24,6 +19,7 @@ vcpkg_cmake_configure(
     OPTIONS
         "-DAV_ENABLE_STATIC=${AVCPP_ENABLE_STATIC}"
         "-DAV_ENABLE_SHARED=${AVCPP_ENABLE_SHARED}"
+        "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
         "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
         -DAV_BUILD_EXAMPLES=OFF
 )

--- a/ports/avcpp/vcpkg.json
+++ b/ports/avcpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "avcpp",
   "version": "2.4.0",
+  "port-version": 1,
   "description": "Wrapper for the FFmpeg that simplify usage it from C++ projects.",
   "homepage": "https://github.com/h4tr3d/avcpp",
   "license": "LGPL-2.1-only OR BSD-3-Clause",

--- a/versions/a-/avcpp.json
+++ b/versions/a-/avcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47233af1b00ba3963bc3a9fce19cad14e6c62a61",
+      "version": "2.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b06ff7d5a249eaa6f633d4fb9ce05b8f6fd8f85b",
       "version": "2.4.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -370,7 +370,7 @@
     },
     "avcpp": {
       "baseline": "2.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "avisynthplus": {
       "baseline": "3.7.3",


### PR DESCRIPTION
Add cmake option to export all symbols to allow for dll linkage

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
