### PR TITLE
[pistache] update to 0.4.25

### DIFF
--- a/ports/pistache/portfile.cmake
+++ b/ports/pistache/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pistacheio/pistache

--- a/ports/pistache/portfile.cmake
+++ b/ports/pistache/portfile.cmake
@@ -1,17 +1,43 @@
-if(NOT VCPKG_TARGET_IS_LINUX)
-    message(FATAL_ERROR "${PORT} currently only supports Linux platform.")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pistacheio/pistache
-    REF 9dc080b9ebbe6fc1726b45e9db1550305938313e #2021-03-31
-    SHA512 b55c395fb98af85317590ed2502564af5e92e30a35618132568c6ab589a6d0971570ad20ddbd1f49d9dd8cf54692866c69cfc1350c6fdccf9efb039aacf153b4
+    REF "v${VERSION}"
+    SHA512 2f6d3178354bd4fe78e48fbb0b15055c2a92bee4f4fcee26c3bcc2076df8ca47ef4cac931ee565f5003837beb78a2456ed7d2b6a39083860631426fd074b497c
     HEAD_REF master
 )
 
+if ("ssl" IN_LIST FEATURES)
+    list(APPEND BUILD_OPTIONS -DPISTACHE_USE_SSL=true)
+endif()
+
+if ("rapidjson" IN_LIST FEATURES)
+    list(APPEND BUILD_OPTIONS -DPISTACHE_USE_RAPIDJSON=true)
+else()
+    list(APPEND BUILD_OPTIONS -DPISTACHE_USE_RAPIDJSON=false)
+endif()
+
+if ("brotli" IN_LIST FEATURES)
+    list(APPEND BUILD_OPTIONS -DPISTACHE_USE_CONTENT_ENCODING_BROTLI=true)
+endif()
+
+if ("zstd" IN_LIST FEATURES)
+    list(APPEND BUILD_OPTIONS -DPISTACHE_USE_CONTENT_ENCODING_ZSTD=true)
+endif()
+
+if ("deflate" IN_LIST FEATURES)
+    list(APPEND BUILD_OPTIONS -DPISTACHE_USE_CONTENT_ENCODING_DEFLATE=true)
+endif()
+
+if ("libevent" IN_LIST FEATURES)
+    list(APPEND BUILD_OPTIONS -DPISTACHE_FORCE_LIBEVENT=true)
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${BUILD_OPTIONS}
+        -DPISTACHE_BUILD_TESTS=false
+        -DPISTACHE_BUILD_EXAMPLES=false
 )
 vcpkg_install_meson()
 

--- a/ports/pistache/portfile.cmake
+++ b/ports/pistache/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pistacheio/pistache

--- a/ports/pistache/vcpkg.json
+++ b/ports/pistache/vcpkg.json
@@ -13,6 +13,7 @@
     }
   ],
   "default-features": [
+    "libevent",
     "rapidjson"
   ],
   "features": {

--- a/ports/pistache/vcpkg.json
+++ b/ports/pistache/vcpkg.json
@@ -1,15 +1,56 @@
 {
   "name": "pistache",
-  "version-date": "2021-03-31",
-  "port-version": 3,
-  "description": "Pistache is a modern and elegant HTTP and REST framework for C++. It is entirely written in pure-C++11 and provides a clear and pleasant API",
-  "homepage": "https://github.com/oktal/pistache",
-  "supports": "linux",
+  "version": "0.4.25",
+  "description": "Pistache is a modern and elegant HTTP and REST framework for C++. It is entirely written in pure-C++17 and provides a clear and pleasant API",
+  "homepage": "https://github.com/pistacheio/pistache",
+  "license": "Apache-2.0",
+  "supports": "!(uwp | android)",
   "dependencies": [
-    "rapidjson",
+    "date",
     {
       "name": "vcpkg-tool-meson",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "rapidjson"
+  ],
+  "features": {
+    "brotli": {
+      "description": "add support for Brotli compressed content encoding",
+      "dependencies": [
+        "brotli"
+      ]
+    },
+    "deflate": {
+      "description": "add support for deflate compressed content encoding",
+      "dependencies": [
+        "zlib"
+      ]
+    },
+    "libevent": {
+      "description": "force use of libevent",
+      "dependencies": [
+        "libevent"
+      ]
+    },
+    "rapidjson": {
+      "description": "add support for rapidjson",
+      "dependencies": [
+        "rapidjson"
+      ]
+    },
+    "ssl": {
+      "description": "add support for SSL server",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "zstd": {
+      "description": "add support for Zstandard compressed content encoding",
+      "dependencies": [
+        "zstd"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7065,8 +7065,8 @@
       "port-version": 0
     },
     "pistache": {
-      "baseline": "2021-03-31",
-      "port-version": 3
+      "baseline": "0.4.25",
+      "port-version": 0
     },
     "pixel": {
       "baseline": "2022-03-15",

--- a/versions/p-/pistache.json
+++ b/versions/p-/pistache.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3ff776da0c1a277c891b8e0cf3eaf416829ee6c9",
+      "git-tree": "7ff35e59e0430c87a376746bac0f4ac86dbfc671",
       "version": "0.4.25",
       "port-version": 0
     },

--- a/versions/p-/pistache.json
+++ b/versions/p-/pistache.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "18aae0b4963438c6e8fcbb23d8698cb992326850",
+      "git-tree": "7ff35e59e0430c87a376746bac0f4ac86dbfc671",
       "version": "0.4.25",
       "port-version": 0
     },

--- a/versions/p-/pistache.json
+++ b/versions/p-/pistache.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7ff35e59e0430c87a376746bac0f4ac86dbfc671",
+      "git-tree": "3ff776da0c1a277c891b8e0cf3eaf416829ee6c9",
       "version": "0.4.25",
       "port-version": 0
     },

--- a/versions/p-/pistache.json
+++ b/versions/p-/pistache.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18aae0b4963438c6e8fcbb23d8698cb992326850",
+      "version": "0.4.25",
+      "port-version": 0
+    },
+    {
       "git-tree": "270e04cb56d330fc6cd8482697341ed0d3bf1320",
       "version-date": "2021-03-31",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

homepage has been changed.
Windows and macOS have been supported.
There are lots of features.
