### PR TITLE
[freetype-gl] update to 1.0

### DIFF
--- a/ports/freetype-gl/0005-add-version.patch
+++ b/ports/freetype-gl/0005-add-version.patch
@@ -6,6 +6,6 @@ index 3b33096..a5ae350 100644
  
  Name: freetype-gl
  Description: OpenGL text using one vertex buffer, one texture and FreeType
-+Version: 2022-01-17
++Version: v1.0
  Libs: -L${libdir} -lfreetype-gl
  Cflags: -I${includedir}

--- a/ports/freetype-gl/portfile.cmake
+++ b/ports/freetype-gl/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rougier/freetype-gl
-    REF 85d7850744465ac1dcd00b202787d72a4a3a1f5d
-    SHA512 4505b2162610500336ab975a5a0ac2c09503f51b2fb52b433018059f628ef6f6add9618c940a80efebc311d82fe96fa813d356acbd858cc2dbac6a1829ab3031
+    REF "v${VERSION}"
+    SHA512 0bdba3cf4e1460588a41b7f8e6d5ce46ecf437f2be605297a6a9676c3c2875fbc5cd3c4c36ab8902bb5827a1c1749c0e27cda36b98d1fef32576099ab4ed7e21
     HEAD_REF master
     PATCHES
         0001-Link-to-dependencies-also-for-static-build.patch

--- a/ports/freetype-gl/vcpkg.json
+++ b/ports/freetype-gl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "freetype-gl",
-  "version-date": "2022-01-17",
-  "port-version": 3,
+  "version": "1.0",
   "description": "OpenGL text using one vertex buffer, one texture and FreeType",
   "homepage": "https://github.com/rougier/freetype-gl",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2917,8 +2917,8 @@
       "port-version": 0
     },
     "freetype-gl": {
-      "baseline": "2022-01-17",
-      "port-version": 3
+      "baseline": "1.0",
+      "port-version": 0
     },
     "freexl": {
       "baseline": "2.0.0",

--- a/versions/f-/freetype-gl.json
+++ b/versions/f-/freetype-gl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "214e21b36f0f4b0ae0d9514eed1eba20f3c2ff4d",
+      "version": "1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e61e27b5a7928879435242d50ac2470fe79cb3e3",
       "version-date": "2022-01-17",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.