### PR TITLE
[triton] Update to 2025-02-15

### DIFF
--- a/ports/triton/portfile.cmake
+++ b/ports/triton/portfile.cmake
@@ -19,7 +19,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 set(ADDITIONAL_OPTIONS "")
 if(PYTHON_BINDINGS)
-    include("${CURRENT_INSTALLED_DIR}/share/python3/vcpkg-port-config.cmake")
     vcpkg_get_vcpkg_installed_python(PYTHON3)
     list(APPEND ADDITIONAL_OPTIONS
         "-DPYTHON_EXECUTABLE=${PYTHON3}"

--- a/ports/triton/portfile.cmake
+++ b/ports/triton/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO JonathanSalwan/Triton
-  REF a61651ce331ac53ec09e1d8fef5eab744e98c9de
-  SHA512 b53befe232e986409789533ac39b371b5701d9b9b72ee47c6486408c57f72800d2192b0f65bd0cc751147fbea2f8c0ef5b6375c913bd1d57393236a619f319c9
+  REF e312eafcdf507d9aebd0f8a7daf2eb4c28a19d30
+  SHA512 eb184859fe3023f188f7828335924da36c45dea90dc1ece7d8cf770dc7951022d4e51647cdd520e9bc91a8e01cab4a8801808e469900bdbbc3806624c132ad8d
   HEAD_REF master
   PATCHES
     fix_bin_path.patch
@@ -19,7 +19,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 set(ADDITIONAL_OPTIONS "")
 if(PYTHON_BINDINGS)
-    vcpkg_find_acquire_program(PYTHON3)
+    include("${CURRENT_INSTALLED_DIR}/share/python3/vcpkg-port-config.cmake")
+    vcpkg_get_vcpkg_installed_python(PYTHON3)
     list(APPEND ADDITIONAL_OPTIONS
         "-DPYTHON_EXECUTABLE=${PYTHON3}"
     )
@@ -48,4 +49,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/triton/vcpkg.json
+++ b/ports/triton/vcpkg.json
@@ -22,11 +22,7 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "vcpkg-get-python",
-      "host": true
-    },
+    }
     "z3"
   ],
   "features": {

--- a/ports/triton/vcpkg.json
+++ b/ports/triton/vcpkg.json
@@ -22,7 +22,7 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
     "z3"
   ],
   "features": {

--- a/ports/triton/vcpkg.json
+++ b/ports/triton/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "triton",
-  "version-date": "2023-08-16",
+  "version-date": "2025-02-15",
   "description": "Triton is a Dynamic Binary Analysis (DBA) framework. It provides internal components like a Dynamic Symbolic Execution (DSE) engine, a dynamic taint engine, AST representations of the x86, x86-64, ARM32 and AArch64 Instructions Set Architecture (ISA), SMT simplification passes, an SMT solver interface and, the last but not least, Python bindings.",
   "homepage": "https://github.com/JonathanSalwan/Triton",
   "license": "Apache-2.0",
@@ -21,6 +21,10 @@
     },
     {
       "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-get-python",
       "host": true
     },
     "z3"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9317,7 +9317,7 @@
       "port-version": 4
     },
     "triton": {
-      "baseline": "2023-08-16",
+      "baseline": "2025-02-15",
       "port-version": 0
     },
     "trompeloeil": {

--- a/versions/t-/triton.json
+++ b/versions/t-/triton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69e9581279ce74b4a760d4b1b6084327038c6197",
+      "version-date": "2025-02-15",
+      "port-version": 0
+    },
+    {
       "git-tree": "2d0facf413b0d9a2a4678af72776046a1c24f970",
       "version-date": "2023-08-16",
       "port-version": 0

--- a/versions/t-/triton.json
+++ b/versions/t-/triton.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "69e9581279ce74b4a760d4b1b6084327038c6197",
+      "git-tree": "a6d904152c09aa0e037ed01f1551de272733752b",
       "version-date": "2025-02-15",
       "port-version": 0
     },


### PR DESCRIPTION
1. Update version to 2025-02-15.
2. Fix feature python compilation error.
```
CMake Error at F:/vcpkg/downloads/tools/cmake-3.30.1-windows/cmake-3.30.1-windows-i386/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find Python3 (missing: Development Development.Module
  Development.Embed) (found version "3.12.7")
```

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

All features and usage test passed with x64-windows triplet.