### PR TITLE
[liquid-dsp] Add new port

### DIFF
--- a/ports/liquid-dsp/portfile.cmake
+++ b/ports/liquid-dsp/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jgaeddert/liquid-dsp
+    REF "v${VERSION}"
+    SHA512 04988cfc68ea562a47f16f5232e5eafada29d37e517ccfadd8dac9d83270c2cc2c1b5e9725e92b7cf6fed6d954aaa89b254038a2d7481e87202048a9521e4e22
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_AUTOTESTS=OFF
+        -DBUILD_BENCHMARKS=OFF
+        -DBUILD_SANDBOX=OFF
+        -DBUILD_DOC=OFF
+        -DCOVERAGE=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/liquid-dsp/vcpkg.json
+++ b/ports/liquid-dsp/vcpkg.json
@@ -9,10 +9,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ]
 }

--- a/ports/liquid-dsp/vcpkg.json
+++ b/ports/liquid-dsp/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "liquid-dsp",
+  "version": "1.7.0",
+  "description": "Digital signal processing library for software-defined radios.",
+  "homepage": "https://liquidsdr.org/",
+  "license": "MIT",
+  "supports": "linux | osx",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/liquid-dsp/vcpkg.json
+++ b/ports/liquid-dsp/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Digital signal processing library for software-defined radios.",
   "homepage": "https://liquidsdr.org/",
   "license": "MIT",
-  "supports": "linux | osx | android",
+  "supports": "linux | osx",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/liquid-dsp/vcpkg.json
+++ b/ports/liquid-dsp/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Digital signal processing library for software-defined radios.",
   "homepage": "https://liquidsdr.org/",
   "license": "MIT",
-  "supports": "linux | osx",
+  "supports": "linux | osx | android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5588,6 +5588,10 @@
       "baseline": "2.4.2",
       "port-version": 0
     },
+    "liquid-dsp": {
+      "baseline": "1.7.0",
+      "port-version": 0
+    },
     "litehtml": {
       "baseline": "0.9.0",
       "port-version": 0

--- a/versions/l-/liquid-dsp.json
+++ b/versions/l-/liquid-dsp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c2344b2877179baad7d1cbe779cbc5abd0c26c35",
+      "git-tree": "823f83e0e888525d9d3449d7407bb3eaba1670f3",
       "version": "1.7.0",
       "port-version": 0
     }

--- a/versions/l-/liquid-dsp.json
+++ b/versions/l-/liquid-dsp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c2344b2877179baad7d1cbe779cbc5abd0c26c35",
+      "version": "1.7.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/liquid-dsp.json
+++ b/versions/l-/liquid-dsp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "823f83e0e888525d9d3449d7407bb3eaba1670f3",
+      "git-tree": "17364342a9872db3e65cc60257a7e4734f328dbd",
       "version": "1.7.0",
       "port-version": 0
     }

--- a/versions/l-/liquid-dsp.json
+++ b/versions/l-/liquid-dsp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "17364342a9872db3e65cc60257a7e4734f328dbd",
+      "git-tree": "823f83e0e888525d9d3449d7407bb3eaba1670f3",
       "version": "1.7.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
