### PR TITLE
[vcpkg baseline] Expect plplot:arm-neon-android=fail

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -865,6 +865,7 @@ platform-folders:x64-uwp=fail
 plib:arm-neon-android=fail
 plib:arm64-android=fail
 plib:x64-android=fail
+plplot:arm-neon-android=fail
 plplot:arm64-android=fail
 plplot:arm64-windows-static-md=fail
 plplot:arm64-windows=fail


### PR DESCRIPTION
Port plplot doesn't support cross-builds at the moment. This triplet was hidden behind harfbuzz/pango/pixman port issues which are fixed now.