### PR TITLE
[libosmium] update to v2.21

### DIFF
--- a/ports/libosmium/portfile.cmake
+++ b/ports/libosmium/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO osmcode/libosmium
     REF "v${VERSION}"
-    SHA512 72e881e221dc3e62d7459b5cd84bf65de4fc0149bed66fe0534107d0d4dc30e5d474df685b44af07e6065a690dd7b31b877b5b040b8e0b4b0b971738175c34a3
+    SHA512 fb87d5ae37c6d864ba1b265bda8e8a213fe9714d4e3cc47bd87ec05d07b9007494d37752ec4223bc5a2d957eac090d752d71f1944cb5200ae3d4af8ac97b9e10
 )
 
 vcpkg_cmake_configure(

--- a/ports/libosmium/vcpkg.json
+++ b/ports/libosmium/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libosmium",
-  "version-semver": "2.20.0",
+  "version-semver": "2.21.0",
   "port-version": 1,
   "description": "A fast and flexible C++ library for working with OpenStreetMap data",
   "homepage": "https://osmcode.org/libosmium/",

--- a/ports/libosmium/vcpkg.json
+++ b/ports/libosmium/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libosmium",
   "version-semver": "2.21.0",
-  "port-version": 1,
   "description": "A fast and flexible C++ library for working with OpenStreetMap data",
   "homepage": "https://osmcode.org/libosmium/",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4941,7 +4941,7 @@
       "port-version": 1
     },
     "libosmium": {
-      "baseline": "2.20.0",
+      "baseline": "2.21.0",
       "port-version": 1
     },
     "libosmscout": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4942,7 +4942,7 @@
     },
     "libosmium": {
       "baseline": "2.21.0",
-      "port-version": 1
+      "port-version": 0
     },
     "libosmscout": {
       "baseline": "1.1.1",

--- a/versions/l-/libosmium.json
+++ b/versions/l-/libosmium.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "080d7421f665ac3b7f6e2a9e540442cc9d2675f6",
+      "version-semver": "2.21.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4e43abda3d2ab79b2d813717eef1b330b390557f",
       "version-semver": "2.20.0",
       "port-version": 1

--- a/versions/l-/libosmium.json
+++ b/versions/l-/libosmium.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "080d7421f665ac3b7f6e2a9e540442cc9d2675f6",
+      "git-tree": "1521fd94a5060bf49f8aa9893bcea7daceb67093",
       "version-semver": "2.21.0",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "4e43abda3d2ab79b2d813717eef1b330b390557f",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


 
