### PR TITLE
[plplot] Complete the missing parameters

### DIFF
--- a/ports/plplot/portfile.cmake
+++ b/ports/plplot/portfile.cmake
@@ -51,13 +51,13 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/plplot)
 vcpkg_fixup_pkgconfig()
 
 if("wxwidgets" IN_LIST FEATURES)
-    file(GLOB _pkg_components "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
-    foreach(_pkg_comp IN ITEMS ${_pkg_components})
-        vcpkg_replace_string("${_pkg_comp}" "mswu" "mswud" IGNORE_UNCHANGED)
+    file(GLOB pkg_files "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
+    foreach(pkg_file IN ITEMS ${pkg_files})
+        vcpkg_replace_string("${pkg_file}" "${prefix}/lib/mswu" "${prefix}/lib/mswud" IGNORE_UNCHANGED)
     endforeach()
 endif()
 

--- a/ports/plplot/portfile.cmake
+++ b/ports/plplot/portfile.cmake
@@ -51,15 +51,13 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/plplot)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_fixup_pkgconfig()
 
 if("wxwidgets" IN_LIST FEATURES)
     file(GLOB _pkg_components "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
-    foreach(_pkg_comp ${_pkg_components})
-        file(READ ${_pkg_comp} _content)
-        string(REPLACE "mswu" "mswud" _content ${_content})
-        file(WRITE ${_pkg_comp} ${_content})
+    foreach(_pkg_comp IN ITEMS ${_pkg_components})
+        vcpkg_replace_string("${_pkg_comp}" "mswu" "mswud" IGNORE_UNCHANGED)
     endforeach()
 endif()
 

--- a/ports/plplot/vcpkg.json
+++ b/ports/plplot/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "plplot",
   "version-semver": "5.15.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "PLplot is a cross-platform software package for creating scientific plots whose (UTF-8) plot symbols and text are limited in practice only by what Unicode-aware system fonts are installed on a user's computer.",
   "homepage": "http://plplot.org/",
   "license": null,

--- a/ports/plplot/vcpkg.json
+++ b/ports/plplot/vcpkg.json
@@ -3,7 +3,7 @@
   "version-semver": "5.15.0",
   "port-version": 4,
   "description": "PLplot is a cross-platform software package for creating scientific plots whose (UTF-8) plot symbols and text are limited in practice only by what Unicode-aware system fonts are installed on a user's computer.",
-  "homepage": "http://plplot.org/",
+  "homepage": "https://plplot.sourceforge.net/",
   "license": null,
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7094,7 +7094,7 @@
     },
     "plplot": {
       "baseline": "5.15.0",
-      "port-version": 3
+      "port-version": 4
     },
     "plustache": {
       "baseline": "0.4.0",

--- a/versions/p-/plplot.json
+++ b/versions/p-/plplot.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "46ba5a3c6a9488cc36a0287375723e758737e326",
+      "git-tree": "e876a75a0e8e457fe3a268002e1cae2390982a6d",
       "version-semver": "5.15.0",
       "port-version": 4
     },

--- a/versions/p-/plplot.json
+++ b/versions/p-/plplot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46ba5a3c6a9488cc36a0287375723e758737e326",
+      "version-semver": "5.15.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "14cc290f2c25513e8badb2c955755f2feaa31abd",
       "version-semver": "5.15.0",
       "port-version": 3


### PR DESCRIPTION
Apply suggestions of https://github.com/microsoft/vcpkg/pull/43996#discussion_r1972350222.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.