### PR TITLE
[llvm] Modify the license

### DIFF
--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "llvm",
   "version": "18.1.6",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
-  "license": "Apache-2.0",
+  "license": "Apache-2.0 WITH LLVM-exception",
   "supports": "!uwp & !(arm & windows)",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5590,7 +5590,7 @@
     },
     "llvm": {
       "baseline": "18.1.6",
-      "port-version": 3
+      "port-version": 4
     },
     "lmdb": {
       "baseline": "0.9.33",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de2757d5adacfd8a2d00a79278a84680d2beca11",
+      "version": "18.1.6",
+      "port-version": 4
+    },
+    {
       "git-tree": "4037972c311903335c3cca2fbb4683570f309ff9",
       "version": "18.1.6",
       "port-version": 3


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43085

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.