### PR TITLE
[plplot] Fix the absolute path in pc file

### DIFF
--- a/ports/plplot/fix-pc-absolute.patch
+++ b/ports/plplot/fix-pc-absolute.patch
@@ -1,0 +1,26 @@
+diff --git a/cmake/modules/wingcc.cmake b/cmake/modules/wingcc.cmake
+index 25a7494..bb0f476 100644
+--- a/cmake/modules/wingcc.cmake
++++ b/cmake/modules/wingcc.cmake
+@@ -40,7 +40,7 @@ if(PLD_wingcc)
+   endif(GDI32_LIBRARY)
+   if(GDI32_LIBRARY AND COMDLG32_LIBRARY)
+     message(STATUS "Looking for gdi32 header and library - found")
+-    set(wingcc_LINK_FLAGS "${GDI32_LIBRARY};${COMDLG32_LIBRARY}")
++    set(wingcc_LINK_FLAGS "-lgdi32;-lcomdlg32")
+     if(WITH_FREETYPE)
+       set(
+       wingcc_COMPILE_FLAGS
+diff --git a/cmake/modules/wingdi.cmake b/cmake/modules/wingdi.cmake
+index bbe7aed..24c29f9 100644
+--- a/cmake/modules/wingdi.cmake
++++ b/cmake/modules/wingdi.cmake
+@@ -41,7 +41,7 @@ if(PLD_wingdi)
+   endif(GDI32_LIBRARY)
+   if(GDI32_LIBRARY AND COMDLG32_LIBRARY AND COMCTL32_LIBRARY)
+     message(STATUS "Looking for gdi32 header and library - found")
+-    set(wingdi_LINK_FLAGS "${GDI32_LIBRARY};${COMDLG32_LIBRARY};${COMCTL32_LIBRARY}")
++    set(wingdi_LINK_FLAGS "-lgdi32;-lcomdlg32;-lcomctl32")
+     set(DRIVERS_LINK_FLAGS ${DRIVERS_LINK_FLAGS} ${wingdi_LINK_FLAGS})
+   else(GDI32_LIBRARY AND COMDLG32_LIBRARY AND COMCTL32_LIBRARY)
+     message(STATUS "Looking for gdi32 header and library - not found")

--- a/ports/plplot/portfile.cmake
+++ b/ports/plplot/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO plplot/plplot
@@ -10,6 +8,7 @@ vcpkg_from_sourceforge(
         subdirs.patch
         install-interface-include-directories.patch
         use-math-h-nan.patch
+        fix-pc-absolute.patch
 )
 
 vcpkg_check_features(

--- a/ports/plplot/portfile.cmake
+++ b/ports/plplot/portfile.cmake
@@ -54,6 +54,15 @@ vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/plplot)
 vcpkg_fixup_pkgconfig()
 
+if("wxwidgets" IN_LIST FEATURES)
+    file(GLOB _pkg_components "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
+    foreach(_pkg_comp ${_pkg_components})
+        file(READ ${_pkg_comp} _content)
+        string(REPLACE "mswu" "mswud" _content ${_content})
+        file(WRITE ${_pkg_comp} ${_content})
+    endforeach()
+endif()
+
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"

--- a/ports/plplot/usage
+++ b/ports/plplot/usage
@@ -11,3 +11,12 @@ plplot provides CMake targets:
     target_link_libraries(main PRIVATE PLPLOT::csirocsa)
     # QSAS Time Format Conversion Library
     target_link_libraries(main PRIVATE PLPLOT::qsastime)
+
+plplot provides pkg-config modules:
+
+  # C++ binding
+  plplot-c++
+  # Core C library
+  plplot
+  # WxWidgets binding, optional, feature "wxwidgets"
+  plplot-wxwidgets

--- a/ports/plplot/vcpkg.json
+++ b/ports/plplot/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "plplot",
   "version-semver": "5.15.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "PLplot is a cross-platform software package for creating scientific plots whose (UTF-8) plot symbols and text are limited in practice only by what Unicode-aware system fonts are installed on a user's computer.",
   "homepage": "http://plplot.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7090,7 +7090,7 @@
     },
     "plplot": {
       "baseline": "5.15.0",
-      "port-version": 2
+      "port-version": 3
     },
     "plustache": {
       "baseline": "0.4.0",

--- a/versions/p-/plplot.json
+++ b/versions/p-/plplot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a5df216c377031b4c7be090a338cea9cbe0b6c4",
+      "version-semver": "5.15.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "650f7b8973b4a28f84fc0e8ab1711e468417f564",
       "version-semver": "5.15.0",
       "port-version": 2

--- a/versions/p-/plplot.json
+++ b/versions/p-/plplot.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1a5df216c377031b4c7be090a338cea9cbe0b6c4",
+      "git-tree": "14cc290f2c25513e8badb2c955755f2feaa31abd",
       "version-semver": "5.15.0",
       "port-version": 3
     },


### PR DESCRIPTION
Fixes #43985, fix the following absolute path in pc file:
```
C:/Program Files (x86)/Windows Kits/10/Lib/10.0.26100.0/um/x64/Gdi32.Lib
C:/Program Files (x86)/Windows Kits/10/Lib/10.0.26100.0/um/x64/ComDlg32.Lib
```
Fix usage of pkgconfig error:
```
1> [CMake] CMake Error in main/CMakeLists.txt:
1> [CMake]   Imported target "PkgConfig::test" includes non-existent path
1> [CMake] 
1> [CMake]     "F:/0224/installed/x64-windows/debug/lib/mswu"
1> [CMake] 
1> [CMake]   in its INTERFACE_INCLUDE_DIRECTORIES
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
