### PR TITLE
[colmap,glew] Avoid GLU

### DIFF
--- a/ports/colmap/glew-get-error-string.diff
+++ b/ports/colmap/glew-get-error-string.diff
@@ -1,0 +1,13 @@
+diff --git a/src/thirdparty/SiftGPU/GlobalUtil.cpp b/src/thirdparty/SiftGPU/GlobalUtil.cpp
+index e98ef6b..10fb19b 100644
+--- a/src/thirdparty/SiftGPU/GlobalUtil.cpp
++++ b/src/thirdparty/SiftGPU/GlobalUtil.cpp
+@@ -137,7 +137,7 @@ void GlobalUtil::CheckErrorsGL(const char* location)
+ 	const char *errstr;
+ 	while (errnum = glGetError())
+ 	{
+-		errstr = (const char *)(gluErrorString(errnum));
++		errstr = (const char *)(glewGetErrorString(errnum));
+ 		if(errstr) {
+ 			std::cerr << errstr;
+ 		}

--- a/ports/colmap/no-glu.diff
+++ b/ports/colmap/no-glu.diff
@@ -1,5 +1,5 @@
 diff --git a/src/thirdparty/SiftGPU/GlobalUtil.cpp b/src/thirdparty/SiftGPU/GlobalUtil.cpp
-index e98ef6b..10fb19b 100644
+index e98ef6b..39435db 100644
 --- a/src/thirdparty/SiftGPU/GlobalUtil.cpp
 +++ b/src/thirdparty/SiftGPU/GlobalUtil.cpp
 @@ -137,7 +137,7 @@ void GlobalUtil::CheckErrorsGL(const char* location)
@@ -7,7 +7,7 @@ index e98ef6b..10fb19b 100644
  	while (errnum = glGetError())
  	{
 -		errstr = (const char *)(gluErrorString(errnum));
-+		errstr = (const char *)(glewGetErrorString(errnum));
++		errstr = nullptr; // just print errnum
  		if(errstr) {
  			std::cerr << errstr;
  		}

--- a/ports/colmap/portfile.cmake
+++ b/ports/colmap/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 1260db4346cc33c6c35efdee0157450fccef67dbc9de876fdc997c7cb90daec716e5ccec97df0a77e3e8686f43ec79f2c0a1523ea12eca2ee158347cb52dea48
     HEAD_REF main
+    PATCHES
+        glew-get-error-string.diff
 )
 
 if (NOT TRIPLET_SYSTEM_ARCH STREQUAL "x64" AND ("cuda" IN_LIST FEATURES OR "cuda-redist" IN_LIST FEATURES))

--- a/ports/colmap/portfile.cmake
+++ b/ports/colmap/portfile.cmake
@@ -1,4 +1,5 @@
-set(COLMAP_REF "aa087848a8bd09cebf3e3cc8a5732552f30c51ad") # v3.11.1
+# Update both, literally.
+set(COLMAP_REF 3.11.1 "682ea9ac4020a143047758739259b3ff04dabe8d")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -17,8 +18,10 @@ endif()
 # set GIT_COMMIT_ID and GIT_COMMIT_DATE
 if(DEFINED VCPKG_HEAD_VERSION)
     set(GIT_COMMIT_ID "${VCPKG_HEAD_VERSION}")
+elseif(NOT VERSION IN_LIST COLMAP_REF)
+    message(FATAL_ERROR "Version ${VERSION} missing in COLMAP_REF (${COLMAP_REF})")
 else()
-    set(GIT_COMMIT_ID "${COLMAP_REF}")
+    list(GET COLMAP_REF 1 GIT_COMMIT_ID)
 endif()
 
 string(TIMESTAMP COLMAP_GIT_COMMIT_DATE "%Y-%m-%d")

--- a/ports/colmap/portfile.cmake
+++ b/ports/colmap/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     SHA512 1260db4346cc33c6c35efdee0157450fccef67dbc9de876fdc997c7cb90daec716e5ccec97df0a77e3e8686f43ec79f2c0a1523ea12eca2ee158347cb52dea48
     HEAD_REF main
     PATCHES
-        glew-get-error-string.diff
+        no-glu.diff
 )
 
 if (NOT TRIPLET_SYSTEM_ARCH STREQUAL "x64" AND ("cuda" IN_LIST FEATURES OR "cuda-redist" IN_LIST FEATURES))

--- a/ports/colmap/vcpkg.json
+++ b/ports/colmap/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "colmap",
   "version": "3.11.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "COLMAP is a general-purpose Structure-from-Motion (SfM) and Multi-View Stereo (MVS) pipeline with a graphical and command-line interface. It offers a wide range of features for reconstruction of ordered and unordered image collections. The software is licensed under the new BSD license.",
   "homepage": "https://colmap.github.io/",
   "license": "BSD-3-Clause",

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -31,6 +31,9 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/glew)
 # Skip check the required dependency opengl
 vcpkg_fixup_pkgconfig(SKIP_CHECK)
 
+# Burn-in CMake build config
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/GL/glew.h" "ifndef GLEW_NO_GLU" "if 0")
+
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
 set(_targets_cmake_files)
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")

--- a/ports/glew/vcpkg.json
+++ b/ports/glew/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glew",
   "version": "2.2.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.",
   "homepage": "https://github.com/nigels-com/glew",
   "supports": "!android",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3130,7 +3130,7 @@
     },
     "glew": {
       "baseline": "2.2.0",
-      "port-version": 4
+      "port-version": 5
     },
     "glfw3": {
       "baseline": "3.4",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1794,7 +1794,7 @@
     },
     "colmap": {
       "baseline": "3.11.1",
-      "port-version": 1
+      "port-version": 2
     },
     "color-console": {
       "baseline": "2022-03-20",

--- a/versions/c-/colmap.json
+++ b/versions/c-/colmap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e924da50379a927afa2980cf7c77efe0fc822ba",
+      "version": "3.11.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "7f2f32bedf07a0ac7a5bc43b81268b20b41b060e",
       "version": "3.11.1",
       "port-version": 1

--- a/versions/c-/colmap.json
+++ b/versions/c-/colmap.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9e924da50379a927afa2980cf7c77efe0fc822ba",
+      "git-tree": "7deee951326bf2685951c8d5ff7cbc3618ec5567",
       "version": "3.11.1",
       "port-version": 2
     },

--- a/versions/g-/glew.json
+++ b/versions/g-/glew.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "deee148de63ca706630edc3408d1c9a471f8884f",
+      "version": "2.2.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "bf42d73479dcd0f239b71dbed4d0d3af22efb294",
       "version": "2.2.0",
       "port-version": 4


### PR DESCRIPTION
Alternative glew fix vs. https://github.com/microsoft/vcpkg/pull/43641.
(As suggested in comments.)

Note that both PRs make the port deviate from glew documentation,
https://github.com/nigels-com/glew/blob/3da315c23aa80b5727e51f21bbe33823bf4c0511/doc/install.html#L158-L159.

And the port has more problems.