### PR TITLE
[dartsim] Disable use spdlog by option `DART_SKIP_spdlog`

### DIFF
--- a/ports/dartsim/portfile.cmake
+++ b/ports/dartsim/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_cmake_configure(
         -DDART_SKIP_IPOPT=ON
         -DDART_SKIP_NLOPT=ON
         -DDART_SKIP_pagmo=ON
+        -DDART_SKIP_spdlog=ON
         -Durdfdom_headers_VERSION_MAJOR=1 # urdfdom-headers does not expose a header macro for its version.
         -Durdfdom_headers_VERSION_MINOR=0 # versions of at least 1.0.0 use std:: constructs in their ABI instead of boost:: ones.
         -Durdfdom_headers_VERSION_PATCH=0

--- a/ports/dartsim/vcpkg.json
+++ b/ports/dartsim/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dartsim",
   "version": "6.15.0",
+  "port-version": 1,
   "description": "Dynamic Animation and Robotics Toolkit",
   "homepage": "https://dartsim.github.io/",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2190,7 +2190,7 @@
     },
     "dartsim": {
       "baseline": "6.15.0",
-      "port-version": 0
+      "port-version": 1
     },
     "dataframe": {
       "baseline": "3.4.0",

--- a/versions/d-/dartsim.json
+++ b/versions/d-/dartsim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60fa91b5b2ee9ae9185c5e0de85ab771fb917dd4",
+      "version": "6.15.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "76bb71f86f7f9f4d34e002e65db4ccff572f6a1d",
       "version": "6.15.0",
       "port-version": 0


### PR DESCRIPTION
Fix the config error which was found in CI pipeline https://dev.azure.com/vcpkg/public/_build/results?buildId=111680&view=logs&jobId=7922e5c4-0103-5f8f-ad17-45ce9bb98e80&j=7922e5c4-0103-5f8f-ad17-45ce9bb98e80&t=8ceef4ed-9be5-594f-e707-4e1dd58a3d21:
```
CMake Error at D:/installed/x64-windows/share/dart/dart_dartTargets.cmake:60 (set_target_properties):
  The link interface of target "dart" contains:

    spdlog::spdlog_header_only

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  D:/installed/x64-windows/share/dart/DARTConfig.cmake:91 (include)
  D:/installed/x64-windows/share/dart/DARTConfig.cmake:88 (dart_traverse_components)
  D:/installed/x64-windows/share/dart/DARTConfig.cmake:133 (dart_traverse_components)
  D:/installed/x64-windows/share/dart/DARTConfig.cmake:181 (dart_package_init)
  D:/a/_work/1/s/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
  D:/installed/x64-windows/share/cmake/gz-cmake3/cmake3/GzFindPackage.cmake:246 (find_package)
  CMakeLists.txt:71 (gz_find_package)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
