### PR TITLE
[libmypaint ,mypaint-brushes] new ports

### DIFF
--- a/ports/libmypaint/portfile.cmake
+++ b/ports/libmypaint/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/mypaint/libmypaint/releases/download/v${VERSION}/libmypaint-${VERSION}.tar.xz"
+    FILENAME "libmypaint-${VERSION}.tar.xz"
+    SHA512 e9413fd6a5336791ab3228a5ad9e7f06871d075c7ded236942f896a205ba44ea901a945fdc97b8be357453a1505331b59e824fe67500fbcda0cc4f11f79af608
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+)
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        --disable-i18n
+        --with-glib
+)
+
+vcpkg_make_install()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libmypaint/vcpkg.json
+++ b/ports/libmypaint/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "libmypaint",
+  "version": "1.6.1",
+  "description": "Brush library used by MyPaint",
+  "homepage": "mypaint.org",
+  "license": "ISC",
+  "supports": "!windows | mingw",
+  "dependencies": [
+    "glib",
+    "json-c",
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}

--- a/ports/mypaint-brushes/portfile.cmake
+++ b/ports/mypaint-brushes/portfile.cmake
@@ -1,0 +1,27 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/mypaint/mypaint-brushes/releases/download/v${VERSION}/mypaint-brushes-${VERSION}.tar.xz"
+    FILENAME "mypaint-brushes-${VERSION}.tar.xz"
+    SHA512 22ff99c40a2fff71efd5c25a462cefb9948f0d258aee12e3eb924bac53733a2573e100454e2f3e4631d59eac013c2aaa7f32ff566843d23df971bf2aaa1181bd
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+)
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+)
+
+vcpkg_make_install()
+
+vcpkg_copy_pdbs()
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/mypaint-brushes/pkgconfig/mypaint-brushes-1.0.pc" "${CURRENT_PACKAGES_DIR}/share/pkgconfig/mypaint-brushes-1.0.pc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/" "${CURRENT_PACKAGES_DIR}/share/mypaint-brushes/pkgconfig")
+vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/mypaint-brushes/vcpkg.json
+++ b/ports/mypaint-brushes/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "mypaint-brushes",
+  "version": "1.3.1",
+  "description": "Data package. Brushes used by MyPaint and other software using libmypaint.",
+  "homepage": "mypaint.org",
+  "license": "CC0-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4876,6 +4876,10 @@
       "baseline": "1.25.2",
       "port-version": 0
     },
+    "libmypaint": {
+      "baseline": "1.6.1",
+      "port-version": 0
+    },
     "libmysofa": {
       "baseline": "1.3.2",
       "port-version": 0
@@ -6255,6 +6259,10 @@
     "mygui": {
       "baseline": "3.4.3",
       "port-version": 3
+    },
+    "mypaint-brushes": {
+      "baseline": "1.3.1",
+      "port-version": 0
     },
     "mysql-connector-cpp": {
       "baseline": "9.1.0",

--- a/versions/l-/libmypaint.json
+++ b/versions/l-/libmypaint.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "abd548dd40da39a6509ed1efde4325add5c109fa",
+      "version": "1.6.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/m-/mypaint-brushes.json
+++ b/versions/m-/mypaint-brushes.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1b3d02f7d8b0780de1a8e2e7e0fefc307fd7a7eb",
+      "version": "1.3.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

