### PR TITLE
[hello-imgui] Test, fix

### DIFF
--- a/ports/hello-imgui/cmake-config.diff
+++ b/ports/hello-imgui/cmake-config.diff
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 26ae5f7..10a58fa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -407,7 +407,8 @@ if(HELLOIMGUI_INSTALL)
+         VERSION ${hello_imgui_VERSION}
+         COMPATIBILITY AnyNewerVersion)
+ 
+-    install(FILES "hello_imgui_cmake/hello-imguiConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/hello-imguiConfigVersion.cmake"
++    configure_file("${PROJECT_SOURCE_DIR}/hello_imgui_cmake/hello-imguiConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/hello-imguiConfig.cmake" @ONLY)
++    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/hello-imguiConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/hello-imguiConfigVersion.cmake"
+         DESTINATION lib/cmake/hello_imgui)
+ endif()
+ 
+diff --git a/hello_imgui_cmake/hello-imguiConfig.cmake b/hello_imgui_cmake/hello-imguiConfig.cmake
+index 2b93540..6cfa3f8 100644
+--- a/hello_imgui_cmake/hello-imguiConfig.cmake
++++ b/hello_imgui_cmake/hello-imguiConfig.cmake
+@@ -1,6 +1,9 @@
+ include(CMakeFindDependencyMacro)
+-find_dependency(imgui CONFIG REQUIRED)
+-find_dependency(glad CONFIG REQUIRED)
++find_dependency(imgui CONFIG)
++find_dependency(nlohmann_json CONFIG)
++if("@HELLOIMGUI_HAS_OPENGL3@")
++    find_dependency(glad CONFIG)
++endif()
+ 
+ include(${CMAKE_CURRENT_LIST_DIR}/hello_imgui_cmake/hello_imgui_add_app.cmake)
+ include(${CMAKE_CURRENT_LIST_DIR}/hello-imgui-targets.cmake)

--- a/ports/hello-imgui/imgui-test-engine.diff
+++ b/ports/hello-imgui/imgui-test-engine.diff
@@ -1,0 +1,24 @@
+diff --git a/src/hello_imgui_test_engine_integration/hello_imgui_test_engine_cmake.cmake b/src/hello_imgui_test_engine_integration/hello_imgui_test_engine_cmake.cmake
+index fda2d91..44c76a3 100644
+--- a/src/hello_imgui_test_engine_integration/hello_imgui_test_engine_cmake.cmake
++++ b/src/hello_imgui_test_engine_integration/hello_imgui_test_engine_cmake.cmake
+@@ -147,9 +147,6 @@ endfunction()
+ 
+ # Public API for this module
+ function(add_imgui_test_engine)
+-    _fetch_imgui_test_engine_if_needed()
+-    _add_imgui_test_engine_lib()
+-    _configure_imgui_with_test_engine()
+     _add_hello_imgui_test_engine_integration()
+     # _add_imgui_test_engine_app_minimal_example()
+ endfunction()
+diff --git a/src/hello_imgui_test_engine_integration/test_engine_integration.cpp b/src/hello_imgui_test_engine_integration/test_engine_integration.cpp
+index 9f5bb59..2be0fa1 100644
+--- a/src/hello_imgui_test_engine_integration/test_engine_integration.cpp
++++ b/src/hello_imgui_test_engine_integration/test_engine_integration.cpp
+@@ -1,4 +1,4 @@
+-#include "imgui_test_engine/imgui_te_engine.h"
++#include <imgui_te_engine.h>
+ #include "hello_imgui/runner_params.h"
+ #include "hello_imgui/internal/functional_utils.h"
+ #include "hello_imgui/internal/backend_impls/opengl_setup_helper/opengl_screenshot.h"

--- a/ports/hello-imgui/portfile.cmake
+++ b/ports/hello-imgui/portfile.cmake
@@ -88,11 +88,9 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share/hello-imgui/hello_imgui_cmake/ios-cmake"
 )
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
 if (no_rendering_backend OR no_platform_backend)
