### PR TITLE
[pcl] Fix missing chrono includes

### DIFF
--- a/ports/pcl/add-chrono-includes.patch
+++ b/ports/pcl/add-chrono-includes.patch
@@ -1,0 +1,117 @@
+diff --git a/apps/src/ppf_object_recognition.cpp b/apps/src/ppf_object_recognition.cpp
+index b12ac2a0f..9889d0c6a 100644
+--- a/apps/src/ppf_object_recognition.cpp
++++ b/apps/src/ppf_object_recognition.cpp
+@@ -9,6 +9,7 @@
+ #include <pcl/segmentation/sac_segmentation.h>
+ #include <pcl/visualization/pcl_visualizer.h>
+ 
++#include <chrono>
+ #include <thread>
+ 
+ using namespace pcl;
+diff --git a/examples/stereo/example_stereo_baseline.cpp b/examples/stereo/example_stereo_baseline.cpp
+index bf21c6f8f..594ab2465 100644
+--- a/examples/stereo/example_stereo_baseline.cpp
++++ b/examples/stereo/example_stereo_baseline.cpp
+@@ -1,3 +1,4 @@
++#include <chrono>
+ #include <thread>
+ 
+ #include <pcl/stereo/stereo_matching.h>
+diff --git a/tools/obj_rec_ransac_accepted_hypotheses.cpp b/tools/obj_rec_ransac_accepted_hypotheses.cpp
+index f75bd66a7..f884cd9c9 100644
+--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
++++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
+@@ -58,6 +58,7 @@
+ #include <vtkHedgeHog.h>
+ #include <vtkMatrix4x4.h>
+ #include <algorithm>
++#include <chrono>
+ #include <cstdio>
+ #include <thread>
+ #include <vector>
+diff --git a/tools/obj_rec_ransac_hash_table.cpp b/tools/obj_rec_ransac_hash_table.cpp
+index bde3d9413..88b959944 100644
+--- a/tools/obj_rec_ransac_hash_table.cpp
++++ b/tools/obj_rec_ransac_hash_table.cpp
+@@ -53,6 +53,7 @@
+ #include <vtkDataArray.h>
+ #include <vtkPointData.h>
+ #include <vtkGlyph3D.h>
++#include <chrono>
+ #include <cstdio>
+ #include <thread>
+ 
+diff --git a/tools/obj_rec_ransac_model_opps.cpp b/tools/obj_rec_ransac_model_opps.cpp
+index d82cbfb16..e6b27a67d 100644
+--- a/tools/obj_rec_ransac_model_opps.cpp
++++ b/tools/obj_rec_ransac_model_opps.cpp
+@@ -52,6 +52,7 @@
+ #include <vtkDataArray.h>
+ #include <vtkPointData.h>
+ #include <vtkHedgeHog.h>
++#include <chrono>
+ #include <cstdio>
+ #include <thread>
+ 
+diff --git a/tools/obj_rec_ransac_orr_octree.cpp b/tools/obj_rec_ransac_orr_octree.cpp
+index c21a193c4..6f55c0916 100644
+--- a/tools/obj_rec_ransac_orr_octree.cpp
++++ b/tools/obj_rec_ransac_orr_octree.cpp
+@@ -63,6 +63,7 @@
+ #include <vtkRenderWindow.h>
+ #include <vector>
+ #include <list>
++#include <chrono>
+ #include <cstdlib>
+ #include <cstring>
+ #include <cstdio>
+diff --git a/tools/obj_rec_ransac_orr_octree_zprojection.cpp b/tools/obj_rec_ransac_orr_octree_zprojection.cpp
+index 446d53511..42204cfc6 100644
+--- a/tools/obj_rec_ransac_orr_octree_zprojection.cpp
++++ b/tools/obj_rec_ransac_orr_octree_zprojection.cpp
+@@ -62,6 +62,7 @@
+ #include <vtkCubeSource.h>
+ #include <vtkPointData.h>
+ #include <vector>
++#include <chrono>
+ #include <cstdlib>
+ #include <cstring>
+ #include <cstdio>
+diff --git a/tools/obj_rec_ransac_result.cpp b/tools/obj_rec_ransac_result.cpp
+index 884dea61b..78b54eb77 100644
+--- a/tools/obj_rec_ransac_result.cpp
++++ b/tools/obj_rec_ransac_result.cpp
+@@ -57,6 +57,7 @@
+ #include <vtkRenderer.h>
+ #include <vtkRenderWindow.h>
+ #include <vtkTransform.h>
++#include <chrono>
+ #include <cstdio>
+ #include <list>
+ #include <thread>
+diff --git a/tools/obj_rec_ransac_scene_opps.cpp b/tools/obj_rec_ransac_scene_opps.cpp
+index 70ddfe42a..a1d5099a8 100644
+--- a/tools/obj_rec_ransac_scene_opps.cpp
++++ b/tools/obj_rec_ransac_scene_opps.cpp
+@@ -53,6 +53,7 @@
+ #include <vtkDataArray.h>
+ #include <vtkPointData.h>
+ #include <vtkHedgeHog.h>
++#include <chrono>
+ #include <cstdio>
+ #include <thread>
+ 
+diff --git a/visualization/include/pcl/visualization/impl/registration_visualizer.hpp b/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
+index 884735e4a..4a40b11f5 100644
+--- a/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
++++ b/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
+@@ -38,6 +38,7 @@
+ 
+ #pragma once
+ 
++#include <chrono>
+ #include <thread>
+ 
+ 

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         install-layout.patch
         install-examples.patch
         fix-clang-cl.patch
+        add-chrono-includes.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" PCL_SHARED_LIBS)

--- a/ports/pcl/vcpkg.json
+++ b/ports/pcl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pcl",
   "version": "1.15.0",
+  "port-version": 1,
   "description": "Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.",
   "homepage": "https://github.com/PointCloudLibrary/pcl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6994,7 +6994,7 @@
     },
     "pcl": {
       "baseline": "1.15.0",
-      "port-version": 0
+      "port-version": 1
     },
     "pcre": {
       "baseline": "8.45",

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3842f1300f7fa0b46da6784433678e964520ddf",
+      "version": "1.15.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "62b18d0fdff587cc5f1e0253c109807d47a69723",
       "version": "1.15.0",
       "port-version": 0


### PR DESCRIPTION
Fixes build failure when using MSVC STL 17.13 and newer (see https://github.com/microsoft/STL/releases/tag/vs-2022-17.13 )

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

Fixes #44047

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

I have added the patch to the pcl repo (upstream): https://github.com/PointCloudLibrary/pcl/pull/6243

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
