### PR TITLE
[restc-cpp] update to 1.0.0

### DIFF
--- a/ports/restc-cpp/portfile.cmake
+++ b/ports/restc-cpp/portfile.cmake
@@ -4,15 +4,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jgaa/restc-cpp
     REF "v${VERSION}"
-    SHA512 0f74d825d3958810c270748c2810953fe394d0bf1f147d81b9177803e29a86c702715d5995c5966c4fe671b7689f26d9a0fad4e82d111277bbd3ddce1a68f73a
+    SHA512 c0c3795161654b91283b1536ba744ce50be248ebd68c2c28a1d29783d06adcfea16b1ca5b1eff27ff62f8bb347fbf3f56c6b49ee5b5875eb4eecf6824caca129
     HEAD_REF master
-    PATCHES
-        0001-exclude-cmake-external-projects.patch
-
-        # This patch is a combination of these two commits:
-        # https://github.com/jgaa/restc-cpp/commit/f6144b1a93a00e11335e2cfa724da91925b08adb
-        # https://github.com/jgaa/restc-cpp/commit/5470ee36b973fac960b3566e47efe873c21b43fa
-        boost-1.86-fix.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/restc-cpp/portfile.cmake
+++ b/ports/restc-cpp/portfile.cmake
@@ -13,7 +13,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         openssl       RESTC_CPP_WITH_TLS
         zlib          RESTC_CPP_WITH_ZLIB
         threaded-ctx  RESTC_CPP_THREADED_CTX
-        boost-log     RESTC_CPP_LOG_WITH_BOOST_LOG
 )
 
 vcpkg_cmake_configure(

--- a/ports/restc-cpp/vcpkg.json
+++ b/ports/restc-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "restc-cpp",
-  "version-semver": "0.10.0",
-  "port-version": 4,
+  "version-semver": "1.0.0",
   "description": "Modern C++ REST Client library",
   "homepage": "https://github.com/jgaa/restc-cpp",
   "license": "MIT",

--- a/ports/restc-cpp/vcpkg.json
+++ b/ports/restc-cpp/vcpkg.json
@@ -11,6 +11,7 @@
     "boost-coroutine",
     "boost-date-time",
     "boost-filesystem",
+    "boost-log",
     "boost-program-options",
     "boost-system",
     "boost-uuid",
@@ -29,12 +30,6 @@
     "zlib"
   ],
   "features": {
-    "boost-log": {
-      "description": "Use boost-log for logging.",
-      "dependencies": [
-        "boost-log"
-      ]
-    },
     "openssl": {
       "description": "OpenSSL support.",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7953,8 +7953,8 @@
       "port-version": 3
     },
     "restc-cpp": {
-      "baseline": "0.10.0",
-      "port-version": 4
+      "baseline": "1.0.0",
+      "port-version": 0
     },
     "restclient-cpp": {
       "baseline": "2024-01-09",

--- a/versions/r-/restc-cpp.json
+++ b/versions/r-/restc-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b0a4e23072d9b0434d3af12df61db9b7bd26230b",
+      "git-tree": "1f9d26a71420d660c5877fdf6f4f5e5cbc22d35b",
       "version-semver": "1.0.0",
       "port-version": 0
     },

--- a/versions/r-/restc-cpp.json
+++ b/versions/r-/restc-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0a4e23072d9b0434d3af12df61db9b7bd26230b",
+      "version-semver": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a235e9d1d43ab7da08a5e411ab04db28877e6108",
       "version-semver": "0.10.0",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.