### PR TITLE
[qt5-webengine] fix spellcheck buildflags issue

### DIFF
--- a/ports/qt5-webengine/fix-spellcheck-buildflags.patch
+++ b/ports/qt5-webengine/fix-spellcheck-buildflags.patch
@@ -1,0 +1,12 @@
+diff --git a/src/3rdparty/chromium/content/browser/BUILD.gn b/src/3rdparty/chromium/content/browser/BUILD.gn
+index 1466f33d4..3fc848a56 100644
+--- a/src/3rdparty/chromium/content/browser/BUILD.gn
++++ b/src/3rdparty/chromium/content/browser/BUILD.gn
+@@ -40,6 +40,7 @@ jumbo_static_library("devtools_protocol") {
+     "//content/browser/devtools:protocol_sources",
+     "//content/common:buildflags",
+     "//third_party/inspector_protocol:crdtp",
++    "//components/spellcheck:buildflags",
+   ]
+ 
+   sources = [

--- a/ports/qt5-webengine/portfile.cmake
+++ b/ports/qt5-webengine/portfile.cmake
@@ -64,6 +64,7 @@ set(PATCHES common.pri.patch
             0001-Support-ICU-74-in-LazyTextBreakIterator.patch
             workaround-protobuf-issue.patch
             0001-Fix-jumbo-build-error-due-to-ResolveColor-redefiniti.patch
+	    fix-spellcheck-buildflags.patch
             )
 
 set(OPTIONS)

--- a/ports/qt5-webengine/vcpkg.json
+++ b/ports/qt5-webengine/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-webengine",
   "version": "5.15.16",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt WebEngine provides functionality for rendering regions of dynamic web content.",
   "license": null,
   "supports": "!static",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7538,7 +7538,7 @@
     },
     "qt5-webengine": {
       "baseline": "5.15.16",
-      "port-version": 1
+      "port-version": 2
     },
     "qt5-webglplugin": {
       "baseline": "5.15.16",

--- a/versions/q-/qt5-webengine.json
+++ b/versions/q-/qt5-webengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7785e40d08d000118d180514d7e5f5f30a75ada8",
+      "version": "5.15.16",
+      "port-version": 2
+    },
+    {
       "git-tree": "92f56035f25cfc039d74c70b6905c1b78e480e2e",
       "version": "5.15.16",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #43497
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
