### PR TITLE
[icu] Add a way to set --with-data-packaging value during configuration

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -79,6 +79,13 @@ elseif(VCPKG_CROSSCOMPILING)
     list(APPEND CONFIGURE_OPTIONS "--with-cross-build=${_VCPKG_TOOL_PATH}")
 endif()
 
+# The package osg can be configured to use different data packaging options via a custom triplet file:
+# Possible values are library, static, auto, files and archive
+# https://unicode-org.github.io/icu/userguide/icu_data/#building-and-linking-against-icu-data
+if(NOT DEFINED icu_data_packaging)
+    set(icu_data_packaging "auto")
+endif()
+
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     PROJECT_SUBPATH source
@@ -87,6 +94,7 @@ vcpkg_configure_make(
     ADDITIONAL_MSYS_PACKAGES autoconf-archive
     OPTIONS
         ${CONFIGURE_OPTIONS}
+        --with-data-packaging=${icu_data_packaging}
         --disable-samples
         --disable-tests
         --disable-layoutex

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "icu",
   "version": "74.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3558,7 +3558,7 @@
     },
     "icu": {
       "baseline": "74.2",
-      "port-version": 4
+      "port-version": 5
     },
     "ideviceinstaller": {
       "baseline": "2023-07-21",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "998e417c6e6e8d7350dfd1eac1214fbb7aa1994b",
+      "version": "74.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "291bbc492b8f73dea0dbd12051e9b12b21aef900",
       "version": "74.2",
       "port-version": 4


### PR DESCRIPTION
Fixes #42410

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.