### PR TITLE
[intel-mkl] Fixed usage error under x64-windows-static-md triplet

### DIFF
--- a/ports/intel-mkl/portfile.cmake
+++ b/ports/intel-mkl/portfile.cmake
@@ -237,6 +237,11 @@ endif()
 file(COPY "${mkl_dir}/lib/cmake/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "MKL_CMAKE_PATH}/../../../" "MKL_CMAKE_PATH}/../../")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "redist/\${MKL_ARCH}" "bin")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "define_param(MKL_LINK DEFAULT_MKL_LINK MKL_LINK_LIST)" 
+[[define_param(MKL_LINK DEFAULT_MKL_LINK MKL_LINK_LIST)
+if(NOT BUILD_SHARED_LIBS)
+ set(MKL_LINK "static")
+endif()]])
 #TODO: Hardcode settings from portfile in config.cmake
 #TODO: Give lapack/blas information about the correct BLA_VENDOR depending on settings. 
 

--- a/ports/intel-mkl/portfile.cmake
+++ b/ports/intel-mkl/portfile.cmake
@@ -237,11 +237,12 @@ endif()
 file(COPY "${mkl_dir}/lib/cmake/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "MKL_CMAKE_PATH}/../../../" "MKL_CMAKE_PATH}/../../")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "redist/\${MKL_ARCH}" "bin")
+if(NOT BUILD_SHARED_LIBS)
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "define_param(MKL_LINK DEFAULT_MKL_LINK MKL_LINK_LIST)" 
 [[define_param(MKL_LINK DEFAULT_MKL_LINK MKL_LINK_LIST)
-if(NOT BUILD_SHARED_LIBS)
  set(MKL_LINK "static")
-endif()]])
+]])
+endif()
 #TODO: Hardcode settings from portfile in config.cmake
 #TODO: Give lapack/blas information about the correct BLA_VENDOR depending on settings. 
 
@@ -249,11 +250,11 @@ file(INSTALL "${mkl_dir}/licensing" DESTINATION "${CURRENT_PACKAGES_DIR}/share/$
 file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.mkl.product,v=2023.0.0-*")
 vcpkg_install_copyright(FILE_LIST "${package_path}/licenses/license.htm")
 
-file(REMOVE_RECURSE
-    "${extract_0_dir}"
-    "${extract_1_dir}"
-    "${CURRENT_PACKAGES_DIR}/lib/intel64/cmake"
-    "${CURRENT_PACKAGES_DIR}/lib/intel64/pkgconfig"
-)
+#file(REMOVE_RECURSE
+#    "${extract_0_dir}"
+#    "${extract_1_dir}"
+#    "${CURRENT_PACKAGES_DIR}/lib/intel64/cmake"
+#    "${CURRENT_PACKAGES_DIR}/lib/intel64/pkgconfig"
+#)
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/intel-mkl/portfile.cmake
+++ b/ports/intel-mkl/portfile.cmake
@@ -250,11 +250,11 @@ file(INSTALL "${mkl_dir}/licensing" DESTINATION "${CURRENT_PACKAGES_DIR}/share/$
 file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.mkl.product,v=2023.0.0-*")
 vcpkg_install_copyright(FILE_LIST "${package_path}/licenses/license.htm")
 
-#file(REMOVE_RECURSE
-#    "${extract_0_dir}"
-#    "${extract_1_dir}"
-#    "${CURRENT_PACKAGES_DIR}/lib/intel64/cmake"
-#    "${CURRENT_PACKAGES_DIR}/lib/intel64/pkgconfig"
-#)
+file(REMOVE_RECURSE
+    "${extract_0_dir}"
+    "${extract_1_dir}"
+    "${CURRENT_PACKAGES_DIR}/lib/intel64/cmake"
+    "${CURRENT_PACKAGES_DIR}/lib/intel64/pkgconfig"
+)
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/intel-mkl/portfile.cmake
+++ b/ports/intel-mkl/portfile.cmake
@@ -237,7 +237,7 @@ endif()
 file(COPY "${mkl_dir}/lib/cmake/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "MKL_CMAKE_PATH}/../../../" "MKL_CMAKE_PATH}/../../")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "redist/\${MKL_ARCH}" "bin")
-if(NOT BUILD_SHARED_LIBS)
+if(${VCPKG_LIBRARY_LINKAGE} STREQUAL "static")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "define_param(MKL_LINK DEFAULT_MKL_LINK MKL_LINK_LIST)" 
 [[define_param(MKL_LINK DEFAULT_MKL_LINK MKL_LINK_LIST)
  set(MKL_LINK "static")

--- a/ports/intel-mkl/vcpkg.json
+++ b/ports/intel-mkl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "intel-mkl",
   "version": "2023.0.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Intel® Math Kernel Library (Intel® MKL) accelerates math processing routines, increases application performance, and reduces development time on Intel® processors.",
   "homepage": "https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3754,7 +3754,7 @@
     },
     "intel-mkl": {
       "baseline": "2023.0.0",
-      "port-version": 4
+      "port-version": 5
     },
     "intelrdfpmathlib": {
       "baseline": "20U2",

--- a/versions/i-/intel-mkl.json
+++ b/versions/i-/intel-mkl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "adf55bc00720c423a9083b3d92ad738b6cc202ce",
+      "version": "2023.0.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "ca06d4f88eaf67a10c1b988c5a2e3d8a74741d66",
       "version": "2023.0.0",
       "port-version": 4

--- a/versions/i-/intel-mkl.json
+++ b/versions/i-/intel-mkl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "adf55bc00720c423a9083b3d92ad738b6cc202ce",
+      "git-tree": "e98b719b40bc8b36dc685ddf8f9f7a6abfff14dc",
       "version": "2023.0.0",
       "port-version": 5
     },

--- a/versions/i-/intel-mkl.json
+++ b/versions/i-/intel-mkl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "04e191f07bb05f05dd21b71bdd6c7cd104e049ce",
+      "git-tree": "4be49a487c0c55a67bb79fa1d90be6b515b99f67",
       "version": "2023.0.0",
       "port-version": 5
     },

--- a/versions/i-/intel-mkl.json
+++ b/versions/i-/intel-mkl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e98b719b40bc8b36dc685ddf8f9f7a6abfff14dc",
+      "git-tree": "04e191f07bb05f05dd21b71bdd6c7cd104e049ce",
       "version": "2023.0.0",
       "port-version": 5
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/42834
Fix the following error.
```
[cmake] CMake Error at E:/dev/vcpkg/installed/x64-windows-static-md/share/mkl/MKLConfig.cmake:103 (message):
[cmake]   mkl_intel_thread.*.dll not found
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test passed with x64-windows-static-md triplet.