### PR TITLE
[rocksdb] update to v9.10.0

### DIFF
--- a/ports/rocksdb/0002-fix-android.patch
+++ b/ports/rocksdb/0002-fix-android.patch
@@ -1,0 +1,16 @@
+ env/io_posix.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/env/io_posix.h b/env/io_posix.h
+index 60788df9b..8ddfb3456 100644
+--- a/env/io_posix.h
++++ b/env/io_posix.h
+@@ -30,7 +30,7 @@
+ // For non linux platform, the following macros are used only as place
+ // holder.
+ #if !(defined OS_LINUX) && !(defined OS_FREEBSD) && !(defined CYGWIN) && \
+-    !(defined OS_AIX) && !(defined OS_ANDROID)
++    !(defined OS_AIX) && !(defined OS_ANDROID && __ANDROID_API__ >= 23)
+ #define POSIX_FADV_NORMAL 0     /* [MC1] no further special treatment */
+ #define POSIX_FADV_RANDOM 1     /* [MC1] expect random page refs */
+ #define POSIX_FADV_SEQUENTIAL 2 /* [MC1] expect sequential page refs */

--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO facebook/rocksdb
   REF "v${VERSION}"
-  SHA512 34afd421c86bdb3741f49e35466efbaef041d8461bedf7d32fa6d808e3cc38807aafddfd0bb563f34d21de8f0d31dfc26dcae3208c2dd36da449913cef9a3e1b
+  SHA512 b9a53c13f69e723cc41f8431ffc2f0b0be7a85d7a598b2f7a41cf89c34cb3ec55ba8b7874d579914851da59f252e2fcbe8091e490e9a6eca68d7995e2f8b667e
   HEAD_REF main
   PATCHES
     0001-fix-dependencies.patch

--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
   HEAD_REF main
   PATCHES
     0001-fix-dependencies.patch
+    0002-fix-android.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" WITH_MD_LIBRARY)

--- a/ports/rocksdb/vcpkg.json
+++ b/ports/rocksdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rocksdb",
-  "version": "9.8.4",
+  "version": "9.10.0",
   "description": "A library that provides an embeddable, persistent key-value store for fast storage",
   "homepage": "https://github.com/facebook/rocksdb",
   "license": "GPL-2.0-only OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8029,7 +8029,7 @@
       "port-version": 0
     },
     "rocksdb": {
-      "baseline": "9.8.4",
+      "baseline": "9.10.0",
       "port-version": 0
     },
     "rpclib": {

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc6b3a48e3bb11c057b54b6fcd3951742b6f27f2",
+      "git-tree": "6587a5da30b690d56e47430a61cddbd3737e4f2d",
       "version": "9.10.0",
       "port-version": 0
     },

--- a/versions/r-/rocksdb.json
+++ b/versions/r-/rocksdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc6b3a48e3bb11c057b54b6fcd3951742b6f27f2",
+      "version": "9.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "efc6be9410c84ce01053b664e06702749d8c0951",
       "version": "9.8.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
