### PR TITLE
[air-ctl] fix resize error

### DIFF
--- a/ports/air-ctl/fix-resize-error.patch
+++ b/ports/air-ctl/fix-resize-error.patch
@@ -1,0 +1,12 @@
+diff --git a/src/container/hash_map.c b/src/container/hash_map.c
+index 3f9de33..b1dd419 100644
+--- a/src/container/hash_map.c
++++ b/src/container/hash_map.c
+@@ -104,6 +104,7 @@ int CTL_hash_map_insert(CTL_hash_map *handle, const void *key, const void *eleme
+ 	if (handle->size > (handle->B_size - 1) * LOAD_FACTOR)
+ 	{
+ 		resize(handle);
++		index = __index(hash, handle->B_size);
+ 	}
+ 
+ 	__CTL_hash_map_node *new_node = (__CTL_hash_map_node *)CTL_malloc(sizeof(__CTL_hash_map_node));

--- a/ports/air-ctl/portfile.cmake
+++ b/ports/air-ctl/portfile.cmake
@@ -1,9 +1,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO  inie0722/CTL
-    REF a19d7db16232b160901cc65b8398ece2526b5e41 #v1.1.2
-    SHA512 867f3c07073a9c9ce60d95d8c6eff37e49bd10d45fd93891cbdd7b6e77e5302048b7b054b597d382f1f581636a8b3042291d87a9eadd7f2b33c4c532dc23ae5d
+    REPO  inie0722/air-ctl
+    REF "v${VERSION}"
+    SHA512 88a20b0d833770820a8ef56725441cd4258b222ed12bb731a695c17a29c76709ed185f3a8e038d7f7437295847ff9ba77a65c5165ad7d70645c044a24365bfe9
     HEAD_REF master
+    PATCHES
+        fix-resize-error.patch
 )
 
 vcpkg_cmake_configure(
@@ -15,4 +17,4 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/air-ctl/vcpkg.json
+++ b/ports/air-ctl/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "air-ctl",
   "version": "1.1.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "C template container library",
-  "homepage": "https://github.com/inie0722/CTL",
+  "homepage": "https://github.com/inie0722/air-ctl",
   "license": "BSL-1.0",
   "dependencies": [
     {

--- a/versions/a-/air-ctl.json
+++ b/versions/a-/air-ctl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64e71578e1de4345d83acbe731b524acc7228bed",
+      "version": "1.1.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "a55917cb84ea50c01d4c56c474171fd71952f076",
       "version": "1.1.2",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -54,7 +54,7 @@
     },
     "air-ctl": {
       "baseline": "1.1.2",
-      "port-version": 2
+      "port-version": 3
     },
     "aixlog": {
       "baseline": "1.5.0",


### PR DESCRIPTION
Add patch to fix resize error. Upstream has been merged https://github.com/inie0722/air-ctl/commit/79a2e67f846da732b7f2ab30c0e0f2af7e2669de
Fix homepage and REPO.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
