### PR TITLE
[imgui] Update to support SDL3

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -99,6 +99,18 @@ if(IMGUI_BUILD_SDL2_RENDERER_BINDING)
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer2.cpp)
 endif()
 
+if(IMGUI_BUILD_SDL3_BINDING)
+    find_package(SDL3 CONFIG REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC SDL3::SDL3)
+    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdl3.cpp)
+endif()
+
+if(IMGUI_BUILD_SDL3_RENDERER_BINDING)
+    find_package(SDL3 CONFIG REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC SDL3::SDL3)
+    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer3.cpp)
+endif()
+
 if(IMGUI_BUILD_VULKAN_BINDING)
     find_package(Vulkan REQUIRED)
     target_link_libraries(${PROJECT_NAME} PUBLIC Vulkan::Vulkan)
@@ -235,6 +247,14 @@ if(NOT IMGUI_SKIP_HEADERS)
 
     if(IMGUI_BUILD_SDL2_RENDERER_BINDING)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer2.h DESTINATION include)
+    endif()
+
+    if(IMGUI_BUILD_SDL3_BINDING)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdl3.h DESTINATION include)
+    endif()
+
+    if(IMGUI_BUILD_SDL3_RENDERER_BINDING)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer3.h DESTINATION include)
     endif()
 
     if(IMGUI_BUILD_VULKAN_BINDING)

--- a/ports/imgui/imgui-config.cmake.in
+++ b/ports/imgui/imgui-config.cmake.in
@@ -18,6 +18,10 @@ if (@IMGUI_BUILD_SDL2_BINDING@ OR @IMGUI_BUILD_SDL2_RENDERER_BINDING@)
     find_dependency(SDL2 CONFIG)
 endif()
 
+if (@IMGUI_BUILD_SDL3_BINDING@ OR @IMGUI_BUILD_SDL3_RENDERER_BINDING@)
+    find_dependency(SDL3 CONFIG)
+endif()
+
 if (@IMGUI_BUILD_VULKAN_BINDING@)
     find_dependency(Vulkan)
 endif()

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -37,6 +37,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     osx-binding                 IMGUI_BUILD_OSX_BINDING
     sdl2-binding                IMGUI_BUILD_SDL2_BINDING
     sdl2-renderer-binding       IMGUI_BUILD_SDL2_RENDERER_BINDING
+    sdl3-binding                IMGUI_BUILD_SDL3_BINDING
+    sdl3-renderer-binding       IMGUI_BUILD_SDL3_RENDERER_BINDING
     vulkan-binding              IMGUI_BUILD_VULKAN_BINDING
     win32-binding               IMGUI_BUILD_WIN32_BINDING
     freetype                    IMGUI_FREETYPE

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -113,6 +113,18 @@
         "sdl2"
       ]
     },
+    "sdl3-binding": {
+      "description": "Make available SDL3 binding",
+      "dependencies": [
+        "sdl3"
+      ]
+    },
+    "sdl3-renderer-binding": {
+      "description": "Make available SDL3 Renderer binding",
+      "dependencies": [
+        "sdl3"
+      ]
+    },
     "test-engine": {
       "description": "Build test engine",
       "supports": "!uwp",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.