### PR TITLE
[duckdb] new port

### DIFF
--- a/ports/duckdb/bigobj.patch
+++ b/ports/duckdb/bigobj.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2624479..4496860 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -727,6 +727,9 @@ function(add_library_unity NAME MODE)
+     enable_unity_build(${NAME} SRCS)
+   endif()
+   add_library(${NAME} OBJECT ${SRCS})
++  if(MSVC)
++    target_compile_options(${NAME} PRIVATE /bigobj)
++  endif()
+ endfunction()
+ 
+ function(disable_target_warnings NAME)

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -1,10 +1,11 @@
-set(DUCKDB_SHORT_HASH 401c8061c6)
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO duckdb/duckdb
         REF v${VERSION}
-        SHA512 ecd036ff975e90c4e9cc3a25784169f5938db19eacd2abc201719d329ec1055608bb2270de22bf409d828196ede6ffe95369154c916916e13a7a14071b05652e
+        SHA512 f5bca7a3b6f763b4b1a1f39e53c6f818925584fb44886e291ac3546fe50de545e80d16b4120f0126020e44b601a1b9193f4faad7a3dc8799cda843b1965038f2
         HEAD_REF master
+	PATCHES
+	    unvendor_icu.patch
 )
 
 # Remove vendored dependencies which are not properly namespaced
