### PR TITLE
[seacas]: fix dependencies

### DIFF
--- a/ports/seacas/vcpkg.json
+++ b/ports/seacas/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "seacas",
   "version-date": "2022-11-22",
-  "port-version": 7,
+  "port-version": 8,
   "description": "The Sandia Engineering Analysis Code Access System (SEACAS) is a suite of preprocessing, postprocessing, translation, and utility applications supporting finite element analysis software using the Exodus database file format.",
   "homepage": "https://github.com/sandialabs/seacas",
   "license": null,
@@ -43,10 +43,7 @@
       "dependencies": [
         {
           "name": "matio",
-          "default-features": false,
-          "features": [
-            "hdf5"
-          ]
+          "default-features": false
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8278,7 +8278,7 @@
     },
     "seacas": {
       "baseline": "2022-11-22",
-      "port-version": 7
+      "port-version": 8
     },
     "seal": {
       "baseline": "4.1.2",

--- a/versions/s-/seacas.json
+++ b/versions/s-/seacas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b34ab268c818a03016c980c6ccd8d6f7b3e5a4c",
+      "version-date": "2022-11-22",
+      "port-version": 8
+    },
+    {
       "git-tree": "405532a89129aa97af0759ecf8e4da3ee4d8a543",
       "version-date": "2022-11-22",
       "port-version": 7


### PR DESCRIPTION
matio does not have a hdf5 feature anymore (found by `x-test-features`). 