### PR TITLE
[sdl2-image] Update to 2.8.4

### DIFF
--- a/ports/sdl2-image/fix-findwebp.patch
+++ b/ports/sdl2-image/fix-findwebp.patch
@@ -8,7 +8,7 @@ index 65a8811..1f29faa 100644
          message(STATUS "${PROJECT_NAME}: Using system libwebp")
 -        find_package(webp REQUIRED)
 +        find_package(webp NAMES WebP CONFIG REQUIRED)
-         list(APPEND PC_REQUIRES libwebp)
+         list(APPEND PC_REQUIRES libwebp libwebpdemux)
      endif()
      if(SDL2IMAGE_WEBP_SHARED)
 diff --git a/SDL2_imageConfig.cmake.in b/SDL2_imageConfig.cmake.in

--- a/ports/sdl2-image/portfile.cmake
+++ b/ports/sdl2-image/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL_image
     REF "release-${VERSION}"
-    SHA512 1ec6e7d08bbcd28bba6c972b2e4a11a1da841abef3ffb3d29669b0f5eb0839f39044b0b334c0707274dd51192e081f25bdab97c6710d632422c4ed0274a30f18
+    SHA512 112a523b44630b4e03b100c89f794bc5bc6707965426436c914478948fec6aea9c3a5a4f4b20f6f6bf03ac9440bffddebfd31c1ecd5b99c46bc06e08e0b05f15
     HEAD_REF main
     PATCHES 
         fix-findwebp.patch

--- a/ports/sdl2-image/vcpkg.json
+++ b/ports/sdl2-image/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sdl2-image",
-  "version": "2.8.2",
-  "port-version": 2,
+  "version": "2.8.4",
   "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
   "homepage": "https://github.com/libsdl-org/SDL_image",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8249,8 +8249,8 @@
       "port-version": 11
     },
     "sdl2-image": {
-      "baseline": "2.8.2",
-      "port-version": 2
+      "baseline": "2.8.4",
+      "port-version": 0
     },
     "sdl2-mixer": {
       "baseline": "2.8.0",

--- a/versions/s-/sdl2-image.json
+++ b/versions/s-/sdl2-image.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3190ce60e37965fc1692fc28d0d4a307bf8b8636",
+      "version": "2.8.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "61b91c7aa89e01e237616121222f98e505a6d44b",
       "version": "2.8.2",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.