### PR TITLE
[vcpkg baseline][libgcrypt][libmem] Remove libgcrypt:x64-android and add libmem

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -536,8 +536,6 @@ libdc1394:arm64-android=fail
 libflac:arm-neon-android=fail
 libfreenect2:arm64-windows=fail
 libfreenect2:arm64-windows-static-md=fail
-# inline assembly requires more registers than available
-libgcrypt:x64-android=fail
 # error: call to undeclared function 'mktime_z'
 libgnutls:arm-neon-android=fail
 libgnutls:arm64-android=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -577,6 +577,16 @@ libmariadb:x64-windows-static-md=skip
 libmaxminddb:arm64-android=fail
 libmaxminddb:arm-neon-android=fail
 libmaxminddb:x64-android=fail
+# libmem embedded lib llvm, fixing in https://github.com/microsoft/vcpkg/pull/43311
+libmem:arm64-uwp                =skip
+libmem:arm64-windows            =skip
+libmem:arm64-windows-static-md  =skip
+libmem:x64-linux                =skip
+libmem:x64-uwp                  =skip
+libmem:x64-windows              =skip
+libmem:x64-windows-static       =skip
+libmem:x64-windows-static-md    =skip
+libmem:x86-windows              =skip
 # libmesh installs tons of problematic files that conflict with other ports (boost, eigen, etc)
 libmesh:x64-linux=skip
 libmikmod:arm-neon-android=fail


### PR DESCRIPTION
### [libgcrypt] Remove libgcrypt:x64-android from fail list

Port `libgcrypt` passed on https://dev.azure.com/vcpkg/public/_build/results?buildId=111545&view=logs&j=f1a99d27-903c-5ce5-ab6b-a2a85be7b723&t=3d4837a4-bf80-5754-7acb-3d75317102c8&l=44763

```log
PASSING, REMOVE FROM FAIL LIST: libgcrypt:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
```

See 

* https://github.com/microsoft/vcpkg/pull/42984
* https://github.com/microsoft/vcpkg/pull/43212

---

### [libmem] Skip as workaround in ci.baseline.txt and fix patch EO

Port `libmem` failed due to embedded `llvm` conflicted with port `llvm` https://dev.azure.com/vcpkg/public/_build/results?buildId=111477&view=logs&j=7922e5c4-0103-5f8f-ad17-45ce9bb98e80&t=8ceef4ed-9be5-594f-e707-4e1dd58a3d21&l=60196

Skip it in `ci.baseline.txt` as workaround

~Fix patch EOL from \r\n to \n~

Fixing in https://github.com/microsoft/vcpkg/pull/43311