### PR TITLE
[libtommath] Use upstream bcrypt patch

### DIFF
--- a/ports/libtommath/bcrypt.patch
+++ b/ports/libtommath/bcrypt.patch
@@ -1,50 +1,67 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,8 +22,10 @@
+ #-----------------------------------------------------------------------------
+ include(GNUInstallDirs)
+ include(CheckIPOSupported)
+ include(CMakePackageConfigHelpers)
++include(CMakePushCheckState)
++include(CheckSymbolExists)
+ # default is "No tests"
+ option(BUILD_TESTING "" OFF)
+ include(CTest)
+ include(sources.cmake)
+@@ -118,8 +120,19 @@
+ target_link_options(${PROJECT_NAME} BEFORE PRIVATE
+     ${LTM_LD_FLAGS}
+ )
+ 
++if(MSVC)
++    cmake_push_check_state()
++    set(CMAKE_REQUIRED_LIBRARIES bcrypt)
++    check_symbol_exists(BCryptGenRandom "Windows.h;bcrypt.h" BCRYPT_AVAILABLE)
++    cmake_pop_check_state()
++    if(BCRYPT_AVAILABLE)
++        target_compile_definitions(${PROJECT_NAME} PRIVATE LTM_WIN32_BCRYPT)
++        target_link_libraries(${PROJECT_NAME} PRIVATE bcrypt)
++    endif()
++endif()
++
+ set(PUBLIC_HEADERS tommath.h)
+ set(C89 False CACHE BOOL "(Usually maintained automatically) Enable when the library is in c89 mode to package the correct header files on install")
+ if(C89)
+     list(APPEND PUBLIC_HEADERS tommath_c89.h)
 diff --git a/bn_s_mp_rand_platform.c b/bn_s_mp_rand_platform.c
 --- a/bn_s_mp_rand_platform.c
 +++ b/bn_s_mp_rand_platform.c
-@@ -32,20 +32,20 @@
+@@ -28,8 +28,19 @@
+ #endif
+ 
+ #define WIN32_LEAN_AND_MEAN
+ #include <windows.h>
++
++#ifdef LTM_WIN32_BCRYPT
++#include <bcrypt.h>
++#pragma comment(lib, "bcrypt")
++
++static mp_err s_read_wincsp(void *p, size_t n)
++{
++   return BCRYPT_SUCCESS(BCryptGenRandom(NULL, (PUCHAR)p, (ULONG)n,
++                                         BCRYPT_USE_SYSTEM_PREFERRED_RNG)) ? MP_OKAY : MP_ERR;
++}
++#else
  #include <wincrypt.h>
  
  static mp_err s_read_wincsp(void *p, size_t n)
  {
--   static HCRYPTPROV hProv = 0;
--   if (hProv == 0) {
--      HCRYPTPROV h = 0;
--      if (!CryptAcquireContext(&h, NULL, MS_DEF_PROV, PROV_RSA_FULL,
--                               (CRYPT_VERIFYCONTEXT | CRYPT_MACHINE_KEYSET)) &&
--          !CryptAcquireContext(&h, NULL, MS_DEF_PROV, PROV_RSA_FULL,
--                               CRYPT_VERIFYCONTEXT | CRYPT_MACHINE_KEYSET | CRYPT_NEWKEYSET)) {
-+   static BCRYPT_ALG_HANDLE hAlg = 0;
-+   if (hAlg == 0) {
-+      BCRYPT_ALG_HANDLE h = 0;
-+      NTSTATUS status = BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_RSA_ALGORITHM, NULL,
-+                                                    BCRYPT_HASH_REUSABLE_FLAG);
-+      if(!BCRYPT_SUCCESS(status)) {
-          return MP_ERR;
-       }
--      hProv = h;
-+      hAlg = h;
+@@ -45,8 +56,9 @@
+       hProv = h;
     }
--   return CryptGenRandom(hProv, (DWORD)n, (BYTE *)p) == TRUE ? MP_OKAY : MP_ERR;
-+   NTSTATUS status = BCryptGenRandom(hAlg, (PUCHAR)p, (ULONG)n, 0);
-+   return BCRYPT_SUCCESS(status) ? MP_OKAY : MP_ERR;
+    return CryptGenRandom(hProv, (DWORD)n, (BYTE *)p) == TRUE ? MP_OKAY : MP_ERR;
  }
++#endif
  #endif /* WIN32 */
  
  #if !defined(BN_S_READ_WINCSP_C) && defined(__linux__) && defined(__GLIBC_PREREQ)
-diff --git a/CMakeLists.txt b/CMakeLists.txt
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -117,8 +117,13 @@
- )
- target_link_options(${PROJECT_NAME} BEFORE PRIVATE
-     ${LTM_LD_FLAGS}
- )
-+if(WIN32)
-+    target_link_options(${PROJECT_NAME} PRIVATE
-+        bcrypt.lib
-+    )
-+endif()
- 
- set(PUBLIC_HEADERS tommath.h)
- set(C89 False CACHE BOOL "(Usually maintained automatically) Enable when the library is in c89 mode to package the correct header files on install")
- if(C89)
+ #if __GLIBC_PREREQ(2, 25)

--- a/ports/libtommath/vcpkg.json
+++ b/ports/libtommath/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtommath",
   "version": "1.3.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "LibTomMath is a free open source portable number theoretic multiple-precision integer library written entirely in C.",
   "homepage": "https://www.libtom.net/LibTomMath/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5266,7 +5266,7 @@
     },
     "libtommath": {
       "baseline": "1.3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libtorch": {
       "baseline": "2.1.2",

--- a/versions/l-/libtommath.json
+++ b/versions/l-/libtommath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22eed88d2b6d6ed3b4534de9bf87900e67050394",
+      "version": "1.3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "11ad9c01ff8b7c69858db06f1ed1a52dc9bbc2f7",
       "version": "1.3.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Ref: https://github.com/libtom/libtommath/issues/588