### PR TITLE
[ada-url] Fix tools build error

### DIFF
--- a/ports/ada-url/no-cpm.patch
+++ b/ports/ada-url/no-cpm.patch
@@ -11,10 +11,10 @@ index 1b55e39..23ce61f 100644
    # We use googletest in the tests
    if(ADA_TESTING)
 diff --git a/tools/cli/CMakeLists.txt b/tools/cli/CMakeLists.txt
-index 397b428..5860fd1 100644
+index 397b428..4b49928 100644
 --- a/tools/cli/CMakeLists.txt
 +++ b/tools/cli/CMakeLists.txt
-@@ -8,12 +8,7 @@ if(MSVC AND BUILD_SHARED_LIBS)
+@@ -8,12 +8,8 @@ if(MSVC AND BUILD_SHARED_LIBS)
          "$<TARGET_FILE:ada>"      # <--this is in-file
          "$<TARGET_FILE_DIR:adaparse>")                 # <--this is out-file path
  endif()
@@ -24,6 +24,7 @@ index 397b428..5860fd1 100644
 -  VERSION 3.2.0
 -  OPTIONS "CXXOPTS_BUILD_EXAMPLES NO" "CXXOPTS_BUILD_TESTS NO" "CXXOPTS_ENABLE_INSTALL YES"
 -)
++find_package(cxxopts CONFIG REQUIRED)
 +find_package(fmt CONFIG REQUIRED)
  target_link_libraries(adaparse PRIVATE cxxopts::cxxopts fmt::fmt)
  

--- a/ports/ada-url/vcpkg.json
+++ b/ports/ada-url/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ada-url",
   "version": "3.1.1",
+  "port-version": 1,
   "description": "WHATWG-compliant and fast URL parser written in modern C++",
   "homepage": "https://ada-url.com/",
   "license": "MIT OR Apache-2.0",

--- a/versions/a-/ada-url.json
+++ b/versions/a-/ada-url.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f54e28b057c39b440deb728045837eade4429b19",
+      "version": "3.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "28c5463040101be137c2484cb58eac89bfe17183",
       "version": "3.1.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -38,7 +38,7 @@
     },
     "ada-url": {
       "baseline": "3.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ade": {
       "baseline": "0.1.2e",


### PR DESCRIPTION
Fix the following installation error of `ada-url[tools]`:
```
CMake Error at tools/cli/CMakeLists.txt:12 (target_link_libraries):
  Target "adaparse" links to:

    cxxopts::cxxopts

  but the target was not found.
```
Usage passed on x64-windows.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
