### PR TITLE
[sqlite-orm] Update to 1.9.1

### DIFF
--- a/ports/sqlite-orm/portfile.cmake
+++ b/ports/sqlite-orm/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fnc12/sqlite_orm
     REF "v${VERSION}"
-    SHA512 a9a31b534d9374364672d698a1d08ba3d0b2c06d91a3fc38c3fcf73eb2efc272f118bb05c5b4ea720ceac01f54ee02debd86de31cad645001ed2b8db943ebe33
+    SHA512 3e939ddb31e8f03a5f885e459b1ba8040b58e697a715148b829b075d612d1c8a5686ec889155ec9804929e11ec11285a39af3f1eb27a4edf0bcc56c4ee7530b1
     HEAD_REF master
     PATCHES 
         fix-dependency.patch

--- a/ports/sqlite-orm/vcpkg.json
+++ b/ports/sqlite-orm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite-orm",
-  "version": "1.9",
+  "version": "1.9.1",
   "description": "SQLite ORM light header only library for modern C++",
   "homepage": "https://github.com/fnc12/sqlite_orm",
   "license": "AGPL-3.0-or-later OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8689,7 +8689,7 @@
       "port-version": 0
     },
     "sqlite-orm": {
-      "baseline": "1.9",
+      "baseline": "1.9.1",
       "port-version": 0
     },
     "sqlite3": {

--- a/versions/s-/sqlite-orm.json
+++ b/versions/s-/sqlite-orm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc8cbd8ea3c6b8e883dc338e94cdb3188539fed8",
+      "version": "1.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "199d90fac299fcdcb22eaaeb3aaceea4490da339",
       "version": "1.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
