### PR TITLE
[libvorbis] Upgrade CMake 3.5

### DIFF
--- a/ports/libvorbis/portfile.cmake
+++ b/ports/libvorbis/portfile.cmake
@@ -13,6 +13,10 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 # https://github.com/xiph/vorbis/issues/113
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_POLICY_VERSION_MINIMUM
 )
 
 vcpkg_cmake_install()

--- a/ports/libvorbis/vcpkg.json
+++ b/ports/libvorbis/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libvorbis",
   "version": "1.3.7",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format",
   "homepage": "https://github.com/xiph/vorbis",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5390,7 +5390,7 @@
     },
     "libvorbis": {
       "baseline": "1.3.7",
-      "port-version": 3
+      "port-version": 4
     },
     "libvpx": {
       "baseline": "1.13.1",

--- a/versions/l-/libvorbis.json
+++ b/versions/l-/libvorbis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "149b8037ad8023f0f1b130616cf1a90238083cb0",
+      "version": "1.3.7",
+      "port-version": 4
+    },
+    {
       "git-tree": "23d11198ff2df7a3af54f1c4645ef71a141f2a85",
       "version": "1.3.7",
       "port-version": 3


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/44342
I have submitted an issue on upstream: https://github.com/xiph/vorbis/issues/113
Failed due to https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features

> Compatibility with versions of CMake older than 3.5 has been removed.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
