### PR TITLE
[avro-c] update to 1.12.0

### DIFF
--- a/ports/avro-c/avro.patch
+++ b/ports/avro-c/avro.patch
@@ -1,5 +1,5 @@
 diff --git a/lang/c/CMakeLists.txt b/lang/c/CMakeLists.txt
-index aa923e1..9ee7937 100644
+index 123676b..d5797b4 100644
 --- a/lang/c/CMakeLists.txt
 +++ b/lang/c/CMakeLists.txt
 @@ -22,6 +22,9 @@ enable_testing()
@@ -20,7 +20,7 @@ index aa923e1..9ee7937 100644
 -if (SNAPPY_FOUND AND ZLIB_FOUND)  # Snappy borrows crc32 from zlib
 +find_package(Snappy CONFIG REQUIRED)
 +if (Snappy_FOUND AND ZLIB_FOUND)  # Snappy borrows crc32 from zlib
-     set(SNAPPY_PKG libsnappy)
+     set(SNAPPY_PKG snappy)
      add_definitions(-DSNAPPY_CODEC)
 +    set(SNAPPY_LIBRARIES Snappy::snappy)
 +    if (UNIX)
@@ -45,7 +45,7 @@ index aa923e1..9ee7937 100644
      set(LZMA_PKG liblzma)
      add_definitions(-DLZMA_CODEC)
 @@ -179,20 +187,26 @@ set(CODEC_LIBRARIES ${ZLIB_LIBRARIES} ${LZMA_LIBRARIES} ${SNAPPY_LIBRARIES})
- set(CODEC_PKG "@ZLIB_PKG@ @LZMA_PKG@ @SNAPPY_PKG@")
+ set(CODEC_PKG "${ZLIB_PKG} ${LZMA_PKG} ${SNAPPY_PKG}")
  
  # Jansson JSON library
 -pkg_check_modules(JANSSON jansson>=2.3)

--- a/ports/avro-c/portfile.cmake
+++ b/ports/avro-c/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/avro
     REF "release-${VERSION}"
-    SHA512 728609f562460e1115366663ede2c5d4acbdd6950c1ee3e434ffc65d28b72e3a43c3ebce93d0a8459f0c4f6c492ebb9444e2127a0385f38eb7cdf74b28f0c3ed
+    SHA512 8cc6ef3cf1e0a919118c8ba5817a1866dc4f891fa95873c0fe1b4b388858fbadee8ed50406fa0006882cab40807fcf00c5a2dcd500290f3868d9d06b287eacb6
     HEAD_REF master
     PATCHES
         avro.patch          # Private vcpkg build fixes
@@ -39,4 +39,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" AND NOT VCPKG_TARGET_IS_WINDOWS)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-file(INSTALL "${SOURCE_PATH}/lang/c/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/lang/c/LICENSE")

--- a/ports/avro-c/vcpkg.json
+++ b/ports/avro-c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "avro-c",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "description": "Apache Avro is a data serialization system",
   "homepage": "https://github.com/apache/avro",
   "license": "Apache-2.0",

--- a/versions/a-/avro-c.json
+++ b/versions/a-/avro-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9776bebec8f77c6ea2322fec051fae2d12a1f524",
+      "version": "1.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "76ef10758076c92faaae286e1d38c1770dc4f23c",
       "version": "1.11.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -377,7 +377,7 @@
       "port-version": 1
     },
     "avro-c": {
-      "baseline": "1.11.3",
+      "baseline": "1.12.0",
       "port-version": 0
     },
     "avro-cpp": {


### PR DESCRIPTION
Update `avro-c` to 1.12.0.
No feature needs to test.
Usage tested pass on` x64-windows`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
