### PR TITLE
[manif] Update version to 0.0.5

### DIFF
--- a/ports/manif/portfile.cmake
+++ b/ports/manif/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO artivis/manif
-    REF bb3f6758ae467b7f24def71861798d131f157032
-    SHA512 aaead27e1a177a1ded644bac270702c7d6232ac5345148be41d3ebca7e181d194e106d74f175182af51a72a4f26d5632749306d86676b5cb8862ddc34ea16a05
+    REF "${VERSION}"
+    SHA512 ab74e6c67641a9bb33bf779fb70d4f79d0758840f28750448c0a26714cd3941376f128cd3936d7329f9c74becc18440fca2a1ff52759f99019fb430287a3a52f
     HEAD_REF devel
 )
 
@@ -16,3 +16,5 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/manif/cmake)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/manif/usage
+++ b/ports/manif/usage
@@ -1,0 +1,4 @@
+manif provides CMake targets:
+
+    find_package(manif CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE MANIF::manif)

--- a/ports/manif/vcpkg.json
+++ b/ports/manif/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "manif",
-  "version-date": "2023-07-17",
+  "version": "0.0.5",
   "description": "A small C++11 header-only library for Lie theory.",
   "homepage": "https://github.com/artivis/manif",
   "documentation": "https://artivis.github.io/manif/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5765,7 +5765,7 @@
       "port-version": 0
     },
     "manif": {
-      "baseline": "2023-07-17",
+      "baseline": "0.0.5",
       "port-version": 0
     },
     "manifold": {

--- a/versions/m-/manif.json
+++ b/versions/m-/manif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a42f06eab26de6a24426fdcf6b0c914bf863fb63",
+      "version": "0.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "85cbc740d2b88302059e858e4f0fe74cf59c5a08",
       "version-date": "2023-07-17",
       "port-version": 0


### PR DESCRIPTION
If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.