### PR TITLE
[ecal] Update to 5.13.3

### DIFF
--- a/ports/ecal/portfile.cmake
+++ b/ports/ecal/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eclipse-ecal/ecal
-    REF v${VERSION}
-    SHA512 fde579c21ef31f5cd7902129d5d00717ddab1105d58cc5b352c374c14cbd2f61297a788d3ac5fa548946035b1759130857561f830a36e546e2a6ca88dbf63854 
+    REF "v${VERSION}"
+    SHA512 8134873a3ac0ba48955fdb837aaeaccbd76b81cde6af0099060daedb26bca107cb472af39058358ad094da02ead8f735afb73acd627b19ab210c42039ffa92b8 
     HEAD_REF master
     PATCHES
         0001-disable-app-plugins.patch

--- a/ports/ecal/vcpkg.json
+++ b/ports/ecal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ecal",
-  "version-semver": "5.13.2",
+  "version-semver": "5.13.3",
   "description": "eCAL - enhanced Communication Abstraction Layer",
   "homepage": "https://eclipse-ecal.github.io/ecal/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2509,7 +2509,7 @@
       "port-version": 0
     },
     "ecal": {
-      "baseline": "5.13.2",
+      "baseline": "5.13.3",
       "port-version": 0
     },
     "ecm": {

--- a/versions/e-/ecal.json
+++ b/versions/e-/ecal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8ddc8c3ae20bd64dea86af3d825bcb5e58cf998",
+      "version-semver": "5.13.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "1753feade0a74f9779efc017cc2d29cd7005b15a",
       "version-semver": "5.13.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #44322
Usage passed on x64-windows.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
