### PR TITLE
[sdl2-image] Add the proper AVIF support

### DIFF
--- a/ports/sdl2-image/portfile.cmake
+++ b/ports/sdl2-image/portfile.cmake
@@ -11,10 +11,10 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        avif          SDL2IMAGE_AVIF
         libjpeg-turbo SDL2IMAGE_JPG
         libwebp       SDL2IMAGE_WEBP
         tiff          SDL2IMAGE_TIF
-        avif          SDL2IMAGE_AVIF
 )
 
 vcpkg_cmake_configure(

--- a/ports/sdl2-image/portfile.cmake
+++ b/ports/sdl2-image/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_check_features(
         libjpeg-turbo SDL2IMAGE_JPG
         libwebp       SDL2IMAGE_WEBP
         tiff          SDL2IMAGE_TIF
+        avif          SDL2IMAGE_AVIF
 )
 
 vcpkg_cmake_configure(

--- a/ports/sdl2-image/vcpkg.json
+++ b/ports/sdl2-image/vcpkg.json
@@ -21,6 +21,12 @@
     }
   ],
   "features": {
+    "avif": {
+      "description": "Support for AVIF image format",
+      "dependencies": [
+        "libavif"
+      ]
+    },
     "libjpeg-turbo": {
       "description": "Support for JPEG image format",
       "dependencies": [
@@ -40,12 +46,6 @@
           "name": "tiff",
           "default-features": false
         }
-      ]
-    },
-    "avif": {
-      "description": "Support for AVIF image format",
-      "dependencies": [
-        "libavif"
       ]
     }
   }

--- a/ports/sdl2-image/vcpkg.json
+++ b/ports/sdl2-image/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl2-image",
   "version": "2.8.8",
+  "port-version": 1,
   "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
   "homepage": "https://github.com/libsdl-org/SDL_image",
   "license": "Zlib",
@@ -39,6 +40,12 @@
           "name": "tiff",
           "default-features": false
         }
+      ]
+    },
+    "avif": {
+      "description": "Support for AVIF image format",
+      "dependencies": [
+        "libavif"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8350,7 +8350,7 @@
     },
     "sdl2-image": {
       "baseline": "2.8.8",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl2-mixer": {
       "baseline": "2.8.1",

--- a/versions/s-/sdl2-image.json
+++ b/versions/s-/sdl2-image.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b9c58a9cdaaaa91d25290f0418ca786576eec0df",
+      "git-tree": "5cc9de78d44947f2029569202beba4b5af8ea2cc",
       "version": "2.8.8",
       "port-version": 1
     },

--- a/versions/s-/sdl2-image.json
+++ b/versions/s-/sdl2-image.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b9c58a9cdaaaa91d25290f0418ca786576eec0df",
+      "version": "2.8.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "59d6bd7369432c4558c87cc90402c5bc65e004c5",
       "version": "2.8.8",
       "port-version": 0


### PR DESCRIPTION
The AVIF support for `sdl2-image` depends on the external library `libavif`, which should be installed if we want to have the proper AVIF support.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
