### PR TITLE
[qtbase] set CMAKE_OSX_DEPLOYMENT_TARGET

### DIFF
--- a/ports/qtbase/cmake/qt_install_submodule.cmake
+++ b/ports/qtbase/cmake/qt_install_submodule.cmake
@@ -12,10 +12,6 @@ if(VCPKG_TARGET_IS_ANDROID AND NOT ANDROID_SDK_ROOT)
     message(FATAL_ERROR "${PORT} requires ANDROID_SDK_ROOT to be set. Consider adding it to the triplet." )
 endif()
 
-if(VCPKG_TARGET_IS_OSX AND (NOT VCPKG_OSX_DEPLOYMENT_TARGET OR VCPKG_OSX_DEPLOYMENT_TARGET VERSION_GREATER_EQUAL "15.0"))
-    message(WARNING "Qt6 does not yet cleanly support macOS 15.0, consider adding set(VCPKG_OSX_DEPLOYMENT_TARGET 14.0) or earlier to a custom triplet (https://learn.microsoft.com/en-us/vcpkg/users/examples/overlay-triplets-linux-dynamic#overriding-default-triplets).")
-endif()
-
 function(qt_download_submodule_impl)
     cmake_parse_arguments(PARSE_ARGV 0 "_qarg" "" "SUBMODULE" "PATCHES")
 

--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -309,9 +309,14 @@ set(TOOL_NAMES
         tracepointgen
     )
 
+if(NOT DEFINED VCPKG_OSX_DEPLOYMENT_TARGET) 
+    set(VCPKG_OSX_DEPLOYMENT_TARGET 14) 
+endif()
+
 qt_install_submodule(PATCHES    ${${PORT}_PATCHES}
                      TOOL_NAMES ${TOOL_NAMES}
                      CONFIGURE_OPTIONS
+                        -DCMAKE_OSX_DEPLOYMENT_TARGET=${VCPKG_OSX_DEPLOYMENT_TARGET}
                         ##--trace-expand
                         ${FEATURE_OPTIONS}
                         ${FEATURE_CORE_OPTIONS}

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.8.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7578,7 +7578,7 @@
     },
     "qtbase": {
       "baseline": "6.8.1",
-      "port-version": 2
+      "port-version": 3
     },
     "qtcharts": {
       "baseline": "6.8.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b7373fead09e11ba35bc1681d4b679b6bf88a6c",
+      "version": "6.8.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "eecb74d47973f04985c59537871ade171b34550f",
       "version": "6.8.1",
       "port-version": 2


### PR DESCRIPTION
Attempt to mitigate https://codereview.qt-project.org/c/qt/qtbase/+/606910

I confirmed that this issue occurs on macOS 15 and can be mitigated by setting VCPKG_OSX_DEPLOYMENT_TARGET. I also verified that downstream ports remain functional by successfully building libqglviewer.