### PR TITLE
[arrow] Update to 19.0.0

### DIFF
--- a/ports/arrow/0004-android-musl.patch
+++ b/ports/arrow/0004-android-musl.patch
@@ -1,16 +1,3 @@
-diff --git a/cpp/src/arrow/CMakeLists.txt b/cpp/src/arrow/CMakeLists.txt
-index 6dc8358..2b91efa 100644
---- a/cpp/src/arrow/CMakeLists.txt
-+++ b/cpp/src/arrow/CMakeLists.txt
-@@ -166,7 +166,7 @@ if(WIN32)
-   list(APPEND ARROW_SYSTEM_LINK_LIBS "ws2_32")
- endif()
-
--if(NOT WIN32 AND NOT APPLE)
-+if(NOT WIN32 AND NOT APPLE AND NOT ANDROID)
-   # Pass -lrt on Linux only
-   list(APPEND ARROW_SYSTEM_LINK_LIBS rt)
- endif()
 diff --git a/cpp/src/arrow/vendored/musl/strptime.c b/cpp/src/arrow/vendored/musl/strptime.c
 index 41912fd..0ea36e9 100644
 --- a/cpp/src/arrow/vendored/musl/strptime.c

--- a/ports/arrow/0006-cmake-msvcruntime.patch
+++ b/ports/arrow/0006-cmake-msvcruntime.patch
@@ -1,0 +1,24 @@
+diff --git a/cpp/cmake_modules/ThirdpartyToolchain.cmake b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+index abfe6d274f..8bacfe89af 100644
+--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+@@ -886,9 +886,17 @@ foreach(CONFIG DEBUG MINSIZEREL RELEASE RELWITHDEBINFO)
+   set(EP_CXX_FLAGS_${CONFIG} "${CMAKE_CXX_FLAGS_${CONFIG}}")
+   set(EP_C_FLAGS_${CONFIG} "${CMAKE_C_FLAGS_${CONFIG}}")
+   if(CONFIG STREQUAL DEBUG)
+-    set(EP_MSVC_RUNTIME_LIBRARY MultiThreadedDebugDLL)
++    if(BUILD_SHARED_LIBS)
++      set(EP_MSVC_RUNTIME_LIBRARY MultiThreadedDebugDLL)
++     else()
++      set(EP_MSVC_RUNTIME_LIBRARY MultiThreadedDebug)
++    endif()
+   else()
+-    set(EP_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
++    if(BUILD_SHARED_LIBS)
++      set(EP_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
++    else()
++      set(EP_MSVC_RUNTIME_LIBRARY MultiThreaded)
++    endif()
+   endif()
+   string(APPEND EP_CXX_FLAGS_${CONFIG}
+          " ${CMAKE_CXX_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_${EP_MSVC_RUNTIME_LIBRARY}}")

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     ARCHIVE_PATH
     URLS "https://archive.apache.org/dist/arrow/arrow-${VERSION}/apache-arrow-${VERSION}.tar.gz"
     FILENAME apache-arrow-${VERSION}.tar.gz
-    SHA512 7249c03a6097bc64fb0092143e4d4aaef3227565147e6254f026ddd504177c8dd565a184a0df39743dc989070dc3785e5b66f738c8e310ed9c982b61c2ec4914
+    SHA512 6820de33a5d5b0922ea64dd8ff55d186ef02596ad0415578067aaf3e5cf7d3eead473bc3a5f92d6d3f19b97d153fe1c901359008d922d1ffb0fc2a65dc860c79
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_extract_source_archive(
         0003-utf8proc.patch
         0004-android-musl.patch
         0005-android-datetime.patch
+        0006-cmake-msvcruntime.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arrow",
-  "version": "18.1.0",
+  "version": "19.0.0",
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4d98ac93e3838ab0e5012ef48276efda7aa84bf6",
+      "git-tree": "f85d9f8584758bca48a085085010aa677e331908",
       "version": "19.0.0",
       "port-version": 0
     },

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d98ac93e3838ab0e5012ef48276efda7aa84bf6",
+      "version": "19.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cff712c97f67ce2ef9061d823c751f5e209e5838",
       "version": "18.1.0",
       "port-version": 0

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f85d9f8584758bca48a085085010aa677e331908",
+      "git-tree": "36b25d8cfc7098069e26a5185c684dddffa7cd47",
       "version": "19.0.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -245,7 +245,7 @@
       "port-version": 7
     },
     "arrow": {
-      "baseline": "18.1.0",
+      "baseline": "19.0.0",
       "port-version": 0
     },
     "arsenalgear": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
