### PR TITLE
[protobuf] Update to 5.29.3

### DIFF
--- a/ports/protobuf/fix-static-build.patch
+++ b/ports/protobuf/fix-static-build.patch
@@ -2,7 +2,7 @@ diff --git a/cmake/install.cmake b/cmake/install.cmake
 index 65765ca29..f5ad69102 100644
 --- a/cmake/install.cmake
 +++ b/cmake/install.cmake
-@@ -61,7 +61,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
+@@ -65,7 +65,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
      endforeach ()
    endif ()
    foreach (binary IN LISTS _protobuf_binaries)
@@ -11,11 +11,12 @@ index 65765ca29..f5ad69102 100644
        set_property(TARGET ${binary}
          PROPERTY INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
      elseif (APPLE)
-@@ -81,7 +81,6 @@ set(protobuf_HEADERS
+@@ -85,7 +85,5 @@ set(protobuf_HEADERS
    ${cpp_features_proto_proto_srcs}
    ${descriptor_proto_proto_srcs}
    ${plugin_proto_proto_srcs}
 -  ${java_features_proto_proto_srcs}
+-  ${go_features_proto_proto_srcs}
  )
  if (protobuf_BUILD_LIBUPB)
    list(APPEND protobuf_HEADERS ${libupb_hdrs})

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512 2f8b1c52fae3cea6188d2ea10da90314167eb150b23005928b4d2186a81b33c4ba0d79967fc1637ed3f96f9fb3b365433cbd4a1ce01d4c319927538cd63852ec
+    SHA512 0c776133f5789d21baa8860cb41e7926a162d74810a01722b762a78f93e559494e903fcaa092515bfe2ce057fd065a5dd000b316edb1af32c2ef9dbadf02b4c6
     HEAD_REF master
     PATCHES
         fix-static-build.patch
@@ -43,6 +43,7 @@ file(REMOVE_RECURSE
     "${SOURCE_PATH}/python"
     "${SOURCE_PATH}/ruby"
     "${SOURCE_PATH}/rust"
+    "${SOURCE_PATH}/go"
 )
 
 vcpkg_cmake_configure(

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512 0c776133f5789d21baa8860cb41e7926a162d74810a01722b762a78f93e559494e903fcaa092515bfe2ce057fd065a5dd000b316edb1af32c2ef9dbadf02b4c6
+    SHA512 32a9ae3de113b8c94e2aed21ad8f58e5ed4419a6d4078e51f614f0fabbf3bfe6c4affc62c2c1326e030a54df0fdcc47bb715b45022191a363f17680ec651b68e
     HEAD_REF master
     PATCHES
         fix-static-build.patch

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protobuf",
-  "version": "5.29.2",
+  "version": "5.29.3",
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/ports/utf8-range/portfile.cmake
+++ b/ports/utf8-range/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512 18b49716ac15800f4ed970a2b2dc3235299933e1ab34edbffd0c1eeabd1ade37b3ea50d90b9a814211aa83ee7a335d9dae1763a088f8899ff64341911d3678c1
+    SHA512 0c776133f5789d21baa8860cb41e7926a162d74810a01722b762a78f93e559494e903fcaa092515bfe2ce057fd065a5dd000b316edb1af32c2ef9dbadf02b4c6
     HEAD_REF main
     PATCHES
         fix-cmake.patch

--- a/ports/utf8-range/portfile.cmake
+++ b/ports/utf8-range/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512 0c776133f5789d21baa8860cb41e7926a162d74810a01722b762a78f93e559494e903fcaa092515bfe2ce057fd065a5dd000b316edb1af32c2ef9dbadf02b4c6
+    SHA512 32a9ae3de113b8c94e2aed21ad8f58e5ed4419a6d4078e51f614f0fabbf3bfe6c4affc62c2c1326e030a54df0fdcc47bb715b45022191a363f17680ec651b68e
     HEAD_REF main
     PATCHES
         fix-cmake.patch

--- a/ports/utf8-range/vcpkg.json
+++ b/ports/utf8-range/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "utf8-range",
-  "version": "5.29.1",
+  "version": "5.29.3",
   "description": "Fast UTF-8 validation with Range algorithm (NEON+SSE4+AVX2)",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7277,7 +7277,7 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "5.29.2",
+      "baseline": "5.29.3",
       "port-version": 0
     },
     "protobuf-c": {
@@ -9413,7 +9413,7 @@
       "port-version": 4
     },
     "utf8-range": {
-      "baseline": "5.29.1",
+      "baseline": "5.29.3",
       "port-version": 0
     },
     "utf8h": {

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "35a1fd3eb976dcc10e805130bacc46956132b39c",
+      "git-tree": "53c97b927087d1919f2a7ef6c34e4caf1a00cdf9",
       "version": "5.29.3",
       "port-version": 0
     },

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35a1fd3eb976dcc10e805130bacc46956132b39c",
+      "version": "5.29.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "7580944fa0ddb236554a4a96b65846697e04564a",
       "version": "5.29.2",
       "port-version": 0

--- a/versions/u-/utf8-range.json
+++ b/versions/u-/utf8-range.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf3131be80b6bee79f9cdc4304d1e6b41ed4ec78",
+      "version": "5.29.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "09bb6fc16a60acee3536d8e7febd6fcca82a67ac",
       "version": "5.29.1",
       "port-version": 0

--- a/versions/u-/utf8-range.json
+++ b/versions/u-/utf8-range.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bf3131be80b6bee79f9cdc4304d1e6b41ed4ec78",
+      "git-tree": "67a0b0ded179b27dc30195bab68549fab519e1e2",
       "version": "5.29.3",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


