### PR TITLE
[graaf] new port

### DIFF
--- a/ports/graaf/portfile.cmake
+++ b/ports/graaf/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bobluppes/graaf
+    REF "v${VERSION}"
+    SHA512 e97eeadaab079cf6ff429d2580ea7be454a6583b8cc5cd231065c7c51a87d52d60457370dc9688a7e426ffc7ef79ad9670e44966dd367224a4124bcd5755f080
+)
+
+file(COPY "${SOURCE_PATH}/include/graaflib" DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/graaf/usage
+++ b/ports/graaf/usage
@@ -1,0 +1,4 @@
+graaf is header-only and can be used from CMake via:
+
+  find_path(GRAAF_INCLUDE_DIRS "graaflib/graph.h")
+  target_include_directories(main PRIVATE ${GRAAF_INCLUDE_DIRS})

--- a/ports/graaf/vcpkg.json
+++ b/ports/graaf/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "graaf",
+  "version": "1.1.1",
+  "description": "A general-purpose lightweight C++ graph library",
+  "homepage": "https://bobluppes.github.io/graaf/",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3252,6 +3252,10 @@
       "baseline": "2020-05-20",
       "port-version": 4
     },
+    "graaf": {
+      "baseline": "1.1.1",
+      "port-version": 0
+    },
     "grantlee": {
       "baseline": "5.3.1",
       "port-version": 2

--- a/versions/g-/graaf.json
+++ b/versions/g-/graaf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "608792629708669aef95575491d7ff4d009fa548",
+      "version": "1.1.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #43919

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] ~~Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).~~
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.