### PR TITLE
[DO-NOT-MERGE] [vcpkg-tool-legacy-cmake-3] Try CMake 3 runtime

### DIFF
--- a/ports/double-conversion/portfile.cmake
+++ b/ports/double-conversion/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+x_vcpkg_get_legacy_cmake_3(SET_CMAKE_COMMAND)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )

--- a/ports/double-conversion/vcpkg.json
+++ b/ports/double-conversion/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "double-conversion",
   "version": "3.3.0",
+  "port-version": 1,
   "description": "Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles.",
   "homepage": "https://github.com/google/double-conversion",
   "dependencies": [
@@ -10,6 +11,10 @@
     },
     {
       "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-legacy-cmake-3",
       "host": true
     }
   ]

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -52,6 +52,8 @@ if(VCPKG_TARGET_IS_EMSCRIPTEN)
     )
 endif()
 
+x_vcpkg_get_legacy_cmake_3(SET_CMAKE_COMMAND)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openblas",
   "version": "0.3.28",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/OpenMathLib/OpenBLAS",
   "license": "BSD-3-Clause",
@@ -16,6 +16,10 @@
     },
     {
       "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-legacy-cmake-3",
       "host": true
     }
   ],

--- a/ports/vcpkg-tool-legacy-cmake-3/portfile.cmake
+++ b/ports/vcpkg-tool-legacy-cmake-3/portfile.cmake
@@ -1,0 +1,14 @@
+set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
+
+file(INSTALL
+    "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+vcpkg_download_distfile(ARCHIVE_PATH
+    URLS "https://gitlab.kitware.com/cmake/cmake/-/raw/v${VERSION}/Copyright.txt?ref_type=tags&inline=false"
+    SHA512 20133e162759f39a7a614bd9278b616aa9af75673b1dc12a84156252b71be217acda98506d6e32f43f24438f8a1e9dd80d47e916a8ff2afd82ff99db68e978dc
+    FILENAME "${PORT}-${VERSION}-Copyright.txt"
+)
+
+vcpkg_install_copyright(FILE_LIST "${ARCHIVE_PATH}")

