### PR TITLE
[libdivide] update to 5.2.0

### DIFF
--- a/ports/libdivide/no-werror.patch
+++ b/ports/libdivide/no-werror.patch
@@ -1,19 +1,25 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7800a13..f01a139 100644
+index 136400d..f54a722 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -15,10 +15,10 @@ include(CMakeSanitize)
- 
+@@ -15,15 +15,15 @@ include(CMakePushCheckState)
  # Maximum warnings level & warnings as error
- add_compile_options(
--    "$<$<CXX_COMPILER_ID:MSVC>:/W4;/WX>"
--    "$<$<CXX_COMPILER_ID:GNU>:-Wall;-Wextra;-pedantic;-Werror>"
--    "$<$<CXX_COMPILER_ID:Clang>:-Wall;-Wextra;-pedantic;-Werror>"
--    "$<$<CXX_COMPILER_ID:AppleClang>:-Wall;-Wextra;-pedantic;-Werror>"
-+    "$<$<CXX_COMPILER_ID:MSVC>:/W4>"
-+    "$<$<CXX_COMPILER_ID:GNU>:-Wall;-Wextra;-pedantic>"
-+    "$<$<CXX_COMPILER_ID:Clang>:-Wall;-Wextra;-pedantic>"
-+    "$<$<CXX_COMPILER_ID:AppleClang>:-Wall;-Wextra;-pedantic>"
- )
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+     if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC") # clang-cl
+-        add_compile_options("/W4;/WX;")
++        add_compile_options("/W4")
+     else() # clang native
+-        add_compile_options("-Wall;-Wextra;-pedantic;-Werror")
++        add_compile_options("-Wall;-Wextra;-pedantic")
+     endif()
+ else()
+     add_compile_options(
+-        "$<$<CXX_COMPILER_ID:MSVC>:/W4;/WX>"
+-        "$<$<CXX_COMPILER_ID:GNU>:-Wall;-Wextra;-pedantic;-Werror>"
+-        "$<$<CXX_COMPILER_ID:AppleClang>:-Wall;-Wextra;-pedantic;-Werror>"
++        "$<$<CXX_COMPILER_ID:MSVC>:/W4>"
++        "$<$<CXX_COMPILER_ID:GNU>:-Wall;-Wextra;-pedantic>"
++        "$<$<CXX_COMPILER_ID:AppleClang>:-Wall;-Wextra;-pedantic>"
+     )
+ endif()
  
- # Build options ################################################

--- a/ports/libdivide/portfile.cmake
+++ b/ports/libdivide/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ridiculousfish/libdivide
     REF "v${VERSION}"
-    SHA512 1c94dabca83984ef8190ba91b328e5e994a9bc41b4f4b6800d7417db3312283576759ba3039741a4f045adab6f0391b82ba93523b802bb6a37bc3fd693a80e05
+    SHA512 1a429b436e545360fb898e059ce689f5123d3fce25242d5a54e52588b75c97008918c1dc5e43f537eb8b2e61577339955ca66d9bbb0eb4440a00500a8a146ccf
     HEAD_REF master
     PATCHES
         no-werror.patch
@@ -10,7 +10,7 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        test BUILD_TESTS
+        test LIBDIVIDE_BUILD_TESTS
 )
 
 vcpkg_cmake_configure(
@@ -21,7 +21,6 @@ vcpkg_cmake_configure(
         -DLIBDIVIDE_AVX2=OFF
         -DLIBDIVIDE_AVX512=OFF
         -DLIBDIVIDE_NEON=OFF
-        -DENABLE_VECTOR_EXTENSIONS=OFF
 )
 
 vcpkg_cmake_install()
@@ -32,4 +31,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright) 
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libdivide/vcpkg.json
+++ b/ports/libdivide/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdivide",
-  "version": "5.1",
+  "version": "5.2.0",
   "description": "libdivide.h is a header-only C/C++ library for optimizing integer division.",
   "homepage": "https://github.com/ridiculousfish/libdivide",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4445,7 +4445,7 @@
       "port-version": 11
     },
     "libdivide": {
-      "baseline": "5.1",
+      "baseline": "5.2.0",
       "port-version": 0
     },
     "libdjinterop": {

--- a/versions/l-/libdivide.json
+++ b/versions/l-/libdivide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e81740fc7d610d3c1f30867c8aa127c7db25bcd",
+      "version": "5.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ad57bd243a7411f834cb0dafae9f2b4ffa76c0a3",
       "version": "5.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ridiculousfish/libdivide/blob/v5.2.0/CMakeLists.txt
- ENABLE_VECTOR_EXTENSIONS has been removed.
- BUILD_TESTS has been renamed to LIBDIVIDE_BUILD_TESTS.
