### PR TITLE
[meshoptimizer] Update to 0.23

### DIFF
--- a/ports/meshoptimizer/portfile.cmake
+++ b/ports/meshoptimizer/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeux/meshoptimizer
     REF v${VERSION}
-    SHA512 6fbb9c5a98dad8616562d60ed5eb08030c101edd81fb028d906ea0aa8261369e942c0eeadf163283c8acac7858728b9277ef557cb8d38e972c7fe97771c0b4c4
+    SHA512 f2f1d951bfb5c9b51d1a8485b3ce5e6ba4b5d3475fbefb0129fd54ce6dfaaeb923ad03c603733ba3865cb7ff6516da92ccdf326e5d672ef2114f515fd3582395
     HEAD_REF master
 )
 

--- a/ports/meshoptimizer/vcpkg.json
+++ b/ports/meshoptimizer/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "meshoptimizer",
-  "version": "0.22",
+  "version": "0.23",
   "description": "Mesh optimization library that makes meshes smaller and faster to render",
   "homepage": "https://github.com/zeux/meshoptimizer",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5881,7 +5881,7 @@
       "port-version": 6
     },
     "meshoptimizer": {
-      "baseline": "0.22",
+      "baseline": "0.23",
       "port-version": 0
     },
     "metis": {

--- a/versions/m-/meshoptimizer.json
+++ b/versions/m-/meshoptimizer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60127d521117d7e21408ea9ee5a0f8aca4b1d31d",
+      "version": "0.23",
+      "port-version": 0
+    },
+    {
       "git-tree": "27a20559dc52f7a8755700aa7a7980d915c98626",
       "version": "0.22",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
