### PR TITLE
Downgrade win_flex_bison to 2.5.24.

### DIFF
--- a/scripts/cmake/vcpkg_find_acquire_program(BISON).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(BISON).cmake
@@ -1,9 +1,9 @@
 if(CMAKE_HOST_WIN32)
     # This download shall be the same as in vcpkg_find_acquire_program(FLEX).cmake
-    set(program_version 2.5.25)
+    set(program_version 2.5.24)
     set(download_urls "https://github.com/lexxmark/winflexbison/releases/download/v${program_version}/win_flex_bison-${program_version}.zip")
     set(download_filename "win_flex_bison-${program_version}.zip")
-    set(download_sha512 2a829eb05003178c89f891dd0a67add360c112e74821ff28e38feb61dac5b66e9d3d5636ff9eef055616aaf282ee8d6be9f14c6ae4577f60bdcec96cec9f364e)
+    set(download_sha512 dc89fcdaa7071fbbf88b0755b799d69223240c28736924b4c30968c08e7e0b116c7e05ae98a9257be26a1dfb4aa70a628808a6b6018706bf857555c5b4335018)
     set(tool_subdirectory "${program_version}")
     set(program_name win_bison)
     set(paths_to_search "${DOWNLOADS}/tools/win_flex/${program_version}")

--- a/scripts/cmake/vcpkg_find_acquire_program(BISON).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(BISON).cmake
@@ -1,5 +1,8 @@
 if(CMAKE_HOST_WIN32)
     # This download shall be the same as in vcpkg_find_acquire_program(FLEX).cmake
+    # Note that this is 2.5.24 rather than 2.5.25 due to a race in %TEMP% in 2.5.25
+    # For more information, see: https://github.com/microsoft/vcpkg/issues/29139
+    # or: https://github.com/lexxmark/winflexbison/issues/86
     set(program_version 2.5.24)
     set(download_urls "https://github.com/lexxmark/winflexbison/releases/download/v${program_version}/win_flex_bison-${program_version}.zip")
     set(download_filename "win_flex_bison-${program_version}.zip")

--- a/scripts/cmake/vcpkg_find_acquire_program(FLEX).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(FLEX).cmake
@@ -1,5 +1,8 @@
 if(CMAKE_HOST_WIN32)
     # This download shall be the same as in vcpkg_find_acquire_program(BISON).cmake
+    # Note that this is 2.5.24 rather than 2.5.25 due to a race in %TEMP% in 2.5.25
+    # For more information, see: https://github.com/microsoft/vcpkg/issues/29139
+    # or: https://github.com/lexxmark/winflexbison/issues/86
     set(program_version 2.5.24)
     set(download_urls "https://github.com/lexxmark/winflexbison/releases/download/v${program_version}/win_flex_bison-${program_version}.zip")
     set(download_filename "win_flex_bison-${program_version}.zip")

--- a/scripts/cmake/vcpkg_find_acquire_program(FLEX).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(FLEX).cmake
@@ -1,9 +1,9 @@
 if(CMAKE_HOST_WIN32)
     # This download shall be the same as in vcpkg_find_acquire_program(BISON).cmake
-    set(program_version 2.5.25)
+    set(program_version 2.5.24)
     set(download_urls "https://github.com/lexxmark/winflexbison/releases/download/v${program_version}/win_flex_bison-${program_version}.zip")
     set(download_filename "win_flex_bison-${program_version}.zip")
-    set(download_sha512 2a829eb05003178c89f891dd0a67add360c112e74821ff28e38feb61dac5b66e9d3d5636ff9eef055616aaf282ee8d6be9f14c6ae4577f60bdcec96cec9f364e)
+    set(download_sha512 dc89fcdaa7071fbbf88b0755b799d69223240c28736924b4c30968c08e7e0b116c7e05ae98a9257be26a1dfb4aa70a628808a6b6018706bf857555c5b4335018)
     set(tool_subdirectory "${program_version}")
     set(program_name win_flex)
     set(paths_to_search "${DOWNLOADS}/tools/win_flex/${program_version}")


### PR DESCRIPTION
Attempts to workaround https://github.com/microsoft/vcpkg/issues/29139 / https://github.com/lexxmark/winflexbison/issues/86

It looks like others are pinning 1 version older and that seems to fix the problem for them.

Related: https://github.com/m-kuhn/QGIS/commit/23d6c2f2da57100ee7b04a280e3982f50421fd28
Related: https://github.com/microsoft/vcpkg/pull/23084
Related: https://github.com/lexxmark/winflexbison/commit/2bfaf44a53b7282615cd611378f0b4e936c819b1 (appears to be a fix, but no release has happened yet)
