### PR TITLE
[libzip] Add patch to initialize `have_dos_time`

### DIFF
--- a/ports/libzip/initialize-have_dos_time.patch
+++ b/ports/libzip/initialize-have_dos_time.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/zip_close.c b/lib/zip_close.c
+index 6948c0e..5efb2c6 100644
+--- a/lib/zip_close.c
++++ b/lib/zip_close.c
+@@ -304,7 +304,8 @@ static int add_data(zip_t *za, zip_source_t *src, zip_dirent_t *de, zip_uint32_t
+     int is_zip64;
+     zip_flags_t flags;
+     bool needs_recompress, needs_decompress, needs_crc, needs_compress, needs_reencrypt, needs_decrypt, needs_encrypt;
+-    bool have_dos_time, dirent_changed;
++    bool dirent_changed;
++    bool have_dos_time = false;
+     time_t mtime_before_copy;
+ 
+     if (zip_source_stat(src, &st) < 0) {

--- a/ports/libzip/portfile.cmake
+++ b/ports/libzip/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-dependency.patch
         use-requires.patch
+        initialize-have_dos_time.patch # https://github.com/nih-at/libzip/commit/aa3a6b4da7577de63581f8db2f9d2757481b4cc8
 )
 
 vcpkg_check_features(

--- a/ports/libzip/vcpkg.json
+++ b/ports/libzip/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libzip",
   "version": "1.11.3",
+  "port-version": 1,
   "description": "A C library for reading, creating, and modifying zip archives.",
   "homepage": "https://github.com/nih-at/libzip",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5518,7 +5518,7 @@
     },
     "libzip": {
       "baseline": "1.11.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libzippp": {
       "baseline": "7.1-1.10.1",

--- a/versions/l-/libzip.json
+++ b/versions/l-/libzip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f75a432198c3d56a29979861a8491e2749e875ed",
+      "version": "1.11.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "3c65a9b711fa88eb7e9680652f65a6c84f3af44c",
       "version": "1.11.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #43647, add patch from upstream commit https://github.com/nih-at/libzip/commit/aa3a6b4da7577de63581f8db2f9d2757481b4cc8.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.