### PR TITLE
[pdal] Update to 2.8.4

### DIFF
--- a/ports/pdal-dimbuilder/portfile.cmake
+++ b/ports/pdal-dimbuilder/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     #[[
         Attention: pdal must be updated together with pdal-dimbuilder
     #]]
-    SHA512 7296fc73521bb3c01ea515a565f2b54402e08c147dd2d51ea09d611c59e502700b561f7495cb8cb36bf0b59b88dc3ed08ed068991bd739c16265a36e8c95b613
+    SHA512 16350288122aae0c6f59bf91d1ee631b85e9653d76b706d27427706484fefbbe5f7fa3bc3ec1f1fda0fd37fb6cb0388d3ed712db614c22aff5dcd66b4998ff1e
     HEAD_REF master
     PATCHES
         namespace-nl.diff

--- a/ports/pdal-dimbuilder/vcpkg.json
+++ b/ports/pdal-dimbuilder/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pdal-dimbuilder",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "A tool used by the PDAL build process",
   "homepage": "https://pdal.io/",
   "license": "BSD-3-Clause",

--- a/ports/pdal/portfile.cmake
+++ b/ports/pdal/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     #[[
         Attention: pdal-dimbuilder must be updated together with pdal
     #]]
-    SHA512 7296fc73521bb3c01ea515a565f2b54402e08c147dd2d51ea09d611c59e502700b561f7495cb8cb36bf0b59b88dc3ed08ed068991bd739c16265a36e8c95b613
+    SHA512 16350288122aae0c6f59bf91d1ee631b85e9653d76b706d27427706484fefbbe5f7fa3bc3ec1f1fda0fd37fb6cb0388d3ed712db614c22aff5dcd66b4998ff1e
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/pdal/vcpkg.json
+++ b/ports/pdal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pdal",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "PDAL - Point Data Abstraction Library is a library for manipulating point cloud data.",
   "homepage": "https://pdal.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6985,7 +6985,7 @@
       "port-version": 0
     },
     "pdal": {
-      "baseline": "2.8.3",
+      "baseline": "2.8.4",
       "port-version": 0
     },
     "pdal-c": {
@@ -6993,7 +6993,7 @@
       "port-version": 0
     },
     "pdal-dimbuilder": {
-      "baseline": "2.8.3",
+      "baseline": "2.8.4",
       "port-version": 0
     },
     "pdcurses": {

--- a/versions/p-/pdal-dimbuilder.json
+++ b/versions/p-/pdal-dimbuilder.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "247fd325eb4de5174b888fd43fa6bc546e61f11c",
+      "version": "2.8.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "6dd659017978894ea856d827c3b691c92630b870",
       "version": "2.8.3",
       "port-version": 0

--- a/versions/p-/pdal.json
+++ b/versions/p-/pdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f80abfd246a963a2ab5b532f60f67f28de9cef65",
+      "version": "2.8.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "41927ca2826308f48a692ded77249ab2b50941e5",
       "version": "2.8.3",
       "port-version": 0


### PR DESCRIPTION
Update `pdal` and `pdal-dimbuilder` to version 2.8.4.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux