### PR TITLE
[c-ares] update to 1.34.4

### DIFF
--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO c-ares/c-ares
     REF "v${VERSION}"
-    SHA512 bafe97923a316bb4c33f616448faa04b938f46336cdf26a38ab619faeabcaa88f285e645f4309b928995008e9a0ede232609d58ee344a1729a9e29a9cbe4d94c
+    SHA512 7bd4ca8f1a1b6d7b6662c724315bb5d4ca1d3c19e5ff4e06e3567ea25d5f8fd60f9c5f9ade055f08dc7fc3dec0e40e96f8284207b3e03c0975fd962d4a9fcb47
     HEAD_REF main
     PATCHES
         avoid-docs.patch

--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO c-ares/c-ares
     REF "v${VERSION}"
-    SHA512 0c4041ef3ec8e54d11826ae5ea3dbb3752fbd6dcfeb65c3777e56309dc0f4944068c24d54b39cced219c7ee440aae7a6704269558627c26a90001d872d99ded9
+    SHA512 bafe97923a316bb4c33f616448faa04b938f46336cdf26a38ab619faeabcaa88f285e645f4309b928995008e9a0ede232609d58ee344a1729a9e29a9cbe4d94c
     HEAD_REF main
     PATCHES
         avoid-docs.patch

--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO c-ares/c-ares
     REF "v${VERSION}"
-    SHA512 87ca8ceda8b4afbc3e68014c6c8604550f17e6b343330801c396aae393f1c98747e65d3459db7b9626abc73f1216422e794a0d0f044dd1fda3efda4005b0ef1f
+    SHA512 5924d706341e35ad467bf48c88a8f53617d5fb94546b1d9dd24a7091cc84763e52f9bbdfa39abdf1aa55099d4b87116af56bf584b99a5c8f5e554ecf9d7bc8a8
     HEAD_REF main
     PATCHES
         avoid-docs.patch

--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c-ares",
-  "version-semver": "1.34.3",
+  "version-semver": "1.34.4",
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "license": "MIT-CMU",

--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,11 +1,9 @@
 {
   "name": "c-ares",
-  "version-semver": "1.31.0",
-  "port-version": 1,
+  "version-semver": "1.33.0",
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "license": "MIT-CMU",
-  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c-ares",
-  "version-semver": "1.34.2",
+  "version-semver": "1.34.3",
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "license": "MIT-CMU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1433,8 +1433,8 @@
       "port-version": 5
     },
     "c-ares": {
-      "baseline": "1.31.0",
-      "port-version": 1
+      "baseline": "1.33.0",
+      "port-version": 0
     },
     "c-dbg-macro": {
       "baseline": "2020-02-29",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1457,7 +1457,7 @@
       "port-version": 6
     },
     "c-ares": {
-      "baseline": "1.34.3",
+      "baseline": "1.34.4",
       "port-version": 0
     },
     "c-dbg-macro": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1457,7 +1457,7 @@
       "port-version": 6
     },
     "c-ares": {
-      "baseline": "1.34.2",
+      "baseline": "1.34.3",
       "port-version": 0
     },
     "c-dbg-macro": {

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7450d43c71f90bacb38c23f1172ac6c9cccb083",
+      "version-semver": "1.34.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "c01c2a71a29047cc895afe3286f691c68f36927b",
       "version-semver": "1.34.3",
       "port-version": 0

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c01c2a71a29047cc895afe3286f691c68f36927b",
+      "version-semver": "1.34.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "78f3eb04280f992a8af0ebc68f67d965542ebffc",
       "version-semver": "1.34.2",
       "port-version": 0

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05a0806e25d8f4ab5a0e147c157bfffb345b4da8",
+      "version-semver": "1.33.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6c07bb206a33f3005265a3e2db4c697a3097f8f3",
       "version-semver": "1.31.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43075
Usage test passed with x64-windows triplet.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.