### PR TITLE
[apriltag] update to 3.4.3

### DIFF
--- a/ports/apriltag/portfile.cmake
+++ b/ports/apriltag/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AprilRobotics/apriltag
     REF v${VERSION}
-    SHA512 2e7edda62e1f196ac954cb999d11a43e81e4e8a5de296b7ce28744a0ec3a4a3209b413e2328aaebce61b2eef782209855ca1112c489bbcb5437387ab6379a849
+    SHA512 861f473ab861dfe749084aefccf52299bdbdf067cff539098a87d007b65711f2e3549ec442fa71011992ea37772fa1e97f1b22a2b130753694a0b8d5d798423e
     HEAD_REF master
 )
 
@@ -24,7 +24,7 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_cmake_config_fixup(CONFIG_PATH share/${PORT}/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/${PORT}/cmake)
 vcpkg_fixup_pkgconfig()
 
 if (VCPKG_TARGET_IS_WINDOWS)
@@ -38,3 +38,5 @@ endif()
 
 file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/apriltag" "${CURRENT_PACKAGES_DIR}/lib/apriltag")

--- a/ports/apriltag/vcpkg.json
+++ b/ports/apriltag/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "apriltag",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "AprilTag is a visual fiducial system popular for robotics research.",
   "homepage": "https://april.eecs.umich.edu/software/apriltag",
   "license": "BSD-2-Clause",

--- a/versions/a-/apriltag.json
+++ b/versions/a-/apriltag.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26d8a1ec2c86d1c448765293461fe5e5249cfecb",
+      "version": "3.4.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "86a28ae0577f8da4f1bb690d7d372732b92e9ac0",
       "version": "3.4.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -177,7 +177,7 @@
       "port-version": 0
     },
     "apriltag": {
-      "baseline": "3.4.2",
+      "baseline": "3.4.3",
       "port-version": 0
     },
     "apsi": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
