### PR TITLE
[skia] Fix dependency skia

### DIFF
--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/skia
     REF "chrome/m${VERSION}"
-    SHA512 3147cdd4636feeba1f3a1c9026b8d5d9e500e5cc4d99281a6f7fc36962e5365cbc45d358732381bd42ee8c721ca2c8ba963e5ba1344750c9e3a54be697f0e0f9
+    SHA512 3364983567b91ec6f03a148e4c1dee6eeb132b1e3d21bcbc94a5fd2ab16f22fe62a8b0e9392da67a55c4e665031de65c252f68ddc1b02700b9ede773a8ec0934
     PATCHES
         disable-msvc-env-setup.patch
         # disable-dev-test.patch

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "skia",
   "version": "134",
+  "port-version": 1,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8530,7 +8530,7 @@
     },
     "skia": {
       "baseline": "134",
-      "port-version": 0
+      "port-version": 1
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d7fbbbcc1266ffd087146df7925ac2cc375d3ccc",
+      "version": "134",
+      "port-version": 1
+    },
+    {
       "git-tree": "5a4b4ce7f523b0ce686476844b3eb047ce661596",
       "version": "134",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/44207. Fix dependency skia:

/opt/vcpkg/downloads/google-skia-chrome_-m134.tar.gz.28895.part: error: download from https://github.com/google/skia/archive/chrome/m134.tar.gz had an unexpected hash
note: Expected: 3147cdd4636feeba1f3a1c9026b8d5d9e500e5cc4d99281a6f7fc36962e5365cbc45d358732381bd42ee8c721ca2c8ba963e5ba1344750c9e3a54be697f0e0f9
note: Actual : 3364983567b91ec6f03a148e4c1dee6eeb132b1e3d21bcbc94a5fd2ab16f22fe62a8b0e9392da67a55c4e665031de65c252f68ddc1b02700b9ede773a8ec0934

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.