### PR TITLE
[openmvg] Fix linux build

### DIFF
--- a/ports/openmvg/portfile.cmake
+++ b/ports/openmvg/portfile.cmake
@@ -76,14 +76,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/openMVG/")
-file(RENAME "${CURRENT_PACKAGES_DIR}/lib/openMVG/cmake" "${CURRENT_PACKAGES_DIR}/share/openMVG/cmake")
-if(NOT VCPKG_BUILD_TYPE)
-  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/share/openMVG/")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/openMVG/cmake" "${CURRENT_PACKAGES_DIR}/debug/share/openMVG/cmake")
-endif()
-
-vcpkg_cmake_config_fixup(PACKAGE_NAME openMVG)
+vcpkg_cmake_config_fixup(PACKAGE_NAME openMVG CONFIG_PATH lib/openMVG/cmake)
 
 file(REMOVE_RECURSE
      "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/openmvg/portfile.cmake
+++ b/ports/openmvg/portfile.cmake
@@ -83,7 +83,7 @@ if(NOT VCPKG_BUILD_TYPE)
   file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/openMVG/cmake" "${CURRENT_PACKAGES_DIR}/debug/share/openMVG/cmake")
 endif()
 
-vcpkg_cmake_config_fixup()
+vcpkg_cmake_config_fixup(PACKAGE_NAME openMVG)
 
 file(REMOVE_RECURSE
      "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/openmvg/vcpkg.json
+++ b/ports/openmvg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openmvg",
   "version": "2.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "open Multiple View Geometry library. Basis for 3D computer vision and Structure from Motion.",
   "license": "MPL-2.0-no-copyleft-exception",
   "supports": "(x86 | x64 | arm64) & !xbox",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -832,7 +832,6 @@ openmesh:x64-uwp=fail
 openmpi:arm-neon-android=fail
 openmpi:arm64-android=fail
 openmpi:x64-android=fail
-openmvg:x64-linux=fail
 openmvg:arm64-windows-static-md=fail
 openmvs:arm64-windows-static-md=fail
 openscap:arm-neon-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6746,7 +6746,7 @@
     },
     "openmvg": {
       "baseline": "2.1",
-      "port-version": 1
+      "port-version": 2
     },
     "openmvs": {
       "baseline": "2.1.0",

--- a/versions/o-/openmvg.json
+++ b/versions/o-/openmvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3aa3b68a6e28664aa5021b9462a3bdc9d487f5cc",
+      "version": "2.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "004bc9d5fa217b3e1f94c62f850107d47ff7427b",
       "version": "2.1",
       "port-version": 1

--- a/versions/o-/openmvg.json
+++ b/versions/o-/openmvg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3aa3b68a6e28664aa5021b9462a3bdc9d487f5cc",
+      "git-tree": "38533476276dcfa0df12c138514db2dfed75dec9",
       "version": "2.1",
       "port-version": 2
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43106
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.