### PR TITLE
[google-cloud-cpp] update to the latest release (v2.34.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
     REF "v${VERSION}"
-    SHA512 f57857a0853fa0980bb2c07d25d22240ce27a005a41cc99bf25ca0148fe7c9d5717eeb393519a37f05b40d4c114dde30e959e994700aece1ca2c45e68cd9bf77
+    SHA512 f19e422cf15c6242244fc487982ae2d94cd354a6159e2340bb019ed0eeb7071488a0aa0fddd37e9318a179dac51f58ec208323d31b2f23f4e4dc85ccacb5c4ac
     HEAD_REF main
 )
 

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3201,7 +3201,7 @@
       "port-version": 0
     },
     "google-cloud-cpp": {
-      "baseline": "2.33.0",
+      "baseline": "2.34.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb115f597f862e27443a6a4f0031c2f58dc03d0c",
+      "version": "2.34.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "541916b36ffb283704df2f201a6d12f591cdd361",
       "version": "2.33.0",
       "port-version": 0


### PR DESCRIPTION
Updates google-cloud-cpp to the latest release (v2.34.0)

Tested locally (on x64-linux) with:

```
./vcpkg remove google-cloud-cpp && ./vcpkg install 'google-cloud-cpp[*]'
```

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
