### PR TITLE
[glibmm] Update to 2.80.1

### DIFF
--- a/ports/glibmm/portfile.cmake
+++ b/ports/glibmm/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIBMM_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(GLIBMM_ARCHIVE
     URLS "https://ftp.gnome.org/pub/GNOME/sources/glibmm/${GLIBMM_MAJOR_MINOR}/glibmm-${VERSION}.tar.xz"
     FILENAME "glibmm-${VERSION}.tar.xz"
-    SHA512 5ace15c492be553e2c6abd8d0699197239261feaa2b45ff77181f59bb98b584dc822bdd46dbdee35691cc5a955a3b88e03f58532459236fd780823354c35d0a6
+    SHA512 6f9ee91212077f3712a5ba99507479b5c99d021670e6bf298afc7239fafed8a40b3b17bfae96d9a7fa7fb199c3994b81b433c8275afe89839229a1fe20ba791e
 )
 
 vcpkg_extract_source_archive(

--- a/ports/glibmm/vcpkg.json
+++ b/ports/glibmm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glibmm",
-  "version": "2.78.1",
+  "version": "2.80.1",
   "description": "This is glibmm, a C++ API for parts of glib that are useful for C++.",
   "homepage": "https://www.gtkmm.org.",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3145,7 +3145,7 @@
       "port-version": 0
     },
     "glibmm": {
-      "baseline": "2.78.1",
+      "baseline": "2.80.1",
       "port-version": 0
     },
     "glm": {

--- a/versions/g-/glibmm.json
+++ b/versions/g-/glibmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a25c0ff9ecf2824710c645d6b236f10341ab68e6",
+      "version": "2.80.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "05b0a2d69b2ddb67eef2f6922dfb06c47c3b33d1",
       "version": "2.78.1",
       "port-version": 0


### PR DESCRIPTION
Must update for Android NDK r28.
Can't use latest release because it needs newer glib.