### PR TITLE
[projectm] Add new port 

### DIFF
--- a/ports/projectm/macos-pkgconfig.patch
+++ b/ports/projectm/macos-pkgconfig.patch
@@ -1,0 +1,13 @@
+--- a/src/libprojectM/CMakeLists.txt      2025-01-24 16:19:05.235818993 +0100
++++ b/src/libprojectM/CMakeLists.txt      2025-01-24 16:18:52.445824000 +0100
+@@ -212,7 +212,9 @@
+
+         set(PKGCONFIG_PACKAGE_NAME "${PROJECTM_LIBRARY_BASE_OUTPUT_NAME}")
+         set(PKGCONFIG_PACKAGE_DESCRIPTION "projectM Music Visualizer")
+-        set(PKGCONFIG_PACKAGE_REQUIREMENTS_ALL "opengl")
++        if(NOT APPLE)
++            set(PKGCONFIG_PACKAGE_REQUIREMENTS_ALL "opengl")
++        endif()
+
+         generate_pkg_config_files(projectM ${PROJECTM_LIBRARY_BASE_OUTPUT_NAME})
+

--- a/ports/projectm/portfile.cmake
+++ b/ports/projectm/portfile.cmake
@@ -1,0 +1,57 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO projectM-visualizer/projectm
+    REF "v${VERSION}"
+    SHA512 "c59885d1b6c96372f451b436a47a10e72f94e114b0dad913aa91b3ee5b48ce77f8423c011f60786cb2a2577d3875cba8e58f2e70e60116672cbc49b2de695ad4"
+    HEAD_REF master
+    PATCHES
+        macos-pkgconfig.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "boost-filesystem" ENABLE_BOOST_FILESYSTEM
+)
+
+if (NOT ENABLE_BOOST_FILESYSTEM)
+    message(STATUS
+        "If your current vcpkg target triplet or toolchain does not support C++17 or lacks std::filesystem support, "
+        "please enable the \"boost-filesystem\" feature.")
+endif ()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+
+        # Use projectm-eval and GLM from ports as well
+        -DENABLE_SYSTEM_PROJECTM_EVAL=ON
+        -DENABLE_SYSTEM_GLM=ON
+
+        # Enforce additional build flags
+        -DENABLE_PLAYLIST=ON
+        -DENABLE_SDL_UI=OFF
+        -DBUILD_TESTING=OFF
+        -DBUILD_DOCS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "projectM4"
+    CONFIG_PATH "lib/cmake/projectM4"
+    DO_NOT_DELETE_PARENT_CONFIG_PATH
+)
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "projectM4Playlist"
+    CONFIG_PATH "lib/cmake/projectM4Playlist"
+)
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/projectm/usage
+++ b/ports/projectm/usage
@@ -1,0 +1,9 @@
+projectm provides CMake targets:
+
+  find_package(projectM4 REQUIRED)
+  target_link_libraries(main PRIVATE libprojectM::projectM)
+
+To use and link the playlist library component:
+
+  find_package(projectM4 REQUIRED COMPONENTS Playlist)
+  target_link_libraries(main PRIVATE libprojectM::playlist)

--- a/ports/projectm/vcpkg.json
+++ b/ports/projectm/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "projectm",
+  "version": "4.1.4",
+  "description": "The projectM Music Visualizer. A cross-platform, OpenGL-based reimplementation of Milkdrop as a reusable library.",
+  "homepage": "https://github.com/projectM-visualizer/projectm",
+  "license": "LGPL-2.1-only AND MIT AND MIT-0",
+  "dependencies": [
+    {
+      "name": "glew",
+      "platform": "windows"
+    },
+    "glm",
+    "opengl",
+    "projectm-eval",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "boost-filesystem": {
+      "description": "Use boost::filesystem instead of std::filesystem to target toolchains and platforms without C++17 support",
+      "dependencies": [
+        "boost-filesystem"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7228,6 +7228,10 @@
       "baseline": "9.5.1",
       "port-version": 0
     },
+    "projectm": {
+      "baseline": "4.1.4",
+      "port-version": 0
+    },
     "projectm-eval": {
       "baseline": "1.0.0",
       "port-version": 1

--- a/versions/p-/projectm.json
+++ b/versions/p-/projectm.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2232688923256f7411cc89a6331fbdd9e1da3425",
+      "version": "4.1.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Second attempt on adding a portfile for the projectM Music Visualizer library, now using the recently added projectm-eval port as a dependency.

The port has an optional feature, "boost-filesystem", which can be enabled to use Boost instead of the C++ STL to implement portable filesystem support. When used on toolchains without C++17 support, this feature must be enabled by the user. As there's no way to check this automatically before the need to enable it, the portfile will emit a message to the user instead:

```
-- If your current vcpkg target triplet or toolchain does not support C++17 or lacks std::filesystem support, please enable the "boost-filesystem" feature.
```