### PR TITLE
[vtk] add feature

### DIFF
--- a/ports/vtk/fix-tbbsmptool.patch
+++ b/ports/vtk/fix-tbbsmptool.patch
@@ -1,0 +1,15 @@
+diff --git a/Common/Core/SMP/TBB/vtkSMPToolsImpl.txx b/Common/Core/SMP/TBB/vtkSMPToolsImpl.txx
+index e5792ee..e81d5ed 100644
+--- a/Common/Core/SMP/TBB/vtkSMPToolsImpl.txx
++++ b/Common/Core/SMP/TBB/vtkSMPToolsImpl.txx
+@@ -190,6 +190,10 @@ int vtkSMPToolsImpl<BackendType::TBB>::GetEstimatedNumberOfThreads();
+ template <>
+ bool vtkSMPToolsImpl<BackendType::TBB>::GetSingleThread();
+ 
++//--------------------------------------------------------------------------------
++template <>
++VTKCOMMONCORE_EXPORT vtkSMPToolsImpl<BackendType::TBB>::vtkSMPToolsImpl();
++
+ VTK_ABI_NAMESPACE_END
+ } // namespace smp
+ } // namespace detail

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -39,6 +39,7 @@ vcpkg_from_github(
         opencascade-7.8.0.patch
         no-libharu-for-ioexport.patch
         no-libproj-for-netcdf.patch
+		fix-tbbsmptool.patch #https://gitlab.kitware.com/vtk/vtk/-/merge_requests/11530
 )
 
 # =============================================================================
@@ -241,11 +242,25 @@ else()
     )
 endif()
 
+if("tbb" IN_LIST FEATURES)
+    list(APPEND ADDITIONAL_OPTIONS
+	    -DVTK_SMP_IMPLEMENTATION_TYPE=TBB
+	)
+endif()
+
+if("openmp" IN_LIST FEATURES)
+	list(APPEND ADDITIONAL_OPTIONS
+	    -DVTK_SMP_IMPLEMENTATION_TYPE=OpenMP
+	)
+endif()
+
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
     "cuda"         VTK_USE_CUDA
     "mpi"          VTK_USE_MPI
     "all"          VTK_BUILD_ALL_MODULES
+	"tbb"          VTK_SMP_ENABLE_TBB
+	"openmp"       VTK_SMP_ENABLE_OPENMP      
 )
 
 # =============================================================================

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.3.0-pv5.12.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": null,
@@ -218,6 +218,9 @@
         }
       ]
     },
+    "openmp": {
+      "description": "Use openmp multithreading parallel implementation"
+    },
     "openvr": {
       "description": "OpenVR functionality for VTK",
       "dependencies": [
@@ -315,6 +318,12 @@
       "description": "SQL functionality for VTK",
       "dependencies": [
         "sqlite3"
+      ]
+    },
+    "tbb": {
+      "description": "Use TBB multithreading parallel implementation",
+	  "dependencies": [
+        "tbb"
       ]
     },
     "utf8": {

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -322,7 +322,7 @@
     },
     "tbb": {
       "description": "Use TBB multithreading parallel implementation",
-	  "dependencies": [
+      "dependencies": [
         "tbb"
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9538,7 +9538,7 @@
     },
     "vtk": {
       "baseline": "9.3.0-pv5.12.1",
-      "port-version": 6
+      "port-version": 7
     },
     "vtk-dicom": {
       "baseline": "0.8.16",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "87b52d62a474be8a4eac9f1e0283d887b59623d2",
+      "git-tree": "99106a39e2e8608b7a33f937bdaa62be93fdbbca",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 7
     },

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "87b52d62a474be8a4eac9f1e0283d887b59623d2",
+      "version-semver": "9.3.0-pv5.12.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "5727b06657959909b4ffe7608c3d849acb38f286",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 6


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43284
Fix the following errors:
```
vtkSMPToolsAPI.cxx.obj : error LNK2005: "public: __cdecl vtk::detail::smp::vtkSMPToolsImpl<2>::vtkSMPToolsImpl<2>(void)" (??0?$vtkSMPToolsImpl@$01@smp@detail@vtk@@QEAA@XZ) already defined in vtkSMPToolsImpl.cxx.obj
   Creating library lib\vtkCommonCore-9.3d.lib and object lib\vtkCommonCore-9.3d.exp
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Two features test passed with x64-windows triplet.