### PR TITLE
[cppitertools] update to 2.2

### DIFF
--- a/ports/cppitertools/portfile.cmake
+++ b/ports/cppitertools/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ryanhaining/cppitertools
-    REF 539a5be8359c4330b3f88ed1821f32bb5c89f5f6
-    SHA512 cab0cb8a6b711824c13ca013b3349b9decb84f2dab6305bfb1bdd013f7426d5b199c127dadabeaaafc2e7ff6ad442222dd0fffee9aaacfa27d3aeb82c344ae4f
+    REF "v${VERSION}"
+    SHA512 27b6b50e5cbb901a844adf65f2c3ad27368907acfc972267b51700b8f2d3d2205a0da4f130f88c0df791d23d84198083caffbf54ab5114354ddc43728538f44c
     HEAD_REF master
 )
 

--- a/ports/cppitertools/vcpkg.json
+++ b/ports/cppitertools/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "cppitertools",
-  "version": "2.1",
-  "port-version": 3,
+  "version": "2.2",
   "description": "Range-based for loop add-ons inspired by the Python builtins and itertools library",
   "homepage": "https://github.com/ryanhaining/cppitertools",
+  "license": "BSD-2-Clause",
   "dependencies": [
     "boost-optional",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1965,8 +1965,8 @@
       "port-version": 2
     },
     "cppitertools": {
-      "baseline": "2.1",
-      "port-version": 3
+      "baseline": "2.2",
+      "port-version": 0
     },
     "cppkafka": {
       "baseline": "0.4.0",

--- a/versions/c-/cppitertools.json
+++ b/versions/c-/cppitertools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ed0b0e14e29b9d30f9ae606ae2a7ef6c3dce0f8",
+      "version": "2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "b982722ea8f4a1a9d6178b9b3eacd78a7fa96590",
       "version": "2.1",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
