### PR TITLE
[gettext] Fix path related issues with MSVC

### DIFF
--- a/ports/gettext/0001-xgettext-Fix-some-test-failures-on-MSVC.patch
+++ b/ports/gettext/0001-xgettext-Fix-some-test-failures-on-MSVC.patch
@@ -1,0 +1,93 @@
+From e5cf655767413f38e8a308f6e0440d7d283ef841 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20Sch=C3=BCrmann?= <daschuer@mixxx.org>
+Date: Wed, 12 Mar 2025 00:55:16 +0100
+Subject: [PATCH] xgettext: Fix some test failures on MSVC.
+
+* gettext-tools/src/locating-rule.c: Include <dirent.h> always.
+(HAVE_DIR): Remove macro.
+(locating_rule_list_add_from_directory): Don't test HAVE_DIR.
+* gettext-tools/src/msginit.c: Include <dirent.h> always.
+(HAVE_DIR): Remove macro.
+(find_pot): Don't test HAVE_DIR.
+---
+ gettext-tools/src/locating-rule.c | 12 +-----------
+ gettext-tools/src/msginit.c       | 12 +-----------
+ 2 files changed, 2 insertions(+), 22 deletions(-)
+
+diff --git a/gettext-tools/src/locating-rule.c b/gettext-tools/src/locating-rule.c
+index c6f4b1b..d38bb15 100644
+--- a/gettext-tools/src/locating-rule.c
++++ b/gettext-tools/src/locating-rule.c
+@@ -27,15 +27,7 @@
+ #include "concat-filename.h"
+ #include "c-strcase.h"
+ 
+-#if HAVE_DIRENT_H
+-# include <dirent.h>
+-#endif
+-
+-#if HAVE_DIRENT_H
+-# define HAVE_DIR 1
+-#else
+-# define HAVE_DIR 0
+-#endif
++#include <dirent.h>
+ 
+ #include "dir-list.h"
+ #include <errno.h>
+@@ -411,7 +403,6 @@ bool
+ locating_rule_list_add_from_directory (struct locating_rule_list_ty *rules,
+                                        const char *directory)
+ {
+-#if HAVE_DIR
+   DIR *dirp;
+ 
+   dirp = opendir (directory);
+@@ -445,7 +436,6 @@ locating_rule_list_add_from_directory (struct locating_rule_list_ty *rules,
+   if (closedir (dirp))
+     return false;
+ 
+-#endif
+   return true;
+ }
+ 
+diff --git a/gettext-tools/src/msginit.c b/gettext-tools/src/msginit.c
+index 9ff75e7..736c671 100644
+--- a/gettext-tools/src/msginit.c
++++ b/gettext-tools/src/msginit.c
+@@ -39,15 +39,7 @@
+ 
+ #include <unistd.h>
+ 
+-#if HAVE_DIRENT_H
+-# include <dirent.h>
+-#endif
+-
+-#if HAVE_DIRENT_H
+-# define HAVE_DIR 1
+-#else
+-# define HAVE_DIR 0
+-#endif
++#include <dirent.h>
+ 
+ #include <textstyle.h>
+ 
+@@ -491,7 +483,6 @@ or by email to <%s>.\n"),
+ static const char *
+ find_pot ()
+ {
+-#if HAVE_DIR
+   DIR *dirp;
+   char *found = NULL;
+ 
+@@ -534,7 +525,6 @@ Please specify the input .pot file through the --input option.\n")));
+       if (found != NULL)
+         return found;
+     }
+-#endif
+ 
+   multiline_error (xstrdup (""),
+                    xstrdup (_("\
+-- 
+2.34.1
+

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
         subdirs.patch
         parallel-gettext-tools.patch
         config-step-order.patch
+        0001-xgettext-Fix-some-test-failures-on-MSVC.patch
 )
 
 set(subdirs "")

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gettext",
   "version": "0.22.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A GNU framework to help produce multi-lingual messages.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "license": "GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3106,7 +3106,7 @@
     },
     "gettext": {
       "baseline": "0.22.5",
-      "port-version": 1
+      "port-version": 2
     },
     "gettext-libintl": {
       "baseline": "0.22.5",

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26b118cdddb84cdc2e8cc6b0330ca39e2799055b",
+      "version": "0.22.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "1c1122632dae7ab9078655ee52e41c415ee4cfb4",
       "version": "0.22.5",
       "port-version": 1


### PR DESCRIPTION
Fixes #44299.

This fixes the issue of not working HAVE_DIR macro by back porting an non release upstream patch: 
https://github.com/autotools-mirror/gettext/commit/a0c87a41816692c300623f56779900543ff8f55c
and ads "dirent" as dependency. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
