### PR TITLE
[libmultisense] Add LibMultiSense port

### DIFF
--- a/ports/libmultisense/portfile.cmake
+++ b/ports/libmultisense/portfile.cmake
@@ -1,0 +1,62 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO carnegierobotics/LibMultiSense
+    REF ${VERSION}
+    SHA512 354c9eec33e9153496b0858b8dc6e5735218585abecf885f356f643d833ebf00a63fc4571634283c430de07045f2be544b0e6d445599fce4c1655af671b758bd
+    HEAD_REF master
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        utilities MULTISENSE_BUILD_UTILITIES
+)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+set(PACKAGE_NAME MultiSense)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "${PACKAGE_NAME}"
+    CONFIG_PATH "lib/cmake/${PACKAGE_NAME}"
+)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+if ("utilities" IN_LIST FEATURES)
+    vcpkg_copy_tools(
+        TOOL_NAMES
+            AprilTagTestUtility
+            ChangeFps
+            ChangeIpUtility
+            ChangeResolution
+            ChangeTransmitDelay
+            ColorImageUtility
+            DeviceInfoUtility
+            ExternalCalUtility
+            FlashUtility
+            ImageCalUtility
+            ImuConfigUtility
+            ImuTestUtility
+            LidarCalUtility
+            PointCloudUtility
+            RectifiedFocalLengthUtility
+            SaveImageUtility
+            VersionInfoUtility
+        AUTO_CLEAN
+    )
+endif ()
+
+file(
+    INSTALL "${SOURCE_PATH}/LICENSE.TXT"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"     
+    RENAME copyright
+)
+file(
+    INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)

--- a/ports/libmultisense/portfile.cmake
+++ b/ports/libmultisense/portfile.cmake
@@ -1,3 +1,7 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO carnegierobotics/LibMultiSense

--- a/ports/libmultisense/usage
+++ b/ports/libmultisense/usage
@@ -1,0 +1,4 @@
+libmultisense provides CMake targets:
+
+    find_package(MultiSense)
+    target_link_libraries(main PRIVATE MultiSense)

--- a/ports/libmultisense/vcpkg.json
+++ b/ports/libmultisense/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "libmultisense",
+  "version": "6.1.0",
+  "description": "A C++ library for interfacing with the MultiSense S family of sensors from Carnegie Robotics.",
+  "homepage": "https://github.com/carnegierobotics/LibMultiSense",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "utilities": {
+      "description": "Build MultiSense utility applications."
+    }
+  }
+}

--- a/ports/libmultisense/vcpkg.json
+++ b/ports/libmultisense/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "6.1.0",
   "description": "A C++ library for interfacing with the MultiSense S family of sensors from Carnegie Robotics.",
   "homepage": "https://github.com/carnegierobotics/LibMultiSense",
+  "supports": "linux | (windows & !static)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4844,6 +4844,10 @@
       "baseline": "2.7.1",
       "port-version": 0
     },
+    "libmultisense": {
+      "baseline": "6.1.0",
+      "port-version": 0
+    },
     "libmupdf": {
       "baseline": "1.25.2",
       "port-version": 0

--- a/versions/l-/libmultisense.json
+++ b/versions/l-/libmultisense.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "421ae36bed4141d00e84d1877a00e0db37946734",
+      "git-tree": "720294982a8079963638f6ccb9a5292541f63e82",
       "version": "6.1.0",
       "port-version": 0
     }

--- a/versions/l-/libmultisense.json
+++ b/versions/l-/libmultisense.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "421ae36bed4141d00e84d1877a00e0db37946734",
+      "version": "6.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
