### PR TITLE
[lexbor] update to 2.4.0

### DIFF
--- a/ports/lexbor/portfile.cmake
+++ b/ports/lexbor/portfile.cmake
@@ -2,7 +2,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lexbor/lexbor
     REF v${VERSION}
-    SHA512 add1832f2e1927538206329703cd717fb30cb6ae2f52e1a0042961062cbcafd2e3ce4437ee2081ad7b2d51c6b63b910be06987e47c4a7007321db52b2812e515
+    SHA512 c12a04df5852464e6448a771ca6914ae5eeec48d84f0d199d034b65260edf49a7c47bbd8c910e1bf62b2592237a352368d1640660b2c55c5e5cd355c79782350
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        perf  LEXBOR_WITH_PERF
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
@@ -11,13 +17,14 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+    ${FEATURE_OPTIONS}
     -DLEXBOR_BUILD_SHARED=${BUILD_SHARED}
     -DLEXBOR_BUILD_STATIC=${BUILD_STATIC}
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/include/lexbor/html/tree/insertion_mode"
     "${CURRENT_PACKAGES_DIR}/debug/include/lexbor/html/tree/insertion_mode"
 )

--- a/ports/lexbor/vcpkg.json
+++ b/ports/lexbor/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lexbor",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Lexbor is development of an open source HTML Renderer library.",
   "homepage": "https://github.com/lexbor/lexbor",
   "supports": "!uwp",
@@ -13,5 +13,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "perf": {
+      "description": "Enables support for rdtsc",
+      "supports": "!arm"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4257,7 +4257,7 @@
       "port-version": 3
     },
     "lexbor": {
-      "baseline": "2.3.0",
+      "baseline": "2.4.0",
       "port-version": 0
     },
     "lfreist-hwinfo": {

--- a/versions/l-/lexbor.json
+++ b/versions/l-/lexbor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a1c8b0e692108899df6b14cdc169e9af294aae83",
+      "version": "2.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae940a82ff44ebbeea58d1022e28ae1d1f853213",
       "version": "2.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

lexbor/2.4.0 adds `LEXBOR_WITH_PERF` cmake option.
