### PR TITLE
[libmupdf] Update to 1.25.2 and fix build error C2099

### DIFF
--- a/ports/libmupdf/fix-NAN-on-Win11.patch
+++ b/ports/libmupdf/fix-NAN-on-Win11.patch
@@ -1,0 +1,22 @@
+diff --git a/source/fitz/geometry.c b/source/fitz/geometry.c
+index 473d1dc..b02ab39 100644
+--- a/source/fitz/geometry.c
++++ b/source/fitz/geometry.c
+@@ -29,6 +29,8 @@
+ #define MAX4(a,b,c,d) fz_max(fz_max(a,b), fz_max(c,d))
+ #define MIN4(a,b,c,d) fz_min(fz_min(a,b), fz_min(c,d))
+ 
++#define MY_NAN (0.0 / 0.0)
++
+ /*	A useful macro to add with overflow detection and clamping.
+ 
+ 	We want to do "b = a + x", but to allow for overflow. Consider the
+@@ -388,7 +390,7 @@ const fz_irect fz_invalid_irect = { 0, 0, -1, -1 };
+ const fz_irect fz_unit_bbox = { 0, 0, 1, 1 };
+ 
+ const fz_quad fz_infinite_quad = { { -INFINITY, INFINITY}, {INFINITY, INFINITY}, {-INFINITY, -INFINITY}, {INFINITY, -INFINITY} };
+-const fz_quad fz_invalid_quad = { {NAN, NAN}, {NAN, NAN}, {NAN, NAN}, {NAN, NAN} };
++const fz_quad fz_invalid_quad = { {MY_NAN, MY_NAN}, {MY_NAN, MY_NAN}, {MY_NAN, MY_NAN}, {MY_NAN, MY_NAN} };
+ 
+ fz_irect
+ fz_irect_from_rect(fz_rect r)

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -4,10 +4,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ArtifexSoftware/mupdf
     REF "${VERSION}"
-    SHA512 d8b6d643b12c9cdf91bf292c8d43a0086eb614a87344d12bbac04e74fc5a333dc699cd37c7715e73f2bee00a233e9b80a1942b879a51275aa865aa12c6fa6b0d
+    SHA512 6d053b140a34061fcf5eb30f23f87e51dd8e80be29a3e505c42312c11198491102a79c2ca290f13971d25b9a286354ad44bd825593c076373c18f58bbc7b950e
     HEAD_REF master
     PATCHES
         dont-generate-extract-3rd-party-things.patch
+        fix-NAN-on-Win11.patch # https://github.com/ArtifexSoftware/mupdf/pull/54
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/libmupdf/vcpkg.json
+++ b/ports/libmupdf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmupdf",
-  "version": "1.24.11",
+  "version": "1.25.2",
   "description": "a lightweight PDF, XPS, and E-book library",
   "homepage": "https://github.com/ArtifexSoftware/mupdf",
   "license": "AGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4857,7 +4857,7 @@
       "port-version": 0
     },
     "libmupdf": {
-      "baseline": "1.24.11",
+      "baseline": "1.25.2",
       "port-version": 0
     },
     "libmysofa": {

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "defca87fb5e4293272118094c10f9825a924e84e",
+      "version": "1.25.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "f76ab7716730acd4fdfdc16d23a19099fed8bc2a",
       "version": "1.24.11",
       "port-version": 0


### PR DESCRIPTION
Update` libmupdf` to 1.25.2, fix build error `F:\0103\buildtrees\libmupdf\src\1.25.2-b62745c8fa.clean\source\fitz\geometry.c(391): error C2099: initializer is not a constant`, I have submitted a upstream PR: https://github.com/ArtifexSoftware/mupdf/pull/54.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
