### PR TITLE
[pangolin] Update to 0.9.3

### DIFF
--- a/ports/pangolin/portfile.cmake
+++ b/ports/pangolin/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stevenlovegrove/Pangolin
     REF "v${VERSION}"
-    SHA512 ef2461770def3b0752d23df0c9a0090b733943249404528d0b2ba985d08c9083aabe685e3fd00be08318ea7b90dc38e9735ab004124643619e6cf369d64f6321
+    SHA512 554a262bfba533926eb691cb41aa73d3b0af710fba324a877fddd9a7b7d89fb067cff04ee130c070c124740f0a84c42f83dfcc7da78ae6b5118e451d332fdc9b
     HEAD_REF master
     PATCHES
         devendor-palsigslot.patch

--- a/ports/pangolin/vcpkg.json
+++ b/ports/pangolin/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pangolin",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Lightweight GUI Library",
   "homepage": "https://github.com/stevenlovegrove/Pangolin",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6861,7 +6861,7 @@
       "port-version": 1
     },
     "pangolin": {
-      "baseline": "0.9.2",
+      "baseline": "0.9.3",
       "port-version": 0
     },
     "pangomm": {

--- a/versions/p-/pangolin.json
+++ b/versions/p-/pangolin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1160800955291a7ca10fecd0fc9f1a41894db758",
+      "version": "0.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "71d44252a59ed3737ec204b4789bcd2d30d5e621",
       "version": "0.9.2",
       "port-version": 0


### PR DESCRIPTION
Update `pangolin` to 0.9.3. No feature needs to be tested, the usage test passed on `x64-windows` (header files found).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
