### PR TITLE
[morphologica] update to v3.4.4

### DIFF
--- a/ports/morphologica/portfile.cmake
+++ b/ports/morphologica/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ABRG-Models/morphologica
     REF "v${VERSION}"
-    SHA512 0c92fd191b8eae57fae389517433d83ab3498bec3806cc658499d1ab1a294ed8b861dba38b5592c0ffec9c45fa9a8a453df660b35878f360b8395b948a958e52 
+    SHA512 222c9d3a479f5288ecb3f3d8f05f39e0e0981c397b1c6472f022dc7ebc8a20f03cf048208216f7f90c441b3eb2ea49c625e587e0c2c469bef32707abec7c0e42 
 )
 
 vcpkg_cmake_configure(

--- a/ports/morphologica/vcpkg.json
+++ b/ports/morphologica/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "morphologica",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "C++ header-only graphing and data visualization with Modern OpenGL",
   "homepage": "https://github.com/ABRG-Models/morphologica",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6045,7 +6045,7 @@
       "port-version": 5
     },
     "morphologica": {
-      "baseline": "3.4.3",
+      "baseline": "3.4.4",
       "port-version": 0
     },
     "morton-nd": {

--- a/versions/m-/morphologica.json
+++ b/versions/m-/morphologica.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06a63ae6afacc6619cc3476ac43f8dd65d4e179a",
+      "version": "3.4.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "5466b5703932a35e1d51b0b5392da26fe3f0abcb",
       "version": "3.4.3",
       "port-version": 0


### PR DESCRIPTION

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
