### PR TITLE
[ntf-core] Update to 2.5.4

### DIFF
--- a/ports/ntf-core/dont-use-lib64.patch
+++ b/ports/ntf-core/dont-use-lib64.patch
@@ -1,10 +1,23 @@
 diff --git a/repository.cmake b/repository.cmake
-index 9b6c699..ed2ce32 100644
+index f02ba90..4dbd81f 100644
 --- a/repository.cmake
 +++ b/repository.cmake
-@@ -1737,11 +1737,7 @@ function (ntf_group_end)
+@@ -3151,11 +3151,7 @@ function (ntf_adapter_end)
+         set(target_output_name "${target}")
+     endif()
  
-     ntf_ufid_string_has(UFID ${build_ufid} FLAG "64" OUTPUT is_64_bit)
+-    if (${is_64_bit} AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+-        set(lib_name "lib64" CACHE INTERNAL "")
+-    else()
+-        set(lib_name "lib" CACHE INTERNAL "")
+-    endif()
++    set(lib_name "lib" CACHE INTERNAL "")
+ 
+     # Set the relative path to the library directory under the prefix. For
+     # example: lib64
+@@ -4028,11 +4024,7 @@ function (ntf_group_end)
+         set(target_output_name "${target}")
+     endif()
  
 -    if (${is_64_bit} AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
 -        set(lib_name "lib64" CACHE INTERNAL "")

--- a/ports/ntf-core/portfile.cmake
+++ b/ports/ntf-core/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bloomberg/ntf-core
     REF "${VERSION}"
-    SHA512 57662d2dd105b2781e580623c26cd7bde84fce8374bbd70c18595a5f6934869b7a570f0d3c2e17e115f6c7eb1067541f8d19523639815b285324061f807d3179
+    SHA512 f30ffc438c656e5bbababa87c8dfe40ac35ffd0962b6fba26c41246aeedc883a4949a3c19ee941cf9d7a54c504d8feb3dcd46b2eb9f4078dcb91e8cb4c60d614
     HEAD_REF main
     PATCHES dont-use-lib64.patch
 )
@@ -10,8 +10,10 @@ vcpkg_from_github(
 # ntf-core requires debugger information to for dev tooling purposes, so we just fake it
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS "-DNTF_BUILD_WITH_USAGE_EXAMPLES=0"
-            "-DNTF_TOOLCHAIN_DEBUGGER_PATH=NOT-FOUND"
+    OPTIONS 
+        "-DNTF_BUILD_WITH_USAGE_EXAMPLES=0"
+        "-DNTF_TOOLCHAIN_DEBUGGER_PATH=NOT-FOUND"
+        -DNTF_BUILD_SYSTEM=ON
 )
 
 vcpkg_cmake_build()
@@ -26,7 +28,7 @@ function(fix_pkgconfig_ufid lib_dir ufid pc_name)
         set(build_mode "debug")
     endif()
 
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/${lib_dir}/cmake/${pc_name}Targets-${build_mode}.cmake" "/${ufid}" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/${lib_dir}/cmake/${pc_name}/${pc_name}-Targets-${build_mode}.cmake" "/${ufid}" "")
 endfunction()
 
 function(fix_install_dir lib_dir ufid)
@@ -42,23 +44,14 @@ endfunction()
 fix_install_dir("lib" "opt_exc_mt")
 fix_install_dir("debug/lib" "dbg_exc_mt")
 
