### PR TITLE
[open62541] added multithreading feature

### DIFF
--- a/ports/open62541/portfile.cmake
+++ b/ports/open62541/portfile.cmake
@@ -41,6 +41,10 @@ elseif("mbedtls" IN_LIST FEATURES)
     set(OPEN62541_ENCRYPTION_OPTIONS -DUA_ENABLE_ENCRYPTION=MBEDTLS)
 endif()
 
+if("multithreading" IN_LIST FEATURES)
+    set(OPEN62541_MULTITHREADING_OPTIONS -DUA_MULTITHREADING=100)
+endif()
+
 vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
 vcpkg_add_to_path("${PYTHON3_DIR}")
@@ -50,6 +54,7 @@ vcpkg_cmake_configure(
     OPTIONS
         ${FEATURE_OPTIONS}
         ${OPEN62541_ENCRYPTION_OPTIONS}
+        ${OPEN62541_MULTITHREADING_OPTIONS}
         "-DOPEN62541_VERSION=v${VERSION}"
         -DUA_ENABLE_DEBUG_SANITIZER=OFF
         -DUA_MSVC_FORCE_STATIC_CRT=OFF

--- a/ports/open62541/vcpkg.json
+++ b/ports/open62541/vcpkg.json
@@ -42,6 +42,9 @@
     "methodcalls": {
       "description": "Enable the Method service set"
     },
+    "multithreading": {
+      "description": "Enable multi threading support"
+    },
     "openssl": {
       "description": "Enable encryption support (uses OpenSSL)",
       "dependencies": [

--- a/ports/open62541/vcpkg.json
+++ b/ports/open62541/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "open62541",
   "version": "1.3.15",
+  "port-version": 1,
   "description": "open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.",
   "homepage": "https://open62541.org",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6626,7 +6626,7 @@
     },
     "open62541": {
       "baseline": "1.3.15",
-      "port-version": 0
+      "port-version": 1
     },
     "open62541pp": {
       "baseline": "0.16.0",

--- a/versions/o-/open62541.json
+++ b/versions/o-/open62541.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3aa648b287030af52b876ec25c8960879df2683b",
+      "version": "1.3.15",
+      "port-version": 1
+    },
+    {
       "git-tree": "96ef706dfc63eac612ac3a62f5884f88aaba030c",
       "version": "1.3.15",
       "port-version": 0

--- a/versions/o-/open62541.json
+++ b/versions/o-/open62541.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3aa648b287030af52b876ec25c8960879df2683b",
+      "git-tree": "069f0994eea700649515980c5d35eb9157bbe990",
       "version": "1.3.15",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #42179

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This PR only adds a feature, no other changes are made,

p.s. This is my first vcpkg PR, feedback is welcome.