### PR TITLE
[presentmon] update to 2.3.0

### DIFF
--- a/ports/presentmon/portfile.cmake
+++ b/ports/presentmon/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GameTechDev/PresentMon
     REF "v${VERSION}"
-    SHA512 30945e61ba09e23ebc05e3f8a0e96a298349dad6a83043a37df9e1af0c892bee1704214e8f6ddc8cdaa9f527deb16f27b3653c855eab6bbc2f9ce509da4ded00
+    SHA512 1c606dd53a05b88a500a2deeb7099ce3cf0e9edfdf6ce8f9a1a91efecf9049bf700368066cbafc1e196f4bf8a6e43da86a2f10ad0843b582ab851e366a33eda4
     HEAD_REF main
 )
 

--- a/ports/presentmon/vcpkg.json
+++ b/ports/presentmon/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "presentmon",
-  "version-semver": "2.1.1",
+  "version-semver": "2.3.0",
   "description": "PresentMon is a tool to capture and analyze ETW events related to swap chain presentation on Windows.",
   "supports": "windows & !uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7229,7 +7229,7 @@
       "port-version": 0
     },
     "presentmon": {
-      "baseline": "2.1.1",
+      "baseline": "2.3.0",
       "port-version": 0
     },
     "proj": {

--- a/versions/p-/presentmon.json
+++ b/versions/p-/presentmon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d397dd1c9203af9da5d7833dc04117cdacaff59",
+      "version-semver": "2.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "320eb831b4a4a59b6ed3825c1caefcf9a860bd8a",
       "version-semver": "2.1.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43724.
Update presentmon to 2.3.0.
All feature tested pass on the following triplets:
- x64-windows
- x64-windows-static
- x86-windows
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.