### PR TITLE
[sdl3-image] Fix sdl3-image.pc file

### DIFF
--- a/ports/sdl3-image/portfile.cmake
+++ b/ports/sdl3-image/portfile.cmake
@@ -41,7 +41,7 @@ endif()
 vcpkg_fixup_pkgconfig()
 
 if(NOT VCPKG_TARGET_IS_LINUX AND NOT VCPKG_TARGET_IS_ANDROID AND NOT VCPKG_BUILD_TYPE)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/SDL3-image.pc" "-lSDL3_image" "-lSDL3_imaged")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl3-image.pc" "-lSDL3_image" "-lSDL3_imaged")
 endif()
 
 file(REMOVE_RECURSE 

--- a/ports/sdl3-image/vcpkg.json
+++ b/ports/sdl3-image/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl3-image",
   "version": "3.1.0",
+  "port-version": 1,
   "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
   "homepage": "https://github.com/libsdl-org/SDL_image",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8286,7 +8286,7 @@
     },
     "sdl3-image": {
       "baseline": "3.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "seacas": {
       "baseline": "2022-11-22",

--- a/versions/s-/sdl3-image.json
+++ b/versions/s-/sdl3-image.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f37b53e6e17516d3e0de2aa6c98ee101309061f",
+      "version": "3.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e5c443cbdf6896a4989f1a0a6034be21c3fc43c0",
       "version": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #43500

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.