### PR TITLE
[libebur128] fix build for arm64-windows

### DIFF
--- a/ports/libebur128/0001-remove-warning-message.patch
+++ b/ports/libebur128/0001-remove-warning-message.patch
@@ -1,0 +1,11 @@
+--- a/ebur128/ebur128.c	2021-02-14 15:31:05.000000000 +0100
++++ b/ebur128/ebur128.c	2025-01-28 10:43:26.975886500 +0100
+@@ -606,7 +606,7 @@
+ #define TURN_OFF_FTZ _mm_setcsr(mxcsr);
+ #define FLUSH_MANUALLY
+ #else
+-#warning "manual FTZ is being used, please enable SSE2 (-msse2 -mfpmath=sse)"
++//#warning "manual FTZ is being used, please enable SSE2 (-msse2 -mfpmath=sse)"
+ #define TURN_ON_FTZ
+ #define TURN_OFF_FTZ
+ #define FLUSH_MANUALLY                                                         \

--- a/ports/libebur128/portfile.cmake
+++ b/ports/libebur128/portfile.cmake
@@ -1,12 +1,10 @@
-if((VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64") AND VCPKG_TARGET_IS_WINDOWS)
-    message(FATAL_ERROR "${PORT} does not support Windows ARM")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jiixyj/libebur128
     REF v1.2.6
     SHA512 ab188c6d32cd14613119258313a8a3fb1167b55501c9f5b6d3ba738d674bc58f24ac3034c23d9730ed8dc3e95a23619bfb81719e4c79807a9a16c1a5b3423582
+    PATCHES
+        0001-remove-warning-message.patch
 )
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libebur128/vcpkg.json
+++ b/ports/libebur128/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "libebur128",
   "version": "1.2.6",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A library implementing the EBU R128 audio loudness standard",
   "homepage": "https://github.com/jiixyj/libebur128",
   "license": "MIT",
-  "supports": "!(arm & windows)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4486,7 +4486,7 @@
     },
     "libebur128": {
       "baseline": "1.2.6",
-      "port-version": 2
+      "port-version": 3
     },
     "libedit": {
       "baseline": "2024-08-08",

--- a/versions/l-/libebur128.json
+++ b/versions/l-/libebur128.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3254ea84f13ac860f7ee1643cccf89a1f225c534",
+      "version": "1.2.6",
+      "port-version": 3
+    },
+    {
       "git-tree": "97dd5a1812c03f1822d75e8fa10ade616c7d9f15",
       "version": "1.2.6",
       "port-version": 2


### PR DESCRIPTION
When you build libebur128 for arm64-windows, obviously that CPU doesn't support SSE2 instruction set, so a warning message is printed for telling the user that the portable C version is used instead. However, this warning made vcpkg to fail the build. This patch simply comments that `#warning` for the preprocessor and now the library can be built for also arm64 without troubles.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:
END OF PORT UPDATE CHECKLIST (delete this line) -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] ~~SHA512s are updated for each updated download.~~
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
