### PR TITLE
[sentry-native] update to 0.7.19

### DIFF
--- a/ports/sentry-native/fix-usage-runtime.patch
+++ b/ports/sentry-native/fix-usage-runtime.patch
@@ -2,10 +2,10 @@ diff --git a/external/crashpad/handler/CMakeLists.txt b/external/crashpad/handle
 index be0e544..b0d44af 100644
 --- a/external/crashpad/handler/CMakeLists.txt
 +++ b/external/crashpad/handler/CMakeLists.txt
-@@ -89,7 +89,7 @@ if(NOT IOS)
-         main.cc
-     )
-
+@@ -87,7 +87,7 @@ target_compile_options(crashpad_handler PRIVATE
+            $<$<COMPILE_LANGUAGE:CXX>:-Wno-ignored-attributes>
+        )
+    endif()
 -    if(LINUX)
 +    if(LINUX AND BUILD_SHARED_LIBS)
          target_sources(crashpad_handler PRIVATE

--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 1d7b909019e4e9c88f5cc142484f944d57edad4a93df9db1e50e3b5584304694029557cf7286ed48dc952485b8682f03cf43491bb6980f8f517c4c4c7ad8fa2b
+    SHA512 dc44e278bc3cd58e25a587165268b9be852289d692350240b5f87558ebcccf87febf25bb3882d5039ac40d7b2ae307ac55f251ad6ee90bb2cb58f3b50d7e9fa8
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8309,7 +8309,7 @@
       "port-version": 1
     },
     "sentry-native": {
-      "baseline": "0.7.18",
+      "baseline": "0.7.19",
       "port-version": 0
     },
     "septag-dmon": {

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f48101fc58a4d40792081bc5fe3acada7aa907d",
+      "version": "0.7.19",
+      "port-version": 0
+    },
+    {
       "git-tree": "6174389ee3b7d1866941781507d7da2d47ada313",
       "version": "0.7.18",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
