### PR TITLE
[directxmath] upstream patch applied to resolve build issues with Xbox

### DIFF
--- a/ports/directxmath/cmake-xbox.patch
+++ b/ports/directxmath/cmake-xbox.patch
@@ -1,12 +1,3 @@
-From 16453a55b4e894435de82ca0a1d4a89c570aff18 Mon Sep 17 00:00:00 2001
-From: Chuck Walbourn <chuckw@microsoft.com>
-Date: Sun, 2 Mar 2025 11:34:45 -0800
-Subject: [PATCH] CMake update for Xbox scenarios
-
----
- CMakeLists.txt | 4 ++++
- 1 file changed, 4 insertions(+)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 7041f14..baa06bd 100644
 --- a/CMakeLists.txt

--- a/ports/directxmath/cmake-xbox.patch
+++ b/ports/directxmath/cmake-xbox.patch
@@ -1,0 +1,27 @@
+From 16453a55b4e894435de82ca0a1d4a89c570aff18 Mon Sep 17 00:00:00 2001
+From: Chuck Walbourn <chuckw@microsoft.com>
+Date: Sun, 2 Mar 2025 11:34:45 -0800
+Subject: [PATCH] CMake update for Xbox scenarios
+
+---
+ CMakeLists.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7041f14..baa06bd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,6 +5,10 @@ cmake_minimum_required (VERSION 3.20)
+ 
+ set(DIRECTXMATH_VERSION 3.20)
+ 
++if(WINDOWS_STORE OR (DEFINED XBOX_CONSOLE_TARGET))
++  set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
++endif()
++
+ project(DirectXMath
+   VERSION ${DIRECTXMATH_VERSION}
+   DESCRIPTION "DirectXMath SIMD C++ math library"
+-- 
+2.48.1.windows.1
+

--- a/ports/directxmath/include-path-fix.patch
+++ b/ports/directxmath/include-path-fix.patch
@@ -1,12 +1,3 @@
-From 994441ebfa63fe1440bf430c99b5ba3eaba02c66 Mon Sep 17 00:00:00 2001
-From: Chuck Walbourn <chuckw@microsoft.com>
-Date: Tue, 26 Nov 2024 17:44:02 -0800
-Subject: [PATCH] CMake update to avoid directxmath subdir for include
-
----
- CMakeLists.txt | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index d10adc1..7041f14 100644
 --- a/CMakeLists.txt

--- a/ports/directxmath/portfile.cmake
+++ b/ports/directxmath/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF oct2024
     SHA512 501a3c8b51cd6d3d4fbcc511c2c37f1d0511bd84d546d5254c2bc81238c11242b9d62c7a153ee110dc9d96a0c7d2544428d8de832c943b680b0cb09d8e3760f2
     HEAD_REF main
-    PATCHES include-path-fix.patch cmake-xbox.patch
+    PATCHES
+        include-path-fix.patch
+        cmake-xbox.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/directxmath/portfile.cmake
+++ b/ports/directxmath/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     REF oct2024
     SHA512 501a3c8b51cd6d3d4fbcc511c2c37f1d0511bd84d546d5254c2bc81238c11242b9d62c7a153ee110dc9d96a0c7d2544428d8de832c943b680b0cb09d8e3760f2
     HEAD_REF main
-    PATCHES include-path-fix.patch
+    PATCHES include-path-fix.patch cmake-xbox.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/directxmath/vcpkg.json
+++ b/ports/directxmath/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "directxmath",
   "version-date": "2024-12-02",
-  "port-version": 1,
+  "port-version": 2,
   "description": "DirectXMath SIMD C++ math library",
   "homepage": "https://github.com/Microsoft/DirectXMath",
   "documentation": "https://docs.microsoft.com/windows/win32/dxmath/directxmath-portal",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2310,7 +2310,7 @@
     },
     "directxmath": {
       "baseline": "2024-12-02",
-      "port-version": 1
+      "port-version": 2
     },
     "directxmesh": {
       "baseline": "2024-10-28",

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1288e86c5eda5f30d11d9f99a93c5b59a983d3b6",
+      "git-tree": "fab4da3540c445785e099b46edcc85e96579869a",
       "version-date": "2024-12-02",
       "port-version": 2
     },

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1288e86c5eda5f30d11d9f99a93c5b59a983d3b6",
+      "version-date": "2024-12-02",
+      "port-version": 2
+    },
+    {
       "git-tree": "c93ddde0a2ee30591dc28b758308ddb4bef60156",
       "version-date": "2024-12-02",
       "port-version": 1

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fab4da3540c445785e099b46edcc85e96579869a",
+      "git-tree": "b55481f4a716fd6b095b6611d0264825d0f04624",
       "version-date": "2024-12-02",
       "port-version": 2
     },


### PR DESCRIPTION
In some build scenarios, the try-compile for an EXE or DLL will fail but this library is header-only. I updated the CMake upstream to only validate 'static library' scenarios with try-compile.