### PR TITLE
[opentelemetry-cpp] Add opentracing shim feature

### DIFF
--- a/ports/opentelemetry-cpp/fix-target_link.patch
+++ b/ports/opentelemetry-cpp/fix-target_link.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5fd2c6f..d8a1b2c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -714,7 +714,7 @@ include_directories(api/include)
+ add_subdirectory(api)
+ 
+ if(WITH_OPENTRACING)
+-  find_package(OpenTracing CONFIG QUIET)
++  find_package(OpenTracing CONFIG REQUIRED)
+   if(NOT OpenTracing_FOUND)
+     set(OPENTRACING_DIR "third_party/opentracing-cpp")
+     message(STATUS "Trying to use local ${OPENTRACING_DIR} from submodule")
+diff --git a/opentracing-shim/CMakeLists.txt b/opentracing-shim/CMakeLists.txt
+index b77b9c1..dff6439 100644
+--- a/opentracing-shim/CMakeLists.txt
++++ b/opentracing-shim/CMakeLists.txt
+@@ -24,7 +24,7 @@ if(OPENTRACING_DIR)
+   target_link_libraries(${this_target} opentelemetry_api opentracing)
+ else()
+   target_link_libraries(${this_target} opentelemetry_api
+-                        OpenTracing::opentracing)
++                        OpenTracing::opentracing-static)
+ endif()
+ 
+ if(OPENTELEMETRY_INSTALL)

--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         cmake-quirks.diff
+        fix-target_link.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -22,6 +23,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         otlp-grpc WITH_OTLP_GRPC
         geneva WITH_GENEVA
         user-events WITH_USER_EVENTS
+        opentracing WITH_OPENTRACING
     INVERTED_FEATURES
         user-events BUILD_TRACEPOINTS
 )

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.19.0",
+  "port-version": 1,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."
@@ -45,6 +46,13 @@
           "platform": "windows"
         },
         "opentelemetry-cpp-contrib-version"
+      ]
+    },
+    "opentracing": {
+      "description": "Whether to include the Opentracing shim",
+      "supports": "!uwp & static",
+      "dependencies": [
+        "opentracing"
       ]
     },
     "otlp-grpc": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6758,7 +6758,7 @@
     },
     "opentelemetry-cpp": {
       "baseline": "1.19.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opentelemetry-cpp-contrib-version": {
       "baseline": "2025-02-03",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "504c4846c73c12886bbdb1b69b2093230a1451a0",
+      "version-semver": "1.19.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8137d32958a0605dc25781d8b8085a77e9b51d29",
       "version-semver": "1.19.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #43974

Add opentracing shim feature

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
