### PR TITLE
[amd-amf] Update to 1.4.36

### DIFF
--- a/ports/amd-amf/portfile.cmake
+++ b/ports/amd-amf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GPUOpen-LibrariesAndSDKs/AMF
     REF "v${VERSION}"
-    SHA512 8a2aa3a358a7c0cfac47f545b8a375de86652d6590795161ad592e49219f54f5ec8dd06d5d48ea9e091fac09e83dbac2044d7ed551898f907cc1b30eea66b7ab
+    SHA512 589fccabaadb27e48e9adb1d3594db2adadee343c966f8db99ff29a92ec78ae6b0c42f13113a4fc66da0044ee660cfa1caf6867c508af044935646c09f5af50e
     HEAD_REF master
 )
 

--- a/ports/amd-amf/vcpkg.json
+++ b/ports/amd-amf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "amd-amf",
-  "version": "1.4.35",
+  "version": "1.4.36",
   "description": "AMD Advanced Media Framework headers",
   "homepage": "https://github.com/GPUOpen-LibrariesAndSDKs/AMF",
   "license": "MIT",

--- a/versions/a-/amd-amf.json
+++ b/versions/a-/amd-amf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd224304fd2caeb6f476511884069744e4b88f8f",
+      "version": "1.4.36",
+      "port-version": 0
+    },
+    {
       "git-tree": "47db5211b49a66cf05a86858cddd41d2c4b5d8a9",
       "version": "1.4.35",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -105,7 +105,7 @@
       "port-version": 0
     },
     "amd-amf": {
-      "baseline": "1.4.35",
+      "baseline": "1.4.36",
       "port-version": 0
     },
     "ampl-asl": {


### PR DESCRIPTION
Update `amd-amf` to 1.4.36, usage passed on `x64-windows`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
