### PR TITLE
[qlementine-icons] Add port

### DIFF
--- a/ports/qlementine-icons/cmake.patch
+++ b/ports/qlementine-icons/cmake.patch
@@ -1,0 +1,109 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3173dd4..2fd1a7d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ cmake_minimum_required(VERSION 3.17.5)
+ 
+ # Set project information.
+-project("qlementine_icons"
++project("qlementine-icons"
+   LANGUAGES CXX
+   VERSION 1.6.0.0
+   DESCRIPTION "Modern icon theme for Qt applications."
+@@ -12,6 +12,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
+ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
++set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+ 
+ # Find Qt.
+ find_package(Qt6 REQUIRED COMPONENTS Core Widgets Svg)
+@@ -21,6 +22,6 @@ qt_standard_project_setup()
+ add_subdirectory(sources)
+ 
+ # Sandbox.
+-if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
++if(QLEMENTINE_ICONS_SANDBOX)
+   add_subdirectory(sandbox)
+ endif()
+diff --git a/cmake/config.cmake.in b/cmake/config.cmake.in
+new file mode 100644
+index 0000000..abcf8fc
+--- /dev/null
++++ b/cmake/config.cmake.in
+@@ -0,0 +1,8 @@
++@PACKAGE_INIT@
++
++include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
++include(CMakeFindDependencyMacro)
++
++find_dependency(Qt6 REQUIRED COMPONENTS Core Svg)
++
++check_required_components(@PROJECT_NAME@)
+diff --git a/sources/CMakeLists.txt b/sources/CMakeLists.txt
+index 5fb2c18..196b21d 100644
+--- a/sources/CMakeLists.txt
++++ b/sources/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ # Create the library.
+ add_library(${PROJECT_NAME} STATIC)
+-add_library(oclero::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
++include(CMakePackageConfigHelpers)
+ 
+ file(GLOB_RECURSE QRC_FILES "resources/icons/*.qrc")
+ file(GLOB_RECURSE HPP_FILES "include/oclero/qlementine/icons/*.hpp")
+@@ -16,11 +16,15 @@ target_sources(${PROJECT_NAME}
+ target_include_directories(${PROJECT_NAME}
+   PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+   PRIVATE
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+ )
+ 
+-target_link_libraries(${PROJECT_NAME} PRIVATE Qt::Core Qt::Svg)
++target_link_libraries(${PROJECT_NAME}
++  PUBLIC
++    Qt::Core
++    Qt::Svg)
+ 
+ set_target_properties(${PROJECT_NAME} PROPERTIES
+   LINKER_LANGUAGE CXX
+@@ -34,3 +38,36 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
+ )
+ 
+ target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
++
++# Install target
++configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/../cmake/config.cmake.in"
++  "${CMAKE_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake"
++  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
++
++write_basic_package_version_file("${CMAKE_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake"
++  VERSION "${PROJECT_VERSION}"
++  COMPATIBILITY AnyNewerVersion)
++
++install(TARGETS ${PROJECT_NAME}
++  EXPORT "${PROJECT_NAME}Targets"
++  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++
++install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
++  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/")
++
++install(EXPORT "${PROJECT_NAME}Targets"
++  FILE "${PROJECT_NAME}Targets.cmake"
++  NAMESPACE unofficial::${PROJECT_NAME}::
++  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
++
++install(FILES
++  "${CMAKE_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake"
++  "${CMAKE_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake"
++  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
++
++export(EXPORT "${PROJECT_NAME}Targets"
++  FILE "${CMAKE_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake"
++  NAMESPACE unofficial::${PROJECT_NAME}::)

--- a/ports/qlementine-icons/portfile.cmake
+++ b/ports/qlementine-icons/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO oclero/qlementine-icons
+    REF "v${VERSION}"
+    SHA512 0b703325266d069e47d9640ed1dc38b6fcc521344678f15f75e268a3a2a574136deea25d82618b1d09c3900f38e702b1fc036f4b860b2348a933da47daefe6de
+    PATCHES
+        cmake.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DQLEMENTINE_ICONS_SANDBOX=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/qlementine-icons)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_copy_pdbs()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/qlementine-icons/usage
+++ b/ports/qlementine-icons/usage
@@ -1,0 +1,4 @@
+qlementine-icons provides CMake targets:
+
+  find_package(qlementine-icons CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE unofficial::qlementine-icons::qlementine-icons)

--- a/ports/qlementine-icons/vcpkg.json
+++ b/ports/qlementine-icons/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "qlementine-icons",
+  "version": "1.6.0",
+  "description": "Modern icon set for desktop Qt applications.",
+  "homepage": "https://github.com/oclero/qlementine-icons/",
+  "documentation": "https://oclero.github.io/qlementine-icons/",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "gui"
+      ]
+    },
+    "qtsvg",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7364,6 +7364,10 @@
       "baseline": "1.0.2",
       "port-version": 0
     },
+    "qlementine-icons": {
+      "baseline": "1.6.0",
+      "port-version": 0
+    },
     "qmex": {
       "baseline": "2024-10-31",
       "port-version": 0

--- a/versions/q-/qlementine-icons.json
+++ b/versions/q-/qlementine-icons.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e5567f1e380ac4e2b14902e792cabb38ec2721df",
+      "version": "1.6.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
