### PR TITLE
[nanopb] Fix double quote position error in nanopb_PROTOC_PATH

### DIFF
--- a/ports/nanopb/portfile.cmake
+++ b/ports/nanopb/portfile.cmake
@@ -28,7 +28,7 @@ vcpkg_cmake_configure(
         -Dnanopb_BUILD_RUNTIME=ON
         -DBUILD_STATIC_LIBS=${nanopb_BUILD_STATIC_LIBS}
         -Dnanopb_MSVC_STATIC_RUNTIME=${nanopb_STATIC_LINKING}
-        -Dnanopb_PROTOC_PATH="${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf/protoc${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+        "-Dnanopb_PROTOC_PATH=${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf/protoc${VCPKG_HOST_EXECUTABLE_SUFFIX}"
         ${FEATURE_OPTIONS}
         -DCMAKE_INSTALL_DATADIR=share/${PORT}
     MAYBE_UNUSED_VARIABLES

--- a/ports/nanopb/vcpkg.json
+++ b/ports/nanopb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nanopb",
   "version-semver": "0.4.9",
+  "port-version": 1,
   "description": "A small code-size Protocol Buffers implementation in ANSI C.",
   "homepage": "https://jpa.kapsi.fi/nanopb/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6258,7 +6258,7 @@
     },
     "nanopb": {
       "baseline": "0.4.9",
-      "port-version": 0
+      "port-version": 1
     },
     "nanoprintf": {
       "baseline": "0.5.3",

--- a/versions/n-/nanopb.json
+++ b/versions/n-/nanopb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "37a686a5762360696c1946d2eda20b972b75acb6",
+      "version-semver": "0.4.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "1f5737c00d41a894367cab2acb6ef934043fcd8e",
       "version-semver": "0.4.9",
       "port-version": 0


### PR DESCRIPTION
Fixes #44014. When there are spaces in the vcpkg storage path, the incorrect placement of double quotes will cause the following error:
```
CMake Warning:
  Ignoring extra path from command line:
   "test/vcpkg/installed/x64-windows/tools/protobuf/protoc.exe"

...

CMake Error at CMakeLists.txt:51 (message):
  protoc compiler not found
```

Change
```
-Dnanopb_PROTOC_PATH="${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf/protoc${VCPKG_HOST_EXECUTABLE_SUFFIX}"
```
to
```
"-Dnanopb_PROTOC_PATH=${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf/protoc${VCPKG_HOST_EXECUTABLE_SUFFIX}"
OR
-Dnanopb_PROTOC_PATH=${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf/protoc${VCPKG_HOST_EXECUTABLE_SUFFIX}
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.