### PR TITLE
[luau] update to 0.660

### DIFF
--- a/ports/luau/cmake-config-export.patch
+++ b/ports/luau/cmake-config-export.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 51fa919e..9854f32c 100644
+index 5286fd9..9f5544b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -65,30 +65,30 @@ add_library(Luau.VM.Internals INTERFACE)
+@@ -65,31 +65,31 @@ add_library(Luau.VM.Internals INTERFACE)
  
  include(Sources.cmake)
  
@@ -10,12 +10,14 @@ index 51fa919e..9854f32c 100644
 +target_include_directories(Luau.Common INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Common/include> $<INSTALL_INTERFACE:include/luau>)
  
  target_compile_features(Luau.CLI.lib PUBLIC cxx_std_17)
- target_link_libraries(Luau.CLI.lib PRIVATE Luau.Common)
+-target_include_directories(Luau.CLI.lib PUBLIC CLI/include)
++target_include_directories(Luau.CLI.lib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CLI/include> $<INSTALL_INTERFACE:include/luau>)
+ target_link_libraries(Luau.CLI.lib PRIVATE Luau.Common Luau.Config)
  
  target_compile_features(Luau.Ast PUBLIC cxx_std_17)
 -target_include_directories(Luau.Ast PUBLIC Ast/include)
 +target_include_directories(Luau.Ast PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Ast/include> $<INSTALL_INTERFACE:include/luau>)
- target_link_libraries(Luau.Ast PUBLIC Luau.Common Luau.CLI.lib)
+ target_link_libraries(Luau.Ast PUBLIC Luau.Common)
  
  target_compile_features(Luau.Compiler PUBLIC cxx_std_17)
 -target_include_directories(Luau.Compiler PUBLIC Compiler/include)
@@ -39,7 +41,7 @@ index 51fa919e..9854f32c 100644
  target_link_libraries(Luau.EqSat PUBLIC Luau.Common)
  
  target_compile_features(Luau.CodeGen PRIVATE cxx_std_17)
-@@ -97,7 +97,7 @@ target_link_libraries(Luau.CodeGen PRIVATE Luau.VM Luau.VM.Internals) # Code gen
+@@ -98,7 +98,7 @@ target_link_libraries(Luau.CodeGen PRIVATE Luau.VM Luau.VM.Internals) # Code gen
  target_link_libraries(Luau.CodeGen PUBLIC Luau.Common)
  
  target_compile_features(Luau.VM PRIVATE cxx_std_11)
@@ -48,7 +50,7 @@ index 51fa919e..9854f32c 100644
  target_link_libraries(Luau.VM PUBLIC Luau.Common)
  
  target_include_directories(isocline PUBLIC extern/isocline/include)
-@@ -182,22 +182,6 @@ if(MSVC AND LUAU_BUILD_CLI)
+@@ -183,22 +183,6 @@ if(MSVC AND LUAU_BUILD_CLI)
      set_target_properties(Luau.Repl.CLI PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
  endif()
  
@@ -71,7 +73,7 @@ index 51fa919e..9854f32c 100644
  # On Windows and Android threads are provided, on Linux/Mac/iOS we use pthreads
  add_library(osthreads INTERFACE)
  if(CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin|iOS")
-@@ -287,3 +271,54 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.EqSat Luau.Cod
+@@ -288,3 +272,54 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.EqSat Luau.Cod
          endif()
      endif()
  endforeach()
@@ -126,10 +128,9 @@ index 51fa919e..9854f32c 100644
 +    NAMESPACE unofficial::luau::
 +    DESTINATION "${CMAKE_INSTALL_DATADIR}/unofficial-luau"
 +)
-\ No newline at end of file
-diff --git a/cmake/unofficial-luau-config.cmake b/cmake/unofficial-luau-config.cmake
+diff --git b/cmake/unofficial-luau-config.cmake b/cmake/unofficial-luau-config.cmake
 new file mode 100644
-index 00000000..2680ef31
+index 0000000..2680ef3
 --- /dev/null
 +++ b/cmake/unofficial-luau-config.cmake
 @@ -0,0 +1 @@

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 a3be52f7958d364693c0bc2541b08082852917b53a80cc4fbdde3167c9068b269f8476882592eafac4c4d674ed6d51ba25a52eaa3b2b6d4dce4603f6aad73f6b
+    SHA512 1f5886a1516730cb13fe6275b558121a3b5e7d220c1ffae51cb3a0507b8a10697ef99af056c68af0e0103e723f821d3fb9c83a89b58df1432fa9fe36afb91164
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.651",
+  "version": "0.660",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5685,7 +5685,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.651",
+      "baseline": "0.660",
       "port-version": 0
     },
     "luminoengine": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,9 +1,14 @@
 {
-    "versions": [
-        {
-            "version": "0.651",
-            "port-version": 0,
-            "git-tree": "b24888fd538d5e53526c0a7b6f37646f9aec0556"
-        }
-    ]
+  "versions": [
+    {
+      "git-tree": "70efa05416e195b201393f9c3a905362d4af0795",
+      "version": "0.660",
+      "port-version": 0
+    },
+    {
+      "git-tree": "b24888fd538d5e53526c0a7b6f37646f9aec0556",
+      "version": "0.651",
+      "port-version": 0
+    }
+  ]
 }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
