### PR TITLE
[mujoco] Update to 3.2.7

### DIFF
--- a/ports/mujoco/fix_dependencies.patch
+++ b/ports/mujoco/fix_dependencies.patch
@@ -1,17 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e34b07e..56ed5e8 100644
+index aaac4e38..58bafedb 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -87,7 +87,7 @@ add_subdirectory(src/xml)
- add_subdirectory(src/render)
+@@ -95,7 +95,7 @@ add_subdirectory(src/render)
+ add_subdirectory(src/thread)
  add_subdirectory(src/ui)
  
--target_compile_definitions(mujoco PRIVATE _GNU_SOURCE CCD_STATIC_DEFINE MUJOCO_DLL_EXPORTS)
-+target_compile_definitions(mujoco PRIVATE _GNU_SOURCE MUJOCO_DLL_EXPORTS)
+-target_compile_definitions(mujoco PRIVATE _GNU_SOURCE CCD_STATIC_DEFINE MUJOCO_DLL_EXPORTS -DMC_IMPLEM_ENABLE)
++target_compile_definitions(mujoco PRIVATE _GNU_SOURCE MUJOCO_DLL_EXPORTS -DMC_IMPLEM_ENABLE)
  if(MUJOCO_ENABLE_AVX_INTRINSICS)
    target_compile_definitions(mujoco PUBLIC mjUSEPLATFORMSIMD)
  endif()
