### PR TITLE
[wpilib] Fix format call error under fmt

### DIFF
--- a/ports/wpilib/fix-fmt.patch
+++ b/ports/wpilib/fix-fmt.patch
@@ -1,0 +1,32 @@
+diff --git a/wpimath/src/main/native/include/units/base.h b/wpimath/src/main/native/include/units/base.h
+index 3c939f3..09c56e5 100644
+--- a/wpimath/src/main/native/include/units/base.h
++++ b/wpimath/src/main/native/include/units/base.h
+@@ -183,9 +183,10 @@ namespace units
+ 	struct fmt::formatter<units::namespaceName::nameSingular ## _t> \
+ 		: fmt::formatter<double> \
+ 	{\
+-		template <typename FormatContext>\
+-		auto format(const units::namespaceName::nameSingular ## _t& obj,\
+-								FormatContext& ctx) -> decltype(ctx.out()) \
++		template <typename FmtContext>\
++		auto format(\
++				const units::namespaceName::nameSingular ## _t& obj,\
++				FmtContext& ctx) const\
+ 		{\
+ 			auto out = ctx.out();\
+ 			out = fmt::formatter<double>::format(obj(), ctx);\
+@@ -2890,9 +2891,10 @@ namespace units
+ template <>
+ struct fmt::formatter<units::dimensionless::dB_t> : fmt::formatter<double>
+ {
+-	template <typename FormatContext>
+-	auto format(const units::dimensionless::dB_t& obj,
+-							FormatContext& ctx) -> decltype(ctx.out())
++	template <typename FmtContext>
++	auto format(
++			const units::dimensionless::dB_t& obj,
++			FmtContext& ctx) const
+ 	{
+ 		auto out = ctx.out();
+ 		out = fmt::formatter<double>::format(obj(), ctx);

--- a/ports/wpilib/portfile.cmake
+++ b/ports/wpilib/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         missing-find_dependency.patch
         fix-usage.patch
         fix-build-error-with-fmt11.patch
+        fix-fmt.patch #https://github.com/wpilibsuite/allwpilib/pull/6796
 )
 
 if("allwpilib" IN_LIST FEATURES)

--- a/ports/wpilib/vcpkg.json
+++ b/ports/wpilib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wpilib",
   "version-date": "2023-08-24",
-  "port-version": 1,
+  "port-version": 2,
   "description": "WPILib is the software library package for the FIRST Robotics Competition. The core install includes wpiutil, a common utilies library, and ntcore, the base NetworkTables library.",
   "homepage": "https://github.com/wpilibsuite/allwpilib",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9830,7 +9830,7 @@
     },
     "wpilib": {
       "baseline": "2023-08-24",
-      "port-version": 1
+      "port-version": 2
     },
     "wren": {
       "baseline": "0.4.0",

--- a/versions/w-/wpilib.json
+++ b/versions/w-/wpilib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d40fba76fe504d60de31286b322d5d4f0e5d65db",
+      "version-date": "2023-08-24",
+      "port-version": 2
+    },
+    {
       "git-tree": "2fcd17f46e3a3690ef340ba7da121efac75e28cc",
       "version-date": "2023-08-24",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43518
Use upstream PR [6796](https://github.com/wpilibsuite/allwpilib/pull/6796) to fix the following errors.
```
/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/include/fmt/base.h:1402:23: error: no matching member function for call to 'format'
 1402 |     ctx.advance_to(cf.format(*static_cast<qualified_type*>(arg), ctx));
      |                    ~~~^~~~~~
/Users/leanderSchulten/git_projekte/vcpkg/vcpkg_installed/arm64-osx/include/fmt/base.h:1383:21: note: in instantiation of function template specialization 'fmt::detail::value<fmt::context>::format_custom_arg<units::unit_t<units::unit<std::ratio<437817087, 63500>, units::base_unit<std::ratio<-1>, std::ratio<1>, std::ratio<-2>>>>, fmt::formatter<units::pressure::pounds_per_square_inch_t>>' requested here
 1383 |     custom.format = format_custom_arg<
      |                     ^
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/wpilib/src/c8680f742a-4e1a895adc.clean/wpilibc/src/main/native/cpp/PneumaticHub.cpp:154:11: note: in instantiation of function template specialization 'frc::MakeError<units::unit_t<units::unit<std::ratio<437817087, 63500>, units::base_unit<std::ratio<-1>, std::ratio<1>, std::ratio<-2>>>> &>' requested here
  154 |     throw FRC_MakeError(err::ParameterOutOfRange,
      |           ^
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/wpilib/src/c8680f742a-4e1a895adc.clean/wpilibc/src/main/native/include/frc/Errors.h:154:10: note: expanded from macro 'FRC_MakeError'
  154 |   ::frc::MakeError(status, __FILE__, __LINE__, __FUNCTION__, \
      |          ^
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/wpilib/src/c8680f742a-4e1a895adc.clean/wpimath/src/main/native/include/units/pressure.h:51:1: note: candidate function template not viable: 'this' argument has type 'const fmt::formatter<units::pressure::pounds_per_square_inch_t>', but method is not marked const
   51 | UNIT_ADD(pressure, pounds_per_square_inch, pounds_per_square_inch, psi,
      | ^
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/wpilib/src/c8680f742a-4e1a895adc.clean/wpimath/src/main/native/include/units/base.h:291:2: note: expanded from macro 'UNIT_ADD'
  291 |         UNIT_ADD_IO(namespaceName,nameSingular, abbreviation)\
      |         ^
/Users/leanderSchulten/git_projekte/vcpkg/buildtrees/wpilib/src/c8680f742a-4e1a895adc.clean/wpimath/src/main/native/include/units/base.h:187:8: note: expanded from macro 'UNIT_ADD_IO'
  187 |                 auto format(const units::namespaceName::nameSingular ## _t& obj,\
      |                      ^
1 error generated.
```
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Usage test passed with x64-windows and arm64-osx triplets.