### PR TITLE
[subprocess] add new port

### DIFF
--- a/ports/subprocess/portfile.cmake
+++ b/ports/subprocess/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
 )
 
 # This is a header only library
-file(INSTALL "${SOURCE_PATH}/subprocess.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(INSTALL "${SOURCE_PATH}/subprocess.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/subprocess/portfile.cmake
+++ b/ports/subprocess/portfile.cmake
@@ -10,4 +10,4 @@ vcpkg_from_github(
 file(INSTALL "${SOURCE_PATH}/subprocess.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/subprocess/portfile.cmake
+++ b/ports/subprocess/portfile.cmake
@@ -1,0 +1,13 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO sheredom/subprocess.h
+    REF b49c56e9fe214488493021017bf3954b91c7c1f5
+    SHA512 5d068660ae6e980d80271c0cecfd6e9057e9b04d1fd5154d60de0de9d062716a6c9b94a8ebadf722b49808b0761d5572d3495990efd18901516820a87f8ddf03
+    HEAD_REF master
+)
+
+# This is a header only library
+file(INSTALL "${SOURCE_PATH}/subprocess.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")

--- a/ports/subprocess/vcpkg.json
+++ b/ports/subprocess/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "subprocess",
+  "version-date": "2024-07-20",
+  "description": "A simple one header solution to launching processes and interacting with them for C/C++.",
+  "homepage": "https://github.com/sheredom/subprocess.h",
+  "license": "Unlicense"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8800,6 +8800,10 @@
       "baseline": "2018-11-15",
       "port-version": 9
     },
+    "subprocess": {
+      "baseline": "2024-07-20",
+      "port-version": 0
+    },
     "suitesparse": {
       "baseline": "5.8.0",
       "port-version": 2

--- a/versions/s-/subprocess.json
+++ b/versions/s-/subprocess.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f5043454361d55e5d798604a1f50a2c3f76175d0",
+      "git-tree": "c6d1e3514a58a59754d5858b3bfd262f5b9993d2",
       "version-date": "2024-07-20",
       "port-version": 0
     }

--- a/versions/s-/subprocess.json
+++ b/versions/s-/subprocess.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f5043454361d55e5d798604a1f50a2c3f76175d0",
+      "version-date": "2024-07-20",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

