### PR TITLE
[usearch] add features

### DIFF
--- a/ports/usearch/portfile.cmake
+++ b/ports/usearch/portfile.cmake
@@ -4,11 +4,21 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 6aa32a96f5f672aa57287257133aa8931b13b8738aaa156bee24c77d9b5340d1d9720aaaad099946b3e7b6b35522f10241a30cd4084a641d658158c9d4b53453
     HEAD_REF main
+    PATCHES
+        use-vcpkg-ports.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        fp16     USEARCH_USE_FP16LIB
+        jemalloc USEARCH_USE_JEMALLOC
+        simsimd  USEARCH_USE_SIMSIMD
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DUSEARCH_INSTALL=ON
         -DUSEARCH_BUILD_TEST_CPP=OFF
         -DUSEARCH_BUILD_BENCH_CPP=OFF

--- a/ports/usearch/use-vcpkg-ports.patch
+++ b/ports/usearch/use-vcpkg-ports.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c94fe5c..be088c9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -149,18 +149,6 @@ target_include_directories(
+     ${USEARCH_TARGET_NAME} ${USEARCH_SYSTEM_INCLUDE} INTERFACE $<BUILD_INTERFACE:${USEARCH_INCLUDE_BUILD_DIR}>
+                                                                $<INSTALL_INTERFACE:include>
+ )
+-if (USEARCH_USE_FP16LIB)
+-    target_include_directories(
+-        ${USEARCH_TARGET_NAME} ${USEARCH_SYSTEM_INCLUDE} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/fp16/include>
+-                                                                   $<INSTALL_INTERFACE:fp16/include>
+-    )
+-endif()
+-if (USEARCH_USE_SIMSIMD)
+-    target_include_directories(
+-        ${USEARCH_TARGET_NAME} ${USEARCH_SYSTEM_INCLUDE} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/simsimd/include>
+-                                                                   $<INSTALL_INTERFACE:simsimd/include>
+-    )
+-endif()
+ 
+ # Install a pkg-config file, so other tools can find this
+ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkg-config.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc")
+@@ -220,8 +208,7 @@ if (NOT CMAKE_BUILD_TYPE)
+ endif ()
+ 
+ # Include directories
+-set(USEARCH_HEADER_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/fp16/include"
+-                            "${CMAKE_CURRENT_SOURCE_DIR}/simsimd/include"
++set(USEARCH_HEADER_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/include"
+ )
+ 
+ # Function to setup target

--- a/ports/usearch/vcpkg.json
+++ b/ports/usearch/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "usearch",
   "version": "2.17.2",
+  "port-version": 1,
   "description": "Fastest Search & Clustering engine × for Vectors & Strings",
   "homepage": "https://github.com/unum-cloud/usearch",
   "license": "Apache-2.0",
@@ -13,5 +14,28 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "fp16"
+  ],
+  "features": {
+    "fp16": {
+      "description": "Use software emulation for half-precision types",
+      "dependencies": [
+        "fp16"
+      ]
+    },
+    "jemalloc": {
+      "description": "Use JeMalloc for faster memory allocations",
+      "dependencies": [
+        "jemalloc"
+      ]
+    },
+    "simsimd": {
+      "description": "Use SimSIMD hardware-accelerated metrics",
+      "dependencies": [
+        "simsimd"
+      ]
+    }
+  }
 }

--- a/ports/usearch/vcpkg.json
+++ b/ports/usearch/vcpkg.json
@@ -15,9 +15,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "fp16"
-  ],
   "features": {
     "fp16": {
       "description": "Use software emulation for half-precision types",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9414,7 +9414,7 @@
     },
     "usearch": {
       "baseline": "2.17.2",
-      "port-version": 0
+      "port-version": 1
     },
     "usockets": {
       "baseline": "0.8.8",

--- a/versions/u-/usearch.json
+++ b/versions/u-/usearch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f23392616f3aa730c431737dcdf774551dac5737",
+      "version": "2.17.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf3a48e25fa6298bb0a325872d813c11421b7e8f",
       "version": "2.17.2",
       "port-version": 0

--- a/versions/u-/usearch.json
+++ b/versions/u-/usearch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f23392616f3aa730c431737dcdf774551dac5737",
+      "git-tree": "50da7c77dca04b357388a72af5e3a91c5176dfb0",
       "version": "2.17.2",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

usearch provides several options for external dependencies.
