### PR TITLE
[eabase] update to 2024-08-18 (for eastl, eathread)

### DIFF
--- a/ports/eabase/fix_cmake_install.patch
+++ b/ports/eabase/fix_cmake_install.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 89c6703..ab8e553 100644
+index 652f07f..264aaf5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -4,6 +4,9 @@
@@ -12,64 +12,50 @@ index 89c6703..ab8e553 100644
  #-------------------------------------------------------------------------------------------
  # Options
  #-------------------------------------------------------------------------------------------
-@@ -22,13 +25,51 @@ endif()
- add_definitions(-D_CHAR16T)
- 
- if (NOT EABASE_BUILD_TESTS)
--	#-------------------------------------------------------------------------------------------
--	# Header only library 
--	#-------------------------------------------------------------------------------------------
--	add_library(EABase INTERFACE) 
+@@ -24,14 +27,38 @@ add_definitions(-D_CHAR16T)
+ #-------------------------------------------------------------------------------------------
+ # Header only library 
+ #-------------------------------------------------------------------------------------------
+-add_library(EABase INTERFACE) 
 -
--	#-------------------------------------------------------------------------------------------
--	# Include dirs
--	#-------------------------------------------------------------------------------------------
--	target_include_directories(EABase INTERFACE include/Common)
-+    #-------------------------------------------------------------------------------------------
-+    # Header only library 
-+    #-------------------------------------------------------------------------------------------
-+    add_library(EABase INTERFACE)
-+    add_library(EABase::EABase ALIAS EABase)
-+
-+    #-------------------------------------------------------------------------------------------
-+    # Include dirs
-+    #-------------------------------------------------------------------------------------------
-+    target_include_directories(EABase INTERFACE
-+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/Common>
-+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-+    )
-+
-+    # create and install an export set for eabase target as EABase::EABase
-+    set(EABase_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/EABase")
-+
-+    configure_package_config_file(
-+        EABaseConfig.cmake.in
-+        ${CMAKE_CURRENT_BINARY_DIR}/EABaseConfig.cmake
-+        INSTALL_DESTINATION ${EABase_CMAKE_CONFIG_DESTINATION}
-+    )
-+
-+    # create and install an export set for Terra target as Terra
-+    install(
-+        TARGETS EABase EXPORT EABaseTargets
-+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+    )
-+
-+
-+    install(EXPORT EABaseTargets DESTINATION ${EABase_CMAKE_CONFIG_DESTINATION})
-+
-+    write_basic_package_version_file(
-+      "${CMAKE_CURRENT_BINARY_DIR}/EABaseConfigVersion.cmake"
-+      VERSION 2.09.12
-+      COMPATIBILITY SameMajorVersion
-+    )
-+
-+    install(TARGETS EABase LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-+    install(DIRECTORY "include/Common/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-+
-+    install(
-+        FILES
-+            "${CMAKE_CURRENT_BINARY_DIR}/EABaseConfig.cmake"
-+            "${CMAKE_CURRENT_BINARY_DIR}/EABaseConfigVersion.cmake"
-+        DESTINATION ${EABase_CMAKE_CONFIG_DESTINATION}
-+    )
- endif()
++add_library(EABase INTERFACE)
++add_library(EABase::EABase ALIAS EABase)
+ #-------------------------------------------------------------------------------------------
+ # Include dirs
+ #-------------------------------------------------------------------------------------------
+-target_include_directories(EABase INTERFACE include/Common)
+-
+-#-------------------------------------------------------------------------------------------
+-# Installation
+-#-------------------------------------------------------------------------------------------
+-install(DIRECTORY include/Common/EABase DESTINATION include)
++target_include_directories(EABase INTERFACE
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/Common>
++    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++)
++# create and install an export set for eabase target as EABase::EABase
++set(EABase_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/EABase")
++configure_package_config_file(
++    EABaseConfig.cmake.in
++    ${CMAKE_CURRENT_BINARY_DIR}/EABaseConfig.cmake
++    INSTALL_DESTINATION ${EABase_CMAKE_CONFIG_DESTINATION}
++)
++# create and install an export set for Terra target as Terra
++install(
++    TARGETS EABase EXPORT EABaseTargets
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
++install(EXPORT EABaseTargets DESTINATION ${EABase_CMAKE_CONFIG_DESTINATION})
++write_basic_package_version_file(
++  "${CMAKE_CURRENT_BINARY_DIR}/EABaseConfigVersion.cmake"
++  VERSION 2.09.12
++  COMPATIBILITY SameMajorVersion
++)
++install(TARGETS EABase LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
++install(DIRECTORY "include/Common/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++install(
++    FILES
++        "${CMAKE_CURRENT_BINARY_DIR}/EABaseConfig.cmake"
++        "${CMAKE_CURRENT_BINARY_DIR}/EABaseConfigVersion.cmake"
++    DESTINATION ${EABase_CMAKE_CONFIG_DESTINATION}
++)

--- a/ports/eabase/portfile.cmake
+++ b/ports/eabase/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO electronicarts/EABase
-    REF d1be0a1d0fc01a9bf8f3f2cea75018df0d2410ee
-    SHA512 84a11bea06aecbf9a659d92b1ac904b99b2b82023650f4f376b5e68a744f631c5dbdd53d25f746ffb01b428415ac86e4fb8ba758db844acf80560fabe4d77733
+    REF 123363eb82e132c0181ac53e43226d8ee76dea12
+    SHA512 8df5279d1b303047e832b8b0ddb6cdf51cca753efaeb2a36f7fa5ebc015c2f37cc6a68184b919deb45f09dfd89f9f8f79f18c487817d231f1b049102ceae610f
     HEAD_REF master
     PATCHES
     fix_cmake_install.patch

--- a/ports/eabase/vcpkg.json
+++ b/ports/eabase/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "eabase",
-  "version-string": "2.09.12",
-  "port-version": 3,
+  "version-date": "2024-08-18",
   "description": "Electronic Arts Base. EABase is a small set of header files that define platform-independent data types and macros.",
   "homepage": "https://github.com/electronicarts/EABase",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2457,8 +2457,8 @@
       "port-version": 0
     },
     "eabase": {
-      "baseline": "2.09.12",
-      "port-version": 3
+      "baseline": "2024-08-18",
+      "port-version": 0
     },
     "earcut-hpp": {
       "baseline": "2.2.4",

--- a/versions/e-/eabase.json
+++ b/versions/e-/eabase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "414a2b49e81c82eefcd778b01c1dc66ade9ad4fc",
+      "version-date": "2024-08-18",
+      "port-version": 0
+    },
+    {
       "git-tree": "71d9d1d988dad11e4eaa0cb39cc1a957a839308d",
       "version-string": "2.09.12",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The eabase was updated on 2024-08-18 and has not been released or tagged yet.
[Issue about this](https://github.com/electronicarts/EABase/issues/12) was created 3 months ago and has not yet received any response.

Meanwhile, the latest eastl and eathread need the latest eabase because they include the latest eabase by git submodule.

This PR is to bring eabase up to date in order to upgrade eastl and eathread.



