### PR TITLE
[etcd-cpp-apiv3] fix find cpprestsdk when build core only

### DIFF
--- a/ports/etcd-cpp-apiv3/fix-find-cpprestsdk.patch
+++ b/ports/etcd-cpp-apiv3/fix-find-cpprestsdk.patch
@@ -1,13 +1,19 @@
 diff --git a/etcd-cpp-api-config.in.cmake b/etcd-cpp-api-config.in.cmake
-index c1a9047..23bf32f 100644
+index c1a9047..c12b748 100644
 --- a/etcd-cpp-api-config.in.cmake
 +++ b/etcd-cpp-api-config.in.cmake
-@@ -15,7 +15,7 @@ if(NOT gRPC_FOUND)
+@@ -15,9 +15,11 @@ if(NOT gRPC_FOUND)
      find_dependency(GRPC)
  endif()
  
 -find_dependency(cpprestsdk)
-+find_package(cpprestsdk QUIET)
- if(cpprestsdk_FOUND)
-     set(CPPREST_LIB cpprestsdk::cpprest)
+-if(cpprestsdk_FOUND)
+-    set(CPPREST_LIB cpprestsdk::cpprest)
++if (NOT @BUILD_ETCD_CORE_ONLY@)
++    find_dependency(cpprestsdk)
++    if(cpprestsdk_FOUND)
++        set(CPPREST_LIB cpprestsdk::cpprest)
++    endif()
  endif()
+ 
+ set(ETCD_CPP_HOME "${CMAKE_CURRENT_LIST_DIR}/../../..")

--- a/ports/etcd-cpp-apiv3/fix-find-cpprestsdk.patch
+++ b/ports/etcd-cpp-apiv3/fix-find-cpprestsdk.patch
@@ -1,0 +1,13 @@
+diff --git a/etcd-cpp-api-config.in.cmake b/etcd-cpp-api-config.in.cmake
+index c1a9047..23bf32f 100644
+--- a/etcd-cpp-api-config.in.cmake
++++ b/etcd-cpp-api-config.in.cmake
+@@ -15,7 +15,7 @@ if(NOT gRPC_FOUND)
+     find_dependency(GRPC)
+ endif()
+ 
+-find_dependency(cpprestsdk)
++find_package(cpprestsdk QUIET)
+ if(cpprestsdk_FOUND)
+     set(CPPREST_LIB cpprestsdk::cpprest)
+ endif()

--- a/ports/etcd-cpp-apiv3/portfile.cmake
+++ b/ports/etcd-cpp-apiv3/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         "${GRPC_PATCH}"
+        fix-find-cpprestsdk.patch
 )
 file(WRITE "${SOURCE_PATH}/cmake/UploadPPA.cmake" "")
 

--- a/ports/etcd-cpp-apiv3/vcpkg.json
+++ b/ports/etcd-cpp-apiv3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "etcd-cpp-apiv3",
   "version": "0.15.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The etcd-cpp-apiv3 is a C++ API for etcd's v3 client API, i.e., ETCDCTL_API=3.",
   "homepage": "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2590,7 +2590,7 @@
     },
     "etcd-cpp-apiv3": {
       "baseline": "0.15.4",
-      "port-version": 2
+      "port-version": 3
     },
     "etl": {
       "baseline": "20.39.4",

--- a/versions/e-/etcd-cpp-apiv3.json
+++ b/versions/e-/etcd-cpp-apiv3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "95aa773ba06195fe1f287efb2fa96c9f82f48ab7",
+      "git-tree": "294ed70c0aa28d439d90290e0b4eb2a4ba4bf4c5",
       "version": "0.15.4",
       "port-version": 3
     },

--- a/versions/e-/etcd-cpp-apiv3.json
+++ b/versions/e-/etcd-cpp-apiv3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "95aa773ba06195fe1f287efb2fa96c9f82f48ab7",
+      "version": "0.15.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "cae8fca4e862441e5fc85b5955988e41ea70f66e",
       "version": "0.15.4",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

etcd-cpp-apiv3 use find_dependency(cpprest), and that will return early if `cpprestsdk` is not found, which results in `etcd-targets` not being properly imported when the `async` feature is not enabled.


