### PR TITLE
[opencl] v2024.10.24 release

### DIFF
--- a/ports/opencl/001-remove-extra-install-rules.patch
+++ b/ports/opencl/001-remove-extra-install-rules.patch
@@ -1,0 +1,36 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index dfb336d..ef97f82 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -114,13 +114,6 @@ foreach(UTIL_LIB_NAME IN ITEMS Utils UtilsCpp)
+     DESTINATION ${config_package_location}
+     COMPONENT binary
+   )
+-
+-  # For packaging the utils libraries
+-  install(
+-    TARGETS ${UTIL_LIB_TARGET}
+-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    COMPONENT binary
+-  )
+ endforeach()
+ 
+ if(OPENCL_SDK_BUILD_SAMPLES)
+diff --git a/lib/src/Extensions/CMakeLists.txt b/lib/src/Extensions/CMakeLists.txt
+index e05d4e7..017f7ad 100644
+--- a/lib/src/Extensions/CMakeLists.txt
++++ b/lib/src/Extensions/CMakeLists.txt
+@@ -151,13 +151,6 @@ if (OPENCL_EXTENSION_LOADER_INSTALL)
+         DESTINATION ${OPENCL_EXTENSION_LOADER_CONFIG_PATH}
+         COMPONENT binary
+     )
+-
+-    # For packaging the extensions library
+-    install(
+-        TARGETS OpenCLExt
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        COMPONENT binary
+-    )
+ endif()
+ 
+ if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)

--- a/ports/opencl/portfile.cmake
+++ b/ports/opencl/portfile.cmake
@@ -1,16 +1,19 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/OpenCL-SDK
-    REF "${VERSION}"
-    SHA512 995ed5cff95fec7ffd8470f04eb4d00325f9acb20cc1f0d78442890d0636554c2526c015351f4b19bc673dcadd531bb62d9d3c8c526dd921f236cb5035e906e0
+    REF "v${VERSION}"
+    SHA512 be396a7aad6251d9d1f1af265ecf20f3428d87610d680c14d92fb5b060a59ce8b8522135a0dd29eaf20e75683e45c1c8ea55035a7c3ec3eddc4bc7680d68b66e
     HEAD_REF main
+    PATCHES
+        # see https://github.com/KhronosGroup/OpenCL-SDK/pull/88/files#r1905072265
+        001-remove-extra-install-rules.patch
 )
 
 vcpkg_from_github(
     OUT_SOURCE_PATH OPENCL_HEADERS
     REPO KhronosGroup/OpenCL-Headers
-    REF "${VERSION}"
-    SHA512 2f1a46d58a5a9329470bab4c3662f17e81aab9558bfd9e1aafa14d3e1ab129513ab9493eeeb3cc48f0f91f0bc6b61bd54e28d7083eed58af9f34cd973cc93de1
+    REF "v${VERSION}"
+    SHA512 9d2ed2a8346bc3f967989091d8cc36148ffe5ff13fe30e12354cc8321c09328bbe23e74817526b99002729c884438a3b1834e175a271f6d36e8341fd86fc1ad5
     HEAD_REF main
 )
 if(NOT EXISTS "${SOURCE_PATH}/external/OpenCL-Headers/CMakeLists.txt")
@@ -21,8 +24,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH OPENCL_CLHPP
     REPO KhronosGroup/OpenCL-CLHPP
-    REF "${VERSION}"
-    SHA512 6396cd67a2edef6a76695857e3e45f7eeb8cdaa8c729197357c6374ac58b41caa37bbe8c3b7a1724d43d3805f8cd5edd53a8ed833d6415bf072745800b744572
+    REF "v${VERSION}"
+    SHA512 7cdadc8ef182d1556346bd34b5a9ffe6e239ab61ec527e5609d69e1bcaf81a88f3fc534f5bdeed037236e1b0e61f1544d2a95c06df55f9cd8e03e13baf4143ba
     HEAD_REF main
 )
 if(NOT EXISTS "${SOURCE_PATH}/external/OpenCL-CLHPP/CMakeLists.txt")
@@ -33,8 +36,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH OPENCL_ICD_LOADER
     REPO KhronosGroup/OpenCL-ICD-Loader
-    REF "${VERSION}"
-    SHA512 12d62183e49c5a1f813807291744d816008afca55b09f5acf2eef1bce50a453bf35a8dfbeb5f433022b0c5517f0a210d7123a3bac7a15ea63cc10f3bc71510f0
+    REF "v${VERSION}"
+    SHA512 29043eff21076440046314edf62bb488b7e4e17d9fbdac4c3727d8e2523c0c8fbf89ee7fcf762528af761ddbcb4be24e5f062ffa82f778401d6365faa35344a8
     HEAD_REF main
 )
 if(NOT EXISTS "${SOURCE_PATH}/external/OpenCL-ICD-Loader/CMakeLists.txt")
@@ -49,7 +52,6 @@ vcpkg_from_github(
     SHA512 d6fa8b6788cabdbb185a6ffba79c994762924a1c60595b769a7d3bb4a3ddf0f80cdeac7bd915cffa720f9123a720a1b7f0023fd7f2cf58906d15758529a99e2d
     HEAD_REF master
 )
