### PR TITLE
[vcpkg baseline] Fix opencv4

### DIFF
--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -363,6 +363,7 @@ vcpkg_cmake_configure(
         -DARM=${TARGET_IS_ARM}
         ###### use c++17 to enable features that fail with c++11 (halide, protobuf, etc.)
         -DCMAKE_CXX_STANDARD=17
+        -DTHRUST_IGNORE_CUB_VERSION_CHECK=1
         ###### ocv_options
         -DINSTALL_TO_MANGLED_PATHS=OFF
         -DOpenCV_INSTALL_BINARIES_PREFIX=

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.10.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6734,7 +6734,7 @@
     },
     "opencv4": {
       "baseline": "4.10.0",
-      "port-version": 5
+      "port-version": 6
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6165e42e5c32fb07ea268b451460219d457ca2a5",
+      "version": "4.10.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "176f72c465d0770b93bc5c394d4993de54ad9c71",
       "version": "4.10.0",
       "port-version": 5


### PR DESCRIPTION
Trying to fix ci failure https://dev.azure.com/vcpkg/public/_build/results?buildId=113099&view=results

Error from the logs:
```
/usr/local/cuda/targets/x86_64-linux/include/thrust/system/cuda/config.h:122:2: error: #error The version of CUB in your include path is not compatible with this release of Thrust. CUB is now included in the CUDA Toolkit, so you no longer need to use your own checkout of CUB. Define THRUST_IGNORE_CUB_VERSION_CHECK to ignore this.
  122 | #error The version of CUB in your include path is not compatible with this release of Thrust. CUB is now included in the CUDA Toolkit, so you no longer need to use your own checkout of CUB. Define THRUST_IGNORE_CUB_VERSION_CHECK to ignore this.
      |  ^~~~~

```