### PR TITLE
[libslirp] Update to 4.9.0

### DIFF
--- a/ports/libslirp/portfile.cmake
+++ b/ports/libslirp/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO slirp/libslirp
     REF "v${VERSION}"
-    SHA512 eef9d77f1588c4e3dcf91cd53e54db235d624998fc64df75d389657411635f28bfcbe0c81cd3b0ede7792eea1eb7ef716b8a87a199a6be1e9a29da27ca4a1df4
+    SHA512 503035b24f657f610398c23656b0783bc15ec08d020e42085fd4f558a642d067dab21dd339d0f243f8f34347c3bc82edf22e6a9fc8164bfdfb9bfd7878af9fae
     HEAD_REF master
 )
 

--- a/ports/libslirp/vcpkg.json
+++ b/ports/libslirp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libslirp",
-  "version-semver": "4.8.0",
+  "version-semver": "4.9.0",
   "description": "libslirp is a user-mode networking library used by virtual machines, containers or various tools.",
   "homepage": "https://gitlab.freedesktop.org/slirp/libslirp",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5073,7 +5073,7 @@
       "port-version": 1
     },
     "libslirp": {
-      "baseline": "4.8.0",
+      "baseline": "4.9.0",
       "port-version": 0
     },
     "libsm": {

--- a/versions/l-/libslirp.json
+++ b/versions/l-/libslirp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d4a7394ed8ea938086b3f1612ee4164c73dc3a7",
+      "version-semver": "4.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "bef9b504fbf03a1210018f21a7cf76413a27e08d",
       "version-semver": "4.8.0",
       "port-version": 0


### PR DESCRIPTION
The following usage passed on x64-windows:
```
libslirp provides pkg-config modules:

  # User-space network stack
  slirp
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

