### PR TITLE
[nghttp2] update to 1.65.0

### DIFF
--- a/ports/nghttp2/portfile.cmake
+++ b/ports/nghttp2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nghttp2/nghttp2
     REF "v${VERSION}"
-    SHA512 35f8230a0fa2825f0bc400d4852d8e8b484f659c67b00639ccd074a0029088f016e967db2f62b6b64af1f8ef684f5809a833e7f922e38b9405f7cc7756bcfb75
+    SHA512 caadc645eea3769eecf5ed7efc72041fa069db4d8906861e2770965b3b5d5fc595a6160b2608d10f957efa89c1c31a55e3ef7fe8618a5a1973b0cc45a3f1dcef
     HEAD_REF master
 )
 
@@ -28,6 +28,7 @@ vcpkg_cmake_configure(
         -DCMAKE_DISABLE_FIND_PACKAGE_LibXml2=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Jemalloc=ON
     MAYBE_UNUSED_VARIABLES
+        CMAKE_DISABLE_FIND_PACKAGE_Libngtcp2_crypto_quictls
         ENABLE_STATIC_CRT
 )
 vcpkg_cmake_install()

--- a/ports/nghttp2/vcpkg.json
+++ b/ports/nghttp2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nghttp2",
-  "version": "1.64.0",
+  "version": "1.65.0",
   "description": "Implementation of the Hypertext Transfer Protocol version 2 in C",
   "homepage": "https://github.com/nghttp2/nghttp2",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6409,7 +6409,7 @@
       "port-version": 4
     },
     "nghttp2": {
-      "baseline": "1.64.0",
+      "baseline": "1.65.0",
       "port-version": 0
     },
     "nghttp2-asio": {

--- a/versions/n-/nghttp2.json
+++ b/versions/n-/nghttp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c6c0f58fa40de3a567e40bcf361c6d448d5f7fb",
+      "version": "1.65.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "773b09ca4f753ae883a290619f54897c8e0ce38a",
       "version": "1.64.0",
       "port-version": 0


### PR DESCRIPTION
remove cmake with ngtcp2 quictls flags


