### PR TITLE
[sdflib] new port

### DIFF
--- a/ports/sdflib/add_export.patch
+++ b/ports/sdflib/add_export.patch
@@ -1,0 +1,47 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 86b6169..bf7f532 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -59,7 +59,7 @@ add_library(${PROJECT_NAME} STATIC  ${SOURCE_FILES} ${HEADER_FILES} ${PUBLIC_HEA
+                                     ${SDF_SOURCE_FILES} ${SDF_HEADER_FILES}
+                                     ${UTILS_SOURCE_FILES} ${UTILS_HEADER_FILES})
+ 
+-target_include_directories(${PROJECT_NAME} PUBLIC include/)
++target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/> $<INSTALL_INTERFACE:include>)
+ target_include_directories(${PROJECT_NAME} PRIVATE src/)
+ 
+ # Add shaders
+@@ -236,3 +236,20 @@ if(SDFLIB_BUILD_DEBUG_APPS)
+     # target_link_libraries(ImageQueryTime PUBLIC ${PROJECT_NAME} CGAL::CGAL OpenVDB::openvdb)
+     target_link_libraries(ImageQueryTime PUBLIC ${PROJECT_NAME})
+ endif()
++
++install(TARGETS ${PROJECT_NAME} icg EXPORT unofficial-${PROJECT_NAME}Config
++    RUNTIME DESTINATION bin
++    ARCHIVE DESTINATION lib
++    LIBRARY DESTINATION lib
++)
++
++install(EXPORT unofficial-${PROJECT_NAME}Config
++    NAMESPACE unofficial::${PROJECT_NAME}::
++    DESTINATION share/unofficial-sdflib
++)
++install(
++    DIRECTORY "include/"    # Trailing slash is important to copy only the contents
++    DESTINATION include     # Destination folder in the install directory
++    FILES_MATCHING
++    PATTERN "*.h"           # Match header files
++)
+diff --git a/libs/CMakeLists.txt b/libs/CMakeLists.txt
+index 1fa9fe7..d1f5014 100644
+--- a/libs/CMakeLists.txt
++++ b/libs/CMakeLists.txt
+@@ -139,7 +139,7 @@ if(SDFLIB_BUILD_APPS OR SDFLIB_BUILD_DEBUG_APPS)
+ 
+ # icg
+ add_library(icg INTERFACE)
+-target_include_directories(icg INTERFACE InteractiveComputerGraphics)
++target_include_directories(icg INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/InteractiveComputerGraphics> $<INSTALL_INTERFACE:include>)
+ 
+ if(SDFLIB_BUILD_APPS OR SDFLIB_BUILD_DEBUG_APPS)
+ 	# glfw

--- a/ports/sdflib/portfile.cmake
+++ b/ports/sdflib/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO UPC-ViRVIG/SdfLib
+    REF c32eb7b133f8c05fee5605499b7f5bd36039dd08
+    SHA512 86c4aeb66da3f59c4110abd96ac659aadddb8f67eacb0c7a5557e3741aeb56c8f5ef464c0d7fbe5853c86b523198dd2876e87473e3903ba00e03e489684ae06f
+    PATCHES
+        add_export.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSDFLIB_USE_ASSIMP=OFF
+        -DSDFLIB_USE_OPENMP=OFF
+        -DSDFLIB_USE_ENOKI=OFF
+        -DSDFLIB_USE_SYSTEM_GLM=ON
+        -DSDFLIB_USE_SYSTEM_SPDLOG=ON
+        -DSDFLIB_USE_SYSTEM_CEREAL=ON
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-sdflib CONFIG_PATH share/unofficial-sdflib)
+
+file(READ "${CURRENT_PACKAGES_DIR}/share/unofficial-sdflib/unofficial-SdfLibConfig.cmake" SDFLIB_CONFIG)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/unofficial-sdflib/unofficial-SdfLibConfig.cmake" "
+include(CMakeFindDependencyMacro)
+find_dependency(glm CONFIG)
+find_dependency(spdlog CONFIG)
+find_dependency(cereal CONFIG)
+${SDFLIB_CONFIG}
+")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sdflib/vcpkg.json
+++ b/ports/sdflib/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "sdflib",
+  "version-date": "2024-09-06",
+  "description": "Library for accelerating the queries of signed distance fields from triangle meshes.",
+  "homepage": "https://github.com/UPC-ViRVIG/SdfLib",
+  "license": "MIT",
+  "dependencies": [
+    "cereal",
+    "glm",
+    "spdlog",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8212,6 +8212,10 @@
       "baseline": "2.1.0",
       "port-version": 0
     },
+    "sdflib": {
+      "baseline": "2024-09-06",
+      "port-version": 0
+    },
     "sdformat10": {
       "baseline": "10.0.0",
       "port-version": 5

--- a/versions/s-/sdflib.json
+++ b/versions/s-/sdflib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8f8433aa1d7a084cd525c5bf86a4463164a20c65",
+      "version-date": "2024-09-06",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.