### PR TITLE
[sleef] Allow to crosscompile

### DIFF
--- a/ports/sleef/0001-Add-missing-exe-suffix-for-host-executables.patch
+++ b/ports/sleef/0001-Add-missing-exe-suffix-for-host-executables.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6f4f3e8..039e6fc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -320,7 +320,11 @@ function(add_host_executable TARGETNAME)
+     endif()
+   else()
+     add_executable(${TARGETNAME} IMPORTED GLOBAL)
+-    set_property(TARGET ${TARGETNAME} PROPERTY IMPORTED_LOCATION ${NATIVE_BUILD_DIR}/bin/${TARGETNAME})
++    if(CMAKE_HOST_WIN32)
++      set_property(TARGET ${TARGETNAME} PROPERTY IMPORTED_LOCATION ${NATIVE_BUILD_DIR}/bin/${TARGETNAME}.exe)
++    else()
++      set_property(TARGET ${TARGETNAME} PROPERTY IMPORTED_LOCATION ${NATIVE_BUILD_DIR}/bin/${TARGETNAME})
++    endif()
+   endif()
+ endfunction()
+ 
+-- 
+2.34.1
+

--- a/ports/sleef/portfile.cmake
+++ b/ports/sleef/portfile.cmake
@@ -4,7 +4,14 @@ vcpkg_from_github(
     REF ${VERSION}
     SHA512 218b4e7e2eeb1f9b45e56c2fbb46062480480c55f49b6b0d138d910374e7791c7dd909b964fbf9e2e984a896a3b162eb5aabaaa770692e1db440627e7ad07945
     HEAD_REF master
+    PATCHES
+        0001-Add-missing-exe-suffix-for-host-executables.patch
 )
+
+set(CROSSCOMP_OPTIONS "")
+if(VCPKG_CROSSCOMPILING)
+    set(CROSSCOMP_OPTIONS "-DNATIVE_BUILD_DIR=${CURRENT_HOST_INSTALLED_DIR}/manual-tools/${PORT}")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -14,37 +21,21 @@ vcpkg_cmake_configure(
         -DSLEEF_BUILD_QUAD=ON
         -DSLEEF_BUILD_GNUABI_LIBS=${VCPKG_TARGET_IS_LINUX}
         -DSLEEF_BUILD_TESTS=OFF
-        -DSLEEF_BUILD_INLINE_HEADERS=OFF
+        ${CROSSCOMP_OPTIONS}
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sleef)
 vcpkg_copy_pdbs()
+if(NOT VCPKG_CROSSCOMPILING)
+    vcpkg_copy_tools(
+        TOOL_NAMES mkrename qmkrename mkalias mkdispatch mkdisp qmkdisp mkunroll 
+        SEARCH_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/manual-tools/${PORT}/bin"
+        AUTO_CLEAN)
+endif()    
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sleef)
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
-# Install DLL and PDB files
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-        if(VCPKG_TARGET_IS_WINDOWS)
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleef.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleef.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleefdft.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleefdft.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleefquad.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/sleefquad.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-        endif()
-    endif()
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-        if(VCPKG_TARGET_IS_WINDOWS)
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleef.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleef.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleefdft.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleefdft.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleefquad.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/bin/sleefquad.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-        endif()
-    endif()
-endif()

--- a/ports/sleef/vcpkg.json
+++ b/ports/sleef/vcpkg.json
@@ -1,11 +1,16 @@
 {
   "name": "sleef",
   "version": "3.8",
+  "port-version": 1,
   "description": "SIMD Library for Evaluating Elementary Functions, vectorized libm and DFT",
   "homepage": "https://sleef.org/",
   "license": "BSL-1.0",
-  "supports": "!uwp & !(arm & windows) & !(arm64 & osx)",
+  "supports": "!(arm & windows)",
   "dependencies": [
+    {
+      "name": "sleef",
+      "host": true
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1044,7 +1044,6 @@ sjpeg:arm64-android=fail
 sjpeg:x64-android=fail
 sleef:arm-neon-android=fail
 sleef:arm64-android=fail
-sleef:x64-android=fail
 sleef:x86-windows=fail
 slikenet:arm-neon-android=fail
 slikenet:arm64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8546,7 +8546,7 @@
     },
     "sleef": {
       "baseline": "3.8",
-      "port-version": 0
+      "port-version": 1
     },
     "sleepy-discord": {
       "baseline": "2025-02-08",

--- a/versions/s-/sleef.json
+++ b/versions/s-/sleef.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2cdaa4e9420352cd81759a054a7a19ec1200b336",
+      "version": "3.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "c89d656c909c14f1fc6acacfe75c13231d88bcea",
       "version": "3.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
