### PR TITLE
[curl] Don't export implicit link dirs

### DIFF
--- a/ports/curl/pkgconfig-curl-config.patch
+++ b/ports/curl/pkgconfig-curl-config.patch
@@ -1,16 +1,19 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b6b74c1..d01a127 100644
+index cb97dd5..7f3b25d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -2260,6 +2260,7 @@ if(NOT CURL_DISABLE_INSTALL)
+@@ -2258,8 +2258,10 @@ if(NOT CURL_DISABLE_INSTALL)
+       endif()
+     endif()
    endforeach()
++  list(APPEND _sys_libdirs ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
  
    foreach(_libdir IN LISTS _custom_libdirs CURL_LIBDIRS)
 +    cmake_path(SET _libdir NORMALIZE "${_libdir}")
      list(FIND _sys_libdirs "${_libdir}" _libdir_index)
      if(_libdir_index LESS 0)
        list(APPEND _ldflags "-L${_libdir}")
-@@ -2271,7 +2272,30 @@ if(NOT CURL_DISABLE_INSTALL)
+@@ -2271,7 +2273,30 @@ if(NOT CURL_DISABLE_INSTALL)
      set(_implicit_libs ${CMAKE_C_IMPLICIT_LINK_LIBRARIES})
    endif()
  
@@ -42,7 +45,7 @@ index b6b74c1..d01a127 100644
      if(TARGET "${_lib}")
        set(_libname "${_lib}")
        get_target_property(_imported "${_libname}" IMPORTED)
-@@ -2286,6 +2310,10 @@ if(NOT CURL_DISABLE_INSTALL)
+@@ -2286,6 +2311,10 @@ if(NOT CURL_DISABLE_INSTALL)
          continue()
        endif()
      endif()
@@ -53,7 +56,7 @@ index b6b74c1..d01a127 100644
      if(_lib MATCHES "^-")  # '-framework <name>'
        list(APPEND _ldflags "${_lib}")
      elseif(_lib MATCHES "/")
-@@ -2294,17 +2322,24 @@ if(NOT CURL_DISABLE_INSTALL)
+@@ -2294,17 +2323,24 @@ if(NOT CURL_DISABLE_INSTALL)
        get_filename_component(_libdir ${_lib} DIRECTORY)
        get_filename_component(_libname ${_lib} NAME_WE)
        if(_libname MATCHES "^lib")
@@ -81,7 +84,7 @@ index b6b74c1..d01a127 100644
      endif()
    endforeach()
  
-@@ -2330,11 +2365,11 @@ if(NOT CURL_DISABLE_INSTALL)
+@@ -2330,11 +2366,11 @@ if(NOT CURL_DISABLE_INSTALL)
      set(LIBCURL_PC_REQUIRES "")
      set(LIBCURL_PC_LIBS     "")
      set(LIBCURL_PC_CFLAGS   "")
@@ -97,18 +100,19 @@ index b6b74c1..d01a127 100644
    if(BUILD_STATIC_LIBS)
      set(ENABLE_STATIC       "yes")
 diff --git a/curl-config.in b/curl-config.in
-index 5518416..e418afc 100644
+index 5518416..c0c29da 100644
 --- a/curl-config.in
 +++ b/curl-config.in
-@@ -156,6 +156,7 @@ while test "$#" -gt 0; do
+@@ -155,7 +155,7 @@ while test "$#" -gt 0; do
+       curllibdir=''
      fi
      if test 'X@ENABLE_SHARED@' = 'Xno'; then
-       echo "${curllibdir}-lcurl @LIBCURL_PC_LIBS_PRIVATE@"
+-      echo "${curllibdir}-lcurl @LIBCURL_PC_LIBS_PRIVATE@"
 +      echo "@libdir@/libcurl.@libext@ @LIBCURL_PC_LDFLAGS_PRIVATE@ @CURL_CONFIG_LIBS_PRIVATE@ @LIBCURL_PC_LIBS_PRIVATE@"
      else
        echo "${curllibdir}-lcurl"
      fi
-@@ -167,7 +168,7 @@ while test "$#" -gt 0; do
+@@ -167,7 +167,7 @@ while test "$#" -gt 0; do
  
    --static-libs)
      if test 'X@ENABLE_STATIC@' != 'Xno'; then

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "curl",
   "version": "8.12.0",
+  "port-version": 1,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": "curl AND ISC AND BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2126,7 +2126,7 @@
     },
     "curl": {
       "baseline": "8.12.0",
-      "port-version": 0
+      "port-version": 1
     },
     "curlcpp": {
       "baseline": "3.1",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c1d4d30018a3a20662c9e9e30dd1f3c4eebd3c37",
+      "version": "8.12.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "751c4da14da7d3634a26a7ff7ca76a24de133cd6",
       "version": "8.12.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/pull/43463#issuecomment-2638611717.

Tested locally with `vcpkg-ci-curl:arm-android` with NDK r22b and VCPKG_CMAKE_SYSTEM_VERSION 16.