### PR TITLE
[ryml] update to 0.7.2

### DIFF
--- a/ports/jsonnet/0005-use-upstream-rapidyaml.patch
+++ b/ports/jsonnet/0005-use-upstream-rapidyaml.patch
@@ -45,3 +45,12 @@ index e328df5..2cafbb7 100644
  #include "state.h"
  #include "static_analysis.h"
  #include "string_utils.h"
+@@ -1637,7 +1637,7 @@ class Interpreter {
+     }
+ 
+     const ryml::Tree treeFromString(const std::string& s) {
+-        return ryml::parse(c4::to_csubstr(s));
++        return ryml::parse_in_arena(ryml::to_csubstr(s));
+     }
+ 
+     const std::vector<std::string> split(const std::string& s, const std::string& delimiter) {

--- a/ports/jsonnet/vcpkg.json
+++ b/ports/jsonnet/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "jsonnet",
   "version": "0.20.0",
+  "port-version": 1,
   "description": "Jsonnet - The data templating language",
   "homepage": "https://github.com/google/jsonnet",
   "license": "Apache-2.0",

--- a/ports/ryml/cmake-fix.patch
+++ b/ports/ryml/cmake-fix.patch
@@ -1,22 +1,24 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d18407c..db19e0b 100644
+index d80b395..8f1699e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -21,8 +21,7 @@ option(RYML_DBG "Enable (very verbose) ryml debug prints." OFF)
+@@ -27,10 +27,7 @@ option(RYML_INSTALL "Enable install target" ON)
  
  #-------------------------------------------------------
  
 -c4_require_subproject(c4core INCORPORATE
--    SUBDIRECTORY ${RYML_EXT_DIR}/c4core)
+-    SUBDIRECTORY ${RYML_EXT_DIR}/c4core
+-    OVERRIDE C4CORE_INSTALL ${RYML_INSTALL}
+-)
 +find_package(c4core CONFIG REQUIRED)
  
  c4_add_library(ryml
      SOURCES
-@@ -54,10 +53,10 @@ c4_add_library(ryml
+@@ -77,10 +74,10 @@ c4_add_library(ryml
          ryml.natvis
      SOURCE_ROOT ${RYML_SRC_DIR}
      INC_DIRS
-+    $<BUILD_INTERFACE:${C4CORE_INCLUDE_DIR}>
++        $<BUILD_INTERFACE:${C4CORE_INCLUDE_DIR}>
          $<BUILD_INTERFACE:${RYML_SRC_DIR}>
          $<INSTALL_INTERFACE:include>
 -    LIBS c4core

--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/rapidyaml
     REF "v${VERSION}"
-    SHA512 861f1d2c39c5c8d455e8d40e3ecadd828b948c5dea2bcb88ba92686ca77b9a7d69ab2d94407732eab574e4e3c7b319d0f1b31250b18fb513310847192623a2f7
+    SHA512 2ff14776498dc8a55cb257c38fbea5b1a1fc5c4c09ade5b10c45cb4afcaf0cc587674723bedf38fd04b3179a18ba7357a929484b154474d658d597d0f9ee8d2e
     HEAD_REF master
     PATCHES cmake-fix.patch
 )

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ryml",
-  "version": "0.5.0",
-  "port-version": 1,
+  "version": "0.7.2",
   "description": "Rapid YAML library",
   "homepage": "https://github.com/biojppm/rapidyaml",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8113,8 +8113,8 @@
       "port-version": 2
     },
     "ryml": {
-      "baseline": "0.5.0",
-      "port-version": 1
+      "baseline": "0.7.2",
+      "port-version": 0
     },
     "ryu": {
       "baseline": "2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3906,7 +3906,7 @@
     },
     "jsonnet": {
       "baseline": "0.20.0",
-      "port-version": 0
+      "port-version": 1
     },
     "juce": {
       "baseline": "8.0.4",

--- a/versions/j-/jsonnet.json
+++ b/versions/j-/jsonnet.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d0bfbc90a7c02fa2944141ac5128e054e222ae7f",
+      "version": "0.20.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d58bf2d0d8b29fbcd87bfa9bcc4725aaec9283ad",
       "version": "0.20.0",
       "port-version": 0

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f7cac7caba15d67f117443f9332679f17006223",
+      "version": "0.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c8ceae82ba08f1a242ec0b15f80424db37e4847c",
       "version": "0.5.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