@@ -18,19 +19,15 @@ file(REMOVE_RECURSE
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" DUCKDB_BUILD_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DUCKDB_BUILD_DYNAMIC)
 
-set(EXTENSION_LIST "autocomplete;httpfs;icu;json;parquet;tpcds;tpch")
-set(EXTENSION_LOAD_LIST "")
+set(EXTENSION_LIST "autocomplete;httpfs;icu;json;tpcds;tpch")
+set(BUILD_EXTENSIONS "")
 foreach(EXT ${EXTENSION_LIST})
     if(${EXT} IN_LIST FEATURES)
-        list(APPEND EXTENSION_LOAD_LIST ${EXT})
+        list(APPEND BUILD_EXTENSIONS ${EXT})
     endif()
 endforeach()
-if(NOT "${EXTENSION_LOAD_LIST}" STREQUAL "")
-    set(LOAD_EXTENSIONS_FLAG "-DBUILD_EXTENSIONS='${EXTENSION_LOAD_LIST}'")
-endif()
-
-if(NOT "parquet" IN_LIST FEATURES)
-    set(SKIP_PARQUET_FLAG "-DSKIP_EXTENSIONS=parquet")
+if(NOT "${BUILD_EXTENSIONS}" STREQUAL "")
+    set(BUILD_EXTENSIONS_FLAG "-DBUILD_EXTENSIONS='${BUILD_EXTENSIONS}'")
 endif()
 
 vcpkg_cmake_configure(
@@ -40,8 +37,7 @@ vcpkg_cmake_configure(
             -DDUCKDB_EXPLICIT_VERSION=v${VERSION}
             -DBUILD_UNITTESTS=OFF
             -DBUILD_SHELL=FALSE
-            "${SKIP_PARQUET_FLAG}"
-            "${LOAD_EXTENSIONS_FLAG}"
+            "${BUILD_EXTENSIONS_FLAG}"
             -DENABLE_EXTENSION_AUTOLOADING=1
             -DENABLE_EXTENSION_AUTOINSTALL=1
 	    -DENABLE_SANITIZER=OFF

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
         HEAD_REF master
 	PATCHES
 	    unvendor_icu.patch
+	    bigobj.patch
 )
 
 # Remove vendored dependencies which are not properly namespaced

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -42,9 +42,9 @@ vcpkg_cmake_configure(
             -DENABLE_EXTENSION_AUTOLOADING=1
             -DENABLE_EXTENSION_AUTOINSTALL=1
             -DWITH_INTERNAL_ICU=OFF
-        -DENABLE_SANITIZER=OFF
+            -DENABLE_SANITIZER=OFF
             -DENABLE_THREAD_SANITIZER=OFF
-        -DENABLE_UBSAN=OFF
+            -DENABLE_UBSAN=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -1,0 +1,73 @@
+set(DUCKDB_SHORT_HASH 401c8061c6)
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO duckdb/duckdb
+        REF v${VERSION}
+        SHA512 ecd036ff975e90c4e9cc3a25784169f5938db19eacd2abc201719d329ec1055608bb2270de22bf409d828196ede6ffe95369154c916916e13a7a14071b05652e
+        HEAD_REF master
+)
+
+# Remove vendored dependencies which are not properly namespaced
+file(REMOVE_RECURSE
+    "${SOURCE_PATH}/third_party/catch"
+    "${SOURCE_PATH}/third_party/imdb"
+    "${SOURCE_PATH}/third_party/snowball"
+    "${SOURCE_PATH}/third_party/tpce-tool"
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" DUCKDB_BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DUCKDB_BUILD_DYNAMIC)
+
+set(EXTENSION_LIST "autocomplete;httpfs;icu;json;parquet;tpcds;tpch")
+set(EXTENSION_LOAD_LIST "")
+foreach(EXT ${EXTENSION_LIST})
+    if(${EXT} IN_LIST FEATURES)
+        list(APPEND EXTENSION_LOAD_LIST ${EXT})
+    endif()
+endforeach()
+if(NOT "${EXTENSION_LOAD_LIST}" STREQUAL "")
+    set(LOAD_EXTENSIONS_FLAG "-DBUILD_EXTENSIONS='${EXTENSION_LOAD_LIST}'")
+endif()
+
+if(NOT "parquet" IN_LIST FEATURES)
+    set(SKIP_PARQUET_FLAG "-DSKIP_EXTENSIONS=parquet")
+endif()
+
+vcpkg_cmake_configure(
+        SOURCE_PATH ${SOURCE_PATH}
+        OPTIONS
+            -DOVERRIDE_GIT_DESCRIBE=v${VERSION}
+            -DDUCKDB_EXPLICIT_VERSION=v${VERSION}
+            -DBUILD_UNITTESTS=OFF
+            -DBUILD_SHELL=FALSE
+            "${SKIP_PARQUET_FLAG}"
+            "${LOAD_EXTENSIONS_FLAG}"
+            -DENABLE_EXTENSION_AUTOLOADING=1
+            -DENABLE_EXTENSION_AUTOINSTALL=1
+	    -DENABLE_SANITIZER=OFF
+            -DENABLE_THREAD_SANITIZER=OFF
+	    -DENABLE_UBSAN=OFF
+)
+vcpkg_cmake_install()
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/CMake")
+    vcpkg_cmake_config_fixup(CONFIG_PATH CMake)
+elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/DuckDB")
+    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/DuckDB")
+elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT}")
+    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/include/duckdb/main/capi/header_generation"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/duckdb/storage/serialization")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -4,9 +4,9 @@ vcpkg_from_github(
         REF v${VERSION}
         SHA512 f5bca7a3b6f763b4b1a1f39e53c6f818925584fb44886e291ac3546fe50de545e80d16b4120f0126020e44b601a1b9193f4faad7a3dc8799cda843b1965038f2
         HEAD_REF master
-	PATCHES
-	    unvendor_icu.patch
-	    bigobj.patch
+    PATCHES
+        bigobj.patch
+        unvendor_icu_and_find_dependency.patch # https://github.com/duckdb/duckdb/pull/16176 + https://github.com/duckdb/duckdb/pull/16197
 )
 
 # Remove vendored dependencies which are not properly namespaced
@@ -41,10 +41,12 @@ vcpkg_cmake_configure(
             "${BUILD_EXTENSIONS_FLAG}"
             -DENABLE_EXTENSION_AUTOLOADING=1
             -DENABLE_EXTENSION_AUTOINSTALL=1
-	    -DENABLE_SANITIZER=OFF
+            -DWITH_INTERNAL_ICU=OFF
+        -DENABLE_SANITIZER=OFF
             -DENABLE_THREAD_SANITIZER=OFF
-	    -DENABLE_UBSAN=OFF
+        -DENABLE_UBSAN=OFF
 )
+
 vcpkg_cmake_install()
 
 if(EXISTS "${CURRENT_PACKAGES_DIR}/CMake")

--- a/ports/duckdb/unvendor_icu.patch
+++ b/ports/duckdb/unvendor_icu.patch
@@ -1,0 +1,46 @@
+diff --git a/extension/icu/CMakeLists.txt b/extension/icu/CMakeLists.txt
+index 65cbe38..a1f02f2 100644
+--- a/extension/icu/CMakeLists.txt
++++ b/extension/icu/CMakeLists.txt
+@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 2.8.12...3.29)
+ project(ICUExtension)
+ 
+ include_directories(include)
+-include_directories(third_party/icu/common)
+-include_directories(third_party/icu/i18n)
+-
+-add_subdirectory(third_party)
++option(WITH_INTERNAL_ICU "Use vendored copy of icu" TRUE)
++if(WITH_INTERNAL_ICU)
++    include_directories(third_party/icu/common)
++    include_directories(third_party/icu/i18n)
++    
++    add_subdirectory(third_party)
++endif()
+ 
+ set(ICU_EXTENSION_FILES
+     ${ICU_LIBRARY_FILES}
+@@ -26,6 +29,10 @@ set(ICU_EXTENSION_FILES
+ 
+ build_static_extension(icu ${ICU_EXTENSION_FILES})
+ link_threads(icu_extension)
++if(NOT WITH_INTERNAL_ICU)
++    find_package(ICU COMPONENTS i18n REQUIRED)
++    target_link_libraries(icu_extension ICU::i18n)
++endif()
+ disable_target_warnings(icu_extension)
+ set(PARAMETERS "-no-warnings")
+ build_loadable_extension(icu ${PARAMETERS} ${ICU_EXTENSION_FILES})
+diff --git a/extension/icu/icu-datefunc.cpp b/extension/icu/icu-datefunc.cpp
+index 995f594..a8092b6 100644
+--- a/extension/icu/icu-datefunc.cpp
++++ b/extension/icu/icu-datefunc.cpp
+@@ -72,7 +72,7 @@ unique_ptr<FunctionData> ICUDateFunc::Bind(ClientContext &context, ScalarFunctio
+ }
+ 
+ void ICUDateFunc::SetTimeZone(icu::Calendar *calendar, const string_t &tz_id) {
+-	auto tz = icu_66::TimeZone::createTimeZone(icu::UnicodeString::fromUTF8(icu::StringPiece(tz_id.GetString())));
++	auto tz = icu::TimeZone::createTimeZone(icu::UnicodeString::fromUTF8(icu::StringPiece(tz_id.GetString())));
+ 	if (*tz == icu::TimeZone::getUnknown()) {
+ 		delete tz;
+ 		throw NotImplementedException("Unknown TimeZone '%s'", tz_id.GetString());

--- a/ports/duckdb/unvendor_icu_and_find_dependency.patch
+++ b/ports/duckdb/unvendor_icu_and_find_dependency.patch
@@ -1,5 +1,22 @@
+diff --git a/DuckDBConfig.cmake.in b/DuckDBConfig.cmake.in
+index ef61b6b..2e5270e 100644
+--- a/DuckDBConfig.cmake.in
++++ b/DuckDBConfig.cmake.in
+@@ -4,6 +4,12 @@
+ #  DuckDB_INCLUDE_DIRS - include directories for DuckDB
+ #  DuckDB_LIBRARIES    - libraries to link against
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(Threads)
++if(NOT @WITH_INTERNAL_ICU@)
++    find_dependency(ICU COMPONENTS i18n uc)
++endif()
++
+ # Compute paths
+ get_filename_component(DuckDB_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ set(DuckDB_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 diff --git a/extension/icu/CMakeLists.txt b/extension/icu/CMakeLists.txt
-index 65cbe38..a1f02f2 100644
+index 65cbe38..6a38f93 100644
 --- a/extension/icu/CMakeLists.txt
 +++ b/extension/icu/CMakeLists.txt
 @@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 2.8.12...3.29)
@@ -8,13 +25,12 @@ index 65cbe38..a1f02f2 100644
  include_directories(include)
 -include_directories(third_party/icu/common)
 -include_directories(third_party/icu/i18n)
--
--add_subdirectory(third_party)
 +option(WITH_INTERNAL_ICU "Use vendored copy of icu" TRUE)
 +if(WITH_INTERNAL_ICU)
 +    include_directories(third_party/icu/common)
 +    include_directories(third_party/icu/i18n)
-+    
+ 
+-add_subdirectory(third_party)
 +    add_subdirectory(third_party)
 +endif()
  
@@ -25,8 +41,8 @@ index 65cbe38..a1f02f2 100644
  build_static_extension(icu ${ICU_EXTENSION_FILES})
  link_threads(icu_extension)
 +if(NOT WITH_INTERNAL_ICU)
-+    find_package(ICU COMPONENTS i18n REQUIRED)
-+    target_link_libraries(icu_extension ICU::i18n)
++    find_package(ICU COMPONENTS i18n uc REQUIRED)
++    target_link_libraries(icu_extension ICU::i18n ICU::uc)
 +endif()
  disable_target_warnings(icu_extension)
  set(PARAMETERS "-no-warnings")

--- a/ports/duckdb/usage
+++ b/ports/duckdb/usage
@@ -1,0 +1,6 @@
+The package DuckDB provides CMake targets:
+
+    find_package(DuckDB CONFIG REQUIRED)
+    find_package(Threads REQUIRED)
+    target_include_directories(main PRIVATE ${DuckDB_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE "$<IF:$<BOOL:${DUCKDB_BUILD_STATIC}>,duckdb_static,duckdb>")

--- a/ports/duckdb/usage
+++ b/ports/duckdb/usage
@@ -2,5 +2,4 @@ The package DuckDB provides CMake targets:
 
     find_package(DuckDB CONFIG REQUIRED)
     find_package(Threads REQUIRED)
-    target_include_directories(main PRIVATE ${DuckDB_INCLUDE_DIRS})
     target_link_libraries(main PRIVATE "$<IF:$<BOOL:${DUCKDB_BUILD_STATIC}>,duckdb_static,duckdb>")

--- a/ports/duckdb/usage
+++ b/ports/duckdb/usage
@@ -1,4 +1,4 @@
 The package DuckDB provides CMake targets:
 
     find_package(DuckDB CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE "$<IF:$<BOOL:${DUCKDB_BUILD_STATIC}>,duckdb_static,duckdb>")
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:duckdb>,duckdb,duckdb_static>)

--- a/ports/duckdb/usage
+++ b/ports/duckdb/usage
@@ -1,5 +1,4 @@
 The package DuckDB provides CMake targets:
 
     find_package(DuckDB CONFIG REQUIRED)
-    find_package(Threads REQUIRED)
     target_link_libraries(main PRIVATE "$<IF:$<BOOL:${DUCKDB_BUILD_STATIC}>,duckdb_static,duckdb>")

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "High-performance in-process analytical database system",
   "homepage": "https://duckdb.org",
   "license": "MIT",
@@ -15,9 +15,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "parquet"
-  ],
   "features": {
     "autocomplete": {
       "description": "Statically link the autocomplete extension into DuckDB"
@@ -29,13 +26,13 @@
       ]
     },
     "icu": {
-      "description": "Statically link the icu extension into DuckDB"
+      "description": "Statically link the icu extension into DuckDB",
+      "dependencies": [
+        "icu"
+      ]
     },
     "json": {
       "description": "Statically link the json extension into DuckDB"
-    },
-    "parquet": {
-      "description": "Statically link the parquet extension into DuckDB"
     },
     "tpcds": {
       "description": "Statically link the tpcds extension into DuckDB"

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -28,7 +28,10 @@
     "icu": {
       "description": "Statically link the icu extension into DuckDB",
       "dependencies": [
-        "icu"
+        {
+          "name": "icu",
+          "default-features": false
+        }
       ]
     },
     "json": {

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,0 +1,47 @@
+{
+  "name": "duckdb",
+  "version": "1.1.3",
+  "description": "High-performance in-process analytical database system",
+  "homepage": "https://duckdb.org",
+  "license": "MIT",
+  "supports": "!(uwp | android | (windows & arm64))",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "parquet"
+  ],
+  "features": {
+    "autocomplete": {
+      "description": "Statically link the autocomplete extension into DuckDB"
+    },
+    "httpfs": {
+      "description": "Statically link the httpfs extension into DuckDB",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "icu": {
+      "description": "Statically link the icu extension into DuckDB"
+    },
+    "json": {
+      "description": "Statically link the json extension into DuckDB"
+    },
+    "parquet": {
+      "description": "Statically link the parquet extension into DuckDB"
+    },
+    "tpcds": {
+      "description": "Statically link the tpcds extension into DuckDB"
+    },
+    "tpch": {
+      "description": "Statically link the tpch extension into DuckDB"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2412,6 +2412,10 @@
       "baseline": "1.21",
       "port-version": 0
     },
+    "duckdb": {
+      "baseline": "1.1.3",
+      "port-version": 0
+    },
     "duckx": {
       "baseline": "1.2.2",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2413,7 +2413,7 @@
       "port-version": 0
     },
     "duckdb": {
-      "baseline": "1.1.3",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "duckx": {

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,13 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "bc15d82a55a74e85c30a2f5f5abedc2079c82f70",
+      "git-tree": "072afeb0b1b419ea0c189ab2192e5f852823f45d",
       "version": "1.2.0",
-      "port-version": 0
-    },
-    {
-      "git-tree": "8551edbb799a15c241ead90163f707ebe134f00b",
-      "version": "1.1.3",
       "port-version": 0
     }
   ]

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c5b29a2c383c83583df4fc3df5799c39d5162939",
+      "git-tree": "bc15d82a55a74e85c30a2f5f5abedc2079c82f70",
       "version": "1.2.0",
       "port-version": 0
     },

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c5b29a2c383c83583df4fc3df5799c39d5162939",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8551edbb799a15c241ead90163f707ebe134f00b",
       "version": "1.1.3",
       "port-version": 0

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8551edbb799a15c241ead90163f707ebe134f00b",
+      "version": "1.1.3",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "072afeb0b1b419ea0c189ab2192e5f852823f45d",
+      "git-tree": "02e6c406fafcd36a23c51998c14c1e95653b2254",
       "version": "1.2.0",
       "port-version": 0
     }


### PR DESCRIPTION
Adds a new duckdb port, this is based on https://github.com/microsoft/vcpkg/pull/34607
Vendored dependencies which are not properly namespaced have been removed as a result of the discussion in https://github.com/microsoft/vcpkg/pull/34607 .