### PR TITLE
[tinyexif] update to 1.0.3 and fix usage

### DIFF
--- a/ports/tinyexif/portfile.cmake
+++ b/ports/tinyexif/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cdcseacave/TinyEXIF
-    REF ccd676f1b91d59da40b4f9c1edda4408fb65e62e #2024-09-03
-    SHA512 3e0017372ca98c9746833c73b27d598b947e169e9b27b55f3d2229da61edc1fa2b3929435c647a618558bed7ff3e124358eb615a565704f96635f2345cfd557a
+    REF ${VERSION}
+    SHA512 1285566c70f4de3c882a433d65595f18d848ecf8e9b16e1ea3aa7a1773fb70ba090c7cc726238132cccfc403c3750950175c675d25206be38cddb64f16193795
     HEAD_REF master
 )
 
@@ -23,5 +23,11 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+file(READ "${CURRENT_PACKAGES_DIR}/share/tinyexif/TinyEXIFConfig.cmake" _contents)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/tinyexif/TinyEXIFConfig.cmake" "
+include(CMakeFindDependencyMacro)
+find_dependency(tinyxml2)
+${_contents}")
+
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/README.md")

--- a/ports/tinyexif/vcpkg.json
+++ b/ports/tinyexif/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyexif",
-  "version-date": "2024-09-03",
+  "version": "1.0.3",
   "description": "tiny ISO-compliant C++ EXIF and XMP parsing library for JPEG images",
   "homepage": "https://github.com/cdcseacave/TinyEXIF",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9089,7 +9089,7 @@
       "port-version": 0
     },
     "tinyexif": {
-      "baseline": "2024-09-03",
+      "baseline": "1.0.3",
       "port-version": 0
     },
     "tinyexpr": {

--- a/versions/t-/tinyexif.json
+++ b/versions/t-/tinyexif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d788313f574c26b9cd938b21a6f1e083d827565a",
+      "version": "1.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "af10ad276177102ebd11c98213fc039627479511",
       "version-date": "2024-09-03",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43750.
Update `tinyexif` to 1.0.3 and fix the usage:

```
CMake Error at E:/vcpkg_latest/installed/x64-windows/share/tinyexif/TinyEXIFTargets.cmake:61 (set_target_properties):
The link interface of target "TinyEXIF" contains:

tinyxml2::tinyxml2
but the target was not found. Possible reasons include:

* There is a typo in the target name.
* A find_package call is missing for an IMPORTED target.
* An ALIAS target is missing.
```

No feature needs to test.
Usage tested pass on `x64-windows`.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.