### PR TITLE
[skia] shared library compilation of skparagraph

### DIFF
--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         graphite.patch
         vulkan-headers.patch
         pdfsubsetfont-uwp.diff
+	skparagraph-dllexport.patch
 )
 
 # De-vendor
@@ -119,7 +120,6 @@ elseif(VCPKG_TARGET_IS_WINDOWS)
         string(APPEND OPTIONS " skia_enable_winuwp=true skia_enable_fontmgr_win=false skia_use_xps=false")
     endif()
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-        string(APPEND OPTIONS " skia_enable_skparagraph=false")
         string(APPEND OPTIONS " skia_enable_bentleyottmann=false")
     endif()
 endif()

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_github(
         graphite.patch
         vulkan-headers.patch
         pdfsubsetfont-uwp.diff
-	skparagraph-dllexport.patch
+        skparagraph-dllexport.patch
 )
 
 # De-vendor

--- a/ports/skia/skparagraph-dllexport.patch
+++ b/ports/skia/skparagraph-dllexport.patch
@@ -28,8 +28,8 @@ index ae2f9922d0..96c0fad8a1 100644
  namespace skia {
  namespace textlayout {
  
-+#if !defined(SKSHAPER_IMPLEMENTATION)
-+    #define SKSHAPER_IMPLEMENTATION 0
++#if !defined(SKPARAGRAPH_IMPLEMENTATION)
++    #define SKPARAGRAPH_IMPLEMENTATION 0
 +#endif
 +
 +#if !defined(SKPARAGRAPH_API)

--- a/ports/skia/skparagraph-dllexport.patch
+++ b/ports/skia/skparagraph-dllexport.patch
@@ -96,8 +96,8 @@ index 98ec228ffb..0e1625ae6a 100644
  namespace skia {
  namespace textlayout {
  
-+#if !defined(SKSHAPER_IMPLEMENTATION)
-+    #define SKSHAPER_IMPLEMENTATION 0
++#if !defined(SKPARAGRAPH_IMPLEMENTATION)
++    #define SKPARAGRAPH_IMPLEMENTATION 0
 +#endif
 +
 +#if !defined(SKPARAGRAPH_API)

--- a/ports/skia/skparagraph-dllexport.patch
+++ b/ports/skia/skparagraph-dllexport.patch
@@ -64,8 +64,8 @@ index feac5622bb..9dab883a6d 100644
  namespace textlayout {
  
 -class ParagraphBuilder {
-+#if !defined(SKSHAPER_IMPLEMENTATION)
-+    #define SKSHAPER_IMPLEMENTATION 0
++#if !defined(SKPARAGRAPH_IMPLEMENTATION)
++    #define SKPARAGRAPH_IMPLEMENTATION 0
 +#endif
 +
 +#if !defined(SKPARAGRAPH_API)

--- a/ports/skia/skparagraph-dllexport.patch
+++ b/ports/skia/skparagraph-dllexport.patch
@@ -136,8 +136,8 @@ index 4bc2fb9dbc..25774c6665 100644
  namespace skia {
  namespace textlayout {
  
-+#if !defined(SKSHAPER_IMPLEMENTATION)
-+    #define SKSHAPER_IMPLEMENTATION 0
++#if !defined(SKPARAGRAPH_IMPLEMENTATION)
++    #define SKPARAGRAPH_IMPLEMENTATION 0
 +#endif
 +
 +#if !defined(SKPARAGRAPH_API)

--- a/ports/skia/skparagraph-dllexport.patch
+++ b/ports/skia/skparagraph-dllexport.patch
@@ -1,0 +1,231 @@
+diff --git a/modules/skparagraph/BUILD.gn b/modules/skparagraph/BUILD.gn
+index 801bbae0b5..399c8a809e 100644
+--- a/modules/skparagraph/BUILD.gn
++++ b/modules/skparagraph/BUILD.gn
+@@ -20,6 +20,9 @@ if (skia_enable_skparagraph && skia_enable_skshaper && skia_enable_skunicode &&
+       "include",
+       "utils",
+     ]
++    if (is_component_build) {
++      defines += [ "SKPARAGRAPH_DLL" ]
++    }
+   }
+ 
+   skia_component("skparagraph") {
+@@ -27,6 +30,7 @@ if (skia_enable_skparagraph && skia_enable_skshaper && skia_enable_skunicode &&
+     public_configs = [ ":public_config" ]
+     public = skparagraph_public
+     sources = skparagraph_sources
++    defines = [ "SKPARAGRAPH_IMPLEMENTATION=1" ]
+     public_deps = [
+       "../..:skia",
+       "../skunicode",
+diff --git a/modules/skparagraph/include/FontCollection.h b/modules/skparagraph/include/FontCollection.h
+index ae2f9922d0..96c0fad8a1 100644
+--- a/modules/skparagraph/include/FontCollection.h
++++ b/modules/skparagraph/include/FontCollection.h
+@@ -16,9 +16,29 @@
+ namespace skia {
+ namespace textlayout {
+ 
++#if !defined(SKSHAPER_IMPLEMENTATION)
++    #define SKSHAPER_IMPLEMENTATION 0
++#endif
++
++#if !defined(SKPARAGRAPH_API)
++    #if defined(SKPARAGRAPH_DLL)
++        #if defined(_MSC_VER)
++            #if SKPARAGRAPH_IMPLEMENTATION
++                #define SKPARAGRAPH_API __declspec(dllexport)
++            #else
++                #define SKPARAGRAPH_API __declspec(dllimport)
++            #endif
++        #else
++            #define SKPARAGRAPH_API __attribute__((visibility("default")))
++        #endif
++    #else
++        #define SKPARAGRAPH_API
++    #endif
++#endif
++
+ class TextStyle;
+ class Paragraph;
+-class FontCollection : public SkRefCnt {
++class SKPARAGRAPH_API FontCollection : public SkRefCnt {
+ public:
+     FontCollection();
+ 
+diff --git a/modules/skparagraph/include/ParagraphBuilder.h b/modules/skparagraph/include/ParagraphBuilder.h
+index feac5622bb..9dab883a6d 100644
+--- a/modules/skparagraph/include/ParagraphBuilder.h
++++ b/modules/skparagraph/include/ParagraphBuilder.h
+@@ -16,7 +16,27 @@
+ namespace skia {
+ namespace textlayout {
+ 
+-class ParagraphBuilder {
++#if !defined(SKSHAPER_IMPLEMENTATION)
++    #define SKSHAPER_IMPLEMENTATION 0
++#endif
++
++#if !defined(SKPARAGRAPH_API)
++    #if defined(SKPARAGRAPH_DLL)
++        #if defined(_MSC_VER)
++            #if SKPARAGRAPH_IMPLEMENTATION
++                #define SKPARAGRAPH_API __declspec(dllexport)
++            #else
++                #define SKPARAGRAPH_API __declspec(dllimport)
++            #endif
++        #else
++            #define SKPARAGRAPH_API __attribute__((visibility("default")))
++        #endif
++    #else
++        #define SKPARAGRAPH_API
++    #endif
++#endif
++
++class SKPARAGRAPH_API ParagraphBuilder {
+ protected:
+     ParagraphBuilder() {}
+ 
+diff --git a/modules/skparagraph/include/ParagraphStyle.h b/modules/skparagraph/include/ParagraphStyle.h
+index 98ec228ffb..0e1625ae6a 100644
+--- a/modules/skparagraph/include/ParagraphStyle.h
++++ b/modules/skparagraph/include/ParagraphStyle.h
+@@ -18,6 +18,26 @@
+ namespace skia {
+ namespace textlayout {
+ 
++#if !defined(SKSHAPER_IMPLEMENTATION)
++    #define SKSHAPER_IMPLEMENTATION 0
++#endif
++
++#if !defined(SKPARAGRAPH_API)
++    #if defined(SKPARAGRAPH_DLL)
++        #if defined(_MSC_VER)
++            #if SKPARAGRAPH_IMPLEMENTATION
++                #define SKPARAGRAPH_API __declspec(dllexport)
++            #else
++                #define SKPARAGRAPH_API __declspec(dllimport)
++            #endif
++        #else
++            #define SKPARAGRAPH_API __attribute__((visibility("default")))
++        #endif
++    #else
++        #define SKPARAGRAPH_API
++    #endif
++#endif
++
+ struct StrutStyle {
+     StrutStyle();
+ 
+@@ -75,7 +95,7 @@ private:
+     bool fHalfLeading;
+ };
+ 
+-struct ParagraphStyle {
++struct SKPARAGRAPH_API ParagraphStyle {
+     ParagraphStyle();
+ 
+     bool operator==(const ParagraphStyle& rhs) const {
+diff --git a/modules/skparagraph/include/TextStyle.h b/modules/skparagraph/include/TextStyle.h
+index 4bc2fb9dbc..25774c6665 100644
+--- a/modules/skparagraph/include/TextStyle.h
++++ b/modules/skparagraph/include/TextStyle.h
+@@ -21,6 +21,26 @@
+ namespace skia {
+ namespace textlayout {
+ 
++#if !defined(SKSHAPER_IMPLEMENTATION)
++    #define SKSHAPER_IMPLEMENTATION 0
++#endif
++
++#if !defined(SKPARAGRAPH_API)
++    #if defined(SKPARAGRAPH_DLL)
++        #if defined(_MSC_VER)
++            #if SKPARAGRAPH_IMPLEMENTATION
++                #define SKPARAGRAPH_API __declspec(dllexport)
++            #else
++                #define SKPARAGRAPH_API __declspec(dllimport)
++            #endif
++        #else
++            #define SKPARAGRAPH_API __attribute__((visibility("default")))
++        #endif
++    #else
++        #define SKPARAGRAPH_API
++    #endif
++#endif
++
+ static inline bool nearlyZero(SkScalar x, SkScalar tolerance = SK_ScalarNearlyZero) {
+     if (SkIsFinite(x)) {
+         return SkScalarNearlyZero(x, tolerance);
+@@ -148,9 +168,9 @@ struct PlaceholderStyle {
+     SkScalar fBaselineOffset = 0;
+ };
+ 
+-class TextStyle {
++class SKPARAGRAPH_API TextStyle {
+ public:
+-    TextStyle() = default;
++    TextStyle();
+     TextStyle(const TextStyle& other) = default;
+     TextStyle& operator=(const TextStyle& other) = default;
+ 
+@@ -288,8 +308,6 @@ public:
+     void setPlaceholder() { fIsPlaceholder = true; }
+ 
+ private:
+-    static const std::vector<SkString>* kDefaultFontFamilies;
+-
+     Decoration fDecoration = {
+             TextDecoration::kNoDecoration,
+             // TODO: switch back to kGaps when (if) switching flutter to skparagraph
+@@ -302,7 +320,7 @@ private:
+ 
+     SkFontStyle fFontStyle;
+ 
+-    std::vector<SkString> fFontFamilies = *kDefaultFontFamilies;
++    std::vector<SkString> fFontFamilies;
+ 
+     SkScalar fFontSize = 14.0;
+     SkScalar fHeight = 1.0;
+diff --git a/modules/skparagraph/src/TextStyle.cpp b/modules/skparagraph/src/TextStyle.cpp
+index 492f94fe10..9889cc90aa 100644
+--- a/modules/skparagraph/src/TextStyle.cpp
++++ b/modules/skparagraph/src/TextStyle.cpp
+@@ -6,9 +6,13 @@
+ namespace skia {
+ namespace textlayout {
+ 
+-const std::vector<SkString>* TextStyle::kDefaultFontFamilies =
++static const std::vector<SkString>* kDefaultFontFamilies =
+         new std::vector<SkString>{SkString(DEFAULT_FONT_FAMILY)};
+ 
++TextStyle::TextStyle() : fFontFamilies(*kDefaultFontFamilies)
++{
++}
++
+ TextStyle TextStyle::cloneForPlaceholder() {
+     TextStyle result;
+     result.fColor = fColor;
+diff --git a/modules/skparagraph/utils/TestFontCollection.cpp b/modules/skparagraph/utils/TestFontCollection.cpp
+index b74a3b99cf..3fe2b129da 100644
+--- a/modules/skparagraph/utils/TestFontCollection.cpp
++++ b/modules/skparagraph/utils/TestFontCollection.cpp
+@@ -57,6 +57,8 @@ bool TestFontCollection::addFontFromFile(const std::string& path, const std::str
+     if (!file) {
+         return false;
+     }
++
++#if 0
+ #if defined(SK_TYPEFACE_FACTORY_FREETYPE)
+     sk_sp<SkTypeface> face =
+             SkTypeface_FreeType::MakeFromStream(std::move(file), SkFontArguments());
+@@ -72,6 +74,7 @@ bool TestFontCollection::addFontFromFile(const std::string& path, const std::str
+     } else {
+         fFontProvider->registerTypeface(std::move(face), SkString(familyName.c_str()));
+     }
++#endif
+ 
+     return true;
+ }

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "skia",
   "version": "129",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8458,7 +8458,7 @@
     },
     "skia": {
       "baseline": "129",
-      "port-version": 2
+      "port-version": 3
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc9da53ed051cba6b6172dc743b6c691adccd9c9",
+      "version": "129",
+      "port-version": 3
+    },
+    {
       "git-tree": "942c0f5227b85eb96fad153a7b57c12debb33b4c",
       "version": "129",
       "port-version": 2


### PR DESCRIPTION
Fixes #39860 for skparagraph

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
