### PR TITLE
[flint] Fix download URL

### DIFF
--- a/ports/flint/portfile.cmake
+++ b/ports/flint/portfile.cmake
@@ -1,6 +1,6 @@
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.flintlib.org/flint-${VERSION}.zip"
+    URLS "https://flintlib.org/download/flint-${VERSION}.zip"
     FILENAME "flint-${VERSION}.zip"
     SHA512 3dd9a4e79e08ab6bc434a786c8d4398eba6cb04e57bcb8d01677f4912cddf20ed3a971160a3e2d533d9a07b728678b0733cc8315bcb39a3f13475b6efa240062
 )

--- a/ports/flint/vcpkg.json
+++ b/ports/flint/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "flint",
   "version-semver": "2.9.0",
+  "port-version": 1,
   "description": "Fast Library for Number Theory",
   "homepage": "https://www.flintlib.org/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2834,7 +2834,7 @@
     },
     "flint": {
       "baseline": "2.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "fltk": {
       "baseline": "1.3.9",

--- a/versions/f-/flint.json
+++ b/versions/f-/flint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a97f4feeae9387e45588c117e8c85df1c00b49c",
+      "version-semver": "2.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "282413c373b7f2f2d2d38783fc9c9d8c4492de16",
       "version-semver": "2.9.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

The download page appears to have moved. Refer to: https://flintlib.org/downloads.html.

This patch resolves the following 404 error:

---

Package: flint:x64-linux@2.9.0

**Host Environment**

- Host: x64-linux
- Compiler: GNU 11.4.0
-    vcpkg-tool version: 2025-01-29-a75ad067f470c19f030361064e32a2585392bee2
    vcpkg-scripts version: 344525f74e 2025-02-13 (4 hours ago)

**To Reproduce**

`vcpkg install flint`

**Failure logs**

```
Downloading http://www.flintlib.org/flint-2.9.0.zip -> flint-2.9.0.zip
error: curl: (22) The requested URL returned error: 404
note: If you are using a proxy, please ensure your proxy settings are correct.
Possible causes are:
1. You are actually using an HTTP proxy, but setting HTTPS_PROXY variable to `https//address:port`.
This is not correct, because `https://` prefix claims the proxy is an HTTPS proxy, while your proxy (v2ray, shadowsocksr, etc...) is an HTTP proxy.
Try setting `http://address:port` to both HTTP_PROXY and HTTPS_PROXY instead.
2. If you are using Windows, vcpkg will automatically use your Windows IE Proxy Settings set by your proxy software. See: https://github.com/microsoft/vcpkg-tool/pull/77
The value set by your proxy might be wrong, or have same `https://` prefix issue.
3. Your proxy's remote server is our of service.
If you believe this is not a temporary download server failure and vcpkg needs to be changed to download this file from a different location, please submit an issue to https://github.com/Microsoft/vcpkg/issues
CMake Error at scripts/cmake/vcpkg_download_distfile.cmake:124 (message):
  Download failed, halting portfile.
Call Stack (most recent call first):
  ports/flint/portfile.cmake:2 (vcpkg_download_distfile)
  scripts/ports.cmake:196 (include)
```