### PR TITLE
[libgit2] Fix includes

### DIFF
--- a/ports/libgit2/fix-comment.diff
+++ b/ports/libgit2/fix-comment.diff
@@ -1,0 +1,13 @@
+diff --git a/include/git2/stdint.h b/include/git2/stdint.h
+index 4b235c73f..4f532e13c 100644
+--- a/include/git2/stdint.h
++++ b/include/git2/stdint.h
+@@ -221,7 +221,7 @@ typedef uint64_t  uintmax_t;
+ #endif /* __STDC_LIMIT_MACROS ] */
+ 
+ 
+-/* 7.18.4 Limits of other integer types
++/* 7.18.4 Limits of other integer types */
+ 
+ #if !defined(__cplusplus) || defined(__STDC_CONSTANT_MACROS) /* [    See footnote 224 at page 260 */
+ 

--- a/ports/libgit2/fix-include-path.diff
+++ b/ports/libgit2/fix-include-path.diff
@@ -1,0 +1,13 @@
+diff --git a/src/libgit2/CMakeLists.txt b/src/libgit2/CMakeLists.txt
+index a7d3c7ca4..f8a8910f8 100644
+--- a/src/libgit2/CMakeLists.txt
++++ b/src/libgit2/CMakeLists.txt
+@@ -58,7 +58,7 @@ set(LIBGIT2_SYSTEM_LIBS ${LIBGIT2_SYSTEM_LIBS} PARENT_SCOPE)
+ add_library(libgit2package ${SRC_RC} ${LIBGIT2_OBJECTS})
+ target_link_libraries(libgit2package ${LIBGIT2_SYSTEM_LIBS})
+ target_include_directories(libgit2package SYSTEM PRIVATE ${LIBGIT2_INCLUDES})
+-target_include_directories(libgit2package INTERFACE $<INSTALL_INTERFACE:./include/git2>)
++target_include_directories(libgit2package INTERFACE $<INSTALL_INTERFACE:include>)
+ 
+ set_target_properties(libgit2package PROPERTIES C_STANDARD 99)
+ set_target_properties(libgit2package PROPERTIES C_EXTENSIONS OFF)

--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
         cli-include-dirs.diff
         dependencies.diff
         mingw-winhttp.diff
+        fix-comment.diff
+        fix-include-path.diff
 )
 file(REMOVE_RECURSE
     "${SOURCE_PATH}/cmake/FindPCRE.cmake"

--- a/ports/libgit2/vcpkg.json
+++ b/ports/libgit2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libgit2",
   "version-semver": "1.9.0",
+  "port-version": 1,
   "description": "A C library implementing the Git core methods with a solid API",
   "homepage": "https://github.com/libgit2/libgit2",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4614,7 +4614,7 @@
     },
     "libgit2": {
       "baseline": "1.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libgme": {
       "baseline": "0.6.3",

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd43a6db3bcd49e9edb44df076071df90018114c",
+      "version-semver": "1.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "102403456a0c59d10e9949dc2513b9176d6f02d2",
       "version-semver": "1.9.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


This PR apply 2 patches:

```fix-comment.diff``` is from this commit:
https://github.com/libgit2/libgit2/commit/2fa13adf09c8dd1f334f57023390043ea3f71cb2

```fix-include-path.diff``` is from this PR:
https://github.com/libgit2/libgit2/pull/7039

