### PR TITLE
[yaml-cpp] add license to the manifest

### DIFF
--- a/ports/yaml-cpp/vcpkg.json
+++ b/ports/yaml-cpp/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "yaml-cpp",
   "version-semver": "0.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec.",
   "homepage": "https://github.com/jbeder/yaml-cpp",
   "documentation": "https://codedocs.xyz/jbeder/yaml-cpp/index.html",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10058,7 +10058,7 @@
     },
     "yaml-cpp": {
       "baseline": "0.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "yara": {
       "baseline": "4.5.2",

--- a/versions/y-/yaml-cpp.json
+++ b/versions/y-/yaml-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "447c1a228690199df9139b51e254e51403d9a963",
+      "version-semver": "0.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "eb1a38369faa80d2af500df32ef6d4a747336dcb",
       "version-semver": "0.8.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #43843

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
