### PR TITLE
[avcpp] Update to 2.6.0

### DIFF
--- a/ports/avcpp/portfile.cmake
+++ b/ports/avcpp/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO h4tr3d/avcpp
     REF "v${VERSION}"
-    SHA512 365ed55e0c2bf2a699899ed6e303fe28fb9d51286579e9d7d1586132c8ab1b09c4b66e94f8061e860d73b60a28fa44769dcfdf030cb0947acfb7cdfd616127d9
+    SHA512 628e11b57c9294864afdc07365cedd3b4973773491de1de31dc063f2491057eecda1abb3a46a6dda4d0746a8d9f264a855b3e546c1e23b38cef3fe0754ee7ff8
     HEAD_REF master
     PATCHES
         0002-av_init_packet_deprecation.patch

--- a/ports/avcpp/vcpkg.json
+++ b/ports/avcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "avcpp",
-  "version": "2.4.0",
+  "version": "2.6.0",
   "description": "Wrapper for the FFmpeg that simplify usage it from C++ projects.",
   "homepage": "https://github.com/h4tr3d/avcpp",
   "license": "LGPL-2.1-only OR BSD-3-Clause",

--- a/versions/a-/avcpp.json
+++ b/versions/a-/avcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "810881ae390fbb443d46b0d97b61afc80bcef999",
+      "version": "2.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b06ff7d5a249eaa6f633d4fb9ce05b8f6fd8f85b",
       "version": "2.4.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -369,7 +369,7 @@
       "port-version": 0
     },
     "avcpp": {
-      "baseline": "2.4.0",
+      "baseline": "2.6.0",
       "port-version": 0
     },
     "avisynthplus": {


### PR DESCRIPTION
The following usage passed on x64-windows:
```
avcpp provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(avcpp CONFIG REQUIRED)
  target_link_libraries(main PRIVATE avcpp::avcpp avcpp::FFmpeg)

avcpp provides pkg-config modules:

  # FFmpeg libraries C++ interface
  libavcpp
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.