### PR TITLE
[ryml] Update to 0.7.2

### DIFF
--- a/ports/ryml/cmake-fix.patch
+++ b/ports/ryml/cmake-fix.patch
@@ -2,12 +2,14 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index d18407c..db19e0b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -21,8 +21,7 @@ option(RYML_DBG "Enable (very verbose) ryml debug prints." OFF)
+@@ -21,10 +21,7 @@ option(RYML_DBG "Enable (very verbose) ryml debug prints." OFF)
  
  #-------------------------------------------------------
  
 -c4_require_subproject(c4core INCORPORATE
--    SUBDIRECTORY ${RYML_EXT_DIR}/c4core)
+-    SUBDIRECTORY ${RYML_EXT_DIR}/c4core
+-    OVERRIDE C4CORE_INSTALL ${RYML_INSTALL}
+-)
 +find_package(c4core CONFIG REQUIRED)
  
  c4_add_library(ryml

--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/rapidyaml
     REF "v${VERSION}"
-    SHA512 861f1d2c39c5c8d455e8d40e3ecadd828b948c5dea2bcb88ba92686ca77b9a7d69ab2d94407732eab574e4e3c7b319d0f1b31250b18fb513310847192623a2f7
+    SHA512 2ff14776498dc8a55cb257c38fbea5b1a1fc5c4c09ade5b10c45cb4afcaf0cc587674723bedf38fd04b3179a18ba7357a929484b154474d658d597d0f9ee8d2e
     HEAD_REF master
     PATCHES cmake-fix.patch
 )

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ryml",
-  "version": "0.5.0",
-  "port-version": 1,
+  "version": "0.7.2",
   "description": "Rapid YAML library",
   "homepage": "https://github.com/biojppm/rapidyaml",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8113,8 +8113,8 @@
       "port-version": 2
     },
     "ryml": {
-      "baseline": "0.5.0",
-      "port-version": 1
+      "baseline": "0.7.2",
+      "port-version": 0
     },
     "ryu": {
       "baseline": "2.0",

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3bcbc342152b2bc33cfd425098689095be01ceef",
+      "version": "0.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c8ceae82ba08f1a242ec0b15f80424db37e4847c",
       "version": "0.5.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
