### PR TITLE
[scnlib] support fast-float 7.0.0

### DIFF
--- a/ports/scnlib/portfile.cmake
+++ b/ports/scnlib/portfile.cmake
@@ -6,6 +6,9 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 db14d71da3c1ecb849f00ac1e334f39c532592230e950aa1009ff00ba56670cb71e33ca457fd4ac66595ff43f0dca0e42d45f672848b9cde3cba80f19ef8693f
     HEAD_REF master
+    PATCHES
+        # support fast_float 7.0.0
+        scnlib-pr-136.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/scnlib/scnlib-pr-136.patch
+++ b/ports/scnlib/scnlib-pr-136.patch
@@ -1,0 +1,26 @@
+diff --git a/src/scn/impl.cpp b/src/scn/impl.cpp
+index aa0d334..ab859a4 100644
+--- a/src/scn/impl.cpp
++++ b/src/scn/impl.cpp
+@@ -721,15 +721,17 @@ scan_expected<std::ptrdiff_t> fast_float_fallback(impl_init_data<CharT> data,
+ struct fast_float_impl_base : impl_base {
+     fast_float::chars_format get_flags() const
+     {
+-        unsigned format_flags{};
++        fast_float::chars_format format_flags{};
+         if ((m_options & float_reader_base::allow_fixed) != 0) {
+-            format_flags |= fast_float::fixed;
++            format_flags =
++                static_cast<fast_float::chars_format>(format_flags | fast_float::chars_format::fixed);
+         }
+         if ((m_options & float_reader_base::allow_scientific) != 0) {
+-            format_flags |= fast_float::scientific;
++            format_flags =
++                static_cast<fast_float::chars_format>(format_flags | fast_float::chars_format::scientific);
+         }
+ 
+-        return static_cast<fast_float::chars_format>(format_flags);
++        return format_flags;
+     }
+ };
+ 

--- a/ports/scnlib/vcpkg.json
+++ b/ports/scnlib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "scnlib",
   "version": "4.0.1",
+  "port-version": 1,
   "description": "scnlib is a modern C++ library for replacing scanf and std::istream",
   "homepage": "https://scnlib.dev/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8190,7 +8190,7 @@
     },
     "scnlib": {
       "baseline": "4.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "scope-guard": {
       "baseline": "1.1.0",

--- a/versions/s-/scnlib.json
+++ b/versions/s-/scnlib.json
@@ -6,6 +6,11 @@
       "port-version": 1
     },
     {
+      "git-tree": "c4f32fa5eff83c4abe03aa721dcc57c3fd3f0a02",
+      "version": "4.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "cbbd6d359bd0838808caa2ffd0982f87c8587fab",
       "version": "3.0.1",
       "port-version": 0

--- a/versions/s-/scnlib.json
+++ b/versions/s-/scnlib.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "f48d5065901a6d4da13812c735e147ff3d065415",
+      "git-tree": "b26c97d1ad11fc4a361f470db0f66b9afccd218c",
       "version": "4.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     {
       "git-tree": "cbbd6d359bd0838808caa2ffd0982f87c8587fab",

--- a/versions/s-/scnlib.json
+++ b/versions/s-/scnlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c4f32fa5eff83c4abe03aa721dcc57c3fd3f0a02",
+      "git-tree": "f48d5065901a6d4da13812c735e147ff3d065415",
       "version": "4.0.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Related PR is https://github.com/microsoft/vcpkg/pull/43461.

I met CI error on updating fast-float to 7.0.0 because scnlib doesn't support fast-float 7.0.0.
[The PR to fix it](https://github.com/eliaskosunen/scnlib/pull/136) is already created, but not merged yet.

I created this PR to make scnlib compatible with fast-float 7.0.0 by applying a patch to scnlib and to make vcpkg's fast-float CI successful.
I would like to avoid not being able to update fast-float for scnlib.

If there are any better way, please tell me. 
I am new to vcpkg. I want to know the vcpkg way.


