### PR TITLE
[cairo] fix mingw build failure

### DIFF
--- a/ports/cairo/dw-extra.patch
+++ b/ports/cairo/dw-extra.patch
@@ -1,0 +1,13 @@
+diff --git a/src/win32/dw-extra.h b/src/win32/dw-extra.h
+index 424fb606d..a9daced21 100644
+--- a/src/win32/dw-extra.h
++++ b/src/win32/dw-extra.h
+@@ -23,6 +23,8 @@
+ typedef DWRITE_COLOR_GLYPH_RUN1 DWRITE_COLOR_GLYPH_RUN1_WORKAROUND;
+ #endif
+ 
++#if !defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 11
+ DEFINE_ENUM_FLAG_OPERATORS(DWRITE_GLYPH_IMAGE_FORMATS);
++#endif
+ 
+ #endif /* DWRITE_EXTRA_H */

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -3,6 +3,8 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     list(APPEND EXTRA_PATCHES fix_clang-cl_build.patch)
 endif()
 
+list(APPEND EXTRA_PATCHES dw-extra.patch)
+
 vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     GITLAB_URL https://gitlab.freedesktop.org

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cairo",
   "version": "1.18.2",
+  "port-version": 1,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "LGPL-2.1-only OR MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1482,7 +1482,7 @@
     },
     "cairo": {
       "baseline": "1.18.2",
-      "port-version": 0
+      "port-version": 1
     },
     "cairomm": {
       "baseline": "1.18.0",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "862af45fc3b9935807833a3917a755b202d529e9",
+      "git-tree": "b332aecd569cb46a2677231dd3b326c139453401",
       "version": "1.18.2",
       "port-version": 1
     },

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "862af45fc3b9935807833a3917a755b202d529e9",
+      "version": "1.18.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "84c6e863f1f936bd0db07b3302e568ac1c98531c",
       "version": "1.18.2",
       "port-version": 0


### PR DESCRIPTION
	new file:   ports/cairo/dw-extra.patch
	modified:   ports/cairo/portfile.cmake
	modified:   ports/cairo/vcpkg.json
	modified:   versions/baseline.json
	modified:   versions/c-/cairo.json

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


