### PR TITLE
[poco] RFC: Add features to POCO to allow reducing build time

### DIFF
--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -30,6 +30,7 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" POCO_MT)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        cppparser   ENABLE_CPPPARSER
         crypto      ENABLE_CRYPTO
         mongodb     ENABLE_MONGODB
         netssl      ENABLE_NETSSL
@@ -71,7 +72,6 @@ vcpkg_cmake_configure(
         -DENABLE_NET=ON
         -DENABLE_SEVENZIP=ON
         -DENABLE_ZIP=ON
-        -DENABLE_CPPPARSER=ON
         -DENABLE_PAGECOMPILER=ON
         -DENABLE_PAGECOMPILER_FILE2PAGE=ON
         -DPOCO_DISABLE_INTERNAL_OPENSSL=ON

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -38,6 +38,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         pdf             ENABLE_PDF
         pocodoc         ENABLE_POCODOC
         postgresql      ENABLE_DATA_POSTGRESQL
+        sqlite3         ENABLE_DATA_SQLITE
 )
 
 # POCO_ENABLE_NETSSL_WIN: 

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -30,13 +30,14 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" POCO_MT)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        cppparser   ENABLE_CPPPARSER
-        crypto      ENABLE_CRYPTO
-        mongodb     ENABLE_MONGODB
-        netssl      ENABLE_NETSSL
-        pdf         ENABLE_PDF
-        pocodoc     ENABLE_POCODOC
-        postgresql  ENABLE_DATA_POSTGRESQL
+        activerecord    ENABLE_ACTIVERECORD
+        cppparser       ENABLE_CPPPARSER
+        crypto          ENABLE_CRYPTO
+        mongodb         ENABLE_MONGODB
+        netssl          ENABLE_NETSSL
+        pdf             ENABLE_PDF
+        pocodoc         ENABLE_POCODOC
+        postgresql      ENABLE_DATA_POSTGRESQL
 )
 
 # POCO_ENABLE_NETSSL_WIN: 
@@ -63,6 +64,7 @@ vcpkg_cmake_configure(
         -DPOCO_MT=${POCO_MT}
         -DENABLE_TESTS=OFF
         # Allow enabling and disabling components
+        -DENABLE_ACTIVERECORD_COMPILER=${ENABLE_ACTIVERECORD}
         -DENABLE_ENCODINGS=ON
         -DENABLE_ENCODINGS_COMPILER=ON
         -DENABLE_XML=ON
@@ -87,7 +89,10 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 # Move apps to the tools folder
-vcpkg_copy_tools(TOOL_NAMES cpspc f2cpsp tec poco-arc AUTO_CLEAN)
+vcpkg_copy_tools(TOOL_NAMES cpspc f2cpsp tec AUTO_CLEAN)
+if (ENABLE_ACTIVERECORD STREQUAL "ON")
+    vcpkg_copy_tools(TOOL_NAMES poco-arc AUTO_CLEAN)
+endif()
 if (ENABLE_POCODOC STREQUAL "ON")
     vcpkg_copy_tools(TOOL_NAMES PocoDoc AUTO_CLEAN)
 endif()

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         crypto      ENABLE_CRYPTO
         netssl      ENABLE_NETSSL
         pdf         ENABLE_PDF
+        pocodoc     ENABLE_POCODOC
         postgresql  ENABLE_DATA_POSTGRESQL
 )
 
