### PR TITLE
[implot3d] New port

### DIFF
--- a/ports/implot3d/CMakeLists.txt
+++ b/ports/implot3d/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.8)
+project(implot3d CXX)
+
+find_package(imgui CONFIG REQUIRED)
+get_target_property(IMGUI_INCLUDE_DIRS imgui::imgui
+    INTERFACE_INCLUDE_DIRECTORIES
+)
+
+set(CMAKE_DEBUG_POSTFIX d)
+
+add_library(${PROJECT_NAME} "")
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
+target_include_directories(
+	${PROJECT_NAME}
+	PUBLIC
+	   	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+		$<INSTALL_INTERFACE:include>
+	PRIVATE
+		${IMGUI_INCLUDE_DIRS}
+)
+
+target_sources(
+	${PROJECT_NAME}
+	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/implot3d.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/implot3d_items.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/implot3d_demo.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/implot3d_meshes.cpp
+)
+
+install(
+	TARGETS ${PROJECT_NAME}
+	EXPORT ${PROJECT_NAME}_target
+	ARCHIVE DESTINATION lib
+	LIBRARY DESTINATION lib
+	RUNTIME DESTINATION bin
+)
+
+if(NOT IMPLOT3D_SKIP_HEADERS)
+    install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/implot3d.h
+		${CMAKE_CURRENT_SOURCE_DIR}/implot3d_internal.h
+        DESTINATION include
+    )
+endif()
+
+install(
+	EXPORT ${PROJECT_NAME}_target
+	NAMESPACE ${PROJECT_NAME}::
+	FILE ${PROJECT_NAME}-config.cmake
+	DESTINATION share/${PROJECT_NAME}
+)

--- a/ports/implot3d/CMakeLists.txt
+++ b/ports/implot3d/CMakeLists.txt
@@ -34,13 +34,11 @@ install(
 	RUNTIME DESTINATION bin
 )
 
-if(NOT IMPLOT3D_SKIP_HEADERS)
-    install(FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/implot3d.h
-		${CMAKE_CURRENT_SOURCE_DIR}/implot3d_internal.h
-        DESTINATION include
-    )
-endif()
+install(FILES
+	${CMAKE_CURRENT_SOURCE_DIR}/implot3d.h
+	${CMAKE_CURRENT_SOURCE_DIR}/implot3d_internal.h
+	DESTINATION include
+)
 
 install(
 	EXPORT ${PROJECT_NAME}_target

--- a/ports/implot3d/CMakeLists.txt
+++ b/ports/implot3d/CMakeLists.txt
@@ -3,7 +3,12 @@ project(implot3d CXX)
 
 set(CMAKE_DEBUG_POSTFIX d)
 
-add_library(${PROJECT_NAME} "")
+add_library(${PROJECT_NAME} ""
+		${CMAKE_CURRENT_SOURCE_DIR}/implot3d.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/implot3d_items.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/implot3d_demo.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/implot3d_meshes.cpp
+)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
 
@@ -15,15 +20,6 @@ target_include_directories(
 	PUBLIC
 	   	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 		$<INSTALL_INTERFACE:include>
-)
-
-target_sources(
-	${PROJECT_NAME}
-	PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/implot3d.cpp
-		${CMAKE_CURRENT_SOURCE_DIR}/implot3d_items.cpp
-		${CMAKE_CURRENT_SOURCE_DIR}/implot3d_demo.cpp
-		${CMAKE_CURRENT_SOURCE_DIR}/implot3d_meshes.cpp
 )
 
 install(

--- a/ports/implot3d/CMakeLists.txt
+++ b/ports/implot3d/CMakeLists.txt
@@ -1,23 +1,20 @@
 cmake_minimum_required(VERSION 3.8)
 project(implot3d CXX)
 
-find_package(imgui CONFIG REQUIRED)
-get_target_property(IMGUI_INCLUDE_DIRS imgui::imgui
-    INTERFACE_INCLUDE_DIRECTORIES
-)
-
 set(CMAKE_DEBUG_POSTFIX d)
 
 add_library(${PROJECT_NAME} "")
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
+
+find_package(imgui CONFIG REQUIRED)
+target_link_libraries(${PROJECT_NAME} PUBLIC imgui::imgui)
+
 target_include_directories(
 	${PROJECT_NAME}
 	PUBLIC
 	   	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 		$<INSTALL_INTERFACE:include>
-	PRIVATE
-		${IMGUI_INCLUDE_DIRS}
 )
 
 target_sources(

--- a/ports/implot3d/portfile.cmake
+++ b/ports/implot3d/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO brenocq/implot3d
+    REF v${VERSION}
+    SHA512 163aeb62d7d4bd4cac0ea0bad26b4d2dd399ac078cfa6fb414b969006ef3683c3865f5db322fd8d46d7b74e32d7492cd0574fbf30fcd6ac5696f1f1d04e0f7cb
+    HEAD_REF master
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS_DEBUG
+        -DIMPLOT3D_SKIP_HEADERS=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/implot3d/portfile.cmake
+++ b/ports/implot3d/portfile.cmake
@@ -21,4 +21,6 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup()
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/implot3d/portfile.cmake
+++ b/ports/implot3d/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO brenocq/implot3d
-    REF v${VERSION}
+    REF "v${VERSION}"
     SHA512 163aeb62d7d4bd4cac0ea0bad26b4d2dd399ac078cfa6fb414b969006ef3683c3865f5db322fd8d46d7b74e32d7492cd0574fbf30fcd6ac5696f1f1d04e0f7cb
     HEAD_REF master
 )

--- a/ports/implot3d/vcpkg.json
+++ b/ports/implot3d/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "implot3d",
+  "version": "0.2",
+  "description": "Immediate Mode 3D Plotting",
+  "homepage": "https://github.com/brenocq/implot3d",
+  "license": "MIT",
+  "dependencies": [
+    "imgui",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3724,6 +3724,10 @@
       "baseline": "0.16",
       "port-version": 0
     },
+    "implot3d": {
+      "baseline": "0.2",
+      "port-version": 0
+    },
     "indicators": {
       "baseline": "2.3",
       "port-version": 0

--- a/versions/i-/implot3d.json
+++ b/versions/i-/implot3d.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ff5a907ebd99fd67fec45958cfade70136f9ae5c",
+      "version": "0.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/i-/implot3d.json
+++ b/versions/i-/implot3d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "baa880bc548df3ebbfb3c8778500e4beb6cfaccd",
+      "git-tree": "944d14000d6f1d3aae5590000a43f1384b8724ee",
       "version": "0.2",
       "port-version": 0
     }

--- a/versions/i-/implot3d.json
+++ b/versions/i-/implot3d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ff5a907ebd99fd67fec45958cfade70136f9ae5c",
+      "git-tree": "baa880bc548df3ebbfb3c8778500e4beb6cfaccd",
       "version": "0.2",
       "port-version": 0
     }


### PR DESCRIPTION
Add new port implot3d: https://github.com/brenocq/implot3d

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.