### PR TITLE
[spirv-headers] Fix port usage

### DIFF
--- a/ports/spirv-headers/portfile.cmake
+++ b/ports/spirv-headers/portfile.cmake
@@ -13,8 +13,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/cmake/SPIRV-Headers")
 vcpkg_fixup_pkgconfig()
-
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/spirv-headers/vcpkg.json
+++ b/ports/spirv-headers/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "spirv-headers",
   "version": "1.3.296.0",
+  "port-version": 1,
   "description": "Machine-readable files for the SPIR-V Registry",
   "homepage": "https://github.com/KhronosGroup/SPIRV-Headers",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8642,7 +8642,7 @@
     },
     "spirv-headers": {
       "baseline": "1.3.296.0",
-      "port-version": 0
+      "port-version": 1
     },
     "spirv-reflect": {
       "baseline": "1.3.296.0",

--- a/versions/s-/spirv-headers.json
+++ b/versions/s-/spirv-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f033533a90ad1916f14db7560d6eb495336d8ac8",
+      "version": "1.3.296.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f1e872bb8327f8ab7b0cc5640673236419b497d0",
       "version": "1.3.296.0",
       "port-version": 0


### PR DESCRIPTION
Usage test passed with x64-windows triplet.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
