### PR TITLE
[vcpkg baseline][libmem] Remove embedded llvm and use port dependency instead

### DIFF
--- a/ports/libmem/0001-CMakeLists.patch
+++ b/ports/libmem/0001-CMakeLists.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 534057a..049805a 100644
+index 534057a..6241a58 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,6 +1,6 @@
@@ -18,49 +18,46 @@ index 534057a..049805a 100644
  # External dependencies
  set(EXTERNAL_DEPENDENCIES_DIR "${PROJECT_SOURCE_DIR}/external")
  set(CAPSTONE_DIR "${EXTERNAL_DEPENDENCIES_DIR}/capstone")
-@@ -67,6 +68,7 @@ add_library(keystone STATIC IMPORTED)
+@@ -66,6 +67,7 @@ set_target_properties(capstone PROPERTIES IMPORTED_LOCATION ${CAPSTONE_IMPORT_DI
+ add_library(keystone STATIC IMPORTED)
  set_target_properties(keystone PROPERTIES IMPORTED_LOCATION ${KEYSTONE_IMPORT_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}keystone${CMAKE_STATIC_LIBRARY_SUFFIX})
  # End of external dependencies
- 
 +endif()
+ 
  set(LIBMEM_DIR "${PROJECT_SOURCE_DIR}")
  set(LIBMEM_INC "${LIBMEM_DIR}/include")
- set(INTERNAL_DIR "${LIBMEM_DIR}/internal")
-@@ -89,24 +91,21 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
+@@ -89,10 +91,17 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
  	endif()
  	file(GLOB LIBMEM_SRC ${LIBMEM_ARCH_SRC} "${LIBMEM_DIR}/src/freebsd/*.c" "${LIBMEM_DIR}/src/freebsd/ptrace/*.c" "${LIBMEM_DIR}/src/common/*.c" "${LIBMEM_DIR}/src/common/*.cpp" "${INTERNAL_DIR}/posixutils/*.c" "${INTERNAL_DIR}/elfutils/*.c" "${INTERNAL_DIR}/demangler/*.cpp")
  endif()
 +find_package(PkgConfig)
-+pkg_check_modules(keystone REQUIRED keystone)
++pkg_check_modules(keystone REQUIRED IMPORTED_TARGET keystone)
 +find_package(capstone CONFIG REQUIRED)
++find_package(LLVM CONFIG REQUIRED)
++target_compile_definitions(LLVMDemangle INTERFACE ${LLVM_DEFINITIONS})
++target_include_directories(LLVMDemangle INTERFACE ${LLVM_INCLUDE_DIRS})
++
  set(LIBMEM_DEPS
 -	capstone
 -	keystone
 -	llvm
 +	capstone::capstone
-+	"${keystone_LINK_LIBRARIES}"
++	PkgConfig::keystone
++	LLVMDemangle
  )
--
--if (LIBMEM_BUILD_STATIC)
--	add_library(libmem STATIC ${LIBMEM_SRC})
--else()
--	add_library(libmem SHARED ${LIBMEM_SRC})
--endif()
-+file(GLOB_RECURSE LLVM_DEM_SRC "${LIBMEM_DIR}/external/llvm/lib/*.cpp")
-+add_library(libmem ${LIBMEM_SRC} ${LLVM_DEM_SRC})
- target_include_directories(libmem PRIVATE "${LIBMEM_DIR}/src" "${INTERNAL_DIR}" "${COMMON_DIR}")
+ 
+ if (LIBMEM_BUILD_STATIC)
+@@ -104,9 +113,6 @@ target_include_directories(libmem PRIVATE "${LIBMEM_DIR}/src" "${INTERNAL_DIR}"
  
  include_directories(${PROJECT_SOURCE_DIR}
  	${LIBMEM_INC}
 -	${CAPSTONE_INC}
 -	${KEYSTONE_INC}
 -	${LLVM_INC}
-+	"${keystone_INCLUDE_DIRS}"
-+	"${LIBMEM_DIR}/external/llvm/include"
  )
  
  if (LIBMEM_BUILD_TESTS)
-@@ -116,10 +115,6 @@ endif()
+@@ -116,10 +122,6 @@ endif()
  
  set_target_properties(libmem PROPERTIES POSITION_INDEPENDENT_CODE True INCLUDES ${LIBMEM_INC})
  target_compile_definitions(libmem PUBLIC LM_EXPORT)
@@ -71,7 +68,7 @@ index 534057a..049805a 100644
  
  if(${CMAKE_SYSTEM_NAME} STREQUAL Windows OR ${CMAKE_SYSTEM_NAME} STREQUAL CYGWIN)
  	set(LIBMEM_DEPS
-@@ -152,7 +147,7 @@ else()
+@@ -152,7 +154,7 @@ else()
  endif()
  
  target_link_libraries(libmem ${LIBMEM_DEPS})
@@ -80,7 +77,7 @@ index 534057a..049805a 100644
  	# Create a bundled static library containing all dependencies (to mimic the shared library behavior)
  	set_target_properties(libmem PROPERTIES OUTPUT_NAME "libmem_partial")
  	set(libmem_bundle_files "$<TARGET_FILE:libmem>")
-@@ -193,7 +188,7 @@ if(LIBMEM_BUILD_STATIC)
+@@ -193,7 +195,7 @@ if(LIBMEM_BUILD_STATIC)
  	endif()
  endif()
  
@@ -89,7 +86,7 @@ index 534057a..049805a 100644
  	if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL CYGWIN)
  		cmake_path(SET CMAKE_INSTALL_PREFIX "$ENV{ProgramFiles}")
  	else()
-@@ -202,14 +197,17 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL Windows OR ${CMAKE_SYSTEM_NAME} STREQUAL CYGWIN
+@@ -202,14 +204,25 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL Windows OR ${CMAKE_SYSTEM_NAME} STREQUAL CYGWIN
  	endif()
  	set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/libmem")
  	execute_process(COMMAND mkdir "${CMAKE_INSTALL_PREFIX}")
@@ -104,13 +101,21 @@ index 534057a..049805a 100644
 -	RUNTIME DESTINATION lib)
 -
  install(DIRECTORY ${LIBMEM_INC}/libmem DESTINATION include)
-+install(TARGETS libmem EXPORT libmem-target
++install(TARGETS libmem EXPORT libmem-targets
 +	LIBRARY DESTINATION lib
 +	ARCHIVE DESTINATION lib
 +	RUNTIME DESTINATION bin
 +)
-+install(EXPORT libmem-target NAMESPACE libmem:: DESTINATION "share/libmem")
++install(EXPORT libmem-targets NAMESPACE libmem:: DESTINATION "share/libmem")
 +include(CMakePackageConfigHelpers)
-+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libmem-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/libmem-config.cmake" @ONLY)
++configure_package_config_file(
++	"${CMAKE_CURRENT_LIST_DIR}/libmem-config.cmake.in"
++	"${CMAKE_CURRENT_BINARY_DIR}/libmem-config.cmake"
++	INSTALL_DESTINATION "share/libmem"
++)
 +write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/libmem-config-version.cmake" VERSION 5.0.4 COMPATIBILITY SameMajorVersion)
-+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libmem-config.cmake" "${CMAKE_CURRENT_BINARY_DIR}/libmem-config-version.cmake" DESTINATION "share/libmem")
++install(FILES
++		"${CMAKE_CURRENT_BINARY_DIR}/libmem-config.cmake"
++		"${CMAKE_CURRENT_BINARY_DIR}/libmem-config-version.cmake"
++	DESTINATION "share/libmem"
++)

--- a/ports/libmem/libmem-config.cmake.in
+++ b/ports/libmem/libmem-config.cmake.in
@@ -1,5 +1,11 @@
 @PACKAGE_INIT@
 include(CMakeFindDependencyMacro)
+
 find_dependency(capstone CONFIG)
-include("${CMAKE_CURRENT_LIST_DIR}/libmem-target.cmake")
-check_required_components(libmem)
+
+find_dependency(PkgConfig)
+pkg_check_modules(keystone REQUIRED IMPORTED_TARGET keystone)
+
+find_dependency(LLVM CONFIG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/libmem-targets.cmake")

--- a/ports/libmem/portfile.cmake
+++ b/ports/libmem/portfile.cmake
@@ -10,9 +10,13 @@ vcpkg_from_github(
 file(REMOVE "${SOURCE_PATH}/PreLoad.cmake")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/libmem-config.cmake.in" DESTINATION "${SOURCE_PATH}")
 vcpkg_find_acquire_program(PKGCONFIG)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LIBMEM_BUILD_STATIC)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DLIBMEM_BUILD_TESTS=OFF
+        -DLIBMEM_DEEP_TESTS=OFF
+        -DLIBMEM_BUILD_STATIC=${LIBMEM_BUILD_STATIC}
         "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
 )
 vcpkg_cmake_install()

--- a/ports/libmem/vcpkg.json
+++ b/ports/libmem/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmem",
   "version": "5.0.4",
+  "port-version": 1,
   "description": "Advanced Game Hacking Library for C, Modern C++, Rust and Python (Windows/Linux/FreeBSD) (Process/Memory Hacking) (Hooking/Detouring) (Cross Platform) (x86/x64/ARM/ARM64) (DLL/SO Injection) (Internal/External) (Assembler/Disassembler)",
   "homepage": "https://github.com/rdbo/libmem",
   "license": "AGPL-3.0-only",
@@ -8,6 +9,10 @@
   "dependencies": [
     "capstone",
     "keystone",
+    {
+      "name": "llvm",
+      "default-features": false
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -577,16 +577,6 @@ libmariadb:x64-windows-static-md=skip
 libmaxminddb:arm64-android=fail
 libmaxminddb:arm-neon-android=fail
 libmaxminddb:x64-android=fail
-# libmem embedded lib llvm, fixing in https://github.com/microsoft/vcpkg/pull/43311
-libmem:arm64-uwp                =skip
-libmem:arm64-windows            =skip
-libmem:arm64-windows-static-md  =skip
-libmem:x64-linux                =skip
-libmem:x64-uwp                  =skip
-libmem:x64-windows              =skip
-libmem:x64-windows-static       =skip
-libmem:x64-windows-static-md    =skip
-libmem:x86-windows              =skip
 # libmesh installs tons of problematic files that conflict with other ports (boost, eigen, etc)
 libmesh:x64-linux=skip
 libmikmod:arm-neon-android=fail

--- a/scripts/test_ports/vcpkg-ci-libmem/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-libmem/portfile.cmake
@@ -1,4 +1,10 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 
-vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_find_acquire_program(PKGCONFIG)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+    OPTIONS
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+)
 vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-libmem/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-libmem/project/CMakeLists.txt
@@ -1,4 +1,5 @@
-project(libmem-test)
+cmake_minimum_required(VERSION 3.25.1)
+project(libmem-test CXX)
 set(CMAKE_CXX_STANDARD 17)
 find_package(libmem CONFIG REQUIRED)
 add_executable(main main.cpp)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4790,7 +4790,7 @@
     },
     "libmem": {
       "baseline": "5.0.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libmesh": {
       "baseline": "1.5.0",

--- a/versions/l-/libmem.json
+++ b/versions/l-/libmem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3976946c21950dfa4dbd506e05cf3b592da1b7f",
+      "version": "5.0.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "1f851ca1aa9ecd0a88c38d20b44a6b09b3ce0d9f",
       "version": "5.0.4",
       "port-version": 0


### PR DESCRIPTION
Port `libmem` failed due to embedded `llvm` conflicted with port `llvm` https://dev.azure.com/vcpkg/public/_build/results?buildId=111477&view=logs&j=7922e5c4-0103-5f8f-ad17-45ce9bb98e80&t=8ceef4ed-9be5-594f-e707-4e1dd58a3d21&l=60196

Update `libmem` to remove embedded lib llvm and use `llvm` port instead.

### Test

The port usage tests pass with the following triplets:

* x64-linux
* x64-windows