### PR TITLE
[rapidjson] update version to 2025-02-05

### DIFF
--- a/ports/mysql-connector-cpp/cmake-project-include.cmake
+++ b/ports/mysql-connector-cpp/cmake-project-include.cmake
@@ -1,4 +1,4 @@
-#[[ 
+#[[
     vcpkg overloads find_package().
     mysql-connector-cpp overloads find_dependency().
 

--- a/ports/mysql-connector-cpp/cmake-project-include.cmake
+++ b/ports/mysql-connector-cpp/cmake-project-include.cmake
@@ -24,7 +24,6 @@ if(NOT TARGET ext::protoc)
 endif()
 
 find_package(RapidJSON CONFIG REQUIRED)
-add_library(RapidJSON::rapidjson ALIAS rapidjson)
 
 find_package(ZLIB REQUIRED)
 add_library(ext::z ALIAS ZLIB::ZLIB)

--- a/ports/mysql-connector-cpp/cmake-project-include.cmake
+++ b/ports/mysql-connector-cpp/cmake-project-include.cmake
@@ -24,6 +24,7 @@ if(NOT TARGET ext::protoc)
 endif()
 
 find_package(RapidJSON CONFIG REQUIRED)
+add_library(RapidJSON::rapidjson ALIAS RapidJSON)
 
 find_package(ZLIB REQUIRED)
 add_library(ext::z ALIAS ZLIB::ZLIB)

--- a/ports/mysql-connector-cpp/mysql-connector-cpp-config.cmake.in
+++ b/ports/mysql-connector-cpp/mysql-connector-cpp-config.cmake.in
@@ -19,7 +19,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/unofficial-mysql-connector-cpp-targets.cmake"
 if(NOT UNOFFICIAL_MYSQL_CONNECTOR_CPP_INITIALIZED)
     if(NOT "@BUILD_SHARED_LIBS@")
         set_target_properties(unofficial::mysql-connector-cpp::connector PROPERTIES
-            INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:Threads::Threads>;$<LINK_ONLY:OpenSSL::SSL>;$<LINK_ONLY:RapidJSON::rapidjson>;$<LINK_ONLY:ZLIB::ZLIB>;$<LINK_ONLY:>;$<LINK_ONLY:lz4::lz4>;$<LINK_ONLY:zstd::libzstd>"
+            INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:Threads::Threads>;$<LINK_ONLY:OpenSSL::SSL>;$<LINK_ONLY:RapidJSON>;$<LINK_ONLY:ZLIB::ZLIB>;$<LINK_ONLY:>;$<LINK_ONLY:lz4::lz4>;$<LINK_ONLY:zstd::libzstd>"
         )
         # Cf. mysql-concpp-config.cmake.in
         if(WIN32)

--- a/ports/mysql-connector-cpp/mysql-connector-cpp-config.cmake.in
+++ b/ports/mysql-connector-cpp/mysql-connector-cpp-config.cmake.in
@@ -19,7 +19,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/unofficial-mysql-connector-cpp-targets.cmake"
 if(NOT UNOFFICIAL_MYSQL_CONNECTOR_CPP_INITIALIZED)
     if(NOT "@BUILD_SHARED_LIBS@")
         set_target_properties(unofficial::mysql-connector-cpp::connector PROPERTIES
-            INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:Threads::Threads>;$<LINK_ONLY:OpenSSL::SSL>;$<LINK_ONLY:rapidjson>;$<LINK_ONLY:ZLIB::ZLIB>;$<LINK_ONLY:>;$<LINK_ONLY:lz4::lz4>;$<LINK_ONLY:zstd::libzstd>"
+            INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:Threads::Threads>;$<LINK_ONLY:OpenSSL::SSL>;$<LINK_ONLY:RapidJSON::rapidjson>;$<LINK_ONLY:ZLIB::ZLIB>;$<LINK_ONLY:>;$<LINK_ONLY:lz4::lz4>;$<LINK_ONLY:zstd::libzstd>"
         )
         # Cf. mysql-concpp-config.cmake.in
         if(WIN32)

--- a/ports/mysql-connector-cpp/vcpkg.json
+++ b/ports/mysql-connector-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mysql-connector-cpp",
   "version": "9.1.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "This is a release of MySQL Connector/C++, the C++ interface for communicating with MySQL servers.",
   "homepage": "https://github.com/mysql/mysql-connector-cpp",
   "license": null,

