### PR TITLE
[sbp] Update to 6.2.1

### DIFF
--- a/ports/sbp/portfile.cmake
+++ b/ports/sbp/portfile.cmake
@@ -7,24 +7,24 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO swift-nav/libsbp
-    REF v3.4.10
-    SHA512 bbdcefad9ff8995759b577790bcffb94355bd0ee29f259fa8d51f54907e252b55871dc5a841e21d23e661fd5b33109761eb20b66c2fb73e9e7de8a34cc8d6528
+    REF "v${VERSION}"
+    SHA512 9894f212631bc884ff1a586332bd7a11741a4331a90da4909badd382deb08d415ddf2d38b3cee35a6a0bb66f3308f0db072bbc6b9165da704b51637b4825fd58
     HEAD_REF master
-    PATCHES
-      "win32-install-fix.patch"
 )
 
 vcpkg_from_github(
     OUT_SOURCE_PATH CMAKE_EXTRA_MODS
     REPO swift-nav/cmake
-    REF 373d4fcafbbc0c208dc9ecb278d36ed8c9448eda
-    SHA512 afefc8c7a3fb43ee65b9b8733968a5836938460abbf1bc9e8330f83c3ac4a5819f71a36dcb034004296161c592f4d61545ba10016d6666e7eaf1dca556d99e2e
+    REF 65c9a396568701c382ca5a5515e6bb598f7d61b2
+    SHA512 e8b1b1e48c7f6d71b156668ba6e0c0898d6a9b6c9e86bc63cb2b5a4cffa844a0a9a175699db8417bcb70bc4c6b278d32327f5c709e7db7b69ab2a81e7c398b23
     HEAD_REF master
 )
 
 # Copy cmake files to expected location
 file(INSTALL "${CMAKE_EXTRA_MODS}/CCache.cmake" DESTINATION "${SOURCE_PATH}/c/cmake/common")
 file(INSTALL "${CMAKE_EXTRA_MODS}/SwiftCmakeOptions.cmake" DESTINATION "${SOURCE_PATH}/c/cmake/common")
+file(INSTALL "${CMAKE_EXTRA_MODS}/SwiftTargets.cmake" DESTINATION "${SOURCE_PATH}/c/cmake/common")
+file(INSTALL "${CMAKE_EXTRA_MODS}/ListTargets.cmake" DESTINATION "${SOURCE_PATH}/c/cmake/common")
 file(INSTALL "${CMAKE_EXTRA_MODS}/CompileOptions.cmake" DESTINATION "${SOURCE_PATH}/c/cmake/common")
 file(INSTALL "${CMAKE_EXTRA_MODS}/LanguageStandards.cmake" DESTINATION "${SOURCE_PATH}/c/cmake/common")
 file(INSTALL "${CMAKE_EXTRA_MODS}/ClangFormat.cmake" DESTINATION "${SOURCE_PATH}/c/cmake/common")
@@ -40,6 +40,6 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/sbp/vcpkg.json
+++ b/ports/sbp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sbp",
-  "version-semver": "3.4.10",
-  "port-version": 1,
+  "version-semver": "6.2.1",
   "description": "Swift Navigation Binary Protocol (SBP) is a binary protocol for communicating GNSS data used by Piksi devices.",
   "homepage": "https://github.com/swift-nav/libsbp",
   "documentation": "https://support.swiftnav.com/support/solutions/articles/44001850782-swift-binary-protocol",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8165,8 +8165,8 @@
       "port-version": 1
     },
     "sbp": {
-      "baseline": "3.4.10",
-      "port-version": 1
+      "baseline": "6.2.1",
+      "port-version": 0
     },
     "scenepic": {
       "baseline": "1.1.1",

--- a/versions/s-/sbp.json
+++ b/versions/s-/sbp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f1b2248608d862914a49566c9f5ebb8681c5695",
+      "version-semver": "6.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ef46c718c23128379c5050d907d0a90d335206b3",
       "version-semver": "3.4.10",
       "port-version": 1


### PR DESCRIPTION
Update `sbp` to 6.2.1, remove the outdated patch `win32-install-fix.patch`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.