### PR TITLE
[vulkan-memory-allocator-hpp] Add vk_mem_alloc.cppm

### DIFF
--- a/ports/vulkan-memory-allocator-hpp/portfile.cmake
+++ b/ports/vulkan-memory-allocator-hpp/portfile.cmake
@@ -7,6 +7,9 @@ vcpkg_from_github(
 )
 
 file(COPY "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+
+file(COPY "${SOURCE_PATH}/src/vk_mem_alloc.cppm" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-vulkan-memory-allocator-hpp-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/vulkan-memory-allocator-hpp/vcpkg.json
+++ b/ports/vulkan-memory-allocator-hpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vulkan-memory-allocator-hpp",
   "version": "3.1.0",
+  "port-version": 1,
   "description": "C++ bindings for VulkanMemoryAllocator (Development branch)",
   "homepage": "https://github.com/YaaZ/VulkanMemoryAllocator-Hpp",
   "license": "CC0-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9650,7 +9650,7 @@
     },
     "vulkan-memory-allocator-hpp": {
       "baseline": "3.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vulkan-sdk-components": {
       "baseline": "1.4.304.1",

--- a/versions/v-/vulkan-memory-allocator-hpp.json
+++ b/versions/v-/vulkan-memory-allocator-hpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46c30259ccc070ffefcb8c2a95908ccfe9d4dada",
+      "version": "3.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b9f973889aed3d994bd84da71014effa986eb9c3",
       "version": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #43667

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.