### PR TITLE
[onnx] Remove `Protobuf_INCLUDE_DIR` in ONNXConfig.cmake and use `find_dependency(protobuf)`

### DIFF
--- a/ports/onnx/fix-dependency-protobuf.patch
+++ b/ports/onnx/fix-dependency-protobuf.patch
@@ -10,3 +10,19 @@ index d81ac1d..9f97998 100644
  if((ONNX_USE_LITE_PROTO AND TARGET protobuf::libprotobuf-lite) OR ((NOT ONNX_USE_LITE_PROTO) AND TARGET protobuf::libprotobuf))
    # Sometimes we need to use protoc compiled for host architecture while linking
    # libprotobuf against target architecture. See https://github.com/caffe2/caffe
+diff --git a/cmake/ONNXConfig.cmake.in b/cmake/ONNXConfig.cmake.in
+index d588f8a..dbd4398 100644
+--- a/cmake/ONNXConfig.cmake.in
++++ b/cmake/ONNXConfig.cmake.in
+@@ -6,9 +6,8 @@
+ # library version information
+ set(ONNX_VERSION "@ONNX_VERSION@")
+ 
+-list(APPEND CMAKE_PREFIX_PATH "@PROTOBUF_DIR@")
+-set(Protobuf_INCLUDE_DIR "@PROTOBUF_INCLUDE_DIR@")
+-find_package(Protobuf REQUIRED)
++include(CMakeFindDependencyMacro)
++find_dependency(protobuf CONFIG)
+ 
+ # import targets
+ include ("${CMAKE_CURRENT_LIST_DIR}/ONNXTargets.cmake")

--- a/ports/onnx/portfile.cmake
+++ b/ports/onnx/portfile.cmake
@@ -64,10 +64,6 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ONNX)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/ONNXConfig.cmake" "# import targets" 
-[[# import targets
-include(CMakeFindDependencyMacro)
-find_dependency(protobuf CONFIG)]])
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/onnx/vcpkg.json
+++ b/ports/onnx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "onnx",
   "version-semver": "1.16.2",
+  "port-version": 1,
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://onnx.ai",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6610,7 +6610,7 @@
     },
     "onnx": {
       "baseline": "1.16.2",
-      "port-version": 0
+      "port-version": 1
     },
     "onnx-optimizer": {
       "baseline": "0.3.19",

--- a/versions/o-/onnx.json
+++ b/versions/o-/onnx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "262df4daa9534c3c514b1a4f7c048369b575568f",
+      "version-semver": "1.16.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "57d8f77c2964232239ba10b3f2ebf16698486d9a",
       "version-semver": "1.16.2",
       "port-version": 0


### PR DESCRIPTION
## Description

Current `onnx` port generates config file which hides `Protobuf_INCLUDE_DIR`.

```log
CMake Error at C:/Program Files/CMake/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find Protobuf (missing: Protobuf_INCLUDE_DIR) (found version
  "3.21.12.0")
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  C:/Program Files/CMake/share/cmake-3.30/Modules/FindProtobuf.cmake:752 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  C:/Users/luncl/Desktop/onnxruntime/.build/x64-windows/share/protobuf/vcpkg-cmake-wrapper.cmake:16 (_find_package)
  C:/vcpkg/scripts/buildsystems/vcpkg.cmake:813 (include)
  C:/Users/luncl/Desktop/onnxruntime/.build/x64-windows/share/onnx/ONNXConfig.cmake:11 (find_package)
```

```cmake
list(APPEND CMAKE_PREFIX_PATH "")
set(Protobuf_INCLUDE_DIR "") # causes "missing: Protobuf_INCLUDE_DIR"...
find_package(Protobuf REQUIRED) # line 11

# import targets
include(CMakeFindDependencyMacro)
find_dependency(protobuf CONFIG)
include ("${CMAKE_CURRENT_LIST_DIR}/ONNXTargets.cmake")
```

The PR moves `vcpkg_replace_string` of the portfile.cmake into the patch for ONNXConfig.cmake.in.
This eventually generates ONNXConfig.cmake without `find_package(Protobuf REQUIRED)`

```cmake
include(CMakeFindDependencyMacro)
find_dependency(protobuf CONFIG)

# import targets
include ("${CMAKE_CURRENT_LIST_DIR}/ONNXTargets.cmake")
```

### Reproduction

CMake side is simple.

```cmake
cmake_minimum_required(VERSION 3.30)
project(example CXX)

find_package(ONNX REQUIRED)
```

Expect `protobuf` is using old version for some reason.
Version after `4.25.1#1` works well.

With vcpkg manifest which uses `protobuf` version `3.21.12#4`.

```json
{
  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
  "name": "test",
  "version-date": "2025-01-06",
  "description": "...",
  "license": null,
  "dependencies": [
    {
      "name": "protobuf",
      "version>=": "3.21.12"
    },
    {
      "name": "onnx",
      "version>=": "1.16.2"
    }
  ],
  "overrides": [
    {
      "name": "protobuf",
      "version": "3.21.12#4"
    },
    {
      "name": "onnx",
      "version": "1.16.2"
    }
  ]
}
```

vcpkg configuration uses 2024.12.16 release.

```json
{
    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
    "default-registry": {
        "kind": "git",
        "repository": "https://github.com/Microsoft/vcpkg",
        "baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f"
    }
}
```

```console
$ cmake -B build "-DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_INSTALLED_DIR=$(Get-Location)/externals"
-- Building for: Visual Studio 17 2022
-- Running vcpkg install
Detecting compiler hash for triplet x64-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.42.34433/bin/Hostx64/x64/cl.exe
All requested packages are currently installed.
Total install time: 1.3 us
protobuf provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(protobuf CONFIG REQUIRED)
  target_link_libraries(main PRIVATE protobuf::libprotoc protobuf::libprotobuf protobuf::libprotobuf-lite)

protobuf provides pkg-config modules:

  # Google's Data Interchange Format
  protobuf-lite

  # Google's Data Interchange Format
  protobuf

onnx provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(ONNX CONFIG REQUIRED)
  target_link_libraries(main PRIVATE ONNX::onnx ONNX::onnx_proto)

-- Running vcpkg install - done
-- The CXX compiler identification is MSVC 19.42.34435.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.42.34433/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at C:/Program Files/CMake/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find Protobuf (missing: Protobuf_INCLUDE_DIR)
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)       
  C:/Program Files/CMake/share/cmake-3.30/Modules/FindProtobuf.cmake:752 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  externals/x64-windows/share/protobuf/vcpkg-cmake-wrapper.cmake:16 (_find_package)
  C:/vcpkg/scripts/buildsystems/vcpkg.cmake:813 (include)
  externals/x64-windows/share/onnx/ONNXConfig.cmake:11 (find_package)
  C:/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
  CMakeLists.txt:4 (find_package)


-- Configuring incomplete, errors occurred!
```

## References

* https://github.com/luncliff/vcpkg-registry/pull/212
* https://github.com/microsoft/vcpkg/issues/42854

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
