### PR TITLE
[c4core] update to 0.2.5

### DIFF
--- a/ports/c4core/disable-cpack.patch
+++ b/ports/c4core/disable-cpack.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ba9983c..41ea81a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -115,7 +115,7 @@ endif()
+ c4_add_dev_targets()
+ 
+ if(C4CORE_INSTALL)
+-    c4_pack_project(TYPE LIBRARY)
++#    c4_pack_project(TYPE LIBRARY)
+ endif()
+ 
+ 

--- a/ports/c4core/portfile.cmake
+++ b/ports/c4core/portfile.cmake
@@ -5,18 +5,18 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/c4core
     REF "v${VERSION}"
-    SHA512 23e45d186d03a64701376fbb63b5e3608dfdac7188eefd869976e97149ee772c7547e460b305c938650a721eac0c0573b70b5a5a2cd7211192cf9c87f019548c
+    SHA512 ed98ec8adc1b414e61f7e7c329b499a6b48730fbad5c160393c285f42b0a4a3810b4f06499a3f3585c309b7bfe080289d86c6dd43f89b658f9d029543c3c2847
     HEAD_REF master
 )
 
-set(CM_COMMIT_HASH fe41e86552046c3df9ba73a40bf3d755df028c1e)
+set(CM_COMMIT_HASH 386e367dfa5369289f706d70c6790fefc099dd27)
 
 # Get cmake scripts for c4core
 vcpkg_download_distfile(
     CMAKE_ARCHIVE
     URLS "https://github.com/biojppm/cmake/archive/${CM_COMMIT_HASH}.zip"
     FILENAME "cmake-${CM_COMMIT_HASH}.zip"
-    SHA512 7292f9856d9c41581f2731e73fdf08880e0f4353b757da38a13ec89b62c5c8cb52b9efc1a9ff77336efa0b6809727c17649e607d8ecacc965a9b2a7a49925237
+    SHA512 676a5b29873c04dc5399213e5398cb73e3765f6f390ea0cf400c4e2835ccee7173ae6d29099451845a3cac1ae957d3d6cc2ac686d6361dce140d0e94cce11dc7
 )
 
 vcpkg_extract_source_archive(
@@ -46,13 +46,13 @@ vcpkg_extract_source_archive(
 file(REMOVE_RECURSE "${SOURCE_PATH}/src/c4/ext/debugbreak")
 file(RENAME "${SOURCE_PATH_DEBUGBREAK}" "${SOURCE_PATH}/src/c4/ext/debugbreak")
 
-set(FF_COMMIT_HASH 052975dd5f8166d0f9e4a215fa75a349d5985b91)
+set(FF_COMMIT_HASH d57ca3da1f115afd802394988391fbb6ead6b37c)
 
 vcpkg_download_distfile(
     FAST_FLOAT_ARCHIVE
     URLS "https://github.com/biojppm/fast_float/archive/${FF_COMMIT_HASH}.zip"
     FILENAME "fast_float-${FF_COMMIT_HASH}.zip"
-    SHA512 af63cbf1d6620cda87a5f0ca06dcaf46ddfe63658ae5ba91232a2416e8179cba3b2b3d06ff53c1ab2ba3745ae39b0cb787e04be3a9dbe1287605704c2ed13019
+    SHA512 5e42c4070841ead0ab5d2f8b0238b7e6e58cb823b3c1fea33a8a826c31a48b094a64b9a4e1c072d8c834be0da6e46a908932396b9cfa204db3ca83c11bdcafa4
 )
 
 vcpkg_extract_source_archive(

--- a/ports/c4core/portfile.cmake
+++ b/ports/c4core/portfile.cmake
@@ -7,6 +7,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 14cd0afbe5c1907ae150fa916354bfb16849d8faadd569b26d4ca05d425d78a12b2af51a49301c1bcad18b840fa46ba1076fcdd5f5baf07677ec0ced4a9b23de
     HEAD_REF master
+    PATCHES
+        disable-cpack.patch
 )
 
 set(CM_COMMIT_HASH b8e95acb1bdd564e47ac57d903a483604d90cbfa)

--- a/ports/c4core/portfile.cmake
+++ b/ports/c4core/portfile.cmake
@@ -5,18 +5,18 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/c4core
     REF "v${VERSION}"
-    SHA512 ed98ec8adc1b414e61f7e7c329b499a6b48730fbad5c160393c285f42b0a4a3810b4f06499a3f3585c309b7bfe080289d86c6dd43f89b658f9d029543c3c2847
+    SHA512 14cd0afbe5c1907ae150fa916354bfb16849d8faadd569b26d4ca05d425d78a12b2af51a49301c1bcad18b840fa46ba1076fcdd5f5baf07677ec0ced4a9b23de
     HEAD_REF master
 )
 
-set(CM_COMMIT_HASH 386e367dfa5369289f706d70c6790fefc099dd27)
+set(CM_COMMIT_HASH b8e95acb1bdd564e47ac57d903a483604d90cbfa)
 
 # Get cmake scripts for c4core
 vcpkg_download_distfile(
     CMAKE_ARCHIVE
     URLS "https://github.com/biojppm/cmake/archive/${CM_COMMIT_HASH}.zip"
     FILENAME "cmake-${CM_COMMIT_HASH}.zip"
-    SHA512 676a5b29873c04dc5399213e5398cb73e3765f6f390ea0cf400c4e2835ccee7173ae6d29099451845a3cac1ae957d3d6cc2ac686d6361dce140d0e94cce11dc7
+    SHA512 662c750279f4f1068bda60e999c54148e75f7a0daaf69e0540023770ef9008bab3d3acd41e06a193e5a095c614ccbdaa1c75fd4157cf03995dbbae6a6a24b445
 )
 
 vcpkg_extract_source_archive(
@@ -28,13 +28,13 @@ vcpkg_extract_source_archive(
 file(REMOVE_RECURSE "${SOURCE_PATH}/cmake")
 file(RENAME "${SOURCE_PATH_CMAKE}" "${SOURCE_PATH}/cmake")
 
-set(DB_COMMIT_HASH 5dcbe41d2bd4712c8014aa7e843723ad7b40fd74)
+set(DB_COMMIT_HASH 328e4abca3384cbd0a69e70f263cc7b2794bff09)
 
 vcpkg_download_distfile(
     DEBUGBREAK_ARCHIVE
     URLS "https://github.com/biojppm/debugbreak/archive/${DB_COMMIT_HASH}.zip"
     FILENAME "debugbreak-${DB_COMMIT_HASH}.zip"
-    SHA512 a4735225058b48031e68c91853c71d3cc31c8f2bfc3592cfc7a9a16f406224a814535ecade81ab4ead76458eeab8752e7e7cd521d893db5791dd4aaac3ba20d9
+    SHA512 47208fd7578d7fa0ff2d9170955b073cd761b271bc512072eab3bfd8e7f06d4bd5503837957acd388cbb95fde7f67b4c024f8809a1214417400f3bed4dab3ece
 )
 
 vcpkg_extract_source_archive(
@@ -46,13 +46,13 @@ vcpkg_extract_source_archive(
 file(REMOVE_RECURSE "${SOURCE_PATH}/src/c4/ext/debugbreak")
 file(RENAME "${SOURCE_PATH_DEBUGBREAK}" "${SOURCE_PATH}/src/c4/ext/debugbreak")
 
-set(FF_COMMIT_HASH d57ca3da1f115afd802394988391fbb6ead6b37c)
+set(FF_COMMIT_HASH d28a3320c2de0963b6e469b8ca3bbc36496de684)
 
 vcpkg_download_distfile(
     FAST_FLOAT_ARCHIVE
     URLS "https://github.com/biojppm/fast_float/archive/${FF_COMMIT_HASH}.zip"
     FILENAME "fast_float-${FF_COMMIT_HASH}.zip"
-    SHA512 5e42c4070841ead0ab5d2f8b0238b7e6e58cb823b3c1fea33a8a826c31a48b094a64b9a4e1c072d8c834be0da6e46a908932396b9cfa204db3ca83c11bdcafa4
+    SHA512 7642badc0af2e57303667de4fe6dbd61b633d82e9a42571f241a2e4ae8e385529096b4dcf22e7beb6998bf36f28eec10f7af396032db41f6a59ab6a8bffaf34a
 )
 
 vcpkg_extract_source_archive(

--- a/ports/c4core/vcpkg.json
+++ b/ports/c4core/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c4core",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "description": "Library of low-level C++ utilities",
   "homepage": "https://github.com/biojppm/c4core",
   "license": "MIT",

--- a/ports/c4core/vcpkg.json
+++ b/ports/c4core/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c4core",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Library of low-level C++ utilities",
   "homepage": "https://github.com/biojppm/c4core",
   "license": "MIT",

--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/rapidyaml
     REF "v${VERSION}"
-    SHA512 2ff14776498dc8a55cb257c38fbea5b1a1fc5c4c09ade5b10c45cb4afcaf0cc587674723bedf38fd04b3179a18ba7357a929484b154474d658d597d0f9ee8d2e
+    SHA512 964b17d43c2d8e0f820eaabb19aae594886c4b83668913f1ecf66581ed5c5ee0294551400d24926bcde90f34e1e6b8517761d0a8c8c51e53bd5336761e6d77b4
     HEAD_REF master
     PATCHES cmake-fix.patch
 )

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ryml",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Rapid YAML library",
   "homepage": "https://github.com/biojppm/rapidyaml",
   "license": "MIT",

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "Rapid YAML library",
   "homepage": "https://github.com/biojppm/rapidyaml",
   "license": "MIT",
-  "supports": "!uwp & !(windows & arm)",
   "dependencies": [
     {
       "name": "c4core",

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Rapid YAML library",
   "homepage": "https://github.com/biojppm/rapidyaml",
   "license": "MIT",
+  "supports": "!uwp & !(windows & arm)",
   "dependencies": [
     {
       "name": "c4core",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1453,7 +1453,7 @@
       "port-version": 0
     },
     "c4core": {
-      "baseline": "0.2.1",
+      "baseline": "0.2.3",
       "port-version": 0
     },
     "c89stringutils": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8129,7 +8129,7 @@
       "port-version": 2
     },
     "ryml": {
-      "baseline": "0.7.2",
+      "baseline": "0.8.0",
       "port-version": 0
     },
     "ryu": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1453,7 +1453,7 @@
       "port-version": 0
     },
     "c4core": {
-      "baseline": "0.2.3",
+      "baseline": "0.2.5",
       "port-version": 0
     },
     "c89stringutils": {

--- a/versions/c-/c4core.json
+++ b/versions/c-/c4core.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "064592ecf11a425f067f3b53e01f2e9a96f98ed3",
-      "version": "0.2.3",
+      "git-tree": "9827bdaa5b16055045968eda5d13d5dfb4d3fe35",
+      "version": "0.2.5",
       "port-version": 0
     },
     {

--- a/versions/c-/c4core.json
+++ b/versions/c-/c4core.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9827bdaa5b16055045968eda5d13d5dfb4d3fe35",
+      "git-tree": "65a14492c99ee904e56fc2b74182c2f7b5db3b73",
       "version": "0.2.5",
       "port-version": 0
     },

--- a/versions/c-/c4core.json
+++ b/versions/c-/c4core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "064592ecf11a425f067f3b53e01f2e9a96f98ed3",
+      "version": "0.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "01cd83a31d0cb744a2c93789a442e2dbed78851b",
       "version": "0.2.1",
       "port-version": 0

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea4ece3aece3ddc82a5655cdf0fbc78ad4fea8f9",
+      "version": "0.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8f7cac7caba15d67f117443f9332679f17006223",
       "version": "0.7.2",
       "port-version": 0

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ea4ece3aece3ddc82a5655cdf0fbc78ad4fea8f9",
+      "git-tree": "ab0176713ad30935f8ac0d3b4332c097960b8f04",
       "version": "0.8.0",
       "port-version": 0
     },

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ab0176713ad30935f8ac0d3b4332c097960b8f04",
+      "git-tree": "ea4ece3aece3ddc82a5655cdf0fbc78ad4fea8f9",
       "version": "0.8.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Internal libraries (biojppm/cmake, biojppm/fast_float) are also updated.
ryml which uses c4core is updated too.
