### PR TITLE
[vcpkg scripts] fix relative_tool_dir debug match

### DIFF
--- a/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
+++ b/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
@@ -34,7 +34,7 @@ function(vcpkg_copy_tool_dependencies tool_dir)
             BASE_DIRECTORY "${CURRENT_PACKAGES_DIR}"
             OUTPUT_VARIABLE relative_tool_dir
         )
-        if(relative_tool_dir MATCHES "/debug/")
+        if(relative_tool_dir MATCHES "^/?debug/")
             z_vcpkg_copy_tool_dependencies_search("${tool_dir}" "${CURRENT_PACKAGES_DIR}/debug/bin")
             z_vcpkg_copy_tool_dependencies_search("${tool_dir}" "${CURRENT_INSTALLED_DIR}/debug/bin")
         else()

--- a/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
+++ b/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
@@ -34,7 +34,7 @@ function(vcpkg_copy_tool_dependencies tool_dir)
             BASE_DIRECTORY "${CURRENT_PACKAGES_DIR}"
             OUTPUT_VARIABLE relative_tool_dir
         )
-        if(relative_tool_dir MATCHES "^/?debug/")
+        if(relative_tool_dir MATCHES "^debug/|/debug/")
             z_vcpkg_copy_tool_dependencies_search("${tool_dir}" "${CURRENT_PACKAGES_DIR}/debug/bin")
             z_vcpkg_copy_tool_dependencies_search("${tool_dir}" "${CURRENT_INSTALLED_DIR}/debug/bin")
         else()


### PR DESCRIPTION
In a debug configuration relative_tool_dir never match /debug/ because cmake_path eat the slash.
In keep the first slash optional just in case.