-    message(STATUS "
+    file(APPEND "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" "
     ########################################################################
        !!!!                    WARNING                              !!!!!
        !!!!   Installed hello-imgui without a viable backend        !!!!!
@@ -122,3 +120,5 @@ if (no_rendering_backend OR no_platform_backend)
     ########################################################################
     ")
 endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/hello-imgui/portfile.cmake
+++ b/ports/hello-imgui/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     "experimental-dx11-binding" HELLOIMGUI_HAS_DIRECTX11
     "experimental-dx12-binding" HELLOIMGUI_HAS_DIRECTX12
     "glfw-binding" HELLOIMGUI_USE_GLFW3
-    "freetype-plutosvg" HELLOIMGUI_USE_FREETYPE # When hello_imgui is built with freetype, it will also build with plutosvg
+    "freetype" HELLOIMGUI_USE_FREETYPE
 )
 
 if (NOT HELLOIMGUI_HAS_OPENGL3

--- a/ports/hello-imgui/portfile.cmake
+++ b/ports/hello-imgui/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 b44741e27278974f6a545a3143abd18027d98503cc912085e08528c467197fb208d2d4876e483f74e518f3dfc14d12c3579e379b9939dc364a1fff4ee98bb8f5
     HEAD_REF master
+    PATCHES
+        cmake-config.diff
 )
 file(REMOVE_RECURSE
     "${SOURCE_PATH}/external/imgui"

--- a/ports/hello-imgui/portfile.cmake
+++ b/ports/hello-imgui/portfile.cmake
@@ -7,6 +7,13 @@ vcpkg_from_github(
     SHA512 b44741e27278974f6a545a3143abd18027d98503cc912085e08528c467197fb208d2d4876e483f74e518f3dfc14d12c3579e379b9939dc364a1fff4ee98bb8f5
     HEAD_REF master
 )
+file(REMOVE_RECURSE
+    "${SOURCE_PATH}/external/imgui"
+    "${SOURCE_PATH}/external/nlohmann_json"
+    "${SOURCE_PATH}/external/OpenGL_Loaders"
+    "${SOURCE_PATH}/external/stb_hello_imgui/stb_image.h"
+    "${SOURCE_PATH}/external/stb_hello_imgui/stb_image_write.h"
+)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES

--- a/ports/hello-imgui/portfile.cmake
+++ b/ports/hello-imgui/portfile.cmake
@@ -17,15 +17,18 @@ file(REMOVE_RECURSE
     "${SOURCE_PATH}/external/stb_hello_imgui/stb_image_write.h"
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+vcpkg_check_features(OUT_FEATURE_OPTIONS options
     FEATURES
-    "opengl3-binding" HELLOIMGUI_HAS_OPENGL3
-    "metal-binding" HELLOIMGUI_HAS_METAL
-    "experimental-vulkan-binding" HELLOIMGUI_HAS_VULKAN
-    "experimental-dx11-binding" HELLOIMGUI_HAS_DIRECTX11
-    "experimental-dx12-binding" HELLOIMGUI_HAS_DIRECTX12
-    "glfw-binding" HELLOIMGUI_USE_GLFW3
-    "freetype" HELLOIMGUI_USE_FREETYPE
+        # "target platforms"
+        opengl3-binding     HELLOIMGUI_HAS_OPENGL3
+        metal-binding       HELLOIMGUI_HAS_METAL
+        experimental-vulkan-binding HELLOIMGUI_HAS_VULKAN
+        experimental-dx11-binding   HELLOIMGUI_HAS_DIRECTX11
+        experimental-dx12-binding   HELLOIMGUI_HAS_DIRECTX12
+        # "platform backend"
+        glfw-binding        HELLOIMGUI_USE_GLFW3
+        # other
+        freetype            HELLOIMGUI_USE_FREETYPE
 )
 
 if (NOT HELLOIMGUI_HAS_OPENGL3
@@ -41,11 +44,10 @@ if (NOT HELLOIMGUI_USE_GLFW3 AND NOT HELLOIMGUI_USE_SDL2)
 endif()
 
 
-set(platform_options "")
 if(VCPKG_TARGET_IS_WINDOWS)
     # Standard win32 options (these are the defaults for HelloImGui)
     # we could add a vcpkg feature for this, but it would have to be platform specific
-    list(APPEND platform_options
+    list(APPEND options
         -DHELLOIMGUI_WIN32_NO_CONSOLE=ON
         -DHELLOIMGUI_WIN32_AUTO_WINMAIN=ON
     )
@@ -54,7 +56,7 @@ endif()
 if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
     # Standard macOS options (these are the defaults for HelloImGui)
     # we could add a vcpkg feature for this, but it would have to be platform specific
-    list(APPEND platform_options
+    list(APPEND options
         -DHELLOIMGUI_MACOS_NO_BUNDLE=OFF
     )
 endif()
@@ -63,6 +65,7 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${options}
         -DHELLOIMGUI_BUILD_DEMOS=OFF
         -DHELLOIMGUI_BUILD_DOCS=OFF
         -DHELLOIMGUI_BUILD_TESTS=OFF
@@ -73,19 +76,6 @@ vcpkg_cmake_configure(
         -DHELLOIMGUI_USE_IMGUI_CMAKE_PACKAGE=ON
         -DHELLO_IMGUI_IMGUI_SHARED=OFF
         -DHELLOIMGUI_BUILD_IMGUI=OFF
-
-        ${platform_options}
-
-        # Rendering backends
-        -DHELLOIMGUI_HAS_OPENGL3=${HELLOIMGUI_HAS_OPENGL3}
-        -DHELLOIMGUI_HAS_METAL=${HELLOIMGUI_HAS_METAL}
-        -DHELLOIMGUI_HAS_VULKAN=${HELLOIMGUI_HAS_VULKAN}
-        -DHELLOIMGUI_HAS_DIRECTX11=${HELLOIMGUI_HAS_DIRECTX11}
-        -DHELLOIMGUI_HAS_DIRECTX12=${HELLOIMGUI_HAS_DIRECTX12}
-
-        # Platform backends
-        -DHELLOIMGUI_USE_GLFW3=${HELLOIMGUI_USE_GLFW3}
-        -DHELLOIMGUI_USE_SDL2=${HELLOIMGUI_USE_SDL2}
 )
 
 vcpkg_cmake_install()

--- a/ports/hello-imgui/usage
+++ b/ports/hello-imgui/usage
@@ -1,8 +1,8 @@
-hello_imgui provides CMake integration:
+hello-imgui provides CMake integration:
 
   set(CMAKE_CXX_STANDARD 17)
   find_package(hello-imgui CONFIG REQUIRED)
   # Usage with `hello_imgui_add_app` (recommended)
   hello_imgui_add_app(main my_main.cpp)
-  # Usage with `target_link_libraries` (no tooling and asset deployment)
+  # Usage with `target_link_libraries` (no tooling, no asset deployment)
   target_link_libraries(main PRIVATE hello-imgui::hello_imgui)

--- a/ports/hello-imgui/usage
+++ b/ports/hello-imgui/usage
@@ -1,17 +1,8 @@
-hello_imgui provides CMake targets and hello_imgui_add_app:
+hello_imgui provides CMake integration:
 
-Usage with `hello_imgui_add_app` (recommended)
-    set(CMAKE_CXX_STANDARD 17)
-    find_package(hello-imgui CONFIG REQUIRED)
-    hello_imgui_add_app(test test.cpp)      # see example below
-
-Usage with `target_link_libraries`
-    set(CMAKE_CXX_STANDARD 17)
-    find_package(hello-imgui CONFIG REQUIRED)
-    # Note the subtle difference between the package name and the target name: hello-imgui vs hello_imgui!
-    target_link_libraries(main PRIVATE hello-imgui::hello_imgui)
-    # this mode will ignore all of hello_imgui cmake tooling, and will not deploy the assets
-
-Example test.cpp:
-    #include "hello_imgui/hello_imgui.h"
-    int main() { HelloImGui::Run([](){ ImGui::Text("Hello, world!"); ImGui::ShowDemoWindow(); }); }
+  set(CMAKE_CXX_STANDARD 17)
+  find_package(hello-imgui CONFIG REQUIRED)
+  # Usage with `hello_imgui_add_app` (recommended)
+  hello_imgui_add_app(main my_main.cpp)
+  # Usage with `target_link_libraries` (no tooling and asset deployment)
+  target_link_libraries(main PRIVATE hello-imgui::hello_imgui)

--- a/ports/hello-imgui/vcpkg.json
+++ b/ports/hello-imgui/vcpkg.json
@@ -12,6 +12,7 @@
         "docking-experimental"
       ]
     },
+    "nlohmann-json",
     "stb",
     {
       "name": "vcpkg-cmake",

--- a/ports/hello-imgui/vcpkg.json
+++ b/ports/hello-imgui/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hello-imgui",
   "version": "1.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Hello ImGui: unleash your creativity in app development and prototyping",
   "homepage": "https://pthom.github.io/hello_imgui/",
   "license": "MIT",
@@ -56,14 +56,13 @@
         }
       ]
     },
-    "freetype-plutosvg": {
-      "description": "Improve font rendering and use colored fonts with freetype and plutosvg",
+    "freetype": {
+      "description": "Use freetype for text rendering",
       "dependencies": [
         {
           "name": "imgui",
           "features": [
-            "freetype",
-            "freetype-svg"
+            "freetype"
           ]
         }
       ]

--- a/ports/hello-imgui/vcpkg.json
+++ b/ports/hello-imgui/vcpkg.json
@@ -2,7 +2,10 @@
   "name": "hello-imgui",
   "version": "1.6.0",
   "port-version": 2,
-  "description": "Hello ImGui: unleash your creativity in app development and prototyping",
+  "description": [
+    "Hello ImGui: unleash your creativity in app development and prototyping",
+    "Note that at least on renderer backend and at least one platform backend must be chosen."
+  ],
   "homepage": "https://pthom.github.io/hello_imgui/",
   "license": "MIT",
   "dependencies": [
@@ -57,17 +60,6 @@
         }
       ]
     },
-    "freetype": {
-      "description": "Use freetype for text rendering",
-      "dependencies": [
-        {
-          "name": "imgui",
-          "features": [
-            "freetype"
-          ]
-        }
-      ]
-    },
     "glfw-binding": {
       "description": "Use GLFW platform backend (default)",
       "dependencies": [
@@ -103,6 +95,17 @@
           "name": "imgui",
           "features": [
             "opengl3-binding"
+          ]
+        }
+      ]
+    },
+    "test-engine": {
+      "description": "Build test engine",
+      "dependencies": [
+        {
+          "name": "imgui",
+          "features": [
+            "test-engine"
           ]
         }
       ]

--- a/scripts/test_ports/vcpkg-ci-hello-imgui/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-hello-imgui/portfile.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-hello-imgui/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-hello-imgui/project/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.30)
+project(hello-imgui-test CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(hello-imgui CONFIG REQUIRED)
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE
+    hello-imgui::hello_imgui
+)

--- a/scripts/test_ports/vcpkg-ci-hello-imgui/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-hello-imgui/project/main.cpp
@@ -1,0 +1,10 @@
+#include <hello_imgui/hello_imgui.h>
+
+int main()
+{
+    HelloImGui::Run([]() {
+        ImGui::Text("Hello vcpkg");
+        ImGui::ShowDemoWindow();
+    });
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-hello-imgui/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-hello-imgui/vcpkg.json
@@ -24,16 +24,16 @@
         {
           "name": "hello-imgui",
           "features": [
-            "freetype",
             "glfw-binding",
-            "opengl3-binding"
+            "opengl3-binding",
+            "test-engine"
           ],
           "platform": "linux"
         },
         {
+          "$comment": "No platform backend available since removal of imgui[sdl2-binding]",
           "name": "hello-imgui",
           "features": [
-            "freetype",
             "opengl3-binding"
           ],
           "platform": "android"
@@ -41,6 +41,7 @@
         {
           "name": "hello-imgui",
           "features": [
+            "glfw-binding",
             "metal-binding"
           ],
           "platform": "ios | osx"
@@ -48,7 +49,7 @@
         {
           "name": "hello-imgui",
           "features": [
-            "freetype",
+            "glfw-binding",
             "opengl3-binding"
           ],
           "platform": "x64 & windows"
@@ -57,7 +58,7 @@
           "name": "hello-imgui",
           "features": [
             "experimental-dx11-binding",
-            "freetype"
+            "glfw-binding"
           ],
           "platform": "x86 & windows"
         },
@@ -65,7 +66,8 @@
           "name": "hello-imgui",
           "features": [
             "experimental-vulkan-binding",
-            "freetype"
+            "glfw-binding",
+            "test-engine"
           ],
           "platform": "arm64 & windows"
         }

--- a/scripts/test_ports/vcpkg-ci-hello-imgui/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-hello-imgui/vcpkg.json
@@ -24,7 +24,50 @@
         {
           "name": "hello-imgui",
           "features": [
-          ]
+            "freetype",
+            "glfw-binding",
+            "opengl3-binding"
+          ],
+          "platform": "linux"
+        },
+        {
+          "name": "hello-imgui",
+          "features": [
+            "freetype",
+            "opengl3-binding"
+          ],
+          "platform": "android"
+        },
+        {
+          "name": "hello-imgui",
+          "features": [
+            "metal-binding"
+          ],
+          "platform": "ios | osx"
+        },
+        {
+          "name": "hello-imgui",
+          "features": [
+            "freetype",
+            "opengl3-binding"
+          ],
+          "platform": "x64 & windows"
+        },
+        {
+          "name": "hello-imgui",
+          "features": [
+            "experimental-dx11-binding",
+            "freetype"
+          ],
+          "platform": "x86 & windows"
+        },
+        {
+          "name": "hello-imgui",
+          "features": [
+            "experimental-vulkan-binding",
+            "freetype"
+          ],
+          "platform": "arm64 & windows"
         }
       ]
     }

