### PR TITLE
[openvino] update to 2024.6.0

### DIFF
--- a/ports/openvino/portfile.cmake
+++ b/ports/openvino/portfile.cmake
@@ -44,7 +44,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openvinotoolkit/openvino
     REF "${VERSION}"
-    SHA512 b003647de3de49e605943488ca9b2e5196b20d95b3152f0c2331c283d4cb253d1bbbb9cde04fa82733d3871d7128c6db6210957660bd89f26462798f782eca47
+    SHA512 5bfe9c0b79b8f8bed7f39b78003424d4b7146d7c6afafc668752a0c8c45558fc8f37cfc26f783beb73c6919cb65313f24fd2e30c81651b34abf74c43c3bb7e32
     HEAD_REF master
     PATCHES
         # vcpkg specific patch, because OV creates a file in source tree, which is prohibited
@@ -84,8 +84,8 @@ if(ENABLE_INTEL_GPU)
     vcpkg_from_github(
         OUT_SOURCE_PATH DEP_SOURCE_PATH
         REPO oneapi-src/oneDNN
-        REF 1722066ad4c0f15495f2d0fcbe9deb2bfd188c36
-        SHA512 0b0461bf42d67f0fe7c6c61289a28e42915f7ac2ea5cc569957b8bb601962bec6135e84a2716911394952dffe2bb557c2d59d42c7f80a8db3c3937ecc6bd8ce8
+        REF 0f269193c7466313888d3338209d0d06a22cc6fa
+        SHA512 892a32b930fbba3364e2ea9ee47bf6faba3b36cb99e836bcc5d57a30a368e5061bb7194219f30dbcede18e3ad5e671c9cfa4192799ac53cfa71706e03556e5bd
     )
     file(COPY "${DEP_SOURCE_PATH}/" DESTINATION "${SOURCE_PATH}/src/plugins/intel_gpu/thirdparty/onednn_gpu")
 

--- a/ports/openvino/vcpkg.json
+++ b/ports/openvino/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openvino",
-  "version": "2024.5.0",
+  "version": "2024.6.0",
   "maintainers": "OpenVINO Developers <openvino@intel.com>",
   "summary": "This is a port for Open Visual Inference And Optimization toolkit for AI inference",
   "description": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6789,7 +6789,7 @@
       "port-version": 0
     },
     "openvino": {
-      "baseline": "2024.5.0",
+      "baseline": "2024.6.0",
       "port-version": 0
     },
     "openvpn3": {

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86228f04cb6e121048ad4b9c588d3f338d826fd2",
+      "version": "2024.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "244afb074f2bdd5195e2631afdfe8af8753c5362",
       "version": "2024.5.0",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
