### PR TITLE
[vcpkg-ci-mdl-sdk] Add test port.

### DIFF
--- a/scripts/test_ports/vcpkg-ci-mdl-sdk/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-mdl-sdk/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/scripts/test_ports/vcpkg-ci-mdl-sdk/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-mdl-sdk/portfile.cmake
@@ -1,1 +1,3 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)

--- a/scripts/test_ports/vcpkg-ci-mdl-sdk/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-mdl-sdk/portfile.cmake
@@ -1,3 +1,1 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)

--- a/scripts/test_ports/vcpkg-ci-mdl-sdk/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-mdl-sdk/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "vcpkg-ci-mdl-sdk",
+  "version-string": "ci",
+  "description": "Port to force features of certain ports within CI",
+  "license": "BSD-3-Clause",
+  "supports": "!x86 & !(windows & (staticcrt | arm | uwp)) & !(osx & arm) & !android",
+  "dependencies": [
+    {
+      "name": "mdl-sdk",
+      "default-features": false,
+      "features": [
+        "dds",
+        "openimageio"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/scripts/test_ports/vcpkg-ci-mdl-sdk/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-mdl-sdk/vcpkg.json
@@ -3,7 +3,7 @@
   "version-string": "ci",
   "description": "Port to force features of certain ports within CI",
   "license": "BSD-3-Clause",
-  "supports": "!x86 & !(windows & (staticcrt | arm | uwp)) & !(osx & arm) & !android",
+  "supports": "!x86 & !(windows & (staticcrt | arm | uwp | static)) & !(osx & arm) & !android",
   "dependencies": [
     {
       "name": "mdl-sdk",

--- a/scripts/test_ports/vcpkg-ci-mdl-sdk/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-mdl-sdk/vcpkg.json
@@ -3,7 +3,7 @@
   "version-string": "ci",
   "description": "Port to force features of certain ports within CI",
   "license": "BSD-3-Clause",
-  "supports": "!x86 & !(windows & (staticcrt | arm | uwp | static)) & !(osx & arm) & !android",
+  "supports": "!(windows & static)",
   "dependencies": [
     {
       "name": "mdl-sdk",


### PR DESCRIPTION
Add test port to prevent future regressions of mdl-sdk features, in particular for the openimageio feature, as it happened in #37489.

(I believe the unchecked items below do not really apply for new **test** ports.)

- [x] Changes comply with the [maintainer guide]
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.