--- a/scripts/test_ports/vcpkg-ci-hello-imgui/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-hello-imgui/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "vcpkg-ci-hello-imgui",
+  "version-string": "ci",
+  "description": "Port to force features of hello-imgui within CI",
+  "homepage": "https://github.com/microsoft/vcpkg",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "hello-imgui",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "all"
+  ],
+  "features": {
+    "all": {
+      "description": "Test all features",
+      "dependencies": [
+        {
+          "name": "hello-imgui",
+          "features": [
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3538,7 +3538,7 @@
     },
     "hello-imgui": {
       "baseline": "1.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "hexl": {
       "baseline": "1.2.5",

--- a/versions/h-/hello-imgui.json
+++ b/versions/h-/hello-imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d5ca2e9e5bc11096b64d6db8097f526b1d9acb6c",
+      "version": "1.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "ad86a79efe058977548ffde34179005239f78266",
       "version": "1.6.0",
       "port-version": 1

--- a/versions/h-/hello-imgui.json
+++ b/versions/h-/hello-imgui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d5ca2e9e5bc11096b64d6db8097f526b1d9acb6c",
+      "git-tree": "7b5fb698a8594d93f40dc96edbbce679a852c1bf",
       "version": "1.6.0",
       "port-version": 2
     },


### PR DESCRIPTION
Add test port.
Remove vendored copies of dependencies.
Fix use of dependencies and CMake config.
Add comments for current lack of an SDL platform backend.
Remove feature "freetype-plutosvg". Freetype support in entirely contained in `imgui`. Amends https://github.com/microsoft/vcpkg/pull/44230.
Add feature "test-engine" based on what is built into the imgui library.
