### PR TITLE
[bgfx] update to 1.129.8866-491

### DIFF
--- a/ports/bgfx/portfile.cmake
+++ b/ports/bgfx/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_download_distfile(
   ARCHIVE_FILE
   URLS https://github.com/bkaradzic/bgfx.cmake/releases/download/v${VERSION}/bgfx.cmake.v${VERSION}.tar.gz
   FILENAME bgfx.cmake.v${VERSION}.tar.gz
-  SHA512 879ffef9623238b5e4ff88ac1bd655203adf76f4232f8e36f9a7ba5d0baab11ef80fdc7b3fea110e54d22f284106d51e12bf468459d82dc50a177555b4e4ada9
+  SHA512 503f31965f7be5631f0952a1e1bcc6484cb8b1a28261ae949f367317cf7432950c52f4363f4ad55d3ae0bc73302edafe2ca8ac5e817b6e09d886c7760ff8ce60
 )
 
 vcpkg_extract_source_archive(

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bgfx",
-  "version": "1.128.8808-482",
+  "version": "1.129.8866-491",
   "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
   "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
   "homepage": "https://bkaradzic.github.io/bgfx/overview.html",

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a31ddfefd30660f6e321840607f6ae654849b8f9",
+      "version": "1.129.8866-491",
+      "port-version": 0
+    },
+    {
       "git-tree": "38419e14182a560fb1b84d51f88e68af9174e90c",
       "version": "1.128.8808-482",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -641,7 +641,7 @@
       "port-version": 0
     },
     "bgfx": {
-      "baseline": "1.128.8808-482",
+      "baseline": "1.129.8866-491",
       "port-version": 0
     },
     "bigint": {


### PR DESCRIPTION
This update unifies the shader compilation cmake function to object and to header.

Users using `BGFX_EMBEDDED_SHADER` for spirv will have to change paths from "spv/" to "spirv/" and "mtl/" to "metal/".

Changelog: https://github.com/bkaradzic/bgfx.cmake/compare/v1.128.8808-482...v1.129.8866-491

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.