### PR TITLE
[x265] update to 4.1

### DIFF
--- a/ports/x265/disable-install-pdb.patch
+++ b/ports/x265/disable-install-pdb.patch
@@ -1,13 +1,13 @@
 diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
-index 11512ff..9ac8057 100755
+index 6183a6d..eaa5c6f 100644
 --- a/source/CMakeLists.txt
 +++ b/source/CMakeLists.txt
-@@ -603,7 +603,7 @@ if(SVTHEVC_FOUND)
+@@ -842,7 +842,7 @@ if(SVTHEVC_FOUND)
  endif()
  
  install(FILES x265.h "${PROJECT_BINARY_DIR}/x265_config.h" DESTINATION include)
 -if((WIN32 AND ENABLE_CLI) OR (WIN32 AND ENABLE_SHARED))
 +if(0)
      if(MSVC_IDE)
-         install(FILES "${PROJECT_BINARY_DIR}/Debug/x265.pdb" DESTINATION ${BIN_INSTALL_DIR} CONFIGURATIONS Debug)
-         install(FILES "${PROJECT_BINARY_DIR}/RelWithDebInfo/x265.pdb" DESTINATION ${BIN_INSTALL_DIR} CONFIGURATIONS RelWithDebInfo)
+         if(ENABLE_CLI)
+             install(FILES "${PROJECT_BINARY_DIR}/Debug/x265.pdb" DESTINATION ${BIN_INSTALL_DIR} CONFIGURATIONS Debug)

--- a/ports/x265/pkgconfig.diff
+++ b/ports/x265/pkgconfig.diff
@@ -1,8 +1,8 @@
 diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
-index a407271..a575642 100755
+index eaa5c6f..8a9ec44 100644
 --- a/source/CMakeLists.txt
 +++ b/source/CMakeLists.txt
-@@ -572,6 +572,9 @@ else()
+@@ -811,6 +811,9 @@ else()
  endif()
  if(NOT MSVC)
      set_target_properties(x265-static PROPERTIES OUTPUT_NAME x265)
@@ -12,7 +12,7 @@ index a407271..a575642 100755
  endif()
  if(EXTRA_LIB)
      target_link_libraries(x265-static ${EXTRA_LIB})
-@@ -655,8 +658,10 @@ if(ENABLE_SHARED)
+@@ -906,8 +909,10 @@ if(ENABLE_SHARED)
      endif(SVTHEVC_FOUND)
      if(MSVC)
          set_target_properties(x265-shared PROPERTIES OUTPUT_NAME libx265)
@@ -23,9 +23,9 @@ index a407271..a575642 100755
      endif()
      if(UNIX)
          set_target_properties(x265-shared PROPERTIES VERSION ${X265_BUILD})
-@@ -693,7 +698,11 @@ endif()
+@@ -944,7 +949,11 @@ endif()
  
- if(X265_LATEST_TAG)
+ if(X265_LATEST_TAG OR NOT GIT_FOUND)
      # convert lists of link libraries into -lstdc++ -lm etc..
 +    cmake_policy(SET CMP0057 NEW)
      foreach(LIB ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES} ${PLATFORM_LIBS})

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_bitbucket(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO multicoreware/x265_git
     REF "${VERSION}"
-    SHA512 cfc3fdd7ce10a6cadf4515707d8f338fe58329cbbbcac11a85f00376e29156baccfb19a514ac2bc816432d15a2a4eb1bb7e16e3a870b6b9f9bc28e1a44270091
+    SHA512 4b7d71f22f0a7f12ff93f9a01e361df2b80532cd8dac01b5465e63b5d8182f1a05c0289ad95f3aa972c963aa6cd90cb3d594f8b9a96f556a006cf7e1bdd9edda
     HEAD_REF master
     PATCHES
         disable-install-pdb.patch

--- a/ports/x265/vcpkg.json
+++ b/ports/x265/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "x265",
-  "version": "3.6",
+  "version": "4.1",
   "description": "x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.",
   "homepage": "https://bitbucket.org/multicoreware/x265_git/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9785,7 +9785,7 @@
       "port-version": 1
     },
     "x265": {
-      "baseline": "3.6",
+      "baseline": "4.1",
       "port-version": 0
     },
     "x86-simd-sort": {

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1339ba96a9ac2711d282d16e067b1d420ed0a9f8",
+      "version": "4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "89429aa82874053b23e7094d6e57bda7cfe6ab3e",
       "version": "3.6",
       "port-version": 0


### PR DESCRIPTION
All feature and usage test passed with x64-windows triplet.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
