### PR TITLE
[sdl2-mixer] update to 2.8.1

### DIFF
--- a/ports/sdl2-mixer/portfile.cmake
+++ b/ports/sdl2-mixer/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL_mixer
     REF "release-${VERSION}"
-    SHA512 e4c9a4418725ce019bb62216c8fd484cf04b34e2099af633d4c84e0e558fe6ba1921e791c5dde319266ffe3a1237f887871c819a249a8df7e9440c36fce181da
+    SHA512 653ec1f0af0b749b9ed0acd3bfcaa40e1e1ecf34af3127eb74019502ef42a551de226daef4cc89e6a51715f013e0ba0b1e48ae17d6aeee931271f2d10e82058a
     PATCHES 
         fix-pkg-prefix.patch
 )

--- a/ports/sdl2-mixer/vcpkg.json
+++ b/ports/sdl2-mixer/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sdl2-mixer",
-  "version": "2.8.0",
-  "port-version": 3,
+  "version": "2.8.1",
   "description": "Multi-channel audio mixer library for SDL.",
   "homepage": "https://github.com/libsdl-org/SDL_mixer",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8269,8 +8269,8 @@
       "port-version": 0
     },
     "sdl2-mixer": {
-      "baseline": "2.8.0",
-      "port-version": 3
+      "baseline": "2.8.1",
+      "port-version": 0
     },
     "sdl2-mixer-ext": {
       "baseline": "2.6.0",

--- a/versions/s-/sdl2-mixer.json
+++ b/versions/s-/sdl2-mixer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3a4c9ad83e4941db5d8b61a1832d1fd79756073",
+      "version": "2.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "dd4194d58e9c97835f6d38257f1af245e659e2de",
       "version": "2.8.0",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
