### PR TITLE
[tbb] Fix build for macOS with GCC

### DIFF
--- a/ports/tbb/fix-gcc-without-gas.patch
+++ b/ports/tbb/fix-gcc-without-gas.patch
@@ -1,0 +1,57 @@
+diff --git a/cmake/compilers/GNU.cmake b/cmake/compilers/GNU.cmake
+index da6b408..b18fbf6 100644
+--- a/cmake/compilers/GNU.cmake
++++ b/cmake/compilers/GNU.cmake
+@@ -55,6 +55,7 @@ execute_process(
+     ERROR_STRIP_TRAILING_WHITESPACE
+ )
+ set(ASSEMBLER_VERSION_LINE ${ASSEMBLER_VERSION_LINE_OUT}${ASSEMBLER_VERSION_LINE_ERR})
++if ("${ASSEMBLER_VERSION_LINE}" MATCHES "GNU assembler version")
+ string(REGEX REPLACE ".*GNU assembler version ([0-9]+)\\.([0-9]+).*" "\\1" _tbb_gnu_asm_major_version "${ASSEMBLER_VERSION_LINE}")
+ string(REGEX REPLACE ".*GNU assembler version ([0-9]+)\\.([0-9]+).*" "\\2" _tbb_gnu_asm_minor_version "${ASSEMBLER_VERSION_LINE}")
+ unset(ASSEMBLER_VERSION_LINE_OUT)
+@@ -65,6 +66,7 @@ message(TRACE "Extracted GNU assembler version: major=${_tbb_gnu_asm_major_versi
+ math(EXPR _tbb_gnu_asm_version_number  "${_tbb_gnu_asm_major_version} * 1000 + ${_tbb_gnu_asm_minor_version}")
+ set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} "-D__TBB_GNU_ASM_VERSION=${_tbb_gnu_asm_version_number}")
+ message(STATUS "GNU Assembler version: ${_tbb_gnu_asm_major_version}.${_tbb_gnu_asm_minor_version}  (${_tbb_gnu_asm_version_number})")
++endif()
+ 
+ # Enable Intel(R) Transactional Synchronization Extensions (-mrtm) and WAITPKG instructions support (-mwaitpkg) on relevant processors
+ if (CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|amd64|i.86|x86)" AND NOT EMSCRIPTEN)
+diff --git a/include/oneapi/tbb/detail/_config.h b/include/oneapi/tbb/detail/_config.h
+index e676b15..e144a16 100644
+--- a/include/oneapi/tbb/detail/_config.h
++++ b/include/oneapi/tbb/detail/_config.h
+@@ -335,7 +335,7 @@
+ 
+ #define __TBB_TSX_INTRINSICS_PRESENT (__RTM__ || __INTEL_COMPILER || (_MSC_VER>=1700 && (__TBB_x86_64 || __TBB_x86_32)))
+ 
+-#define __TBB_WAITPKG_INTRINSICS_PRESENT ((__INTEL_COMPILER >= 1900 || (__TBB_GCC_VERSION >= 110000 && __TBB_GNU_ASM_VERSION >= 2032) || __TBB_CLANG_VERSION >= 120000) \
++#define __TBB_WAITPKG_INTRINSICS_PRESENT ((__INTEL_COMPILER >= 1900 || (__TBB_GCC_VERSION >= 110000 && (__APPLE__ || __TBB_GNU_ASM_VERSION >= 2032)) || __TBB_CLANG_VERSION >= 120000) \
+                                          && (_WIN32 || _WIN64 || __unix__ || __APPLE__) && (__TBB_x86_32 || __TBB_x86_64) && !__ANDROID__)
+ 
+ /** Internal TBB features & modes **/
+diff --git a/src/tbb/co_context.h b/src/tbb/co_context.h
+index 60d5437..3a25b0f 100644
+--- a/src/tbb/co_context.h
++++ b/src/tbb/co_context.h
+@@ -46,6 +46,9 @@
+     #elif __clang__
+         #pragma clang diagnostic push
+         #pragma clang diagnostic ignored "-Wdeprecated-declarations"
++    #elif __GNUC__
++        #pragma GCC diagnostic push
++        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+     #endif
+ #endif // __APPLE__
+ 
+@@ -364,6 +367,8 @@ inline void destroy_coroutine(coroutine_type& c) {
+         #pragma warning(pop) // 1478 warning
+     #elif __clang__
+         #pragma clang diagnostic pop // "-Wdeprecated-declarations"
++    #elif __GNUC__
++        #pragma GCC diagnostic pop
+     #endif
+ #endif
+ 
+--

--- a/ports/tbb/portfile.cmake
+++ b/ports/tbb/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-lang.patch # https://github.com/uxlfoundation/oneTBB/pull/1606
+        fix-gcc-without-gas.patch # https://github.com/uxlfoundation/oneTBB/pull/1603
 )
 
 vcpkg_check_features(

--- a/ports/tbb/vcpkg.json
+++ b/ports/tbb/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "tbb",
   "version": "2022.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Intel's Threading Building Blocks.",
   "homepage": "https://github.com/oneapi-src/oneTBB",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8954,7 +8954,7 @@
     },
     "tbb": {
       "baseline": "2022.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "tcb-span": {
       "baseline": "2022-06-15",

--- a/versions/t-/tbb.json
+++ b/versions/t-/tbb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ba5ca689237e53e47f3c9375736ebf901e919ef",
+      "version": "2022.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "e8eb4f6f5f53c1b56598b26a951b8d49cf349d0d",
       "version": "2022.0.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The TBB build currently fails on macOS using GCC. Patch is also submitted upstream. Please see the upstream PR: https://github.com/uxlfoundation/oneTBB/pull/1603