### PR TITLE
[double-conversion] Upgrade CMake 3.5

### DIFF
--- a/ports/double-conversion/portfile.cmake
+++ b/ports/double-conversion/portfile.cmake
@@ -1,9 +1,17 @@
+vcpkg_download_distfile(PATCH_501_FIX_CMAKE_3_5
+    URLS https://github.com/google/double-conversion/commit/101e1ba89dc41ceb75090831da97c43a76cd2906.patch?full_index=1
+    SHA512 a946a1909b10f3ac5262cbe5cd358a74cf018325223403749aaeb81570ef3e2f833ee806afdefcd388e56374629de8ccca0a1cef787afa481c79f9e8f8dcaa13
+    FILENAME google-double-conversion-101e1ba89dc41ceb75090831da97c43a76cd2906.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/double-conversion
     REF "v${VERSION}"
     SHA512 51e84eb7a5c407f7bc8f8b8ca19932ece5c9d8ac18aedff7b7620fc67369d9b2aa8c5a6b133e7f8633d7cc5e3788bad6e60b0e48ac08d0a4bc5e4abe7cee1334
     HEAD_REF master
+    PATCHES
+        "${PATCH_501_FIX_CMAKE_3_5}"
 )
 
 vcpkg_cmake_configure(
@@ -21,5 +29,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Handle copyright
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/double-conversion/vcpkg.json
+++ b/ports/double-conversion/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "double-conversion",
   "version": "3.3.0",
+  "port-version": 1,
   "description": "Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles.",
   "homepage": "https://github.com/google/double-conversion",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2386,7 +2386,7 @@
     },
     "double-conversion": {
       "baseline": "3.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "dp-thread-pool": {
       "baseline": "0.7.0",

--- a/versions/d-/double-conversion.json
+++ b/versions/d-/double-conversion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aab0be9dfa5d0fe2452be21cfd4c7997e437c05b",
+      "version": "3.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "63037e8b38231f15de1dddb0593eebfb0bf32496",
       "version": "3.3.0",
       "port-version": 0


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/43973

Failed due to https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features

> Compatibility with versions of CMake older than 3.5 has been removed.

Backport https://github.com/google/double-conversion/commit/101e1ba89dc41ceb75090831da97c43a76cd2906, upgrading min version to 3.5.

### Checklist

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux (CMake 4.0.0-rc2)