### PR TITLE
[simdjson] update to 3.12.2

### DIFF
--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO simdjson/simdjson
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 c28a235b252d520cf45defab8d64088db71aa8f3fa75746db237cbd8145054b4fb6b8c2783b0a9fefaf8a8f860feb2bd0b2f5ce4303eed8ceca3725d79af6c13
+    SHA512 ee9683dc983458ab0516f79dbf513354d0afa59384e3d606916407257f7962bd1faa63d9c815f200ab43d13c38ee5a187083364b9528a613ae6477afdadbab6c
 )
 
 vcpkg_check_features(

--- a/ports/simdjson/vcpkg.json
+++ b/ports/simdjson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdjson",
-  "version": "3.12.0",
+  "version": "3.12.2",
   "description": "An extremely fast JSON library that can parse gigabytes of JSON per second",
   "homepage": "https://simdjson.org/",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8469,7 +8469,7 @@
       "port-version": 0
     },
     "simdjson": {
-      "baseline": "3.12.0",
+      "baseline": "3.12.2",
       "port-version": 0
     },
     "simdutf": {

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "752e1324d873bed317b893714dd20ac0c3ea2987",
+      "version": "3.12.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2f179416811614e9c85da7f3370de8275af9c90e",
       "version": "3.12.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
