### PR TITLE
[tgui] Prevent unnecessary dependencies

### DIFF
--- a/ports/tgui/vcpkg.json
+++ b/ports/tgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tgui",
   "version": "1.7.0",
+  "port-version": 1,
   "description": "TGUI is an easy to use, cross-platform, C++ GUI for SFML.",
   "homepage": "https://tgui.eu",
   "license": "Zlib",
@@ -33,7 +34,13 @@
     "sfml": {
       "description": "Build the SFML backend",
       "dependencies": [
-        "sfml"
+        {
+          "name": "sfml",
+          "default-features": false,
+          "features": [
+            "graphics"
+          ]
+        }
       ]
     },
     "tool": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9058,7 +9058,7 @@
     },
     "tgui": {
       "baseline": "1.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "think-cell-range": {
       "baseline": "2023.1",

--- a/versions/t-/tgui.json
+++ b/versions/t-/tgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4070d373b00a30726b8662f57c7bd18eb0dac500",
+      "version": "1.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a228fc0e38252f9fc749e1962462f703c43b348e",
       "version": "1.7.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


Currently TGUI's vcpkg.json bring in sfml-audio and sfml-network which it doesn't need.
TGUI only requires sfml-graphics and sfml-windows.