### PR TITLE
[vcpkg-get-python] Add INTERPRETER keyword

### DIFF
--- a/ports/vcpkg-get-python/vcpkg-port-config.cmake
+++ b/ports/vcpkg-get-python/vcpkg-port-config.cmake
@@ -1,6 +1,10 @@
 include_guard(GLOBAL)
 
 function(vcpkg_get_vcpkg_installed_python out_python)
+  cmake_parse_arguments(PARSE_ARGV 1 "arg" "INTERPRETER" "" "")
+  if(DEFINED arg_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
+  endif()
   if(NOT VCPKG_TARGET_IS_WINDOWS)
     # vcpkg installed python on !windows works as normal python would work.
     set(${out_python} "${CURRENT_HOST_INSTALLED_DIR}/tools/python3/python3" PARENT_SCOPE)
@@ -8,6 +12,9 @@ function(vcpkg_get_vcpkg_installed_python out_python)
   endif()
   if(DEFINED CACHE{z_vcpkg_get_vcpkg_installed_python})
     set(${out_python} "${z_vcpkg_get_vcpkg_installed_python}" PARENT_SCOPE)
+    return()
+  elseif(arg_INTERPRETER AND DEFINED CACHE{z_vcpkg_get_vcpkg_installed_python_interpreter})
+    set(${out_python} "${z_vcpkg_get_vcpkg_installed_python_interpreter}" PARENT_SCOPE)
     return()
   endif()
 
@@ -48,10 +55,26 @@ if vcpkg_bin_path.is_dir():
 "
 )
 
- file(COPY "${CURRENT_INSTALLED_DIR}/${PYTHON3_INCLUDE}/" DESTINATION "${python_base}/include")
- set(suffix "PCBuild/AMD64") # TODO: ask python for the correct suffix.
- file(COPY "${CURRENT_INSTALLED_DIR}/lib/python${PYTHON3_VERSION_MAJOR}${PYTHON3_VERSION_MINOR}.lib" DESTINATION "${python_base}/${suffix}")
+  # This part is intentionally copies headers and link libraries from the target
+  # installation (CURRENT_INSTALLED_DIR): The function provides infrastructure for
+  # building extensions for the target python while running the host python interpreter.
+  # The calling port is responsible to provided the target python3 dependency.
+  # However, it is possible to use just the interpreter,
+  # e.g. for running extensions already installed in the host triplet.
+  if(EXISTS "${CURRENT_INSTALLED_DIR}/lib/python${PYTHON3_VERSION_MAJOR}${PYTHON3_VERSION_MINOR}.lib")
+    file(COPY "${CURRENT_INSTALLED_DIR}/${PYTHON3_INCLUDE}/" DESTINATION "${python_base}/include")
+    set(suffix "PCBuild/AMD64") # TODO: ask python for the correct suffix.
+    file(COPY "${CURRENT_INSTALLED_DIR}/lib/python${PYTHON3_VERSION_MAJOR}${PYTHON3_VERSION_MINOR}.lib" DESTINATION "${python_base}/${suffix}")
+    set(z_vcpkg_get_vcpkg_installed_python "${python_base}/Scripts/python.exe" CACHE INTERNAL "")
+  elseif(arg_INTERPRETER)
+    set(z_vcpkg_get_vcpkg_installed_python_interpreter "${python_base}/Scripts/python.exe" CACHE INTERNAL "")
+  else()
+    message(${Z_VCPKG_BACKCOMPAT_MESSAGE_LEVEL}
+      "Target python3 installation was not found, and the INTERPRETER wasn't given."
+      " Either add a \"python3\" dependency to ${PORT},"
+      " or add 'INTERPRETER' to the '${CMAKE_CURRENT_FUNCTION}' call."
+    )
+  endif()
 
- set(${out_python} "${python_base}/Scripts/python.exe" PARENT_SCOPE)
- set(z_vcpkg_get_vcpkg_installed_python "${python_base}/Scripts/python.exe" CACHE INTERNAL "")
+  set(${out_python} "${python_base}/Scripts/python.exe" PARENT_SCOPE)
 endfunction()

--- a/ports/vcpkg-get-python/vcpkg.json
+++ b/ports/vcpkg-get-python/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-get-python",
-  "version-date": "2024-06-22",
+  "version-date": "2025-02-09",
   "license": "MIT",
   "supports": "native"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9477,7 +9477,7 @@
       "port-version": 0
     },
     "vcpkg-get-python": {
-      "baseline": "2024-06-22",
+      "baseline": "2025-02-09",
       "port-version": 0
     },
     "vcpkg-get-python-packages": {

--- a/versions/v-/vcpkg-get-python.json
+++ b/versions/v-/vcpkg-get-python.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a0384810888b341ad84b0e08559481ff9a82150",
+      "version-date": "2025-02-09",
+      "port-version": 0
+    },
+    {
       "git-tree": "e1993fbd0925b052b31f62967690a2634cb952a2",
       "version-date": "2024-06-22",
       "port-version": 0


### PR DESCRIPTION
Allow avoiding installation order flakiness when consumers don't depend on target python3 because they only need an interpreter which is compatible with extensions installed on the host.

Based on PR review:
This function is intentionally copies headers and link libraries from the target installation (CURRENT_INSTALLED_DIR): The function provides infrastructure for building extensions for the target python while running the host python interpreter.  
The calling port is responsible to provided the target python3 dependency.
