### PR TITLE
[dartsim] Update to 6.15.0

### DIFF
--- a/ports/dartsim/disable_unit_tests_examples_and_tutorials.patch
+++ b/ports/dartsim/disable_unit_tests_examples_and_tutorials.patch
@@ -1,8 +1,8 @@
 ﻿diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 100bfb8b59be..b0779885c788 100644
+index fc5249444a5c..39c29e92bb33 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -292,7 +292,7 @@ add_subdirectory(dart)
+@@ -376,7 +376,7 @@ add_subdirectory(dart)
  
  set(DART_IN_SOURCE_BUILD TRUE)
  
@@ -10,12 +10,12 @@ index 100bfb8b59be..b0779885c788 100644
 +if(0)
  
    # Add a "tests" target to build unit tests.
-   enable_testing()
+   include(CTest)
 diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
-index 08ef983cdcfa..7092d89bb17d 100644
+index 37cadf4f8de1..fcfbd13cf793 100644
 --- a/python/CMakeLists.txt
 +++ b/python/CMakeLists.txt
-@@ -1,6 +1,8 @@
+@@ -22,9 +22,11 @@ endif()
  set(DART_DARTPY_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/dartpy")
  
  add_subdirectory(dartpy)
@@ -24,3 +24,6 @@ index 08ef983cdcfa..7092d89bb17d 100644
  add_subdirectory(examples)
  add_subdirectory(tutorials)
 +endif()
+ 
+ message(STATUS "")
+ message(STATUS "[ dartpy ]")

--- a/ports/dartsim/fix-pc-dependencies.patch
+++ b/ports/dartsim/fix-pc-dependencies.patch
@@ -1,8 +1,0 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -70,3 +70,3 @@
- set(DART_PKG_DESC "Dynamic Animation and Robotics Toolkit.")
--set(DART_PKG_EXTERNAL_DEPS "eigen, ccd, fcl, assimp, boost")
-+set(DART_PKG_EXTERNAL_DEPS "assimp, ccd, eigen3, fcl, octomap")
- 

--- a/ports/dartsim/portfile.cmake
+++ b/ports/dartsim/portfile.cmake
@@ -5,11 +5,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dartsim/dart
     REF v${VERSION}
-    SHA512 6d04da37d0eb40a35a3aaec583af024e2edf71d68bb38b6832760de21a349221387644ed9be0cc1e451c669bbf48eb53d8d0cd3be1b1b265a30be2aa17c7e48b
+    SHA512 3c621245c5dc1bf26932c33c940e2b09aaebd1a15f3620616c60296f18a67e1044728543b4f640f92caf8f98295e350679b70eb11aecadea9e4a28aaf370ea75
     HEAD_REF main
     PATCHES
         disable_unit_tests_examples_and_tutorials.patch
-        fix-pc-dependencies.patch
 )
 
 vcpkg_cmake_configure(
@@ -41,7 +40,7 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dart/config.hpp" "#define DART_ROOT_PATH \"${SOURCE_PATH}/\"" "")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dart/config.hpp" "#define DART_DATA_PATH \"${SOURCE_PATH}/data/\"" "")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dart/config.hpp" "#define DART_DATA_LOCAL_PATH \"${SOURCE_PATH}/data/\"" "")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dart/config.hpp" "#define DART_DATA_GLOBAL_PATH \"${CURRENT_PACKAGES_DIR}/share/doc/dart/data/\"" "")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/dart/config.hpp" "#define DART_DATA_GLOBAL_PATH                                                  \\\n  \"${CURRENT_PACKAGES_DIR}/share/doc/dart/data/\"" "")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/dartsim/vcpkg.json
+++ b/ports/dartsim/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "dartsim",
-  "version": "6.12.2",
-  "port-version": 3,
+  "version": "6.15.0",
   "description": "Dynamic Animation and Robotics Toolkit",
   "homepage": "https://dartsim.github.io/",
   "license": "BSD-2-Clause",
+  "supports": "!x86",
   "dependencies": [
     "assimp",
     "boost-algorithm",
@@ -24,6 +24,7 @@
     "octomap",
     "ode",
     "opengl",
+    "osg",
     "tinyxml2",
     "urdfdom",
     {

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -374,7 +374,7 @@ gamenetworkingsockets:x64-android=fail
 # There is an open PR that try to fix that.
 gazebo:x64-windows=fail
 gazebo:x64-windows-static-md=fail
-gazebo:x86-windows=fail
+gazebo:x86-windows=skip
 gazebo:x64-linux=fail
 gdk-pixbuf:arm-neon-android=fail
 gdk-pixbuf:arm64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2205,8 +2205,8 @@
       "port-version": 3
     },
     "dartsim": {
-      "baseline": "6.12.2",
-      "port-version": 3
+      "baseline": "6.15.0",
+      "port-version": 0
     },
     "dataframe": {
       "baseline": "3.4.0",

--- a/versions/d-/dartsim.json
+++ b/versions/d-/dartsim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76bb71f86f7f9f4d34e002e65db4ccff572f6a1d",
+      "version": "6.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d586df3f633aafc829fd66b18ad22120a9bbed2",
       "version": "6.12.2",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
