### PR TITLE
[zlib-ng] Support zlib compatibility mode

### DIFF
--- a/ports/zlib-ng/portfile.cmake
+++ b/ports/zlib-ng/portfile.cmake
@@ -6,12 +6,18 @@ vcpkg_from_github(
     HEAD_REF develop
 )
 
+# Set ZLIB_COMPAT in the triplet file to turn on
+if(NOT DEFINED ZLIB_COMPAT)
+    set(ZLIB_COMPAT OFF)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DZLIB_FULL_VERSION=${ZLIB_FULL_VERSION}"
         -DZLIB_ENABLE_TESTS=OFF
         -DWITH_NEW_STRATEGIES=ON
+        -DZLIB_COMPAT=${ZLIB_COMPAT}
     OPTIONS_RELEASE
         -DWITH_OPTIM=ON
 )
@@ -46,7 +52,13 @@ if(VCPKG_TARGET_IS_WINDOWS AND (NOT (VCPKG_LIBRARY_LINKAGE STREQUAL static AND V
 endif()
 
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/zlib-ng)
+
+if(ZLIB_COMPAT)
+    set(_cmake_dir "ZLIB")
+else()
+    set(_cmake_dir "zlib-ng")
+endif()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${_cmake_dir})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
                     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/zlib-ng/vcpkg.json
+++ b/ports/zlib-ng/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zlib-ng",
   "version": "2.2.3",
+  "port-version": 1,
   "description": "zlib replacement with optimizations for 'next generation' systems",
   "homepage": "https://github.com/zlib-ng/zlib-ng",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10014,7 +10014,7 @@
     },
     "zlib-ng": {
       "baseline": "2.2.3",
-      "port-version": 0
+      "port-version": 1
     },
     "zlmediakit": {
       "baseline": "2024-09-29",

--- a/versions/z-/zlib-ng.json
+++ b/versions/z-/zlib-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8282d357a50be706405e9aed44a79a333a8e8af1",
+      "version": "2.2.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "ed44efd13b274af9870aaf05424d1f1b9558b230",
       "version": "2.2.3",
       "port-version": 0


### PR DESCRIPTION
Use the value of `ZLIB_COMPAT` to set the directory used by `vcpkg_cmake_config_fixup`.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
