### PR TITLE
[vcpkg baseline][salome-configuration][salome-medcoupling] Update to official download source on GitHub

### DIFF
--- a/ports/salome-configuration/portfile.cmake
+++ b/ports/salome-configuration/portfile.cmake
@@ -1,7 +1,11 @@
-vcpkg_from_git(
+string(REPLACE "." "_" UNDERSCORE_VERSION "${VERSION}")
+
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH_CONFIG
-    URL "https://git.salome-platform.org/gitpub/tools/configuration.git"
-    REF "25f724f7a6c0000330a40c3851dcd8bc2493e1fa"
+    REPO SalomePlatform/configuration
+    REF "V${UNDERSCORE_VERSION}"
+    SHA512 e905a0f1e1105f5a630153036b80942032ccc07fad411d390e4da19d56561e224ac2ac681873b97d811d33ce4b0c9518ce3488b54414a42e011c39628d8e1673
+    HEAD_REF master
 )
 
 file(COPY "${SOURCE_PATH_CONFIG}/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/salome-configuration/vcpkg.json
+++ b/ports/salome-configuration/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "salome-configuration",
   "version": "9.10.0",
+  "port-version": 1,
   "description": "Configuration files and other utilities for SALOME platform",
   "homepage": "https://www.salome-platform.org",
   "license": "LGPL-2.1-or-later",

--- a/ports/salome-medcoupling/portfile.cmake
+++ b/ports/salome-medcoupling/portfile.cmake
@@ -4,10 +4,14 @@ if(VCPKG_TARGET_IS_WINDOWS)
     # in the EXPORTS macros.
 endif()
 
-vcpkg_from_git(
+string(REPLACE "." "_" UNDERSCORE_VERSION "${VERSION}")
+
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL "https://git.salome-platform.org/gitpub/tools/medcoupling.git"
-    REF "fe2e38d301902c626f644907e00e499552bb2fa5"
+    REPO SalomePlatform/medcoupling
+    REF "V${UNDERSCORE_VERSION}"
+    SHA512 576b10daf58830e934a3f9d06abc63a22be76b995b2c2f2d1ab0bf16a76f3ba90f583eab06be2d665874cb433f8c990b7a7fd6724f69a5a3f9a5c20c775407cd
+    HEAD_REF master
     PATCHES 
         win.patch 
         fix-missing-symbols.patch

--- a/ports/salome-medcoupling/vcpkg.json
+++ b/ports/salome-medcoupling/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "salome-medcoupling",
   "version": "9.10.0",
+  "port-version": 1,
   "description": "salome-medcoupling is a part of SALOME platform to manipulate meshes and fields in memory, and use salome-med format for files.",
   "homepage": "https://www.salome-platform.org",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8142,7 +8142,7 @@
     },
     "salome-configuration": {
       "baseline": "9.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "salome-med-fichier": {
       "baseline": "4.1.1",
@@ -8150,7 +8150,7 @@
     },
     "salome-medcoupling": {
       "baseline": "9.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sassc": {
       "baseline": "3.6.2",

--- a/versions/s-/salome-configuration.json
+++ b/versions/s-/salome-configuration.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "729c277b29f980cab19babca0dadc1a1ffb6de61",
+      "version": "9.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2cbf34b9ab5a63d3b341c3a8c3e1b0cf48c1c6d9",
       "version": "9.10.0",
       "port-version": 0

--- a/versions/s-/salome-medcoupling.json
+++ b/versions/s-/salome-medcoupling.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b5a4eb9704cc5b12228fdaeffbf6b4e34609431",
+      "version": "9.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5b007fe28cfb58ed83464e901ce70e8a1ef4bfa5",
       "version": "9.10.0",
       "port-version": 0


### PR DESCRIPTION
Fix `salome-configuration` and `salome-medcoupling` failed https://dev.azure.com/vcpkg/public/_build/results?buildId=111477&view=logs&j=f79cfdd7-47a8-597f-8f57-dc3e21a8f2ad&t=4f03addf-ef5a-50a2-71be-19894d9df4e3&l=52875

```log
fatal: unable to access 'https://git.salome-platform.org/gitpub/tools/configuration.git/': SSL: certificate subject name (opencascade.com) does not match target host name 'git.salome-platform.org'
```

Update download source to official https://github.com/SalomePlatform referred from `https://www.salome-platform.org/` -> `Resources` -> `Git Repositories`