### PR TITLE
[cnats] update version 3.10.1

### DIFF
--- a/ports/cnats/portfile.cmake
+++ b/ports/cnats/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nats-io/nats.c
     REF "v${VERSION}"
-    SHA512 59820cb7a4cf6aa0e4bd01c6eb19217e43bd4eeb100a883cf5d58ec52ddf195aba5e6c57d4054a9fd18f13f6667ad0f5876c7a8e829a593cfc2e799bd2cbd8b1
+    SHA512 2edd9c19ca06f866696f2125fc1452568ad255ff09d26e58eb9c64e21e1d4fbfae208edc0f31eb93f87470f365b5701109f526d75ba5c8f4f0458766677ab2a7
     HEAD_REF main
     PATCHES
         fix-sodium-dep.patch

--- a/ports/cnats/vcpkg.json
+++ b/ports/cnats/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cnats",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "A C client for the NATS messaging system",
   "homepage": "https://github.com/nats-io/nats.c",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1761,7 +1761,7 @@
       "port-version": 3
     },
     "cnats": {
-      "baseline": "3.10.0",
+      "baseline": "3.10.1",
       "port-version": 0
     },
     "cnl": {

--- a/versions/c-/cnats.json
+++ b/versions/c-/cnats.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "77e01aa33abd8784f48843fd365296d9eab3f581",
+      "git-tree": "8c37f1714365a6c786a13ee08f69d94fd42c242d",
       "version": "3.10.1",
       "port-version": 0
     },

--- a/versions/c-/cnats.json
+++ b/versions/c-/cnats.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77e01aa33abd8784f48843fd365296d9eab3f581",
+      "version": "3.10.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b733949bf6101a81c740a1c3df955bb1b4071148",
       "version": "3.10.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.