### PR TITLE
[x-plane] Fix download address

### DIFF
--- a/ports/x-plane/portfile.cmake
+++ b/ports/x-plane/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 set(XPSDK_VERSION "401")
 vcpkg_download_distfile(
     XPLANE_SDK_ZIP
-    URLS "https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sample_templates/XPSDK${XPSDK_VERSION}.zip"
+    URLS "https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sdk_zip_files/XPSDK${XPSDK_VERSION}.zip"
     FILENAME "XPSDK${XPSDK_VERSION}.zip"
     SHA512 8e00789befd15f5b1cb4f426ddf9c3f7f021c5fba50b907e8af5fbf09abbc362804b5d1543332855d01e8ae91b9c50a55933e63df6e11e88e58c10ca8f949bf4
 )

--- a/ports/x-plane/vcpkg.json
+++ b/ports/x-plane/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "x-plane",
   "version": "4.0.1",
+  "port-version": 1,
   "description": "The X-Plane Plugin SDK",
   "homepage": "https://developer.x-plane.com/sdk/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9770,7 +9770,7 @@
     },
     "x-plane": {
       "baseline": "4.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "x264": {
       "baseline": "0.164.3108",

--- a/versions/x-/x-plane.json
+++ b/versions/x-/x-plane.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "605d085f1c9ef0cf423d20a5dc574003b42a4e2e",
+      "version": "4.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "be6ff276d2a18e64a2cf91a50ef1a53d26a33fa8",
       "version": "4.0.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #43264. The upstream download address has changed from `https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sample_templates/XPSDK${XPSDK_VERSION}.zip` to `https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sdk_zip_files/XPSDK${XPSDK_VERSION}.zip`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.