### PR TITLE
[sdl3-ttf] new port

### DIFF
--- a/ports/sdl3-ttf/portfile.cmake
+++ b/ports/sdl3-ttf/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         harfbuzz SDLTTF_HARFBUZZ
-	svg SDLTTF_PLUTOSVG
+	svg      SDLTTF_PLUTOSVG
 )
 
 vcpkg_cmake_configure(
@@ -22,9 +22,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
-    vcpkg_cmake_config_fixup(PACKAGE_NAME SDL3_ttf CONFIG_PATH cmake)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME sdl3_ttf CONFIG_PATH cmake)
 else()
-    vcpkg_cmake_config_fixup(PACKAGE_NAME SDL3_ttf CONFIG_PATH lib/cmake/SDL3_ttf)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME sdl3_ttf CONFIG_PATH lib/cmake/SDL3_ttf)
 endif()
 
 vcpkg_fixup_pkgconfig()

--- a/ports/sdl3-ttf/portfile.cmake
+++ b/ports/sdl3-ttf/portfile.cmake
@@ -27,6 +27,12 @@ else()
     vcpkg_cmake_config_fixup(PACKAGE_NAME sdl3_ttf CONFIG_PATH lib/cmake/SDL3_ttf)
 endif()
 
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/sdl3_ttf/SDL3_ttfConfig.cmake"
+"# sdl3_ttf cmake project-config input for CMakeLists.txt script"
+[[# sdl3_ttf cmake project-config input for CMakeLists.txt script
+include(CMakeFindDependencyMacro)
+find_dependency(SDL3 CONFIG)]])
+
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/sdl3-ttf/portfile.cmake
+++ b/ports/sdl3-ttf/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO  libsdl-org/SDL_ttf
+    REF "preview-${VERSION}"
+    SHA512 c6a2002d4a1227747a2986c257f3888ce4fc84b1c1d862142df5e2e7cbd9c9490c9c9b375dd16f8f0ecfc5313681d8cb5e267b907c0d52bd738a4c63695fd485 
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        harfbuzz SDLTTF_HARFBUZZ
+	svg SDLTTF_PLUTOSVG
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSDLTTF_VENDORED=OFF
+        -DSDLTTF_SAMPLES=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
+    vcpkg_cmake_config_fixup(PACKAGE_NAME SDL3_ttf CONFIG_PATH cmake)
+else()
+    vcpkg_cmake_config_fixup(PACKAGE_NAME SDL3_ttf CONFIG_PATH lib/cmake/SDL3_ttf)
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/licenses")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/sdl3-ttf/portfile.cmake
+++ b/ports/sdl3-ttf/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         harfbuzz SDLTTF_HARFBUZZ
-	svg      SDLTTF_PLUTOSVG
+        svg      SDLTTF_PLUTOSVG
 )
 
 vcpkg_cmake_configure(

--- a/ports/sdl3-ttf/usage
+++ b/ports/sdl3-ttf/usage
@@ -1,0 +1,4 @@
+sdl3-ttf provides CMake targets:
+
+    find_package(SDL3_ttf CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SDL3_ttf::SDL3_ttf>,SDL3_ttf::SDL3_ttf,SDL3_ttf::SDL3_ttf-static>)

--- a/ports/sdl3-ttf/usage
+++ b/ports/sdl3-ttf/usage
@@ -1,4 +1,4 @@
 sdl3-ttf provides CMake targets:
 
-    find_package(SDL3_ttf CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SDL3_ttf::SDL3_ttf>,SDL3_ttf::SDL3_ttf,SDL3_ttf::SDL3_ttf-static>)
+  find_package(SDL3_ttf CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:SDL3_ttf::SDL3_ttf>,SDL3_ttf::SDL3_ttf,SDL3_ttf::SDL3_ttf-static>)

--- a/ports/sdl3-ttf/vcpkg.json
+++ b/ports/sdl3-ttf/vcpkg.json
@@ -5,7 +5,10 @@
   "homepage": "https://www.libsdl.org/projects/SDL_ttf/",
   "license": "Zlib",
   "dependencies": [
-    "freetype",
+    {
+      "name": "freetype",
+      "default-features": false
+    },
     {
       "name": "sdl3",
       "default-features": false

--- a/ports/sdl3-ttf/vcpkg.json
+++ b/ports/sdl3-ttf/vcpkg.json
@@ -1,0 +1,36 @@
+{
+  "name": "sdl3-ttf",
+  "version": "3.1.0",
+  "description": "A library for rendering TrueType fonts with SDL",
+  "homepage": "https://www.libsdl.org/projects/SDL_ttf/",
+  "license": "Zlib",
+  "dependencies": [
+    "freetype",
+    {
+      "name": "sdl3",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "harfbuzz": {
+      "description": "Enable HarfBuzz support",
+      "dependencies": [
+        "harfbuzz"
+      ]
+    },
+    "svg": {
+      "description": "Enable plutosvg for color emoji support",
+      "dependencies": [
+        "plutosvg"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8320,6 +8320,10 @@
       "baseline": "3.2.0",
       "port-version": 0
     },
+    "sdl3-ttf": {
+      "baseline": "3.1.0",
+      "port-version": 0
+    },
     "seacas": {
       "baseline": "2022-11-22",
       "port-version": 8

--- a/versions/s-/sdl3-ttf.json
+++ b/versions/s-/sdl3-ttf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fa0239502489d787a074de617542309b0cfb7e6e",
+      "git-tree": "e04f2a774fa7a6f4668b41641b077c4395e89b73",
       "version": "3.1.0",
       "port-version": 0
     }

--- a/versions/s-/sdl3-ttf.json
+++ b/versions/s-/sdl3-ttf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2dbeb0be407e288701632522c8d735ceadbe97bc",
+      "git-tree": "5f357b9177182cd52a9ea83779ff6e2ce0a5eddc",
       "version": "3.1.0",
       "port-version": 0
     }

--- a/versions/s-/sdl3-ttf.json
+++ b/versions/s-/sdl3-ttf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5f357b9177182cd52a9ea83779ff6e2ce0a5eddc",
+      "git-tree": "580095b6cdeb525fe480869f54f801b064fbccd7",
       "version": "3.1.0",
       "port-version": 0
     }

--- a/versions/s-/sdl3-ttf.json
+++ b/versions/s-/sdl3-ttf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2dbeb0be407e288701632522c8d735ceadbe97bc",
+      "version": "3.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/sdl3-ttf.json
+++ b/versions/s-/sdl3-ttf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "580095b6cdeb525fe480869f54f801b064fbccd7",
+      "git-tree": "fa0239502489d787a074de617542309b0cfb7e6e",
       "version": "3.1.0",
       "port-version": 0
     }


### PR DESCRIPTION
Fixes #43848
Fixes #43738 

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
