### PR TITLE
[libphonenumber] update to 9.0.0

### DIFF
--- a/ports/libphonenumber/portfile.cmake
+++ b/ports/libphonenumber/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/libphonenumber
     REF "v${VERSION}"
-    SHA512 8cc5be5aaaf832288ac011131b41026a44dba702b96a4dbdafcd55e43c870130a089e96187fa4fb8df75e5065185a2eb9af25ece4a7d5b1fcc459b875dceb662
+    SHA512 4cf67bf7beb98ea716564add8dc58e4baf57cefa518cc498c7945fb73e6432f8b990482366b3f6b4f9bc5bf48f8ff2e16f7644e27022393ea018a27ad5cf09a5
     HEAD_REF master
     PATCHES 
         fix-re2-identifiers.patch

--- a/ports/libphonenumber/vcpkg.json
+++ b/ports/libphonenumber/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libphonenumber",
-  "version": "8.13.55",
+  "version": "9.0.0",
   "description": "Google's common Java, C++ and JavaScript library for parsing, formatting, and validating international phone numbers.",
   "homepage": "https://github.com/google/libphonenumber",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4997,7 +4997,7 @@
       "port-version": 2
     },
     "libphonenumber": {
-      "baseline": "8.13.55",
+      "baseline": "9.0.0",
       "port-version": 0
     },
     "libplist": {

--- a/versions/l-/libphonenumber.json
+++ b/versions/l-/libphonenumber.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ba1cb227b94301c33094e014c526dd2d96279107",
+      "version": "9.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a0a4e43fcec35bfdd93e4e75578ee3fbe095c495",
       "version": "8.13.55",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
