### PR TITLE
[flatbuffers] update to 25.2.10

### DIFF
--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/flatbuffers
     REF "v${VERSION}"
-    SHA512 f97762ba41b9cfef648e93932fd789324c6bb6ebc5b7aeca8185c9ef602294b67d73aea7ae371035579a1419cbfbeba7c3e88b31b5a5848db98f5e8a03b982b1
+    SHA512 809366e176f4459ee3010b7c3e2c7e6f800fdf0c5cc2d39846885e793fd933602176aeecbfbdc92aec7dadbcd54fc8ba0d57741c034251078136262bdac10ce8
     HEAD_REF master
     PATCHES
         fix-uwp-build.patch

--- a/ports/flatbuffers/vcpkg.json
+++ b/ports/flatbuffers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "flatbuffers",
-  "version": "24.12.23",
+  "version": "25.1.21",
   "description": "FlatBuffers is a cross platform serialization library architected for maximum memory efficiency. It allows you to directly access serialized data without parsing/unpacking it first, while still having great forwards/backwards compatibility.",
   "homepage": "https://google.github.io/flatbuffers/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2817,7 +2817,7 @@
       "port-version": 0
     },
     "flatbuffers": {
-      "baseline": "24.12.23",
+      "baseline": "25.1.21",
       "port-version": 0
     },
     "flatbush": {

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6286132eb355fb461555dd32efde38ed8b110eb0",
+      "version": "25.1.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "0d7ebd8b3c4d124bad8101cdecc4ae77d4386c8c",
       "version": "24.12.23",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
