### PR TITLE
[minizip-ng] update to 4.0.8

### DIFF
--- a/ports/minizip-ng/dependencies.diff
+++ b/ports/minizip-ng/dependencies.diff
@@ -7,7 +7,7 @@ index c684e3e..c3b6fff 100644
          list(APPEND MINIZIP_LBD ${BZIP2_LIBRARY_DIRS})
  
 -        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lbz2")
-+        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} bzip2")
++        set(PC_PRIVATE_DEPS "${PC_PRIVATE_DEPS} bzip2")
      elseif(MZ_FETCH_LIBS)
          clone_repo(bzip2 https://sourceware.org/git/bzip2.git master)
  
@@ -24,7 +24,7 @@ index c684e3e..c3b6fff 100644
          list(APPEND MINIZIP_LBD ${LIBLZMA_LIBRARY_DIRS})
  
 -        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -llzma")
-+        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} liblzma")
++        set(PC_PRIVATE_DEPS "${PC_PRIVATE_DEPS} liblzma")
      elseif(MZ_FETCH_LIBS)
          set(BUILD_TESTING OFF CACHE BOOL "Build lzma tests" FORCE)
  
@@ -45,7 +45,7 @@ index c684e3e..c3b6fff 100644
          list(APPEND MINIZIP_LBD ${ZSTD_LIBRARY_DIRS})
  
 -        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lzstd")
-+        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} libzstd")
++        set(PC_PRIVATE_DEPS "${PC_PRIVATE_DEPS} libzstd")
      elseif(MZ_FETCH_LIBS)
          set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "Build zstd programs")
  

--- a/ports/minizip-ng/dependencies.diff
+++ b/ports/minizip-ng/dependencies.diff
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9ded851..8f3c767 100644
+index c684e3e..c3b6fff 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -254,7 +254,7 @@ if(MZ_BZIP2)
@@ -7,7 +7,7 @@ index 9ded851..8f3c767 100644
          list(APPEND MINIZIP_LBD ${BZIP2_LIBRARY_DIRS})
  
 -        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lbz2")
-+        set(PC_PRIVATE_DEPS "${PC_PRIVATE_DEPS} bzip2")
++        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} bzip2")
      elseif(MZ_FETCH_LIBS)
          clone_repo(bzip2 https://sourceware.org/git/bzip2.git master)
  
@@ -24,7 +24,7 @@ index 9ded851..8f3c767 100644
          list(APPEND MINIZIP_LBD ${LIBLZMA_LIBRARY_DIRS})
  
 -        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -llzma")
-+        set(PC_PRIVATE_DEPS "${PC_PRIVATE_DEPS} liblzma")
++        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} liblzma")
      elseif(MZ_FETCH_LIBS)
          set(BUILD_TESTING OFF CACHE BOOL "Build lzma tests" FORCE)
  
@@ -45,7 +45,7 @@ index 9ded851..8f3c767 100644
          list(APPEND MINIZIP_LBD ${ZSTD_LIBRARY_DIRS})
  
 -        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lzstd")
-+        set(PC_PRIVATE_DEPS "${PC_PRIVATE_DEPS} libzstd")
++        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} libzstd")
      elseif(MZ_FETCH_LIBS)
          set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "Build zstd programs")
  
@@ -67,12 +67,3 @@ index 9ded851..8f3c767 100644
      else()
          message(STATUS "OpenSSL library not found")
  
-@@ -735,7 +732,7 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
-     if(MINIZIP_DEP_PKG)
-         string(APPEND MINIZIP_CONFIG_CONTENT "include(CMakeFindDependencyMacro)\n")
-         foreach(pkg_name ${MINIZIP_DEP_PKG})
--            string(APPEND MINIZIP_CONFIG_CONTENT "find_dependency(${pkg_name} REQUIRED)\n")
-+            string(APPEND MINIZIP_CONFIG_CONTENT "find_dependency(${pkg_name})\n")
-         endforeach()
-     endif()
-     string(APPEND MINIZIP_CONFIG_CONTENT "include(\"\${CMAKE_CURRENT_LIST_DIR}/${MINIZIP_TARGET}.cmake\")")

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/minizip-ng
     REF "${VERSION}"
-    SHA512 af9c8743d34bbc8f371a018debfab5f857aadb9a1129b048dbce9085122bef209ade34837784f91424c9eba92406d2e222476d9f8038839908679f7b7dc9e3eb
+    SHA512 673798114e29a41ce87906b705dd92c5dc1ed1798aefaa20f0e3d7c1f27b9593e0c4c1271e02585ecc234ce835b14b02227c37f1a7fba4c7a98b822f10711b85
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "minizip-ng",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5993,7 +5993,7 @@
       "port-version": 1
     },
     "minizip-ng": {
-      "baseline": "4.0.7",
+      "baseline": "4.0.8",
       "port-version": 0
     },
     "mio": {

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44873f1c7f7b7ad033891aac9b955c0ec049d6b7",
+      "version": "4.0.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "eeefed8ea3d0bded7e8333a05870153f5e4899a0",
       "version": "4.0.7",
       "port-version": 0

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "44873f1c7f7b7ad033891aac9b955c0ec049d6b7",
+      "git-tree": "7f04dbfaf539622a45fd3321b7caadcdac0e210b",
       "version": "4.0.8",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
