### PR TITLE
[debian-libfilezilla] new port

### DIFF
--- a/ports/debian-libfilezilla/portfile.cmake
+++ b/ports/debian-libfilezilla/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://snapshot.debian.org/archive/debian/20241024T205158Z/pool/main/libf/libfilezilla/libfilezilla_${VERSION}.debian.tar.xz"
+    FILENAME "libfilezilla-${VERSION}.tar.gz"
+    SHA512 75d9d803832a668663458d22cf09153da33948cb30acaa9bb6f61c0a667d1b879bc231ad68b8d1f18b854f85215774124ca0be2e0cb6cabd2f6abfcf4f99e531
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+)
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        --disable-locales
+)
+
+vcpkg_make_install()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/debian-libfilezilla/vcpkg.json
+++ b/ports/debian-libfilezilla/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "debian-libfilezilla",
+  "version": "0.49.0-2",
+  "description": "small and modern C++ library, offering some basic functionality to build high-performing, platform-independent programs.",
+  "homepage": "https://salsa.debian.org/debian/libfilezilla/",
+  "license": "GPL-2.0-or-later",
+  "supports": "!windows | mingw",
+  "dependencies": [
+    "cppunit",
+    "gmp",
+    "libgnutls",
+    "nettle",
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2256,6 +2256,10 @@
       "baseline": "3.6.9",
       "port-version": 1
     },
+    "debian-libfilezilla": {
+      "baseline": "0.49.0-2",
+      "port-version": 0
+    },
     "debug-assert": {
       "baseline": "1.3.4",
       "port-version": 0

--- a/versions/d-/debian-libfilezilla.json
+++ b/versions/d-/debian-libfilezilla.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "44b69985dd03b5c73abadb6d9e96061271a4f2c2",
+      "version": "0.49.0-2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