--- a/ports/rapidjson/portfile.cmake
+++ b/ports/rapidjson/portfile.cmake
@@ -38,6 +38,6 @@ string(REPLACE "\${RapidJSON_SOURCE_DIR}" "\${RapidJSON_CMAKE_DIR}/../.." _conte
 string(REPLACE "set( RapidJSON_SOURCE_DIR \"${SOURCE_PATH}\")" "" _contents "${_contents}")
 string(REPLACE "set( RapidJSON_DIR \"${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel\")" "" _contents "${_contents}")
 string(REPLACE "\${RapidJSON_CMAKE_DIR}/../../../include" "\${RapidJSON_CMAKE_DIR}/../../include" _contents "${_contents}")
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/RapidJSONConfig.cmake" ${_contents})
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/RapidJSONConfig.cmake" "${_contents}\nset(RAPIDJSON_INCLUDE_DIRS \"\${RapidJSON_INCLUDE_DIRS}\")\n")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license.txt")

--- a/ports/rapidjson/portfile.cmake
+++ b/ports/rapidjson/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Tencent/rapidjson
-    REF a95e013b97ca6523f32da23f5095fcc9dd6067e5 # accessed on 2023-07-17
-    SHA512 19bf9a579df70cbeaf60c7ccf25c92c327bffe95b0df14f27f2132134d5bb214e98a45e021eb287c4790e301f84bb095e0bdb3c97f65a37fbeb254970d97c005
+    REF 24b5e7a8b27f42fa16b96fc70aade9106cf7102f # 2025-02-05
+    SHA512 50f8723414a6e63eadd45f97be5c44e9fff2d06216c8cc4df802f5bfc2a9416a039f2c69e9bb1882f7e756cd38a7097eea05cab76c739f45805dc41617140799
     FILE_DISAMBIGUATOR 2
     HEAD_REF master
 )
@@ -34,7 +34,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 file(READ "${CURRENT_PACKAGES_DIR}/share/${PORT}/RapidJSONConfig.cmake" _contents)
-string(REPLACE "VERSION 3.0" "VERSION 3.5...3.30" _contents "${_contents}")
+string(REPLACE "VERSION 3.5" "VERSION 3.5...3.31" _contents "${_contents}")
 string(REPLACE "\${RapidJSON_SOURCE_DIR}" "\${RapidJSON_CMAKE_DIR}/../.." _contents "${_contents}")
 string(REPLACE "set( RapidJSON_SOURCE_DIR \"${SOURCE_PATH}\")" "" _contents "${_contents}")
 string(REPLACE "set( RapidJSON_DIR \"${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel\")" "" _contents "${_contents}")

--- a/ports/rapidjson/portfile.cmake
+++ b/ports/rapidjson/portfile.cmake
@@ -34,11 +34,10 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 file(READ "${CURRENT_PACKAGES_DIR}/share/${PORT}/RapidJSONConfig.cmake" _contents)
-string(REPLACE "VERSION 3.5" "VERSION 3.5...3.31" _contents "${_contents}")
 string(REPLACE "\${RapidJSON_SOURCE_DIR}" "\${RapidJSON_CMAKE_DIR}/../.." _contents "${_contents}")
 string(REPLACE "set( RapidJSON_SOURCE_DIR \"${SOURCE_PATH}\")" "" _contents "${_contents}")
 string(REPLACE "set( RapidJSON_DIR \"${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel\")" "" _contents "${_contents}")
 string(REPLACE "\${RapidJSON_CMAKE_DIR}/../../../include" "\${RapidJSON_CMAKE_DIR}/../../include" _contents "${_contents}")
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/RapidJSONConfig.cmake" "${_contents}\nset(RAPIDJSON_INCLUDE_DIRS \"\${RapidJSON_INCLUDE_DIRS}\")\n")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/RapidJSONConfig.cmake" ${_contents})
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license.txt")

--- a/ports/rapidjson/vcpkg.json
+++ b/ports/rapidjson/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rapidjson",
-  "version-date": "2023-07-17",
-  "port-version": 2,
+  "version-date": "2025-02-05",
   "description": "A fast JSON parser/generator for C++ with both SAX/DOM style API <http://rapidjson.org/>",
   "homepage": "http://rapidjson.org/",
   "license": "MIT",

--- a/ports/vowpal-wabbit/cmake_fix_existing_rapidjson_target.patch
+++ b/ports/vowpal-wabbit/cmake_fix_existing_rapidjson_target.patch
@@ -1,0 +1,19 @@
+diff --git a/ext_libs/ext_libs.cmake b/ext_libs/ext_libs.cmake
+index e03de8690..7f1055809 100644
+--- a/ext_libs/ext_libs.cmake
++++ b/ext_libs/ext_libs.cmake
+@@ -37,8 +37,12 @@ endif()
+ if(RAPIDJSON_SYS_DEP)
+   # Since EXACT is not specified, any version compatible with 1.1.0 is accepted (>= 1.1.0)
+   find_package(RapidJSON 1.1.0 CONFIG REQUIRED)
+-  add_library(RapidJSON INTERFACE)
+-  target_include_directories(RapidJSON INTERFACE ${RapidJSON_INCLUDE_DIRS} ${RAPIDJSON_INCLUDE_DIRS})
++
++  # 2025-02-05: RapidJSON adds itself as a target in this version, so there is no need for these commands
++  if(NOT TARGET RapidJSON)
++    add_library(RapidJSON INTERFACE)
++    target_include_directories(RapidJSON INTERFACE ${RapidJSON_INCLUDE_DIRS} ${RAPIDJSON_INCLUDE_DIRS})
++  endif()
+ else()
+   add_library(RapidJSON INTERFACE)
+   target_include_directories(RapidJSON SYSTEM INTERFACE "${CMAKE_CURRENT_LIST_DIR}/rapidjson/include")

