### PR TITLE
[libxlsxwriter] update to 1.1.9

### DIFF
--- a/ports/libxlsxwriter/dependencies.diff
+++ b/ports/libxlsxwriter/dependencies.diff
@@ -1,18 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0e855c77..36ea4195 100644
+index e444dcc..68ef7b8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -230,8 +230,8 @@ message("zlib version: " ${ZLIB_VERSION})
- 
- # MINIZIP
- if (USE_SYSTEM_MINIZIP)
--    find_package(MINIZIP "1.0" REQUIRED)
--    list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${MINIZIP_INCLUDE_DIRS})
-+    find_package(MINIZIP NAMES unofficial-minizip REQUIRED)
-+    set(MINIZIP_LIBRARIES unofficial::minizip::minizip)
+@@ -240,8 +240,8 @@ if(USE_SYSTEM_MINIZIP)
+         pkg_check_modules(MINIZIP minizip)
+         list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${MINIZIP_INCLUDE_DIRS}/..)
+     else(NOT MINIZIP_FOUND)
+-        find_package(MINIZIP "1.0" REQUIRED)
+-        list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${MINIZIP_INCLUDE_DIRS})
++        find_package(MINIZIP NAMES unofficial-minizip REQUIRED)
++        set(MINIZIP_LIBRARIES unofficial::minizip::minizip)
+     endif()
  endif()
  
- # LIBRARY
 diff --git a/dev/release/pkg-config.txt b/dev/release/pkg-config.txt
 index a87d080..fa58047 100644
 --- a/dev/release/pkg-config.txt

--- a/ports/libxlsxwriter/portfile.cmake
+++ b/ports/libxlsxwriter/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jmcnamara/libxlsxwriter
     REF "v${VERSION}"
-    SHA512 4d1df3b66e694629025ba4154a746d896f9fa32c727267cfbeacf72a3fc70d1b34c7bc767a03bca81395bbe2ff366fc4f4184c2c40126bc6b2d58b33a758cc8f
+    SHA512 b1d5827e5cfc4f455eaf48b181c26d7642d0a65d261a068c1123ff49b2fa1aedd8c2a716b7915803c861973b1de286e49e1761c2e5a523e7c0ba353f5994d48d
     HEAD_REF main
     PATCHES
         dependencies.diff
@@ -16,7 +16,7 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS 
+    OPTIONS
         -DUSE_SYSTEM_MINIZIP=1
         -DWINDOWSSTORE=${USE_WINDOWSSTORE}
 )

--- a/ports/libxlsxwriter/vcpkg.json
+++ b/ports/libxlsxwriter/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxlsxwriter",
-  "version": "1.1.8",
-  "port-version": 1,
+  "version": "1.1.9",
   "description": "Libxlsxwriter is a C library that can be used to write text, numbers, formulas and hyperlinks to multiple worksheets in an Excel 2007+ XLSX file.",
   "homepage": "https://github.com/jmcnamara/libxlsxwriter",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5429,8 +5429,8 @@
       "port-version": 0
     },
     "libxlsxwriter": {
-      "baseline": "1.1.8",
-      "port-version": 1
+      "baseline": "1.1.9",
+      "port-version": 0
     },
     "libxml2": {
       "baseline": "2.13.5",

--- a/versions/l-/libxlsxwriter.json
+++ b/versions/l-/libxlsxwriter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a4a8c37d3a9f01b4da4dd513178a92fc7b671cb8",
+      "version": "1.1.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "42b31d240d66d5886a4d28123cda5ea9c6f30511",
       "version": "1.1.8",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/jmcnamara/libxlsxwriter/releases/tag/v1.1.9
