### PR TITLE
[vcpkg baseline][salome-configuration] Modify ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -984,6 +984,12 @@ rpclib:x64-uwp=fail
 rtmidi:arm-neon-android=fail
 rtmidi:arm64-android=fail
 rtmidi:x64-android=fail
+#The library home page cannot be accessed, temporarily add it to ci.baseline.txt to avoid affecting other ports
+salome-configuration:x64-linux=fail
+salome-configuration:x86-windows=fail
+salome-configuration:x64-windows=fail
+salome-configuration:x64-windows-static=fail
+salome-configuration:x64-windows-static-md=fail
 salome-medcoupling:x64-linux=fail
 # Visual Studio 17.12 compiler bug, fixed in 17.13: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2242053
 saucer:arm64-windows-static-md=fail


### PR DESCRIPTION
Fix CI issue:
````
REGRESSION: salome-configuration:x64-linux failed with BUILD_FAILED
REGRESSION: salome-configuration:x64-windows failed with BUILD_FAILED
REGRESSION: salome-configuration:x64-windows-static failed with BUILD_FAILED
REGRESSION: salome-configuration:x64-windows-static-md failed with BUILD_FAILED
REGRESSION: salome-configuration:x86-windows failed with BUILD_FAILED
````

Because the home page of the `salome-configuration` library cannot be accessed, temporarily add it to `ci.baseline.txt` to avoid affecting other ports.
```
fatal: unable to access 'https://git.salome-platform.org/gitpub/tools/configuration.git/': The requested URL returned error: 502
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [ ] ~~SHA512s are updated for each updated download~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [ ] ~~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~~
- [x] Only one version is added to each modified port's versions file.
