### PR TITLE
[hello-imgui] fix depends on features of imgui that does not exists

### DIFF
--- a/ports/hello-imgui/portfile.cmake
+++ b/ports/hello-imgui/portfile.cmake
@@ -16,8 +16,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     "experimental-dx11-binding" HELLOIMGUI_HAS_DIRECTX11
     "experimental-dx12-binding" HELLOIMGUI_HAS_DIRECTX12
     "glfw-binding" HELLOIMGUI_USE_GLFW3
-    "sdl2-binding" HELLOIMGUI_USE_SDL2
-    "freetype-lunasvg" HELLOIMGUI_USE_FREETYPE # When hello_imgui is built with freetype, it will also build with lunasvg
+    "freetype-plutosvg" HELLOIMGUI_USE_FREETYPE # When hello_imgui is built with freetype, it will also build with plutosvg
 )
 
 if (NOT HELLOIMGUI_HAS_OPENGL3

--- a/ports/hello-imgui/vcpkg.json
+++ b/ports/hello-imgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "hello-imgui",
   "version": "1.6.0",
+  "port-version": 1,
   "description": "Hello ImGui: unleash your creativity in app development and prototyping",
   "homepage": "https://pthom.github.io/hello_imgui/",
   "license": "MIT",
@@ -55,14 +56,14 @@
         }
       ]
     },
-    "freetype-lunasvg": {
-      "description": "Improve font rendering and use colored fonts with freetype and lunasvg",
+    "freetype-plutosvg": {
+      "description": "Improve font rendering and use colored fonts with freetype and plutosvg",
       "dependencies": [
         {
           "name": "imgui",
           "features": [
             "freetype",
-            "freetype-lunasvg"
+            "freetype-svg"
           ]
         }
       ]
@@ -102,17 +103,6 @@
           "name": "imgui",
           "features": [
             "opengl3-binding"
-          ]
-        }
-      ]
-    },
-    "sdl2-binding": {
-      "description": "Use SDL2 platform backend",
-      "dependencies": [
-        {
-          "name": "imgui",
-          "features": [
-            "sdl2-binding"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3542,7 +3542,7 @@
     },
     "hello-imgui": {
       "baseline": "1.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "hexl": {
       "baseline": "1.2.5",

--- a/versions/h-/hello-imgui.json
+++ b/versions/h-/hello-imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad86a79efe058977548ffde34179005239f78266",
+      "version": "1.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4a401a4fdbe63f61272ac09ef44f9a8cdcd74537",
       "version": "1.6.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #44212

1. Since Imgui has implemented a backend for sdl3 https://github.com/microsoft/vcpkg/pull/42850, hello-imgui[sdl2-binding] depends on imgui[sdl2-binding] which does not exist, hello-imgui still supports sdl2-binding but not sdl3-binding, I removed the feature sdl2-binding.
2. Since imgui switched opentype svg support to plutosvg https://github.com/microsoft/vcpkg/pull/43567, hello-imgui[freetype-lunasvg] depends on imgui[freetype-lunasvg] which does not exist..

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.