### PR TITLE
[vcpkg baseline][google-cloud-cpp] Fix googleapis download

### DIFF
--- a/ports/google-cloud-cpp/fix-googleapis-download.patch
+++ b/ports/google-cloud-cpp/fix-googleapis-download.patch
@@ -1,32 +1,8 @@
 diff --git a/external/googleapis/CMakeLists.txt b/external/googleapis/CMakeLists.txt
-index 5e93f522..30101d12 100644
+index 5e93f522..30132c06 100644
 --- a/external/googleapis/CMakeLists.txt
 +++ b/external/googleapis/CMakeLists.txt
-@@ -18,23 +18,6 @@ if (NOT GOOGLE_CLOUD_CPP_ENABLE_GRPC)
-     return()
- endif ()
- 
--include(GoogleapisConfig)
--
--set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
--    "https://github.com/googleapis/googleapis/archive/${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
--    "https://storage.googleapis.com/cloud-cpp-community-archive/github.com/googleapis/googleapis/archive/${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
--)
--set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL_HASH
--    "${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}")
--if (GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL)
--    set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
--        ${GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL})
--endif ()
--if (GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL_HASH)
--    set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL_HASH
--        "${GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL_HASH}")
--endif ()
--
- set(EXTERNAL_GOOGLEAPIS_PROTO_FILES
-     # cmake-format: sort
-     "google/api/annotations.proto"
-@@ -114,7 +97,7 @@ include(GoogleCloudCppCommonOptions)
+@@ -114,7 +114,7 @@ include(GoogleCloudCppCommonOptions)
  # the generated libraries.  The Conan packages (https://conan.io), will need to
  # patch this value.  Setting the value in a single place makes such patching
  # easier.
@@ -35,40 +11,23 @@ index 5e93f522..30101d12 100644
  set(EXTERNAL_GOOGLEAPIS_SOURCE
      "${EXTERNAL_GOOGLEAPIS_PREFIX}/src/googleapis_download"
      PARENT_SCOPE)
-@@ -138,32 +121,6 @@ foreach (file IN LISTS protolists)
+@@ -138,6 +138,7 @@ foreach (file IN LISTS protolists)
      endforeach ()
  endforeach ()
  
--include(ExternalProject)
--
--externalproject_add(
--    googleapis_download
--    EXCLUDE_FROM_ALL ON
--    PREFIX "${EXTERNAL_GOOGLEAPIS_PREFIX}"
--    URL ${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL}
--    URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL_HASH}
--    PATCH_COMMAND
--        ""
--        # ~~~
--        # Scaffolding for patching googleapis after download. For example:
--        #   PATCH_COMMAND
--        #       patch
--        #       -p1
--        #       --input=/workspace/external/googleapis.patch
--        # NOTE: This should only be used while developing with a new
--        # protobuf message. No changes to `PATCH_COMMAND` should ever be
--        # committed to the main branch.
--        # ~~~
--    CONFIGURE_COMMAND ""
--    BUILD_COMMAND ""
--    INSTALL_COMMAND ""
--    BUILD_BYPRODUCTS ${EXTERNAL_GOOGLEAPIS_BYPRODUCTS}
--    LOG_DOWNLOAD OFF)
--
++if(0)
+ include(ExternalProject)
+ 
+ externalproject_add(
+@@ -163,6 +164,7 @@ externalproject_add(
+     INSTALL_COMMAND ""
+     BUILD_BYPRODUCTS ${EXTERNAL_GOOGLEAPIS_BYPRODUCTS}
+     LOG_DOWNLOAD OFF)
++endif()
+ 
  google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
  
- google_cloud_cpp_add_protos_property()
-@@ -204,7 +161,6 @@ function (external_googleapis_add_library proto)
+@@ -204,7 +206,6 @@ function (external_googleapis_add_library proto)
  endfunction ()
  
  function (external_googleapis_set_version_and_alias short_name)

--- a/ports/google-cloud-cpp/fix-googleapis-download.patch
+++ b/ports/google-cloud-cpp/fix-googleapis-download.patch
@@ -1,0 +1,78 @@
+diff --git a/external/googleapis/CMakeLists.txt b/external/googleapis/CMakeLists.txt
+index 5e93f522..30101d12 100644
+--- a/external/googleapis/CMakeLists.txt
++++ b/external/googleapis/CMakeLists.txt
+@@ -18,23 +18,6 @@ if (NOT GOOGLE_CLOUD_CPP_ENABLE_GRPC)
+     return()
+ endif ()
+ 
+-include(GoogleapisConfig)
+-
+-set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
+-    "https://github.com/googleapis/googleapis/archive/${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
+-    "https://storage.googleapis.com/cloud-cpp-community-archive/github.com/googleapis/googleapis/archive/${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
+-)
+-set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL_HASH
+-    "${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}")
+-if (GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL)
+-    set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
+-        ${GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL})
+-endif ()
+-if (GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL_HASH)
+-    set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL_HASH
+-        "${GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL_HASH}")
+-endif ()
+-
+ set(EXTERNAL_GOOGLEAPIS_PROTO_FILES
+     # cmake-format: sort
+     "google/api/annotations.proto"
+@@ -114,7 +97,7 @@ include(GoogleCloudCppCommonOptions)
+ # the generated libraries.  The Conan packages (https://conan.io), will need to
+ # patch this value.  Setting the value in a single place makes such patching
+ # easier.
+-set(EXTERNAL_GOOGLEAPIS_PREFIX "${PROJECT_BINARY_DIR}/external/googleapis")
++set(EXTERNAL_GOOGLEAPIS_PREFIX "${CMAKE_SOURCE_DIR}/external/googleapis")
+ set(EXTERNAL_GOOGLEAPIS_SOURCE
+     "${EXTERNAL_GOOGLEAPIS_PREFIX}/src/googleapis_download"
+     PARENT_SCOPE)
+@@ -138,32 +121,6 @@ foreach (file IN LISTS protolists)
+     endforeach ()
+ endforeach ()
+ 
+-include(ExternalProject)
+-
+-externalproject_add(
+-    googleapis_download
+-    EXCLUDE_FROM_ALL ON
+-    PREFIX "${EXTERNAL_GOOGLEAPIS_PREFIX}"
+-    URL ${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL}
+-    URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL_HASH}
+-    PATCH_COMMAND
+-        ""
+-        # ~~~
+-        # Scaffolding for patching googleapis after download. For example:
+-        #   PATCH_COMMAND
+-        #       patch
+-        #       -p1
+-        #       --input=/workspace/external/googleapis.patch
+-        # NOTE: This should only be used while developing with a new
+-        # protobuf message. No changes to `PATCH_COMMAND` should ever be
+-        # committed to the main branch.
+-        # ~~~
+-    CONFIGURE_COMMAND ""
+-    BUILD_COMMAND ""
+-    INSTALL_COMMAND ""
+-    BUILD_BYPRODUCTS ${EXTERNAL_GOOGLEAPIS_BYPRODUCTS}
+-    LOG_DOWNLOAD OFF)
+-
+ google_cloud_cpp_find_proto_include_dir(PROTO_INCLUDE_DIR)
+ 
+ google_cloud_cpp_add_protos_property()
+@@ -204,7 +161,6 @@ function (external_googleapis_add_library proto)
+ endfunction ()
+ 
+ function (external_googleapis_set_version_and_alias short_name)
+-    add_dependencies("google_cloud_cpp_${short_name}" googleapis_download)
+     set_target_properties(
+         "google_cloud_cpp_${short_name}"
+         PROPERTIES EXPORT_NAME google-cloud-cpp::${short_name}

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -6,7 +6,21 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 889afa01c67b2a6566bfd557a3a1990806888b967e7383d9fd8b67aff93ed1430e463715f0ba44f178d4ac241f08c08b2973f83b3c5e6e53e7c634a63e39d3ef
     HEAD_REF main
+    PATCHES fix-googleapis-download.patch
 )
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH_GOOGLEAPIS
+    REPO googleapis/googleapis
+    REF 280725e991516d4a0f136268faf5aa6d32d21b54
+    SHA512 80da8175c52ae83eaa300783377d9f3d86593fa0bcd4723c5afea4cafa8bf4a2575fb2af48f7e944eabdb11ec8c946a14d9d75f70384744a3bfb2cc71ec2b1ed
+    HEAD_REF master
+)
+
+if(NOT EXISTS "${SOURCE_PATH}/external/googleapis/src")
+    file(MAKE_DIRECTORY "${SOURCE_PATH}/external/googleapis/src")
+    file(RENAME "${SOURCE_PATH_GOOGLEAPIS}" "${SOURCE_PATH}/external/googleapis/src/googleapis_download")
+endif()
 
 if ("grpc-common" IN_LIST FEATURES)
     vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/grpc")

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
     PATCHES fix-googleapis-download.patch
 )
 
