### PR TITLE
[ms-gdk] Added new port for the Microsoft GDK

### DIFF
--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -1,7 +1,7 @@
 set(GDK_EDITION_NUMBER 241001)
 
 # The GDK contains a combination of static C++ libraries and DLL-based extension libraries.
-set(VCPKG_LIBRARY_LINKAGE dynamic)
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -1,5 +1,6 @@
 set(GDK_EDITION_NUMBER 241001)
 
+# The GDK contains a combination of static C++ libraries and DLL-based extension libraries.
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 
 vcpkg_download_distfile(ARCHIVE

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(
     PACKAGE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
     NO_REMOVE_ONE_LEVEL
 )
 

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -17,7 +17,7 @@ vcpkg_extract_source_archive(
 set(GRDK_PATH "${PACKAGE_PATH}/native/${GDK_EDITION_NUMBER}/GRDK")
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${GRDK_PATH}
+    SOURCE_PATH "${GRDK_PATH}"
 )
 
 vcpkg_cmake_install()

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -1,5 +1,7 @@
 set(GDK_EDITION_NUMBER 241001)
 
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"
     FILENAME "ms-gdk.${VERSION}.zip"

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -1,6 +1,6 @@
 set(GDK_EDITION_NUMBER 241001)
 
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -1,9 +1,9 @@
-set(GDK_EDITION_NUMBER 241000)
+set(GDK_EDITION_NUMBER 241001)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"
     FILENAME "ms-gdk.${VERSION}.zip"
-    SHA512 a3ff91cb033a33e971db0b25285f665c80f3e5b97cd5e1b1859ed0a9b3da77285359665a9d0a7f3b5473ac094ed7351c3e6534c656cc5e54daf69af0890ba3e8
+    SHA512 47cd422fddce2594626c3c0319965a66bdd422dde79474d2ba1993feaeb9d7dadc684f7cd297d13e14fe526f06d64856f5de70b97242ba529777a3101423a3bc
 )
 
 vcpkg_extract_source_archive(

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -1,0 +1,64 @@
+set(GDK_EDITION_NUMBER 241000)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"
+    FILENAME "ms-gdk.${VERSION}.zip"
+    SHA512 0
+)
+
+vcpkg_extract_source_archive(
+    PACKAGE_PATH
+    ARCHIVE ${ARCHIVE}
+    NO_REMOVE_ONE_LEVEL
+)
+
+set(GRDK_PATH "${PACKAGE_PATH}/native/${GDK_EDITION_NUMBER}/GRDK")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${GRDK_PATH}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.gameruntime)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.game.chat.2.cpp.api)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.libhttpclient)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.services.api.c)
+vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.xcurl.api)
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.multiplayer.cpp)
+vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.party.cpp)
+vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.partyxboxlive.cpp)
+vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.services.c)
+
+file(INSTALL "${PACKAGE_PATH}/native/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+file(INSTALL "${PACKAGE_PATH}/native/bin/GameConfigEditorDependencies" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(REMOVE
+    "${CURRENT_PACKAGES_DIR}/debug/lib/Microsoft.Xbox.Services.142.GDK.C.lib"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/Microsoft.Xbox.Services.142.GDK.C.pdb"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/Microsoft.Xbox.Services.GDK.C.Thunks.lib"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/Microsoft.Xbox.Services.GDK.C.Thunks.pdb"
+    )
+
+file(REMOVE
+    "${CURRENT_PACKAGES_DIR}/lib/Microsoft.Xbox.Services.142.GDK.C.debug.lib"
+    "${CURRENT_PACKAGES_DIR}/lib/Microsoft.Xbox.Services.142.GDK.C.debug.pdb"
+    "${CURRENT_PACKAGES_DIR}/lib/Microsoft.Xbox.Services.GDK.C.Thunks.debug.lib"
+    "${CURRENT_PACKAGES_DIR}/lib/Microsoft.Xbox.Services.GDK.C.Thunks.debug.pdb"
+    )
+
+vcpkg_install_copyright(FILE_LIST
+    "${PACKAGE_PATH}/LICENSE.md"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.LibHttpClient/Include/httpClient/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.XCurl.API/Include/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/cpprest/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/pplx/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-c/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-cpp/ThirdPartyNotices.txt"
+    "${GRDK_PATH}/ExtensionLibraries/PlayFab.Multiplayer.Cpp/Include/NOTICE.txt"
+    "${GRDK_PATH}/ExtensionLibraries/PlayFab.Party.Cpp/Include/NOTICE.txt"
+    "${GRDK_PATH}/ExtensionLibraries/PlayFab.PartyXboxLive.Cpp/Include/NOTICE.txt"
+)

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -3,7 +3,7 @@ set(GDK_EDITION_NUMBER 241000)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"
     FILENAME "ms-gdk.${VERSION}.zip"
