### PR TITLE
[stringzilla] update to 3.12.3

### DIFF
--- a/ports/stringzilla/portfile.cmake
+++ b/ports/stringzilla/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/StringZilla
     REF "v${VERSION}"
-    SHA512 d48069bc4e5c648a67132ddfe30943d3945e92682cd3faab97834164dbb0fa1b8023fca6428d5fd1b4e6a44fd9bcd7a943b4251e54e2dc16337021c5fa0d208f
+    SHA512 436b2b639d9d66d62d618d07174231f4e4dd9855edc6e03a5746c8c2f5205c2af9be9dfbf88a95fc12bb8d4abfffdf925fd85c0bd14b5ab3734d2f1105990f41
     HEAD_REF master
 )
 

--- a/ports/stringzilla/vcpkg.json
+++ b/ports/stringzilla/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stringzilla",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "description": "StringZilla is the GodZilla of string libraries, using SIMD and SWAR to accelerate string operations on modern CPUs.",
   "homepage": "https://github.com/ashvardanian/StringZilla",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8865,7 +8865,7 @@
       "port-version": 1
     },
     "stringzilla": {
-      "baseline": "3.12.2",
+      "baseline": "3.12.3",
       "port-version": 0
     },
     "strong-type": {

--- a/versions/s-/stringzilla.json
+++ b/versions/s-/stringzilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d1a849c7aeb121403a4eb8987ad51ff92f23d3cb",
+      "version": "3.12.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "e54cd7ebe5ab9cc7152bc1b7cdf0208f740259d5",
       "version": "3.12.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
