### PR TITLE
[msquic] update to 2.4.8

### DIFF
--- a/ports/msquic/portfile.cmake
+++ b/ports/msquic/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH QUIC_SOURCE_PATH
     REPO microsoft/msquic
     REF "v${VERSION}"
-    SHA512 c6e4b5f5d9b7e92469a6733a99eaf677909a5b2287869f0bbcc61fbcda6db4a6e920b327ede43fc9b1b0a3d09518c568dc1f38ad5fbb3ace14c1c031012b9968
+    SHA512 1dca477f62484988c4f74d80a671560a48e8ed60602189a4066f337b13786528f38a86437881538089bf47b5db3d228cb006cae298f27b574850612181ee00d9
     HEAD_REF master
     PATCHES
         fix-install.patch # Adjust install path of build outputs

--- a/ports/msquic/vcpkg.json
+++ b/ports/msquic/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "msquic",
-  "version": "2.4.7",
-  "port-version": 3,
+  "version": "2.4.8",
   "description": "Cross-platform, C implementation of the IETF QUIC protocol",
   "homepage": "https://github.com/microsoft/msquic",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6225,8 +6225,8 @@
       "port-version": 4
     },
     "msquic": {
-      "baseline": "2.4.7",
-      "port-version": 3
+      "baseline": "2.4.8",
+      "port-version": 0
     },
     "mstch": {
       "baseline": "1.0.2",

--- a/versions/m-/msquic.json
+++ b/versions/m-/msquic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3509b90a15065b7d89109b53e179b2908dda7dda",
+      "version": "2.4.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "4e5648681b1e1f2ac74e7ab7be04d1215a0063bf",
       "version": "2.4.7",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/microsoft/msquic/releases/tag/v2.4.8