### PR TITLE
[zycore] update to 1.5.1

### DIFF
--- a/ports/zycore/portfile.cmake
+++ b/ports/zycore/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zyantific/zycore-c
     REF "v${VERSION}"
-    SHA512 f57af4e5c6f919299e673ff4afd19a7e3cc01acaf5cde73db47063eb30881487fa33d2fd5707a3e55a8cd8df4bb4b668bc7273b8b8b5eebea1e78c1c36f715b2
+    SHA512 e9afc9e9f30007d3adb4299edde1fcd5f45135415ed6fd78d64c5dc12d1930d61db11bde89964b34f28afebd9784e734cd2c90f0e846763f198e2e5cc6364874
     HEAD_REF master
 )
 

--- a/ports/zycore/vcpkg.json
+++ b/ports/zycore/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zycore",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Provides platform independent types, macros and a fallback for environments without LibC.",
   "homepage": "https://github.com/zyantific/zycore-c",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10169,7 +10169,7 @@
       "port-version": 0
     },
     "zycore": {
-      "baseline": "1.5.0",
+      "baseline": "1.5.1",
       "port-version": 0
     },
     "zydis": {

--- a/versions/z-/zycore.json
+++ b/versions/z-/zycore.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7915c818a3989348398a0a40b8043e18fb26ae7",
+      "version": "1.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "226a1abf7ca1f76cdea8707e06158b1f099417e0",
       "version": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.