### PR TITLE
[libgeotiff] Update to 1.7.4

### DIFF
--- a/ports/libgeotiff/portfile.cmake
+++ b/ports/libgeotiff/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/libgeotiff
     REF  ${VERSION}
-    SHA512 4cbe221ae72e1ebe8e0cf7036c2bca019633f82cab125dd5b78e524e80d2c05cbfced89f5dc35c7d6d8d1253cc0aaad751150353f773813a037d53ddaa3427f7
+    SHA512 03468e8eeaf97d82798bf341cf2e27753eb47af985fb08fc6176be799bd0e1e879c6d1701577f7568f269cbef0bb0a20ae460bb943f847daf49aa54601441683
     HEAD_REF master
     PATCHES
         cmakelists.patch

--- a/ports/libgeotiff/vcpkg.json
+++ b/ports/libgeotiff/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libgeotiff",
-  "version": "1.7.3",
-  "port-version": 1,
+  "version": "1.7.4",
   "description": "Libgeotiff is an open source library on top of libtiff for reading and writing GeoTIFF information tags.",
   "homepage": "https://github.com/OSGeo/libgeotiff",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4609,8 +4609,8 @@
       "port-version": 3
     },
     "libgeotiff": {
-      "baseline": "1.7.3",
-      "port-version": 1
+      "baseline": "1.7.4",
+      "port-version": 0
     },
     "libgig": {
       "baseline": "4.4.1",

--- a/versions/l-/libgeotiff.json
+++ b/versions/l-/libgeotiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "749705c57437e7cb122ca826ddfe7c7b8a23ddea",
+      "version": "1.7.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "160d4b272c93184c34fdb69402484ac856ad10f5",
       "version": "1.7.3",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
