### PR TITLE
[vcpkg scripts] Fix command prompt error

### DIFF
--- a/scripts/vcpkg-tools.json
+++ b/scripts/vcpkg-tools.json
@@ -70,7 +70,7 @@
     {
       "name": "git",
       "os": "windows",
-      "version": "2.7.4",
+      "version": "2.43.0",
       "executable": "mingw64/bin/git.exe",
       "url": "https://github.com/git-for-windows/git/releases/download/v2.43.0.windows.1/PortableGit-2.43.0-64-bit.7z.exe",
       "sha512": "02ec40f55a6de18f305530e9415b6ce0a597359ebb9a58cf727ac84eceb0003b0f437941b76872b6568157a333c8e6e8d865a36faf874fd5f04774deb6a9387a",
@@ -79,19 +79,19 @@
     {
       "name": "git",
       "os": "linux",
-      "version": "2.7.4",
+      "version": "2.43.0",
       "executable": ""
     },
     {
       "name": "git",
       "os": "osx",
-      "version": "2.7.4",
+      "version": "2.43.0",
       "executable": ""
     },
     {
       "name": "git",
       "os": "freebsd",
-      "version": "2.7.4",
+      "version": "2.43.0",
       "executable": ""
     },
     {

--- a/scripts/vcpkg-tools.json
+++ b/scripts/vcpkg-tools.json
@@ -79,19 +79,19 @@
     {
       "name": "git",
       "os": "linux",
-      "version": "2.43.0",
+      "version": "2.7.4",
       "executable": ""
     },
     {
       "name": "git",
       "os": "osx",
-      "version": "2.43.0",
+      "version": "2.7.4",
       "executable": ""
     },
     {
       "name": "git",
       "os": "freebsd",
-      "version": "2.43.0",
+      "version": "2.7.4",
       "executable": ""
     },
     {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43368

- [ ] ~Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).~
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~

Verify that the command output is correct.