### PR TITLE
[openssl] emscripten toolchain controls thread support

### DIFF
--- a/ports/openssl/unix/portfile.cmake
+++ b/ports/openssl/unix/portfile.cmake
@@ -89,13 +89,19 @@ elseif(VCPKG_TARGET_IS_MINGW)
 elseif(VCPKG_TARGET_IS_EMSCRIPTEN)
     set(OPENSSL_ARCH linux-x32)
     vcpkg_list(APPEND CONFIGURE_OPTIONS
-        threads
         no-engine
         no-asm
         no-sse2
         no-srtp
         --cross-compile-prefix=
     )
+    # Cf. https://emscripten.org/docs/porting/pthreads.html:
+    # For Pthreads support, not just openssl but everything
+    # must be compiled and linked with `-pthread`.
+    # This makes it a triplet/toolchain-wide setting.
+    if(NOT " ${VCPKG_DETECTED_CMAKE_C_FLAGS} " MATCHES " -pthread ")
+        vcpkg_list(APPEND CONFIGURE_OPTIONS no-threads)
+    endif()
 else()
     message(FATAL_ERROR "Unknown platform")
 endif()

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openssl",
   "version": "3.4.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6770,7 +6770,7 @@
     },
     "openssl": {
       "baseline": "3.4.0",
-      "port-version": 1
+      "port-version": 2
     },
     "opensubdiv": {
       "baseline": "3.5.0",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "45588fdc81fd5b293cc4729cef3f239d9fb3071c",
+      "version": "3.4.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "facccb0b0c47f9804b6e336096d0985c3e541eec",
       "version": "3.4.0",
       "port-version": 1


### PR DESCRIPTION
Cf. https://emscripten.org/docs/porting/pthreads.html:  
For Pthreads support in emscripten, all C and C++ source files must be compiled AND linked with `pthread`.

Unconditionally enabling thread support in openssl made some downstream builds fail (https://github.com/microsoft/vcpkg/pull/43463#issuecomment-2638699054), and even successful builds (as before #43463) would not comply with the documented requirement.

This PR couples openssl threads support for emscripten to the presence of `-pthread` in the C flags from the triplet/toolchain. Triplet/toolchain ensures that all C and C++ source files ae compiled AND linked with `pthread` (subject to per-port customization).

This change has been tested with `vcpkg-ci-curl[core]:wasm32-emscripten` with default settings (i.e. no `-pthread`) and with `CFLAGS=-pthread`.