### PR TITLE
[man-group-sparrow] New port

### DIFF
--- a/ports/man-group-sparrow/find-date.patch
+++ b/ports/man-group-sparrow/find-date.patch
@@ -1,8 +1,8 @@
 diff --git a/sparrowConfig.cmake.in b/sparrowConfig.cmake.in
-index 07a688f..cadb864 100644
+index 8b46226..a13454b 100644
 --- a/sparrowConfig.cmake.in
 +++ b/sparrowConfig.cmake.in
-@@ -18,6 +18,10 @@
+@@ -22,6 +22,10 @@
  
  include(CMakeFindDependencyMacro)
  
@@ -10,6 +10,6 @@ index 07a688f..cadb864 100644
 +    find_dependency(date)
 +endif()
 +
- if(NOT TARGET @PROJECT_NAME@)
+ if(NOT TARGET sparrow::sparrow)
      include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
-     get_target_property(@PROJECT_NAME@_INCLUDE_DIRS @PROJECT_NAME@ INTERFACE_INCLUDE_DIRECTORIES)
+     get_target_property(@PROJECT_NAME@_INCLUDE_DIRS sparrow::sparrow INTERFACE_INCLUDE_DIRECTORIES)

--- a/ports/man-group-sparrow/find-date.patch
+++ b/ports/man-group-sparrow/find-date.patch
@@ -1,0 +1,15 @@
+diff --git a/sparrowConfig.cmake.in b/sparrowConfig.cmake.in
+index 07a688f..cadb864 100644
+--- a/sparrowConfig.cmake.in
++++ b/sparrowConfig.cmake.in
+@@ -18,6 +18,10 @@
+ 
+ include(CMakeFindDependencyMacro)
+ 
++if("@USE_DATE_POLYFILL@")
++    find_dependency(date)
++endif()
++
+ if(NOT TARGET @PROJECT_NAME@)
+     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+     get_target_property(@PROJECT_NAME@_INCLUDE_DIRS @PROJECT_NAME@ INTERFACE_INCLUDE_DIRECTORIES)

--- a/ports/man-group-sparrow/portfile.cmake
+++ b/ports/man-group-sparrow/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO man-group/sparrow
     REF "${VERSION}"
-    SHA512 f60cf7386955793b34720a2c24ecf29ad2568855c7344a6ab3e72c8bde2899cc9ea0ed880cc84b95feeb32413941e5c895d740c04cd2efd3fecd9b109adac317
+    SHA512 587c7b5abea6eb856d0bd664e23d63ae4878f3b2991de4b014221096eb5ee0844bafe2c0ca18f58ad19b564073a1c07a70297ae40d4635534e44d23c539f5efa
     HEAD_REF main
     PATCHES
         find-date.patch
@@ -18,10 +18,17 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         large-int-placeholder USE_LARGE_INT_PLACEHOLDERS
 )
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(SPARROW_BUILD_SHARED ON)
+else()
+    set(SPARROW_BUILD_SHARED OFF)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        -DSPARROW_BUILD_SHARED=${SPARROW_BUILD_SHARED}
         -DBUILD_TESTS=OFF
         -DBUILD_EXAMPLES=OFF
 )

--- a/ports/man-group-sparrow/portfile.cmake
+++ b/ports/man-group-sparrow/portfile.cmake
@@ -1,0 +1,34 @@
+if(VCPKG_TARGET_IS_LINUX)
+    message("Warning: `sparrow` requires Clang12+ or GCC 11+ on Linux")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO man-group/sparrow
+    REF "${VERSION}"
+    SHA512 f60cf7386955793b34720a2c24ecf29ad2568855c7344a6ab3e72c8bde2899cc9ea0ed880cc84b95feeb32413941e5c895d740c04cd2efd3fecd9b109adac317
+    HEAD_REF main
+    PATCHES
+        find-date.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        date       USE_DATE_POLYFILL
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DBUILD_TESTS=OFF
+        -DBUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME sparrow CONFIG_PATH share/cmake/sparrow)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/man-group-sparrow/portfile.cmake
+++ b/ports/man-group-sparrow/portfile.cmake
@@ -1,5 +1,5 @@
 if(VCPKG_TARGET_IS_LINUX)
