### PR TITLE
[awlib] fix mac build

### DIFF
--- a/ports/awlib/fix-mac-build.patch
+++ b/ports/awlib/fix-mac-build.patch
@@ -1,0 +1,44 @@
+diff --git a/io/include/aw/io/mmap_file.h b/io/include/aw/io/mmap_file.h
+index 98469732..65e82aac 100644
+--- a/io/include/aw/io/mmap_file.h
++++ b/io/include/aw/io/mmap_file.h
+@@ -83,18 +83,18 @@ using win32::file_mapping;
+ inline file_mode get_file_mode(map_perms perms)
+ {
+ 	using mp = map_perms;
+-	switch (perms) {
+-	case mp::none:
+-	case mp::none|mp::exec:
++	switch (static_cast<unsigned>(perms)) {
++	case static_cast<unsigned>(mp::none):
++	case static_cast<unsigned>(mp::none|mp::exec):
+ 		return file_mode::none;
+-	case mp::read:
+-	case mp::read|mp::exec:
++	case static_cast<unsigned>(mp::read):
++	case static_cast<unsigned>(mp::read|mp::exec):
+ 		return file_mode::read;
+-	case mp::write:
++	case static_cast<unsigned>(mp::write):
+ 		return file_mode::write;
+-	case mp::write|mp::exec:
+-	case mp::rdwr:
+-	case mp::rdwr|mp::exec:
++	case static_cast<unsigned>(mp::write|mp::exec):
++	case static_cast<unsigned>(mp::rdwr):
++	case static_cast<unsigned>(mp::rdwr|mp::exec):
+ 		return file_mode::read|file_mode::write;
+ 	}
+ 
+diff --git a/types/include/aw/types/byte_buffer.h b/types/include/aw/types/byte_buffer.h
+index 82f46934..b38c46a9 100644
+--- a/types/include/aw/types/byte_buffer.h
++++ b/types/include/aw/types/byte_buffer.h
+@@ -8,6 +8,7 @@
+  */
+ #ifndef aw_types_byte_buffer_h
+ #define aw_types_byte_buffer_h
++#include <cstdlib>
+ #include <memory>
+ namespace aw {
+ /**

--- a/ports/awlib/portfile.cmake
+++ b/ports/awlib/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF ${VERSION}
     SHA512 bfb4668abc3db176744bb674a20bf770c6406db522a14191069b8d833414285ca784f042c3ad50404f7f8bc76afe69627dfcf540080e12316abbbfe420955526
     HEAD_REF master
+    PATCHES
+        fix-mac-build.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/awlib/vcpkg.json
+++ b/ports/awlib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "awlib",
   "version-date": "2024-04-06",
+  "port-version": 1,
   "description": "Cross-platform utility library",
   "homepage": "https://github.com/absurdworlds/awlib",
   "license": "LGPL-3.0-or-later",

--- a/versions/a-/awlib.json
+++ b/versions/a-/awlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e81b74f7134ef57eeabdfee3984e76eef3a7707",
+      "version-date": "2024-04-06",
+      "port-version": 1
+    },
+    {
       "git-tree": "539db7a8b7652c86c735594e04dc1a1e09647035",
       "version-date": "2024-04-06",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -386,7 +386,7 @@
     },
     "awlib": {
       "baseline": "2024-04-06",
-      "port-version": 0
+      "port-version": 1
     },
     "aws-c-auth": {
       "baseline": "0.8.0",


### PR DESCRIPTION
Fixes 
```
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/awlib/src/2024-04-06-4d0885f5ee.clean/types/include/aw/types/byte_buffer.h:25:75: error: no member named 'malloc' in namespace 'std'; did you mean simply 'malloc'?
   25 |         std::unique_ptr<byte_type, free_deleter> memory{ static_cast<byte_type*>(std::malloc(size)) };
      |                                                                                  ^~~~~~~~~~~
      |                                                                                  malloc
```
Patch from https://github.com/absurdworlds/awlib/pull/45