### PR TITLE
[rapidjson] Set Cmake minimum required version to a range

### DIFF
--- a/ports/rapidjson/portfile.cmake
+++ b/ports/rapidjson/portfile.cmake
@@ -34,7 +34,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 file(READ "${CURRENT_PACKAGES_DIR}/share/${PORT}/RapidJSONConfig.cmake" _contents)
-string(REPLACE "VERSION 3.0" "VERSION 3.5" _contents "${_contents}")
+string(REPLACE "VERSION 3.0" "VERSION 3.5...3.30" _contents "${_contents}")
 string(REPLACE "\${RapidJSON_SOURCE_DIR}" "\${RapidJSON_CMAKE_DIR}/../.." _contents "${_contents}")
 string(REPLACE "set( RapidJSON_SOURCE_DIR \"${SOURCE_PATH}\")" "" _contents "${_contents}")
 string(REPLACE "set( RapidJSON_DIR \"${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel\")" "" _contents "${_contents}")

--- a/ports/rapidjson/vcpkg.json
+++ b/ports/rapidjson/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rapidjson",
   "version-date": "2023-07-17",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A fast JSON parser/generator for C++ with both SAX/DOM style API <http://rapidjson.org/>",
   "homepage": "http://rapidjson.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7834,7 +7834,7 @@
     },
     "rapidjson": {
       "baseline": "2023-07-17",
-      "port-version": 1
+      "port-version": 2
     },
     "rapidxml": {
       "baseline": "1.13",

--- a/versions/r-/rapidjson.json
+++ b/versions/r-/rapidjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "38b67535aa1b51fd521021ec77ccb36f01431bd2",
+      "version-date": "2023-07-17",
+      "port-version": 2
+    },
+    {
       "git-tree": "a3dfe7dca3a1a27564b1fc5a9aea657cd9dae01c",
       "version-date": "2023-07-17",
       "port-version": 1


### PR DESCRIPTION
This suppresses Cmake deprecation warnings when running newer versions of Cmake.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
