### PR TITLE
[openctm] Use 7zip provided by vcpkg

### DIFF
--- a/ports/openctm/CMakeLists.txt
+++ b/ports/openctm/CMakeLists.txt
@@ -4,6 +4,8 @@ project(
   VERSION 1.0.3
   LANGUAGES C)
 
+find_package(7zip CONFIG REQUIRED)
+
 set(PUBLIC_HEADERS lib/openctm.h lib/openctmpp.h)
 
 add_library(
@@ -12,19 +14,14 @@ add_library(
   lib/compressMG2.c
   lib/compressRAW.c
   lib/openctm.c
-  lib/stream.c
-  lib/liblzma/Alloc.c
-  lib/liblzma/LzFind.c
-  lib/liblzma/LzmaDec.c
-  lib/liblzma/LzmaEnc.c
-  lib/liblzma/LzmaLib.c)
+  lib/stream.c)
 
 target_include_directories(
   openctm
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/lib>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/lib/liblzma>
          $<INSTALL_INTERFACE:include>)
-target_compile_definitions(openctm PRIVATE OPENCTM_BUILD LZMA_PREFIX_CTM)
+target_link_libraries(openctm PRIVATE 7zip::7zip)
+target_compile_definitions(openctm PRIVATE OPENCTM_BUILD)
 if(NOT BUILD_SHARED_LIBS)
   target_compile_definitions(openctm PUBLIC OPENCTM_STATIC)
 endif()

--- a/ports/openctm/portfile.cmake
+++ b/ports/openctm/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_sourceforge(
     REF OpenCTM-1.0.3
     SHA512 fdfa08d19ecbfea99ba01aa2032e941ed6313394a96bd69f8984c2d2d079d836c616471d2bdf6f40175e75659f3ad0ba41502bc3d8224091472f40893ea8746e
     FILENAME "OpenCTM-1.0.3-src.tar.bz2"
+    PATCHES
+        use-7zip.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
@@ -18,4 +20,4 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-openctm)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/openctm/use-7zip.patch
+++ b/ports/openctm/use-7zip.patch
@@ -1,0 +1,24 @@
+diff --git a/lib/stream.c b/lib/stream.c
+index 53b1b72..bb47c3b 100644
+--- a/lib/stream.c
++++ b/lib/stream.c
+@@ -310,8 +310,7 @@ int _ctmStreamWritePackedInts(_CTMcontext * self, CTMint * aData,
+                          outProps,
+                          &outPropsSize,
+                          self->mCompressionLevel, // Level (0-9)
+-                         0, -1, -1, -1, -1, -1,   // Default values (set by level)
+-                         lzmaAlgo                 // Algorithm (0 = fast, 1 = normal)
++                         0, -1, -1, -1, -1, -1   // Default values (set by level)
+                         );
+ 
+   // Free temporary array
+@@ -477,8 +476,7 @@ int _ctmStreamWritePackedFloats(_CTMcontext * self, CTMfloat * aData,
+                          outProps,
+                          &outPropsSize,
+                          self->mCompressionLevel, // Level (0-9)
+-                         0, -1, -1, -1, -1, -1,   // Default values (set by level)
+-                         lzmaAlgo                 // Algorithm (0 = fast, 1 = normal)
++                         0, -1, -1, -1, -1, -1   // Default values (set by level)
+                         );
+ 
+   // Free temporary array

--- a/ports/openctm/vcpkg.json
+++ b/ports/openctm/vcpkg.json
@@ -1,10 +1,12 @@
 {
   "name": "openctm",
   "version": "1.0.3",
+  "port-version": 1,
   "description": "OpenCTM — the Open Compressed Triangle Mesh file format — is a file format, a software library and a tool set for compression of 3D triangle meshes.",
   "homepage": "http://openctm.sourceforge.net/",
   "license": "Zlib",
   "dependencies": [
+    "7zip",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6714,7 +6714,7 @@
     },
     "openctm": {
       "baseline": "1.0.3",
-      "port-version": 0
+      "port-version": 1
     },
     "opencv": {
       "baseline": "4.10.0",

--- a/versions/o-/openctm.json
+++ b/versions/o-/openctm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92ac7a53f30a5fadc0cf5186f2d256c87d494471",
+      "version": "1.0.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "ea30144a8ad57cb95b0603de14e4dc8e9f7b2ea2",
       "version": "1.0.3",
       "port-version": 0


### PR DESCRIPTION
Fixes

#44085 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

To test create a main.cpp file with:

```c++
#include <7zip/C/LzmaLib.h>
#include <openctm.h>

int main()
{
    LzmaCompress({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {});
    ctmNewContext({});
}
```

and compile with a statically linked triplet like x64-linux or x64-windows-static.
