### PR TITLE
[smf] Update to 0.2.0

### DIFF
--- a/ports/smf/portfile.cmake
+++ b/ports/smf/portfile.cmake
@@ -1,14 +1,15 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vpetrigo/smf
-    REF v0.1.1
-    SHA512 56e06ebcaa84beae2c65ab508b0b331a8c473600e91fcb797b413b774da0bbc7e2e44b93af810d739158a6ccf157f6ca32ba52efc8e47c366f94dec892623aa3
+    REF "v${VERSION}"
+    SHA512 177eca0cfe3120e5dabe70695c78f9035255e7f07f9722783b269a2531573d6a3357c5a807800b7b61448e6aa7cbdd996980662b71cd23711b78cc2ce892f64d
     HEAD_REF main
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         hierarchical    SMF_ANCESTOR_SUPPORT
+        init-transition SMF_INITIAL_TRANSITION
 )
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/smf/vcpkg.json
+++ b/ports/smf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "smf",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "State machine framework",
   "homepage": "https://github.com/vpetrigo/smf",
   "license": "Apache-2.0",
@@ -17,6 +17,17 @@
   "features": {
     "hierarchical": {
       "description": "Enable hierarchical state machine support"
+    },
+    "init-transition": {
+      "description": "Enable state machine initial transition feature",
+      "dependencies": [
+        {
+          "name": "smf",
+          "features": [
+            "hierarchical"
+          ]
+        }
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8553,7 +8553,7 @@
       "port-version": 0
     },
     "smf": {
-      "baseline": "0.1.1",
+      "baseline": "0.2.0",
       "port-version": 0
     },
     "smpeg2": {

--- a/versions/s-/smf.json
+++ b/versions/s-/smf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "769a567db662e44f8f4b825c8413973a2473222c",
+      "version": "0.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a3c982437f774a6d7d18552556c00d8cfb0f3a2c",
       "version": "0.1.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
