### PR TITLE
[glew] Fix build with CMake 4.0

### DIFF
--- a/ports/glew/cmake_version.patch
+++ b/ports/glew/cmake_version.patch
@@ -1,0 +1,13 @@
+diff --git a/build/cmake/CMakeLists.txt b/build/cmake/CMakeLists.txt
+index 419c243..8c66ae2 100644
+--- a/build/cmake/CMakeLists.txt
++++ b/build/cmake/CMakeLists.txt
+@@ -4,7 +4,7 @@ endif ()
+ 
+ project (glew C)
+ 
+-cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 3.5)
+ 
+ include(GNUInstallDirs)
+ 

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_extract_source_archive(
     PATCHES
         fix-LNK2019.patch
         base_address.patch # Accepted upstream as https://github.com/nigels-com/glew/commit/ef7d12ecb7f1f336f6d3a80cebd6163b2c094108
+        cmake_version.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/glew/vcpkg.json
+++ b/ports/glew/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glew",
   "version": "2.2.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.",
   "homepage": "https://github.com/nigels-com/glew",
   "supports": "!android",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3150,7 +3150,7 @@
     },
     "glew": {
       "baseline": "2.2.0",
-      "port-version": 5
+      "port-version": 6
     },
     "glfw3": {
       "baseline": "3.4",

--- a/versions/g-/glew.json
+++ b/versions/g-/glew.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98d4ecc965968cdc8c85c0347c4638bbda36bef4",
+      "version": "2.2.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "deee148de63ca706630edc3408d1c9a471f8884f",
       "version": "2.2.0",
       "port-version": 5


### PR DESCRIPTION
This PR fixes the compilation of the GLEW port with CMake 4.0, which removed compatibility with versions of CMake older than version 3.5 (see https://cmake.org/cmake/help/v4.0/release/4.0.html#deprecated-and-removed-features). I have tested on CMake 4.0.0 RC2 that the build process no longer fails with the proposed changes.

While this issue was fixed in the upstream repo some time ago, vcpkg uses the sources of the last release, which has been created a few years ago. `portfile.cmake` makes this statement why using the code from the main branch of the upstream repo is not directly possible:

```
# Don't change to vcpkg_from_github! The sources in the git repository (archives) are missing some files that are distributed inside releases.
# More info: https://github.com/nigels-com/glew/issues/31 and https://github.com/nigels-com/glew/issues/13
```

... so I think the solution proposed by this PR using a patch is the best solution for now.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
