### PR TITLE
[libxlsxwriter] Disable optional dependency pkgconfig

### DIFF
--- a/ports/libxlsxwriter/5001-prefer-cmake-config.diff
+++ b/ports/libxlsxwriter/5001-prefer-cmake-config.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c9ceb6c..724bd6c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -309,7 +309,7 @@ list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS})
+ 
+ # Set the minizip includes.
+ if(USE_SYSTEM_MINIZIP)
+-    if(MSVC)
++    if(1)
+         find_package(MINIZIP NAMES unofficial-minizip REQUIRED)
+         set(MINIZIP_LIBRARIES unofficial::minizip::minizip)
+     else()

--- a/ports/libxlsxwriter/portfile.cmake
+++ b/ports/libxlsxwriter/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 588d939c3ba9758debffbe675580d2013c0e18ff8cbfdf2b4aaad28a5a013c579ca06206c2b0446b25203db48e59af8a16168e32f265e0939f046b18bf598803
     HEAD_REF main
+    PATCHES
+        5001-prefer-cmake-config.diff
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/third_party/minizip")
 
@@ -15,8 +17,11 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON   # Make sure there are no unexpected pkgconfig for `5001-prefer-cmake-config.diff`.
         -DUSE_SYSTEM_MINIZIP=1
         -DWINDOWSSTORE=${USE_WINDOWSSTORE}
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_DISABLE_FIND_PACKAGE_PkgConfig
 )
 
 vcpkg_cmake_install()

--- a/ports/libxlsxwriter/vcpkg.json
+++ b/ports/libxlsxwriter/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libxlsxwriter",
   "version": "1.2.1",
+  "port-version": 1,
   "description": "Libxlsxwriter is a C library that can be used to write text, numbers, formulas and hyperlinks to multiple worksheets in an Excel 2007+ XLSX file.",
   "homepage": "https://github.com/jmcnamara/libxlsxwriter",
   "documentation": "https://libxlsxwriter.github.io",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5462,7 +5462,7 @@
     },
     "libxlsxwriter": {
       "baseline": "1.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libxml2": {
       "baseline": "2.13.5",

--- a/versions/l-/libxlsxwriter.json
+++ b/versions/l-/libxlsxwriter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6dcf0a97673425c61bf087a2f7c1d074bb8c2d8",
+      "version": "1.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "dddfee1e4171f44599ee2211f1e221e2cb73f95d",
       "version": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/44074

Prefer CMake config, disabling the optional dependency `pkgconfig`.

Implement https://github.com/microsoft/vcpkg/pull/44041#pullrequestreview-2646623771 and https://github.com/microsoft/vcpkg/pull/44041#issuecomment-2689376355, follows https://github.com/microsoft/vcpkg/pull/43674

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux
* x64-windows