### PR TITLE
[libgit2] Add usage instruction

### DIFF
--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -112,3 +112,8 @@ These source files are part of ntlmclient, distributed under the MIT license.
     list(APPEND file_list "${CURRENT_BUILDTREES_DIR}/Notice for ntlmclient")
 endif()
 vcpkg_install_copyright(FILE_LIST ${file_list})
+
+file(
+    INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)

--- a/ports/libgit2/usage
+++ b/ports/libgit2/usage
@@ -1,0 +1,5 @@
+
+libgit2 provides a CMake config file:
+
+    find_package("libgit2" CONFIG REQUIRED)
+    target_include_directories("main" PRIVATE "libgit2::libgit2package")

--- a/ports/libgit2/vcpkg.json
+++ b/ports/libgit2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libgit2",
   "version-semver": "1.9.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A C library implementing the Git core methods with a solid API",
   "homepage": "https://github.com/libgit2/libgit2",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4618,7 +4618,7 @@
     },
     "libgit2": {
       "baseline": "1.9.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libgme": {
       "baseline": "0.6.3",

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d36002d84ad6885b0c1b1e668b4d14b3320476ed",
+      "version-semver": "1.9.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "fd43a6db3bcd49e9edb44df076071df90018114c",
       "version-semver": "1.9.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

This is a follow-up to #43822.
I forgot to add the usage instruction, to reflect that libgit2 now has an official cmake target as of version 1.9.
