### PR TITLE
[octave] update to 9.4.0

### DIFF
--- a/ports/octave/portfile.cmake
+++ b/ports/octave/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://ftpmirror.gnu.org/octave/octave-${VERSION}.tar.xz"
          "https://ftp.gnu.org/gnu/octave/octave-${VERSION}.tar.xz"
     FILENAME "octave-${VERSION}.tar.xz"
-    SHA512 9550162681aee88b4bcb94c5081ed0470df0d3f7c5307b25878b94b19f1282002ba69f0c4c79877e81f61122bfba1b2671ed5007a28fbb2d755bda466a3c46d8
+    SHA512 f0a5ec7d3a14ee18c9a48bab240004ed67ce475b7d5f67037a102d20585b2a78475f260efac33396697dac12c3c49cbabdb2c1370e608ca9ae8ef7954a4e2d92
 )
 
 vcpkg_extract_source_archive(

--- a/ports/octave/vcpkg.json
+++ b/ports/octave/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "octave",
-  "version": "9.3.0",
-  "port-version": 2,
+  "version": "9.4.0",
   "description": "High-level interpreted language, primarily intended for numerical computations.",
   "homepage": "https://octave.org/",
   "documentation": "https://docs.octave.org/latest/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6541,8 +6541,8 @@
       "port-version": 0
     },
     "octave": {
-      "baseline": "9.3.0",
-      "port-version": 2
+      "baseline": "9.4.0",
+      "port-version": 0
     },
     "octomap": {
       "baseline": "1.10.0",

--- a/versions/o-/octave.json
+++ b/versions/o-/octave.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d8f8dbd764cc7e0a6599ff4ed9aff9fd59b7efe",
+      "version": "9.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "802b30081c9cc3102f4bc8badc74ce173d21bb0f",
       "version": "9.3.0",
       "port-version": 2


### PR DESCRIPTION
Usage test passed with x64-linux triplet.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

