### PR TITLE
[kleidiai] Add new port

### DIFF
--- a/ports/kleidiai/portfile.cmake
+++ b/ports/kleidiai/portfile.cmake
@@ -17,9 +17,7 @@ vcpkg_cmake_configure(
     WINDOWS_USE_MSBUILD
     OPTIONS
         -DKLEIDIAI_BUILD_TESTS=OFF
-        -DKLEIDIAI_BUILD_EXAMPLES=OFF
-        -DKLEIDIAI_BUILD_TOOLS=OFF
-        -DKLEIDIAI_WITH_TESTS=OFF
+        -DKLEIDIAI_BUILD_BENCHMARK=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/kleidiai/portfile.cmake
+++ b/ports/kleidiai/portfile.cmake
@@ -25,4 +25,4 @@ vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share") # Avoids empty debug folder in the zip.
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSES/BSD-3-Clause.txt")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSES/Apache-2.0.txt")

--- a/ports/kleidiai/portfile.cmake
+++ b/ports/kleidiai/portfile.cmake
@@ -21,7 +21,8 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup()
+# The following line of code doesn't work because kleidiai_arm64-windows/debug/share/kleidiai' does not exist.
+#vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share") # Avoids empty debug folder in the zip.
 

--- a/ports/kleidiai/portfile.cmake
+++ b/ports/kleidiai/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    message(FATAL_ERROR "kleidiai port only supports arm64 architecture.  Skipping build for ${VCPKG_TARGET_ARCHITECTURE}.")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ARM-software/kleidiai
+    REF 81480ed1de6a3936b3b09ac071013e4afd445881
+    SHA512 24d93bcc52b8529317c1f0c45cb6ffe892f459c5509966a033de79d35b9525ded23ebfdda9e4f17966c13b719d76f0278321dc21df28c630e4b370c92df9095a
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    WINDOWS_USE_MSBUILD
+    OPTIONS
+        -DKLEIDIAI_BUILD_TESTS=OFF
+        -DKLEIDIAI_BUILD_EXAMPLES=OFF
+        -DKLEIDIAI_BUILD_TOOLS=OFF
+        -DKLEIDIAI_WITH_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share") # Avoids empty debug folder in the zip.
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSES/BSD-3-Clause.txt")

--- a/ports/kleidiai/vcpkg.json
+++ b/ports/kleidiai/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "kleidiai",
+  "version-semver": "0.17.0",
+  "description": "Arm's KleidiAI library for efficient neural network inference.",
+  "homepage": "https://github.com/ARM-software/kleidiai",
+  "license": "Apache-2.0",
+  "supports": "arm64",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/kleidiai/vcpkg.json
+++ b/ports/kleidiai/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kleidiai",
-  "version-semver": "0.17.0",
+  "version-semver": "1.5.0",
   "description": "Arm's KleidiAI library for efficient neural network inference.",
   "homepage": "https://github.com/ARM-software/kleidiai",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4188,6 +4188,10 @@
       "baseline": "2024-01-20",
       "port-version": 0
     },
+    "kleidiai": {
+      "baseline": "1.5.0",
+      "port-version": 0
+    },
     "klein": {
       "baseline": "2021-05-09",
       "port-version": 0

--- a/versions/k-/kleidiai.json
+++ b/versions/k-/kleidiai.json
@@ -1,0 +1,14 @@
+{
+  "versions": [
+    {
+      "git-tree": "ffa79c597f1c69e20133695efd74a0a4c2585eae",
+      "version-semver": "1.5.0",
+      "port-version": 0
+    },
+    {
+      "git-tree": "e993f511aa802f4502404f383fa000e00bc59269",
+      "version-semver": "0.17.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/k-/kleidiai.json
+++ b/versions/k-/kleidiai.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ffa79c597f1c69e20133695efd74a0a4c2585eae",
+      "git-tree": "54165c45eeee11a7c9231fccd00d04af8e148388",
       "version-semver": "1.5.0",
       "port-version": 0
     },

--- a/versions/k-/kleidiai.json
+++ b/versions/k-/kleidiai.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "54165c45eeee11a7c9231fccd00d04af8e148388",
+      "git-tree": "1fecb8c6e799b07d1c43a515c3737f8ebd241993",
       "version-semver": "1.5.0",
       "port-version": 0
     },


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

