### PR TITLE
[libbacktrace] Update to 2024-11-30

### DIFF
--- a/ports/libbacktrace/portfile.cmake
+++ b/ports/libbacktrace/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ianlancetaylor/libbacktrace
-    REF 14818b7783eeb9a56c3f0fca78cefd3143f8c5f6
-    SHA512 d96c337cda6d230b162d983b2ab6ff6643895158f1d6f2e814bf28a2212a0cf46313935c2ed95a4408e6ad1da3c0c1ccb09847cf8b8b2ca6ad299101b8f79dd4
+    REF 1db85642e3fca189cf4e076f840a45d6934b2456
+    SHA512 a7f7a1233f551326e4ae1ba91db0fb905cf2737c20284c9aaf26cfe448b2a54efeaaa678e3abccbe0856c2a19019412208da7c1a82d319a58fe4d66d0a952aa0
 )
 
 vcpkg_configure_make(

--- a/ports/libbacktrace/vcpkg.json
+++ b/ports/libbacktrace/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libbacktrace",
-  "version-date": "2023-11-30",
-  "port-version": 1,
+  "version-date": "2024-11-30",
   "description": "The libbacktrace library may be linked into a program or library and used to produce symbolic backtraces.",
   "homepage": "https://github.com/ianlancetaylor/libbacktrace",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4349,8 +4349,8 @@
       "port-version": 7
     },
     "libbacktrace": {
-      "baseline": "2023-11-30",
-      "port-version": 1
+      "baseline": "2024-11-30",
+      "port-version": 0
     },
     "libbf": {
       "baseline": "1.0.0",

--- a/versions/l-/libbacktrace.json
+++ b/versions/l-/libbacktrace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c231fe43ac03b2250f605fac80e2cc80eb025bb8",
+      "version-date": "2024-11-30",
+      "port-version": 0
+    },
+    {
       "git-tree": "b3758864f5b04051a1db75cd9842a05f4afcdcb5",
       "version-date": "2023-11-30",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43148

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
