### PR TITLE
[mongo-c-driver,libbson] Update to 1.30.0

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 8624966472603d5a20b2b01488660897b3ba9910fb69a41996852836bd5d4eb7e2c7fcfba3bdfcb01715ed83d08c7f9e93f98b59d1fe88f67f1a5a7de9b0a42e
+    SHA512 8a3873e41e73ce1d653a5dfb5c6232596afde0395409d77f1a5076a80cff83819fa923443b43aae76ebb50dd8f44dda8ea27ef7ca60b09e4464f4d5984076911
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "1.29.2",
+  "version": "1.30.0",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/mongo-c-driver/fix-mingw.patch
+++ b/ports/mongo-c-driver/fix-mingw.patch
@@ -1,8 +1,8 @@
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index be0bfb2..6e295d6 100644
+index 5be5265..b2bc27d 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -206,7 +206,7 @@ endfunction()
+@@ -209,7 +209,7 @@ endfunction()
  # Per-backend link libs/options:
  set(SecureTransport/LINK_LIBRARIES "-framework CoreFoundation" "-framework Security")
  set(SecureTransport/pkg_config_LIBS -framework Corefoundation -framework Security)
@@ -11,7 +11,7 @@ index be0bfb2..6e295d6 100644
  set(SecureChannel/pkg_config_LIBS ${SecureChannel/LINK_LIBRARIES})
  set(LibreSSL/LINK_LIBRARIES LibreSSL::TLS LibreSSL::Crypto)
  set(LibreSSL/pkg_config_LIBS -ltls -lcrypto)
-@@ -357,7 +357,7 @@ function(_use_sasl libname)
+@@ -360,7 +360,7 @@ function(_use_sasl libname)
     target_link_libraries(_mongoc-dependencies INTERFACE _mongoc-sasl_backend)
     install(TARGETS _mongoc-sasl_backend EXPORT mongoc-targets)
     if(libname STREQUAL "SSPI")
@@ -21,11 +21,11 @@ index be0bfb2..6e295d6 100644
     elseif(libname STREQUAL "CYRUS")
        find_package(SASL2 2.0 REQUIRED)
 diff --git a/src/libmongoc/src/mongoc/mongoc-client.c b/src/libmongoc/src/mongoc/mongoc-client.c
-index 80f15f8..28a0742 100644
+index 096e0f9..62eca88 100644
 --- a/src/libmongoc/src/mongoc/mongoc-client.c
 +++ b/src/libmongoc/src/mongoc/mongoc-client.c
 @@ -18,8 +18,8 @@
- #include "mongoc-config.h"
+ #include <mongoc/mongoc-config.h>
  #ifdef MONGOC_HAVE_DNSAPI
  /* for DnsQuery_UTF8 */
 -#include <Windows.h>
@@ -36,12 +36,12 @@ index 80f15f8..28a0742 100644
  #else
  #if defined(MONGOC_HAVE_RES_NSEARCH) || defined(MONGOC_HAVE_RES_SEARCH)
 diff --git a/src/libmongoc/src/mongoc/mongoc-socket.c b/src/libmongoc/src/mongoc/mongoc-socket.c
-index e417d7d..cccabf5 100644
+index df48fd0..3231035 100644
 --- a/src/libmongoc/src/mongoc/mongoc-socket.c
 +++ b/src/libmongoc/src/mongoc/mongoc-socket.c
 @@ -25,7 +25,7 @@
- #include "mongoc-socket-private.h"
- #include "mongoc-trace-private.h"
+ #include <mongoc/mongoc-socket-private.h>
+ #include <mongoc/mongoc-trace-private.h>
  #ifdef _WIN32
 -#include <Mstcpip.h>
 +#include <mstcpip.h>
@@ -49,7 +49,7 @@ index e417d7d..cccabf5 100644
  #endif
  #include <common-cmp-private.h>
 diff --git a/src/libmongoc/src/mongoc/mongoc-sspi-private.h b/src/libmongoc/src/mongoc/mongoc-sspi-private.h
-index a2df035..a1ade8a 100644
+index 381c417..3c7689c 100644
 --- a/src/libmongoc/src/mongoc/mongoc-sspi-private.h
 +++ b/src/libmongoc/src/mongoc/mongoc-sspi-private.h
 @@ -28,7 +28,7 @@ BSON_BEGIN_DECLS

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 8624966472603d5a20b2b01488660897b3ba9910fb69a41996852836bd5d4eb7e2c7fcfba3bdfcb01715ed83d08c7f9e93f98b59d1fe88f67f1a5a7de9b0a42e
+    SHA512 8a3873e41e73ce1d653a5dfb5c6232596afde0395409d77f1a5076a80cff83819fa923443b43aae76ebb50dd8f44dda8ea27ef7ca60b09e4464f4d5984076911
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.29.2",
+  "version": "1.30.0",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4357,7 +4357,7 @@
       "port-version": 4
     },
     "libbson": {
-      "baseline": "1.29.2",
+      "baseline": "1.30.0",
       "port-version": 0
     },
     "libcaer": {
@@ -6069,7 +6069,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.29.2",
+      "baseline": "1.30.0",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20609dd6afc7efcd211ddc9610f38a85c95a80de",
+      "version": "1.30.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cccf130ea44fbb30844c2f0b1d6d3794818b8267",
       "version": "1.29.2",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "10faa06881a9c7815cc0b7f713a5aeaf0de3c0fa",
+      "version": "1.30.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d35218325984c456e1b40f6431f6a6976b94b329",
       "version": "1.29.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #43648

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

All features passed with following triplets:
```
x86-windows
x64-windows
x64-windows-static
```
Usage test passed on `x64-windows`.