### PR TITLE
[openvdb] Add NanoVDB tools feature

### DIFF
--- a/ports/openvdb/portfile.cmake
+++ b/ports/openvdb/portfile.cmake
@@ -21,11 +21,11 @@ vcpkg_check_features(
         "tools" OPENVDB_BUILD_TOOLS
         "ax"    OPENVDB_BUILD_AX
         "nanovdb" OPENVDB_BUILD_NANOVDB
+        "nanovdb-tools" NANOVDB_BUILD_TOOLS
 )
 
 if (OPENVDB_BUILD_NANOVDB)
     set(NANOVDB_OPTIONS
-    -DNANOVDB_BUILD_TOOLS=OFF
     -DNANOVDB_USE_INTRINSICS=ON
     -DNANOVDB_USE_CUDA=ON
     -DNANOVDB_CUDA_KEEP_PTX=ON
@@ -66,6 +66,10 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_
 
 if (OPENVDB_BUILD_TOOLS)
     vcpkg_copy_tools(TOOL_NAMES vdb_print vdb_render vdb_view vdb_lod AUTO_CLEAN)
+endif()
+
+if (NANOVDB_BUILD_TOOLS)
+    vcpkg_copy_tools(TOOL_NAMES nanovdb_convert nanovdb_print nanovdb_validate AUTO_CLEAN)
 endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)

--- a/ports/openvdb/vcpkg.json
+++ b/ports/openvdb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openvdb",
   "version": "12.0.0",
+  "port-version": 1,
   "description": "Sparse volume data structure and tools",
   "homepage": "https://github.com/dreamworksanimation/openvdb",
   "license": "MPL-2.0",
@@ -42,6 +43,17 @@
       "description": "A lightweight GPU friendly version of VDB initially targeting rendering applications",
       "dependencies": [
         "cuda"
+      ]
+    },
+    "nanovdb-tools": {
+      "description": "NanoVDB tools: print, validate, and convert.",
+      "dependencies": [
+        {
+          "name": "openvdb",
+          "features": [
+            "nanovdb"
+          ]
+        }
       ]
     },
     "tools": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6878,7 +6878,7 @@
     },
     "openvdb": {
       "baseline": "12.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openvino": {
       "baseline": "2025.0.0",

--- a/versions/o-/openvdb.json
+++ b/versions/o-/openvdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a440c407a2282daceb06a6d4cd539a8ba067872",
+      "version": "12.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bb88224f64822d690b692169cbcdb87ffdb9d597",
       "version": "12.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
