### PR TITLE
[cpp-pinyin] update to 1.0.2

### DIFF
--- a/ports/cpp-pinyin/portfile.cmake
+++ b/ports/cpp-pinyin/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfgitpr/cpp-pinyin
     REF  "${VERSION}"
-    SHA512 de8bfaa56c951591ed360be74fa164f0fcd8fe19c42ae6fdf0e63ba8e375b9e5dc6f6577a9a34a2c5b638a799f701c1cb54fbfa07f32003e91cac58e660ab4ec
+    SHA512 5ad5425f5c804607c90c801fac722971a6ddac39914807b9a0885dfcdcc0c2afc577893956164af4c2e1d8f87a3a63be884215d84be37e861abc25b98ab565ec
     HEAD_REF main
 )
 
@@ -13,7 +13,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DCPP_PINYIN_BUILD_STATIC=${CPP_PINYIN_BUILD_STATIC}
         -DCPP_PINYIN_BUILD_TESTS=FALSE
-        "-DVCPKG_DICT_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}"
+        -DCPP_PINYIN_VCPKG_DICT_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}
 )
 
 vcpkg_cmake_install()

--- a/ports/cpp-pinyin/vcpkg.json
+++ b/ports/cpp-pinyin/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-pinyin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A lightweight Chinese/Cantonese to Pinyin library.",
   "homepage": "https://github.com/wolfgitpr/cpp-pinyin",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1925,7 +1925,7 @@
       "port-version": 0
     },
     "cpp-pinyin": {
-      "baseline": "1.0.1",
+      "baseline": "1.0.2",
       "port-version": 0
     },
     "cpp-redis": {

--- a/versions/c-/cpp-pinyin.json
+++ b/versions/c-/cpp-pinyin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e058994c7efb41c68dca581b9a8e38b3cad6e05c",
+      "version": "1.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "dabdc5308769f7a7f3c569e4d23c3e81b1657141",
       "version": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.