### PR TITLE
[oscpack] add new port

### DIFF
--- a/ports/oscpack/add-cmake-install-target.patch
+++ b/ports/oscpack/add-cmake-install-target.patch
@@ -1,0 +1,51 @@
+From 3a7ee65ecf43b97cc4a8c7cea5493de0d2b992fa Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20Sch=C3=BCrmann?= <daschuer@mixxx.org>
+Date: Wed, 15 Jan 2025 07:58:23 +0100
+Subject: [PATCH] Add cmake install target
+
+---
+ CMakeLists.txt | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e8bef70..4f200b2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -42,6 +42,34 @@ osc/OscOutboundPacketStream.cpp
+ 
+ )
+ 
++set(IP_HEADERS 
++  ip/IpEndpointName.h
++  ip/NetworkingUtils.h
++  ip/PacketListener.h
++  ip/TimerListener.h
++  ip/UdpSocket.h
++)
++
++
++set(OSC_HEADERS 
++  osc/MessageMappingOscPacketListener.h
++  osc/OscException.h
++  osc/OscHostEndianness.h
++  osc/OscOutboundPacketStream.h
++  osc/OscPacketListener.h
++  osc/OscPrintReceivedElements.h
++  osc/OscReceivedElements.h
++  osc/OscTypes.h
++)
++
++INSTALL(TARGETS oscpack
++  RUNTIME DESTINATION bin
++  LIBRARY DESTINATION lib
++  ARCHIVE DESTINATION lib
++)
++
++INSTALL(FILES ${IP_HEADERS} DESTINATION include/ip)
++INSTALL(FILES ${OSC_HEADERS} DESTINATION include/osc)
+ 
+ ADD_EXECUTABLE(OscUnitTests tests/OscUnitTests.cpp)
+ TARGET_LINK_LIBRARIES(OscUnitTests oscpack ${LIBS})
+-- 
+2.34.1
+

--- a/ports/oscpack/link-ws2_32-and-winmm.patch
+++ b/ports/oscpack/link-ws2_32-and-winmm.patch
@@ -1,0 +1,25 @@
+From d2a920a78f3b29df26d8e1e8ca6a0e93260999db Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20Sch=C3=BCrmann?= <daschuer@mixxx.org>
+Date: Wed, 15 Jan 2025 21:56:46 +0100
+Subject: [PATCH] link Ws2_32 and winmm
+
+---
+ CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1fc1fbe..1b3c4aa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -43,6 +43,8 @@ osc/OscOutboundPacketStream.cpp
+ 
+ )
+ 
++TARGET_LINK_LIBRARIES(oscpack PRIVATE ${LIBS})
++
+ set(IP_HEADERS 
+   ip/IpEndpointName.h
+   ip/NetworkingUtils.h
+-- 
+2.34.1
+

--- a/ports/oscpack/portfile.cmake
+++ b/ports/oscpack/portfile.cmake
@@ -1,0 +1,31 @@
+if (VCPKG_TARGET_IS_WINDOWS)
+    # This can (and should) be removed if oscpack ever supports dynamically linking on Windows
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO RossBencina/oscpack
+    REF release_1_1_0
+    SHA512 7a61a364cab4914c81e113d7aeee2b4accf5e560f500df6634232e0093f564ed4bb0ef8e87d2c8a18f245b0c7ec25f41e64f42f20a6654c22bb5c02aa253bbd0
+    PATCHES
+      add-cmake-install-target.patch
+      link-ws2_32-and-winmm.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_build()
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" 
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+

--- a/ports/oscpack/usage
+++ b/ports/oscpack/usage
@@ -1,0 +1,10 @@
+oscpack can be used from CMake via:
+
+    find_path(OSCPACK_INCLUDE_DIRS "osc" PATH_SUFFIXES "oscpack")
+    find_library(OSCPACK_LIBRARY oscpack REQUIRED)
+    target_include_directories(main PRIVATE ${OSCPACK_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE ${OSCPACK_LIBRARY})
+    
+In case of Windows static link in addition: 
+
+    target_link_libraries(main PRIVATE ws2_32 winmm)

--- a/ports/oscpack/vcpkg.json
+++ b/ports/oscpack/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "oscpack",
+  "version": "1.1.0",
+  "description": "A simple C++ Open Sound Control (OSC) packet manipulation library",
+  "homepage": "http://www.rossbencina.com/code/oscpack",
+  "license": null,
+  "supports": "!(windows & !static)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6836,6 +6836,10 @@
       "baseline": "1.5.1",
       "port-version": 0
     },
+    "oscpack": {
+      "baseline": "1.1.0",
+      "port-version": 0
+    },
     "osg": {
       "baseline": "3.6.5",
       "port-version": 25

--- a/versions/o-/oscpack.json
+++ b/versions/o-/oscpack.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fb55144b36990517045fd8a9c7898d464b76ca21",
+      "version": "1.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines. https://repology.org/project/oscpack/versions
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.