### PR TITLE
[bitserializer] bring this port back

### DIFF
--- a/ports/bitserializer/portfile.cmake
+++ b/ports/bitserializer/portfile.cmake
@@ -1,0 +1,41 @@
+# All components of BitSerializer is "header only" except CSV archive
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO PavelKisliak/BitSerializer
+    REF v0.75
+    SHA512 ae31f17a0b4e488892f676eafe94e2d43a381153b9179891a9d3a6380c7b3f12d29bc20b7be270a71305bc7c27b08395f6aa8a8be26c52934e148e7140d34d21
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "cpprestjson-archive"  BUILD_CPPRESTJSON_ARCHIVE
+        "rapidjson-archive"    BUILD_RAPIDJSON_ARCHIVE
+        "pugixml-archive"      BUILD_PUGIXML_ARCHIVE
+        "rapidyaml-archive"    BUILD_RAPIDYAML_ARCHIVE
+        "csv-archive"          BUILD_CSV_ARCHIVE
+        "msgpack-archive"      BUILD_MSGPACK_ARCHIVE
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+if (NOT (${BUILD_CSV_ARCHIVE} OR ${BUILD_MSGPACK_ARCHIVE}))
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+endif()
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/license.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/bitserializer/usage
+++ b/ports/bitserializer/usage
@@ -1,0 +1,12 @@
+BitSerializer provides CMake targets:
+
+    find_package(bitserializer CONFIG REQUIRED)
+    # Link only archives which you are specified in the features list when install
+    target_link_libraries(main PRIVATE
+        BitSerializer::cpprestjson-archive
+        BitSerializer::rapidjson-archive
+        BitSerializer::pugixml-archive
+        BitSerializer::rapidyaml-archive
+        BitSerializer::csv-archive
+        BitSerializer::msgpack-archive
+    )

--- a/ports/bitserializer/vcpkg.json
+++ b/ports/bitserializer/vcpkg.json
@@ -1,0 +1,49 @@
+{
+  "name": "bitserializer",
+  "version": "0.75",
+  "description": "C++ 17 library for serialization to JSON, XML, YAML, CSV, MsgPack",
+  "homepage": "https://github.com/PavelKisliak/BitSerializer",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cpprestjson-archive": {
+      "description": "Module for support JSON (implementation based on the CppRestSDK library)",
+      "dependencies": [
+        "cpprestsdk"
+      ]
+    },
+    "csv-archive": {
+      "description": "Module for support CSV"
+    },
+    "msgpack-archive": {
+      "description": "Module for support MsgPack"
+    },
+    "pugixml-archive": {
+      "description": "Module for support XML (implementation based on the PugiXml library)",
+      "dependencies": [
+        "pugixml"
+      ]
+    },
+    "rapidjson-archive": {
+      "description": "Module for support JSON (implementation based on the RapidJson library)",
+      "dependencies": [
+        "rapidjson"
+      ]
+    },
+    "rapidyaml-archive": {
+      "description": "Module for support YAML (implementation based on the RapidYaml library)",
+      "dependencies": [
+        "ryml"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

as @PavelKisliak said in https://github.com/microsoft/vcpkg/pull/42678#issuecomment-2695449458