### PR TITLE
[polyclipping] add license

### DIFF
--- a/ports/polyclipping/vcpkg.json
+++ b/ports/polyclipping/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "polyclipping",
   "version": "6.4.2",
-  "port-version": 12,
+  "port-version": 13,
   "description": "The Clipper library performs clipping and offsetting for both lines and polygons. All four boolean clipping operations are supported - intersection, union, difference and exclusive-or. Polygons can be of any shape including self-intersecting polygons.",
   "homepage": "https://sourceforge.net/projects/polyclipping/",
+  "license": "BSL-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7174,7 +7174,7 @@
     },
     "polyclipping": {
       "baseline": "6.4.2",
-      "port-version": 12
+      "port-version": 13
     },
     "polyhook2": {
       "baseline": "2024-06-03",

--- a/versions/p-/polyclipping.json
+++ b/versions/p-/polyclipping.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2388298c7ad673550c7492454666dd3a34ada895",
+      "version": "6.4.2",
+      "port-version": 13
+    },
+    {
       "git-tree": "7de01c0a001bc72c4d934184b3bd4ae97f860c01",
       "version": "6.4.2",
       "port-version": 12


### PR DESCRIPTION
Fixes #43842

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.