### PR TITLE
[tinyfiledialogs] Update, reproducible download

### DIFF
--- a/ports/tinyfiledialogs/portfile.cmake
+++ b/ports/tinyfiledialogs/portfile.cmake
@@ -1,30 +1,44 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
 
-vcpkg_from_sourceforge(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO tinyfiledialogs
-    FILENAME tinyfiledialogs-current.zip
-    SHA512 6e890014646e69f0002a342d6331ec03dc41749a760dd30ac8a99919adbfc8ba646f988d1f44b0c1991a075d9cd054e481014c8cc8c5e9e8ec56ce2600d6fb03
+# git: not cachable
+# tinyfiledialogs-current.zip: changing SHA512
+# last resort: explicit source files
+# Reviewers may compare git and zip sources at the time of the port update.
+set(ref b071fb40ad9b321408d480a6d1433bf21be01578)
+string(SUBSTRING "${ref}" 0 7 short_ref)
+vcpkg_download_distfile(tinyfiledialogs_c_file
+    URLS "https://sourceforge.net/p/tinyfiledialogs/code/ci/${ref}/tree/tinyfiledialogs.c?format=raw"
+    FILENAME "tinyfiledialogs-${short_ref}.c"
+    SHA512 cc8dd57d47ed9b449d91a66dad421140ef2aa8da00c622c0de3c13c9587ff1b7165343b61e40a2240eef7d15dc27fe28bd4595c89b52e3775060229a7c8a5926
+)
+vcpkg_download_distfile(tinyfiledialogs_h_file
+    URLS "https://sourceforge.net/p/tinyfiledialogs/code/ci/${ref}/tree/tinyfiledialogs.h?format=raw"
+    FILENAME "tinyfiledialogs-${short_ref}.h"
+    SHA512 7b95aa5e32065aee9d16a7cafe644ed93bc9e4cd139882f0298572da1418305ce30d0770e1a6f2b441fb7d9bcb710d57b54ca3c2eb67c9fd5f04c0fdbece31bf
 )
 
-file(REMOVE_RECURSE "${SOURCE_PATH}/dll_cs_lua_R_fortran_pascal")
+file(READ "${tinyfiledialogs_c_file}" c_source)
+if(NOT c_source MATCHES "tinyfd_version.8. = \"([^\"]*)\"" OR NOT CMAKE_MATCH_1 STREQUAL VERSION)
+    message(FATAL_ERROR "Source doesn't declare match version ${VERSION}.")
+elseif(NOT c_source MATCHES [[- License -[\r\n]*(.*)]])
+    message(FATAL_ERROR "Failed to parse license from tinyfiledialogs.c")
+endif()
+string(REGEX REPLACE " *__*.*" "" license "${CMAKE_MATCH_1}")
 
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+set(source_path "${CURRENT_BUILDTREES_DIR}/src/${short_ref}")
+file(MAKE_DIRECTORY "${source_path}")
+file(COPY_FILE "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" "${source_path}/CMakeLists.txt")
+file(COPY_FILE "${tinyfiledialogs_c_file}" "${source_path}/tinyfiledialogs.c")
+file(COPY_FILE "${tinyfiledialogs_h_file}" "${source_path}/tinyfiledialogs.h")
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
+    SOURCE_PATH "${source_path}"
 )
-
 vcpkg_cmake_install()
-
 vcpkg_cmake_config_fixup()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(READ "${CURRENT_PACKAGES_DIR}/include/tinyfiledialogs/tinyfiledialogs.h" _contents)
-# reads between the line "- License -" and a closing "*/"
-if (NOT _contents MATCHES [[- License -(([^*]|\*[^/])*)\*/]])
-    message(FATAL_ERROR "Failed to parse license from tinyfiledialogs.h")
-endif()
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "${CMAKE_MATCH_1}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "${license}")

--- a/ports/tinyfiledialogs/vcpkg.json
+++ b/ports/tinyfiledialogs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyfiledialogs",
-  "version": "3.18.2",
+  "version": "3.19.1",
   "description": "Highly portable and cross-platform dialogs for native inputbox, passwordbox, colorpicker and more",
   "homepage": "https://sourceforge.net/projects/tinyfiledialogs/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9093,7 +9093,7 @@
       "port-version": 0
     },
     "tinyfiledialogs": {
-      "baseline": "3.18.2",
+      "baseline": "3.19.1",
       "port-version": 0
     },
     "tinyfsm": {

--- a/versions/t-/tinyfiledialogs.json
+++ b/versions/t-/tinyfiledialogs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5feca6edf564fe0018f86925bcb0c32263dfdb48",
+      "version": "3.19.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "66dd1c60462dca8ace6d295559d268a9d958c5c0",
       "version": "3.18.2",
       "port-version": 0


### PR DESCRIPTION
Updates to 3.19.1.
Avoids the download with changing SHA512 by loading the two source file directly. Amends #43413, CC @BillyONeal. Fixes https://github.com/microsoft/vcpkg/issues/43483.
Enables shared libs on non-Windows.