### PR TITLE
[qpdf] new port

### DIFF
--- a/ports/qpdf/portfile.cmake
+++ b/ports/qpdf/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO qpdf/qpdf
+    REF "v${VERSION}"
+    SHA512 fdd605ef711d313bdec9979cb8cefb2589f45fc1086f9a6f763348b1c098071a085bdbbd2dccd5b17bf212c42374dc86f4c95e3de935df62d259ab110fad0e6b
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/qpdf)
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/qpdf/vcpkg.json
+++ b/ports/qpdf/vcpkg.json
@@ -1,0 +1,42 @@
+{
+  "name": "qpdf",
+  "version": "11.10.0",
+  "description": "qpdf: A content-preserving PDF document transformer",
+  "homepage": "https://qpdf.sourceforge.io/",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "libjpeg-turbo",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ],
+  "default-features": [
+    "libgnutls"
+  ],
+  "features": {
+    "libgnutls": {
+      "description": "gnutls crypto provider",
+      "dependencies": [
+        "libgnutls"
+      ]
+    },
+    "openssl": {
+      "description": "openssl crypto provider",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "zopfli": {
+      "description": "zopfli compression algorithm",
+      "dependencies": [
+        "zopfli"
+      ]
+    }
+  }
+}

--- a/ports/qpdf/vcpkg.json
+++ b/ports/qpdf/vcpkg.json
@@ -17,7 +17,7 @@
     "zlib"
   ],
   "default-features": [
-    "libgnutls"
+    "openssl"
   ],
   "features": {
     "libgnutls": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7404,6 +7404,10 @@
       "baseline": "0.1.7",
       "port-version": 0
     },
+    "qpdf": {
+      "baseline": "11.10.0",
+      "port-version": 0
+    },
     "qpid-proton": {
       "baseline": "0.38.0",
       "port-version": 2

--- a/versions/q-/qpdf.json
+++ b/versions/q-/qpdf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b7ff29aa6a0749d95f65b1bf124c68034bff01ce",
+      "version": "11.10.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/q-/qpdf.json
+++ b/versions/q-/qpdf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b7ff29aa6a0749d95f65b1bf124c68034bff01ce",
+      "git-tree": "f0f7a0e1412d1e0ed892560a9009ab1d61bdeb43",
       "version": "11.10.0",
       "port-version": 0
     }


### PR DESCRIPTION
Fixes #43708

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