-    SHA512 0
+    SHA512 a3ff91cb033a33e971db0b25285f665c80f3e5b97cd5e1b1859ed0a9b3da77285359665a9d0a7f3b5473ac094ed7351c3e6534c656cc5e54daf69af0890ba3e8
 )
 
 vcpkg_extract_source_archive(
@@ -49,6 +49,8 @@ file(REMOVE
     "${CURRENT_PACKAGES_DIR}/lib/Microsoft.Xbox.Services.GDK.C.Thunks.debug.lib"
     "${CURRENT_PACKAGES_DIR}/lib/Microsoft.Xbox.Services.GDK.C.Thunks.debug.pdb"
     )
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_install_copyright(FILE_LIST
     "${PACKAGE_PATH}/LICENSE.md"

--- a/ports/ms-gdk/usage
+++ b/ports/ms-gdk/usage
@@ -1,28 +1,28 @@
 The Microsoft GDK package provides CMake targets:
 
-    find_package(xbox.gameruntime CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE Xbox::GameRuntime)
+  find_package(xbox.gameruntime CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::GameRuntime)
 
-    find_package(xbox.libhttpclient CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE Xbox::HTTPClient)
+  find_package(xbox.libhttpclient CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::HTTPClient)
 
-    find_package(xbox.xcurl.api CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE Xbox::XCurl)
+  find_package(xbox.xcurl.api CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::XCurl)
 
-    find_package(xbox.services.api.c CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE Xbox::XSAPI)
+  find_package(xbox.services.api.c CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::XSAPI)
 
-    find_package(xbox.game.chat.2.cpp.api CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE Xbox::GameChat2)
+  find_package(xbox.game.chat.2.cpp.api CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::GameChat2)
 
-    find_package(playfab.services.c CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE Xbox::PlayFabServices)
+  find_package(playfab.services.c CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabServices)
 
-    find_package(playfab.multiplayer.cpp CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE Xbox::PlayFabMultiplayer)
+  find_package(playfab.multiplayer.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabMultiplayer)
 
-    find_package(playfab.party.cpp CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE Xbox::PlayFabParty)
+  find_package(playfab.party.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabParty)
 
-    find_package(playfab.partyxboxlive.cpp CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE Xbox::PlayFabPartyLIVE)
+  find_package(playfab.partyxboxlive.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabPartyLIVE)

--- a/ports/ms-gdk/usage
+++ b/ports/ms-gdk/usage
@@ -1,0 +1,28 @@
+The Microsoft GDK package provides CMake targets:
+
+    find_package(xbox.gameruntime CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Xbox::GameRuntime)
+
+    find_package(xbox.libhttpclient CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Xbox::HTTPClient)
+
+    find_package(xbox.xcurl.api CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Xbox::XCurl)
+
+    find_package(xbox.services.api.c CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Xbox::XSAPI)
+
+    find_package(xbox.game.chat.2.cpp.api CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Xbox::GameChat2)
+
+    find_package(playfab.services.c CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Xbox::PlayFabServices)
+
+    find_package(playfab.multiplayer.cpp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Xbox::PlayFabMultiplayer)
+
+    find_package(playfab.party.cpp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Xbox::PlayFabParty)
+
+    find_package(playfab.partyxboxlive.cpp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Xbox::PlayFabPartyLIVE)

--- a/ports/ms-gdk/vcpkg.json
+++ b/ports/ms-gdk/vcpkg.json
@@ -5,7 +5,7 @@
   "homepage": "https://aka.ms/gdkx",
   "documentation": "https://aka.ms/gamedevdocs",
   "license": null,
-  "supports": "windows & x64 & !uwp & !xbox",
+  "supports": "windows & x64 & !uwp & !xbox & !staticcrt",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/ms-gdk/vcpkg.json
+++ b/ports/ms-gdk/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "ms-gdk",
+  "version": "2410.0.1874",
+  "description": "Microsoft Game Development Kit (GDK)",
+  "homepage": "https://aka.ms/gdkx",
+  "documentation": "https://aka.ms/gamedevdocs",
+  "license": null,
+  "supports": "windows & x64 & !uwp & !xbox",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/ms-gdk/vcpkg.json
+++ b/ports/ms-gdk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-gdk",
-  "version": "2410.0.1874",
+  "version": "2410.1.1897",
   "description": "Microsoft Game Development Kit (GDK)",
   "homepage": "https://aka.ms/gdkx",
   "documentation": "https://aka.ms/gamedevdocs",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6117,7 +6117,7 @@
       "port-version": 1
     },
     "ms-gdk": {
-      "baseline": "2410.0.1874",
+      "baseline": "2410.1.1897",
       "port-version": 0
     },
     "ms-gdkx": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6116,6 +6116,10 @@
       "baseline": "alias",
       "port-version": 1
     },
