### PR TITLE
[gz-sim] Add gz-sim port

### DIFF
--- a/ports/gz-gui/portfile.cmake
+++ b/ports/gz-gui/portfile.cmake
@@ -29,6 +29,4 @@ if(VCPKG_TARGET_IS_WINDOWS)
       file(REMOVE ${plugins_debug})
    endif()
 
-    # Lacking pc files for Qt
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 endif()

--- a/ports/gz-gui/vcpkg.json
+++ b/ports/gz-gui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gz-gui",
   "version": "9.0.0",
+  "port-version": 1,
   "description": "Gazebo GUI builds on top of Qt to provide widgets which are useful when developing robotics applications, such as a 3D view, plots, dashboard, etc, and can be used together in a convenient unified interface.",
   "homepage": "https://gazebosim.org/libs/gui",
   "license": "Apache-2.0",

--- a/ports/gz-sim/cxx_flags.patch
+++ b/ports/gz-sim/cxx_flags.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,8 +23,16 @@
+ #============================================================================
+ # Set project-specific options
+ #============================================================================
+ 
++if(WIN32)
++  set(CMAKE_CXX_FLAGS "/bigobj ${CMAKE_CXX_FLAGS}")
++endif()
++
++if(UNIX AND NOT APPLE)
++  set(CMAKE_CXX_FLAGS "-Wl,-Bsymbolic ${CMAKE_CXX_FLAGS}")
++endif()
++
+ option(ENABLE_PROFILER "Enable Gazebo Profiler" FALSE)
+ 
+ if(ENABLE_PROFILER)
+   add_definitions("-DGZ_PROFILER_ENABLE=1")

--- a/ports/gz-sim/dependencies.patch
+++ b/ports/gz-sim/dependencies.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9f309499c..943f60d98 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -121,7 +121,7 @@ gz_find_package (Qt5
+     Quick
+     QuickControls2
+   REQUIRED
+-  PKGCONFIG "Qt5Core Qt5Quick Qt5QuickControls2")
++)
+ 
+ #--------------------------------------
+ # Find gz-physics

--- a/ports/gz-sim/portfile.cmake
+++ b/ports/gz-sim/portfile.cmake
@@ -1,0 +1,38 @@
+string(REGEX MATCH "^[0-9]+" VERSION_MAJOR ${VERSION})
+set(PACKAGE_NAME gazebo)
+
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
+
+ignition_modular_library(
+   NAME ${PACKAGE_NAME}
+   REF ${PORT}${VERSION_MAJOR}_${VERSION}
+   VERSION ${VERSION}
+   SHA512 4ac9debe27a41233c7c2116bd80f277ebe74f4ae639f06555cec4209bb7af6fe741197705fac222b4e00c8493daaf701b1eefee4ff639fdea70703bed80e0f8a
+   OPTIONS
+      -DSKIP_PYBIND11=ON
+      "-DPython3_EXECUTABLE=${PYTHON3}"
+   PATCHES
+      dependencies.patch
+      cxx_flags.patch
+)
+
+IF(EXISTS "${CURRENT_PACKAGES_DIR}/lib/${PORT}-${VERSION_MAJOR}/")
+   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/plugins")
+   file(RENAME "${CURRENT_PACKAGES_DIR}/lib/${PORT}-${VERSION_MAJOR}/" "${CURRENT_PACKAGES_DIR}/plugins/${PORT}-${VERSION_MAJOR}/")
+endif()
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/${PORT}-${VERSION_MAJOR}/")
+   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/plugins")
+   file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/${PORT}-${VERSION_MAJOR}/" "${CURRENT_PACKAGES_DIR}/debug/plugins/${PORT}-${VERSION_MAJOR}/")
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+   file(GLOB BIN_DLLS "${CURRENT_PACKAGES_DIR}/lib/${PORT}${VERSION_MAJOR}-*.dll")
+   file(GLOB BIN_DEBUG_DLLS "${CURRENT_PACKAGES_DIR}/debug/lib/${PORT}${VERSION_MAJOR}-*.dll")
+
+   file(COPY ${BIN_DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/bin/")
+   file(COPY ${BIN_DEBUG_DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/")
+
+   file(REMOVE_RECURSE ${BIN_DLLS} ${BIN_DEBUG_DLLS})
+endif()

--- a/ports/gz-sim/vcpkg.json
+++ b/ports/gz-sim/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "gz-sim",
+  "version": "9.0.0",
+  "description": "Gazebo Sim is an open source robotics simulator.",
+  "homepage": "https://gazebosim.org/libs/sim",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "gz-cmake",
+    "gz-common",
+    "gz-fuel-tools",
+    "gz-gui",
+    "gz-math",
+    "gz-msgs",
+    "gz-physics",
+    "gz-plugin",
+    "gz-rendering",
+    "gz-sensors",
+    "gz-transport",
+    "gz-utils",
+    {
+      "name": "ignition-modularscripts",
+      "host": true
+    },
+    "sdformat"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3438,7 +3438,7 @@
     },
     "gz-gui": {
       "baseline": "9.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "gz-gui7": {
       "baseline": "7.2.1",
@@ -3491,6 +3491,10 @@
     "gz-sensors7": {
       "baseline": "7.3.0",
       "port-version": 1
+    },
+    "gz-sim": {
+      "baseline": "9.0.0",
+      "port-version": 0
     },
     "gz-tools": {
       "baseline": "2.0.1",

--- a/versions/g-/gz-gui.json
+++ b/versions/g-/gz-gui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff1310cb6e15487d525ff301ccafad1af6a66c46",
+      "version": "9.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "41832e3622c06b574473bf4d9355d2fd3429205c",
       "version": "9.0.0",
       "port-version": 0

--- a/versions/g-/gz-sim.json
+++ b/versions/g-/gz-sim.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f4e987fd959e697589da3a4ecc77a1f805001dc4",
+      "version": "9.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

