### PR TITLE
[sleepy-discord] asio 1.32.0 websockets

### DIFF
--- a/ports/sleepy-discord/portfile.cmake
+++ b/ports/sleepy-discord/portfile.cmake
@@ -1,6 +1,5 @@
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        "websocketpp"    USE_WEBSOCKETPP
         "cpr"            USE_CPR
         "voice"          ENABLE_VOICE
         "compression"    USE_ZLIB
@@ -9,20 +8,20 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yourWaifu/sleepy-discord
-    REF 70b9ec13427ea68de6f4213e9dfec6129fbab21b
-    SHA512 c91fbb9a672257c63ee83b40b62961b89568ca33081048b440876c390a2a2e11c602aaf43a6c9485fd85a91248f34a70d7b9ea769d0cfcd4b35b80d58a6ad737
-    HEAD_REF develop
+    REF ae26f3f573f625bc32561776126b4b06707d985c
+    SHA512 68ba8d9a1e48a9cd0374b0a3ec1ae05da54bf3238b1551726c6d5b99e368a995b86a13c7067cd017cdda7eb85085300d19d84f0e7d8a31df5df5f129d6fff904
+    HEAD_REF master
     PATCHES
         fix-messing-header.patch
 )
 
 # Handle version data here to prevent issues from doing this twice in parallel
-set(SLEEPY_DISCORD_VERSION_HASH 70b9ec13427ea68de6f4213e9dfec6129fbab21b)
-set(SLEEPY_DISCORD_VERSION_BUILD 949)
-set(SLEEPY_DISCORD_VERSION_BRANCH "develop")
-set(SLEEPY_DISCORD_VERSION_IS_MASTER 0)
+set(SLEEPY_DISCORD_VERSION_HASH ae26f3f573f625bc32561776126b4b06707d985c)
+set(SLEEPY_DISCORD_VERSION_BUILD 1017)
+set(SLEEPY_DISCORD_VERSION_BRANCH "master")
+set(SLEEPY_DISCORD_VERSION_IS_MASTER 1)
 set(SLEEPY_DISCORD_VERSION_DESCRIPTION_CONCAT " ")
-set(SLEEPY_DISCORD_VERSION_DESCRIPTION "70b9ec13")
+set(SLEEPY_DISCORD_VERSION_DESCRIPTION "ae26f3f")
 configure_file(
     "${SOURCE_PATH}/include/sleepy_discord/version.h.in"
     "${SOURCE_PATH}/include/sleepy_discord/version.h"
@@ -32,7 +31,8 @@ vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS 
         -DSLEEPY_VCPKG=ON 
-        -DAUTO_DOWNLOAD_LIBRARY=OFF 
+        -DAUTO_DOWNLOAD_LIBRARY=OFF
+        -DUSE_ASIO=OFF # ASIO standalone off
         -DUSE_BOOST_ASIO=ON
         -DCMAKE_CXX_STANDARD=17
         ${FEATURE_OPTIONS}

--- a/ports/sleepy-discord/vcpkg.json
+++ b/ports/sleepy-discord/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sleepy-discord",
-  "version-date": "2022-02-05",
-  "port-version": 2,
+  "version-date": "2025-02-08",
   "description": "C++ library for the Discord chat client",
   "homepage": "https://yourwaifu.dev/sleepy-discord/",
   "dependencies": [
@@ -16,8 +15,7 @@
     }
   ],
   "default-features": [
-    "cpr",
-    "websocketpp"
+    "cpr"
   ],
   "features": {
     "compression": {
@@ -37,13 +35,6 @@
       "dependencies": [
         "libsodium",
         "opus"
-      ]
-    },
-    "websocketpp": {
-      "description": "Use Websocketpp for handling WebSockets",
-      "dependencies": [
-        "boost-random",
-        "websocketpp"
       ]
     }
   }

--- a/ports/sleepy-discord/vcpkg.json
+++ b/ports/sleepy-discord/vcpkg.json
@@ -5,6 +5,7 @@
   "homepage": "https://yourwaifu.dev/sleepy-discord/",
   "dependencies": [
     "boost-asio",
+    "openssl",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8481,8 +8481,8 @@
       "port-version": 0
     },
     "sleepy-discord": {
-      "baseline": "2022-02-05",
-      "port-version": 2
+      "baseline": "2025-02-08",
+      "port-version": 0
     },
     "slikenet": {
       "baseline": "2021-06-07",

--- a/versions/s-/sleepy-discord.json
+++ b/versions/s-/sleepy-discord.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "04c1f475c2a1a60a4cf64ff84e621a3d88396963",
+      "git-tree": "54d97afb9a3148a60f7fac2da8e1b9a81e0b330f",
       "version-date": "2025-02-08",
       "port-version": 0
     },

--- a/versions/s-/sleepy-discord.json
+++ b/versions/s-/sleepy-discord.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8831ed07308ae79e2dd1fa34604246f3a5004b8b",
+      "git-tree": "04c1f475c2a1a60a4cf64ff84e621a3d88396963",
       "version-date": "2025-02-08",
       "port-version": 0
     },

--- a/versions/s-/sleepy-discord.json
+++ b/versions/s-/sleepy-discord.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8831ed07308ae79e2dd1fa34604246f3a5004b8b",
+      "version-date": "2025-02-08",
+      "port-version": 0
+    },
+    {
       "git-tree": "594857bed2d04f35b594acbf4f1488c4ae4c4ad0",
       "version-date": "2022-02-05",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.