### PR TITLE
[expat] update to 2.7.0

### DIFF
--- a/ports/expat/portfile.cmake
+++ b/ports/expat/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libexpat/libexpat
     REF "${REF}"
-    SHA512 6a6c5b0f6a1b2c70715701aeab688e476943704c492a0f2f8afd7fea84615a8d9569eb2b699912676058eff6a7bbdd78b48110ed67ab0250a3d41fe8f128f4e1
+    SHA512 a2fda08b1e269dcdd936e7c8dfbf82ad573f1bafc392bddb54dd656c099f430a727db0c408e2b1f84fa3a2cbee693668b8e185f53bb4868bf15497b94154eae1
     HEAD_REF master
 )
 

--- a/ports/expat/vcpkg.json
+++ b/ports/expat/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "expat",
-  "version": "2.6.4",
+  "version": "2.7.0",
   "description": "XML parser library written in C",
   "homepage": "https://github.com/libexpat/libexpat",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2641,7 +2641,7 @@
       "port-version": 0
     },
     "expat": {
-      "baseline": "2.6.4",
+      "baseline": "2.7.0",
       "port-version": 0
     },
     "expected-lite": {

--- a/versions/e-/expat.json
+++ b/versions/e-/expat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a2154e46f0c81375b5cf4ce94067560ffac9168",
+      "version": "2.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "97dd7e516104f330e1bb5eafff10852211dbd2df",
       "version": "2.6.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
