### PR TITLE
[etcd-cpp-apiv3]Add async feature for etcd-cpp

### DIFF
--- a/ports/etcd-cpp-apiv3/portfile.cmake
+++ b/ports/etcd-cpp-apiv3/portfile.cmake
@@ -16,9 +16,16 @@ vcpkg_from_github(
 )
 file(WRITE "${SOURCE_PATH}/cmake/UploadPPA.cmake" "")
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+    async BUILD_ETCD_CORE_ONLY
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBUILD_ETCD_TESTS=OFF
         -DETCD_W_STRICT=OFF
         "-DGRPC_CPP_PLUGIN=${CURRENT_HOST_INSTALLED_DIR}/tools/grpc/grpc_cpp_plugin${VCPKG_HOST_EXECUTABLE_SUFFIX}"
@@ -32,7 +39,7 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/etcd-cpp-api)
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/etcd-cpp-api-config.cmake"
-    [[ETCD_CPP_HOME "${CMAKE_CURRENT_LIST_DIR}/../../.."]] 
+    [[ETCD_CPP_HOME "${CMAKE_CURRENT_LIST_DIR}/../../.."]]
     [[ETCD_CPP_HOME "${CMAKE_CURRENT_LIST_DIR}/../.."]]
 )
 

--- a/ports/etcd-cpp-apiv3/vcpkg.json
+++ b/ports/etcd-cpp-apiv3/vcpkg.json
@@ -10,10 +10,6 @@
     "boost-random",
     "boost-system",
     "boost-thread",
-    {
-      "name": "cpprestsdk",
-      "default-features": false
-    },
     "grpc",
     "openssl",
     "protobuf",
@@ -24,6 +20,21 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    }
+  ],
+  "default-features": [
+    "async"
+  ],
+  "features": [
+    {
+      "name": "async",
+      "description": "Enable async features supported by cpprestsdk.",
+      "dependencies": [
+        {
+          "name": "cpprestsdk",
+          "default-features": false
+        }
+      ]
     }
   ]
 }

--- a/ports/etcd-cpp-apiv3/vcpkg.json
+++ b/ports/etcd-cpp-apiv3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "etcd-cpp-apiv3",
   "version": "0.15.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The etcd-cpp-apiv3 is a C++ API for etcd's v3 client API, i.e., ETCDCTL_API=3.",
   "homepage": "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3",
   "license": "BSD-3-Clause",
@@ -25,9 +25,8 @@
   "default-features": [
     "async"
   ],
-  "features": [
-    {
-      "name": "async",
+  "features": {
+    "async": {
       "description": "Enable async features supported by cpprestsdk.",
       "dependencies": [
         {
@@ -36,5 +35,5 @@
         }
       ]
     }
-  ]
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2590,7 +2590,7 @@
     },
     "etcd-cpp-apiv3": {
       "baseline": "0.15.4",
-      "port-version": 1
+      "port-version": 2
     },
     "etl": {
       "baseline": "20.39.4",

--- a/versions/e-/etcd-cpp-apiv3.json
+++ b/versions/e-/etcd-cpp-apiv3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cae8fca4e862441e5fc85b5955988e41ea70f66e",
+      "version": "0.15.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "791701d891fdeb2955f502e13c64abd9bb632e15",
       "version": "0.15.4",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

etcd-cpp-apiv3 support build only the core without async runtime, so I add async as a feature.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
