### PR TITLE
[blend2d] support jit on arm

### DIFF
--- a/ports/blend2d/vcpkg.json
+++ b/ports/blend2d/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "blend2d",
   "version-date": "2024-11-23",
+  "port-version": 1,
   "description": "2D Vector Graphics Engine Powered by a JIT Compiler",
   "homepage": "https://github.com/blend2d/blend2d",
   "documentation": "https://blend2d.com/doc/index.html",
@@ -16,16 +17,9 @@
       "host": true
     }
   ],
-  "default-features": [
-    {
-      "name": "jit",
-      "platform": "!arm32"
-    }
-  ],
   "features": {
     "jit": {
       "description": "Enables JIT compiler to generate optimized pipelines.",
-      "supports": "!arm32",
       "dependencies": [
         "asmjit"
       ]

--- a/versions/b-/blend2d.json
+++ b/versions/b-/blend2d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ba2d70e449fbd4b21bcc71a60f8a012e3a4d9518",
+      "version-date": "2024-11-23",
+      "port-version": 1
+    },
+    {
       "git-tree": "d1f7110a127ab278f91765da0f9219d2c3029013",
       "version-date": "2024-11-23",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -686,7 +686,7 @@
     },
     "blend2d": {
       "baseline": "2024-11-23",
-      "port-version": 0
+      "port-version": 1
     },
     "blingfire": {
       "baseline": "0.1.8.1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

`asmjit` which provides `jit` feature to `blend2d` now supports arm architecture.
