### PR TITLE
[vcpkg baseline][unit-test-cmake] Fix install failure

### DIFF
--- a/scripts/test_ports/unit-test-cmake/portfile.cmake
+++ b/scripts/test_ports/unit-test-cmake/portfile.cmake
@@ -1,7 +1,7 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-file(INSTALL "${CURRENT_PORT_DIR}/test-macros.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/test-macros.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-include("${CURRENT_PORT_DIR}/test-macros.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/test-macros.cmake")
 
 if("minimum-required" IN_LIST FEATURES)
     include("${CMAKE_CURRENT_LIST_DIR}/test-vcpkg_minimum_required.cmake")

--- a/scripts/test_ports/vcpkg-make-tests/vcpkg.json
+++ b/scripts/test_ports/vcpkg-make-tests/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "vcpkg-make-tests",
-    "version-string": "1",
+    "version-string": "0",
     "description": "Ensures that the vcpkg-make port functions are unit tested.",
     "license": "MIT",
     "dependencies": [

--- a/scripts/test_ports/vcpkg-make-tests/vcpkg.json
+++ b/scripts/test_ports/vcpkg-make-tests/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "vcpkg-make-tests",
-    "version-string": "0",
+    "version-string": "1",
     "description": "Ensures that the vcpkg-make port functions are unit tested.",
     "license": "MIT",
     "dependencies": [


### PR DESCRIPTION
`vcpkg-make-tests` install failed with below error on https://dev.azure.com/vcpkg/public/_build/results?buildId=113349&view=results:
```
CMake Error at scripts/test_ports/unit-test-cmake/portfile.cmake:2 (file):
  file INSTALL cannot find
  "D:/a/_work/1/s/scripts/test_ports/vcpkg-make-tests/test-macros.cmake":
  File exists.
```
For fixing this error, modified the file path from `CURRENT_PORT_DIR` to `CMAKE_CURRENT_LIST_DIR`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~