### PR TITLE
[cpr] update to 1.11.2

### DIFF
--- a/ports/cpr/fix-static-build.patch
+++ b/ports/cpr/fix-static-build.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2fc6152..b953f8c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -82,7 +82,7 @@ if (MSVC)
+         message(STATUS "Build windows dynamic libs.")
+     else()
+         # Add this to build windows pure static library.
+-        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
++        # set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+         message(STATUS "Build windows static libs.")
+     endif()
+ endif()

--- a/ports/cpr/portfile.cmake
+++ b/ports/cpr/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libcpr/cpr

--- a/ports/cpr/portfile.cmake
+++ b/ports/cpr/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libcpr/cpr
     REF ${VERSION}
-    SHA512 cde62f13b43bad143695e54f5f69dfd250be52d2f6a76ebb3fde3db1e1059eb3c2e9d62e71f4c90f98a33f0053aea7c97bf55d8a7fa8584a37298e6a1bc3b18a
+    SHA512 30caf9257e5e45f809f541a32daf8c6c7001fbaafef0ee0ae8dd59f49736953120cb7c8849ddbff2f7fbc54d80902ec2b905f90f68f63d1f2a2dc63eda577713
     HEAD_REF master
     PATCHES
         disable_werror.patch

--- a/ports/cpr/portfile.cmake
+++ b/ports/cpr/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         disable_werror.patch
+        fix-static-build.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/cpr/vcpkg.json
+++ b/ports/cpr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpr",
-  "version-semver": "1.11.1",
+  "version-semver": "1.11.2",
   "description": "C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.",
   "homepage": "https://github.com/libcpr/cpr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2013,7 +2013,7 @@
       "port-version": 0
     },
     "cpr": {
-      "baseline": "1.11.1",
+      "baseline": "1.11.2",
       "port-version": 0
     },
     "cpu-features": {

--- a/versions/c-/cpr.json
+++ b/versions/c-/cpr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2d8552140535348412cdbddb519f3309105531a8",
+      "git-tree": "89532b891611f00560516f707e7cb857dda10710",
       "version-semver": "1.11.2",
       "port-version": 0
     },

--- a/versions/c-/cpr.json
+++ b/versions/c-/cpr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d8552140535348412cdbddb519f3309105531a8",
+      "version-semver": "1.11.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "dc36316122f82687e1e66ca48958296b16495e42",
       "version-semver": "1.11.1",
       "port-version": 0

--- a/versions/c-/cpr.json
+++ b/versions/c-/cpr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "89532b891611f00560516f707e7cb857dda10710",
+      "git-tree": "36cfe399344149cbea14eece7277207823c26f76",
       "version-semver": "1.11.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.