### PR TITLE
[workflow] update to 0.11.8

### DIFF
--- a/ports/workflow/portfile.cmake
+++ b/ports/workflow/portfile.cmake
@@ -2,8 +2,8 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO sogou/workflow
-        REF "v0.10.10-win"
-        SHA512 61ba0cee8e56bb112c6562697bbd7f53e55c1a12ea2388a23076c4e732ae1337b2b0fcc4f518b2afeb1373a173c1ba7375b175c3df3b25d3013a4d2e292c837c
+        REF "v${VERSION}-win"
+        SHA512 4d33904742c41b9cc5efb38a0950dd1f1ef5a0aacab1d3c1fda899244af5b63e734c74dcb5a231623518880b90fa1db5280bf03c4186e94d293fcd2ad6286929
         HEAD_REF windows
     )
 else()

--- a/ports/workflow/portfile.cmake
+++ b/ports/workflow/portfile.cmake
@@ -2,8 +2,8 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO sogou/workflow
-        REF "v${VERSION}-win"
-        SHA512 c34518ca35f19ab5539ea82cc73ecbc9828413530cec8dbbe56b17517ec6b7b0326a29e5b343b950afe128829c8e23e75d19494e17f7be4fce9edb524c44ee56
+        REF "v0.10.10-win"
+        SHA512 61ba0cee8e56bb112c6562697bbd7f53e55c1a12ea2388a23076c4e732ae1337b2b0fcc4f518b2afeb1373a173c1ba7375b175c3df3b25d3013a4d2e292c837c
         HEAD_REF windows
     )
 else()
@@ -11,7 +11,7 @@ else()
         OUT_SOURCE_PATH SOURCE_PATH
         REPO sogou/workflow
         REF "v${VERSION}"
-        SHA512 25258e9dc161c5b30395caa3525a4ba5de5763cad5761cbdc8bb23d2468eb624ec49455a5c9ab628c219d7436f707da0138229c5fa82bcfccc24a485649acb56
+        SHA512 ea90fb1a9c289a76dfa02b077cb0d99ec27157747f1b73d4437a089560a2659baebd463e2e6f699fbd44ec01e59bcd4d4b2f4556377dd57834f02bde0aefdca3
         HEAD_REF master
     )
 endif()
@@ -35,4 +35,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/workflow/vcpkg.json
+++ b/ports/workflow/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.10.9",
+  "version": "0.11.8",
   "description": "About C++ Parallel Computing and Asynchronous Networking Engine",
   "homepage": "https://github.com/sogou/workflow",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9941,7 +9941,7 @@
       "port-version": 3
     },
     "workflow": {
-      "baseline": "0.10.9",
+      "baseline": "0.11.8",
       "port-version": 0
     },
     "wpilib": {

--- a/versions/w-/workflow.json
+++ b/versions/w-/workflow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "84a2e847afa9c0abf5cd02ed227720b0e0736c2d",
+      "git-tree": "6a63f9977488d092a4c30b9290964d796f341ae4",
       "version": "0.11.8",
       "port-version": 0
     },

--- a/versions/w-/workflow.json
+++ b/versions/w-/workflow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "84a2e847afa9c0abf5cd02ed227720b0e0736c2d",
+      "version": "0.11.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "6b72e08d163acabe70e7804d7b3acc719c406ebf",
       "version": "0.10.9",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/44339.
Update workflow to `v0.11.8`. 

No feature needs to test.
Usage tested pass on `x64-windows`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
