### PR TITLE
[hypre] update to 2.32.0

### DIFF
--- a/ports/hypre/portfile.cmake
+++ b/ports/hypre/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hypre-space/hypre
     REF "v${VERSION}"
-    SHA512 fe92d09b56107845e3a4b7f0e7bbba5f319a7ebdaaecab3e6b89fae1fe2a79a9dd712806823ea518f5960f0eaa1088f6b82ebac63d3940478d36690f3adec4f2
+    SHA512 c1b09a31781ce4e1a411c486424cf7a4df1275d53445ed83d0e4e210dcc87e9c09e17e26cc5ee736aebbd70618674cd3b7dba6736f8e725ba1c3d981869ada24
     HEAD_REF master
 )
 

--- a/ports/hypre/vcpkg.json
+++ b/ports/hypre/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "hypre",
-  "version": "2.29.0",
-  "port-version": 1,
+  "version": "2.32.0",
   "description": "Parallel solvers for sparse linear systems featuring multigrid methods",
   "homepage": "https://computation.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3549,8 +3549,8 @@
       "port-version": 0
     },
     "hypre": {
-      "baseline": "2.29.0",
-      "port-version": 1
+      "baseline": "2.32.0",
+      "port-version": 0
     },
     "iceoryx": {
       "baseline": "2.0.6",

--- a/versions/h-/hypre.json
+++ b/versions/h-/hypre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d48c19d16455ad475af00e34d0741eadc8aad20d",
+      "version": "2.32.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c86dd4b42c27ebdfbfa8c276e3e1b1d8f9ca7333",
       "version": "2.29.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.