### PR TITLE
[libogg] Upgrade CMake 3.5

### DIFF
--- a/ports/libogg/portfile.cmake
+++ b/ports/libogg/portfile.cmake
@@ -14,7 +14,7 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 #https://gitlab.xiph.org/xiph/ogg/-/issues/2304
         -DINSTALL_DOCS=OFF
         -DINSTALL_PKG_CONFIG_MODULE=ON
         -DBUILD_TESTING=OFF

--- a/ports/libogg/portfile.cmake
+++ b/ports/libogg/portfile.cmake
@@ -14,9 +14,12 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         -DINSTALL_DOCS=OFF
         -DINSTALL_PKG_CONFIG_MODULE=ON
         -DBUILD_TESTING=OFF
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_POLICY_VERSION_MINIMUM
 )
 
 vcpkg_cmake_install()

--- a/ports/libogg/vcpkg.json
+++ b/ports/libogg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libogg",
   "version": "1.3.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Ogg is a multimedia container format, and the native file and stream format for the Xiph.org multimedia codecs.",
   "homepage": "https://www.xiph.org/ogg",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4942,7 +4942,7 @@
     },
     "libogg": {
       "baseline": "1.3.5",
-      "port-version": 1
+      "port-version": 2
     },
     "libopenmpt": {
       "baseline": "0.7.13",

--- a/versions/l-/libogg.json
+++ b/versions/l-/libogg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "455877c88aeb81bcdba4c915abfe15096ff3430e",
+      "version": "1.3.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "98e27727c32704393494d32615c25b7b16eb3067",
       "version": "1.3.5",
       "port-version": 1

--- a/versions/l-/libogg.json
+++ b/versions/l-/libogg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "455877c88aeb81bcdba4c915abfe15096ff3430e",
+      "git-tree": "7de72b080f4e8596980840f33de0a62394d99e6b",
       "version": "1.3.5",
       "port-version": 2
     },


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/44135

Failed due to https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features

> Compatibility with versions of CMake older than 3.5 has been removed.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
