### PR TITLE
[gdbm] Add new port, starting on version 1.24

### DIFF
--- a/ports/gdbm/portfile.cmake
+++ b/ports/gdbm/portfile.cmake
@@ -1,12 +1,14 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnu.org/gnu/gdbm/gdbm-${VERSION}.tar.gz"
+         "https://ftpmirror.gnu.org/gdbm/gdbm-${VERSION}.tar.gz"
+         "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gdbm/gdbm-${VERSION}.tar.gz"
     FILENAME "gdbm-${VERSION}.tar.gz"
     SHA512 401ff8c707079f21da1ac1d6f4714a87f224b6f41943078487dc891be49f51fd1ac7a32fd599aae0fad185f2c6ba7432616d328fd6aaab068eb54db9562ff7fa
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/gdbm/portfile.cmake
+++ b/ports/gdbm/portfile.cmake
@@ -1,0 +1,55 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://ftp.gnu.org/gnu/gdbm/gdbm-${VERSION}.tar.gz"
+    FILENAME "gdbm-${VERSION}.tar.gz"
+    SHA512 401ff8c707079f21da1ac1d6f4714a87f224b6f41943078487dc891be49f51fd1ac7a32fd599aae0fad185f2c6ba7432616d328fd6aaab068eb54db9562ff7fa
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    libgdbm-compat      ENABLE_GDBM_COMPAT
+    readline            ENABLE_READLINE
+    memory-mapped-io    ENABLE_MMAP
+)
+
+vcpkg_list(SET options
+    "--enable-gdbmtool-debug=no"
+)
+
+if(${ENABLE_GDBM_COMPAT})
+    list(APPEND options "--enable-libgdbm-compat=yes")
+endif()
+
+if(NOT ${ENABLE_READLINE})
+    list(APPEND options "--without-readline")
+endif()
+
+if(NOT ${ENABLE_MMAP})
+    list(APPEND options "--disable-memory-mapped-io")
+endif()
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+    COPY_SOURCE
+    OPTIONS
+        ${options}
+)
+
+vcpkg_make_install()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/gdbm/info"
+    "${CURRENT_PACKAGES_DIR}/share/gdbm/locale"
+    "${CURRENT_PACKAGES_DIR}/share/gdbm/man1"
+    "${CURRENT_PACKAGES_DIR}/share/gdbm/man3"
+)

--- a/ports/gdbm/portfile.cmake
+++ b/ports/gdbm/portfile.cmake
@@ -11,24 +11,21 @@ vcpkg_extract_source_archive(
     ARCHIVE "${ARCHIVE}"
 )
 
-vcpkg_list(SET options
-    "--enable-gdbmtool-debug=no"
-)
+vcpkg_list(SET options)
 
 if("libgdbm-compat" IN_LIST FEATURES)
     list(APPEND options "--enable-libgdbm-compat=yes")
 endif()
 
-# By default, gdbm is built with readline support. If the readline feature is not enabled, we need to disable it manually.
-# See: https://git.gnu.org.ua/gdbm.git/tree/README?h=v1.24#n44
-if(NOT "readline" IN_LIST FEATURES)
+if("readline" IN_LIST FEATURES)
+    list(APPEND options "--with-readline")
+else()
     list(APPEND options "--without-readline")
 endif()
 
-# By default, gdbm is built with memory-mapped I/O support if mmap is available on the system.
-# If the memory-mapped-io feature is not enabled, we need to disable it manually. This is done to avoid using mmap implicitly.
-# See: https://git.gnu.org.ua/gdbm.git/tree/README?h=v1.24#n30
-if(NOT "memory-mapped-io" IN_LIST FEATURES)
+if("memory-mapped-io" IN_LIST FEATURES)
+    list(APPEND options "--enable-memory-mapped-io")
+else()
     list(APPEND options "--disable-memory-mapped-io")
 endif()
 