@@ -71,7 +72,6 @@ vcpkg_cmake_configure(
         -DENABLE_SEVENZIP=ON
         -DENABLE_ZIP=ON
         -DENABLE_CPPPARSER=ON
-        -DENABLE_POCODOC=ON
         -DENABLE_PAGECOMPILER=ON
         -DENABLE_PAGECOMPILER_FILE2PAGE=ON
         -DPOCO_DISABLE_INTERNAL_OPENSSL=ON
@@ -87,7 +87,11 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 # Move apps to the tools folder
-vcpkg_copy_tools(TOOL_NAMES cpspc f2cpsp PocoDoc tec poco-arc AUTO_CLEAN)
+vcpkg_copy_tools(TOOL_NAMES cpspc f2cpsp tec poco-arc AUTO_CLEAN)
+if (ENABLE_POCODOC STREQUAL "ON")
+    vcpkg_copy_tools(TOOL_NAMES PocoDoc AUTO_CLEAN)
+endif()
+
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -31,6 +31,7 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" POCO_MT)
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         crypto      ENABLE_CRYPTO
+        mongodb     ENABLE_MONGODB
         netssl      ENABLE_NETSSL
         pdf         ENABLE_PDF
         pocodoc     ENABLE_POCODOC
@@ -65,7 +66,6 @@ vcpkg_cmake_configure(
         -DENABLE_ENCODINGS_COMPILER=ON
         -DENABLE_XML=ON
         -DENABLE_JSON=ON
-        -DENABLE_MONGODB=ON
         -DENABLE_REDIS=ON
         -DENABLE_UTIL=ON
         -DENABLE_NET=ON

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -22,10 +22,14 @@
     "zlib"
   ],
   "default-features": [
+    "cppparser",
     "mongodb",
     "pocodoc"
   ],
   "features": {
+    "cppparser": {
+      "description": "C++ parser support for POCO"
+    },
     "crypto": {
       "description": "Crypto support",
       "dependencies": [

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -22,6 +22,7 @@
     "zlib"
   ],
   "default-features": [
+    "mongodb",
     "pocodoc"
   ],
   "features": {
@@ -36,6 +37,9 @@
       "dependencies": [
         "libmariadb"
       ]
+    },
+    "mongodb": {
+      "description": "MongoDB support for POCO"
     },
     "mysql": {
       "description": "Mysql support for POCO",

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -22,11 +22,15 @@
     "zlib"
   ],
   "default-features": [
+    "activerecord",
     "cppparser",
     "mongodb",
     "pocodoc"
   ],
   "features": {
+    "activerecord": {
+      "description": "ActiveRecord support for POCO"
+    },
     "cppparser": {
       "description": "C++ parser support for POCO"
     },

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -21,6 +21,9 @@
     },
     "zlib"
   ],
+  "default-features": [
+    "pocodoc"
+  ],
   "features": {
     "crypto": {
       "description": "Crypto support",
@@ -60,6 +63,9 @@
       "dependencies": [
         "libharu"
       ]
+    },
+    "pocodoc": {
+      "description": "PocoDoc tool support"
     },
     "postgresql": {
       "description": "PostgreSQL support for POCO",

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -9,7 +9,6 @@
   "dependencies": [
     "expat",
     "pcre2",
-    "sqlite3",
     "utf8proc",
     {
       "name": "vcpkg-cmake",
@@ -25,7 +24,8 @@
     "activerecord",
     "cppparser",
     "mongodb",
-    "pocodoc"
+    "pocodoc",
+    "sqlite3"
   ],
   "features": {
     "activerecord": {
@@ -83,6 +83,12 @@
       "description": "PostgreSQL support for POCO",
       "dependencies": [
         "libpqxx"
+      ]
+    },
+    "sqlite3": {
+      "description": "sqlite3 support for POCO",
+      "dependencies": [
+        "sqlite3"
       ]
     }
   }


### PR DESCRIPTION
**Note**: this isn't marked as a draft as I am hoping to get feedback on it, although I do not intend for it to be submitted as-is.

# Background

We use POCO as part of a C++ plugin system, which involves building POCO into our main application/library as well as separate plugin libraries (see [`Poco::ClassLoader`](https://docs.pocoproject.org/current/Poco.ClassLoader.html)). I'm trying to reduce friction for new plugin authors, a large part of which is due to a slow first-compile experience which is dominated by time spent by vcpkg building POCO, especially on older/slower machines.

POCO has good support for building a subset of the library, as seen in its [`CMakeLists.txt`](https://github.com/pocoproject/poco/blob/705403d4f651245d39793a0a95cbf1c774c15461/CMakeLists.txt#L158C1-L188). A small subset of these options are supported by the vcpkg port today, mostly as a way to limit dependencies.

# Proposal

Create vcpkg features for the poco port which align with the rest of the `ENABLE_<FEATURE>` options supported by POCO's `CMakeLists.txt`, including in cases where no third-party vcpkg dependencies are required (e.g. `ENABLE_MONGODB`). This would allow users to only build the relevant subset of POCO when first-build times are important.

Set the default features of the poco port to be equivalent to the current functionality, to avoid breaking existing clients. Potentially remove the default features upon the next version bump, although this is not required.

I am happy to do the legwork here if the vcpkg leadership agrees with the direction, and have mocked up the changes for a few features in this PR.

## History of sqlite3 feature

It seems that the vcpkg poco port has actually regressed in this area (see #42751), having recently removed a `sqlite3` feature resulting in the `sqlite3` dependency being required and `ENABLE_DATA_SQLITE` being left in the default `ON` state. This is unfortunate, as in addition to the increased build time it also gets picked up as a dependency by open-source license and vulnerability management toolchains like [ORT](https://github.com/oss-review-toolkit/ort).

## Build performance impact

Removing even a few features can greatly reduce POCO's build times. I used Clang's `-ftime-trace` feature and [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer) to take some rough measurements of building the poco port locally.

These numbers don't include time spent (or not) building other ports, i.e. the time saved by not building the sqlite3 port itself is not reported.

### State of master as of 1/17/2025
```
**** Time summary:
Compilation (1150 times):
  Parsing (frontend):          876.0 s
  Codegen & opts (backend):    216.9 s
```

### With `activerecord`, `cppparser`, `pocodoc`, `sqlite3` support disabled
```
**** Time summary:
Compilation (938 times):
  Parsing (frontend):          597.4 s
  Codegen & opts (backend):    115.9 s
```

From the build logs I expect further savings are possible, but wanted to get an RFC up first.
