### PR TITLE
[vcpkg baseline][cpputest, ms-gltf] REMOVE FROM FAIL LIST

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -259,7 +259,6 @@ cppcoro:x64-android=fail
 cppcoro:x64-linux=fail
 cppcoro:x64-osx=fail
 cppslippi:x64-linux=fail
-cpputest:arm-neon-android=fail
 crashpad:x64-linux=fail #Compilation failed due to the lack of Clang++ compiler.
 cserialport:arm-neon-android=fail
 cserialport:arm64-android=fail
@@ -741,14 +740,11 @@ moos-essential:x64-windows-release=fail
 moos-essential:x64-windows-static-md=fail
 moos-essential:x64-windows=fail
 moos-essential:x86-windows=fail
-# ms-gdkx and ms-gltf require the Microsoft GDK with Xbox Extensions which is not installed on the CI pipeline machines
+# ms-gdkx require the Microsoft GDK with Xbox Extensions which is not installed on the CI pipeline machines
 ms-gdkx:x64-windows-release=fail
 ms-gdkx:x64-windows-static-md=fail
 ms-gdkx:x64-windows-static=fail
 ms-gdkx:x64-windows=fail
-ms-gltf:arm-neon-android=fail
-ms-gltf:arm64-android=fail
-ms-gltf:x64-android=fail
 # Conflicts with libjpeg-turbo
 mozjpeg:arm-neon-android=fail
 mozjpeg:arm64-android=fail


### PR DESCRIPTION
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=113410&view=results
```
PASSING, REMOVE FROM FAIL LIST: cpputest:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: ms-gltf:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: ms-gltf:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: ms-gltf:arm64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
```
These records were added by PR https://github.com/microsoft/vcpkg/pull/29406, and fixed in PR https://github.com/microsoft/vcpkg/pull/44313 and https://github.com/microsoft/vcpkg/pull/44317, so they are removed from `ci.baseline.txt`.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~