### PR TITLE
[dbus] add supports for x11 feature

### DIFF
--- a/ports/dbus/vcpkg.json
+++ b/ports/dbus/vcpkg.json
@@ -36,7 +36,7 @@
     },
     "x11": {
       "description": "Build with X11 autolaunch support",
-      "supports": "linux",
+      "supports": "!windows",
       "dependencies": [
         "libx11"
       ]

--- a/ports/dbus/vcpkg.json
+++ b/ports/dbus/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dbus",
   "version": "1.16.2",
+  "port-version": 1,
   "description": "D-Bus specification and reference implementation, including libdbus and dbus-daemon",
   "homepage": "https://gitlab.freedesktop.org/dbus/dbus",
   "license": "AFL-2.1 OR GPL-2.0-or-later",
@@ -36,7 +37,10 @@
     "x11": {
       "description": "Build with X11 autolaunch support",
       "dependencies": [
-        "libx11"
+        {
+          "name": "libx11",
+          "platform": "linux"
+        }
       ]
     }
   }

--- a/ports/dbus/vcpkg.json
+++ b/ports/dbus/vcpkg.json
@@ -36,11 +36,9 @@
     },
     "x11": {
       "description": "Build with X11 autolaunch support",
+      "supports": "linux",
       "dependencies": [
-        {
-          "name": "libx11",
-          "platform": "linux"
-        }
+        "libx11"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2254,7 +2254,7 @@
     },
     "dbus": {
       "baseline": "1.16.2",
-      "port-version": 0
+      "port-version": 1
     },
     "dcmtk": {
       "baseline": "3.6.9",

--- a/versions/d-/dbus.json
+++ b/versions/d-/dbus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "11d433ccf6ad99deb375b35f9ae0aec548e09bb9",
+      "git-tree": "53859bc14ee6f5ac022edc297a6569bc880abdec",
       "version": "1.16.2",
       "port-version": 1
     },

--- a/versions/d-/dbus.json
+++ b/versions/d-/dbus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a65a65b1caa0afed559ab281d94497fe3433d219",
+      "git-tree": "11d433ccf6ad99deb375b35f9ae0aec548e09bb9",
       "version": "1.16.2",
       "port-version": 1
     },

--- a/versions/d-/dbus.json
+++ b/versions/d-/dbus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a65a65b1caa0afed559ab281d94497fe3433d219",
+      "version": "1.16.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "ef5eaa8192465a6bd08ec9e664f5f2f467295257",
       "version": "1.16.2",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/44269.
X11 does not support the Windows platform. see https://gitlab.freedesktop.org/dbus/dbus/-/issues/550.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