+    "ms-gdk": {
+      "baseline": "2410.0.1874",
+      "port-version": 0
+    },
     "ms-gdkx": {
       "baseline": "1.0.0",
       "port-version": 1

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f3d4799ad6afaa137b1c6e672b94297d145af091",
+      "git-tree": "55b2ad59e5cc59bb90a8a8eb259c0a93a84ece16",
       "version": "2410.1.1897",
       "port-version": 0
     }

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -4,11 +4,6 @@
       "git-tree": "e8fba173ede65a17cd157e774755e8cf949b72d1",
       "version": "2410.1.1897",
       "port-version": 0
-    },
-    {
-      "git-tree": "c875a3aa6e19fbaa6582d73179af2c6454ec8bf3",
-      "version": "2410.0.1874",
-      "port-version": 0
     }
   ]
 }

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8a9d6953b554c94d7a8fbbf7f1b38b432c500787",
+      "git-tree": "f3d4799ad6afaa137b1c6e672b94297d145af091",
       "version": "2410.1.1897",
       "port-version": 0
     }

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ab1024ee202c09735cc8c1d8ef777b4b1926270c",
+      "version": "2410.1.1897",
+      "port-version": 0
+    },
+    {
       "git-tree": "c875a3aa6e19fbaa6582d73179af2c6454ec8bf3",
       "version": "2410.0.1874",
       "port-version": 0

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ab1024ee202c09735cc8c1d8ef777b4b1926270c",
+      "git-tree": "e8fba173ede65a17cd157e774755e8cf949b72d1",
       "version": "2410.1.1897",
       "port-version": 0
     },

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e8fba173ede65a17cd157e774755e8cf949b72d1",
+      "git-tree": "8a9d6953b554c94d7a8fbbf7f1b38b432c500787",
       "version": "2410.1.1897",
       "port-version": 0
     }

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c875a3aa6e19fbaa6582d73179af2c6454ec8bf3",
+      "version": "2410.0.1874",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
For the Microsoft GDK releases in 2025, we are moving to a VCPKG-based template for PC development. This publishes the first version of the port to the public registry to enable development/validation of the new template.
