### PR TITLE
[opensubdiv] Enable build on arm architecture

### DIFF
--- a/ports/opensubdiv/vcpkg.json
+++ b/ports/opensubdiv/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "opensubdiv",
   "version-semver": "3.5.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "An Open-Source subdivision surface library.",
   "homepage": "https://github.com/PixarAnimationStudios/OpenSubdiv",
   "license": "Apache-2.0",
-  "supports": "!arm & !uwp",
+  "supports": "!(arm & android) & !uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6766,7 +6766,7 @@
     },
     "opensubdiv": {
       "baseline": "3.5.0",
-      "port-version": 2
+      "port-version": 3
     },
     "opentelemetry-cpp": {
       "baseline": "1.18.0",

--- a/versions/o-/opensubdiv.json
+++ b/versions/o-/opensubdiv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b469c74fb77ea987be2333ae2d66ebba168d672d",
+      "version-semver": "3.5.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "8d12fbded4ab0667d082362ae4b6f57506926c9b",
       "version-semver": "3.5.0",
       "port-version": 2


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
