### PR TITLE
[libdivide] add CPU features

### DIFF
--- a/ports/libdivide/portfile.cmake
+++ b/ports/libdivide/portfile.cmake
@@ -13,14 +13,18 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         test LIBDIVIDE_BUILD_TESTS
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "sse2"   LIBDIVIDE_SSE2
+        "avx2"   LIBDIVIDE_AVX2
+        "avx512" LIBDIVIDE_AVX512
+        "neon"   LIBDIVIDE_NEON
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
-        -DLIBDIVIDE_SSE2=OFF
-        -DLIBDIVIDE_AVX2=OFF
-        -DLIBDIVIDE_AVX512=OFF
-        -DLIBDIVIDE_NEON=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/libdivide/vcpkg.json
+++ b/ports/libdivide/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdivide",
   "version": "5.2.0",
+  "port-version": 1,
   "description": "libdivide.h is a header-only C/C++ library for optimizing integer division.",
   "homepage": "https://github.com/ridiculousfish/libdivide",
   "dependencies": [
@@ -14,6 +15,22 @@
     }
   ],
   "features": {
+    "avx2": {
+      "description": "use avx2 instruction",
+      "supports": "x86 | x64"
+    },
+    "avx512": {
+      "description": "use avx512 instruction",
+      "supports": "x86 | x64"
+    },
+    "neon": {
+      "description": "use avx512 instruction",
+      "supports": "arm"
+    },
+    "sse2": {
+      "description": "use sse2 instruction",
+      "supports": "x86 | x64"
+    },
     "test": {
       "description": "Build test"
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4446,7 +4446,7 @@
     },
     "libdivide": {
       "baseline": "5.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libdjinterop": {
       "baseline": "0.24.3",

--- a/versions/l-/libdivide.json
+++ b/versions/l-/libdivide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f17ae5f408853d70f8c647206e19b7ffe4a0dbc3",
+      "version": "5.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5e81740fc7d610d3c1f30867c8aa127c7db25bcd",
       "version": "5.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Currently all cpu features are disabled. 
This PR add features to enable cpu features on specific environments.

