### PR TITLE
[scripts/vcpkg_install_make] Keep LOGFILE_ROOT undefined since CMake 3.31.0

### DIFF
--- a/scripts/cmake/vcpkg_install_make.cmake
+++ b/scripts/cmake/vcpkg_install_make.cmake
@@ -1,7 +1,6 @@
 function(vcpkg_install_make)
     vcpkg_build_make(
         ${ARGN}
-        LOGFILE_ROOT
         ENABLE_INSTALL
     )
 endfunction()


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/43163, `cmake_parse_arguments(PARSE_ARGV)` processed `arg_LOGFILE_ROOT` become empty string rather than undefined since CMake 3.31

Remove the empty string `LOGFILE_ROOT` in `vcpkg_install_make.cmake` to keep `arg_LOGFILE_ROOT` undefined.

There is no empty string `LOGFILE_ROOT` argument call in other functions.

### Related

* https://github.com/microsoft/vcpkg/pull/42045

### Reference

See https://cmake.org/cmake/help/v3.31/policy/CMP0174.html

> Prior to CMake 3.31, no variable would be defined if the value given after a single-value keyword was an empty string.

> For the NEW behavior, cmake_parse_arguments(PARSE_ARGV) always defines a variable for each keyword given in the arguments, even a single-value keyword with an empty string as its value or no value at all.

### Test

Example port `libcsv` installation tests pass with the following triplets:

* x64-linux (CMake 3.30.1 and CMake 3.31.3)
* x64-windows (CMake 3.30.1 and CMake 3.31.3)