### PR TITLE
[arrow] Update to 19.0.1

### DIFF
--- a/ports/arrow/0008-arrow-parquet-size-statistics-include.patch
+++ b/ports/arrow/0008-arrow-parquet-size-statistics-include.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/src/parquet/size_statistics.cc b/cpp/src/parquet/size_statistics.cc
+index 1ce6c937ad..618e670b5a 100644
+--- a/cpp/src/parquet/size_statistics.cc
++++ b/cpp/src/parquet/size_statistics.cc
+@@ -18,6 +18,7 @@
+ #include "parquet/size_statistics.h"
+
+ #include <algorithm>
++#include <array>
+ #include <numeric>
+ #include <ostream>
+ #include <string_view>

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     ARCHIVE_PATH
     URLS "https://archive.apache.org/dist/arrow/arrow-${VERSION}/apache-arrow-${VERSION}.tar.gz"
     FILENAME apache-arrow-${VERSION}.tar.gz
-    SHA512 6820de33a5d5b0922ea64dd8ff55d186ef02596ad0415578067aaf3e5cf7d3eead473bc3a5f92d6d3f19b97d153fe1c901359008d922d1ffb0fc2a65dc860c79
+    SHA512 524187c6f12bbb677b5d4a53e1608c69b56c83a5c8667bfe82d5a10232c33f151a8a7b5e6e26af48d1e0ca25a5d3dc885b27d9b5e798c7e07f115df8f0779516
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_extract_source_archive(
         0005-android-datetime.patch
         0006-cmake-msvcruntime.patch
         0007-fix-path.patch # From https://github.com/apache/arrow/issues/39023#issuecomment-1835390089
+        0008-arrow-parquet-size-statistics-include.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "arrow",
-  "version": "19.0.0",
-  "port-version": 1,
+  "version": "19.0.1",
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5a6cb56503cf036cc4e5e414ab6022146f658157",
+      "git-tree": "baa90a1de700d2ef44a9d17b7b587e4a48c9dd05",
       "version": "19.0.1",
       "port-version": 0
     },

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a6cb56503cf036cc4e5e414ab6022146f658157",
+      "version": "19.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f4ca71d486f873fbaeae4157f88bcf7b25712440",
       "version": "19.0.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -245,8 +245,8 @@
       "port-version": 7
     },
     "arrow": {
-      "baseline": "19.0.0",
-      "port-version": 1
+      "baseline": "19.0.1",
+      "port-version": 0
     },
     "arsenalgear": {
       "baseline": "2.1.1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
