### PR TITLE
[gtk3] Update to 3.24.43

### DIFF
--- a/ports/gtk3/cairo-cpp-linkage.patch
+++ b/ports/gtk3/cairo-cpp-linkage.patch
@@ -57,6 +57,6 @@ index 287f0cb..d35106f 100644
 @@ -1,4 +1,4 @@
 -project('gtk+', 'c',
 +project('gtk+', 'c', 'cpp',
-   version: '3.24.38',
+   version: '3.24.43',
    default_options: [
      'buildtype=debugoptimized',

--- a/ports/gtk3/portfile.cmake
+++ b/ports/gtk3/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.gnome.org
     REPO GNOME/gtk
     REF "${VERSION}"
-    SHA512 ffb52ee34074be6e88fda40a025044b653d05b69c35819eed159a020a6f1c881a83735aa7bec943470c465328bb3bb20b34afeb3b98cdcfca9d2eaaed3ab61ef
+    SHA512 19e5482e4e843aa946ab79c8ce283a7b44aaac43ad99b6913cbc3c91492bf722ebe0238457b75b82be6d6c65a394d32ebc8732832f3f800145e3cf69d5c1e77c
     PATCHES
         0001-build.patch
         cairo-cpp-linkage.patch

--- a/ports/gtk3/vcpkg.json
+++ b/ports/gtk3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gtk3",
-  "version": "3.24.38",
-  "port-version": 2,
+  "version": "3.24.43",
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3301,8 +3301,8 @@
       "port-version": 1
     },
     "gtk3": {
-      "baseline": "3.24.38",
-      "port-version": 2
+      "baseline": "3.24.43",
+      "port-version": 0
     },
     "gtkmm": {
       "baseline": "4.14.0",

--- a/versions/g-/gtk3.json
+++ b/versions/g-/gtk3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "58162a3fa851d5634818c1e4c86980882a8a80d3",
+      "version": "3.24.43",
+      "port-version": 0
+    },
+    {
       "git-tree": "f26f170ffcbb0ef113b90d3e8c5628bb489c103f",
       "version": "3.24.38",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.