### PR TITLE
[afx] add new port afx

### DIFF
--- a/ports/afx/portfile.cmake
+++ b/ports/afx/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_check_linkage(ONLY_DYAMIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO EnzoMassyle/AudioFX
+    REF "${VERSION}"
+    SHA512  9f1c4492c5612b03b48a17c92d26f20b311e2bfb98921e07cc3e0d045ac79ae82750152db493be40c39e09c45b0399c080529a183bd386d886109ef648c4a175
+    HEAD_REF main
+)
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "AFX")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/afx/usage
+++ b/ports/afx/usage
@@ -1,0 +1,4 @@
+afx library provides CMake targets:
+
+find_package(AFX CONFIG REQUIRED)
+target_link_libraries(main PRIVATE AFX::AFX)

--- a/ports/afx/vcpkg.json
+++ b/ports/afx/vcpkg.json
@@ -1,26 +1,24 @@
 {
-    "name": "afx",
-    "version": "1.0.6",
-    "description" : "An easy to use audio processing library",
-    "homepage": "https://github.com/EnzoMassyle/AudioFX",
-    "license" : "MIT",
-    "dependencies":
-    [
+  "name": "afx",
+  "version": "1.0.6",
+  "description": "An easy to use audio processing library",
+  "homepage": "https://github.com/EnzoMassyle/AudioFX",
+  "license": "MIT",
+  "dependencies": [
     {
-        "name" : "vcpkg-cmake",
-        "host" : true
-    },
-    {
-        "name" : "vcpkg-cmake-config",
-        "host" : true
-    },
-    {
-    "name": "fftw3",
-    "features": [
+      "name": "fftw3",
+      "features": [
         "threads"
-    ]
+      ]
     },
-    "libsndfile"
-    ]
-  }
-  
+    "libsndfile",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/afx/vcpkg.json
+++ b/ports/afx/vcpkg.json
@@ -1,0 +1,26 @@
+{
+    "name": "afx",
+    "version": "1.0.6",
+    "description" : "An easy to use audio processing library",
+    "homepage": "https://github.com/EnzoMassyle/AudioFX",
+    "license" : "MIT",
+    "dependencies":
+    [
+    {
+        "name" : "vcpkg-cmake",
+        "host" : true
+    },
+    {
+        "name" : "vcpkg-cmake-config",
+        "host" : true
+    },
+    {
+    "name": "fftw3",
+    "features": [
+        "threads"
+    ]
+    },
+    "libsndfile"
+    ]
+  }
+  

--- a/versions/a-/afx.json
+++ b/versions/a-/afx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5e16080186b6be0a4b9d053cb38637a8400fbe35",
+      "git-tree": "dc096af9aceb3c5b52792ee5fe615d6481bef5d9",
       "version": "1.0.6",
       "port-version": 0
     }

--- a/versions/a-/afx.json
+++ b/versions/a-/afx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5e16080186b6be0a4b9d053cb38637a8400fbe35",
+      "version": "1.0.6",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -52,6 +52,10 @@
       "baseline": "2020-06-26",
       "port-version": 0
     },
+    "afx": {
+      "baseline": "1.0.6",
+      "port-version": 0
+    },
     "air-ctl": {
       "baseline": "1.1.2",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

[x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
[x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
[x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
[x] The versioning scheme in `vcpkg.json` matches what upstream says.
[x] The license declaration in `vcpkg.json` matches what upstream says.
[x] The installed as the "copyright" file matches what upstream says.
[x] The source code of the component installed comes from an authoritative source.
[x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
[x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
[x] Only one version is in the new port's versions file.
[x] Only one version is added to each modified port's versions file.

