### PR TITLE
[gtest] update to 1.16

### DIFF
--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/googletest
     REF "v${VERSION}"
-    SHA512 9046841044a2bf7edfd96854ad9c44ffae4fcb9fb59a075b367507c0762a98eb32cb6968d46663228272e26321e96f4dd287c95baa22c6af9bad902b8b6ede4e
+    SHA512 bec8dad2a5abbea8e9e5f0ceedd8c9dbdb8939e9f74785476b0948f21f5db5901018157e78387e106c6717326558d6642fc0e39379c62af57bf1205a9df8a18b
     HEAD_REF main
     PATCHES
         001-fix-UWP-death-test.patch

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gtest",
-  "version-semver": "1.15.2",
+  "version-semver": "1.16.0",
   "description": "Google Testing and Mocking Framework",
   "homepage": "https://github.com/google/googletest",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3297,7 +3297,7 @@
       "port-version": 4
     },
     "gtest": {
-      "baseline": "1.15.2",
+      "baseline": "1.16.0",
       "port-version": 0
     },
     "gtk": {

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7448391582abd4a7d61248894ef2979c8f065813",
+      "version-semver": "1.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ac644e3ba0475ca37d4b50913f93920bee7ee38",
       "version-semver": "1.15.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.