### PR TITLE
[mujoco] Update to 2.3.7

### DIFF
--- a/ports/mujoco/fix_x86.patch
+++ b/ports/mujoco/fix_x86.patch
@@ -1,0 +1,24 @@
+diff --git a/include/mujoco/mjtnum.h b/include/mujoco/mjtnum.h
+index b9d78ea1..771fc601 100644
+--- a/include/mujoco/mjtnum.h
++++ b/include/mujoco/mjtnum.h
+@@ -17,9 +17,16 @@
+ 
+ //---------------------------------- floating-point definition -------------------------------------
+ 
+-// compile-time configuration options
+-#define mjUSEDOUBLE               // single or double precision for mjtNum
+-
++#if _WIN32 || _WIN64
++  #if _WIN64
++    // compile-time configuration options
++    #define mjUSEDOUBLE               // single or double precision for mjtNum
++  #else
++  #endif
++#else
++  // compile-time configuration options
++  #define mjUSEDOUBLE               // single or double precision for mjtNum
++#endif
+ 
+ // floating point data type and minval
+ #ifdef mjUSEDOUBLE

--- a/ports/mujoco/portfile.cmake
+++ b/ports/mujoco/portfile.cmake
@@ -2,9 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO deepmind/mujoco
     REF ${VERSION}
-    SHA512 518b9ae09ea7cd4d2095df1be985a30957c6d57846933e111c326e45b61ac002bea014cd0d7902653c85e61ef0ba156b3324eff0edb5613467fe8e07e92dd6da
+    SHA512 40e73339b65f051e9774f5d7f8ca0984b5bdce52fcb46a5e5a8449efc09d7eb5441b918d07ebd8b5cf2f69616ff1a8e32d6b5dab76c9440da1a5e6ce3328c261
     PATCHES
         fix_dependencies.patch
+        fix_x86.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/mujoco/vcpkg.json
+++ b/ports/mujoco/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mujoco",
-  "version": "2.3.2",
-  "port-version": 1,
+  "version": "2.3.7",
   "description": "Multi-Joint dynamics with Contact.",
   "homepage": "https://mujoco.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6197,8 +6197,8 @@
       "port-version": 0
     },
     "mujoco": {
-      "baseline": "2.3.2",
-      "port-version": 1
+      "baseline": "2.3.7",
+      "port-version": 0
     },
     "mujs": {
       "baseline": "1.3.5",

--- a/versions/m-/mujoco.json
+++ b/versions/m-/mujoco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c367ca232833261b6aa8fc90742c149ca37ad86",
+      "version": "2.3.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "c70b9104b75fe8947ddac6e9450207cadb59cb0b",
       "version": "2.3.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
