### PR TITLE
[libzip] update to 1.11.3

### DIFF
--- a/ports/libzip/portfile.cmake
+++ b/ports/libzip/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nih-at/libzip
     REF "v${VERSION}"
-    SHA512 1b0bffe579de5d2c52b23075f5351a5670e9f7a364c14a876ca3c490a85c0c9b1ebd9a97e729c5c7e71d496a3a0a8f28505bfadd7d8423954d3547a9a8f63841
+    SHA512 cf7795ba52685bfc90cf4a3f993d29d6e27eabaca486098e04971fca31ab90a887194e6a77a5a9e19ade1a1d0855400c8108aa79724618f4204b1ba8d5e42c9d
     HEAD_REF master
     PATCHES
         fix-dependency.patch
@@ -38,7 +38,7 @@ vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libzip)
 vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
- 
+
 # Remove include directories from lib
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/libzip" "${CURRENT_PACKAGES_DIR}/debug/lib/libzip")
 

--- a/ports/libzip/use-requires.patch
+++ b/ports/libzip/use-requires.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b2e7724..0af7929 100644
+index 472a7a2..f9479be 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -43,12 +43,14 @@ endif()
+@@ -48,12 +48,14 @@ endif()
  if(ENABLE_GNUTLS)
    find_package(Nettle 3.0)
    find_package(GnuTLS)
@@ -17,7 +17,7 @@ index b2e7724..0af7929 100644
  endif()
  if(WIN32)
    if(ENABLE_WINDOWS_CRYPTO)
-@@ -191,6 +193,7 @@ int main(int argc, char *argv[]) { }" HAVE_NULLABLE)
+@@ -196,6 +198,7 @@ int main(int argc, char *argv[]) { unsigned long x = FICLONERANGE; }" HAVE_FICLO
  test_big_endian(WORDS_BIGENDIAN)
  
  find_package(ZLIB 1.1.2 REQUIRED)
@@ -25,7 +25,7 @@ index b2e7724..0af7929 100644
  # so developers on systems where zlib is named differently (Windows, sometimes)
  # can override the name used in the pkg-config file
  if (NOT ZLIB_LINK_LIBRARY_NAME)
-@@ -227,6 +230,7 @@ if(ENABLE_BZIP2)
+@@ -232,6 +235,7 @@ if(ENABLE_BZIP2)
    else()
      message(WARNING "-- bzip2 library not found; bzip2 support disabled")
    endif(BZIP2_FOUND)
@@ -33,7 +33,7 @@ index b2e7724..0af7929 100644
  endif(ENABLE_BZIP2)
  
  if(ENABLE_LZMA)
-@@ -236,6 +240,7 @@ if(ENABLE_LZMA)
+@@ -241,6 +245,7 @@ if(ENABLE_LZMA)
    else()
      message(WARNING "-- lzma library not found; lzma/xz support disabled")
    endif(LIBLZMA_FOUND)
@@ -41,7 +41,7 @@ index b2e7724..0af7929 100644
  endif(ENABLE_LZMA)
  
  if(ENABLE_ZSTD)
-@@ -250,6 +255,7 @@ if(ENABLE_ZSTD)
+@@ -255,6 +260,7 @@ if(ENABLE_ZSTD)
    else()
      message(WARNING "-- zstd library not found; zstandard support disabled")
    endif(zstd_FOUND)
@@ -49,7 +49,7 @@ index b2e7724..0af7929 100644
  endif(ENABLE_ZSTD)
  
  if (COMMONCRYPTO_FOUND)
-@@ -347,15 +353,16 @@ foreach(LIB ${LIBS_PRIVATE})
+@@ -356,15 +362,16 @@ foreach(LIB ${LIBS_PRIVATE})
    set(LIBS "${LIBS} -l${LIB}")
  endforeach()
  STRING(CONCAT zlib_link_name "-l" ${ZLIB_LINK_LIBRARY_NAME})
@@ -57,7 +57,7 @@ index b2e7724..0af7929 100644
 -string(REGEX REPLACE "-lLibLZMA::LibLZMA" "-llzma" LIBS ${LIBS})
 +string(REGEX REPLACE "-lBZip2::BZip2" "" LIBS ${LIBS})
 +string(REGEX REPLACE "-lLibLZMA::LibLZMA" "" LIBS ${LIBS})
- if(ENABLE_ZSTD)
+ if(zstd_TARGET)
 -  string(REGEX REPLACE "-l${zstd_TARGET}" "-lzstd" LIBS ${LIBS})
 +  string(REGEX REPLACE "-l${zstd_TARGET}" "" LIBS ${LIBS})
  endif()

--- a/ports/libzip/vcpkg.json
+++ b/ports/libzip/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libzip",
-  "version": "1.10.1",
-  "description": "A library for reading, creating, and modifying zip archives.",
+  "version": "1.11.3",
+  "description": "A C library for reading, creating, and modifying zip archives.",
   "homepage": "https://github.com/nih-at/libzip",
   "license": "BSD-3-Clause",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5513,7 +5513,7 @@
       "port-version": 0
     },
     "libzip": {
-      "baseline": "1.10.1",
+      "baseline": "1.11.3",
       "port-version": 0
     },
     "libzippp": {

--- a/versions/l-/libzip.json
+++ b/versions/l-/libzip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c65a9b711fa88eb7e9680652f65a6c84f3af44c",
+      "version": "1.11.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "7f4b7231355f6774a5b6915dace3826173b76cee",
       "version": "1.10.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/nih-at/libzip/releases/tag/v1.11.3
