### PR TITLE
aws - force them to use vcpkg openssl

### DIFF
--- a/ports/aws-c-cal/portfile.cmake
+++ b/ports/aws-c-cal/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_cmake_configure(
     OPTIONS
         "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common" # use extra cmake files
         -DBUILD_TESTING=FALSE
+        -DUSE_OPENSSL=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/aws-c-cal/vcpkg.json
+++ b/ports/aws-c-cal/vcpkg.json
@@ -1,15 +1,13 @@
 {
   "name": "aws-c-cal",
   "version": "0.8.1",
+  "port-version": 1,
   "description": "C99 wrapper for cryptography primitives.",
   "homepage": "https://github.com/awslabs/aws-c-cal",
   "license": "Apache-2.0",
   "dependencies": [
     "aws-c-common",
-    {
-      "name": "openssl",
-      "platform": "!windows & !osx"
-    },
+    "openssl",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/s2n/openssl.patch
+++ b/ports/s2n/openssl.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d16e5f5f0..133934580 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -266,9 +266,10 @@ if (TARGET crypto)
+     message(STATUS "S2N found target: crypto")
+     set(LINK_LIB "crypto")
+ else()
+-    find_package(crypto REQUIRED)
+-    message(STATUS "Using libcrypto from the cmake path")
+-    set(LINK_LIB "AWS::crypto")
++   find_package(OpenSSL REQUIRED)
++   find_package(Threads REQUIRED)
++   set(LINK_LIB OpenSSL::Crypto Threads::Threads)
++   message(STATUS "Using libcrypto from system: ${OPENSSL_CRYPTO_LIBRARY}")    
+ endif()
+ 
+ if (S2N_INTERN_LIBCRYPTO)

--- a/ports/s2n/portfile.cmake
+++ b/ports/s2n/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 17f49a114a3e3934cea2ebff47198417927d405194f901540380844f9481d11ccff2219b3512bd20a1f3d1945515b637b609aceaaa3b55701574df1d859125ec
     PATCHES
         fix-cmake-target-path.patch
+        openssl.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/s2n/vcpkg.json
+++ b/ports/s2n/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "s2n",
   "version": "1.5.9",
+  "port-version": 1,
   "description": "C99 implementation of the TLS/SSL protocols.",
   "homepage": "https://github.com/aws/s2n-tls",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-cal.json
+++ b/versions/a-/aws-c-cal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae1e76b2294cf592859b288d712026c46a69b57e",
+      "version": "0.8.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "2cdde2097cab22f8b121239ab9e0484efd564dd7",
       "version": "0.8.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -394,7 +394,7 @@
     },
     "aws-c-cal": {
       "baseline": "0.8.1",
-      "port-version": 0
+      "port-version": 1
     },
     "aws-c-common": {
       "baseline": "0.10.6",
@@ -8138,7 +8138,7 @@
     },
     "s2n": {
       "baseline": "1.5.9",
-      "port-version": 0
+      "port-version": 1
     },
     "safeint": {
       "baseline": "3.0.28",

--- a/versions/s-/s2n.json
+++ b/versions/s-/s2n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "95874bf291a388a7594609bd1a2d6a1d06d18f9d",
+      "version": "1.5.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "c97aa61e43c57233ca6d62a3e364d85651f9c0ac",
       "version": "1.5.9",
       "port-version": 0


### PR DESCRIPTION
This fixes an issue when aws links against system libcrypto.a instead of vcpkg one creating crashes

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.