### PR TITLE
[SDL2] Fix compiling on gcc

### DIFF
--- a/ports/sdl2/fix-pipewire.patch
+++ b/ports/sdl2/fix-pipewire.patch
@@ -1,0 +1,31 @@
+From 9e079fe9c7931738ed63d257b1d7fb8a07b66824 Mon Sep 17 00:00:00 2001
+From: Neal Gompa <neal@gompa.dev>
+Date: Mon, 10 Feb 2025 05:00:56 -0500
+Subject: [PATCH] pipewire: Ensure that the correct struct is used for
+ enumeration APIs
+
+PipeWire now requires the correct struct type is used, otherwise
+it will fail to compile.
+
+Reference: https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/188d920733f0791413d3386e5536ee7377f71b2f
+
+Fixes: https://github.com/libsdl-org/SDL/issues/12224
+(cherry picked from commit d35bef64e913dd7d5dd3153a4b61f10ef837dad6)
+(cherry picked from commit 6be87ceb33a9aad3bf5204bb13b3a5e8b498fd26)
+---
+ src/audio/pipewire/SDL_pipewire.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/audio/pipewire/SDL_pipewire.c b/src/audio/pipewire/SDL_pipewire.c
+index 889e05decb293..5d1bfc28dedb7 100644
+--- a/src/audio/pipewire/SDL_pipewire.c
++++ b/src/audio/pipewire/SDL_pipewire.c
+@@ -590,7 +590,7 @@ static void node_event_info(void *object, const struct pw_node_info *info)
+ 
+         /* Need to parse the parameters to get the sample rate */
+         for (i = 0; i < info->n_params; ++i) {
+-            pw_node_enum_params(node->proxy, 0, info->params[i].id, 0, 0, NULL);
++            pw_node_enum_params((struct pw_node*)node->proxy, 0, info->params[i].id, 0, 0, NULL);
+         }
+ 
+         hotplug_core_sync(node);

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         deps.patch
         alsa-dep-fix.patch
         cxx-linkage-pkgconfig.diff
+        fix-pipewire.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl2",
   "version": "2.32.2",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8358,7 +8358,7 @@
     },
     "sdl2": {
       "baseline": "2.32.2",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f5273484f07f8644858850d8942dd374535e96d",
+      "version": "2.32.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "5fbe7b04157cab8298b2cafa18e786caf70c6ccd",
       "version": "2.32.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #44412.

This adds a patch typecasting the correct struct for pipewire which is failing on linux with gcc.

https://github.com/libsdl-org/SDL/commit/9e079fe9c7931738ed63d257b1d7fb8a07b66824
https://github.com/libsdl-org/SDL/issues/12484

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.