-    message("Warning: `sparrow` requires Clang12+ or GCC 11+ on Linux")
+    message("Warning: `sparrow` requires Clang18+ or GCC 12+ on Linux")
 endif()
 
 vcpkg_from_github(

--- a/ports/man-group-sparrow/portfile.cmake
+++ b/ports/man-group-sparrow/portfile.cmake
@@ -14,7 +14,8 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        date       USE_DATE_POLYFILL
+        date                  USE_DATE_POLYFILL
+        large-int-placeholder USE_LARGE_INT_PLACEHOLDERS
 )
 
 vcpkg_cmake_configure(

--- a/ports/man-group-sparrow/vcpkg.json
+++ b/ports/man-group-sparrow/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "C++20 idiomatic APIs for the Apache Arrow Columnar Format",
   "homepage": "https://github.com/man-group/sparrow",
   "license": "Apache-2.0",
-  "supports": "!uwp",
+  "supports": "!uwp & !static",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/man-group-sparrow/vcpkg.json
+++ b/ports/man-group-sparrow/vcpkg.json
@@ -19,7 +19,7 @@
     "date",
     {
       "name": "large-int-placeholder",
-      "platform": "windows"
+      "platform": "windows | (arm & android)"
     }
   ],
   "features": {

--- a/ports/man-group-sparrow/vcpkg.json
+++ b/ports/man-group-sparrow/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "description": "C++20 idiomatic APIs for the Apache Arrow Columnar Format",
   "homepage": "https://github.com/man-group/sparrow",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "supports": "!uwp",
   "dependencies": [
     {
@@ -14,6 +14,9 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
+  ],
+  "default-features": [
+    "date"
   ],
   "features": {
     "date": {

--- a/ports/man-group-sparrow/vcpkg.json
+++ b/ports/man-group-sparrow/vcpkg.json
@@ -16,7 +16,8 @@
     }
   ],
   "default-features": [
-    "date"
+    "date",
+    "large-int-placeholder"
   ],
   "features": {
     "date": {
@@ -24,6 +25,9 @@
       "dependencies": [
         "date"
       ]
+    },
+    "large-int-placeholder": {
+      "description": "use types without api for big integers"
     }
   }
 }

--- a/ports/man-group-sparrow/vcpkg.json
+++ b/ports/man-group-sparrow/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "man-group-sparrow",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "C++20 idiomatic APIs for the Apache Arrow Columnar Format",
   "homepage": "https://github.com/man-group/sparrow",
   "license": "Apache-2.0",
-  "supports": "!uwp & !static",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/man-group-sparrow/vcpkg.json
+++ b/ports/man-group-sparrow/vcpkg.json
@@ -17,7 +17,10 @@
   ],
   "default-features": [
     "date",
-    "large-int-placeholder"
+    {
+      "name": "large-int-placeholder",
+      "platform": "windows"
+    }
   ],
   "features": {
     "date": {

--- a/ports/man-group-sparrow/vcpkg.json
+++ b/ports/man-group-sparrow/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "man-group-sparrow",
+  "version": "0.3.0",
+  "description": "C++20 idiomatic APIs for the Apache Arrow Columnar Format",
+  "homepage": "https://github.com/man-group/sparrow",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "date": {
+      "description": "Use date polyfill implementation",
+      "dependencies": [
+        "date"
+      ]
+    }
+  }
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -687,6 +687,8 @@ log4cpp:x64-linux=fail # dynamic exception specifications
 # 32-bit needs android-24
 lua:arm-neon-android=fail
 magma:x64-linux=fail
+# man-group-sparrow requires gcc12 and clang18 or later. linux-x64 always fails because it uses gcc11.
+man-group-sparrow:x64-linux=fail
 mchehab-zbar:arm-neon-android=fail
 mchehab-zbar:arm64-android=fail
 mchehab-zbar:x64-android=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -687,8 +687,6 @@ log4cpp:x64-linux=fail # dynamic exception specifications
 # 32-bit needs android-24
 lua:arm-neon-android=fail
 magma:x64-linux=fail
-# man-group-sparrow requires gcc12 and clang18 or later. linux-x64 always fails because it uses gcc11.
-man-group-sparrow:x64-linux=fail
 mchehab-zbar:arm-neon-android=fail
 mchehab-zbar:arm64-android=fail
 mchehab-zbar:x64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5732,6 +5732,10 @@
       "baseline": "1.0.3",
       "port-version": 0
     },
+    "man-group-sparrow": {
+      "baseline": "0.3.0",
+      "port-version": 0
+    },
     "manif": {
       "baseline": "0.0.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5733,7 +5733,7 @@
       "port-version": 0
     },
     "man-group-sparrow": {
-      "baseline": "0.3.0",
+      "baseline": "0.4.0",
       "port-version": 0
     },
     "manif": {

--- a/versions/m-/man-group-sparrow.json
+++ b/versions/m-/man-group-sparrow.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2fc96012a6109e277cac8d6b9cae6d930d12e477",
+      "version": "0.3.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/m-/man-group-sparrow.json
+++ b/versions/m-/man-group-sparrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2fc96012a6109e277cac8d6b9cae6d930d12e477",
+      "git-tree": "23281677e74f273e6ae0424a54436dd8432b0621",
       "version": "0.3.0",
       "port-version": 0
     }

--- a/versions/m-/man-group-sparrow.json
+++ b/versions/m-/man-group-sparrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "73b124f6ca642956d1aaf64e153b74c15f302280",
+      "git-tree": "523558574344a27dd460f6b298e4c3b2043f1027",
       "version": "0.3.0",
       "port-version": 0
     }

--- a/versions/m-/man-group-sparrow.json
+++ b/versions/m-/man-group-sparrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a33748d04e12b17cab1430a54cf631be9acd47a9",
+      "git-tree": "218996fdce70730befb0c2a71e2e6dc6230d1a7d",
       "version": "0.4.0",
       "port-version": 0
     }

--- a/versions/m-/man-group-sparrow.json
+++ b/versions/m-/man-group-sparrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "23281677e74f273e6ae0424a54436dd8432b0621",
+      "git-tree": "73b124f6ca642956d1aaf64e153b74c15f302280",
       "version": "0.3.0",
       "port-version": 0
     }

--- a/versions/m-/man-group-sparrow.json
+++ b/versions/m-/man-group-sparrow.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "523558574344a27dd460f6b298e4c3b2043f1027",
-      "version": "0.3.0",
+      "git-tree": "12f52f8156f273c32afc2b8b75c893c41831610d",
+      "version": "0.4.0",
       "port-version": 0
     }
   ]

--- a/versions/m-/man-group-sparrow.json
+++ b/versions/m-/man-group-sparrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "12f52f8156f273c32afc2b8b75c893c41831610d",
+      "git-tree": "a33748d04e12b17cab1430a54cf631be9acd47a9",
       "version": "0.4.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

There are several `sparrow` pacakges. [ref](https://repology.org/projects/?search=sparrow)
sparrow 0.3.0 provides shared library only.

