### PR TITLE
[liblzma] Add license

### DIFF
--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "liblzma",
   "version": "5.6.3",
+  "port-version": 1,
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
-  "license": null,
+  "license": "0BSD OR GPL-2.0-or-later OR GPL-3.0-only",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4786,7 +4786,7 @@
     },
     "liblzma": {
       "baseline": "5.6.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libmad": {
       "baseline": "0.16.4",

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1751ecdcd51a32ee52682f4a258a23278aaa96f6",
+      "version": "5.6.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "b5e5694620b41a4d668390e5d14fa2326e0afdc3",
       "version": "5.6.3",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43797

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
