### PR TITLE
[mbedtls] Update to 3.6.2

### DIFF
--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Mbed-TLS/mbedtls
     REF "v${VERSION}"
-    SHA512 e7985a4e7e07328ae55fdad5212f71ac6af903f2b670c6d4bc2a8d6a4b9b7343697a2fd350a836b9425590c838615cd5b2fa851940bd137bb759fa35cd9f0ee8
+    SHA512 ad5a8de072cd7bede21378a3301d8de7c4eec8e113ebe2a3ffe5bf8ebed1b236a52ae0425abe45eafdc534af65b51076ca458e342950174bf1bdbbc06d1bdad1
     HEAD_REF development
     PATCHES
         enable-pthread.patch

--- a/ports/mbedtls/vcpkg.json
+++ b/ports/mbedtls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mbedtls",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "An open source, portable, easy to use, readable and flexible SSL library",
   "homepage": "https://www.trustedfirmware.org/projects/mbed-tls/",
   "license": "Apache-2.0 OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5865,7 +5865,7 @@
       "port-version": 2
     },
     "mbedtls": {
-      "baseline": "3.6.1",
+      "baseline": "3.6.2",
       "port-version": 0
     },
     "mchehab-zbar": {

--- a/versions/m-/mbedtls.json
+++ b/versions/m-/mbedtls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5312822288313d76c7e852e2577da58b0c169c21",
+      "version": "3.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "0c5c07caa2aa3d35d64a07428dfc049a13ea6aad",
       "version": "3.6.1",
       "port-version": 0


### PR DESCRIPTION
Resolve https://github.com/microsoft/vcpkg/issues/43240, update to `3.6.2`.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-windows