### PR TITLE
[shared-mime-info] New port

### DIFF
--- a/ports/shared-mime-info/portfile.cmake
+++ b/ports/shared-mime-info/portfile.cmake
@@ -1,0 +1,33 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_from_gitlab(
+    OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL "https://gitlab.freedesktop.org"
+    REPO "xdg/shared-mime-info"
+    REF "${VERSION}"
+    SHA512 "17b443c2c09a432d09e4c83db956f8c0c3a768cfa9ffb8c87cd2d7c9002b95d010094e2bc64dd35946205a0f8b2d87c4f8f0a1faec86443e2edd502aa8f7cc8f"
+)
+
+set(VCPKG_BUILD_TYPE release)  # only data
+
+vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/libxml2")
+
+# msgfmt can't deal with drive letters on Windows, so we need to use a relative data dir
+file(RELATIVE_PATH GETTEXTDATADIRREL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}" "${SOURCE_PATH}/data")
+set(ENV{GETTEXTDATADIR} "${GETTEXTDATADIRREL}")
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dupdate-mimedb=false
+        -Dbuild-tools=false
+        -Dbuild-translations=false
+        -Dbuild-tests=false
+)
+
+vcpkg_install_meson()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+

--- a/ports/shared-mime-info/vcpkg.json
+++ b/ports/shared-mime-info/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "shared-mime-info",
+  "version": "2.4",
+  "description": "Shared MIME information from Freedesktop.org",
+  "homepage": "https://gitlab.freedesktop.org/xdg/shared-mime-info",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    {
+      "name": "gettext",
+      "host": true,
+      "features": [
+        "tools"
+      ]
+    },
+    {
+      "name": "libxml2",
+      "host": true,
+      "features": [
+        "tools"
+      ]
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8492,6 +8492,10 @@
       "baseline": "1.6.1",
       "port-version": 0
     },
+    "shared-mime-info": {
+      "baseline": "2.4",
+      "port-version": 0
+    },
     "shiftmedia-libgcrypt": {
       "baseline": "1.10.3-1",
       "port-version": 1

--- a/versions/s-/shared-mime-info.json
+++ b/versions/s-/shared-mime-info.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9f518e591954f8a86b8c9a246b428dc566b0b42e",
+      "version": "2.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This adds the Shared MIME information from Freedesktop.org. Before Qt 6.7.2, it was build as part of Qt, now they have moved to Apache Tika with limited coverage for license reasons. 

This PR s on top of https://github.com/microsoft/vcpkg/pull/44340 which should be merged fist. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
