### PR TITLE
[systemc] Update to 2.3.4

### DIFF
--- a/ports/systemc/portfile.cmake
+++ b/ports/systemc/portfile.cmake
@@ -1,15 +1,11 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-set(SYSTEMC_VERSION 2.3.3)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.accellera.org/images/downloads/standards/systemc/systemc-${SYSTEMC_VERSION}.zip"
-    FILENAME "systemc-${SYSTEMC_VERSION}.zip"
-    SHA512 f4df172addf816a1928d411dcab42c1679dc4c9d772f406c10d798a2c174d89cdac7a83947fa8beea1e3aff93da522d2d2daf61a4841ec456af7b7446c5c4a14
-)
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
-    SOURCE_BASE "${SYSTEMC_VERSION}"
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO accellera-official/systemc
+    REF "${VERSION}"
+    SHA512 3ef4b5e9c05b8d03e856598ddc27ad50a0a39a7f9334cd00faefeacdf954b6527104d3238c4e8bfa88c00dc382f4da5a50efbd845fe0b6cc2f5a025c993deefd
+    HEAD_REF main
     PATCHES
         install.patch
 )

--- a/ports/systemc/vcpkg.json
+++ b/ports/systemc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "systemc",
-  "version": "2.3.3",
-  "port-version": 8,
+  "version": "2.3.4",
   "description": "A set of C++ classes and macros which provide an event-driven simulation kernel in C++",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9017,8 +9017,8 @@
       "port-version": 2
     },
     "systemc": {
-      "baseline": "2.3.3",
-      "port-version": 8
+      "baseline": "2.3.4",
+      "port-version": 0
     },
     "tabulate": {
       "baseline": "1.5",

--- a/versions/s-/systemc.json
+++ b/versions/s-/systemc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e23998a33f56dce22c979b493bc154ff60d87f8d",
+      "version": "2.3.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "dbe865a5931720b89f0c20153c65aecc71dd7336",
       "version": "2.3.3",
       "port-version": 8


### PR DESCRIPTION
The version 2.3.4 is added because it's the last 2.* release and some users rely on the older verison. Version 3.0.1 will be added with another PR.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.