### PR TITLE
[rapidfuzz] update to 3.3.1

### DIFF
--- a/ports/rapidfuzz/portfile.cmake
+++ b/ports/rapidfuzz/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO maxbachmann/rapidfuzz-cpp
     REF "v${VERSION}"
-    SHA512 204ee06c1e51b786f0a2efd32a1c2467c3bff2738e8258e6e8fe44b5569afe7c665af1051fdd05dcc98704f3045f5bd2afcba5dba3fc0b34e2facf8944478b48
+    SHA512 c4b34d45b11f71db0cb5ce781b5fe9e81dde7809e9b17aa37138a862afca2b8a15631bf289e592f1fb9f012450c871b2b967353a6f0996783fa59b8ac6521e74
     HEAD_REF master
 )
 

--- a/ports/rapidfuzz/vcpkg.json
+++ b/ports/rapidfuzz/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rapidfuzz",
-  "version": "3.1.1",
-  "description": "Rapid fuzzy string matching library for C++17 using the Levenshtein Distance.",
+  "version": "3.3.1",
+  "description": "Rapid fuzzy string matching library for C++ using the Levenshtein Distance.",
   "homepage": "https://github.com/maxbachmann/rapidfuzz-cpp",
   "license": "MIT",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7833,7 +7833,7 @@
       "port-version": 0
     },
     "rapidfuzz": {
-      "baseline": "3.1.1",
+      "baseline": "3.3.1",
       "port-version": 0
     },
     "rapidhash": {

--- a/versions/r-/rapidfuzz.json
+++ b/versions/r-/rapidfuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "654bdeef545bf953b2587fd2f42f65a2b241dedb",
+      "version": "3.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "69d16c2c7b6ebe829a69d291ae8894237c183405",
       "version": "3.1.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

C++11 and C++14 has been supported since 3.3.0.
https://github.com/rapidfuzz/rapidfuzz-cpp/releases/tag/v3.3.0