### PR TITLE
[libevent] Upgrade CMake 3.5

### DIFF
--- a/ports/libevent/portfile.cmake
+++ b/ports/libevent/portfile.cmake
@@ -42,6 +42,9 @@ vcpkg_cmake_configure(
         -DEVENT__DISABLE_REGRESS=ON
         -DEVENT__DISABLE_SAMPLES=ON
         -DEVENT__DISABLE_MBEDTLS=ON
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 # https://github.com/libevent/libevent/issues/1782
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_POLICY_VERSION_MINIMUM
 )
 
 vcpkg_cmake_install()

--- a/ports/libevent/vcpkg.json
+++ b/ports/libevent/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libevent",
   "version": "2.1.12+20230128",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An event notification library",
   "homepage": "https://github.com/libevent/libevent",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4558,7 +4558,7 @@
     },
     "libevent": {
       "baseline": "2.1.12+20230128",
-      "port-version": 1
+      "port-version": 2
     },
     "libeventheader-decode": {
       "baseline": "1.4.0",

--- a/versions/l-/libevent.json
+++ b/versions/l-/libevent.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41c37cfccb3ea3c7891ddef0db39f7e89e09bee9",
+      "version": "2.1.12+20230128",
+      "port-version": 2
+    },
+    {
       "git-tree": "fb70d948ca21973f4f8e403b0ec54053631a74e2",
       "version": "2.1.12+20230128",
       "port-version": 1


### PR DESCRIPTION
Fixes #44336
I have submitted an issue on upstream: https://github.com/libevent/libevent/issues/1782
Failed due to https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features

> Compatibility with versions of CMake older than 3.5 has been removed.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
