### PR TITLE
[luajit] Fix luajit.exe is broken on Windows

### DIFF
--- a/ports/luajit/portfile.cmake
+++ b/ports/luajit/portfile.cmake
@@ -106,6 +106,6 @@ vcpkg_copy_tools(TOOL_NAMES luajit AUTO_CLEAN)
 
 vcpkg_fixup_pkgconfig()
 
-file(COPY ${SOURCE_PATH}/src/jit/ DESTINATION ${CURRENT_PACKAGES_DIR}/tools/luajit)
+file(COPY "${SOURCE_PATH}/src/jit/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/luajit")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")

--- a/ports/luajit/portfile.cmake
+++ b/ports/luajit/portfile.cmake
@@ -106,4 +106,6 @@ vcpkg_copy_tools(TOOL_NAMES luajit AUTO_CLEAN)
 
 vcpkg_fixup_pkgconfig()
 
+file(COPY ${SOURCE_PATH}/src/jit/ DESTINATION ${CURRENT_PACKAGES_DIR}/tools/luajit)
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")

--- a/ports/luajit/vcpkg.json
+++ b/ports/luajit/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "luajit",
   "version-date": "2023-01-04",
-  "port-version": 5,
+  "port-version": 6,
   "description": "LuaJIT is a Just-In-Time (JIT) compiler for the Lua programming language.",
   "homepage": "https://github.com/LuaJIT/LuaJIT",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5666,7 +5666,7 @@
     },
     "luajit": {
       "baseline": "2023-01-04",
-      "port-version": 5
+      "port-version": 6
     },
     "luasec": {
       "baseline": "1.3.2",

--- a/versions/l-/luajit.json
+++ b/versions/l-/luajit.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ff92fba69b2df498e12fd123cc1cbb536556de3d",
+      "git-tree": "b8914dbb4dbf1c9c8fa62c9053f6fb1509b53f48",
       "version-date": "2023-01-04",
       "port-version": 6
     },

--- a/versions/l-/luajit.json
+++ b/versions/l-/luajit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff92fba69b2df498e12fd123cc1cbb536556de3d",
+      "version-date": "2023-01-04",
+      "port-version": 6
+    },
+    {
       "git-tree": "ca00ef84f25e0b841d36d6aa5403c525ea476b9c",
       "version-date": "2023-01-04",
       "port-version": 5


### PR DESCRIPTION
Fixes #43367

Copy `src\jit` to the same location as luajit.exe fix port bug.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.