### PR TITLE
Add audio engine

### DIFF
--- a/ports/audio-engine/portfile.cmake
+++ b/ports/audio-engine/portfile.cmake
@@ -1,0 +1,26 @@
+set(VCPKG_POLICY_ALLOW_DEBUG_INCLUDE enabled)
+
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+if(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_LINUX)
+    message(FATAL_ERROR "minha-biblioteca only supports Windows and Linux")
+endif()
+
+vcpkg_from_github(
+   OUT_SOURCE_PATH SOURCE_PATH
+   REPO Darkx32/AudioEngine
+   REF "${VERSION}"
+   SHA512 56025f415f6f45e8085f476e98335e922c97e47844bc12f9fc3c14cf108a1934cbb02a67e9a765c1ceb27d3f26b665e47ed4a03539dd50946c20cca980d706d0
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+       -DAUDIOENGINE_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/audio-engine/vcpkg.json
+++ b/ports/audio-engine/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "audio-engine",
+  "version-string": "v1.1",
+  "homepage": "https://github.com/Darkx32/AudioEngine",
+  "description": "AudioEngine created using C++, FFMPEG and OpenAL for a student",
+  "license": "MIT",
+  "supports": "x64 & (windows | linux)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    "ffmpeg",
+    "openal-soft"
+  ]
+}

--- a/ports/audio-engine/vcpkg.json
+++ b/ports/audio-engine/vcpkg.json
@@ -1,16 +1,16 @@
 {
   "name": "audio-engine",
   "version-string": "v1.1",
-  "homepage": "https://github.com/Darkx32/AudioEngine",
   "description": "AudioEngine created using C++, FFMPEG and OpenAL for a student",
+  "homepage": "https://github.com/Darkx32/AudioEngine",
   "license": "MIT",
   "supports": "x64 & (windows | linux)",
   "dependencies": [
+    "ffmpeg",
+    "openal-soft",
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    "ffmpeg",
-    "openal-soft"
+    }
   ]
 }


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.