### PR TITLE
[dbus] Update to 1.16.2

### DIFF
--- a/ports/dbus/portfile.cmake
+++ b/ports/dbus/portfile.cmake
@@ -89,4 +89,4 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
 endif()
 vcpkg_copy_tools(TOOL_NAMES ${TOOLS} AUTO_CLEAN)
 
-vcpkg_install_copyright(FILE_LSIT "${SOURCE_PATH}/COPYING")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/dbus/portfile.cmake
+++ b/ports/dbus/portfile.cmake
@@ -5,13 +5,14 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dbus/dbus
     REF "dbus-${VERSION}"
-    SHA512 8e476b408514e6540c36beb84e8025827c22cda8958b6eb74d22b99c64765eb3cd5a6502aea546e3e5f0534039857b37edee89c659acef40e7cab0939947d4af
+    SHA512 8ad3ab55bf6e2bbe6ff871302c2840c0cb82b4ec785b05f146c577ca1e931825084012ac90251e28c30e44d111e5ca5711b29349f4f0e68a09ba49392e63ac89
     HEAD_REF master
     PATCHES
         cmake.dep.patch
         pkgconfig.patch
         getpeereid.patch # missing check from configure.ac
         libsystemd.patch
+        remove-path.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS options
@@ -88,4 +89,4 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
 endif()
 vcpkg_copy_tools(TOOL_NAMES ${TOOLS} AUTO_CLEAN)
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LSIT "${SOURCE_PATH}/COPYING")

--- a/ports/dbus/remove-path.patch
+++ b/ports/dbus/remove-path.patch
@@ -1,0 +1,12 @@
+diff --git a/bus/CMakeLists.txt b/bus/CMakeLists.txt
+index e464f60..fc991f4 100644
+--- a/bus/CMakeLists.txt
++++ b/bus/CMakeLists.txt
+@@ -113,7 +113,6 @@ if(NOT WIN32)
+     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/legacy-config/system.conf DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/dbus-1)
+     install(DIRECTORY DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/system.d)
+     install(DIRECTORY DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/system-services)
+-    install(DIRECTORY DESTINATION ${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/run/dbus)
+ endif()
+ 
+ if(DBUS_SERVICE)

--- a/ports/dbus/vcpkg.json
+++ b/ports/dbus/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dbus",
-  "version": "1.15.8",
-  "port-version": 5,
+  "version": "1.16.2",
   "description": "D-Bus specification and reference implementation, including libdbus and dbus-daemon",
   "homepage": "https://gitlab.freedesktop.org/dbus/dbus",
   "license": "AFL-2.1 OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2257,8 +2257,8 @@
       "port-version": 3
     },
     "dbus": {
-      "baseline": "1.15.8",
-      "port-version": 5
+      "baseline": "1.16.2",
+      "port-version": 0
     },
     "dcmtk": {
       "baseline": "3.6.9",

--- a/versions/d-/dbus.json
+++ b/versions/d-/dbus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fbc302d7d997554081c4fb2aabe71c5612e887dd",
+      "version": "1.16.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ce28359a2d828a06b421d8a7b3841f83d98f0ed4",
       "version": "1.15.8",
       "port-version": 5

--- a/versions/d-/dbus.json
+++ b/versions/d-/dbus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fbc302d7d997554081c4fb2aabe71c5612e887dd",
+      "git-tree": "ef5eaa8192465a6bd08ec9e664f5f2f467295257",
       "version": "1.16.2",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/43993

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features and usage test passed with x64-linux triplet.