-@@ -110,9 +110,9 @@ target_link_libraries(
+@@ -118,9 +118,9 @@ target_link_libraries(
    mujoco
    PRIVATE ccd
            lodepng
@@ -25,10 +25,10 @@ index e34b07e..56ed5e8 100644
  
  set_target_properties(
 diff --git a/cmake/MujocoDependencies.cmake b/cmake/MujocoDependencies.cmake
-index 9c12ef7..af09f8a 100644
+index 23e4e71e..e4cfad28 100644
 --- a/cmake/MujocoDependencies.cmake
 +++ b/cmake/MujocoDependencies.cmake
-@@ -79,7 +79,7 @@ set(BUILD_SHARED_LIBS
+@@ -90,7 +90,7 @@ set(BUILD_SHARED_LIBS
      CACHE INTERNAL "Build SHARED libraries"
  )
  
@@ -37,10 +37,20 @@ index 9c12ef7..af09f8a 100644
    FetchContent_Declare(
      lodepng
      GIT_REPOSITORY https://github.com/lvandeve/lodepng.git
-@@ -99,35 +99,57 @@ if(NOT TARGET lodepng)
+@@ -110,6 +110,7 @@ if(NOT TARGET lodepng)
    endif()
  endif()
  
++if(0)
+ if(NOT TARGET marchingcubecpp)
+   FetchContent_Declare(
+     marchingcubecpp
+@@ -123,36 +124,60 @@ if(NOT TARGET marchingcubecpp)
+     include_directories(${marchingcubecpp_SOURCE_DIR})
+   endif()
+ endif()
++endif()
++
 +findorfetch(
 +  USE_SYSTEM_PACKAGE
 +  ON
@@ -56,7 +66,7 @@ index 9c12ef7..af09f8a 100644
 +  lodepng
 +  EXCLUDE_FROM_ALL
 +)
-+
+ 
  set(QHULL_ENABLE_TESTING OFF)
  
  findorfetch(
@@ -90,6 +100,7 @@ index 9c12ef7..af09f8a 100644
 +
 +include_directories(
 +  ${Qhull_DIR}/../../include/libqhull_r
++  ${Qhull_DIR}/../../include/marchingcubecpp
 +)
  
  set(tinyxml2_BUILD_TESTING OFF)
@@ -100,7 +111,7 @@ index 9c12ef7..af09f8a 100644
    PACKAGE_NAME
    tinyxml2
    LIBRARY_NAME
-@@ -140,12 +162,14 @@ findorfetch(
+@@ -165,12 +190,14 @@ findorfetch(
    tinyxml2
    EXCLUDE_FROM_ALL
  )
@@ -116,7 +127,31 @@ index 9c12ef7..af09f8a 100644
    PACKAGE_NAME
    tinyobjloader
    LIBRARY_NAME
-@@ -163,7 +187,7 @@ set(ENABLE_DOUBLE_PRECISION ON)
+@@ -189,9 +216,9 @@ option(SDFLIB_USE_OPENMP OFF)
+ option(SDFLIB_USE_ENOKI OFF)
+ findorfetch(
+   USE_SYSTEM_PACKAGE
+-  OFF
++  ON
+   PACKAGE_NAME
+-  sdflib
++  SdfLib
+   LIBRARY_NAME
+   sdflib
+   GIT_REPO
+@@ -202,14 +229,19 @@ findorfetch(
+   SdfLib
+   EXCLUDE_FROM_ALL
+ )
++
++add_library(SdfLib ALIAS SdfLib::SdfLib)
++
++if(0)
+ target_compile_options(SdfLib PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
+ target_link_options(SdfLib PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
++endif()
+ 
+ set(ENABLE_DOUBLE_PRECISION ON)
  set(CCD_HIDE_ALL_SYMBOLS ON)
  findorfetch(
    USE_SYSTEM_PACKAGE
@@ -125,7 +160,7 @@ index 9c12ef7..af09f8a 100644
    PACKAGE_NAME
    ccd
    LIBRARY_NAME
-@@ -176,11 +200,14 @@ findorfetch(
+@@ -222,11 +254,14 @@ findorfetch(
    ccd
    EXCLUDE_FROM_ALL
  )
@@ -140,7 +175,7 @@ index 9c12ef7..af09f8a 100644
  if(WIN32)
    if(MSVC)
      # C4005 is the MSVC equivalent of -Wmacro-redefined.
-@@ -189,6 +216,7 @@ if(WIN32)
+@@ -235,6 +270,7 @@ if(WIN32)
      target_compile_options(ccd PRIVATE -Wno-macro-redefined)
    endif()
  endif()
@@ -149,7 +184,7 @@ index 9c12ef7..af09f8a 100644
  if(MUJOCO_BUILD_TESTS)
    set(ABSL_PROPAGATE_CXX_STD ON)
 diff --git a/simulate/cmake/SimulateDependencies.cmake b/simulate/cmake/SimulateDependencies.cmake
-index fa539c2..8b3b239 100644
+index 5141406c..41f399b7 100644
 --- a/simulate/cmake/SimulateDependencies.cmake
 +++ b/simulate/cmake/SimulateDependencies.cmake
 @@ -86,7 +86,7 @@ findorfetch(

--- a/ports/mujoco/mesh.patch
+++ b/ports/mujoco/mesh.patch
@@ -1,0 +1,51 @@
+diff --git a/src/user/user_mesh.cc b/src/user/user_mesh.cc
+index 4de4e2e3..e8bd6968 100644
+--- a/src/user/user_mesh.cc
++++ b/src/user/user_mesh.cc
+@@ -61,7 +61,6 @@
+ #include "user/user_objects.h"
+ #include "user/user_resource.h"
+ #include "user/user_util.h"
+-#include <tiny_obj_loader.h>
+ 
+ extern "C" {
+ #include "qhull_ra.h"
+@@ -397,7 +396,7 @@ void mjCMesh::CacheMesh(mjCCache* cache, const mjResource* resource,
+       + (sizeof(int) * vertex_index_.size())
+       + (sizeof(int) * normal_index_.size())
+       + (sizeof(int) * texcoord_index_.size())
+-      + (sizeof(unsigned char) * num_face_vertices_.size());
++      + (sizeof(face_vertices_type) * num_face_vertices_.size());
+ 
+   std::shared_ptr<const void> cached_data(mesh, +[](const void* data) {
+     const mjCMesh* mesh = static_cast<const mjCMesh*>(data);
+diff --git a/src/user/user_objects.h b/src/user/user_objects.h
+index bf11a7be..59fcdaf8 100644
+--- a/src/user/user_objects.h
++++ b/src/user/user_objects.h
+@@ -24,6 +24,7 @@
+ #include <string_view>
+ #include <utility>
+ #include <vector>
++#include <tiny_obj_loader.h>
+ 
+ #include <mujoco/mjtnum.h>
+ #include <mujoco/mjmodel.h>
+@@ -32,6 +33,8 @@
+ #include "user/user_cache.h"
+ #include "user/user_util.h"
+ 
++using face_vertices_type = decltype(tinyobj::mesh_t::num_face_vertices)::value_type;
++
+ // forward declarations of all mjC/X classes
+ class mjCError;
+ class mjCBase;
+@@ -964,7 +967,7 @@ class mjCMesh: public mjCMesh_, private mjsMesh {
+   std::vector<int> vertex_index_;
+   std::vector<int> normal_index_;
+   std::vector<int> texcoord_index_;
+-  std::vector<unsigned char> num_face_vertices_;
++  std::vector<face_vertices_type> num_face_vertices_;
+ 
+   // compute the volume and center-of-mass of the mesh given the face center
+   void ComputeVolume(double CoM[3], mjtGeomInertia gtype, const double facecen[3]);

--- a/ports/mujoco/portfile.cmake
+++ b/ports/mujoco/portfile.cmake
@@ -2,9 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO deepmind/mujoco
     REF ${VERSION}
-    SHA512 518b9ae09ea7cd4d2095df1be985a30957c6d57846933e111c326e45b61ac002bea014cd0d7902653c85e61ef0ba156b3324eff0edb5613467fe8e07e92dd6da
+    SHA512 db8b80b33a8a2cf08d5cb70114def49cf529f0a05de379e303086d73e9dd652ed0a4839a1ea8bba79e9a7f7d05421d7c34bfa47b128d444fbb83c3831b87e1c3
     PATCHES
         fix_dependencies.patch
+        mesh.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/mujoco/vcpkg.json
+++ b/ports/mujoco/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mujoco",
-  "version": "2.3.2",
-  "port-version": 1,
+  "version": "3.2.7",
   "description": "Multi-Joint dynamics with Contact.",
   "homepage": "https://mujoco.org",
   "license": "Apache-2.0",
@@ -15,7 +14,9 @@
     },
     "glfw3",
     "lodepng",
+    "marchingcubecpp",
     "qhull",
+    "sdflib",
     "tinyobjloader",
     "tinyxml2",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6193,8 +6193,8 @@
       "port-version": 0
     },
     "mujoco": {
-      "baseline": "2.3.2",
-      "port-version": 1
+      "baseline": "3.2.7",
+      "port-version": 0
     },
     "mujs": {
       "baseline": "1.3.5",

--- a/versions/m-/mujoco.json
+++ b/versions/m-/mujoco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d1390fd33f3bf4d3b3a212a9cf7614b55aa5973",
+      "version": "3.2.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "c70b9104b75fe8947ddac6e9450207cadb59cb0b",
       "version": "2.3.2",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
