### PR TITLE
[libxlsxwriter] update to 1.2.0

### DIFF
--- a/ports/libxlsxwriter/portfile.cmake
+++ b/ports/libxlsxwriter/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jmcnamara/libxlsxwriter
     REF "v${VERSION}"
-    SHA512 b1d5827e5cfc4f455eaf48b181c26d7642d0a65d261a068c1123ff49b2fa1aedd8c2a716b7915803c861973b1de286e49e1761c2e5a523e7c0ba353f5994d48d
+    SHA512 cca431b04eb51444f4dd8f096d50061726277a72e9ec216f9ac88b89dca1b227949ce3aa652bb2e81d1244b04ecdef791b0abde1dcc5b206aa36079a962aaab3
     HEAD_REF main
     PATCHES
         dependencies.diff

--- a/ports/libxlsxwriter/vcpkg.json
+++ b/ports/libxlsxwriter/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxlsxwriter",
-  "version": "1.1.9",
-  "port-version": 1,
+  "version": "1.2.0",
   "description": "Libxlsxwriter is a C library that can be used to write text, numbers, formulas and hyperlinks to multiple worksheets in an Excel 2007+ XLSX file.",
   "homepage": "https://github.com/jmcnamara/libxlsxwriter",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5433,8 +5433,8 @@
       "port-version": 0
     },
     "libxlsxwriter": {
-      "baseline": "1.1.9",
-      "port-version": 1
+      "baseline": "1.2.0",
+      "port-version": 0
     },
     "libxml2": {
       "baseline": "2.13.5",

--- a/versions/l-/libxlsxwriter.json
+++ b/versions/l-/libxlsxwriter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "966bffdbd3fc72c14330670012d786e63f8f0abb",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d19c223fca5963696284824fa0ebb515f87d6b2e",
       "version": "1.1.9",
       "port-version": 1


### PR DESCRIPTION
I am the author and upstream maintainer of libxlsxwriter.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.