### PR TITLE
[pangolin] Add patch to initialise 'pad_'

### DIFF
--- a/ports/pangolin/portfile.cmake
+++ b/ports/pangolin/portfile.cmake
@@ -1,3 +1,8 @@
+vcpkg_download_distfile(INITIALISE_PAD_PATCH
+    URLS https://github.com/stevenlovegrove/Pangolin/commit/0bb8f1b4969f248254e4c4051c053304f86e3c6a.patch?full_index=1
+    FILENAME pangolin-initialise-pad_.patch
+    SHA512 8e82791467f8947d2d31718c9e00ab1273804afccb8f6ba259ed5ee4c626f9354055ee92b38e72d6ffa9e88b1468683cdc159767fad74a52c6707939e2a5c300
+)
 
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
@@ -11,6 +16,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         devendor-palsigslot.patch
+        ${INITIALISE_PAD_PATCH}
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/pangolin/vcpkg.json
+++ b/ports/pangolin/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pangolin",
   "version": "0.9.3",
+  "port-version": 1,
   "description": "Lightweight GUI Library",
   "homepage": "https://github.com/stevenlovegrove/Pangolin",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6950,7 +6950,7 @@
     },
     "pangolin": {
       "baseline": "0.9.3",
-      "port-version": 0
+      "port-version": 1
     },
     "pangomm": {
       "baseline": "2.56.1",

--- a/versions/p-/pangolin.json
+++ b/versions/p-/pangolin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c05a410095b31cee41aff27a058e1d66f3c9fa90",
+      "version": "0.9.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "1160800955291a7ca10fecd0fc9f1a41894db758",
       "version": "0.9.3",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/44251

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
