### PR TITLE
[gstreamer] Fix gstx265enc.c

### DIFF
--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -4,6 +4,12 @@ if(VCPKG_TARGET_IS_WINDOWS)
     )
 endif()
 
+vcpkg_download_distfile(PATCH_PR_7868_FIX_GSTX265ENC_C
+    URLS https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/ee3802cf71b386194e2a6318765e0547b37f52c8.diff
+    SHA512 3cd7395562a563f474ddb535d307e0a6aa30027a8c1cf5efea7560d989c28761eb9afa8dc89d7aee66364118c7ed1cef9a3766129bb830cc3ca6b8742b20fd4c
+    FILENAME gstreamer-gstreamer-1.25.1-ee3802cf71b386194e2a6318765e0547b37f52c8.patch
+)
+
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
@@ -23,7 +29,8 @@ vcpkg_from_gitlab(
         fix-bz2-windows-debug-dependency.patch
         no-downloads.patch
         ${PATCHES}
-		fix-multiple-def.patch
+        fix-multiple-def.patch
+        "${PATCH_PR_7868_FIX_GSTX265ENC_C}"
 )
 
 vcpkg_find_acquire_program(FLEX)

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.24.7",
-  "port-version": 3,
+  "port-version": 4,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3290,7 +3290,7 @@
     },
     "gstreamer": {
       "baseline": "1.24.7",
-      "port-version": 3
+      "port-version": 4
     },
     "gtest": {
       "baseline": "1.15.2",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "169201c9dc33ce6f32f4d9299a54eae41f198d77",
+      "version": "1.24.7",
+      "port-version": 4
+    },
+    {
       "git-tree": "8493048108e3a71b0a0271309f86dba4df884394",
       "version": "1.24.7",
       "port-version": 3


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/43558, failed with `error C2106: '=' : left operand must be l-value` on `gstx265enc.c`

Backport https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/ee3802cf71b386194e2a6318765e0547b37f52c8 to fix.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port feature `gstreamer[core,colormanagement,dash,bzip2-bad,bzip2-good,dtls,gpl,libav,libde265,openh264,mpg123,smoothstreaming,speex,vpx,taglib,webp,faad,openmpt,plugins-base,plugins-bad,plugins-good,plugins-ugly,openjpeg,jpeg,png,x264,x265,ges,flac]` installation tests pass with the following triplets:

* x64-windows