### PR TITLE
[nanojsonc] update 1.2.0

### DIFF
--- a/ports/nanojsonc/portfile.cmake
+++ b/ports/nanojsonc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-source-patterns/nanojsonc
         REF "${VERSION}"
-        SHA512 a83f38c67222d227faf352495b174a16ff6d5a0a45e9d6eda499ca6e8978d2dba184f820c7b726d80468a11fee02460cbd8b189d69a46716bd01c46e7b0607fd
+        SHA512 a79d4bbaf800dcc894df487cf375edb1db1d7e5e3d4c4444f24b80751a718c81cc867eb4890a1b364aed9f93296ee798aa361e24eb7c02627e98dcae5c073880
         HEAD_REF main
 )
 

--- a/ports/nanojsonc/portfile.cmake
+++ b/ports/nanojsonc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-source-patterns/nanojsonc
         REF "${VERSION}"
-        SHA512 8fe36b742b994598d6f5ae30433245f63da5378ff6866f593cf53916e2b2fdc5d85ddc88d20908fd1166c3568f62e2a8dd837270855cb603dad88246a726be51
+        SHA512 a83f38c67222d227faf352495b174a16ff6d5a0a45e9d6eda499ca6e8978d2dba184f820c7b726d80468a11fee02460cbd8b189d69a46716bd01c46e7b0607fd
         HEAD_REF main
 )
 

--- a/ports/nanojsonc/portfile.cmake
+++ b/ports/nanojsonc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-source-patterns/nanojsonc
         REF "${VERSION}"
-        SHA512 f022d2d6158764ba0050523dbff413cd63830778313e81b436bbf9b142d536de005a7c1c6f18b86c4d75414a99fc85c183d8a8d60691dcf5f2ebc1cd87e36a5c
+        SHA512 8fe36b742b994598d6f5ae30433245f63da5378ff6866f593cf53916e2b2fdc5d85ddc88d20908fd1166c3568f62e2a8dd837270855cb603dad88246a726be51
         HEAD_REF main
 )
 

--- a/ports/nanojsonc/portfile.cmake
+++ b/ports/nanojsonc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-source-patterns/nanojsonc
         REF "${VERSION}"
-        SHA512 4cb73a0dc42bc6dbc106ed7bf7d22dbbadf3d92d2055d4b96990b62822978c09e580a87ca1666cf0b915b994fada6a1f6b803eb98d8da6b021a0a2c410d538ff
+        SHA512 f022d2d6158764ba0050523dbff413cd63830778313e81b436bbf9b142d536de005a7c1c6f18b86c4d75414a99fc85c183d8a8d60691dcf5f2ebc1cd87e36a5c
         HEAD_REF main
 )
 

--- a/ports/nanojsonc/vcpkg.json
+++ b/ports/nanojsonc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanojsonc",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "maintainers": "Saad Shams",
   "description": "Event-Driven JSON Parser for C",
   "homepage": "https://github.com/open-source-patterns/nanojsonc",

--- a/ports/nanojsonc/vcpkg.json
+++ b/ports/nanojsonc/vcpkg.json
@@ -5,7 +5,6 @@
   "description": "Event-Driven JSON Parser for C",
   "homepage": "https://github.com/open-source-patterns/nanojsonc",
   "license": "BSD-3-Clause",
-  "supports": "windows | linux | osx | ios | android | uwp | xbox | emscripten | wasm32",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/nanojsonc/vcpkg.json
+++ b/ports/nanojsonc/vcpkg.json
@@ -5,6 +5,7 @@
   "description": "Event-Driven JSON Parser for C",
   "homepage": "https://github.com/open-source-patterns/nanojsonc",
   "license": "BSD-3-Clause",
+  "supports": "windows | linux | osx | ios | android | uwp | xbox | emscripten | wasm32",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6262,7 +6262,7 @@
     },
     "nanojsonc": {
       "baseline": "1.2.0",
-      "port-version": 0
+      "port-version": 2
     },
     "nanomsg": {
       "baseline": "1.2.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6262,7 +6262,7 @@
     },
     "nanojsonc": {
       "baseline": "1.2.0",
-      "port-version": 2
+      "port-version": 0
     },
     "nanomsg": {
       "baseline": "1.2.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6261,7 +6261,7 @@
       "port-version": 5
     },
     "nanojsonc": {
-      "baseline": "1.1.0",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "nanomsg": {

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "75aeb015042b1fd7086221a132dd7215aea939f4",
+      "git-tree": "41dc847f236000b8a703cf452d37ae36c39ec155",
       "version": "1.2.0",
       "port-version": 0
     },

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,14 +1,14 @@
 {
   "versions": [
     {
-      "git-tree": "8163f9c0e1366cfc11ed9177ff26a79157c19591",
+      "git-tree": "bbb90ee87eb2bd63f2f548f2e1e5d1656373f1c2",
       "version": "1.2.0",
-      "port-version": 2
+      "port-version": 0
     },
     {
-      "git-tree": "7f713ade1fffaa8477201a7128d2f616fb968047",
+      "git-tree": "102c65ad71dc556dd82d4af6d83efd96ee316311",
       "version": "1.1.0",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "7680709fd527db1cc26d47f8897c0669cacbfb0f",

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -8,7 +8,7 @@
     {
       "git-tree": "102c65ad71dc556dd82d4af6d83efd96ee316311",
       "version": "1.1.0",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "7680709fd527db1cc26d47f8897c0669cacbfb0f",

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "bbb90ee87eb2bd63f2f548f2e1e5d1656373f1c2",
+      "git-tree": "75aeb015042b1fd7086221a132dd7215aea939f4",
       "version": "1.2.0",
-      "port-version": 2
+      "port-version": 0
     },
     {
       "git-tree": "102c65ad71dc556dd82d4af6d83efd96ee316311",

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3ca4870bb87388ba37733e1d8c5b6c2c6903ca24",
+      "git-tree": "bbb90ee87eb2bd63f2f548f2e1e5d1656373f1c2",
       "version": "1.2.0",
       "port-version": 2
     },

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,14 +1,14 @@
 {
   "versions": [
     {
-      "git-tree": "bbb90ee87eb2bd63f2f548f2e1e5d1656373f1c2",
+      "git-tree": "3ca4870bb87388ba37733e1d8c5b6c2c6903ca24",
       "version": "1.2.0",
-      "port-version": 0
+      "port-version": 2
     },
     {
       "git-tree": "102c65ad71dc556dd82d4af6d83efd96ee316311",
       "version": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     {
       "git-tree": "7680709fd527db1cc26d47f8897c0669cacbfb0f",

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8163f9c0e1366cfc11ed9177ff26a79157c19591",
+      "version": "1.2.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "7f713ade1fffaa8477201a7128d2f616fb968047",
       "version": "1.1.0",
       "port-version": 1

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "102c65ad71dc556dd82d4af6d83efd96ee316311",
+      "git-tree": "7f713ade1fffaa8477201a7128d2f616fb968047",
       "version": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     {
       "git-tree": "7680709fd527db1cc26d47f8897c0669cacbfb0f",


### PR DESCRIPTION
- [x ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x ] SHA512s are updated for each updated download.
- [x ] The "supports" clause reflects platforms that may be fixed by this new version.
- [x ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x ] Any patches that are no longer applied are deleted from the port's directory.
- [x ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x ] Only one version is added to each modified port's versions file.
