### PR TITLE
[openvino] Add reminder for feature gpu when onednn was installed

### DIFF
--- a/ports/openvino/portfile.cmake
+++ b/ports/openvino/portfile.cmake
@@ -1,3 +1,9 @@
+if("gpu" IN_LIST FEATURES)
+    if(EXISTS "${CURRENT_INSTALLED_DIR}/include/oneapi/dnnl/dnnl.h")
+        message(FATAL_ERROR "Can't build feature gpu if onednn is installed. Please remove onednn, and try to install feature gpu again if you need it.")
+    endif()
+endif()
+
 vcpkg_download_distfile(PATCH_002_PROTOBUF # https://github.com/openvinotoolkit/openvino/pull/27510
     URLS https://github.com/openvinotoolkit/openvino/commit/103c3b72259648c990970afb8ce2bec489fcf583.patch?full_index=1
     SHA512 315eb2f651b55fc70a4d6faeb1ac1b5d90d53b9010fdc98f3417beb86854ed733eba105ea51de8795471c5e84340b96cf17d511ea3fe3447c5f961ded661a947

--- a/ports/openvino/vcpkg.json
+++ b/ports/openvino/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "openvino",
   "version": "2024.6.0",
+  "port-version": 1,
   "maintainers": "OpenVINO Developers <openvino@intel.com>",
   "summary": "This is a port for Open Visual Inference And Optimization toolkit for AI inference",
   "description": [
@@ -45,10 +46,6 @@
     {
       "name": "cpu",
       "platform": "!(windows & arm)"
-    },
-    {
-      "name": "gpu",
-      "platform": "x64 & !(osx | uwp)"
     },
     "hetero",
     "ir",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6790,7 +6790,7 @@
     },
     "openvino": {
       "baseline": "2024.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openvpn3": {
       "baseline": "3.10",

--- a/versions/o-/openvino.json
+++ b/versions/o-/openvino.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6306350d49e0e270fe89ff65b196dd28f771cd32",
+      "version": "2024.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "86228f04cb6e121048ad4b9c588d3f338d826fd2",
       "version": "2024.6.0",
       "port-version": 0


### PR DESCRIPTION
Fix `openvino:x64-windows` build failure on [Pipelines - Run 20250117.1](https://dev.azure.com/vcpkg/public/_build/results?buildId=111616&view=results).
```
D:\b\openvino\src\2024.6.0-d34a947277.clean\src\plugins\intel_gpu\thirdparty\onednn_gpu\src\common\c_types_map.hpp(150): error C2065: 'dnnl_f4_e2m1': undeclared identifier
D:\b\openvino\src\2024.6.0-d34a947277.clean\src\plugins\intel_gpu\thirdparty\onednn_gpu\src\common\c_types_map.hpp(151): error C2065: 'dnnl_e8m0': undeclared identifier
D:\b\openvino\src\2024.6.0-d34a947277.clean\src\plugins\intel_gpu\thirdparty\onednn_gpu\src\common\c_types_map.hpp(196): error C2061: syntax error: identifier 'dnnl_rounding_mode_t'
D:\b\openvino\src\2024.6.0-d34a947277.clean\src\plugins\intel_gpu\thirdparty\onednn_gpu\src\common\c_types_map.hpp(198): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
```
`openvino[gpu]` use the third party https://github.com/oneapi-src/oneDNN, it uses the old [header files](https://github.com/oneapi-src/oneDNN/tree/main/include) as its source from `onednn`. These files have version differences with the latest `onednn`. If `onednn` is installed via vcpkg, `openvino[gpu]` fails to install because it includes header files from the `onednn` installation in vcpkg, leading to the related errors mentioned above.

Fix this issue by the following changes:

1. Remove feature `gpu` from default features.
2. Add reminder for feature `gpu`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


