### PR TITLE
[gexiv2] new port

### DIFF
--- a/ports/gexiv2/msvc_def.patch
+++ b/ports/gexiv2/msvc_def.patch
@@ -1,0 +1,203 @@
+From 53770886561d434db53c229cd3d6391939a8185c Mon Sep 17 00:00:00 2001
+From: Jens Georg <mail@jensge.org>
+Date: Mon, 10 Feb 2025 22:15:56 +0100
+Subject: [PATCH] build: Add .def file and a script to update it
+
+---
+ build-aux/update-def-file.sh |   3 +
+ gexiv2/gexiv2.def            | 152 +++++++++++++++++++++++++++++++++++
+ gexiv2/meson.build           |   8 ++
+ 3 files changed, 163 insertions(+)
+ create mode 100755 build-aux/update-def-file.sh
+ create mode 100644 gexiv2/gexiv2.def
+
+diff --git a/build-aux/update-def-file.sh b/build-aux/update-def-file.sh
+new file mode 100755
+index 0000000..950d422
+--- /dev/null
++++ b/build-aux/update-def-file.sh
+@@ -0,0 +1,3 @@
++#!/bin/bash
++
++nm -gD "$1" | grep " T " | cut -f3 -d " " | sort | uniq > "$2"
+diff --git a/gexiv2/gexiv2.def b/gexiv2/gexiv2.def
+new file mode 100644
+index 0000000..de934fd
+--- /dev/null
++++ b/gexiv2/gexiv2.def
+@@ -0,0 +1,151 @@
++EXPORTS
++gexiv2_get_version
++gexiv2_gexiv2_byte_order_get_type
++gexiv2_gexiv2_log_level_get_type
++gexiv2_gexiv2_orientation_get_type
++gexiv2_gexiv2_structure_type_get_type
++gexiv2_gexiv2_xmp_format_flags_get_type
++gexiv2_initialize
++gexiv2_log_get_default_handler
++gexiv2_log_get_handler
++gexiv2_log_get_level
++gexiv2_log_set_handler
++gexiv2_log_set_level
++gexiv2_log_use_glib_logging
++gexiv2_metadata_clear
++gexiv2_metadata_clear_comment
++gexiv2_metadata_clear_exif
++gexiv2_metadata_clear_iptc
++gexiv2_metadata_clear_tag
++gexiv2_metadata_clear_xmp
++gexiv2_metadata_delete_gps_info
++gexiv2_metadata_erase_exif_thumbnail
++gexiv2_metadata_free
++gexiv2_metadata_from_app1_segment
++gexiv2_metadata_from_stream
++gexiv2_metadata_generate_xmp_packet
++gexiv2_metadata_get_comment
++gexiv2_metadata_get_exif_data
++gexiv2_metadata_get_exif_tag_rational
++gexiv2_metadata_get_exif_tags
++gexiv2_metadata_get_exif_thumbnail
++gexiv2_metadata_get_exposure_time
++gexiv2_metadata_get_fnumber
++gexiv2_metadata_get_focal_length
++gexiv2_metadata_get_gps_altitude
++gexiv2_metadata_get_gps_info
++gexiv2_metadata_get_gps_latitude
++gexiv2_metadata_get_gps_longitude
++gexiv2_metadata_get_iptc_tags
++gexiv2_metadata_get_iso_speed
++gexiv2_metadata_get_metadata_pixel_height
++gexiv2_metadata_get_metadata_pixel_width
++gexiv2_metadata_get_mime_type
++gexiv2_metadata_get_orientation
++gexiv2_metadata_get_pixel_height
++gexiv2_metadata_get_pixel_width
++gexiv2_metadata_get_preview_image
++gexiv2_metadata_get_preview_properties
++gexiv2_metadata_get_supports_exif
++gexiv2_metadata_get_supports_iptc
++gexiv2_metadata_get_supports_xmp
++gexiv2_metadata_get_tag_description
++gexiv2_metadata_get_tag_interpreted_string
++gexiv2_metadata_get_tag_label
++gexiv2_metadata_get_tag_long
++gexiv2_metadata_get_tag_multiple
++gexiv2_metadata_get_tag_raw
++gexiv2_metadata_get_tag_string
++gexiv2_metadata_get_tag_type
++gexiv2_metadata_get_type
++gexiv2_metadata_get_xmp_namespace_for_tag
++gexiv2_metadata_get_xmp_packet
++gexiv2_metadata_get_xmp_tags
++gexiv2_metadata_has_exif
++gexiv2_metadata_has_iptc
++gexiv2_metadata_has_tag
++gexiv2_metadata_has_xmp
++gexiv2_metadata_is_exif_tag
++gexiv2_metadata_is_iptc_tag
++gexiv2_metadata_is_xmp_tag
++gexiv2_metadata_new
++gexiv2_metadata_open_buf
++gexiv2_metadata_open_path
++gexiv2_metadata_register_xmp_namespace
++gexiv2_metadata_save_external
++gexiv2_metadata_save_file
++gexiv2_metadata_set_comment
++gexiv2_metadata_set_exif_tag_rational
++gexiv2_metadata_set_exif_thumbnail_from_buffer
++gexiv2_metadata_set_exif_thumbnail_from_file
++gexiv2_metadata_set_gps_info
++gexiv2_metadata_set_metadata_pixel_height
++gexiv2_metadata_set_metadata_pixel_width
++gexiv2_metadata_set_orientation
++gexiv2_metadata_set_tag_long
++gexiv2_metadata_set_tag_multiple
++gexiv2_metadata_set_tag_string
++gexiv2_metadata_set_xmp_tag_struct
++gexiv2_metadata_try_clear_tag
++gexiv2_metadata_try_delete_gps_info
++gexiv2_metadata_try_erase_exif_thumbnail
++gexiv2_metadata_try_generate_xmp_packet
++gexiv2_metadata_try_get_comment
++gexiv2_metadata_try_get_exif_tag_rational
++gexiv2_metadata_try_get_exposure_time
++gexiv2_metadata_try_get_fnumber
++gexiv2_metadata_try_get_focal_length
++gexiv2_metadata_try_get_gps_altitude
++gexiv2_metadata_try_get_gps_info
++gexiv2_metadata_try_get_gps_latitude
++gexiv2_metadata_try_get_gps_longitude
++gexiv2_metadata_try_get_iso_speed
++gexiv2_metadata_try_get_metadata_pixel_height
++gexiv2_metadata_try_get_metadata_pixel_width
++gexiv2_metadata_try_get_orientation
++gexiv2_metadata_try_get_preview_image
++gexiv2_metadata_try_get_tag_description
++gexiv2_metadata_try_get_tag_interpreted_string
++gexiv2_metadata_try_get_tag_label
++gexiv2_metadata_try_get_tag_long
++gexiv2_metadata_try_get_tag_multiple
++gexiv2_metadata_try_get_tag_raw
++gexiv2_metadata_try_get_tag_string
++gexiv2_metadata_try_get_tag_type
++gexiv2_metadata_try_get_xmp_namespace_for_tag
++gexiv2_metadata_try_get_xmp_packet
++gexiv2_metadata_try_has_tag
++gexiv2_metadata_try_register_xmp_namespace
++gexiv2_metadata_try_set_comment
++gexiv2_metadata_try_set_exif_tag_rational
++gexiv2_metadata_try_set_exif_thumbnail_from_buffer
++gexiv2_metadata_try_set_gps_info
++gexiv2_metadata_try_set_metadata_pixel_height
++gexiv2_metadata_try_set_metadata_pixel_width
++gexiv2_metadata_try_set_orientation
++gexiv2_metadata_try_set_tag_long
++gexiv2_metadata_try_set_tag_multiple
++gexiv2_metadata_try_set_tag_string
++gexiv2_metadata_try_set_xmp_tag_struct
++gexiv2_metadata_try_tag_supports_multiple_values
++gexiv2_metadata_try_unregister_all_xmp_namespaces
++gexiv2_metadata_try_unregister_xmp_namespace
++gexiv2_metadata_try_update_gps_info
++gexiv2_metadata_unregister_all_xmp_namespaces
++gexiv2_metadata_unregister_xmp_namespace
++gexiv2_metadata_update_gps_info
++gexiv2_preview_image_free
++gexiv2_preview_image_get_data
++gexiv2_preview_image_get_extension
++gexiv2_preview_image_get_height
++gexiv2_preview_image_get_mime_type
++gexiv2_preview_image_get_type
++gexiv2_preview_image_get_width
++gexiv2_preview_image_try_write_file
++gexiv2_preview_image_write_file
++gexiv2_preview_properties_get_extension
++gexiv2_preview_properties_get_height
++gexiv2_preview_properties_get_mime_type
++gexiv2_preview_properties_get_size
++gexiv2_preview_properties_get_type
++gexiv2_preview_properties_get_width
+diff --git a/gexiv2/meson.build b/gexiv2/meson.build
+index d56409c..fe7de09 100644
+--- a/gexiv2/meson.build
++++ b/gexiv2/meson.build
+@@ -66,8 +66,16 @@ gexiv2 = library('gexiv2',
+                  version: libversion,
+                  darwin_versions: darwin_versions,
+                  dependencies : [gobject, exiv2, gio],
++                 vs_module_defs : 'gexiv2.def',
+                  install : true)
+ 
++update_def_script = find_program('update-def-file.sh', dirs: [meson.project_source_root() / 'build-aux'])
++custom_target('update-def-file',
++  output: 'gexiv2.def',
++  input: gexiv2,
++  command: [update_def_script, '@INPUT@', '@OUTPUT@'],
++  install: false)
++
+ libgexiv2 = declare_dependency(
+     link_with : gexiv2,
+     include_directories : include_directories('..'),
+-- 
+GitLab
+

--- a/ports/gexiv2/portfile.cmake
+++ b/ports/gexiv2/portfile.cmake
@@ -1,0 +1,35 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://download.gnome.org/sources/gexiv2/0.14/gexiv2-${VERSION}.tar.xz"
+    FILENAME "gexiv2-${VERSION}.tar.xz"
+    SHA512 24c97fa09b9ee32cb98da4637ea78eb72ae7e2d1792f9ebb31d63e305b3e0e1f6935b8647589c76c39ba631a15c1d8d2f3879c7dff81433786e9533b6348b6a0
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        msvc_def.patch
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dintrospection=false
+        -Dvapi=false
+        -Dgtk_doc=false
+        -Dpython3=false
+        -Dtests=false
+        -Dtools=false
+    ADDITIONAL_BINARIES
+        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+)
+
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/gexiv2/vcpkg.json
+++ b/ports/gexiv2/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "gexiv2",
+  "version": "0.14.3",
+  "description": "A GObject-based Exiv2 wrapper.",
+  "homepage": "https://gitlab.gnome.org/GNOME/gexiv2/",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    "exiv2",
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3080,6 +3080,10 @@
       "baseline": "2017-10-14",
       "port-version": 6
     },
+    "gexiv2": {
+      "baseline": "0.14.3",
+      "port-version": 0
+    },
     "gflags": {
       "baseline": "2.2.2",
       "port-version": 9

--- a/versions/g-/gexiv2.json
+++ b/versions/g-/gexiv2.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e18bc37283a388c5fd401c915598feca8e50363b",
+      "version": "0.14.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

