### PR TITLE
[steam-audio] Include <chrono> for high_resolution_clock

### DIFF
--- a/ports/steam-audio/add-include-chrono.patch
+++ b/ports/steam-audio/add-include-chrono.patch
@@ -1,0 +1,12 @@
+diff --git a/core/src/core/profiler.h b/core/src/core/profiler.h
+index 888ea43..7249375 100644
+--- a/core/src/core/profiler.h
++++ b/core/src/core/profiler.h
+@@ -17,6 +17,7 @@
+ #pragma once
+ 
+ #include "memory_allocator.h"
++#include <chrono>
+ 
+ namespace ipl {
+ 

--- a/ports/steam-audio/portfile.cmake
+++ b/ports/steam-audio/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
   PATCHES
     use-vcpkg-deps.patch
     fix-arm64-windows.patch
+    add-include-chrono.patch
 )
 
 if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)

--- a/ports/steam-audio/vcpkg.json
+++ b/ports/steam-audio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "steam-audio",
   "version": "4.5.3",
+  "port-version": 1,
   "description": "Valve's steam audio library",
   "homepage": "https://github.com/ValveSoftware/steam-audio",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8766,7 +8766,7 @@
     },
     "steam-audio": {
       "baseline": "4.5.3",
-      "port-version": 0
+      "port-version": 1
     },
     "stftpitchshift": {
       "baseline": "1.4.1",

--- a/versions/s-/steam-audio.json
+++ b/versions/s-/steam-audio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "521dd550b337e47311b7d1661b0d3d40398a9ef0",
+      "version": "4.5.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "e4f552d464d6368d7cc59b014c6f9b62de51df4f",
       "version": "4.5.3",
       "port-version": 0


### PR DESCRIPTION
Due to there are new changes merged by https://github.com/microsoft/STL/pull/5105, so port `steam-audio` need to include `<chrono>` by patching to fix the following error:
```
D:\b\steam-audio\src\ba4a490a67-27c1a63d4c.clean\core\src\core\profiler.h(40): error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\__msvc_chrono.hpp(286): note: see declaration of 'std::chrono'
D:\b\steam-audio\src\ba4a490a67-27c1a63d4c.clean\core\src\core\profiler.h(40): error C2065: 'high_resolution_clock': undeclared identifier
D:\b\steam-audio\src\ba4a490a67-27c1a63d4c.clean\core\src\core\profiler.h(40): error C2923: 'std::chrono::time_point': 'high_resolution_clock' is not a valid template type argument for parameter '_Clock'
D:\b\steam-audio\src\ba4a490a67-27c1a63d4c.clean\core\src\core\profiler.h(40): note: see declaration of 'high_resolution_clock'
D:\b\steam-audio\src\ba4a490a67-27c1a63d4c.clean\core\src\core\profiler.h(40): error C2976: 'std::chrono::time_point': too few template arguments
```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
