### PR TITLE
[cpptrace] Add 0.7.5 

### DIFF
--- a/ports/cpptrace/portfile.cmake
+++ b/ports/cpptrace/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jeremy-rifkin/cpptrace
     REF "v${VERSION}"
-    SHA512 86784217cfca1d55f326d713aba547d1c858c97a8ab5f9c0c79a8a7e395a7ac6adc2fa9efd97f202c1bab817c1ab0472352c2322cd1712b772e8ea2160cf0cca
+    SHA512 45d2e15a1df60a797333ce2c0753db4c7b638d1fbde5135f5fdaa8c3016b95bf70cc2c1dc9902f4e27c5922294e7a7ad1893a502ae8211da82d597a9aa1c11db
     HEAD_REF main
 )
 

--- a/ports/cpptrace/vcpkg.json
+++ b/ports/cpptrace/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpptrace",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Simple, portable, and self-contained stacktrace library for C++11 and newer",
   "homepage": "https://github.com/jeremy-rifkin/cpptrace",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1997,7 +1997,7 @@
       "port-version": 4
     },
     "cpptrace": {
-      "baseline": "0.7.4",
+      "baseline": "0.7.5",
       "port-version": 0
     },
     "cppunit": {

--- a/versions/c-/cpptrace.json
+++ b/versions/c-/cpptrace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "508408d91c5ccf6b4cb9c6937d42bbacd4d0e871",
+      "version": "0.7.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "d855e5b820c9ec4659e5a7ec54c97a0e03b5858c",
       "version": "0.7.4",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
