### PR TITLE
[aliyun-oss-c-sdk] update to 3.11.2

### DIFF
--- a/ports/aliyun-oss-c-sdk/portfile.cmake
+++ b/ports/aliyun-oss-c-sdk/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aliyun/aliyun-oss-c-sdk
     REF ${VERSION}
-    SHA512 f92b2dac43bdfe1a5c9fc012325751ee83d6f5c5f5a646ac8606894c458bd9488bc4a56f926218b213cb905becccddd976e8e94a257d77adf4269d48df27638e
+    SHA512 b00f17e0a55fbf6dfc94c3a109013ea31cb234ce444c4e824749e380aa4d90c0d8440a1705aa8f8ab57c883f03c37757e4f2d09d1a0d960fd2f158128501727e
     HEAD_REF master
     PATCHES
         patch.patch

--- a/ports/aliyun-oss-c-sdk/vcpkg.json
+++ b/ports/aliyun-oss-c-sdk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aliyun-oss-c-sdk",
-  "version": "3.10.1",
+  "version": "3.11.2",
   "description": "Alibaba Cloud Object Storage Service (OSS) is a cloud storage service provided by Alibaba Cloud, featuring massive capacity, security, a low cost, and high reliability.",
   "homepage": "https://github.com/aliyun/aliyun-oss-c-sdk",
   "license": "MIT",

--- a/versions/a-/aliyun-oss-c-sdk.json
+++ b/versions/a-/aliyun-oss-c-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5429486d67b62ed56922feb1824b8521c39274e2",
+      "version": "3.11.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "680bc0ab5a25c9d9ef3191d9ba9f7fe2ae3829b7",
       "version": "3.10.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -77,7 +77,7 @@
       "port-version": 0
     },
     "aliyun-oss-c-sdk": {
-      "baseline": "3.10.1",
+      "baseline": "3.11.2",
       "port-version": 0
     },
     "aliyun-oss-cpp-sdk": {


### PR DESCRIPTION
Update aliyun-oss-c-sdk to 3.11.2.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.