### PR TITLE
[tgui] update to 1.8.0,add sdl3 and raylib support

### DIFF
--- a/ports/tgui/portfile.cmake
+++ b/ports/tgui/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO texus/TGUI
     REF "v${VERSION}"
-    SHA512 24aa59b5eb225987247384dfdfc8bdce1d755cc7daeda6fdff9046eea77a0f2e686d5b03d24cbbd20e7d6d90ae809eae90467a2b1d923de1e2ecf668e28bcff4
+    SHA512 54d46e3604ebe3f3f2ff845da9348152e780a2e67eddc9d6476f5b66b24a3930ced34ac097f4006c9475d7d963d87076dd4ee4cc47aad23b501f14663be5745e
     HEAD_REF 1.x
     PATCHES
         devendor-stb.patch
@@ -31,6 +31,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     sdl2    TGUI_HAS_BACKEND_SDL_RENDERER
     sfml    TGUI_HAS_BACKEND_SFML_GRAPHICS
     tool    TGUI_BUILD_GUI_BUILDER
+    sdl3    TGUI_USE_SDL3
+    raylib  TGUI_HAS_BACKEND_RAYLIB
 )
 
 vcpkg_cmake_configure(

--- a/ports/tgui/vcpkg.json
+++ b/ports/tgui/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tgui",
-  "version": "1.7.0",
-  "port-version": 1,
+  "version": "1.8.0",
   "description": "TGUI is an easy to use, cross-platform, C++ GUI for SFML.",
   "homepage": "https://tgui.eu",
   "license": "Zlib",
@@ -20,6 +19,12 @@
     "sfml"
   ],
   "features": {
+    "raylib": {
+      "description": "Build the RAYLIB backend",
+      "dependencies": [
+        "raylib"
+      ]
+    },
     "sdl2": {
       "description": "Build the SDL backend",
       "dependencies": [
@@ -29,6 +34,17 @@
         },
         "sdl2",
         "sdl2-ttf"
+      ]
+    },
+    "sdl3": {
+      "description": "Build the SDL3 backend",
+      "dependencies": [
+        {
+          "name": "opengl",
+          "platform": "!android & !ios"
+        },
+        "sdl3",
+        "sdl3-ttf"
       ]
     },
     "sfml": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9081,8 +9081,8 @@
       "port-version": 4
     },
     "tgui": {
-      "baseline": "1.7.0",
-      "port-version": 1
+      "baseline": "1.8.0",
+      "port-version": 0
     },
     "think-cell-range": {
       "baseline": "2023.1",

--- a/versions/t-/tgui.json
+++ b/versions/t-/tgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5cfc9daf9c0f559a1cf3e3e73dd3d0e67c12cd50",
+      "version": "1.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4070d373b00a30726b8662f57c7bd18eb0dac500",
       "version": "1.7.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/44141.
Update to `1.8.0`.
Add `sdl3` and `raylib` support.

All feature tested pass on the following triplets:

- x64-windows
- x64-windows-static
- x86-windows

Usage tested pass on `x64-windows`.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
