### PR TITLE
[opentelemetry-cpp] Add WITH_STL features

### DIFF
--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -26,6 +26,31 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         user-events BUILD_TRACEPOINTS
 )
 
+set(STL OFF)
+
+function(set_stl VALUE)
+    if(STL)
+        message(FATAL_ERROR "Only stl version is allowed")
+    endif()
+    set(STL ${VALUE} PARENT_SCOPE)
+endfunction()
+
+foreach(STL_FEATURE ${FEATURES})
+    if(STL_FEATURE STREQUAL "stl-on")
+        set_stl("ON")
+    elseif(STL_FEATURE STREQUAL "stl-cxx11")
+        set_stl("CXX11")
+    elseif(STL_FEATURE STREQUAL "stl-cxx14")
+        set_stl("CXX14")
+    elseif(STL_FEATURE STREQUAL "stl-cxx17")
+        set_stl("CXX17")
+    elseif(STL_FEATURE STREQUAL "stl-cxx20")
+        set_stl("CXX20")
+    elseif(STL_FEATURE STREQUAL "stl-cxx23")
+        set_stl("CXX23")
+    endif()
+endforeach()
+
 # opentelemetry-proto is a third party submodule and opentelemetry-cpp release did not pack it.
 if(WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
     set(OTEL_PROTO_VERSION "1.4.0")
@@ -77,6 +102,7 @@ vcpkg_cmake_configure(
         -DOPENTELEMETRY_INSTALL=ON
         -DWITH_ABSEIL=ON
         -DWITH_BENCHMARK=OFF
+        -DWITH_STL=${STL}
         -DOPENTELEMETRY_EXTERNAL_COMPONENT_PATH=${OPENTELEMETRY_CPP_EXTERNAL_COMPONENTS}
         ${FEATURE_OPTIONS}
     MAYBE_UNUSED_VARIABLES

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -70,6 +70,24 @@
         "prometheus-cpp"
       ]
     },
+    "stl-cxx11": {
+      "description": "Whether to include a dependency on the c++-11 stl (rather than using opentelemetry's own STL implementation)."
+    },
+    "stl-cxx14": {
+      "description": "Whether to include a dependency on the c++-14 stl (rather than using opentelemetry's own STL implementation)."
+    },
+    "stl-cxx17": {
+      "description": "Whether to include a dependency on the c++-17 stl (rather than using opentelemetry's own STL implementation)."
+    },
+    "stl-cxx20": {
+      "description": "Whether to include a dependency on the c++-20 stl (rather than using opentelemetry's own STL implementation)."
+    },
+    "stl-cxx23": {
+      "description": "Whether to include a dependency on the c++-23 stl (rather than using opentelemetry's own STL implementation)."
+    },
+    "stl-on": {
+      "description": "Whether to include a dependency on the c++ stl (rather than using opentelemetry's own STL implementation). This option defaults to (latest)"
+    },
     "user-events": {
       "description": "Whether to include the User Events Exporter from the opentelemetry-cpp-contrib repository",
       "supports": "linux",


### PR DESCRIPTION
This allows opentelemetry to be built with the standard stl types instead of using its own.

The motivation for this change is to make builds smaller and compiler errors a bit more straightforward.

I believe that the use of these exclusive-features is allowed based on [rules about features replacing polyfills](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md#a-feature-may-replace-polyfills-with-aliases-provided-that-replacement-is-baked-into-the-installed-tree). However, it is possible that I am mistaken, and that I can/should only allow the "stl-on" feature (which is slightly sad, because some environments do not have access to stl-cxx23 features).

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [n/a] SHA512s are updated for each updated download.
- [n/a] The "supports" clause reflects platforms that may be fixed by this new version.
- [n/a] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [n/a] Any patches that are no longer applied are deleted from the port's directory.
- [n/a] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [n/a] Only one version is added to each modified port's versions file.

