### PR TITLE
[llgi] Fix dependencies usage

### DIFF
--- a/ports/llgi/fix-cmake-use-vcpkg.patch
+++ b/ports/llgi/fix-cmake-use-vcpkg.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 30cb2da..dbc051b 100644
+index 5fd2ce0..976b845 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -232,8 +232,13 @@ if(BUILD_VULKAN_COMPILER OR BUILD_TOOL)
+@@ -234,8 +234,13 @@ if(BUILD_VULKAN_COMPILER OR BUILD_TOOL)
        spirv-cross-util)
  
    else()
@@ -19,7 +19,7 @@ index 30cb2da..dbc051b 100644
    endif()
  
 diff --git a/tools/ShaderTranspilerCore/CMakeLists.txt b/tools/ShaderTranspilerCore/CMakeLists.txt
-index 4ce40d4..d4950ce 100644
+index bf34437..09e428d 100644
 --- a/tools/ShaderTranspilerCore/CMakeLists.txt
 +++ b/tools/ShaderTranspilerCore/CMakeLists.txt
 @@ -24,6 +24,10 @@ else()
@@ -27,23 +27,9 @@ index 4ce40d4..d4950ce 100644
  endif()
  
 +target_link_libraries(ShaderTranspilerCore PUBLIC
-+  glslang::glslang glslang::SPIRV glslang::OSDependent glslang::MachineIndependent glslang::GenericCodeGen glslang::glslang-default-resource-limits glslang::OGLCompiler glslang::SPVRemapper glslang::HLSL
-+  spirv-cross-cpp spirv-cross-glsl spirv-cross-msl spirv-cross-hlsl
++  glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV glslang::SPVRemapper spirv-cross-cpp spirv-cross-glsl spirv-cross-msl spirv-cross-hlsl
 +)
++
  if(USE_THIRDPARTY_DIRECTORY)
    add_dependencies(ShaderTranspilerCore EP_glslang EP_SPIRV-Cross)
  endif()
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index dbc051b..b898b4c 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -27,9 +27,6 @@ option(SPIRVCROSS_WITHOUT_INSTALL "Compile with spirv-cross without install"
-        OFF)
- option(USE_CREATE_COMPILER_FUNCTION "Whether LLGI::CreateCompiler is used." ON)
- 
--if(LINUX)
--  set(BUILD_VULKAN TRUE)
--endif()
- 
- option(USE_MSVC_RUNTIME_LIBRARY_DLL "compile as multithreaded DLL" ON)
- 

--- a/ports/llgi/fix-cmake-use-vcpkg.patch
+++ b/ports/llgi/fix-cmake-use-vcpkg.patch
@@ -1,8 +1,19 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5fd2ce0..976b845 100644
+index 5fd2ce0..202bcfe 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -234,8 +234,13 @@ if(BUILD_VULKAN_COMPILER OR BUILD_TOOL)
+@@ -27,10 +27,6 @@ option(SPIRVCROSS_WITHOUT_INSTALL "Compile with spirv-cross without install"
+        OFF)
+ option(USE_CREATE_COMPILER_FUNCTION "Whether LLGI::CreateCompiler is used." ON)
+ 
+-if(LINUX)
+-  set(BUILD_VULKAN TRUE)
+-endif()
+-
+ option(USE_MSVC_RUNTIME_LIBRARY_DLL "compile as multithreaded DLL" ON)
+ 
+ include(cmake/ClangFormat.cmake)
+@@ -234,8 +230,13 @@ if(BUILD_VULKAN_COMPILER OR BUILD_TOOL)
        spirv-cross-util)
  
    else()

--- a/ports/llgi/vcpkg.json
+++ b/ports/llgi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "llgi",
   "version-date": "2023-12-19",
+  "port-version": 1,
   "homepage": "https://github.com/altseed/LLGI",
   "license": null,
   "supports": "!(uwp | android)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5562,7 +5562,7 @@
     },
     "llgi": {
       "baseline": "2023-12-19",
-      "port-version": 0
+      "port-version": 1
     },
     "llgl": {
       "baseline": "2023-03-05",

--- a/versions/l-/llgi.json
+++ b/versions/l-/llgi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e720957b493e849332e37363a5f2c152e5da0db4",
+      "version-date": "2023-12-19",
+      "port-version": 1
+    },
+    {
       "git-tree": "70bc60ef323833846200e1ffe0937de2cfaaf77e",
       "version-date": "2023-12-19",
       "port-version": 0

--- a/versions/l-/llgi.json
+++ b/versions/l-/llgi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e720957b493e849332e37363a5f2c152e5da0db4",
+      "git-tree": "2d5d42fc0ae7751b084503404794be4d108972b4",
       "version-date": "2023-12-19",
       "port-version": 1
     },


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/43468

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.