### PR TITLE
[libnick] Update to 2025.2.0

### DIFF
--- a/ports/libnick/portfile.cmake
+++ b/ports/libnick/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NickvisionApps/libnick
     REF "${VERSION}"
-    SHA512 9398493a987b6dec57ea07a2b95104f91eb48df9a6f6e752532356a76eb8a2ddd0f13c63f34e5ba90f555c597afd0dc96885ca3974e1c6264fba4a2f07e9214d
+    SHA512 2541c41b509b60c45639e93d28b320e45d099dcd05d42153a7e0a51f88376782ea4e07f339bc85eaee3f03fdc26a3c05f82e38a2e877e5f0db9a0e70ce2065ff
     HEAD_REF main
 )
 
@@ -27,6 +27,6 @@ vcpkg_copy_pdbs()
 
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/libnick/vcpkg.json
+++ b/ports/libnick/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libnick",
-  "version": "2025.1.0",
+  "version": "2025.2.0",
   "maintainers": "Nicholas Logozzo nlogozzo225@gmail.com",
   "description": "A cross-platform base for native Nickvision applications.",
   "homepage": "https://github.com/NickvisionApps/libnick",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4841,7 +4841,7 @@
       "port-version": 0
     },
     "libnick": {
-      "baseline": "2025.1.0",
+      "baseline": "2025.2.0",
       "port-version": 0
     },
     "libnoise": {

--- a/versions/l-/libnick.json
+++ b/versions/l-/libnick.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cadcc4ef0bf003819e6a9e2690abea7c2652ebdd",
+      "version": "2025.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cd08bd0456ce2fb9b0f64abe6bea869a893ce6b4",
       "version": "2025.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.