### PR TITLE
[libaribcaption] Add new port

### DIFF
--- a/ports/libaribcaption/portfile.cmake
+++ b/ports/libaribcaption/portfile.cmake
@@ -1,0 +1,39 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO xqq/libaribcaption
+    REF "v${VERSION}"
+    SHA512 3f3c802ae68734126d9b4a0525b3353af4c1a3807cd21bfa04b89f2092fe565cb2413bcdd0b762313d40b7e0ab75c7e8066bf4a1879c16637f35ee164f6ef6a4
+    HEAD_REF master
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        directwrite ARIBCC_USE_DIRECTWRITE
+        gdi         ARIBCC_USE_GDI_FONT
+    INVERTED_FEATURES
+        renderer    ARIBCC_NO_RENDERER
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ARIBCC_SHARED_LIBRARY)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DARIBCC_BUILD_TESTS=OFF
+        -DARIBCC_SHARED_LIBRARY=${ARIBCC_SHARED_LIBRARY}
+        -DARIBCC_USE_EMBEDDED_FREETYPE=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME aribcaption CONFIG_PATH "lib/cmake/aribcaption")
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libaribcaption/portfile.cmake
+++ b/ports/libaribcaption/portfile.cmake
@@ -9,10 +9,9 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        directwrite ARIBCC_USE_DIRECTWRITE
-        gdi         ARIBCC_USE_GDI_FONT
+        gdi      ARIBCC_USE_GDI_FONT
     INVERTED_FEATURES
-        renderer    ARIBCC_NO_RENDERER
+        renderer ARIBCC_NO_RENDERER
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ARIBCC_SHARED_LIBRARY)

--- a/ports/libaribcaption/vcpkg.json
+++ b/ports/libaribcaption/vcpkg.json
@@ -15,26 +15,9 @@
     }
   ],
   "default-features": [
-    {
-      "name": "directwrite",
-      "platform": "windows"
-    },
     "renderer"
   ],
   "features": {
-    "directwrite": {
-      "description": "Enable DirectWrite text rendering backend",
-      "supports": "windows",
-      "dependencies": [
-        {
-          "name": "libaribcaption",
-          "default-features": false,
-          "features": [
-            "renderer"
-          ]
-        }
-      ]
-    },
     "gdi": {
       "description": "Enable Win32 GDI font provider",
       "supports": "windows",

--- a/ports/libaribcaption/vcpkg.json
+++ b/ports/libaribcaption/vcpkg.json
@@ -1,0 +1,65 @@
+{
+  "name": "libaribcaption",
+  "version": "1.1.1",
+  "description": "Portable ARIB STD-B24 caption decoder/renderer",
+  "homepage": "https://github.com/xqq/libaribcaption",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "directwrite",
+      "platform": "windows"
+    },
+    "renderer"
+  ],
+  "features": {
+    "directwrite": {
+      "description": "Enable DirectWrite text rendering backend",
+      "supports": "windows",
+      "dependencies": [
+        {
+          "name": "libaribcaption",
+          "default-features": false,
+          "features": [
+            "renderer"
+          ]
+        }
+      ]
+    },
+    "gdi": {
+      "description": "Enable Win32 GDI font provider",
+      "supports": "windows",
+      "dependencies": [
+        {
+          "name": "libaribcaption",
+          "default-features": false,
+          "features": [
+            "renderer"
+          ]
+        }
+      ]
+    },
+    "renderer": {
+      "description": "Build with renderer enabled",
+      "dependencies": [
+        {
+          "name": "fontconfig",
+          "platform": "linux"
+        },
+        {
+          "name": "freetype",
+          "platform": "android | linux"
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4360,6 +4360,10 @@
       "baseline": "3.7.7",
       "port-version": 2
     },
+    "libaribcaption": {
+      "baseline": "1.1.1",
+      "port-version": 0
+    },
     "libass": {
       "baseline": "0.17.3",
       "port-version": 0

--- a/versions/l-/libaribcaption.json
+++ b/versions/l-/libaribcaption.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c44a8a2ac2a3f58b566211007b9dc435850c2a57",
+      "version": "1.1.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
