### PR TITLE
[tinyfiledialogs] Update and switch to zip download.

### DIFF
--- a/ports/tinyfiledialogs/portfile.cmake
+++ b/ports/tinyfiledialogs/portfile.cmake
@@ -1,12 +1,13 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_git(
+vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
-    FETCH_REF master
-    HEAD_REF master
-    URL https://git.code.sf.net/p/tinyfiledialogs/code
-    REF e11f94cd7887b101d64f74892d769f0139b5e166
+    REPO tinyfiledialogs
+    FILENAME tinyfiledialogs-current.zip
+    SHA512 6e890014646e69f0002a342d6331ec03dc41749a760dd30ac8a99919adbfc8ba646f988d1f44b0c1991a075d9cd054e481014c8cc8c5e9e8ec56ce2600d6fb03
 )
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/dll_cs_lua_R_fortran_pascal")
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 

--- a/ports/tinyfiledialogs/vcpkg.json
+++ b/ports/tinyfiledialogs/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tinyfiledialogs",
-  "version": "3.8.8",
-  "port-version": 4,
+  "version": "3.18.2",
   "description": "Highly portable and cross-platform dialogs for native inputbox, passwordbox, colorpicker and more",
   "homepage": "https://sourceforge.net/projects/tinyfiledialogs/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9013,8 +9013,8 @@
       "port-version": 0
     },
     "tinyfiledialogs": {
-      "baseline": "3.8.8",
-      "port-version": 4
+      "baseline": "3.18.2",
+      "port-version": 0
     },
     "tinyfsm": {
       "baseline": "0.3.3",

--- a/versions/t-/tinyfiledialogs.json
+++ b/versions/t-/tinyfiledialogs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66dd1c60462dca8ace6d295559d268a9d958c5c0",
+      "version": "3.18.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "be887c4bad998770f49efced776f0ef5df71d342",
       "version": "3.8.8",
       "port-version": 4


### PR DESCRIPTION
Resolves zip download failure due to vcpkg_from_git being unable to be asset cached. Example: https://dev.azure.com/vcpkg/public/_build/results?buildId=111706

```
Building tinyfiledialogs:arm-neon-android@3.8.8#4... -- Fetching https://git.code.sf.net/p/tinyfiledialogs/code master... CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:127 (message):
    Command failed: /usr/bin/git fetch https://git.code.sf.net/p/tinyfiledialogs/code master -n
    Working Directory: /vcpkg/downloads/git-tmp
    Error code: 128
    See logs for more information:
      /mnt/vcpkg-ci/b/tinyfiledialogs/git-fetch-arm-neon-android-err.log

[...]
remote: error: unable to open object pack directory: ./objects/pack: Transport endpoint is not connected remote: fatal: failed to read object e6f86deb8bab8e2c560587726635e4f7c34ba659: Transport endpoint is not connected remote: aborting due to possible repository corruption on the remote side. fatal: protocol error: bad pack header
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version. **as far as I know**
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
