### PR TITLE
[zydis] update to 4.1.1

### DIFF
--- a/ports/zydis/portfile.cmake
+++ b/ports/zydis/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zyantific/zydis
     REF "v${VERSION}"
-    SHA512 e07add4d43768ded02a238911fde6e74d2391abf8df282f774fca1a8c3fca3e97b03e90e0f3c7c0f3c75485fb29c0be4071d5e5b2e23dd5b8b1a864e3b713fbc
+    SHA512 177e84fedb3449e29ffb6c0b02a92066ba1aa8fb624facad5593902b8e08cb8ae0b20ff38c16987989c8e414d7484d09dab7917c00a8fe54aa9bab4bc90e275d
     HEAD_REF master
     PATCHES
         zycore.patch

--- a/ports/zydis/vcpkg.json
+++ b/ports/zydis/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zydis",
-  "version-semver": "4.1.0",
+  "version-semver": "4.1.1",
   "description": "Fast and lightweight x86/x86-64 disassembler library.",
   "homepage": "https://zydis.re",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10173,7 +10173,7 @@
       "port-version": 0
     },
     "zydis": {
-      "baseline": "4.1.0",
+      "baseline": "4.1.1",
       "port-version": 0
     },
     "zyre": {

--- a/versions/z-/zydis.json
+++ b/versions/z-/zydis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "45ddfb739de0637d4c046d26dd91b88e6caef94e",
+      "version-semver": "4.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a08c5c766c41651280cb783e5dd0a8a5764f9700",
       "version-semver": "4.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Closes #43986 