--- a/ports/gdbm/portfile.cmake
+++ b/ports/gdbm/portfile.cmake
@@ -11,26 +11,24 @@ vcpkg_extract_source_archive(
     ARCHIVE "${ARCHIVE}"
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-  FEATURES
-    libgdbm-compat      ENABLE_GDBM_COMPAT
-    readline            ENABLE_READLINE
-    memory-mapped-io    ENABLE_MMAP
-)
-
 vcpkg_list(SET options
     "--enable-gdbmtool-debug=no"
 )
 
-if(${ENABLE_GDBM_COMPAT})
+if("libgdbm-compat" IN_LIST FEATURES)
     list(APPEND options "--enable-libgdbm-compat=yes")
 endif()
 
-if(NOT ${ENABLE_READLINE})
+# By default, gdbm is built with readline support. If the readline feature is not enabled, we need to disable it manually.
+# See: https://git.gnu.org.ua/gdbm.git/tree/README?h=v1.24#n44
+if(NOT "readline" IN_LIST FEATURES)
     list(APPEND options "--without-readline")
 endif()
 
-if(NOT ${ENABLE_MMAP})
+# By default, gdbm is built with memory-mapped I/O support if mmap is available on the system.
+# If the memory-mapped-io feature is not enabled, we need to disable it manually. This is done to avoid using mmap implicitly.
+# See: https://git.gnu.org.ua/gdbm.git/tree/README?h=v1.24#n30
+if(NOT "memory-mapped-io" IN_LIST FEATURES)
     list(APPEND options "--disable-memory-mapped-io")
 endif()
 

--- a/ports/gdbm/vcpkg.json
+++ b/ports/gdbm/vcpkg.json
@@ -19,7 +19,10 @@
       "description": "Enable the use of mmap(2) for I/O optimizations."
     },
     "readline": {
-      "description": "Enable GNU Readline support."
+      "description": "Enable GNU Readline support.",
+      "dependencies": [
+        "readline"
+      ]
     }
   }
 }

--- a/ports/gdbm/vcpkg.json
+++ b/ports/gdbm/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "gdbm",
+  "version": "1.24",
+  "description": "GDBM is a library of database functions that use extensible hashing and works similar to the standard UNIX dbm.",
+  "homepage": "https://www.gnu.org.ua/software/gdbm/gdbm.html",
+  "license": "GPL-3.0-only",
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ],
+  "features": {
+    "libgdbm-compat": {
+      "description": "Build and install libgdbm_compat, a compatibility layer which provides UNIX-like dbm and ndbm interfaces."
+    },
+    "memory-mapped-io": {
+      "description": "Enable the use of mmap(2) for I/O optimizations."
+    },
+    "readline": {
+      "description": "Enable GNU Readline support."
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3044,6 +3044,10 @@
       "baseline": "3.10.2",
       "port-version": 0
     },
+    "gdbm": {
+      "baseline": "1.24",
+      "port-version": 0
+    },
     "gdcm": {
       "baseline": "3.0.24",
       "port-version": 0

--- a/versions/g-/gdbm.json
+++ b/versions/g-/gdbm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d70bed4fd891680aba72116e355042d42ef79511",
+      "git-tree": "b2ed02ddd8d6842493eeee6a13fa4db4a8551676",
       "version": "1.24",
       "port-version": 0
     }

--- a/versions/g-/gdbm.json
+++ b/versions/g-/gdbm.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d70bed4fd891680aba72116e355042d42ef79511",
+      "version": "1.24",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/g-/gdbm.json
+++ b/versions/g-/gdbm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b2ed02ddd8d6842493eeee6a13fa4db4a8551676",
+      "git-tree": "6f1a4f9089dcb8097ecdf38fda0274e2f19c6294",
       "version": "1.24",
       "port-version": 0
     }


### PR DESCRIPTION
This PR adds a new port for the GDBM package, I need this as a required port as avahi depends on it which I would like to add after this.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
