### PR TITLE
Sample library

### DIFF
--- a/ports/vcpkg-sample-library/portfile.cmake
+++ b/ports/vcpkg-sample-library/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Microsoft/vcpkg-docs
+    REF "${VERSION}"
+    SHA512 4202125968a01219deeee14b81e1d476dab18d968425ba36d640816b0b3db6168f8ccf4120ba20526e9930c8c7294e64d43900ad2aef9d5f28175210d0c3a417
+    HEAD_REF cmake-sample-lib
+)
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "my_sample_lib")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/vcpkg-sample-library/usage
+++ b/ports/vcpkg-sample-library/usage
@@ -1,0 +1,4 @@
+vcpkg-sample-library provides CMake targets:
+
+find_package(my_sample_lib CONFIG REQUIRED)
+target_link_libraries(main PRIVATE my_sample_lib::my_sample_lib)

--- a/ports/vcpkg-sample-library/vcpkg.json
+++ b/ports/vcpkg-sample-library/vcpkg.json
@@ -1,0 +1,19 @@
+
+{
+  "name": "vcpkg-sample-library",
+  "version": "1.0.2",
+  "homepage": "https://github.com/microsoft/vcpkg-docs/tree/cmake-sample-lib",
+  "description": "A sample C++ library designed to serve as a foundational example for a tutorial on packaging libraries with vcpkg.",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name" : "vcpkg-cmake",
+      "host" : true
+    },
+    {
+      "name" : "vcpkg-cmake-config",
+      "host" : true
+    },
+    "fmt"
+  ]
+}

--- a/ports/vcpkg-sample-library/vcpkg.json
+++ b/ports/vcpkg-sample-library/vcpkg.json
@@ -1,19 +1,18 @@
-
 {
   "name": "vcpkg-sample-library",
   "version": "1.0.2",
-  "homepage": "https://github.com/microsoft/vcpkg-docs/tree/cmake-sample-lib",
   "description": "A sample C++ library designed to serve as a foundational example for a tutorial on packaging libraries with vcpkg.",
+  "homepage": "https://github.com/microsoft/vcpkg-docs/tree/cmake-sample-lib",
   "license": "MIT",
   "dependencies": [
+    "fmt",
     {
-      "name" : "vcpkg-cmake",
-      "host" : true
+      "name": "vcpkg-cmake",
+      "host": true
     },
     {
-      "name" : "vcpkg-cmake-config",
-      "host" : true
-    },
-    "fmt"
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9612,6 +9612,10 @@
       "baseline": "2023-03-22",
       "port-version": 3
     },
+    "vcpkg-sample-library": {
+      "baseline": "1.0.2",
+      "port-version": 0
+    },
     "vcpkg-tool-bazel": {
       "baseline": "5.2.0",
       "port-version": 0

--- a/versions/v-/vcpkg-sample-library.json
+++ b/versions/v-/vcpkg-sample-library.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f18287752488c63cd51b7890aacd8b3da1bf79b8",
+      "version": "1.0.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
All done
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
