### PR TITLE
[cpuid] Update option ENABLE_DOCS to LIBCPUID_ENABLE_DOCS

### DIFF
--- a/ports/cpuid/portfile.cmake
+++ b/ports/cpuid/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DENABLE_DOCS=OFF
+        -DLIBCPUID_ENABLE_DOCS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/cpuid/vcpkg.json
+++ b/ports/cpuid/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cpuid",
   "version": "0.7.0",
+  "port-version": 1,
   "description": "Provides CPU identification for the x86 (and x86_64)",
   "homepage": "https://github.com/anrieff/libcpuid",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2030,7 +2030,7 @@
     },
     "cpuid": {
       "baseline": "0.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cpuinfo": {
       "baseline": "2022-07-19",

--- a/versions/c-/cpuid.json
+++ b/versions/c-/cpuid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "12033f70664a516b6f698d62ee473395daba302b",
+      "version": "0.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "af4cf6558e28039e5074af69e24747dfe46bd43f",
       "version": "0.7.0",
       "port-version": 0


### PR DESCRIPTION
Fixes 
```
-- Performing post-build validation
warning: /debug/share should not exist. Please reorganize any important files, then use
file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
error: Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile: /Users/leanderSchulten/git_projekte/vcpkg2/ports/cpuid/portfile.cmake
error: building cpuid:arm64-osx failed with: POST_BUILD_CHECKS_FAILED
```
(found by `x-test-features`)