### PR TITLE
[libtorrent] update to 2.0.11

### DIFF
--- a/ports/libtorrent/portfile.cmake
+++ b/ports/libtorrent/portfile.cmake
@@ -31,7 +31,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO arvidn/libtorrent
         REF "v${VERSION}"
-        SHA512 fb55b04b57a6a1f39b81a4aff2ca899f9ac30b435c278c80181bdd3fef4775a3f91b2345c49b493503ae79ef89841e9a965af9974abe9022be3050922a4057f0
+        SHA512 375fb12754ce73b34b215c1ca077b0ec58a8c91f6a6e4a48e2ae55251be38f647405d135ebeae38f8b0dfb478bcea8d5f0d6509e97f1baddbc2cd2e788948f2a
         HEAD_REF RC_2_0
 )
 

--- a/ports/libtorrent/vcpkg.json
+++ b/ports/libtorrent/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtorrent",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "maintainers": "Arvid Norberg <arvid.norberg@gmail.com>",
   "description": "An efficient feature complete C++ BitTorrent implementation",
   "homepage": "https://libtorrent.org",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5233,7 +5233,7 @@
       "port-version": 10
     },
     "libtorrent": {
-      "baseline": "2.0.10",
+      "baseline": "2.0.11",
       "port-version": 0
     },
     "libtracepoint": {

--- a/versions/l-/libtorrent.json
+++ b/versions/l-/libtorrent.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f442bff5e6f8cc0a4a7b1226db0b7d8069b68b4c",
+      "version": "2.0.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "53949de9ace82d74179d388d9cd26f164a823657",
       "version": "2.0.10",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #43522
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.