### PR TITLE
[libshout] New port of icecast-libshout

### DIFF
--- a/ports/libshout/portfile.cmake
+++ b/ports/libshout/portfile.cmake
@@ -1,0 +1,44 @@
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.xiph.org
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO xiph/icecast-libshout
+    REF "v${VERSION}"
+    HEAD_REF master
+    SHA512 04dbb567f36269506becc3a50eb5fa263cbc308764c3fc1e59c3ab4833ef944479d0d35af33941214ff86899c40253a0ded095e5e217035848ce2694496720b5
+)
+
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.xiph.org
+    OUT_SOURCE_PATH SOURCE_PATH_COMMON
+    REPO xiph/icecast-common
+    REF 5de3e8b3
+    HEAD_REF master
+    SHA512 eb505b9019a97a91e10fa505225dde4f9950f6ae50b54c7afd806f6eebeb865862de85e9d0a114f2e8c4f974c4db60622e71f52f5e758cdb0efcda735bb7ab51
+)
+
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.xiph.org
+    OUT_SOURCE_PATH SOURCE_PATH_M4
+    REPO xiph/icecast-m4
+    REF 57027c6c
+    HEAD_REF master
+    SHA512 d2a9507a5a0d36134c4dc37fe38b3cb4d954dee3ffa5fd2b1bb4cd8af1e7804248e234e55fbcfba20fecec4bf159b2616d14ac537d03ffbff095a02d5f4bf201
+)
+
+file(COPY ${SOURCE_PATH_COMMON}/ DESTINATION ${SOURCE_PATH}/src/common)
+file(COPY ${SOURCE_PATH_M4}/ DESTINATION ${SOURCE_PATH}/m4)
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+)
+
+vcpkg_make_install()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libshout RENAME copyright)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libshout/portfile.cmake
+++ b/ports/libshout/portfile.cmake
@@ -28,9 +28,16 @@ vcpkg_from_gitlab(
 file(COPY ${SOURCE_PATH_COMMON}/ DESTINATION ${SOURCE_PATH}/src/common)
 file(COPY ${SOURCE_PATH_M4}/ DESTINATION ${SOURCE_PATH}/m4)
 
+set(FEATURE_OPTIONS "")
+if(NOT "speex" IN_LIST FEATURES)
+    list(APPEND FEATURE_OPTIONS "--disable-speex")
+endif()
+
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTORECONF
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_make_install()

--- a/ports/libshout/portfile.cmake
+++ b/ports/libshout/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.xiph.org
     OUT_SOURCE_PATH SOURCE_PATH_COMMON
     REPO xiph/icecast-common
-    REF 5de3e8b3
+    REF 5de3e8b3b063002d8a9f52122e97f721e1742531
     HEAD_REF master
     SHA512 eb505b9019a97a91e10fa505225dde4f9950f6ae50b54c7afd806f6eebeb865862de85e9d0a114f2e8c4f974c4db60622e71f52f5e758cdb0efcda735bb7ab51
 )

--- a/ports/libshout/portfile.cmake
+++ b/ports/libshout/portfile.cmake
@@ -20,7 +20,7 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.xiph.org
     OUT_SOURCE_PATH SOURCE_PATH_M4
     REPO xiph/icecast-m4
-    REF 57027c6c
+    REF 57027c6cc3f8b26d59e9560b4ac72a1a06d643b9
     HEAD_REF master
     SHA512 d2a9507a5a0d36134c4dc37fe38b3cb4d954dee3ffa5fd2b1bb4cd8af1e7804248e234e55fbcfba20fecec4bf159b2616d14ac537d03ffbff095a02d5f4bf201
 )

