### PR TITLE
[liboqs] New port

### DIFF
--- a/ports/liboqs/portfile.cmake
+++ b/ports/liboqs/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO open-quantum-safe/liboqs
+    REF ${VERSION}
+    SHA512 93260f15c02108157fa595e252685c49c5fb6433d04b989c381da4e27169577f3011d9174b2ec0c110fff15d2d3c640a9833bf28aa53949e8f33c0e674b6e781
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DOQS_BUILD_ONLY_LIB=ON
+        -DOQS_PERMIT_UNSUPPORTED_ARCHITECTURE=ON
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/liboqs/vcpkg.json
+++ b/ports/liboqs/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "liboqs",
+  "version": "0.12.0",
+  "description": "open source C library for quantum-safe cryptographic algorithms.",
+  "homepage": "https://openquantumsafe.org/",
+  "license": "MIT",
+  "supports": "!uwp & !(windows & static)",
+  "dependencies": [
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4940,6 +4940,10 @@
       "baseline": "0.2.1",
       "port-version": 3
     },
+    "liboqs": {
+      "baseline": "0.12.0",
+      "port-version": 0
+    },
     "liborigin": {
       "baseline": "3.0.3",
       "port-version": 0

--- a/versions/l-/liboqs.json
+++ b/versions/l-/liboqs.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4b6d23279893db529e42f9ca6cb62020b707d790",
+      "version": "0.12.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

