### PR TITLE
[duckdb] update to 1.2.1

### DIFF
--- a/ports/duckdb/httpfs.patch
+++ b/ports/duckdb/httpfs.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4496860..fdda539 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1257,7 +1257,14 @@ endforeach()
+ # Load extensions passed through cmake config var
+ foreach(EXT IN LISTS BUILD_EXTENSIONS)
+   if(NOT "${EXT}" STREQUAL "")
+-    duckdb_extension_load(${EXT})
++    if("${EXT}" STREQUAL "httpfs")
++      duckdb_extension_load(${EXT} 
++        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/httpfs
++        INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/httpfs/extension/httpfs/include
++      )
++    else()
++      duckdb_extension_load(${EXT})
++    endif()
+   endif()
+ endforeach()
+ 

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO duckdb/duckdb
         REF v${VERSION}
-        SHA512 f5bca7a3b6f763b4b1a1f39e53c6f818925584fb44886e291ac3546fe50de545e80d16b4120f0126020e44b601a1b9193f4faad7a3dc8799cda843b1965038f2
+        SHA512 7e2ec4f6d6be6d500b148bd845cc51fe8985190eed8ab6f6fe79012c216cad5592ab3329e2df6b091abcc6ea8937d66f47272baead798c7d711e5d73aa9ffaa7
         HEAD_REF master
     PATCHES
         bigobj.patch

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -7,7 +7,8 @@ vcpkg_from_github(
     PATCHES
         bigobj.patch
         unvendor_icu_and_find_dependency.patch # https://github.com/duckdb/duckdb/pull/16176 + https://github.com/duckdb/duckdb/pull/16197
-)
+        httpfs.patch
+        )
 
 # Remove vendored dependencies which are not properly namespaced
 file(REMOVE_RECURSE
@@ -16,6 +17,16 @@ file(REMOVE_RECURSE
     "${SOURCE_PATH}/third_party/snowball"
     "${SOURCE_PATH}/third_party/tpce-tool"
 )
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH DUCKDB_HTTPFS_SOURCE_PATH
+    REPO duckdb/duckdb_httpfs
+    REF 85ac4667bcb0d868199e156f8dd918b0278db7b9
+    SHA512 5790ed795d394dd1b512aac0d1f1dc5976588d93b34381cab1d78c256428f3047682c7b662b1c855d3b19a9dbf99a6c64f32152dba347c18f2a36e19bcc3c5df
+    HEAD_REF main
+)
+
+file(RENAME "${DUCKDB_HTTPFS_SOURCE_PATH}" "${SOURCE_PATH}/extension/httpfs")
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" DUCKDB_BUILD_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DUCKDB_BUILD_DYNAMIC)

--- a/ports/duckdb/unvendor_icu_and_find_dependency.patch
+++ b/ports/duckdb/unvendor_icu_and_find_dependency.patch
@@ -16,26 +16,28 @@ index ef61b6b..2e5270e 100644
  get_filename_component(DuckDB_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
  set(DuckDB_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 diff --git a/extension/icu/CMakeLists.txt b/extension/icu/CMakeLists.txt
-index 65cbe38..6a38f93 100644
+index 65cbe38..b5585e4 100644
 --- a/extension/icu/CMakeLists.txt
 +++ b/extension/icu/CMakeLists.txt
-@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 2.8.12...3.29)
+@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 2.8.12...3.29)
  project(ICUExtension)
  
  include_directories(include)
 -include_directories(third_party/icu/common)
 -include_directories(third_party/icu/i18n)
+-
+-add_subdirectory(third_party)
 +option(WITH_INTERNAL_ICU "Use vendored copy of icu" TRUE)
 +if(WITH_INTERNAL_ICU)
 +    include_directories(third_party/icu/common)
 +    include_directories(third_party/icu/i18n)
  
--add_subdirectory(third_party)
 +    add_subdirectory(third_party)
 +endif()
- 
++    
  set(ICU_EXTENSION_FILES
      ${ICU_LIBRARY_FILES}
+     icu_extension.cpp
 @@ -26,6 +29,10 @@ set(ICU_EXTENSION_FILES
  
  build_static_extension(icu ${ICU_EXTENSION_FILES})
@@ -48,15 +50,15 @@ index 65cbe38..6a38f93 100644
  set(PARAMETERS "-no-warnings")
  build_loadable_extension(icu ${PARAMETERS} ${ICU_EXTENSION_FILES})
 diff --git a/extension/icu/icu-datefunc.cpp b/extension/icu/icu-datefunc.cpp
-index 995f594..a8092b6 100644
+index 0c38827..c744b68 100644
 --- a/extension/icu/icu-datefunc.cpp
 +++ b/extension/icu/icu-datefunc.cpp
 @@ -72,7 +72,7 @@ unique_ptr<FunctionData> ICUDateFunc::Bind(ClientContext &context, ScalarFunctio
  }
  
- void ICUDateFunc::SetTimeZone(icu::Calendar *calendar, const string_t &tz_id) {
+ bool ICUDateFunc::TrySetTimeZone(icu::Calendar *calendar, const string_t &tz_id) {
 -	auto tz = icu_66::TimeZone::createTimeZone(icu::UnicodeString::fromUTF8(icu::StringPiece(tz_id.GetString())));
 +	auto tz = icu::TimeZone::createTimeZone(icu::UnicodeString::fromUTF8(icu::StringPiece(tz_id.GetString())));
  	if (*tz == icu::TimeZone::getUnknown()) {
  		delete tz;
- 		throw NotImplementedException("Unknown TimeZone '%s'", tz_id.GetString());
+ 		return false;

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "High-performance in-process analytical database system",
   "homepage": "https://duckdb.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2425,7 +2425,7 @@
       "port-version": 0
     },
     "duckdb": {
-      "baseline": "1.2.0",
+      "baseline": "1.2.1",
       "port-version": 0
     },
     "duckx": {

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e68b27b978a2dff4342f1338f56a2889ea2c217",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "02e6c406fafcd36a23c51998c14c1e95653b2254",
       "version": "1.2.0",
       "port-version": 0

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0e68b27b978a2dff4342f1338f56a2889ea2c217",
+      "git-tree": "213b32d9a3a2f7ef1676b475d18efa7d20879888",
       "version": "1.2.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
