### PR TITLE
[libnick] Update to 2025.3.1

### DIFF
--- a/ports/libnick/portfile.cmake
+++ b/ports/libnick/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NickvisionApps/libnick
     REF "${VERSION}"
-    SHA512 2b9dd64e4dcb461bbb7011dc8bb47b833bc04421fe5d5ab226d188150fc4521d03cbf5c9aadd18f4234fe7bd2728715f65b7bf8e8a39bd26210a2f7154565b35
+    SHA512 6ec1e26e43ed7ad250bf26d3e32d68f8c57b7116bb19b5c12d480263218e05c9abbeea92adab78014bdbda3bf2b8b611bc2a8648db422352325ad2db60f5d0d7
     HEAD_REF main
 )
 

--- a/ports/libnick/vcpkg.json
+++ b/ports/libnick/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libnick",
-  "version": "2025.3.0",
+  "version": "2025.3.1",
   "maintainers": "Nicholas Logozzo nlogozzo225@gmail.com",
   "description": "A cross-platform base for native Nickvision applications.",
   "homepage": "https://github.com/NickvisionApps/libnick",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4901,7 +4901,7 @@
       "port-version": 0
     },
     "libnick": {
-      "baseline": "2025.3.0",
+      "baseline": "2025.3.1",
       "port-version": 0
     },
     "libnoise": {

--- a/versions/l-/libnick.json
+++ b/versions/l-/libnick.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "81f915d0da860f92f5ba9d75595cc6762c3bd9bb",
+      "version": "2025.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7907c6179ee9a0f2ae092569575afe517548061e",
       "version": "2025.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
