### PR TITLE
[matio] update to 1.5.28

### DIFF
--- a/ports/matio/portfile.cmake
+++ b/ports/matio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tbeu/matio
     REF "v${VERSION}"
-    SHA512 3ede0ce0c328fc79bff75933368d8ec9eea1d8cb28ea32a41bedb3f184e1c3362bb37bfb582838bc954ab0fff8c9dfd5a1e86831e657c06c2b2bd9d1e47020ff
+    SHA512 358318a249e22f5228516309d267593b8da9005de015dc0f59645fbfd7a5001e10be9144f32437acc2f6921d952e03adbaf8b9ca5b6620e191346bb569c04780
     HEAD_REF master
     PATCHES fix-dependencies.patch
 )

--- a/ports/matio/vcpkg.json
+++ b/ports/matio/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "matio",
-  "version": "1.5.27",
-  "port-version": 1,
+  "version": "1.5.28",
   "description": "MATLAB MAT File I/O Library",
   "homepage": "https://github.com/tbeu/matio",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5813,8 +5813,8 @@
       "port-version": 0
     },
     "matio": {
-      "baseline": "1.5.27",
-      "port-version": 1
+      "baseline": "1.5.28",
+      "port-version": 0
     },
     "matplotlib-cpp": {
       "baseline": "2020-08-27",

--- a/versions/m-/matio.json
+++ b/versions/m-/matio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5c71cc6dfae2b864ddd497890b6723145a250cbf",
+      "version": "1.5.28",
+      "port-version": 0
+    },
+    {
       "git-tree": "5365545edb3db0730c490d4b03dcb84e8f7839dd",
       "version": "1.5.27",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.