### PR TITLE
[tdscpp] update to 20250301

### DIFF
--- a/ports/tdscpp/portfile.cmake
+++ b/ports/tdscpp/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO maharmstone/tdscpp
     REF "${VERSION}"
     HEAD_REF master
-    SHA512 62cab90e17394a5f1c4058bc3a606c1f9542fbad4a749032964ae76dfbcf903f7ff1b20a459c2b3d784c4abb31b5abe7e582b30eaebd83ac9887629221f4a694
+    SHA512 6f7f36918e1047355dc948a803b786df2aacc006654d0604e7af627c8c7d28a5e2fdbd52b306811e0da5ccca044ce231606d9208a04d5358aac62b9e1f9b3139
 )
 
 set(BUILD_tdscpp_ssl OFF)

--- a/ports/tdscpp/vcpkg.json
+++ b/ports/tdscpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tdscpp",
-  "version": "20240707",
+  "version": "20250301",
   "description": "C++ library to communicate with Microsoft SQL Server",
   "homepage": "https://github.com/maharmstone/tdscpp",
   "license": "LGPL-3.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9029,7 +9029,7 @@
       "port-version": 0
     },
     "tdscpp": {
-      "baseline": "20240707",
+      "baseline": "20250301",
       "port-version": 0
     },
     "telnetpp": {

--- a/versions/t-/tdscpp.json
+++ b/versions/t-/tdscpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1b83955c8bafee7455b461edc46a636d519a6bb8",
+      "version": "20250301",
+      "port-version": 0
+    },
+    {
       "git-tree": "61cd67b08b11985301ae613aa5cde3132dfa56fb",
       "version": "20240707",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.