### PR TITLE
[cpp-pinyin] update to 1.0.1

### DIFF
--- a/ports/cpp-pinyin/portfile.cmake
+++ b/ports/cpp-pinyin/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfgitpr/cpp-pinyin
     REF  "${VERSION}"
-    SHA512 cdd78cdc493ab352bfd7c5adfb4642bc587fb26f65b4d81a07e7c89c377222a30730f3e800f028106b66cbc35e32709c1a0e470e9737b6ee9718e3ce9da8137a
+    SHA512 de8bfaa56c951591ed360be74fa164f0fcd8fe19c42ae6fdf0e63ba8e375b9e5dc6f6577a9a34a2c5b638a799f701c1cb54fbfa07f32003e91cac58e660ab4ec
     HEAD_REF main
 )
 

--- a/ports/cpp-pinyin/vcpkg.json
+++ b/ports/cpp-pinyin/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-pinyin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A lightweight Chinese/Cantonese to Pinyin library.",
   "homepage": "https://github.com/wolfgitpr/cpp-pinyin",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1913,7 +1913,7 @@
       "port-version": 0
     },
     "cpp-pinyin": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "cpp-redis": {

--- a/versions/c-/cpp-pinyin.json
+++ b/versions/c-/cpp-pinyin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dabdc5308769f7a7f3c569e4d23c3e81b1657141",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f3a4b0cc31a8acaecebdee019de6f0a07b45037a",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.