### PR TITLE
[sqlite3] update to 3.48.0

### DIFF
--- a/ports/sqlite3/add-config-include.patch
+++ b/ports/sqlite3/add-config-include.patch
@@ -1,9 +1,9 @@
 diff --git a/sqlite3.c b/sqlite3.c
-index a1fbd60..68a4e21 100644
+index 80433f6..cfd213b 100644
 --- a/sqlite3.c
 +++ b/sqlite3.c
-@@ -22,6 +22,7 @@
- */
+@@ -25,6 +25,7 @@
+ #ifndef SQLITE_AMALGAMATION
  #define SQLITE_CORE 1
  #define SQLITE_AMALGAMATION 1
 +#include "sqlite3-vcpkg-config.h"
@@ -11,7 +11,7 @@ index a1fbd60..68a4e21 100644
  # define SQLITE_PRIVATE static
  #endif
 diff --git a/sqlite3.h b/sqlite3.h
-index 0376113..271cf53 100644
+index 4ed8428..f1cf6d4 100644
 --- a/sqlite3.h
 +++ b/sqlite3.h
 @@ -32,6 +32,7 @@

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -4,7 +4,7 @@ string(REGEX REPLACE "^([0-9]+),0*([0-9][0-9]),0*([0-9][0-9]),0*([0-9][0-9])," "
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sqlite.org/2024/sqlite-autoconf-${SQLITE_VERSION}.tar.gz"
     FILENAME "sqlite-autoconf-${SQLITE_VERSION}.zip"
-    SHA512 9f311e7834330d112a633a9ae7c211c602b36b6c44f94a7ff7463217da8f09ba2c469d1f2ca38da5ba88358c40e328a8958c1e4ad466b016f3bd2799ef2431e2
+    SHA512 c607cbc58cdef6910a87ddb6ae8aeabdab2769d6cc33aad04f31fc428ecc5a8eaf19f5d3a3590591aae2c920b106a684891d38efef712f91631602245f6f4d3d
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -2,7 +2,7 @@ string(REGEX REPLACE "^([0-9]+)[.]([0-9]+)[.]([0-9]+)[.]([0-9]+)" "\\1,0\\2,0\\3
 string(REGEX REPLACE "^([0-9]+),0*([0-9][0-9]),0*([0-9][0-9]),0*([0-9][0-9])," "\\1\\2\\3\\4" SQLITE_VERSION "${SQLITE_VERSION}")
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://sqlite.org/2024/sqlite-autoconf-${SQLITE_VERSION}.tar.gz"
+    URLS "https://sqlite.org/2025/sqlite-autoconf-${SQLITE_VERSION}.tar.gz"
     FILENAME "sqlite-autoconf-${SQLITE_VERSION}.zip"
     SHA512 c607cbc58cdef6910a87ddb6ae8aeabdab2769d6cc33aad04f31fc428ecc5a8eaf19f5d3a3590591aae2c920b106a684891d38efef712f91631602245f6f4d3d
 )

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite3",
-  "version": "3.47.2",
+  "version": "3.48.0",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://sqlite.org/",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8677,7 +8677,7 @@
       "port-version": 0
     },
     "sqlite3": {
-      "baseline": "3.47.2",
+      "baseline": "3.48.0",
       "port-version": 0
     },
     "sqlitecpp": {

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "44fbffbcd3f992b6bf02fd4c4edd591db9f986e4",
+      "git-tree": "4bb7f5e19ab8433e2196515b2a7174b6a9bbc0de",
       "version": "3.48.0",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4bb7f5e19ab8433e2196515b2a7174b6a9bbc0de",
+      "git-tree": "035eb1c851406b84ac0e242d73446fba15f7980a",
       "version": "3.48.0",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44fbffbcd3f992b6bf02fd4c4edd591db9f986e4",
+      "version": "3.48.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b22957f23065a61c8f640a9f9763b4fd48b63c01",
       "version": "3.47.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
