### PR TITLE
[sqlpp11] Fix header file cannot be found

### DIFF
--- a/ports/sqlpp11/fix-miss-header.patch
+++ b/ports/sqlpp11/fix-miss-header.patch
@@ -1,0 +1,13 @@
+diff --git a/include/sqlpp11/mysql/sqlpp_mysql.h b/include/sqlpp11/mysql/sqlpp_mysql.h
+index 4257c7a..1408037 100644
+--- a/include/sqlpp11/mysql/sqlpp_mysql.h
++++ b/include/sqlpp11/mysql/sqlpp_mysql.h
+@@ -26,7 +26,7 @@
+  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <mysql.h>
++#include <mysql/mysql.h>
+ 
+ namespace sqlpp
+ {

--- a/ports/sqlpp11/portfile.cmake
+++ b/ports/sqlpp11/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         ddl2cpp_path.patch
         dependencies.diff
+        fix-miss-header.patch
 )
 
 vcpkg_check_features(

--- a/ports/sqlpp11/vcpkg.json
+++ b/ports/sqlpp11/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlpp11",
   "version": "0.64",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A type safe embedded domain specific language for SQL queries and results in C++.",
   "homepage": "https://github.com/rbock/sqlpp11",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8694,7 +8694,7 @@
     },
     "sqlpp11": {
       "baseline": "0.64",
-      "port-version": 2
+      "port-version": 3
     },
     "sqlpp11-connector-mysql": {
       "baseline": "0.61",

--- a/versions/s-/sqlpp11.json
+++ b/versions/s-/sqlpp11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dfc7252b01f1c44f133b24c47a245bed2173b317",
+      "version": "0.64",
+      "port-version": 3
+    },
+    {
       "git-tree": "16c9c831d703248a11117054ee7974a6381fe411",
       "version": "0.64",
       "port-version": 2


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43417

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test passed with x64-windows triplet.