### PR TITLE
[usd] enable arm64 architecture

### DIFF
--- a/ports/usd/vcpkg.json
+++ b/ports/usd/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "usd",
   "version": "24.11",
+  "port-version": 1,
   "description": "Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.",
   "homepage": "https://github.com/PixarAnimationStudios/USD",
   "license": null,
-  "supports": "!x86 & !arm & !android",
+  "supports": "!x86 & !(arm & windows) & !android",
   "dependencies": [
     "opensubdiv",
     "tbb",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9278,7 +9278,7 @@
     },
     "usd": {
       "baseline": "24.11",
-      "port-version": 0
+      "port-version": 1
     },
     "usearch": {
       "baseline": "2.3.2",

--- a/versions/u-/usd.json
+++ b/versions/u-/usd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d4f495620bffe1b0088ede7d5a6dd5c60a5c3f63",
+      "version": "24.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "a96dae4b6c9e6d254b6601fb1be2c0088881a0b4",
       "version": "24.11",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