--- a/ports/vcpkg-tool-legacy-cmake-3/vcpkg-port-config.cmake
+++ b/ports/vcpkg-tool-legacy-cmake-3/vcpkg-port-config.cmake
@@ -1,0 +1,80 @@
+include_guard(GLOBAL)
+
+function(x_vcpkg_get_legacy_cmake_3)
+    cmake_parse_arguments(PARSE_ARGV 0 param "SET_CMAKE_COMMAND;PREPEND_ENV_PATH" "OUT_VAR_COMMAND;OUT_VAR_PATH" "")
+    if(DEFINED param_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unexpected arguments: `${param_UNPARSED_ARGUMENTS}`")
+    endif()
+
+    set(_download_version "3.30.1")
+    set(_download_endpoint "https://github.com/Kitware/CMake/releases/download/v${_download_version}")
+    set(_basename "")
+    set(_sha512 "")
+
+    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE MATCHES "x86|x64")
+        set(_basename "cmake-${_download_version}-windows-i386")
+        set(_extension ".zip")
+        set(_sha512 0b74bd4222064cfb6e42838987704eb21d57ad5f7bbd87714ab570f1d107fa19bd2f14316475338518292bc377bf38b581a07c73267a775cd385bbd1800879b4)
+    elseif(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        set(_basename "cmake-${_download_version}-windows-arm64")
+        set(_extension ".zip")
+        set(_sha512 40bcdeff5ff40044629f49e0effc958a719353330ea39876b919fb7c2d441885c884acf43e644ab5dedcb95503d211c895da1c0b6360e71449bea6a981f8e128)
+    elseif(VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64|arm64")
+        set(_basename "cmake-${_download_version}-macos-universal")
+        set(_extension ".tar.gz")
+        set(_sha512 71290d3b5e51724711e8784f5b21100cb0cffdbb889da7572a26dd171d9052601496de8d39c42d76ef3a9245af2ab35a590bf53ad68d7bb8a2047b64272d2647)
+    elseif(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        set(_basename "cmake-${_download_version}-linux-x86_64")
+        set(_extension ".tar.gz")
+        set(_sha512 84ce1333ed696a1736986fba2853c5d8db0e4c9addaf4a4723911248c6d49ecf545adf8bd46091d198fc7bd1e6c896798661463aa1ce3a726a093883aaa19adf)
+    elseif(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        set(_basename "cmake-${_download_version}-linux-aarch64")
+        set(_extension ".tar.gz")
+        set(_sha512 ec6c1c682dda2381aa5ebef98a2597e4ab6b4563639c28b2f30c20360694b902a7b33c175c796169a9f99ed139f053916042caed58d83298680894c2840dbb87)
+    else()
+        message(FATAL_ERROR "Target not yet supported by '${PORT}'")
+    endif()
+    set(_url "${_download_endpoint}/${_basename}${_extension}")
+    message(DEBUG "URL: '${_url}'")
+    message(DEBUG "SHA512: '${_sha512}'")
+
+    vcpkg_download_distfile(ARCHIVE_PATH
+        URLS "${_url}"
+        SHA512 "${_sha512}"
+        FILENAME "${_basename}${_extension}"
+    )
+
+    message(DEBUG "ARCHIVE_PATH: '${ARCHIVE_PATH}'")
+
+    if(EXISTS "${CURRENT_BUILDTREES_DIR}/x-legacy-cmake-3/${_basename}")
+        file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/x-legacy-cmake-3/${_basename}")
+    endif()
+
+    file(ARCHIVE_EXTRACT
+        INPUT "${ARCHIVE_PATH}"
+        DESTINATION "${CURRENT_BUILDTREES_DIR}/x-legacy-cmake-3"
+    )
+
+    set(_legacy_cmake_3_bin "${CURRENT_BUILDTREES_DIR}/x-legacy-cmake-3/${_basename}/bin")
+    set(_legacy_cmake_3_command "${_legacy_cmake_3_bin}/cmake${VCPKG_HOST_EXECUTABLE_SUFFIX}")
+    if(VCPKG_TARGET_IS_WINDOWS)
+        set(PATH_SEPERATOR ";")
+    else()
+        set(PATH_SEPERATOR ":")
+    endif()
+
+    message(WARNING "Using different CMake in buildtrees: `${_basename}`.")
+
+    if(param_SET_CMAKE_COMMAND)
+        set(CMAKE_COMMAND "${_legacy_cmake_3_command}" PARENT_SCOPE)
+    endif()
+    if(param_PREPEND_ENV_PATH)
+        set(ENV{PATH} "${_legacy_cmake_3_bin}${PATH_SEPERATOR}$ENV{PATH}" PARENT_SCOPE)
+    endif()
+    if(DEFINED param_OUT_VAR_COMMAND)
+        set("${param_OUT_VAR_COMMAND}" "${_legacy_cmake_3_command}" PARENT_SCOPE)
+    endif()
+    if(DEFINED param_OUT_VAR_PATH)
+        set("${param_OUT_VAR_PATH}" "${_legacy_cmake_3_bin}" PARENT_SCOPE)
+    endif()
+endfunction()

--- a/ports/vcpkg-tool-legacy-cmake-3/vcpkg.json
+++ b/ports/vcpkg-tool-legacy-cmake-3/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "vcpkg-tool-legacy-cmake-3",
+  "version-semver": "3.30.1",
+  "description": "https://cmake.org/",
+  "supports": "native"
+}

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -9,7 +9,7 @@ parameters:
   - name: tripletPattern
     displayName: 'Enable triplets which contain this substring'
     type: string
-    default: '-'
+    default: '^none$'
 
 jobs:
 - template: windows/azure-pipelines.yml

--- a/scripts/vcpkg-tools.json
+++ b/scripts/vcpkg-tools.json
@@ -23,50 +23,50 @@
       "name": "cmake",
       "os": "windows",
       "arch": "amd64",
-      "version": "3.30.1",
-      "executable": "cmake-3.30.1-windows-i386/bin/cmake.exe",
-      "url": "https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-windows-i386.zip",
-      "sha512": "0b74bd4222064cfb6e42838987704eb21d57ad5f7bbd87714ab570f1d107fa19bd2f14316475338518292bc377bf38b581a07c73267a775cd385bbd1800879b4",
-      "archive": "cmake-3.30.1-windows-i386.zip"
+      "version": "4.0.0-rc2",
+      "executable": "cmake-4.0.0-rc2-windows-i386/bin/cmake.exe",
+      "url": "https://github.com/Kitware/CMake/releases/download/v4.0.0-rc2/cmake-4.0.0-rc2-windows-i386.zip",
+      "sha512": "fc9c0fda93edc5881d3a12fe45d4c87e1475e9aefec76c76e20a8b5bd065304fe04f961698aeabfd5093e87f9d145bd1c8d59898cce096d7c050aa0c6e9b7c04",
+      "archive": "cmake-4.0.0-rc2-windows-i386.zip"
     },
     {
       "name": "cmake",
       "os": "windows",
       "arch": "arm64",
-      "version": "3.30.1",
-      "executable": "cmake-3.30.1-windows-arm64/bin/cmake.exe",
-      "url": "https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-windows-arm64.zip",
-      "sha512": "40bcdeff5ff40044629f49e0effc958a719353330ea39876b919fb7c2d441885c884acf43e644ab5dedcb95503d211c895da1c0b6360e71449bea6a981f8e128",
-      "archive": "cmake-3.30.1-windows-arm64.zip"
+      "version": "4.0.0-rc2",
+      "executable": "cmake-4.0.0-rc2-windows-arm64/bin/cmake.exe",
+      "url": "https://github.com/Kitware/CMake/releases/download/v4.0.0-rc2/cmake-4.0.0-rc2-windows-arm64.zip",
+      "sha512": "0fe1f95c3c25548fd6edea2680a998ea4a4eab998d00e95447d4a5b6ae5980e8e2d0823599c053883b5405d024185b18c65145ec821f8a450e250767509bc7d8",
+      "archive": "cmake-4.0.0-rc2-windows-arm64.zip"
     },
     {
       "name": "cmake",
       "os": "osx",
-      "version": "3.30.1",
-      "executable": "cmake-3.30.1-macos-universal/CMake.app/Contents/bin/cmake",
-      "url": "https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-macos-universal.tar.gz",
-      "sha512": "71290d3b5e51724711e8784f5b21100cb0cffdbb889da7572a26dd171d9052601496de8d39c42d76ef3a9245af2ab35a590bf53ad68d7bb8a2047b64272d2647",
-      "archive": "cmake-3.30.1-macos-universal.tar.gz"
+      "version": "4.0.0-rc2",
+      "executable": "cmake-4.0.0-rc2-macos-universal/CMake.app/Contents/bin/cmake",
+      "url": "https://github.com/Kitware/CMake/releases/download/v4.0.0-rc2/cmake-4.0.0-rc2-macos-universal.tar.gz",
+      "sha512": "7047f6d6c718dd4d5cc8f8d9a1f6e4e8398869e1b98ca997655f9d72c94dd7905ac181c58ba3e648fe9aaa16d8fed0a475fc692f2f11b2b201f8074b64a1ab2a",
+      "archive": "cmake-4.0.0-rc2-macos-universal.tar.gz"
     },
     {
       "name": "cmake",
       "os": "linux",
       "arch": "arm64",
-      "version": "3.30.1",
-      "executable": "cmake-3.30.1-linux-aarch64/bin/cmake",
-      "url": "https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-linux-aarch64.tar.gz",
-      "sha512": "ec6c1c682dda2381aa5ebef98a2597e4ab6b4563639c28b2f30c20360694b902a7b33c175c796169a9f99ed139f053916042caed58d83298680894c2840dbb87",
-      "archive": "cmake-3.30.1-linux-aarch64.tar.gz"
+      "version": "4.0.0-rc2",
+      "executable": "cmake-4.0.0-rc2-linux-aarch64/bin/cmake",
+      "url": "https://github.com/Kitware/CMake/releases/download/v4.0.0-rc2/cmake-4.0.0-rc2-linux-aarch64.tar.gz",
+      "sha512": "a47322e2d023aa246b711e811661fe6d2dea8be1b168521758a75eeb721abfcacaf22293fcf3153b26adc2db8a11c9e97090cc3d3befc86d6f5ca3fe418e475a",
+      "archive": "cmake-4.0.0-rc2-linux-aarch64.tar.gz"
     },
     {
       "name": "cmake",
       "os": "linux",
-      "version": "3.30.1",
+      "version": "4.0.0-rc2",
       "arch": "amd64",
-      "executable": "cmake-3.30.1-linux-x86_64/bin/cmake",
-      "url": "https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-linux-x86_64.tar.gz",
-      "sha512": "84ce1333ed696a1736986fba2853c5d8db0e4c9addaf4a4723911248c6d49ecf545adf8bd46091d198fc7bd1e6c896798661463aa1ce3a726a093883aaa19adf",
-      "archive": "cmake-3.30.1-linux-x86_64.tar.gz"
+      "executable": "cmake-4.0.0-rc2-linux-x86_64/bin/cmake",
+      "url": "https://github.com/Kitware/CMake/releases/download/v4.0.0-rc2/cmake-4.0.0-rc2-linux-x86_64.tar.gz",
+      "sha512": "65d06bdfb4d21b44f9a067b6027e2f0a64d387fc84c3a472498ff14b61af87eeab867edab5e879340896416d50df7081f8214507384e6f5b5733633b2b67babb",
+      "archive": "cmake-4.0.0-rc2-linux-x86_64.tar.gz"
     },
     {
       "name": "git",


### PR DESCRIPTION
Add command `x_vcpkg_get_legacy_cmake_3(SET_CMAKE_COMMAND)` to set CMake `3.30.1` runtime in `buildtrees`

Workaround of https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features

> Compatibility with versions of CMake older than 3.5 has been removed.
