### PR TITLE
[icecream-cpp] add new port

### DIFF
--- a/ports/icecream-cpp/portfile.cmake
+++ b/ports/icecream-cpp/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO renatoGarcia/icecream-cpp
+    REF "v${VERSION}"
+    SHA512 57410045b5dce11da3bba423347a0b7e861a1ce7eaae4317b08e366ff79530985fc300d12ef5ce9388bc44574cc03fd0b3c2a9b80a3949f41620778b18fd9ace
+    HEAD_REF main
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/icecream-cpp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/icecream-cpp/portfile.cmake
+++ b/ports/icecream-cpp/portfile.cmake
@@ -17,5 +17,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/icecream-cpp)
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/icecream-cpp/portfile.cmake
+++ b/ports/icecream-cpp/portfile.cmake
@@ -17,6 +17,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
-# file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/icecream-cpp/portfile.cmake
+++ b/ports/icecream-cpp/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO renatoGarcia/icecream-cpp
     REF "v${VERSION}"
     SHA512 57410045b5dce11da3bba423347a0b7e861a1ce7eaae4317b08e366ff79530985fc300d12ef5ce9388bc44574cc03fd0b3c2a9b80a3949f41620778b18fd9ace
-    HEAD_REF main
+    HEAD_REF master
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only

--- a/ports/icecream-cpp/portfile.cmake
+++ b/ports/icecream-cpp/portfile.cmake
@@ -22,5 +22,4 @@ else()
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/icecream-cpp/portfile.cmake
+++ b/ports/icecream-cpp/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-if(MSVC)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
     vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 else()
     vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})

--- a/ports/icecream-cpp/portfile.cmake
+++ b/ports/icecream-cpp/portfile.cmake
@@ -15,7 +15,11 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+if(MSVC)
+    vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+else()
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/icecream-cpp/portfile.cmake
+++ b/ports/icecream-cpp/portfile.cmake
@@ -15,8 +15,8 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/icecream-cpp)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+# file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/icecream-cpp/vcpkg.json
+++ b/ports/icecream-cpp/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "icecream-cpp",
+  "version": "1.0.0",
+  "description": "A little (single header) library to help with the print debugging in C++11 and forward.",
+  "homepage": "https://github.com/renatoGarcia/icecream-cpp",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3632,6 +3632,10 @@
       "baseline": "2.32.0",
       "port-version": 0
     },
+    "icecream-cpp": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "iceoryx": {
       "baseline": "2.0.6",
       "port-version": 1

--- a/versions/i-/icecream-cpp.json
+++ b/versions/i-/icecream-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "69ebb02c70c27b2ce1f967254ec0d318e5fbbc9b",
+      "git-tree": "fbffe476157f7991191f0d46cd3199990e785c62",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/i-/icecream-cpp.json
+++ b/versions/i-/icecream-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a0afdb059c1dfe3e39c0cb826346569fd9abadcb",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/i-/icecream-cpp.json
+++ b/versions/i-/icecream-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f908c9c9c4f17ae37f487b0dc8f6dd738399c5d0",
+      "git-tree": "ddc5e95c998d125cf9cadef5f742f0ed8fb4f505",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/i-/icecream-cpp.json
+++ b/versions/i-/icecream-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d2e66987c8dac2451dfaf1ab43023b8537ee853e",
+      "git-tree": "f45a86c34d4fa023eb0be088e187676628843860",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/i-/icecream-cpp.json
+++ b/versions/i-/icecream-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1ab56a7caa9ee22c0b1c4b20ddc5fe9ee59ba418",
+      "git-tree": "69ebb02c70c27b2ce1f967254ec0d318e5fbbc9b",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/i-/icecream-cpp.json
+++ b/versions/i-/icecream-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ddc5e95c998d125cf9cadef5f742f0ed8fb4f505",
+      "git-tree": "d2e66987c8dac2451dfaf1ab43023b8537ee853e",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/i-/icecream-cpp.json
+++ b/versions/i-/icecream-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fbffe476157f7991191f0d46cd3199990e785c62",
+      "git-tree": "f908c9c9c4f17ae37f487b0dc8f6dd738399c5d0",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/i-/icecream-cpp.json
+++ b/versions/i-/icecream-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a0afdb059c1dfe3e39c0cb826346569fd9abadcb",
+      "git-tree": "1ab56a7caa9ee22c0b1c4b20ddc5fe9ee59ba418",
       "version": "1.0.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/renatoGarcia/icecream-cpp/tree/master
