### PR TITLE
[range-v3-vs2015] fix build

### DIFF
--- a/ports/range-v3-vs2015/portfile.cmake
+++ b/ports/range-v3-vs2015/portfile.cmake
@@ -10,6 +10,5 @@ vcpkg_from_github(
 )
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/range-v3-vs2015/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/range-v3-vs2015/copyright)
 file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR} FILES_MATCHING PATTERN "*.hpp")
 vcpkg_copy_pdbs()

--- a/ports/range-v3-vs2015/vcpkg.json
+++ b/ports/range-v3-vs2015/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "range-v3-vs2015",
   "version": "20151130-vcpkg5",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Range library for C++11/14/17.",
   "homepage": "https://github.com/Microsoft/Range-V3-VS2015"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7818,7 +7818,7 @@
     },
     "range-v3-vs2015": {
       "baseline": "20151130-vcpkg5",
-      "port-version": 3
+      "port-version": 4
     },
     "rapidcheck": {
       "baseline": "2023-12-14",

--- a/versions/r-/range-v3-vs2015.json
+++ b/versions/r-/range-v3-vs2015.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "835ff46e7392da24a81e2d4784959154ab930f51",
+      "version": "20151130-vcpkg5",
+      "port-version": 4
+    },
+    {
       "git-tree": "ad11ff1674f1db018ff9b5001fea3c95ef62cc16",
       "version": "20151130-vcpkg5",
       "port-version": 3


### PR DESCRIPTION
Fixes
```
-- Installing: /Users/leanderSchulten/git_projekte/vcpkg2/packages/range-v3-vs2015_arm64-osx/share/range-v3-vs2015/copyright
CMake Error at ports/range-v3-vs2015/portfile.cmake:13 (file):
  file RENAME failed to rename

    /Users/leanderSchulten/git_projekte/vcpkg2/packages/range-v3-vs2015_arm64-osx/share/range-v3-vs2015/LICENSE.txt

  to

    /Users/leanderSchulten/git_projekte/vcpkg2/packages/range-v3-vs2015_arm64-osx/share/range-v3-vs2015/copyright

  because: No such file or directory

Call Stack (most recent call first):
  scripts/ports.cmake:196 (include)
```
(found by `x-test-features`)