### PR TITLE
[loguru] Fix compile flags

### DIFF
--- a/ports/loguru/portfile.cmake
+++ b/ports/loguru/portfile.cmake
@@ -12,13 +12,11 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        fmt BUILD_WITH_FMT
+        fmt LOGURU_USE_FMTLIB
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS_DEBUG
-        -DINSTALL_HEADERS=OFF
     OPTIONS
         ${FEATURE_OPTIONS}
  )

--- a/ports/loguru/vcpkg.json
+++ b/ports/loguru/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "loguru",
   "version": "2.1.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A lightweight and flexible C++ logging library",
   "homepage": "https://github.com/emilk/loguru",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5618,7 +5618,7 @@
     },
     "loguru": {
       "baseline": "2.1.0",
-      "port-version": 4
+      "port-version": 5
     },
     "lpeg": {
       "baseline": "1.1.0",

--- a/versions/l-/loguru.json
+++ b/versions/l-/loguru.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "67bc02375bc51f3331b0962fa141632233e23bff",
+      "version": "2.1.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "fb3e7c33bf919ef01ff262f2b3b40ab89270a12b",
       "version": "2.1.0",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
