### PR TITLE
[boringssl] Reflect Upstream License / Update License

### DIFF
--- a/ports/boringssl/vcpkg.json
+++ b/ports/boringssl/vcpkg.json
@@ -3,6 +3,7 @@
   "version-date": "2024-09-13",
   "description": "BoringSSL is a fork of OpenSSL developed by Google",
   "homepage": "https://boringssl.googlesource.com/boringssl",
+  "license": "Apache-2.0",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/ports/boringssl/vcpkg.json
+++ b/ports/boringssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "boringssl",
   "version-date": "2024-09-13",
+  "port-version": 1,
   "description": "BoringSSL is a fork of OpenSSL developed by Google",
   "homepage": "https://boringssl.googlesource.com/boringssl",
   "license": "Apache-2.0",

--- a/versions/b-/boringssl.json
+++ b/versions/b-/boringssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78e32f29395487348c0dbbc78828b71b020a92b1",
+      "version-date": "2024-09-13",
+      "port-version": 1
+    },
+    {
       "git-tree": "075a0df31951d14eb7bdfe1a6ba728ddfd46a3a2",
       "version-date": "2024-09-13",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1366,7 +1366,7 @@
     },
     "boringssl": {
       "baseline": "2024-09-13",
-      "port-version": 0
+      "port-version": 1
     },
     "botan": {
       "baseline": "3.7.1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The boringssl license provided by Google is Apache-2.0, can be found at https://github.com/google/boringssl/blob/master/LICENSE.