### PR TITLE
[pangomm] Update to 2.56.1

### DIFF
--- a/ports/pangomm/portfile.cmake
+++ b/ports/pangomm/portfile.cmake
@@ -1,8 +1,10 @@
+string(REGEX REPLACE "\\.[0-9]+$" "" MAJOR_MINOR ${VERSION})
+
 # Keep distfile, don't use GitLab!
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnome.org/pub/GNOME/sources/pangomm/2.50/pangomm-2.50.1.tar.xz"
-    FILENAME "pangomm-2.50.1.tar.xz"
-    SHA512 bffc55eedc4f278480a74afcf119b79a295bf5775123f582746ba425e19e2690d627baa9a9813b70db9e063db7efe959f365567dd7bcbc1fc862212ba8225a98
+    URLS "https://ftp.gnome.org/pub/GNOME/sources/pangomm/${MAJOR_MINOR}/pangomm-${VERSION}.tar.xz"
+    FILENAME "pangomm-${VERSION}.tar.xz"
+    SHA512 3000126cdf538f43c131a186999fd39d81ec471f5770d8dfd721ff84cb3f5ad44d17cdcc732299ee9d9f34f2dd1279959cf6e1b863c3a0afc32e49b453db782b
 )
 
 vcpkg_extract_source_archive(
@@ -24,4 +26,4 @@ vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/pangomm/vcpkg.json
+++ b/ports/pangomm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pangomm",
-  "version": "2.50.1",
-  "port-version": 3,
+  "version": "2.56.1",
   "description": "pangomm is the official C++ interface for the Pango font layout library. See, for instance, the Pango::Layout class.",
   "homepage": "https://gitlab.gnome.org/GNOME/pangomm",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6865,8 +6865,8 @@
       "port-version": 0
     },
     "pangomm": {
-      "baseline": "2.50.1",
-      "port-version": 3
+      "baseline": "2.56.1",
+      "port-version": 0
     },
     "parallel-hashmap": {
       "baseline": "2.0.0",

--- a/versions/p-/pangomm.json
+++ b/versions/p-/pangomm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32d7b5a60ba2a7df9c252ee9d848bf9cdc6dc48b",
+      "version": "2.56.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "934da9592c2710373598b3f3d3a53103bad2b1e4",
       "version": "2.50.1",
       "port-version": 3


### PR DESCRIPTION
Update `pangomm` to 2.56.1. No feature needs to be tested, the header file is successfully found via the `.pc` file.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.