### PR TITLE
[cudnn] fix find_library path for arm64 architecture

### DIFF
--- a/ports/cudnn/FindCUDNN.cmake
+++ b/ports/cudnn/FindCUDNN.cmake
@@ -31,7 +31,7 @@ find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
   HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
   PATH_SUFFIXES cuda/include include include/11.8 include/12.0 include/12.1 include/12.2 include/12.3 include/12.4 include/12.5 include/12.6)
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/lib/x86_64-linux-gnu/ /usr/lib/aarch64-linux-gnu/ /usr/
   PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/11.8/x64 lib/12.0/x64 lib/12.1/x64 lib/12.2/x64 lib/12.3/x64 lib/12.4/x64 lib/12.5/x64 lib/12.6/x64)
 
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -12,7 +12,7 @@ find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
   PATH_SUFFIXES cuda/include include include/11.8 include/12.0 include/12.1 include/12.2 include/12.3 include/12.4 include/12.5 include/12.6)
 message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/lib/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/ /usr/
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/lib/x86_64-linux-gnu/ /usr/lib/aarch64-linux-gnu/ /usr/
   PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/11.8/x64 lib/12.0/x64 lib/12.1/x64 lib/12.2/x64 lib/12.3/x64 lib/12.4/x64 lib/12.5/x64 lib/12.6/x64)
 message(STATUS "CUDNN_LIBRARY: ${CUDNN_LIBRARY}")
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")

--- a/ports/cudnn/vcpkg.json
+++ b/ports/cudnn/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cudnn",
   "version": "7.6.5",
-  "port-version": 14,
+  "port-version": 15,
   "description": "NVIDIA's cuDNN deep neural network acceleration library.",
   "homepage": "https://developer.nvidia.com/cudnn",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2122,7 +2122,7 @@
     },
     "cudnn": {
       "baseline": "7.6.5",
-      "port-version": 14
+      "port-version": 15
     },
     "cunit": {
       "baseline": "2.1.3",

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1708ed3cc056c2d863c3e4e7901b057e083eeaa4",
+      "version": "7.6.5",
+      "port-version": 15
+    },
+    {
       "git-tree": "8e17b3aaaea3a6da5858cb6202c3e2cd8e9f9a5e",
       "version": "7.6.5",
       "port-version": 14


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43867.
Change the library path.
The original search path has been added by https://github.com/microsoft/vcpkg/pull/32384.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.