### PR TITLE
[libheif] add features for decoding AVIF, JPEG-2000, JPEG, ISO23001-17

### DIFF
--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -11,14 +11,14 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        hevc     WITH_X265
-        aom      WITH_AOM_DECODER
-        aom      WITH_AOM_ENCODER
-        openjpeg WITH_OpenJPEG_DECODER
-        openjpeg WITH_OpenJPEG_ENCODER
-        jpeg     WITH_JPEG_DECODER
-        jpeg     WITH_JPEG_ENCODER
-	iso23001-17 WITH_UNCOMPRESSED_CODEC
+        hevc        WITH_X265
+        aom         WITH_AOM_DECODER
+        aom         WITH_AOM_ENCODER
+        openjpeg    WITH_OpenJPEG_DECODER
+        openjpeg    WITH_OpenJPEG_ENCODER
+        jpeg        WITH_JPEG_DECODER
+        jpeg        WITH_JPEG_ENCODER
+        iso23001-17 WITH_UNCOMPRESSED_CODEC
 )
 
 vcpkg_cmake_configure(

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         openjpeg WITH_OpenJPEG_ENCODER
         jpeg     WITH_JPEG_DECODER
         jpeg     WITH_JPEG_ENCODER
+	iso23001-17 WITH_UNCOMPRESSED_CODEC
 )
 
 vcpkg_cmake_configure(

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -16,6 +16,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         aom      WITH_AOM_ENCODER
         openjpeg WITH_OpenJPEG_DECODER
         openjpeg WITH_OpenJPEG_ENCODER
+        jpeg     WITH_JPEG_DECODER
+        jpeg     WITH_JPEG_ENCODER
 )
 
 vcpkg_cmake_configure(

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -11,9 +11,11 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        hevc    WITH_X265
-        aom     WITH_AOM_DECODER
-        aom     WITH_AOM_ENCODER
+        hevc     WITH_X265
+        aom      WITH_AOM_DECODER
+        aom      WITH_AOM_ENCODER
+        openjpeg WITH_OpenJPEG_DECODER
+        openjpeg WITH_OpenJPEG_ENCODER
 )
 
 vcpkg_cmake_configure(

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -27,6 +27,7 @@ vcpkg_cmake_configure(
         -DWITH_EXAMPLES=OFF
         -DWITH_DAV1D=OFF
         -DBUILD_TESTING=OFF
+        -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF
         ${FEATURE_OPTIONS}
 )
 vcpkg_cmake_install()

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -12,6 +12,8 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         hevc    WITH_X265
+        aom     WITH_AOM_DECODER
+        aom     WITH_AOM_ENCODER
 )
 
 vcpkg_cmake_configure(

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libheif",
   "version": "1.19.5",
-  "port-version": 2,
+  "port-version": 3,
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -31,6 +31,13 @@
       "dependencies": [
         "x265"
       ]
+    },
+    "aom": {
+      "description": "AVIF decoding and encoding via aom",
+      "license": "BSD-2-Clause",
+      "dependencies": [
+        "aom"
+      ]
     }
   }
 }

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -38,6 +38,13 @@
       "dependencies": [
         "aom"
       ]
+    },
+    "openjpeg": {
+      "description": "JPEG-2000 decoding and encoding via OpenJPEG",
+      "license": "BSD-2-Clause",
+      "dependencies": [
+        "openjpeg"
+      ]
     }
   }
 }

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -25,13 +25,6 @@
     "hevc"
   ],
   "features": {
-    "hevc": {
-      "description": "HEVC encoding via x265",
-      "license": "GPL-2.0-or-later",
-      "dependencies": [
-        "x265"
-      ]
-    },
     "aom": {
       "description": "AVIF decoding and encoding via aom",
       "license": "BSD-2-Clause",
@@ -39,12 +32,16 @@
         "aom"
       ]
     },
-    "openjpeg": {
-      "description": "JPEG-2000 decoding and encoding via OpenJPEG",
-      "license": "BSD-2-Clause",
+    "hevc": {
+      "description": "HEVC encoding via x265",
+      "license": "GPL-2.0-or-later",
       "dependencies": [
-        "openjpeg"
+        "x265"
       ]
+    },
+    "iso23001-17": {
+      "description": "Support for ISO23001-17 (uncompressed) codec",
+      "license": "LGPL-3.0-only"
     },
     "jpeg": {
       "description": "JPEG decoding and encoding via libjpeg-turbo",
@@ -53,9 +50,12 @@
         "libjpeg-turbo"
       ]
     },
-    "iso23001-17": {
-      "description": "Support for ISO23001-17 (uncompressed) codec",
-      "license": "LGPL-3.0-only"
+    "openjpeg": {
+      "description": "JPEG-2000 decoding and encoding via OpenJPEG",
+      "license": "BSD-2-Clause",
+      "dependencies": [
+        "openjpeg"
+      ]
     }
   }
 }

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -45,6 +45,13 @@
       "dependencies": [
         "openjpeg"
       ]
+    },
+    "jpeg": {
+      "description": "JPEG decoding and encoding via libjpeg-turbo",
+      "license": "BSD-3-Clause",
+      "dependencies": [
+        "libjpeg-turbo"
+      ]
     }
   }
 }

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -52,6 +52,10 @@
       "dependencies": [
         "libjpeg-turbo"
       ]
+    },
+    "iso23001-17": {
+      "description": "Support for ISO23001-17 (uncompressed) codec",
+      "license": "LGPL-3.0-only"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4642,7 +4642,7 @@
     },
     "libheif": {
       "baseline": "1.19.5",
-      "port-version": 2
+      "port-version": 3
     },
     "libhsplasma": {
       "baseline": "2024-03-07",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d0395a32f2d98134938385ff45dac8b2dd33deaf",
+      "git-tree": "750c6c2ee08befa80660b188b1a5862cfb5192d0",
       "version": "1.19.5",
       "port-version": 3
     },

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c027153580dd5f67453a888d7c8eed374966ed86",
+      "version": "1.19.5",
+      "port-version": 3
+    },
+    {
       "git-tree": "ecd6b2d082b2b4c294587aaabb0c53b7e1d87f5c",
       "version": "1.19.5",
       "port-version": 2

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c027153580dd5f67453a888d7c8eed374966ed86",
+      "git-tree": "d0395a32f2d98134938385ff45dac8b2dd33deaf",
       "version": "1.19.5",
       "port-version": 3
     },


### PR DESCRIPTION
This adds features for other codecs than HEVC.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
