### PR TITLE
[fastdds] Fix missing fast-discovery-serverd-1.0.1

### DIFF
--- a/ports/fastdds/portfile.cmake
+++ b/ports/fastdds/portfile.cmake
@@ -71,7 +71,9 @@ elseif(VCPKG_TARGET_IS_LINUX)
 endif()
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/fastdds/discovery/parser.py" "tool_path / '../../../bin'" "tool_path / '../../${PORT}'")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fastdds/fast-discovery-server-targets-debug.cmake" "${_IMPORT_PREFIX}/tools/fastdds/fast-discovery-serverd-1.0.1" "${_IMPORT_PREFIX}/tools/fastdds/fast-discovery-server-1.0.1")
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/fastdds/portfile.cmake
+++ b/ports/fastdds/portfile.cmake
@@ -71,7 +71,9 @@ elseif(VCPKG_TARGET_IS_LINUX)
 endif()
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/fastdds/discovery/parser.py" "tool_path / '../../../bin'" "tool_path / '../../${PORT}'")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fastdds/fast-discovery-server-targets-debug.cmake" [[${_IMPORT_PREFIX}/tools/fastdds/fast-discovery-serverd-1.0.1]] [[${_IMPORT_PREFIX}/tools/fastdds/fast-discovery-server-1.0.1]])
+if( VCPKG_BUILD_TYPE STREQUAL "debug")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fastdds/fast-discovery-server-targets-debug.cmake" [[${_IMPORT_PREFIX}/tools/fastdds/fast-discovery-serverd-1.0.1]] [[${_IMPORT_PREFIX}/tools/fastdds/fast-discovery-server-1.0.1]])
+endif()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)

--- a/ports/fastdds/portfile.cmake
+++ b/ports/fastdds/portfile.cmake
@@ -71,7 +71,7 @@ elseif(VCPKG_TARGET_IS_LINUX)
 endif()
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/fastdds/discovery/parser.py" "tool_path / '../../../bin'" "tool_path / '../../${PORT}'")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fastdds/fast-discovery-server-targets-debug.cmake" "${_IMPORT_PREFIX}/tools/fastdds/fast-discovery-serverd-1.0.1" "${_IMPORT_PREFIX}/tools/fastdds/fast-discovery-server-1.0.1")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fastdds/fast-discovery-server-targets-debug.cmake" [[${_IMPORT_PREFIX}/tools/fastdds/fast-discovery-serverd-1.0.1]] [[${_IMPORT_PREFIX}/tools/fastdds/fast-discovery-server-1.0.1]])
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)

--- a/ports/fastdds/usage
+++ b/ports/fastdds/usage
@@ -1,0 +1,5 @@
+fastdds provides CMake targets:
+
+  find_package(fastdds CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE fastdds)
+    

--- a/ports/fastdds/vcpkg.json
+++ b/ports/fastdds/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fastdds",
   "version": "3.1.2",
+  "port-version": 1,
   "description": "eprosima Fast DDS (formerly Fast RTPS) is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.",
   "homepage": "https://www.eprosima.com/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2694,7 +2694,7 @@
     },
     "fastdds": {
       "baseline": "3.1.2",
-      "port-version": 0
+      "port-version": 1
     },
     "fastfeat": {
       "baseline": "391d5e9",

--- a/versions/f-/fastdds.json
+++ b/versions/f-/fastdds.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ec15df54e51a1b0f9c858d0c8e2fb4769820845f",
+      "git-tree": "ddee7c4609b3ee74bca1d95003217c7847b39fc4",
       "version": "3.1.2",
       "port-version": 1
     },

--- a/versions/f-/fastdds.json
+++ b/versions/f-/fastdds.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2cfcd7a0a42583ee59b0a588dc88b3502099cd4a",
+      "git-tree": "ec15df54e51a1b0f9c858d0c8e2fb4769820845f",
       "version": "3.1.2",
       "port-version": 1
     },

--- a/versions/f-/fastdds.json
+++ b/versions/f-/fastdds.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2cfcd7a0a42583ee59b0a588dc88b3502099cd4a",
+      "version": "3.1.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "583c25bed0e0994ddb7c8b647f69508684a5f0b4",
       "version": "3.1.2",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43654

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Usage test passed with x64-linux and x64-windows triplets.
