### PR TITLE
[imgui] add sdl3 bindings

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -99,6 +99,18 @@ if(IMGUI_BUILD_SDL2_RENDERER_BINDING)
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer2.cpp)
 endif()
 
+if(IMGUI_BUILD_SDL3_BINDING)
+    find_package(SDL3 CONFIG REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC SDL3::SDL3)
+    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdl3.cpp)
+endif()
+
+if(IMGUI_BUILD_SDL3_RENDERER_BINDING)
+    find_package(SDL3 CONFIG REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC SDL3::SDL3)
+    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer3.cpp)
+endif()
+
 if(IMGUI_BUILD_VULKAN_BINDING)
     find_package(Vulkan REQUIRED)
     target_link_libraries(${PROJECT_NAME} PUBLIC Vulkan::Vulkan)
@@ -235,6 +247,14 @@ if(NOT IMGUI_SKIP_HEADERS)
 
     if(IMGUI_BUILD_SDL2_RENDERER_BINDING)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer2.h DESTINATION include)
+    endif()
+
+    if(IMGUI_BUILD_SDL3_BINDING)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdl3.h DESTINATION include)
+    endif()
+
+    if(IMGUI_BUILD_SDL3_RENDERER_BINDING)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer3.h DESTINATION include)
     endif()
 
     if(IMGUI_BUILD_VULKAN_BINDING)

--- a/ports/imgui/imgui-config.cmake.in
+++ b/ports/imgui/imgui-config.cmake.in
@@ -18,6 +18,10 @@ if (@IMGUI_BUILD_SDL2_BINDING@ OR @IMGUI_BUILD_SDL2_RENDERER_BINDING@)
     find_dependency(SDL2 CONFIG)
 endif()
 
+if (@IMGUI_BUILD_SDL3_BINDING@ OR @IMGUI_BUILD_SDL3_RENDERER_BINDING@)
+    find_dependency(SDL3 CONFIG)
+endif()
+
 if (@IMGUI_BUILD_VULKAN_BINDING@)
     find_dependency(Vulkan)
 endif()

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -37,6 +37,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     osx-binding                 IMGUI_BUILD_OSX_BINDING
     sdl2-binding                IMGUI_BUILD_SDL2_BINDING
     sdl2-renderer-binding       IMGUI_BUILD_SDL2_RENDERER_BINDING
+    sdl3-binding                IMGUI_BUILD_SDL3_BINDING
+    sdl3-renderer-binding       IMGUI_BUILD_SDL3_RENDERER_BINDING
     vulkan-binding              IMGUI_BUILD_VULKAN_BINDING
     win32-binding               IMGUI_BUILD_WIN32_BINDING
     freetype                    IMGUI_FREETYPE

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui",
   "version": "1.91.7",
+  "port-version": 1,
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",
@@ -105,6 +106,18 @@
       "description": "Make available SDL2 Renderer binding",
       "dependencies": [
         "sdl2"
+      ]
+    },
+    "sdl3-binding": {
+      "description": "Make available SDL3 binding",
+      "dependencies": [
+        "sdl3"
+      ]
+    },
+    "sdl3-renderer-binding": {
+      "description": "Make available SDL3 Renderer binding",
+      "dependencies": [
+        "sdl3"
       ]
     },
     "test-engine": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3682,7 +3682,7 @@
     },
     "imgui": {
       "baseline": "1.91.7",
-      "port-version": 0
+      "port-version": 1
     },
     "imgui-node-editor": {
       "baseline": "0.9.3",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69517b01167c917a8e80937a97cdb6701ad986ee",
+      "version": "1.91.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "9d76ee1246a4a6211168fdefd19a6e70e74605fc",
       "version": "1.91.7",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