+# On update, update REF according to $/cmake/GoogleapisConfig.cmake 's
+# set(_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH_GOOGLEAPIS
     REPO googleapis/googleapis

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "2.35.0",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3206,7 +3206,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "2.35.0",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b73f7b52e296a87fa11d1020b244777bebe5b2c5",
+      "version": "2.35.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e5e364d9a30671192bff0f92134f30a7abccb0f1",
       "version": "2.35.0",
       "port-version": 0

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b73f7b52e296a87fa11d1020b244777bebe5b2c5",
+      "git-tree": "4ea51b6322c1c6407cf2f9bdeee1be65879147d7",
       "version": "2.35.0",
       "port-version": 1
     },

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4ea51b6322c1c6407cf2f9bdeee1be65879147d7",
+      "git-tree": "b30c7f31e3ce20a6197872665bc9939b7d2a95a2",
       "version": "2.35.0",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #43761. The upstream [downloads googleapis](https://github.com/googleapis/google-cloud-cpp/blob/v2.35.0/external/googleapis/CMakeLists.txt#L143-L165) in `CMakeLists.txt` caused the following [error](https://dev.azure.com/vcpkg/public/_build/results?buildId=112281&view=results), so it is now changed to download in `portfile.cmake`.
```
CMake Error at googleapis_download-stamp/download-googleapis_download.cmake:163 (message):
  Each download failed!

    error: downloading 'https://github.com/googleapis/googleapis/archive/280725e991516d4a0f136268faf5aa6d32d21b54.tar.gz' failed
          status_code: 22
          status_string: "HTTP response code said error"
          log:
          --- LOG BEGIN ---
          timeout on name lookup is not supported
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.