### PR TITLE
[json-glib] new port

### DIFF
--- a/ports/json-glib/portfile.cmake
+++ b/ports/json-glib/portfile.cmake
@@ -1,0 +1,41 @@
+string(REGEX MATCH [[^[1-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
+
+vcpkg_download_distfile(ARCHIVE
+    URLS https://download.gnome.org/sources/json-glib/${VERSION_MAJOR_MINOR}/json-glib-${VERSION}.tar.xz
+    FILENAME "json-glib-${VERSION}.tar.xz"
+    SHA512 e1c0e33b17333cf94beb381f505c1819090a11b616dcc23a883f231029dff277c2482823278cbf7b8a07e237d45cbfc7b05f132e1234beff609a739fd5704c6e
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dintrospection=disabled
+        -Ddocumentation=disabled
+        -Dtests=false
+        -Dinstalled_tests=false
+        -Dconformance=false
+        -Dman=false
+        -Dnls=disabled
+    ADDITIONAL_BINARIES
+        "glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'"
+)
+
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSES/LGPL-2.1-or-later.txt" "${SOURCE_PATH}/LICENSES/CC0-1.0.txt" "${SOURCE_PATH}/LICENSES/MIT.txt")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_copy_tools(
+    TOOL_NAMES json-glib-format json-glib-validate
+    AUTO_CLEAN
+)

--- a/ports/json-glib/vcpkg.json
+++ b/ports/json-glib/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "json-glib",
+  "version": "1.10.6",
+  "description": "Implements a full JSON parser and generator using GLib and GObject, and integrates JSON with GLib data types.",
+  "homepage": "https://wiki.gnome.org/Projects/JsonGlib",
+  "license": "LGPL-2.1-or-later AND CC0-1.0 AND MIT",
+  "dependencies": [
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3856,6 +3856,10 @@
       "baseline": "0.3.4",
       "port-version": 0
     },
+    "json-glib": {
+      "baseline": "1.10.6",
+      "port-version": 0
+    },
     "json-rpc-cxx": {
       "baseline": "0.3.2",
       "port-version": 0

--- a/versions/j-/json-glib.json
+++ b/versions/j-/json-glib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "feafbefb98655ce290b96a78b08da2107e1b3034",
+      "version": "1.10.6",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
fix #37698

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

