### PR TITLE
[giflib] Fix build with CMake 4.0

### DIFF
--- a/ports/giflib/CMakeLists.txt
+++ b/ports/giflib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 
 project(giflib C)
 

--- a/ports/giflib/portfile.cmake
+++ b/ports/giflib/portfile.cmake
@@ -27,4 +27,4 @@ vcpkg_copy_pdbs()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/gif")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/giflib/vcpkg.json
+++ b/ports/giflib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "giflib",
   "version": "5.2.2",
+  "port-version": 1,
   "description": "A library for reading and writing gif images.",
   "homepage": "https://sourceforge.net/projects/giflib/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3138,7 +3138,7 @@
     },
     "giflib": {
       "baseline": "5.2.2",
-      "port-version": 0
+      "port-version": 1
     },
     "ginkgo": {
       "baseline": "1.9.0",

--- a/versions/g-/giflib.json
+++ b/versions/g-/giflib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77107ea5a74e4fd5dacee22023f1312a2eef4592",
+      "version": "5.2.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "3763c06b1c8fce08fe96398c747b343707832d62",
       "version": "5.2.2",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/44272

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.