### PR TITLE
[zserge-webview] update to 0.12.0

### DIFF
--- a/ports/zserge-webview/portfile.cmake
+++ b/ports/zserge-webview/portfile.cmake
@@ -3,12 +3,12 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webview/webview
-    REF 8387ff8945fc010e7c4203c021943ce4ca12a276 #commit-2023-04-15
-    SHA512 def8d4d5322546a0d3a767f76a6024c0c09e0da184445836f9c1887ab5bdfa1276fb8f2ed65b1b366c237cb22e935b1c6dd99151417c652cd3c5881255494f69
+    REF ${VERSION}
+    SHA512 f198e414145101693fd2b5724fb017df578770c6edda319ce312cf9e9e1fdc1b1d94beba2e64e75d9746dee16010cc525be8ae7ca0713ee541b75a0a1d9bc791
     HEAD_REF master
 )
 
-file(COPY "${SOURCE_PATH}/webview.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${SOURCE_PATH}/core/include/webview.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 set(WEBVIEW_GTK "0")
 set(WEBVIEW_EDGE "0")
@@ -51,4 +51,4 @@ string(REPLACE
 file(WRITE "${CURRENT_PACKAGES_DIR}/include/webview.h" "${_contents}")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/zserge-webview/vcpkg.json
+++ b/ports/zserge-webview/vcpkg.json
@@ -3,15 +3,5 @@
   "version": "0.12.0",
   "description": "Tiny cross-platform webview library for C/C++/Golang.",
   "homepage": "https://github.com/webview/webview",
-  "license": "MIT",
-  "dependencies": [
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    }
-  ]
+  "license": "MIT"
 }

--- a/ports/zserge-webview/vcpkg.json
+++ b/ports/zserge-webview/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "zserge-webview",
-  "version-date": "2023-04-15",
+  "version": "0.12.0",
   "description": "Tiny cross-platform webview library for C/C++/Golang.",
   "homepage": "https://github.com/webview/webview",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10181,7 +10181,7 @@
       "port-version": 0
     },
     "zserge-webview": {
-      "baseline": "2023-04-15",
+      "baseline": "0.12.0",
       "port-version": 0
     },
     "zstd": {

--- a/versions/z-/zserge-webview.json
+++ b/versions/z-/zserge-webview.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f824ec5d5a4340c8c38bbd5e9467fcec18fab327",
+      "git-tree": "e4176d0e9da4aab7471c1532ae1669b92d27c37a",
       "version": "0.12.0",
       "port-version": 0
     },

--- a/versions/z-/zserge-webview.json
+++ b/versions/z-/zserge-webview.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f824ec5d5a4340c8c38bbd5e9467fcec18fab327",
+      "version": "0.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7d184b0d8540c194ab3013884180efd8dfdc39d4",
       "version-date": "2023-04-15",
       "port-version": 0


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/43875

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
