### PR TITLE
[blpapi] update to 3.25.1

### DIFF
--- a/ports/blpapi/portfile.cmake
+++ b/ports/blpapi/portfile.cmake
@@ -3,15 +3,15 @@
 
 if (VCPKG_TARGET_IS_LINUX)
     vcpkg_download_distfile(ARCHIVE
-        URLS "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_3.24.6.1-linux.tar.gz"
-        FILENAME "blpapi_cpp_3.24.6.1-linux.tar.gz"
-        SHA512 a70b43614a7c3414ca391b4b1a9499a545d6ec98779caafed4317b2bc5cdce3e493bcd600196b340c657ce23287ce6f85833ec270b5301e074884f4640cb19f4
+        URLS "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${VERSION}.1-linux.tar.gz"
+        FILENAME "blpapi_cpp_${VERSION}.1-linux.tar.gz"
+        SHA512 3D1FC0E8E37E21EE53310649EA7D915A4E991DD2FCA400FCD5E490C4533F6C83710426C5D98927631BBDB2622D9FFA864096C82F275DC1C547FCAFE9D1013895
     )
 elseif (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_download_distfile(ARCHIVE
-        URLS "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_3.24.6.1-windows.zip"
-        FILENAME "blpapi_cpp_3.24.6.1-windows.zip"
-        SHA512 1e1dba172767c9fcd0d015f2e8eaa16ef25f643a241144bf4a38ed35c8d8cce9f7fa9f4275636abd8a7307c21def17e50cda0a28bdb3f233d1e7a5affd87d3a5
+        URLS "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${VERSION}.1-windows.zip"
+        FILENAME "blpapi_cpp_${VERSION}.1-windows.zip"
+        SHA512 ED57BF390417D6ED189A3D4379DAE5716441627B20C63B8BEBAAC0AD66C32B89D17697B1C5CE79010F7FFF3F71BC6EC57D15A5D79B597F3507A0A4D2658A6103
     )
 endif()
 
@@ -57,4 +57,4 @@ file(COPY ${CMAKE_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)
 
-file(INSTALL "${SOURCE_PATH}/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.txt")

--- a/ports/blpapi/vcpkg.json
+++ b/ports/blpapi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "blpapi",
-  "version": "3.24.6",
+  "version": "3.25.1",
   "description": "Bloomberg API Library (BLPAPI)",
   "homepage": "https://www.bloomberg.com/professional/support/api-library/",
   "supports": "(linux | (windows & !uwp)) & !static & (x86 | x64)"

--- a/versions/b-/blpapi.json
+++ b/versions/b-/blpapi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23a89d5eb01a5855e931fe5a8405aaca71a5f32e",
+      "version": "3.25.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f06f8feee872cd3a196d20113ed1f77c39554910",
       "version": "3.24.6",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -713,7 +713,7 @@
       "port-version": 0
     },
     "blpapi": {
-      "baseline": "3.24.6",
+      "baseline": "3.25.1",
       "port-version": 0
     },
     "bluescarni-tanuki": {


### PR DESCRIPTION
Update blpapi to 3.25.1.
No feature needs to test.
Usage tested pass on x64-windows.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.