### PR TITLE
[poco] include patch to remove libatomic dependency

### DIFF
--- a/ports/poco/0009-remove-libatomic-dependency.patch
+++ b/ports/poco/0009-remove-libatomic-dependency.patch
@@ -1,0 +1,22 @@
+From e2576ff5ab9f4a69a7d560cd378a377022501a9a Mon Sep 17 00:00:00 2001
+From: Aleksandar Fabijanic <aleks-f@users.noreply.github.com>
+Date: Sat, 7 Dec 2024 17:35:39 -0500
+Subject: [PATCH] fix(cmake): remove libatomic dependency (#4811)
+
+---
+ Foundation/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
+index 5898d22f5c..e985cc39a7 100644
+--- a/Foundation/CMakeLists.txt
++++ b/Foundation/CMakeLists.txt
+@@ -159,7 +159,7 @@ else()
+ 				target_link_libraries(Foundation PUBLIC ${CMAKE_DL_LIBS} rt Threads::Threads)
+ 			else()
+ 				target_compile_definitions(Foundation PUBLIC _XOPEN_SOURCE=500 POCO_HAVE_FD_EPOLL)
+-				target_link_libraries(Foundation PUBLIC pthread atomic ${CMAKE_DL_LIBS} rt)
++				target_link_libraries(Foundation PUBLIC pthread ${CMAKE_DL_LIBS} rt)
+ 			endif()
+ 		endif(APPLE)
+ 	endif(UNIX AND NOT ANDROID)

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
         0007-find-pcre2.patch
         # MSYS2 repo was used as a source. Thanks MSYS2 team: https://github.com/msys2/MINGW-packages/blob/6e7fba42b7f50e1111b7c0ef50048832243b0ac4/mingw-w64-poco/001-fix-build-on-mingw.patch
         0008-fix-mingw-compilation.patch
+        # Should be dropped when upgrading to POC 1.14.1
+        # https://github.com/pocoproject/poco/pull/4811
+        0009-remove-libatomic-dependency.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/Foundation/src/pcre2.h")

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "poco",
   "version": "1.14.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.",
   "homepage": "https://github.com/pocoproject/poco",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7126,7 +7126,7 @@
     },
     "poco": {
       "baseline": "1.14.0",
-      "port-version": 1
+      "port-version": 2
     },
     "podofo": {
       "baseline": "0.10.4",

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03029df7bbc88847dcd6342be29865ade0b24817",
+      "version": "1.14.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "efeff2dbe665e581fb0d034e2d87824d0622419e",
       "version": "1.14.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.