### PR TITLE
[imgui-sfml] Fix dependency opengl

### DIFF
--- a/ports/imgui-sfml/0001-fix_find_package.patch
+++ b/ports/imgui-sfml/0001-fix_find_package.patch
@@ -25,7 +25,7 @@ index 7945482..1c91277 100644
    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
  )
 -target_link_libraries(ImGui-SFML PUBLIC SFML::Graphics OpenGL::GL)
-+target_link_libraries(ImGui-SFML PUBLIC imgui::imgui SFML::Graphics OpenGL::GL)
++target_link_libraries(ImGui-SFML PUBLIC imgui::imgui SFML::Graphics ${OPENGL_LIBRARIES})
  if(WIN32 AND MINGW)
    target_link_libraries(ImGui-SFML PUBLIC imm32)
  endif()

--- a/ports/imgui-sfml/vcpkg.json
+++ b/ports/imgui-sfml/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui-sfml",
   "version": "3.0",
+  "port-version": 1,
   "description": "ImGui binding for use with SFML",
   "homepage": "https://github.com/eliasdaler/imgui-sfml",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3706,7 +3706,7 @@
     },
     "imgui-sfml": {
       "baseline": "3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "imguizmo": {
       "baseline": "2024-05-29",

--- a/versions/i-/imgui-sfml.json
+++ b/versions/i-/imgui-sfml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "061e5f2c8923c6ebe8c9b37ceeb36a8619022f24",
+      "version": "3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "041c903966c2b455356971e36ae5e8bfec447187",
       "version": "3.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #44123. Fix dependency opengl:
```
CMake Error at C:/vcpkg/installed/x64-windows/share/imgui-sfml/ImGui-SFMLConfig.cmake:63 (set_target_properties):
  The link interface of target "ImGui-SFML::ImGui-SFML" contains:

    OpenGL::GL

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  C:/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
  CMakeLists.txt:11 (find_package)
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [] Only one version is added to each modified port's versions file.