### PR TITLE
[octave] add features

### DIFF
--- a/ports/octave/dep_pc_names.patch
+++ b/ports/octave/dep_pc_names.patch
@@ -1,0 +1,14 @@
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -1520,9 +1520,9 @@
+ ### Check for BZIP2 library.
+ 
+ OCTAVE_CHECK_LIB(bz2, BZIP2,
+   [BZIP2 library not found.  Octave will not be able to compress or decompress bzip2 files.],
+-  [bzlib.h], [BZ2_bzCompressInit])
++  [bzlib.h], [BZ2_bzCompressInit],[],[],[],[bzip2])
+ 
+ ### Check for HDF5 library.
+ 
+ save_CPPFLAGS="$CPPFLAGS"

--- a/ports/octave/portfile.cmake
+++ b/ports/octave/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_extract_source_archive(
     ARCHIVE "${ARCHIVE}"
     PATCHES
         run-mk-ops.diff
+        dep_pc_names.patch
 )
 
 include(vcpkg_find_fortran)
@@ -36,6 +37,96 @@ if(VCPKG_HOST_IS_OSX)
     message("${PORT} currently requires the following programs from the system package manager:\n    gsed\n\nIt can be installed with brew gnu-sed")
 endif()
 
+if("bz2" IN_LIST FEATURES)
+    set(BZ2_OPTION "yes")
+else()
+    set(BZ2_OPTION "no")
+endif()
+
+set(SUITESPARSECONFIG_OPTION "no")
+
+if("amd" IN_LIST FEATURES)
+    set(AMD_OPTION "yes")
+    set(SUITESPARSECONFIG_OPTION "yes")
+else()
+    set(AMD_OPTION "no")
+endif()
+
+if("camd" IN_LIST FEATURES)
+    set(CAMD_OPTION "yes")
+    set(SUITESPARSECONFIG_OPTION "yes")
+else()
+    set(CAMD_OPTION "no")
+endif()
+
+if("ccolamd" IN_LIST FEATURES)
+    set(CCOLAMD_OPTION "yes")
+    set(SUITESPARSECONFIG_OPTION "yes")
+else()
+    set(CCOLAMD_OPTION "no")
+endif()
+
+if("cholmod" IN_LIST FEATURES)
+    set(CHOLMOD_OPTION "yes")
+    set(SUITESPARSECONFIG_OPTION "yes")
+else()
+    set(CHOLMOD_OPTION "no")
+endif()
+
+if("colamd" IN_LIST FEATURES)
+    set(COLAMD_OPTION "yes")
+    set(SUITESPARSECONFIG_OPTION "yes")
+else()
+    set(COLAMD_OPTION "no")
+endif()
+
+if("cxsparse" IN_LIST FEATURES)
+    set(CXSPARSE_OPTION "yes")
+    set(SUITESPARSECONFIG_OPTION "yes")
+else()
+    set(CXSPARSE_OPTION "no")
+endif()
+
+if("klu" IN_LIST FEATURES)
+    set(KLU_OPTION "yes")
+    set(SUITESPARSECONFIG_OPTION "yes")
+else()
+    set(KLU_OPTION "no")
+endif()
+
+if("umfpack" IN_LIST FEATURES)
+    set(UMFPACK_OPTION "yes")
+    set(SUITESPARSECONFIG_OPTION "yes")
+else()
+    set(UMFPACK_OPTION "no")
+endif()
+
+if("hdf5" IN_LIST FEATURES)
+    set(HDF5_OPTION "yes")
+else()
+    set(HDF5_OPTION "no")
+endif()
+
+if("fltk" IN_LIST FEATURES)
+    set(FLTK_OPTION "yes")
+else()
+    set(FLTK_OPTION "no")
+endif()
+
+if("fontconfig" IN_LIST FEATURES)
+    set(FONTCONFIG_OPTION "yes")
+else()
+    set(FONTCONFIG_OPTION "no")
+endif()
+
+if("freetype" IN_LIST FEATURES)
+    set(FREETYPE_OPTION "yes")
+else()
+    set(FREETYPE_OPTION "no")
+endif()
+
+vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/fltk")
+
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
@@ -45,24 +136,23 @@ vcpkg_configure_make(
     --disable-hg-id
     --enable-lib-visibility-flags
     --enable-relocate-all
-    --with-amd=no
+    --with-amd=${AMD_OPTION}
     --with-arpack=no
-    --with-bz2=no
-    --with-camd=no
-    --with-ccolamd=no
-    --with-cholmod=no
-    --with-colamd=no
-    --with-cxsparse=no
+    --with-bz2=${BZ2_OPTION}
+    --with-camd=${CAMD_OPTION}
+    --with-ccolamd=${CCOLAMD_OPTION}
+    --with-cholmod=${CHOLMOD_OPTION}
+    --with-colamd=${COLAMD_OPTION}
+    --with-cxsparse=${CXSPARSE_OPTION}
     --with-curl=no
-    --with-cxsparse=no
     --with-fftw3 # yes
     --with-fftw3f # yes
-    --with-fltk=no
-    --with-fontconfig=no
-    --with-freetype=no
+    --with-fltk=${FLTK_OPTION}
+    --with-fontconfig=${FONTCONFIG_OPTION}
+    --with-freetype=${FREETYPE_OPTION}
     --with-glpk # yes
-    --with-hdf5=no
-    --with-klu=no
+    --with-hdf5=${HDF5_OPTION}
+    --with-klu=${KLU_OPTION}
     --with-magick=no
     --with-opengl # yes
     --with-portaudio=no
@@ -73,10 +163,10 @@ vcpkg_configure_make(
     --with-qt=no
     --with-sndfile # yes
     --with-spqr=no
-    --with-suitesparseconfig=no
+    --with-suitesparseconfig=${SUITESPARSECONFIG_OPTION}
     --with-sundials_ida=no
     --with-sundials_nvecserial=no
-    --with-umfpack=no
+    --with-umfpack=${UMFPACK_OPTION}
     --with-z # yes
 )
 vcpkg_install_make()

--- a/ports/octave/vcpkg.json
+++ b/ports/octave/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "octave",
   "version": "9.3.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "High-level interpreted language, primarily intended for numerical computations.",
   "homepage": "https://octave.org/",
   "documentation": "https://docs.octave.org/latest/",
@@ -17,5 +17,124 @@
     "pcre2",
     "readline",
     "zlib"
-  ]
+  ],
+  "features": {
+    "amd": {
+      "description": "suitesparse-amd support",
+      "dependencies": [
+        {
+          "name": "suitesparse-amd",
+          "default-features": false
+        }
+      ]
+    },
+    "bz2": {
+      "description": "bzip2 support",
+      "dependencies": [
+        {
+          "name": "bzip2",
+          "default-features": false
+        }
+      ]
+    },
+    "camd": {
+      "description": "suitesparse-camd support",
+      "dependencies": [
+        {
+          "name": "suitesparse-camd",
+          "default-features": false
+        }
+      ]
+    },
+    "ccolamd": {
+      "description": "suitesparse-ccolamd support",
+      "dependencies": [
+        {
+          "name": "suitesparse-ccolamd",
+          "default-features": false
+        }
+      ]
+    },
+    "cholmod": {
+      "description": "suitesparse-cholmod support",
+      "dependencies": [
+        {
+          "name": "suitesparse-cholmod",
+          "default-features": false
+        }
+      ]
+    },
+    "colamd": {
+      "description": "suitesparse-colamd support",
+      "dependencies": [
+        {
+          "name": "suitesparse-colamd",
+          "default-features": false
+        }
+      ]
+    },
+    "cxsparse": {
+      "description": "suitesparse-cxsparse support",
+      "dependencies": [
+        {
+          "name": "suitesparse-cxsparse",
+          "default-features": false
+        }
+      ]
+    },
+    "fltk": {
+      "description": "fltk support",
+      "dependencies": [
+        {
+          "name": "fltk",
+          "default-features": false
+        }
+      ]
+    },
+    "fontconfig": {
+      "description": "fontconfig support",
+      "dependencies": [
+        {
+          "name": "fontconfig",
+          "default-features": false
+        }
+      ]
+    },
+    "freetype": {
+      "description": "freetype support",
+      "dependencies": [
+        {
+          "name": "freetype",
+          "default-features": false
+        }
+      ]
+    },
+    "hdf5": {
+      "description": "hdf5 support",
+      "dependencies": [
+        {
+          "name": "hdf5",
+          "default-features": false
+        }
+      ]
+    },
+    "klu": {
+      "description": "suitesparse-klu support",
+      "dependencies": [
+        {
+          "name": "suitesparse-klu",
+          "default-features": false
+        }
+      ]
+    },
+    "umfpack": {
+      "description": "suitesparse-umfpack support",
+      "dependencies": [
+        {
+          "name": "suitesparse-umfpack",
+          "default-features": false
+        }
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6554,7 +6554,7 @@
     },
     "octave": {
       "baseline": "9.3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "octomap": {
       "baseline": "1.10.0",

--- a/versions/o-/octave.json
+++ b/versions/o-/octave.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "802b30081c9cc3102f4bc8badc74ce173d21bb0f",
+      "version": "9.3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "cc528d9865bd5b487ad0b152cdedc809b64e497f",
       "version": "9.3.0",
       "port-version": 1


### PR DESCRIPTION
add amd,bz2,camd,ccolamd,cholmod,colamd,core,cxsparse,fltk,fontconfig,freetype,hdf5,klu,umfpack features

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
