### PR TITLE
[opencsg] Update to 1.7.0

### DIFF
--- a/ports/opencsg/portfile.cmake
+++ b/ports/opencsg/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO floriankirsch/OpenCSG
     REF "opencsg-${VERSION_CSG}-release"
-    SHA512 531dda97fbbcfca9bd57eb2d62b34ed382788bafffff05aa4007cf6dd7093c478e6364020e58cda8adcc1bc45485c22e3a94dbc52916da6a8b418412ce7712c6
+    SHA512 ded016e6340b2dca479765bd638d353b1c4605cf7b579ab412cf8d789d56ce307a86576fc45307f87c7ea756bb9aff5db25c8a819352058ce4f7cf3e24056a07
     HEAD_REF master
     PATCHES
         illegal_char.patch

--- a/ports/opencsg/vcpkg.json
+++ b/ports/opencsg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "opencsg",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "OpenCSG is a library that does image-based CSG rendering using OpenGL. OpenCSG is written in C++ and supports most modern graphics hardware using Microsoft Windows or the Linux operating system.",
   "homepage": "https://github.com/floriankirsch/OpenCSG",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6705,7 +6705,7 @@
       "port-version": 3
     },
     "opencsg": {
-      "baseline": "1.6.0",
+      "baseline": "1.7.0",
       "port-version": 0
     },
     "openctm": {

--- a/versions/o-/opencsg.json
+++ b/versions/o-/opencsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bfb8eb4d7ce067837d16f98141766f4ba980b50c",
+      "version": "1.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6979934362ae4a808ccef45ee20545d7422c8e0f",
       "version": "1.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
