### PR TITLE
[joltphysics] Expose rtti option

### DIFF
--- a/ports/joltphysics/portfile.cmake
+++ b/ports/joltphysics/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         debugrenderer       DEBUG_RENDERER_IN_DEBUG_AND_RELEASE
         profiler            PROFILER_IN_DEBUG_AND_RELEASE
+        rtti                CPP_RTTI_ENABLED
 )
 
 vcpkg_cmake_configure(

--- a/ports/joltphysics/vcpkg.json
+++ b/ports/joltphysics/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "joltphysics",
   "version": "5.2.0",
+  "port-version": 1,
   "description": "A multi core friendly rigid body physics and collision detection library suitable for games and VR applications",
   "homepage": "https://github.com/jrouwe/JoltPhysics",
   "license": "MIT",
@@ -20,6 +21,9 @@
     },
     "profiler": {
       "description": "Enable the profiler in Debug and Release builds"
+    },
+    "rtti": {
+      "description": "Enable C++ RTTI"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3854,7 +3854,7 @@
     },
     "joltphysics": {
       "baseline": "5.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "josuttis-jthread": {
       "baseline": "2020-07-21",

--- a/versions/j-/joltphysics.json
+++ b/versions/j-/joltphysics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35a645135c8c7b4e83a7f3e3d5cb62ea8cb094e4",
+      "version": "5.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "60a05c8f3d54f60886a116a6f03cbbe7f76f5b56",
       "version": "5.2.0",
       "port-version": 0


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/42847.

Add feature `rtti` for option `CPP_RTTI_ENABLED` https://github.com/jrouwe/JoltPhysics/blob/v5.2.0/Build/CMakeLists.txt#L45.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port features installation tests pass with the following triplets:

* x64-linux
* x64-windows