### PR TITLE
[anari] Update to hotfix 0.13.1

### DIFF
--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KhronosGroup/ANARI-SDK
   REF "v${VERSION}"
-  SHA512 2e18379a6a09a3f72298a2412ee12ba499ab45a741de05372600be2e0ccf61e505ec4b1d60f260f3179e7573604629fada54f5c0ac55d919a53564d99035d1bb
+  SHA512 86514b51f943aabd779b4c4adcad2d0db69912f2ace8aabeffbee7c3eb24f75e9055bb3690dc19d51b35da8c5f7342dea9437fc04db2094616c672b1e2cb31e0
   HEAD_REF next_release
   PATCHES anari-lib-maybe-static-lib.patch
 )

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "anari",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Cross-Platform 3D Rendering Engine API.",
   "homepage": "https://www.khronos.org/anari",
   "license": "Apache-2.0",

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e0a023514ab5a50fb801731a3376cdf260327c01",
+      "version": "0.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9249b201863285edf8d1ac7e7ffa3913b7fe38af",
       "version": "0.13.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -121,7 +121,7 @@
       "port-version": 0
     },
     "anari": {
-      "baseline": "0.13.0",
+      "baseline": "0.13.1",
       "port-version": 0
     },
     "anax": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
