### PR TITLE
[protobuf-c] Update to 1.5.1

### DIFF
--- a/ports/protobuf-c/fix-crt-linkage.patch
+++ b/ports/protobuf-c/fix-crt-linkage.patch
@@ -2,33 +2,24 @@ diff --git a/build-cmake/CMakeLists.txt b/build-cmake/CMakeLists.txt
 index 98b51eb..0243b80 100644
 --- a/build-cmake/CMakeLists.txt
 +++ b/build-cmake/CMakeLists.txt
-@@ -66,11 +66,6 @@ if(MSVC)
-   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4267 /wd4244")
-   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4244")
+@@ -74,11 +74,6 @@ if(MSVC)
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4267 /wd4244")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4244")
  
 -  # Allow matching protobuf runtime dependency
 -  if(NOT BUILD_SHARED_LIBS)
 -    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 -  endif(NOT BUILD_SHARED_LIBS)
 -
- ENDIF()
+ endif()
  
  get_filename_component(MAIN_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH)
-@@ -103,7 +98,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}) # for generated files
+@@ -103,7 +98,7 @@ if(BUILD_PROTOC)
+   include_directories(${CMAKE_CURRENT_BINARY_DIR}) # for generated files
+ endif()
  
- ENDIF()
- 
--if (MSVC AND NOT BUILD_SHARED_LIBS)
+-if(MSVC AND NOT BUILD_SHARED_LIBS)
 +if (0)
- 	# In case we are building static libraries, link also the runtime library statically
- 	# so that MSVCR*.DLL is not required at runtime.
- 	# https://msdn.microsoft.com/en-us/library/2kzt1wy3.aspx
-@@ -118,7 +113,7 @@ if (MSVC AND NOT BUILD_SHARED_LIBS)
- 		string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
- 	  endif(${flag_var} MATCHES "/MD")
- 	endforeach(flag_var)
--endif (MSVC AND NOT BUILD_SHARED_LIBS)
-+endif ()
- 
- if(WIN32)
-     # Modify the environment to hint protoc where the plugin is
+   # In case we are building static libraries, link also the runtime library
+   # statically so that MSVCR*.DLL is not required at runtime.
+   # https://msdn.microsoft.com/en-us/library/2kzt1wy3.aspx This is achieved by

--- a/ports/protobuf-c/fix-dependency-protobuf.patch
+++ b/ports/protobuf-c/fix-dependency-protobuf.patch
@@ -2,12 +2,12 @@ diff --git a/build-cmake/CMakeLists.txt b/build-cmake/CMakeLists.txt
 index ba0b730..a5161cf 100644
 --- a/build-cmake/CMakeLists.txt
 +++ b/build-cmake/CMakeLists.txt
-@@ -15,7 +15,7 @@ if (MSVC AND NOT BUILD_SHARED_LIBS)
- 	SET(Protobuf_USE_STATIC_LIBS ON)
- endif (MSVC AND NOT BUILD_SHARED_LIBS)
+@@ -15,7 +15,7 @@ if(MSVC AND NOT BUILD_SHARED_LIBS)
+   set(Protobuf_USE_STATIC_LIBS ON)
+ endif()
  
--FIND_PACKAGE(Protobuf REQUIRED)
-+find_package(protobuf CONFIG REQUIRED)
- file(REAL_PATH "${PROTOBUF_INCLUDE_DIR}" PROTOBUF_INCLUDE_DIR)
- INCLUDE_DIRECTORIES(${PROTOBUF_INCLUDE_DIR})
- 
+-find_package(Protobuf CONFIG)
++find_package(Protobuf CONFIG REQUIRED)
+ if(Protobuf_FOUND)
+   # Keep compatibility with FindProtobuf CMake module
+   set(PROTOBUF_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)

--- a/ports/protobuf-c/portfile.cmake
+++ b/ports/protobuf-c/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protobuf-c/protobuf-c
     REF v${VERSION}
-    SHA512 4c540ca58b65e59aaf7149124d915f106e91fc79d60c6ef80b62faf288843250375e13f8773fd24f2ff27485dc2d2e597f0a95e39c186a30069eb470abd28ae7
+    SHA512 009b8f45aade52cccf3177de88a5357c72b1626b8d07acee17da5ad1ed0e9f6a2e24d921e673b14323331e3b25fe2556f49b437d5e071e77c385efdd72ea5fe3
     HEAD_REF master
     PATCHES
         fix-crt-linkage.patch

--- a/ports/protobuf-c/vcpkg.json
+++ b/ports/protobuf-c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protobuf-c",
-  "version-semver": "1.5.0",
+  "version-semver": "1.5.1",
   "description": "This is protobuf-c, a C implementation of the Google Protocol Buffers data serialization format.",
   "homepage": "https://github.com/protobuf-c/protobuf-c",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7285,7 +7285,7 @@
       "port-version": 0
     },
     "protobuf-c": {
-      "baseline": "1.5.0",
+      "baseline": "1.5.1",
       "port-version": 0
     },
     "protopuf": {

--- a/versions/p-/protobuf-c.json
+++ b/versions/p-/protobuf-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a97149a961559d53832ac0d240bd6a7baed7863c",
+      "version-semver": "1.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c01ef23feaae3b86482f38e6da87a147b4f2dd11",
       "version-semver": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
Update to 1.5.1.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux