### PR TITLE
[babl, gexiv2] Add version major_minor

### DIFF
--- a/ports/babl/portfile.cmake
+++ b/ports/babl/portfile.cmake
@@ -1,5 +1,7 @@
+string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
+
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://download.gimp.org/pub/babl/0.1/babl-${VERSION}.tar.xz"
+    URLS "https://download.gimp.org/pub/babl/${VERSION_MAJOR_MINOR}/babl-${VERSION}.tar.xz"
     FILENAME "babl-${VERSION}.tar.xz"
     SHA512 20e40baa6654785d69642e6e85542968db3c5d08da630adc590ff066a52c5938f4ce8a77c0097e00010a905c8c31d8f131eb0308a3f8b6439ab6be4133eae246
 )

--- a/ports/babl/vcpkg.json
+++ b/ports/babl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "babl",
   "version": "0.1.110",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A pixel encoding and color space conversion engine.",
   "homepage": "https://gegl.org/babl/",
   "license": "LGPL-3.0-or-later",

--- a/ports/gexiv2/portfile.cmake
+++ b/ports/gexiv2/portfile.cmake
@@ -1,5 +1,7 @@
+string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
+
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://download.gnome.org/sources/gexiv2/0.14/gexiv2-${VERSION}.tar.xz"
+    URLS "https://download.gnome.org/sources/gexiv2/${VERSION_MAJOR_MINOR}/gexiv2-${VERSION}.tar.xz"
     FILENAME "gexiv2-${VERSION}.tar.xz"
     SHA512 24c97fa09b9ee32cb98da4637ea78eb72ae7e2d1792f9ebb31d63e305b3e0e1f6935b8647589c76c39ba631a15c1d8d2f3879c7dff81433786e9533b6348b6a0
 )

--- a/ports/gexiv2/vcpkg.json
+++ b/ports/gexiv2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gexiv2",
   "version": "0.14.3",
+  "port-version": 1,
   "description": "A GObject-based Exiv2 wrapper.",
   "homepage": "https://gitlab.gnome.org/GNOME/gexiv2/",
   "license": "GPL-2.0-or-later",

--- a/versions/b-/babl.json
+++ b/versions/b-/babl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "feb19fafaacdb7dba45f5c2a42970ba81b2d87c5",
+      "version": "0.1.110",
+      "port-version": 2
+    },
+    {
       "git-tree": "e8ed29ba69e54dd8f218c3f520689f0a27fbdd69",
       "version": "0.1.110",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -554,7 +554,7 @@
     },
     "babl": {
       "baseline": "0.1.110",
-      "port-version": 1
+      "port-version": 2
     },
     "backward-cpp": {
       "baseline": "2023-11-24",
@@ -3098,7 +3098,7 @@
     },
     "gexiv2": {
       "baseline": "0.14.3",
-      "port-version": 0
+      "port-version": 1
     },
     "gflags": {
       "baseline": "2.2.2",

--- a/versions/g-/gexiv2.json
+++ b/versions/g-/gexiv2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad0c22ab714e86df77521a8cbd4f31600ebce08d",
+      "version": "0.14.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "e18bc37283a388c5fd401c915598feca8e50363b",
       "version": "0.14.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