-# The ntf-core build installs CMake configs for both targets into share/ntf-core, which
-# find_package will not be able to find on its own. We use vcpkg_cmake_config_fixup to install
-# CMake configs into share/nts, and then move the ntc CMake configs into share/ntc with this
-# function.
-function(ntf_core_fixup_ntc_config)
-    set(nts_share "${CURRENT_PACKAGES_DIR}/share/nts")
-    set(ntc_share "${CURRENT_PACKAGES_DIR}/share/ntc")
-    file(GLOB ntc_configs "${nts_share}/ntc*.cmake")
-    file(MAKE_DIRECTORY "${ntc_share}")
-    foreach(ntc_config IN LISTS ntc_configs)
-        file(RELATIVE_PATH ntc_config_rel "${nts_share}" "${ntc_config}")
-        file(RENAME "${ntc_config}" "${ntc_share}/${ntc_config_rel}")
-    endforeach()
-endfunction()
-
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake" PACKAGE_NAME nts)
-ntf_core_fixup_ntc_config()
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/ntc")
+file(COPY "F:/vcpkg/packages/ntf-core_x64-windows/share/nts/ntc/"
+     DESTINATION "F:/vcpkg/packages/ntf-core_x64-windows/share/ntc/")
+file(COPY "F:/vcpkg/packages/ntf-core_x64-windows/share/nts/nts/"
+     DESTINATION "F:/vcpkg/packages/ntf-core_x64-windows/share/nts/")
+file(REMOVE_RECURSE "F:/vcpkg/packages/ntf-core_x64-windows/share/nts/ntc")
+file(REMOVE_RECURSE "F:/vcpkg/packages/ntf-core_x64-windows/share/nts/nts")
 
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ntf-core/portfile.cmake
+++ b/ports/ntf-core/portfile.cmake
@@ -46,12 +46,12 @@ fix_install_dir("debug/lib" "dbg_exc_mt")
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake" PACKAGE_NAME nts)
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/ntc")
-file(COPY "F:/vcpkg/packages/ntf-core_x64-windows/share/nts/ntc/"
-     DESTINATION "F:/vcpkg/packages/ntf-core_x64-windows/share/ntc/")
-file(COPY "F:/vcpkg/packages/ntf-core_x64-windows/share/nts/nts/"
-     DESTINATION "F:/vcpkg/packages/ntf-core_x64-windows/share/nts/")
-file(REMOVE_RECURSE "F:/vcpkg/packages/ntf-core_x64-windows/share/nts/ntc")
-file(REMOVE_RECURSE "F:/vcpkg/packages/ntf-core_x64-windows/share/nts/nts")
+file(COPY "${CURRENT_PACKAGES_DIR}/share/nts/ntc/"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/ntc/")
+file(COPY "${CURRENT_PACKAGES_DIR}/share/nts/nts/"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/nts/")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/nts/ntc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/nts/nts")
 
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ntf-core/portfile.cmake
+++ b/ports/ntf-core/portfile.cmake
@@ -45,13 +45,10 @@ fix_install_dir("lib" "opt_exc_mt")
 fix_install_dir("debug/lib" "dbg_exc_mt")
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake" PACKAGE_NAME nts)
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/ntc")
-file(COPY "${CURRENT_PACKAGES_DIR}/share/nts/ntc/"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/share/ntc/")
-file(COPY "${CURRENT_PACKAGES_DIR}/share/nts/nts/"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/share/nts/")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/nts/ntc")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/nts/nts")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/nts" "${CURRENT_PACKAGES_DIR}/share/nts_original")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/nts_original/ntc" "${CURRENT_PACKAGES_DIR}/share/ntc")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/nts_original/nts" "${CURRENT_PACKAGES_DIR}/share/nts")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/nts_original")
 
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ntf-core/vcpkg.json
+++ b/ports/ntf-core/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ntf-core",
-  "version": "2.1.0",
-  "port-version": 1,
+  "version": "2.5.4",
   "description": "The Network Transport Framework: Core Libraries",
   "license": "Apache-2.0",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6461,8 +6461,8 @@
       "port-version": 3
     },
     "ntf-core": {
-      "baseline": "2.1.0",
-      "port-version": 1
+      "baseline": "2.5.4",
+      "port-version": 0
     },
     "nu-book-zxing-cpp": {
       "baseline": "2.3.0",

--- a/versions/n-/ntf-core.json
+++ b/versions/n-/ntf-core.json
@@ -1,14 +1,19 @@
 {
-    "versions": [
-        {
-            "version": "2.1.0",
-            "port-version": 1,
-            "git-tree": "1e517e2393650769e701f62317e905a3f1776367"   
-        },
-        {
-            "version": "2.1.0",
-            "port-version": 0,
-            "git-tree": "eabeb2b30205bef45e72e4a069f21d71797f3f5d"   
-        }
-    ]
+  "versions": [
+    {
+      "git-tree": "0049d2948a6d6360de83d1512c1e75462882304c",
+      "version": "2.5.4",
+      "port-version": 0
+    },
+    {
+      "git-tree": "1e517e2393650769e701f62317e905a3f1776367",
+      "version": "2.1.0",
+      "port-version": 1
+    },
+    {
+      "git-tree": "eabeb2b30205bef45e72e4a069f21d71797f3f5d",
+      "version": "2.1.0",
+      "port-version": 0
+    }
+  ]
 }

--- a/versions/n-/ntf-core.json
+++ b/versions/n-/ntf-core.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39b2d8c4dd7feb259dbbd8e1c35b4753fb66c5bb",
+      "git-tree": "d1e73e8c96422d0e07f45242bcdf38ed59215871",
       "version": "2.5.4",
       "port-version": 0
     },

--- a/versions/n-/ntf-core.json
+++ b/versions/n-/ntf-core.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0049d2948a6d6360de83d1512c1e75462882304c",
+      "git-tree": "39b2d8c4dd7feb259dbbd8e1c35b4753fb66c5bb",
       "version": "2.5.4",
       "port-version": 0
     },


### PR DESCRIPTION
1. Update version to 2.5.4.
2. Fix the following compilation errors.
```
CMake Error at ports/ntf-core/portfile.cmake:36 (file):
  file RENAME failed to rename
    F:/vcpkg/packages/ntf-core_x64-windows/lib/opt_exc_mt
  to
    F:/vcpkg/packages/ntf-core_x64-windows/tmp
  because: The system cannot find the path specified.
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test passed with x64-windows triplet.

Fixes https://github.com/microsoft/vcpkg/issues/43441