### PR TITLE
[hello-imgui] Remove the freetype-lunasvg features

### DIFF
--- a/ports/hello-imgui/portfile.cmake
+++ b/ports/hello-imgui/portfile.cmake
@@ -16,7 +16,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     "experimental-dx11-binding" HELLOIMGUI_HAS_DIRECTX11
     "experimental-dx12-binding" HELLOIMGUI_HAS_DIRECTX12
     "glfw-binding" HELLOIMGUI_USE_GLFW3
-    "freetype-plutosvg" HELLOIMGUI_USE_FREETYPE # When hello_imgui is built with freetype, it will also build with plutosvg
 )
 
 if (NOT HELLOIMGUI_HAS_OPENGL3

--- a/ports/hello-imgui/vcpkg.json
+++ b/ports/hello-imgui/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hello-imgui",
   "version": "1.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Hello ImGui: unleash your creativity in app development and prototyping",
   "homepage": "https://pthom.github.io/hello_imgui/",
   "license": "MIT",
@@ -52,18 +52,6 @@
           "name": "imgui",
           "features": [
             "vulkan-binding"
-          ]
-        }
-      ]
-    },
-    "freetype-plutosvg": {
-      "description": "Improve font rendering and use colored fonts with freetype and plutosvg",
-      "dependencies": [
-        {
-          "name": "imgui",
-          "features": [
-            "freetype",
-            "freetype-svg"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3538,7 +3538,7 @@
     },
     "hello-imgui": {
       "baseline": "1.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "hexl": {
       "baseline": "1.2.5",

--- a/versions/h-/hello-imgui.json
+++ b/versions/h-/hello-imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b9499ab8e07deb6128f0757ef1851c5e09896819",
+      "version": "1.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "ad86a79efe058977548ffde34179005239f78266",
       "version": "1.6.0",
       "port-version": 1


### PR DESCRIPTION
Fixes Commet: https://github.com/microsoft/vcpkg/pull/44230#pullrequestreview-2667105837

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.