### PR TITLE
[pulsar-client-cpp] Bump to 3.7.0

### DIFF
--- a/ports/pulsar-client-cpp/portfile.cmake
+++ b/ports/pulsar-client-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/pulsar-client-cpp
     REF "v${VERSION}"
-    SHA512 9ee1b8d057298079c58c10226dbb07676eb94a11e7aa7b725dd9e0dd4e61e0af7127cda93c8651921fbbf00b91b89e28a88fb9edf3270360886319e94f672e12
+    SHA512 28c828529cc59ace8b9da97a724191a3314c5cfc36a9cf9a91b25b99b70ca2875bc9f8780f26770dc426a2641ad465bb2a47ba501921442fd712fa76edcbc5aa
     HEAD_REF main
     PATCHES
         disable-warnings.patch

--- a/ports/pulsar-client-cpp/vcpkg.json
+++ b/ports/pulsar-client-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pulsar-client-cpp",
-  "version": "3.5.1",
-  "port-version": 1,
+  "version": "3.7.0",
   "description": "The Apache Pulsar C++ library",
   "homepage": "https://github.com/apache/pulsar-client-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7301,8 +7301,8 @@
       "port-version": 0
     },
     "pulsar-client-cpp": {
-      "baseline": "3.5.1",
-      "port-version": 1
+      "baseline": "3.7.0",
+      "port-version": 0
     },
     "pulseaudio": {
       "baseline": "17.0",

--- a/versions/p-/pulsar-client-cpp.json
+++ b/versions/p-/pulsar-client-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e3330db1c269659f1343cb9e4b941550ced08b67",
+      "version": "3.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "632560bc0bda253fffea18938af7bfc141c892e1",
       "version": "3.5.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.