### PR TITLE
[restinio] Update to 0.7.4

### DIFF
--- a/ports/restinio/portfile.cmake
+++ b/ports/restinio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stiffstream/restinio
     REF "v.${VERSION}"
-    SHA512 942bb2b4b7591ae3b336742142bf1df3dc43ae3bfa84e26991bd922670997fe7099438a40607353a733e0a4ba38a33da7bf1ad8e382a284c04ada09a2f149fd8
+    SHA512 457e9eaeb310f731ef360432df6952c3b5a93ae82fef8cc4be62efa02d0cb75e2dda389ab131ad8fe1706ea097c0436f1ecc36feeffb1ed3b77c1a0afb629df7
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only

--- a/ports/restinio/vcpkg.json
+++ b/ports/restinio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "restinio",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A header-only C++14 library that gives you an embedded HTTP/Websocket server targeted primarily for asynchronous processing of HTTP-requests.",
   "homepage": "https://github.com/Stiffstream/restinio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8033,7 +8033,7 @@
       "port-version": 0
     },
     "restinio": {
-      "baseline": "0.7.3",
+      "baseline": "0.7.4",
       "port-version": 0
     },
     "rexo": {

--- a/versions/r-/restinio.json
+++ b/versions/r-/restinio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a2668700fc2f808efaf0b3d9f41b2912bcc37bf9",
+      "version": "0.7.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "3a0ac8e6d33ac8c8d4a79cc2ad31cd5748dcb76e",
       "version": "0.7.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- ~~[ ] The "supports" clause reflects platforms that may be fixed by this new version~~.
- ~~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file~~.
- ~~[ ] Any patches that are no longer applied are deleted from the port's directory~~.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
