### PR TITLE
[google-cloud-cpp] Fix build error on linux

### DIFF
--- a/ports/google-cloud-cpp/fix-googleapis-download.patch
+++ b/ports/google-cloud-cpp/fix-googleapis-download.patch
@@ -35,3 +35,15 @@ index 5e93f522..30132c06 100644
      set_target_properties(
          "google_cloud_cpp_${short_name}"
          PROPERTIES EXPORT_NAME google-cloud-cpp::${short_name}
+diff --git a/protos/google/cloud/compute/CMakeLists.txt b/protos/google/cloud/compute/CMakeLists.txt
+index 0a3b1ed..c054bc3 100644
+--- a/protos/google/cloud/compute/CMakeLists.txt
++++ b/protos/google/cloud/compute/CMakeLists.txt
+@@ -56,7 +56,6 @@ google_cloud_cpp_install_proto_library_headers(compute_protos)
+ # `*.proto` files. We achieve this by having this target depend on all proto
+ # libraries. It has to be defined at the top level of the project.
+ add_dependencies(google-cloud-cpp-protos compute_protos)
+-add_dependencies(compute_protos googleapis_download)
+ 
+ # Get the destination directories based on the GNU recommendations.
+ include(GNUInstallDirs)

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "2.35.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3230,7 +3230,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "2.35.0",
-      "port-version": 1
+      "port-version": 2
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9092abf492bbd95bfc31a164371f2a00183ff2f0",
+      "version": "2.35.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b30c7f31e3ce20a6197872665bc9939b7d2a95a2",
       "version": "2.35.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/44170
Remove the canceled dependency d`ownloads_googleapis` .

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

