### PR TITLE
[libmagic] fix error hash

### DIFF
--- a/ports/libmagic/portfile.cmake
+++ b/ports/libmagic/portfile.cmake
@@ -22,7 +22,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO file/file
     REF FILE5_46
-    SHA512 9165bb5bdbe7b8fccac0c8675d4eb251a286ab2ab7a79e6f8ed98d36fa0928b889cf109c1da3a5cfff64d1b1006b5d73934c2d420484adae6f4c8e26a9ede18f
+    SHA512 fb8157ee8065feaf57412ccdeee57cd8fc853b54ac49b0ddc818eeb1ca3555a7cfd25dea08996503f7c565dcba8c57fd7e4dc5fe3452872c617f5612a94a8f0e
     HEAD_REF master
     PATCHES ${PATCHES}
 )

--- a/ports/libmagic/vcpkg.json
+++ b/ports/libmagic/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmagic",
   "version": "5.46",
+  "port-version": 1,
   "description": "This library can be used to classify files according to magic number tests.",
   "homepage": "https://github.com/file/file",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4774,7 +4774,7 @@
     },
     "libmagic": {
       "baseline": "5.46",
-      "port-version": 0
+      "port-version": 1
     },
     "libmariadb": {
       "baseline": "3.4.1",

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64418c4e61811c2e8829f8253c56173a2836bbcd",
+      "version": "5.46",
+      "port-version": 1
+    },
+    {
       "git-tree": "380e305405e20a74576fcee51673a98a5a49fe18",
       "version": "5.46",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43565.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
