### PR TITLE
[highfive] update homepage

### DIFF
--- a/ports/highfive/vcpkg.json
+++ b/ports/highfive/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "highfive",
   "version": "2.10.1",
+  "port-version": 1,
   "description": "HighFive is a modern header-only C++/C++11 friendly interface for libhdf5",
-  "homepage": "https://github.com/BlueBrain/HighFive",
+  "homepage": "https://github.com/highfive-devs/highfive",
   "license": "BSL-1.0",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3558,7 +3558,7 @@
     },
     "highfive": {
       "baseline": "2.10.1",
-      "port-version": 0
+      "port-version": 1
     },
     "highs": {
       "baseline": "1.9.0",

--- a/versions/h-/highfive.json
+++ b/versions/h-/highfive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96209d6c99e195fc17da5ee927347a5077ae1c49",
+      "version": "2.10.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "030054cadd0db76298fb84c6b8a27ae40513ca04",
       "version": "2.10.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

According to [highfive-devs/highfive on GitHub.](https://github.com/highfive-devs/highfive)
> HighFive was orignally developed and maintained at https://github.com/BlueBrain/HighFive. To continue maintenance of HighFive as an independent open-source code without support from BBP or EPFL, some (one) of the developers decided to create this repository.