### PR TITLE
[toml11] update to 4.3.0

### DIFF
--- a/ports/toml11/portfile.cmake
+++ b/ports/toml11/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ToruNiina/toml11
     REF "v${VERSION}"
-    SHA512 acb29d37150e5752526cf0a38ae7f207fcfd142d3c78d280e706ad404b2d32f5bae6d44d6ce13cc0bdfd3b0fa4a0a94cf732d70b1fd2a01c3c517fee8a4ef05b
+    SHA512 2ceed4f5783a88f9bfb6d044cbf3d1d5dd2b061d4cbe89e9c4e8773b85d37005562365e5e61e68a345867d1c2b3ab9c5ecdc98356b3cdb944b94201ed5edd00b
     HEAD_REF master
 )
 

--- a/ports/toml11/vcpkg.json
+++ b/ports/toml11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "toml11",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "A C++11 header-only toml parser/encoder depending only on C++ standard library.",
   "homepage": "https://github.com/ToruNiina/toml11",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9189,7 +9189,7 @@
       "port-version": 0
     },
     "toml11": {
-      "baseline": "4.2.0",
+      "baseline": "4.3.0",
       "port-version": 0
     },
     "tomlplusplus": {

--- a/versions/t-/toml11.json
+++ b/versions/t-/toml11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f26fdec7e40f482f63d521e552cc636c0ed7a913",
+      "version": "4.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d42cf90d8c98a2a3da2c0d3cd94f038b9093eb60",
       "version": "4.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
