### PR TITLE
[x264] Put x264-164.dll into bin directory

### DIFF
--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -89,9 +89,11 @@ vcpkg_make_configure(
     OPTIONS_RELEASE
         ${OPTIONS_RELEASE}
         --enable-strip
+        "--bindir=\\\${prefix}/bin"
     OPTIONS_DEBUG
         --enable-debug
         --disable-cli
+        "--bindir=\\\${prefix}/bin"
 )
 
 vcpkg_make_install()

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "x264",
   "version": "0.164.3108",
-  "port-version": 1,
+  "port-version": 2,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://www.videolan.org/developers/x264.html",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9938,7 +9938,7 @@
     },
     "x264": {
       "baseline": "0.164.3108",
-      "port-version": 1
+      "port-version": 2
     },
     "x265": {
       "baseline": "4.1",

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9367314b9b01285a64c3c6b5e9f895d0ad0f0e48",
+      "version": "0.164.3108",
+      "port-version": 2
+    },
+    {
       "git-tree": "0b3254a0abf3a2a2748b7353594b401893f74da9",
       "version": "0.164.3108",
       "port-version": 1


### PR DESCRIPTION
Fixes #42955
Fixes #43802


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
