### PR TITLE
[wildmidi] Update to 0.4.6 and fix the usage

### DIFF
--- a/ports/wildmidi/fix-include-path.patch
+++ b/ports/wildmidi/fix-include-path.patch
@@ -1,0 +1,16 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 73fc68c..4a606d6 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -90,6 +90,11 @@ IF (BUILD_SHARED_LIBS)
+         OUTPUT_NAME ${LIBRARY_DYN_NAME} CLEAN_DIRECT_OUTPUT 1
+     )
+ 
++    TARGET_INCLUDE_DIRECTORIES(libwildmidi INTERFACE
++        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
++        $<INSTALL_INTERFACE:include>
++    )
++
+     IF (WIN32)
+         SET_TARGET_PROPERTIES(libwildmidi PROPERTIES
+             DEFINE_SYMBOL DLL_EXPORT

--- a/ports/wildmidi/portfile.cmake
+++ b/ports/wildmidi/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Mindwerks/wildmidi
-    REF wildmidi-0.4.5
-    SHA512 0229914ecc60091b649b790a82ad5e755a2b9dfab7443fb3e3c19f4ae64b82817cafe74d78c27f05c68c3c8fb30092c96da732d27ff82fbd7dd7d577facc23d6
+    REF "wildmidi-${VERSION}"
+    SHA512 b7259578c1b334de13b49e27aef32ad43e41bc04f569601b765ecea789b8da536d07afdb581986b7c91de552db2a625b13d061e52a2c8c51652f3cf3d1a30000
     HEAD_REF master
 )
 
@@ -28,4 +28,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/man")
 
-file(INSTALL "${SOURCE_PATH}/docs/license/LGPLv3.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/docs/license/LGPLv3.txt")

--- a/ports/wildmidi/portfile.cmake
+++ b/ports/wildmidi/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF "wildmidi-${VERSION}"
     SHA512 b7259578c1b334de13b49e27aef32ad43e41bc04f569601b765ecea789b8da536d07afdb581986b7c91de552db2a625b13d061e52a2c8c51652f3cf3d1a30000
     HEAD_REF master
+    PATCHES fix-include-path.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)

--- a/ports/wildmidi/vcpkg.json
+++ b/ports/wildmidi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wildmidi",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "MIDI software synthesizer library.",
   "homepage": "https://github.com/Mindwerks/wildmidi",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9665,7 +9665,7 @@
       "port-version": 0
     },
     "wildmidi": {
-      "baseline": "0.4.5",
+      "baseline": "0.4.6",
       "port-version": 0
     },
     "wincrypt": {

--- a/versions/w-/wildmidi.json
+++ b/versions/w-/wildmidi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8f00b27aa5074d33f3f0439b7226bbcdcb748dc5",
+      "git-tree": "6125f3402595c56f9454a09af832cdd2aa379cc3",
       "version": "0.4.6",
       "port-version": 0
     },

--- a/versions/w-/wildmidi.json
+++ b/versions/w-/wildmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f00b27aa5074d33f3f0439b7226bbcdcb748dc5",
+      "version": "0.4.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "a0da0fad8cf43fc4534ae5fc11060437582fa6b8",
       "version": "0.4.5",
       "port-version": 0


### PR DESCRIPTION
Fixes #43097. Update `wildmidi` to 0.4.6.

Fix the usage of `wildmidi`, upstream PR: https://github.com/Mindwerks/wildmidi/pull/258.
```
CMakeUsage.cpp(5,10): error C1083: Cannot open include file: 'wildmidi_lib.h': No such file or directory 
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
