### PR TITLE
[openssl] Fix build with `"C:\Program Files\<...>\cl.exe"`

### DIFF
--- a/ports/openssl/mkbuildinf.diff
+++ b/ports/openssl/mkbuildinf.diff
@@ -1,0 +1,15 @@
+diff --git a/util/mkbuildinf.pl b/util/mkbuildinf.pl
+index a57c80a..5cecf83 100755
+--- a/util/mkbuildinf.pl
++++ b/util/mkbuildinf.pl
+@@ -9,7 +9,9 @@
+ use strict;
+ use warnings;
+ 
+-my ($cflags, $platform) = @ARGV;
++my $platform = pop @ARGV;
++my $cflags = join(' ', @ARGV);
++$cflags =~ s(\\)(\\\\)g;
+ $cflags = "compiler: $cflags";
+ 
+ # Use the value of the envvar SOURCE_DATE_EPOCH, even if it's

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
     PATCHES
         cmake-config.patch
         command-line-length.patch
+        mkbuildinf.diff
         script-prefix.patch
         asm-armcap.patch
         windows/install-layout.patch

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openssl",
   "version": "3.4.0",
+  "port-version": 1,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6766,7 +6766,7 @@
     },
     "openssl": {
       "baseline": "3.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opensubdiv": {
       "baseline": "3.5.0",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "facccb0b0c47f9804b6e336096d0985c3e541eec",
+      "version": "3.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ce504a83eb9627d54f1cffdb497a6bf5bd970d18",
       "version": "3.4.0",
       "port-version": 0


### PR DESCRIPTION
This fixes the long-standing annoyance that port openssl fails to build with (some) installations of Visual Studio to paths including the space character, also affecting the default location `C:\Program Files\Visual Studio\...`.

The port passes the absolute path of CC and the CFLAGS as detected from the CMake toolchain.
This works for all normal build rules, but not for the invocation of a perl scripts which is meant to write that information into `crypto/buildinf.h` which is created via this rule:
~~~make
$(PERL) <SRCDIR>/util/mkbuildinf.pl "$(CC) $(LIB_CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)" > $@
~~~
 - The rule doesn't properly handle quotes in CC or flags (at least for Windows host), so perl may see multiple arguments when it expects to see *exactly two* arguments.
 - `mkbuildinf.pl` doesn't consider the backslash in filepaths like CC when constructing a C string.

The new patch
 - handles multiple arguments, assuming only that the last one is the platform.
 - quotes all backslashes for C string construction.

NB the full path of the compiler is written as build information into binary aritfacts. If this isn't desired, a different approach must be taken.

Resolves #42740.
Resolves #41751.
Resolves #39912.
Resolves #38723.
Resolves #36175.
Related:
 - https://github.com/openssl/openssl/issues/26253
 - Previous analysis: https://github.com/microsoft/vcpkg/issues/37134#issuecomment-2015717921
 - Previous attempt: https://github.com/microsoft/vcpkg/pull/37716
 - Previous issues: https://github.com/microsoft/vcpkg/issues?q=is%3Aissue%20state%3Aclosed%20openssl%20cversion.c