### PR TITLE
[tbb] Fix build for non-English systems

### DIFF
--- a/ports/tbb/fix-lang.patch
+++ b/ports/tbb/fix-lang.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/compilers/GNU.cmake b/cmake/compilers/GNU.cmake
+index cf6d8bdb..458ea339 100644
+--- a/cmake/compilers/GNU.cmake
++++ b/cmake/compilers/GNU.cmake
+@@ -48,7 +48,7 @@ endif()
+ # information is written to either stdout or stderr. To not make any
+ # assumptions, both are captured.
+ execute_process(
+-    COMMAND ${CMAKE_COMMAND} -E env "LANG=C" ${CMAKE_CXX_COMPILER} -xc -c /dev/null -Wa,-v -o/dev/null
++    COMMAND ${CMAKE_COMMAND} -E env "LC_ALL=C" "LANG=C" ${CMAKE_CXX_COMPILER} -xc -c /dev/null -Wa,-v -o/dev/null
+     OUTPUT_VARIABLE ASSEMBLER_VERSION_LINE_OUT
+     ERROR_VARIABLE ASSEMBLER_VERSION_LINE_ERR
+     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/ports/tbb/portfile.cmake
+++ b/ports/tbb/portfile.cmake
@@ -7,6 +7,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 c87b84964b2c323f61895a532968dfa6413a774c177cffbf6e798a07e74e8da5d449144875771df0a1b02657eeb2a7ae4d41c6c432dbf7ea50e3d5a9ea9f8cd3
     HEAD_REF master
+    PATCHES
+        fix-lang.patch # https://github.com/uxlfoundation/oneTBB/pull/1606
 )
 
 vcpkg_check_features(

--- a/ports/tbb/vcpkg.json
+++ b/ports/tbb/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "tbb",
   "version": "2022.0.0",
+  "port-version": 1,
   "description": "Intel's Threading Building Blocks.",
   "homepage": "https://github.com/oneapi-src/oneTBB",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8858,7 +8858,7 @@
     },
     "tbb": {
       "baseline": "2022.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tcb-span": {
       "baseline": "2022-06-15",

--- a/versions/t-/tbb.json
+++ b/versions/t-/tbb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8eb4f6f5f53c1b56598b26a951b8d49cf349d0d",
+      "version": "2022.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1190d84d0e84ec7100662a4c35cd6a27ce532864",
       "version": "2022.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The TBB build currently fails on non-english systems using GCC. Patch is also submitted upstream. Description see upstream PR: https://github.com/uxlfoundation/oneTBB/pull/1606