### PR TITLE
[libev] The 'select' backend is available to MSVC

### DIFF
--- a/ports/libev/0001-use-select-with-msvc.patch
+++ b/ports/libev/0001-use-select-with-msvc.patch
@@ -1,0 +1,13 @@
+diff --git a/ev.c b/ev.c
+index ec212a1..b80b1e0 100644
+--- a/ev.c
++++ b/ev.c
+@@ -90,7 +90,7 @@
+ #   define EV_USE_NANOSLEEP 0
+ # endif
+ 
+-# if HAVE_SELECT && HAVE_SYS_SELECT_H
++# if HAVE_SELECT && (HAVE_SYS_SELECT_H || defined(_MSC_VER))
+ #  ifndef EV_USE_SELECT
+ #   define EV_USE_SELECT EV_FEATURE_BACKENDS
+ #  endif

--- a/ports/libev/portfile.cmake
+++ b/ports/libev/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES "0000-event-fix-undefined-struct-timeval.patch"
+            "0001-use-select-with-msvc.patch"
 )
 
 set(LIBEV_LINK_FLAGS "")

--- a/ports/libev/vcpkg.json
+++ b/ports/libev/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libev",
   "version": "4.33",
-  "port-version": 3,
+  "port-version": 4,
   "description": "libev is a high-performance event loop/event model with lots of features.",
   "homepage": "http://software.schmorp.de/pkg/libev.html",
   "license": "BSD-2-Clause OR GPL-2.0-or-later"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4478,7 +4478,7 @@
     },
     "libev": {
       "baseline": "4.33",
-      "port-version": 3
+      "port-version": 4
     },
     "libevent": {
       "baseline": "2.1.12+20230128",

--- a/versions/l-/libev.json
+++ b/versions/l-/libev.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2068072af377aafdfdac8404e3435ec2ca6ef3a7",
+      "git-tree": "93adc0ea0491c2b0607d28bca4c732e3b353fc44",
       "version": "4.33",
       "port-version": 4
     },

--- a/versions/l-/libev.json
+++ b/versions/l-/libev.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2068072af377aafdfdac8404e3435ec2ca6ef3a7",
+      "version": "4.33",
+      "port-version": 4
+    },
+    {
       "git-tree": "048b4e081061376e4e6fdcd18670669162f79c7a",
       "version": "4.33",
       "port-version": 3


### PR DESCRIPTION
The libev source expects HAVE_SYS_SELECT_H (`sys/select.h`) to be enabled before the select backend (`EV_USE_SELECT`) can be used. And for Windows, the 'select' backend is the only supported backend.
However, for MSVC, there is no sys/select.h as the select() function is part of winsocks2.h. MinGW does have a sys/select.h.

Without this commit the MSVC build of libev results in _no_ "supported" or "recommended" backends (`ev_supported_backends() == 0` and `ev_recommended_backends() == 0`).

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
