### PR TITLE
[sdl2-image] update to 2.8.8

### DIFF
--- a/ports/sdl2-image/fix-findwebp.patch
+++ b/ports/sdl2-image/fix-findwebp.patch
@@ -1,18 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 65a8811..1f29faa 100644
+index 4ceee1d..9354718 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -690,7 +690,7 @@ if(SDL2IMAGE_WEBP)
+@@ -810,7 +810,7 @@ if(SDL2IMAGE_WEBP)
+         set_target_properties(webp PROPERTIES EXPORT_NAME "external_libwebp")
          add_library(SDL2_image::external_libwebp ALIAS webp)
      else()
-         message(STATUS "${PROJECT_NAME}: Using system libwebp")
--        find_package(webp REQUIRED)
-+        find_package(webp NAMES WebP CONFIG REQUIRED)
-         list(APPEND PC_REQUIRES libwebp libwebpdemux)
-     endif()
-     if(SDL2IMAGE_WEBP_SHARED)
+-        find_package(webp ${required})
++        find_package(webp NAMES WebP CONFIG ${required})
+         if(webp_FOUND)
+             set(SDL2IMAGE_WEBP_ENABLED TRUE)
+             message(STATUS "${PROJECT_NAME}: Using system libwebp")
 diff --git a/SDL2_imageConfig.cmake.in b/SDL2_imageConfig.cmake.in
-index c59e844..7b16a60 100644
+index 7c7efab..925bbc4 100644
 --- a/SDL2_imageConfig.cmake.in
 +++ b/SDL2_imageConfig.cmake.in
 @@ -74,7 +74,7 @@ endif()

--- a/ports/sdl2-image/portfile.cmake
+++ b/ports/sdl2-image/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL_image
     REF "release-${VERSION}"
-    SHA512 112a523b44630b4e03b100c89f794bc5bc6707965426436c914478948fec6aea9c3a5a4f4b20f6f6bf03ac9440bffddebfd31c1ecd5b99c46bc06e08e0b05f15
+    SHA512 3fef846eb0ad51a8b346bb421c87eb81f0e2f186d700a219ebf17146397da404b3683853322989ed939b1672cc36b799582f24bc58a0393fc6c698a65cda2b82
     HEAD_REF main
     PATCHES 
         fix-findwebp.patch

--- a/ports/sdl2-image/vcpkg.json
+++ b/ports/sdl2-image/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl2-image",
-  "version": "2.8.4",
+  "version": "2.8.8",
   "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
   "homepage": "https://github.com/libsdl-org/SDL_image",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8321,7 +8321,7 @@
       "port-version": 11
     },
     "sdl2-image": {
-      "baseline": "2.8.4",
+      "baseline": "2.8.8",
       "port-version": 0
     },
     "sdl2-mixer": {

--- a/versions/s-/sdl2-image.json
+++ b/versions/s-/sdl2-image.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59d6bd7369432c4558c87cc90402c5bc65e004c5",
+      "version": "2.8.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "3190ce60e37965fc1692fc28d0d4a307bf8b8636",
       "version": "2.8.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

