### PR TITLE
[hdf5] Fix exported config

### DIFF
--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -101,6 +101,13 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/hdf5/hdf5-config.cmake"
     [[${HDF5_PACKAGE_NAME}_TOOLS_DIR "${PACKAGE_PREFIX_DIR}/bin"]]
     [[${HDF5_PACKAGE_NAME}_TOOLS_DIR "${PACKAGE_PREFIX_DIR}/tools/hdf5"]]
 )
+if("parallel" IN_LIST FEATURES AND NOT VCPKG_BUILD_TYPE)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/hdf5/hdf5-config.cmake"
+        [[..HDF5_PACKAGE_NAME._MPI_C_LIBRARIES    "..VCPKG_IMPORT_PREFIX.(/lib/[^"]*)"]]
+        [[${HDF5_PACKAGE_NAME}_MPI_C_LIBRARIES    optimized "${VCPKG_IMPORT_PREFIX}\1" debug "${VCPKG_IMPORT_PREFIX}/debug\1"]]
+        REGEX
+    )
+endif()
 
 set(HDF5_TOOLS "")
 if("tools" IN_LIST FEATURES)

--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -97,12 +97,10 @@ foreach(file IN LISTS pc_files)
     endif()
 endforeach()
 
-file(READ "${CURRENT_PACKAGES_DIR}/share/hdf5/hdf5-config.cmake" contents)
-string(REPLACE [[${HDF5_PACKAGE_NAME}_TOOLS_DIR "${PACKAGE_PREFIX_DIR}/bin"]]
-               [[${HDF5_PACKAGE_NAME}_TOOLS_DIR "${PACKAGE_PREFIX_DIR}/tools/hdf5"]]
-               contents ${contents}
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/hdf5/hdf5-config.cmake"
+    [[${HDF5_PACKAGE_NAME}_TOOLS_DIR "${PACKAGE_PREFIX_DIR}/bin"]]
+    [[${HDF5_PACKAGE_NAME}_TOOLS_DIR "${PACKAGE_PREFIX_DIR}/tools/hdf5"]]
 )
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/hdf5/hdf5-config.cmake" ${contents})
 
 set(HDF5_TOOLS "")
 if("tools" IN_LIST FEATURES)

--- a/ports/hdf5/vcpkg.json
+++ b/ports/hdf5/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hdf5",
   "version": "1.14.4.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "HDF5 is a data model, library, and file format for storing and managing data",
   "homepage": "https://www.hdfgroup.org/downloads/hdf5/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3442,7 +3442,7 @@
     },
     "hdf5": {
       "baseline": "1.14.4.3",
-      "port-version": 3
+      "port-version": 4
     },
     "hdr-histogram": {
       "baseline": "0.11.8",

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "785924f8bc52431728d3045a70739ae4e12f9937",
+      "version": "1.14.4.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "865f6593cb402e937d842ad41cda9e5aa06b0230",
       "version": "1.14.4.3",
       "port-version": 3

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "785924f8bc52431728d3045a70739ae4e12f9937",
+      "git-tree": "6be8801c544227613a9bbf14933875bedb493bcd",
       "version": "1.14.4.3",
       "port-version": 4
     },


### PR DESCRIPTION
In hdf5-config.cmake:
~~~diff
-set (${HDF5_PACKAGE_NAME}_EXPORT_LIBRARIES      hdf5-statichdf5_hl-static)
+set (${HDF5_PACKAGE_NAME}_EXPORT_LIBRARIES      hdf5-static;hdf5_hl-static)
~~~
and
~~~diff
-  set (${HDF5_PACKAGE_NAME}_MPI_C_LIBRARIES    "${VCPKG_IMPORT_PREFIX}/lib/libmpi.so")
+  set (${HDF5_PACKAGE_NAME}_MPI_C_LIBRARIES    optimized "${VCPKG_IMPORT_PREFIX}/lib/libmpi.so" debug "${VCPKG_IMPORT_PREFIX}/debug/lib/libmpi.so")
~~~
