### PR TITLE
[libtommath] Use cmake

### DIFF
--- a/ports/libtommath/bcrypt.patch
+++ b/ports/libtommath/bcrypt.patch
@@ -1,0 +1,50 @@
+diff --git a/bn_s_mp_rand_platform.c b/bn_s_mp_rand_platform.c
+--- a/bn_s_mp_rand_platform.c
++++ b/bn_s_mp_rand_platform.c
+@@ -32,20 +32,20 @@
+ #include <wincrypt.h>
+ 
+ static mp_err s_read_wincsp(void *p, size_t n)
+ {
+-   static HCRYPTPROV hProv = 0;
+-   if (hProv == 0) {
+-      HCRYPTPROV h = 0;
+-      if (!CryptAcquireContext(&h, NULL, MS_DEF_PROV, PROV_RSA_FULL,
+-                               (CRYPT_VERIFYCONTEXT | CRYPT_MACHINE_KEYSET)) &&
+-          !CryptAcquireContext(&h, NULL, MS_DEF_PROV, PROV_RSA_FULL,
+-                               CRYPT_VERIFYCONTEXT | CRYPT_MACHINE_KEYSET | CRYPT_NEWKEYSET)) {
++   static BCRYPT_ALG_HANDLE hAlg = 0;
++   if (hAlg == 0) {
++      BCRYPT_ALG_HANDLE h = 0;
++      NTSTATUS status = BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_RSA_ALGORITHM, NULL,
++                                                    BCRYPT_HASH_REUSABLE_FLAG);
++      if(!BCRYPT_SUCCESS(status)) {
+          return MP_ERR;
+       }
+-      hProv = h;
++      hAlg = h;
+    }
+-   return CryptGenRandom(hProv, (DWORD)n, (BYTE *)p) == TRUE ? MP_OKAY : MP_ERR;
++   NTSTATUS status = BCryptGenRandom(hAlg, (PUCHAR)p, (ULONG)n, 0);
++   return BCRYPT_SUCCESS(status) ? MP_OKAY : MP_ERR;
+ }
+ #endif /* WIN32 */
+ 
+ #if !defined(BN_S_READ_WINCSP_C) && defined(__linux__) && defined(__GLIBC_PREREQ)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -117,8 +117,13 @@
+ )
+ target_link_options(${PROJECT_NAME} BEFORE PRIVATE
+     ${LTM_LD_FLAGS}
+ )
++if(WIN32)
++    target_link_options(${PROJECT_NAME} PRIVATE
++        bcrypt.lib
++    )
++endif()
+ 
+ set(PUBLIC_HEADERS tommath.h)
+ set(C89 False CACHE BOOL "(Usually maintained automatically) Enable when the library is in c89 mode to package the correct header files on install")
+ if(C89)

--- a/ports/libtommath/has-set-double.patch
+++ b/ports/libtommath/has-set-double.patch
@@ -1,0 +1,14 @@
+diff --git a/bn_mp_set_double.c b/bn_mp_set_double.c
+--- a/bn_mp_set_double.c
++++ b/bn_mp_set_double.c
+@@ -2,9 +2,9 @@
+ #ifdef BN_MP_SET_DOUBLE_C
+ /* LibTomMath, multiple-precision integer library -- Tom St Denis */
+ /* SPDX-License-Identifier: Unlicense */
+ 
+-#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559)
++#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) || defined(_MSC_VER)
+ mp_err mp_set_double(mp_int *a, double b)
+ {
+    uint64_t frac;
+    int exp;

--- a/ports/libtommath/import-lib.patch
+++ b/ports/libtommath/import-lib.patch
@@ -1,0 +1,12 @@
+diff --git a/sources.cmake b/sources.cmake
+--- a/sources.cmake
++++ b/sources.cmake
+@@ -171,4 +171,8 @@
+ tommath_cutoffs.h
+ tommath_private.h
+ tommath_superclass.h
+ )
++
++if(WIN32)
++    list(APPEND SOURCES tommath.def)
++endif()

--- a/ports/libtommath/msvc-dce.patch
+++ b/ports/libtommath/msvc-dce.patch
@@ -1,0 +1,21 @@
+diff --git a/bn_s_mp_rand_platform.c b/bn_s_mp_rand_platform.c
+--- a/bn_s_mp_rand_platform.c
++++ b/bn_s_mp_rand_platform.c
+@@ -136,13 +136,17 @@
+ 
+ mp_err s_mp_rand_platform(void *p, size_t n)
+ {
+    mp_err err = MP_ERR;
++   #ifndef _MSC_VER
+    if ((err != MP_OKAY) && MP_HAS(S_READ_ARC4RANDOM)) err = s_read_arc4random(p, n);
++   #endif
+    if ((err != MP_OKAY) && MP_HAS(S_READ_WINCSP))     err = s_read_wincsp(p, n);
++   #ifndef _MSC_VER
+    if ((err != MP_OKAY) && MP_HAS(S_READ_GETRANDOM))  err = s_read_getrandom(p, n);
+    if ((err != MP_OKAY) && MP_HAS(S_READ_URANDOM))    err = s_read_urandom(p, n);
+    if ((err != MP_OKAY) && MP_HAS(S_READ_LTM_RNG))    err = s_read_ltm_rng(p, n);
++   #endif
+    return err;
+ }
+ 
+ #endif

--- a/ports/libtommath/usage
+++ b/ports/libtommath/usage
@@ -1,0 +1,9 @@
+libtommath provides CMake targets:
+
+  find_package(libtommath CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE libtommath)
+
+libtommath provides pkg-config modules:
+
+  # public domain library for manipulating large integer numbers
+  libtommath

--- a/ports/libtommath/vcpkg.json
+++ b/ports/libtommath/vcpkg.json
@@ -1,6 +1,17 @@
 {
   "name": "libtommath",
   "version": "1.3.0",
+  "port-version": 1,
   "description": "LibTomMath is a free open source portable number theoretic multiple-precision integer library written entirely in C.",
-  "homepage": "https://www.libtom.net/LibTomMath/"
+  "homepage": "https://www.libtom.net/LibTomMath/",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5226,7 +5226,7 @@
     },
     "libtommath": {
       "baseline": "1.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libtorch": {
       "baseline": "2.1.2",

--- a/versions/l-/libtommath.json
+++ b/versions/l-/libtommath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11ad9c01ff8b7c69858db06f1ed1a52dc9bbc2f7",
+      "version": "1.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2fd65dd0d956f575d8333a0b35ef08c3bc9bcbcd",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
