### PR TITLE
[ptyqt] Update to 0.7.1

### DIFF
--- a/ports/ptyqt/portfile.cmake
+++ b/ports/ptyqt/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kafeg/ptyqt
-    REF 0.6.5
-    SHA512 0deb12be6c0e7bb44775daef3d4361c5d22143bc32cbf251ef99f10784b8996c4aa8e2806f1e08c3b39749ada6e85be91d721830ceee5d6ff86eaf714ef4c928
+    REF "${VERSION}"
+    SHA512 fe24dcbc3f7f94af2af5b47e78090ef1557626921012e9b5ec44334ea10873374df17e43c76b34e1693f26f40b0d20020c11bc1369a565ccb6f49bfce054c7b9
     HEAD_REF master
 )
 
@@ -11,13 +11,13 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -lrt")
 
     if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
-        file(READ ${SOURCE_PATH}/core/CMakeLists.txt filedata)
+        file(READ "${SOURCE_PATH}/core/CMakeLists.txt" filedata)
         string(REPLACE "-static-libstdc++" "-static-libstdc++ -lglib-2.0" filedata "${filedata}")
-        file(WRITE ${SOURCE_PATH}/core/CMakeLists.txt "${filedata}")
+        file(WRITE "${SOURCE_PATH}/core/CMakeLists.txt" "${filedata}")
     else()
-        file(READ ${SOURCE_PATH}/core/CMakeLists.txt filedata)
+        file(READ "${SOURCE_PATH}/core/CMakeLists.txt" filedata)
         string(REPLACE "-static-libstdc++ -lglib-2.0" "-static-libstdc++" filedata "${filedata}")
-        file(WRITE ${SOURCE_PATH}/core/CMakeLists.txt "${filedata}")
+        file(WRITE "${SOURCE_PATH}/core/CMakeLists.txt" "${filedata}")
     endif()
 endif()
 
@@ -38,5 +38,5 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ptyqt/vcpkg.json
+++ b/ports/ptyqt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ptyqt",
-  "version": "0.6.5",
+  "version": "0.7.1",
   "description": "PtyQt - C++ library for work with PseudoTerminals",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7365,7 +7365,7 @@
       "port-version": 14
     },
     "ptyqt": {
-      "baseline": "0.6.5",
+      "baseline": "0.7.1",
       "port-version": 0
     },
     "pugixml": {

--- a/versions/p-/ptyqt.json
+++ b/versions/p-/ptyqt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "625ccee199574666da4d1bc0c34b660725d4a524",
+      "version": "0.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8271563b59832be59aa5c34d89b38875c60bc1e5",
       "version": "0.6.5",
       "port-version": 0


### PR DESCRIPTION
Update `ptyqt` to 0.7.1. No feature needs to be tested.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.