### PR TITLE
[zpp_bits] update to 4.5

### DIFF
--- a/ports/zpp-bits/portfile.cmake
+++ b/ports/zpp-bits/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eyalz800/zpp_bits
     REF "v${VERSION}"
-    SHA512 55757e4a02b680b8eae9e72073bd5612ba7e167bb82c40e89a3e27e3be520b1cd6db11dbb89bfaa4b046ba5b0dab11e02f481cbf93faebc96afc34ab49cd737a
+    SHA512 db3e036a1452b551155ee204ce7e3e6b6a7ab7116142fe434004cdb8d4c910afc9aaed4c3d1d4c831e0c4183a5d9a989d3e538b496d4ef68d1a15684f347c645
     HEAD_REF master
 )
 

--- a/ports/zpp-bits/vcpkg.json
+++ b/ports/zpp-bits/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zpp-bits",
-  "version": "4.4.17",
+  "version": "4.5",
   "description": "A lightweight C++20 serialization and RPC library",
   "homepage": "https://github.com/eyalz800/zpp_bits",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10197,7 +10197,7 @@
       "port-version": 4
     },
     "zpp-bits": {
-      "baseline": "4.4.17",
+      "baseline": "4.5",
       "port-version": 0
     },
     "zserge-webview": {

--- a/versions/z-/zpp-bits.json
+++ b/versions/z-/zpp-bits.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "24290e718eb0a3da5119029ece494a689be4a822",
+      "version": "4.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "2068c0855edbc51965c9001fb5af8d45e5115f26",
       "version": "4.4.17",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/eyalz800/zpp_bits/releases/tag/v4.5
