### PR TITLE
[marchingcubecpp] New port

### DIFF
--- a/ports/marchingcubecpp/portfile.cmake
+++ b/ports/marchingcubecpp/portfile.cmake
@@ -1,0 +1,20 @@
+# header-only library
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO aparis69/MarchingCubeCpp
+    REF f03a1b3ec29b1d7d865691ca8aea4f1eb2c2873d
+    SHA512 879204bbfe6a9ad6a6b050b2ba5126884e0b7d01c883d7319dc1deed0c3f6d1658493ba4b39bfcce8c9643739e812d2d69cdbd9be92cd728e0fcccfeb64f898e
+)
+
+# Install source files
+file(INSTALL 
+        "${SOURCE_PATH}/MC.h"
+        "${SOURCE_PATH}/noise.h"
+     DESTINATION 
+        "${CURRENT_PACKAGES_DIR}/include/${PORT}"
+)
+
+# Install license
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/README.md")

--- a/ports/marchingcubecpp/vcpkg.json
+++ b/ports/marchingcubecpp/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "marchingcubecpp",
+  "version-date": "2023-09-11",
+  "description": "Marching cube implementation.",
+  "homepage": "https://github.com/aparis69/MarchingCubeCpp",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5812,6 +5812,10 @@
       "baseline": "24.08.2",
       "port-version": 1
     },
+    "marchingcubecpp": {
+      "baseline": "2023-09-11",
+      "port-version": 0
+    },
     "mariadb-connector-cpp": {
       "baseline": "1.1.5",
       "port-version": 0

--- a/versions/m-/marchingcubecpp.json
+++ b/versions/m-/marchingcubecpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "905890d4ab4df5bbf4a358fb34c6fb4eb711477e",
+      "version-date": "2023-09-11",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Not found on https://repology.org/
This port is needed for mujoco:
https://github.com/google-deepmind/mujoco/blob/main/cmake/MujocoDependencies.cmake#L116
