### PR TITLE
[libtorch] Include `<chrono>` for `high_resolution_clock`

### DIFF
--- a/ports/libtorch/add-include-chrono.patch
+++ b/ports/libtorch/add-include-chrono.patch
@@ -1,0 +1,11 @@
+diff --git a/torch/csrc/jit/runtime/logging.h b/torch/csrc/jit/runtime/logging.h
+index 5499ecf..269168e 100644
+--- a/torch/csrc/jit/runtime/logging.h
++++ b/torch/csrc/jit/runtime/logging.h
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <chrono>
+ #include <mutex>
+ #include <string>
+ #include <unordered_map>

--- a/ports/libtorch/portfile.cmake
+++ b/ports/libtorch/portfile.cmake
@@ -39,6 +39,7 @@ vcpkg_from_github(
         fix-aten-cutlass.patch
         fix-build-error-with-fmt11.patch
         no-abs-path.patch
+        add-include-chrono.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/caffe2/core/macros.h") # We must use generated header files

--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtorch",
   "version": "2.1.2",
-  "port-version": 9,
+  "port-version": 10,
   "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
   "homepage": "https://pytorch.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5242,7 +5242,7 @@
     },
     "libtorch": {
       "baseline": "2.1.2",
-      "port-version": 9
+      "port-version": 10
     },
     "libtorrent": {
       "baseline": "2.0.10",

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7307f8c37b266aeb61d83e069740e75cff863bf6",
+      "version": "2.1.2",
+      "port-version": 10
+    },
+    {
       "git-tree": "0a4d67bf0f603494ff7ce3e51587513a1df295fe",
       "version": "2.1.2",
       "port-version": 9


### PR DESCRIPTION
Due to there are new changes merged by microsoft/STL#5105, so port `libtorch` need to include `<chrono>` by patching to fix the following error:
```
D:\b\libtorch\src\v2.1.2-48aa56738d.clean\torch/csrc/jit/runtime/logging.h(60): error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\__msvc_chrono.hpp(286): note: see declaration of 'std::chrono'
D:\b\libtorch\src\v2.1.2-48aa56738d.clean\torch/csrc/jit/runtime/logging.h(60): error C2065: 'high_resolution_clock': undeclared identifier
```
Upstream has been fix this issue in https://github.com/pytorch/pytorch/commit/4d0386ce1cfe0559f9a11fd782e42f851759fe79.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.