### PR TITLE
[jwt-cpp] Update to version 0.7.1

### DIFF
--- a/ports/jwt-cpp/external-json.diff
+++ b/ports/jwt-cpp/external-json.diff
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2520e4ed..2a911674 100644
+index 2520e4ed..7209b4e9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -69,11 +69,14 @@ elseif(${JWT_SSL_LIBRARY} MATCHES "wolfSSL")
+@@ -69,11 +69,11 @@ elseif(${JWT_SSL_LIBRARY} MATCHES "wolfSSL")
    list(TRANSFORM wolfssl_INCLUDE_DIRS APPEND "/wolfssl") # This is required to access OpenSSL compatibility API
  endif()
  
@@ -12,10 +12,29 @@ index 2520e4ed..2a911674 100644
  endif()
  
 -if(JWT_BUILD_EXAMPLES OR JWT_BUILD_TESTS)
-+find_path(PICOJSON_INCLUDE_DIR "picojson/picojson.h" REQUIRED)
-+target_include_directories(jwt-cpp INTERFACE "${PICOJSON_INCLUDE_DIR}")
-+
 +if(0)
    if(JWT_EXTERNAL_NLOHMANN_JSON)
      message(STATUS "jwt-cpp: using find_package for nlohmann-json required for tests")
      find_package(nlohmann_json CONFIG REQUIRED)