-vcpkg_replace_string("${SOURCE_PATH}/cmake/Dependencies/whereami/whereami.cmake" [[${CMAKE_CURRENT_BINARY_DIR}/_deps/whereami-external-src]] [[${whereami-external_SOURCE_DIR}]])
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/opencl/vcpkg.json
+++ b/ports/opencl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "opencl",
-  "version-string": "v2024.05.08",
+  "version": "2024.10.24",
   "description": "OpenCL SDK",
   "homepage": "https://github.com/KhronosGroup/OpenCL-SDK",
   "license": "Apache-2.0 AND (MIT OR WTFPL)",

--- a/ports/openvino/004-opencl-v2024.10.24.patch
+++ b/ports/openvino/004-opencl-v2024.10.24.patch
@@ -1,0 +1,64 @@
+commit 255202328d39490f2cdca0d646b2e12b17ac9b69
+Author: Ilya Lavrenov <ilya.lavrenov@intel.com>
+Date:   Mon Jan 6 09:56:08 2025 +0100
+
+    Migrate to OpenCL v2024.10.24
+
+diff --git a/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp b/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
+index 759d796a5e..7246a6f6df 100644
+--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
++++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
+@@ -16,6 +16,10 @@
+ #include <CL/cl2.hpp>
+ #endif
+ 
++#ifndef CL_HPP_PARAM_NAME_CL_INTEL_UNIFIED_SHARED_MEMORY_
++#define OPENVINO_CLHPP_HEADERS_ARE_OLDER_THAN_V2024_10_24
++#endif
++
+ #include <CL/cl_ext.h>
+ 
+ #ifdef _WIN32
+@@ -45,12 +49,16 @@ typedef cl_va_api_device_set_intel    cl_device_set_intel;
+ 
+ #endif // cl_intel_required_subgroup_size
+ 
++#ifdef OPENVINO_CLHPP_HEADERS_ARE_OLDER_THAN_V2024_10_24
++
+ namespace cl {
+ namespace detail {
+-CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SUB_GROUP_SIZES_INTEL, vector<size_type>)
++CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SUB_GROUP_SIZES_INTEL, cl::vector<size_type>)
+ }  // namespace detail
+ }  // namespace cl
+ 
++#endif // OPENVINO_CLHPP_HEADERS_ARE_OLDER_THAN_V2024_10_24
++
+ /***************************************************************
+ * cl_intel_command_queue_families
+ ***************************************************************/
+@@ -260,11 +268,15 @@ typedef cl_bitfield         cl_device_feature_capabilities_intel;
+ 
+ #endif // cl_intel_device_attribute_query
+ 
++#ifndef CL_HPP_PARAM_NAME_CL_INTEL_COMMAND_QUEUE_FAMILIES_
+ #define CL_HPP_PARAM_NAME_CL_INTEL_COMMAND_QUEUE_FAMILIES_(F) \
+     F(cl_device_info, CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL, cl::vector<cl_queue_family_properties_intel>) \
+     \
+     F(cl_command_queue_info, CL_QUEUE_FAMILY_INTEL, cl_uint) \
+     F(cl_command_queue_info, CL_QUEUE_INDEX_INTEL, cl_uint)
++#endif // CL_HPP_PARAM_NAME_CL_INTEL_COMMAND_QUEUE_FAMILIES_
++
++#ifdef OPENVINO_CLHPP_HEADERS_ARE_OLDER_THAN_V2024_10_24
+ 
+ namespace cl {
+ namespace detail {
+@@ -279,6 +291,8 @@ CL_HPP_PARAM_NAME_CL_INTEL_COMMAND_QUEUE_FAMILIES_(CL_HPP_DECLARE_PARAM_TRAITS_)
+ }  // namespace detail
+ }  // namespace cl
+ 
++#endif // OPENVINO_CLHPP_HEADERS_ARE_OLDER_THAN_V2024_10_24
++
+ #include <memory>
+ 
+ namespace {

--- a/ports/openvino/portfile.cmake
+++ b/ports/openvino/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         002-fix-onnx.patch
         003-protobuf.patch
         add-include-chrono.patch #https://github.com/openvinotoolkit/openvino/pull/27782
+        004-opencl-v2024.10.24.patch # https://github.com/openvinotoolkit/openvino/pull/28275
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/openvino/vcpkg.json
+++ b/ports/openvino/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openvino",
   "version": "2024.4.0",
-  "port-version": 5,
+  "port-version": 6,
   "maintainers": "OpenVINO Developers <openvino@intel.com>",
   "summary": "This is a port for Open Visual Inference And Optimization toolkit for AI inference",
   "description": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6657,7 +6657,7 @@
       "port-version": 2
     },
     "opencl": {
-      "baseline": "v2024.05.08",
+      "baseline": "2024.10.24",
       "port-version": 0
     },
     "opencolorio": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6794,7 +6794,7 @@
     },
     "openvino": {
       "baseline": "2024.4.0",
-      "port-version": 5
+      "port-version": 6
     },
     "openvpn3": {
       "baseline": "3.10",

--- a/versions/o-/opencl.json
+++ b/versions/o-/opencl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "038100d3145dff266fc54053ff67c4e98ce7cca4",
+      "version": "2024.10.24",
+      "port-version": 0
+    },
+    {
       "git-tree": "37ee1974a90da69c3cf4536bab58bf7b5a208a47",
       "version-string": "v2024.05.08",
       "port-version": 0

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a52cc9b435c23fc08e94f744aa4799de019a76c7",
+      "version": "2024.4.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "d3497e79615424c72514c072b5f7deb876f35718",
       "version": "2024.4.0",
       "port-version": 5


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
