### PR TITLE
[ncursesw] Add new port

### DIFF
--- a/ports/ncursesw/portfile.cmake
+++ b/ports/ncursesw/portfile.cmake
@@ -1,0 +1,67 @@
+vcpkg_download_distfile(
+    ARCHIVE_PATH
+    URLS
+        "https://invisible-mirror.net/archives/ncurses/ncurses-${VERSION}.tar.gz"
+        "ftp://ftp.invisible-island.net/ncurses/ncurses-${VERSION}.tar.gz"
+        "https://ftp.gnu.org/gnu/ncurses/ncurses-${VERSION}.tar.gz"
+    FILENAME "ncurses-${VERSION}.tgz"
+    SHA512 1c2efff87a82a57e57b0c60023c87bae93f6718114c8f9dc010d4c21119a2f7576d0225dab5f0a227c2cfc6fb6bdbd62728e407f35fce5bf351bb50cf9e0fd34
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE_PATH}"
+)
+
+vcpkg_list(SET OPTIONS)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    list(APPEND OPTIONS
+        --with-cxx-shared
+        --with-shared    # "lib model"
+        --without-normal # "lib model"
+    )
+endif()
+
+if(NOT VCPKG_TARGET_IS_MINGW)
+    list(APPEND OPTIONS
+        --enable-mixed-case
+    )
+endif()
+
+if(VCPKG_TARGET_IS_MINGW)
+    list(APPEND OPTIONS
+        --disable-home-terminfo
+        --enable-term-driver
+        --disable-termcap
+    )
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DETERMINE_BUILD_TRIPLET
+    NO_ADDITIONAL_PATHS
+    OPTIONS
+    ${OPTIONS}
+    --disable-db-install
+    --enable-pc-files
+    --without-ada
+    --without-debug # "lib model"
+    --without-manpages
+    --without-progs
+    --without-tack
+    --without-tests
+    --enable-widec
+    --with-pkg-config-libdir=libdir
+)
+vcpkg_install_make()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/ncursesw/usage
+++ b/ports/ncursesw/usage
@@ -1,0 +1,8 @@
+The package ncursesw is compatible with built-in CMake variables:
+
+    set(CURSES_NEED_NCURSES TRUE)
+    set(CURSES_NEED_WIDE TRUE)
+    find_package(Curses REQUIRED)
+    target_include_directories(main PRIVATE ${CURSES_INCLUDE_DIRS})
+    target_compile_options(main PRIVATE ${CURSES_CFLAGS})
+    target_link_libraries(main PRIVATE ${CURSES_LIBRARIES})

--- a/ports/ncursesw/vcpkg.json
+++ b/ports/ncursesw/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "ncursesw",
+  "version": "6.4",
+  "port-version": 2,
+  "description": "Free software emulation of curses in System V Release 4.0, and more",
+  "homepage": "https://invisible-island.net/ncurses/announce.html",
+  "license": "MIT",
+  "supports": "!windows | mingw"
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