--- a/ports/vowpal-wabbit/portfile.cmake
+++ b/ports/vowpal-wabbit/portfile.cmake
@@ -6,8 +6,9 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 f87229caf65c6c32fb863fa426a39592d41990a43ce4d79f0a076323e47cd3d1a8bd02884afceb662527c87d290e68c51df6263d6a97f3a044f3f7254a38f86a
     HEAD_REF master
-    PATCHES 
+    PATCHES
         cmake_remove_bin_targets.patch
+        cmake_fix_existing_rapidjson_target.patch
         fix-build-error-with-fmt11.patch
 )
 

--- a/ports/vowpal-wabbit/vcpkg.json
+++ b/ports/vowpal-wabbit/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vowpal-wabbit",
   "version": "9.10.0",
+  "port-version": 1,
   "description": "Reduction based online learning framework with a focus on contextual bandits and reinforcement learning.",
   "homepage": "https://github.com/vowpalwabbit/vowpal_wabbit",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6258,7 +6258,7 @@
     },
     "mysql-connector-cpp": {
       "baseline": "9.1.0",
-      "port-version": 3
+      "port-version": 4
     },
     "nameof": {
       "baseline": "0.10.4",
@@ -9650,7 +9650,7 @@
     },
     "vowpal-wabbit": {
       "baseline": "9.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vs-yasm": {
       "baseline": "0.5.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7881,8 +7881,8 @@
       "port-version": 0
     },
     "rapidjson": {
-      "baseline": "2023-07-17",
-      "port-version": 2
+      "baseline": "2025-02-05",
+      "port-version": 0
     },
     "rapidxml": {
       "baseline": "1.13",

--- a/versions/m-/mysql-connector-cpp.json
+++ b/versions/m-/mysql-connector-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e29706dc6aad99e01db67f62a43bc84ef4d6d8b5",
+      "version": "9.1.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "bdd83a314ef53b655567e07757c328eb33694315",
       "version": "9.1.0",
       "port-version": 3

--- a/versions/m-/mysql-connector-cpp.json
+++ b/versions/m-/mysql-connector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e29706dc6aad99e01db67f62a43bc84ef4d6d8b5",
+      "git-tree": "575b33e93143ec6a64145a53468aed6f724441e4",
       "version": "9.1.0",
       "port-version": 4
     },

--- a/versions/m-/mysql-connector-cpp.json
+++ b/versions/m-/mysql-connector-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "575b33e93143ec6a64145a53468aed6f724441e4",
+      "git-tree": "006d95e557432e04a26a9a53a6508c6d2c36d025",
       "version": "9.1.0",
       "port-version": 4
     },

--- a/versions/r-/rapidjson.json
+++ b/versions/r-/rapidjson.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7a6ec0413ae66cfe091582c7961332f87073d820",
+      "git-tree": "c6bf346543ac20893ab895c0be8a919c25cc0c4f",
       "version-date": "2025-02-05",
       "port-version": 0
     },

--- a/versions/r-/rapidjson.json
+++ b/versions/r-/rapidjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad7c0893d8d4785f369e1e6e6dc86431f0442bb2",
+      "version-date": "2025-02-05",
+      "port-version": 0
+    },
+    {
       "git-tree": "38b67535aa1b51fd521021ec77ccb36f01431bd2",
       "version-date": "2023-07-17",
       "port-version": 2

--- a/versions/r-/rapidjson.json
+++ b/versions/r-/rapidjson.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad7c0893d8d4785f369e1e6e6dc86431f0442bb2",
+      "git-tree": "7a6ec0413ae66cfe091582c7961332f87073d820",
       "version-date": "2025-02-05",
       "port-version": 0
     },

--- a/versions/v-/vowpal-wabbit.json
+++ b/versions/v-/vowpal-wabbit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d4bccdc9a60dd049e3d45dee471d7284021fdc2d",
+      "version": "9.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4d38379dd56ce81943770adad88ca2b35814791f",
       "version": "9.10.0",
       "port-version": 0

--- a/versions/v-/vowpal-wabbit.json
+++ b/versions/v-/vowpal-wabbit.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d4bccdc9a60dd049e3d45dee471d7284021fdc2d",
+      "git-tree": "f436f628c40dc7e56c34285742643ececc99dda2",
       "version": "9.10.0",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.