### PR TITLE
crashpad - fixes for release only

### DIFF
--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2024-04-11",
-  "port-version": 5,
+  "port-version": 6,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2026,7 +2026,7 @@
     },
     "crashpad": {
       "baseline": "2024-04-11",
-      "port-version": 5
+      "port-version": 6
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f4a723194e550246d2a2b2717d0d7d1135e09fb0",
+      "version-date": "2024-04-11",
+      "port-version": 6
+    },
+    {
       "git-tree": "8d69f9f6012875359ec0ec69b8808f80a4cf944b",
       "version-date": "2024-04-11",
       "port-version": 5


### PR DESCRIPTION
Building release only doesn't work

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.