### PR TITLE
[neon2sse] Update to 2024-11-24

### DIFF
--- a/ports/neon2sse/portfile.cmake
+++ b/ports/neon2sse/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/ARM_NEON_2_x86_SSE
-    REF a1652fd5253afbf3e39357b012974f93511f6108
-    SHA512 9f8aa283e48eb3b615da3d89ec4165d1ec9599e8e181059c2b9acb2921ce753ce0f29b8c321d7d6661f10eb67e234c629df75853b87c4139a9bb137dbb3f4fc1
+    REF eb8b80b28f956275e291ea04a7beb5ed8289e872
+    SHA512 56aa1c886993b8ab0f5939acd53081e4d23373bab19858397a1a668e130a68423b521c4613f2db4e0f108fd2c9133a529575dba14e5e0046a3bb9f11f96ce2bf
     HEAD_REF master
 )
 
@@ -12,7 +12,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME NEON_2_SSE CONFIG_PATH lib/cmake/NEON_2_SSE)
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug"
                     "${CURRENT_PACKAGES_DIR}/lib"
 )

--- a/ports/neon2sse/vcpkg.json
+++ b/ports/neon2sse/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "neon2sse",
-  "version-date": "2021-09-16",
-  "description": "Open standard for machine learning interoperability",
+  "version-date": "2024-11-24",
+  "description": "The platform independent header allowing to compile any C/C++ code containing ARM NEON intrinsic functions for x86 target systems using SIMD up to AVX2 intrinsic functions",
   "homepage": "https://github.com/intel/ARM_NEON_2_x86_SSE",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6329,7 +6329,7 @@
       "port-version": 0
     },
     "neon2sse": {
-      "baseline": "2021-09-16",
+      "baseline": "2024-11-24",
       "port-version": 0
     },
     "netcdf-c": {

--- a/versions/n-/neon2sse.json
+++ b/versions/n-/neon2sse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c507f8eff09bf65ab71aae5c676684e95d445ce",
+      "version-date": "2024-11-24",
+      "port-version": 0
+    },
+    {
       "git-tree": "02bae7681d6c8c026a5f49dd3b4b37a430ea6878",
       "version-date": "2021-09-16",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

