### PR TITLE
[tracy] Update to version 0.11.1#3

### DIFF
--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -17,9 +17,11 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        on-demand TRACY_ON_DEMAND
-        fibers	  TRACY_FIBERS
-        verbose   TRACY_VERBOSE
+        on-demand       TRACY_ON_DEMAND
+        fibers          TRACY_FIBERS
+        no-sampling     TRACY_NO_SAMPLING
+        no-callstack    TRACY_NO_CALLSTACK
+        verbose         TRACY_VERBOSE
     INVERTED_FEATURES
         crash-handler TRACY_NO_CRASH_HANDLER
 )

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tracy",
   "version": "0.11.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",
@@ -79,6 +79,12 @@
           "platform": "!windows"
         }
       ]
+    },
+    "no-callstack": {
+      "description": "Disable all callstack related functionality"
+    },
+    "no-sampling": {
+      "description": "Disable call stack sampling"
     },
     "on-demand": {
       "description": "Enable on-demand profiling"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9278,7 +9278,7 @@
     },
     "tracy": {
       "baseline": "0.11.1",
-      "port-version": 2
+      "port-version": 3
     },
     "transwarp": {
       "baseline": "2.2.3",

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d88e05dad078272acd68f5d47a696f2143e76b4f",
+      "version": "0.11.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "ff802e1b85c20b5f276c4b82aaa60fc933444ab2",
       "version": "0.11.1",
       "port-version": 2


### PR DESCRIPTION
Add new features 'no-sampling' and 'no-callstack'  to define the TRACY_NO_SAMPLING and TRACY_NO_CALLSTACK preprocessor definitions.

These definitions allow disabling sampling and call stack collection.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