--- a/ports/libshout/portfile.cmake
+++ b/ports/libshout/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_gitlab(
     REPO xiph/icecast-common
     REF 5de3e8b3b063002d8a9f52122e97f721e1742531
     HEAD_REF master
-    SHA512 eb505b9019a97a91e10fa505225dde4f9950f6ae50b54c7afd806f6eebeb865862de85e9d0a114f2e8c4f974c4db60622e71f52f5e758cdb0efcda735bb7ab51
+    SHA512 f064e2b2dd686c7647ba4c5afb9ca7e85b2015643d7a185cc319f47461aacc765e7f9b3e9576e09a73a8af0724a54fafdd7c064756d3c6e97329bb5f77806933
 )
 
 vcpkg_from_gitlab(
@@ -22,7 +22,7 @@ vcpkg_from_gitlab(
     REPO xiph/icecast-m4
     REF 57027c6cc3f8b26d59e9560b4ac72a1a06d643b9
     HEAD_REF master
-    SHA512 d2a9507a5a0d36134c4dc37fe38b3cb4d954dee3ffa5fd2b1bb4cd8af1e7804248e234e55fbcfba20fecec4bf159b2616d14ac537d03ffbff095a02d5f4bf201
+    SHA512 67fe6fad8bf86990b5da311d729b9a746849f3d920c018112b4625b5e0d37a85444be16367967cb18a871c1ca1d679f5924ad3fc8547fbb30746b7e1f4b396bc
 )
 
 file(COPY ${SOURCE_PATH_COMMON}/ DESTINATION ${SOURCE_PATH}/src/common)

--- a/ports/libshout/portfile.cmake
+++ b/ports/libshout/portfile.cmake
@@ -38,7 +38,7 @@ vcpkg_fixup_pkgconfig()
 
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libshout RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libshout/vcpkg.json
+++ b/ports/libshout/vcpkg.json
@@ -1,0 +1,28 @@
+{
+  "name": "libshout",
+  "version": "2.4.6",
+  "description": "A library for communicating with and sending data to an Icecast server.",
+  "homepage": "https://gitlab.xiph.org/xiph/icecast-libshout",
+  "dependencies": [
+    "libogg",
+    "libtheora",
+    "libvorbis",
+    "openssl",
+    "pthread",
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "speex"
+  ],
+  "features": {
+    "speex": {
+      "description": "Enable support for Speex codec",
+      "dependencies": [
+        "speex"
+      ]
+    }
+  }
+}

--- a/ports/libshout/vcpkg.json
+++ b/ports/libshout/vcpkg.json
@@ -16,9 +16,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "speex"
-  ],
   "features": {
     "speex": {
       "description": "Enable support for Speex codec",

--- a/ports/libshout/vcpkg.json
+++ b/ports/libshout/vcpkg.json
@@ -3,6 +3,8 @@
   "version": "2.4.6",
   "description": "A library for communicating with and sending data to an Icecast server.",
   "homepage": "https://gitlab.xiph.org/xiph/icecast-libshout",
+  "license": "LGPL-2.0-or-later",
+  "supports": "!windows",
   "dependencies": [
     "libogg",
     "libtheora",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5096,6 +5096,10 @@
       "baseline": "0.1.0",
       "port-version": 0
     },
+    "libshout": {
+      "baseline": "2.4.6",
+      "port-version": 0
+    },
     "libsigcpp": {
       "baseline": "3.6.0",
       "port-version": 1

--- a/versions/l-/libshout.json
+++ b/versions/l-/libshout.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b1ccf9c305e2a9d44b4c1e1b702d13f46c31ed62",
+      "version": "2.4.6",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libshout.json
+++ b/versions/l-/libshout.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d7873dc2f049ebaa3e94d9f7dd1b7a9b62f9813b",
+      "git-tree": "73c633aaffd3521a604d29a757c47df89c4d49be",
       "version": "2.4.6",
       "port-version": 0
     }

--- a/versions/l-/libshout.json
+++ b/versions/l-/libshout.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b1ccf9c305e2a9d44b4c1e1b702d13f46c31ed62",
+      "git-tree": "d7873dc2f049ebaa3e94d9f7dd1b7a9b62f9813b",
       "version": "2.4.6",
       "port-version": 0
     }

--- a/versions/l-/libshout.json
+++ b/versions/l-/libshout.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "73c633aaffd3521a604d29a757c47df89c4d49be",
+      "git-tree": "755d43d4bb02bfea8f528a9f3db52bd2a610d15e",
       "version": "2.4.6",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