+@@ -131,9 +131,11 @@ if(${JWT_SSL_LIBRARY} MATCHES "wolfSSL")
+   target_compile_definitions(jwt-cpp INTERFACE EXTERNAL_OPTS_OPENVPN)
+ endif()
+ 
+-if(NOT JWT_DISABLE_PICOJSON AND JWT_EXTERNAL_PICOJSON)
++if(0)
+   target_link_libraries(jwt-cpp INTERFACE picojson::picojson>)
+ endif()
++find_path(PICOJSON_INCLUDE_DIR "picojson/picojson.h" REQUIRED)
++target_include_directories(jwt-cpp INTERFACE "${PICOJSON_INCLUDE_DIR}")
+ 
+ # Hunter needs relative paths so the files are placed correctly
+ if(NOT JWT_CMAKE_FILES_INSTALL_DIR)
+@@ -150,7 +152,7 @@ install(TARGETS jwt-cpp EXPORT jwt-cpp-targets PUBLIC_HEADER DESTINATION ${CMAKE
+ install(EXPORT jwt-cpp-targets NAMESPACE jwt-cpp:: FILE jwt-cpp-targets.cmake
+         DESTINATION ${JWT_CMAKE_FILES_INSTALL_DIR})
+ install(DIRECTORY ${JWT_INCLUDE_PATH}/jwt-cpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+-if(NOT JWT_EXTERNAL_PICOJSON AND NOT JWT_DISABLE_PICOJSON)
++if(0)
+   install(FILES ${JWT_INCLUDE_PATH}/picojson/picojson.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/picojson)
+ endif()
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/jwt-cpp-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/jwt-cpp-config-version.cmake

--- a/ports/jwt-cpp/external-json.diff
+++ b/ports/jwt-cpp/external-json.diff
@@ -1,33 +1,21 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5cd876f..8e3dfe6 100644
+index 2520e4ed..2a911674 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -66,9 +66,8 @@ if(JWT_EXTERNAL_PICOJSON)
+@@ -69,11 +69,14 @@ elseif(${JWT_SSL_LIBRARY} MATCHES "wolfSSL")
+   list(TRANSFORM wolfssl_INCLUDE_DIRS APPEND "/wolfssl") # This is required to access OpenSSL compatibility API
+ endif()
+ 
+-if(NOT JWT_DISABLE_PICOJSON AND JWT_EXTERNAL_PICOJSON)
++if(0)
    find_package(picojson 1.3.0 REQUIRED)
  endif()
  
--find_package(nlohmann_json CONFIG)
- 
--if(NOT nlohmann_json_FOUND)
+-if(JWT_BUILD_EXAMPLES OR JWT_BUILD_TESTS)
++find_path(PICOJSON_INCLUDE_DIR "picojson/picojson.h" REQUIRED)
++target_include_directories(jwt-cpp INTERFACE "${PICOJSON_INCLUDE_DIR}")
++
 +if(0)
-   message(STATUS "jwt-cpp: using FetchContent for nlohmann json")
-   include(FetchContent)
-   FetchContent_Declare(nlohmann_json
-@@ -121,6 +120,9 @@ endif()
- 
- if(JWT_EXTERNAL_PICOJSON)
-   target_link_libraries(jwt-cpp INTERFACE picojson::picojson>)
-+else()
-+  find_path(PICOJSON_INCLUDE_DIR "picojson/picojson.h" REQUIRED)
-+  target_include_directories(jwt-cpp INTERFACE "${PICOJSON_INCLUDE_DIR}")
- endif()
- 
- # Hunter needs relative paths so the files are placed correctly
-@@ -139,7 +141,6 @@ install(EXPORT jwt-cpp-targets NAMESPACE jwt-cpp:: FILE jwt-cpp-targets.cmake
-         DESTINATION ${JWT_CMAKE_FILES_INSTALL_DIR})
- install(DIRECTORY ${JWT_INCLUDE_PATH}/jwt-cpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
- if(NOT JWT_EXTERNAL_PICOJSON AND NOT JWT_DISABLE_PICOJSON)
--  install(FILES ${JWT_INCLUDE_PATH}/picojson/picojson.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/picojson)
- endif()
- install(FILES ${CMAKE_CURRENT_BINARY_DIR}/jwt-cpp-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/jwt-cpp-config-version.cmake
-         DESTINATION ${JWT_CMAKE_FILES_INSTALL_DIR})
+   if(JWT_EXTERNAL_NLOHMANN_JSON)
+     message(STATUS "jwt-cpp: using find_package for nlohmann-json required for tests")
+     find_package(nlohmann_json CONFIG REQUIRED)

--- a/ports/jwt-cpp/portfile.cmake
+++ b/ports/jwt-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Thalhammer/jwt-cpp
     REF "v${VERSION}"
-    SHA512 b6fdb93e3f2f065a2eb45fe16cb076a932b8d4bfad2251bd66d2be40d8afaf5c27a9cf17aaea61d8bfa3f5ff9ed3b45f90962dc14d72704ac5b9d717c12cc79f
+    SHA512 1d52816e4d04a50c57e3655e1ebd0fa4e54d03aef49950b800c9c43715cdaceec7a572a02ffff5d358d5f8cde242112da06804fc7a53bc154b3860cf133716a0
     HEAD_REF master
     PATCHES
         external-json.diff

--- a/ports/jwt-cpp/vcpkg.json
+++ b/ports/jwt-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-cpp",
-  "version-semver": "0.7.0",
+  "version-semver": "0.7.1",
   "port-version": 1,
   "description": "A header only library for creating and validating json web tokens in c++",
   "homepage": "https://github.com/Thalhammer/jwt-cpp",

--- a/ports/jwt-cpp/vcpkg.json
+++ b/ports/jwt-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "jwt-cpp",
   "version-semver": "0.7.1",
-  "port-version": 1,
   "description": "A header only library for creating and validating json web tokens in c++",
   "homepage": "https://github.com/Thalhammer/jwt-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3921,7 +3921,8 @@
       "port-version": 2
     },
     "jwt-cpp": {
-      "baseline": "0.7.1"
+      "baseline": "0.7.1",
+      "port-version": 1
     },
     "jxrlib": {
       "baseline": "2019.10.9",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3922,7 +3922,7 @@
     },
     "jwt-cpp": {
       "baseline": "0.7.1",
-      "port-version": 1
+      "port-version": 0
     },
     "jxrlib": {
       "baseline": "2019.10.9",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3921,8 +3921,7 @@
       "port-version": 2
     },
     "jwt-cpp": {
-      "baseline": "0.7.1",
-      "port-version": 1
+      "baseline": "0.7.1"
     },
     "jxrlib": {
       "baseline": "2019.10.9",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3921,7 +3921,7 @@
       "port-version": 2
     },
     "jwt-cpp": {
-      "baseline": "0.7.0",
+      "baseline": "0.7.1",
       "port-version": 1
     },
     "jxrlib": {

--- a/versions/j-/jwt-cpp.json
+++ b/versions/j-/jwt-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "507d93d4288fe96021dfcf07e1a021b92a8f86f8",
+      "git-tree": "d8285d3944c319f9025cf6b47af6c9c09e65273a",
       "version-semver": "0.7.1",
       "port-version": 0
     },

--- a/versions/j-/jwt-cpp.json
+++ b/versions/j-/jwt-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d8285d3944c319f9025cf6b47af6c9c09e65273a",
+      "git-tree": "11d7dba2f3d932d6b90273094d238fa0d53527cb",
       "version-semver": "0.7.1",
       "port-version": 0
     },

--- a/versions/j-/jwt-cpp.json
+++ b/versions/j-/jwt-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ed888c7fc2aa125e626ff0f097b00a4230bab1c",
+      "version-semver": "0.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b0890909dce2e5ce69df737f928c152dd432a6d8",
       "version-semver": "0.7.0",
       "port-version": 1

--- a/versions/j-/jwt-cpp.json
+++ b/versions/j-/jwt-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3ed888c7fc2aa125e626ff0f097b00a4230bab1c",
+      "git-tree": "5b2da8bf0a40566da9a0aa8bf4af6b429978adcd",
       "version-semver": "0.7.1",
       "port-version": 0
     },

--- a/versions/j-/jwt-cpp.json
+++ b/versions/j-/jwt-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5b2da8bf0a40566da9a0aa8bf4af6b429978adcd",
+      "git-tree": "507d93d4288fe96021dfcf07e1a021b92a8f86f8",
       "version-semver": "0.7.1",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

Best attempt to update jwt-cpp, bit rusty with vcpkg but let me know if I missed anything!

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

