### PR TITLE
[tinyfiledialogs] Update to 3.19.0.

### DIFF
--- a/ports/tinyfiledialogs/portfile.cmake
+++ b/ports/tinyfiledialogs/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tinyfiledialogs
     FILENAME tinyfiledialogs-current.zip
-    SHA512 6e890014646e69f0002a342d6331ec03dc41749a760dd30ac8a99919adbfc8ba646f988d1f44b0c1991a075d9cd054e481014c8cc8c5e9e8ec56ce2600d6fb03
+    SHA512 d7ddd37576d8d758a7bccc25cc19698d5c87645b72aaa1dd2cad32abc8c342911764ef3ab14037d1abcb255f2919fccc1bec07118c81977a89d1f7fda70f185f
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/dll_cs_lua_R_fortran_pascal")


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43483.
Fixes tinyfiledialogs error SHA512.

- Issue: #43483
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

