### PR TITLE
[imgui] update to 1.91.9

### DIFF
--- a/ports/hello-imgui/portfile.cmake
+++ b/ports/hello-imgui/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         cmake-config.diff
         imgui-test-engine.diff
+        # PR has been merged into https://github.com/pthom/hello_imgui/pull/142. This patch should not be needed in the next release.
         support-imgui-1_91_9.patch
 )
 file(REMOVE_RECURSE

--- a/ports/hello-imgui/portfile.cmake
+++ b/ports/hello-imgui/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         cmake-config.diff
         imgui-test-engine.diff
+        support-imgui-1_91_9.patch
 )
 file(REMOVE_RECURSE
     "${SOURCE_PATH}/external/imgui"

--- a/ports/hello-imgui/support-imgui-1_91_9.patch
+++ b/ports/hello-imgui/support-imgui-1_91_9.patch
@@ -1,0 +1,49 @@
+diff --git a/src/hello_imgui/impl/imgui_theme.cpp b/src/hello_imgui/impl/imgui_theme.cpp
+index 8bc60cb..87f2de4 100644
+--- a/src/hello_imgui/impl/imgui_theme.cpp
++++ b/src/hello_imgui/impl/imgui_theme.cpp
+@@ -314,7 +314,7 @@ namespace ImGuiTheme
+             style.GrabRounding = 0.0f;
+             style.TabRounding = 0.0f;
+             style.TabBorderSize = 0.0f;
+-            style.TabMinWidthForCloseButton = 0.0f;
++            style.TabCloseButtonMinWidthUnselected = 0.0f;
+             style.ColorButtonPosition = ImGuiDir_Left;
+             style.ButtonTextAlign = ImVec2(0.5f, 0.5f);
+             style.SelectableTextAlign = ImVec2(0.0f, 0.0f);
+@@ -408,7 +408,7 @@ namespace ImGuiTheme
+             style.GrabRounding = 0.0f;
+             style.TabRounding = 0.0f;
+             style.TabBorderSize = 1.0f;
+-            style.TabMinWidthForCloseButton = 0.0f;
++            style.TabCloseButtonMinWidthUnselected = 0.0f;
+             style.ColorButtonPosition = ImGuiDir_Right;
+             style.ButtonTextAlign = ImVec2(0.5f, 0.5f);
+             style.SelectableTextAlign = ImVec2(0.0f, 0.0f);
+@@ -577,7 +577,7 @@ namespace ImGuiTheme
+             style.GrabRounding = 0.0f;
+             style.TabRounding = 4.0f;
+             style.TabBorderSize = 0.0f;
+-            style.TabMinWidthForCloseButton = 0.0f;
++            style.TabCloseButtonMinWidthUnselected = 0.0f;
+             style.ColorButtonPosition = ImGuiDir_Right;
+             style.ButtonTextAlign = ImVec2(0.5f, 0.5f);
+             style.SelectableTextAlign = ImVec2(0.0f, 0.0f);
+@@ -615,7 +615,7 @@ namespace ImGuiTheme
+             style.GrabRounding = 2.0f;
+             style.TabRounding = 4.0f;
+             style.TabBorderSize = 1.0f;
+-            style.TabMinWidthForCloseButton = 0.0f;
++            style.TabCloseButtonMinWidthUnselected = 0.0f;
+             style.ColorButtonPosition = ImGuiDir_Right;
+             style.ButtonTextAlign = ImVec2(0.5f, 0.5f);
+             style.SelectableTextAlign = ImVec2(0.0f, 0.0f);
+@@ -814,7 +814,7 @@ namespace ImGuiTheme
+             style.ScrollbarSize = 15.5f;
+             style.GrabMinSize = 10.89999961853027f;
+             style.TabBorderSize = 1.0f;
+-            style.TabMinWidthForCloseButton = 0.0f;
++            style.TabCloseButtonMinWidthUnselected = 0.0f;
+             style.ColorButtonPosition = ImGuiDir_Right;
+             style.ButtonTextAlign = ImVec2(0.5f, 0.5f);
+             style.SelectableTextAlign = ImVec2(0.0f, 0.5f);

--- a/ports/hello-imgui/vcpkg.json
+++ b/ports/hello-imgui/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hello-imgui",
   "version": "1.6.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "Hello ImGui: unleash your creativity in app development and prototyping",
     "Note that at least on renderer backend and at least one platform backend must be chosen."

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -5,7 +5,7 @@ if ("docking-experimental" IN_LIST FEATURES)
         OUT_SOURCE_PATH SOURCE_PATH
         REPO ocornut/imgui
         REF "v${VERSION}-docking"
-        SHA512 8c43016957a4811922e2bbf9108eecb0c94944e34b357087b8c989eb8c1155483eeb84af6b5291b3512fcd1bfe3e1a2bc04870594e7e9f4e28b0629e3eecbf25 
+        SHA512 3a019533e638b2023e0c71d0455561ee9d589ff33b677c8135345e85c28edb7b83580271d49a787e0e838fd6217d1625baad65e6559ae7faec53f3a309917ecd 
         HEAD_REF docking
     )
 else()
@@ -13,7 +13,7 @@ else()
         OUT_SOURCE_PATH SOURCE_PATH
         REPO ocornut/imgui
         REF "v${VERSION}"
-        SHA512 421aa81b55a85a8c4ea21d1b352e41e916b9e0f3ccfee3dcf415fc69c49a5feffc742c991fe10a19725a3766c92ebc5bff1027d6278ae7b8f1861474e891d6e6
+        SHA512 c9393bd9f6b49b036ad6ab3ba4d972876c6f60ce7f5c13a7a56ff11b3559ea3211b0caa03eed10b4f4fbe9c371e14f7f24866bd476652f543f3ed3aa878ea930
         HEAD_REF master
     )
 endif()
@@ -64,7 +64,7 @@ if ("test-engine" IN_LIST FEATURES)
         OUT_SOURCE_PATH TEST_ENGINE_SOURCE_PATH
         REPO ocornut/imgui_test_engine
         REF "v${VERSION}"
-        SHA512 c6478efa8d26da7c538bc73c20ff5dfdedee98467128b1d88e5efa384fa8969ff06ff076878c1c4223646ec87ebab4b44081f1cc029fef389eb4c3cfdca57ae7
+        SHA512 44d6fd1c26c9c2cb3fcbd1560dba8e056f84dc170051dcb8db5d642945fb26475006a8166486f7f62e900a97d65f2f98d364ac06c121a57309b3229cc41556a4
         HEAD_REF master
     )
 

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.91.8",
-  "port-version": 4,
+  "version": "1.91.9",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3562,7 +3562,7 @@
     },
     "hello-imgui": {
       "baseline": "1.6.0",
-      "port-version": 2
+      "port-version": 3
     },
     "hexl": {
       "baseline": "1.2.5",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3721,8 +3721,8 @@
       "port-version": 0
     },
     "imgui": {
-      "baseline": "1.91.8",
-      "port-version": 4
+      "baseline": "1.91.9",
+      "port-version": 0
     },
     "imgui-node-editor": {
       "baseline": "0.9.3",

--- a/versions/h-/hello-imgui.json
+++ b/versions/h-/hello-imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b34e1f65c5c6269c656b4e523a253bb78edca85",
+      "version": "1.6.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "7b5fb698a8594d93f40dc96edbbce679a852c1bf",
       "version": "1.6.0",
       "port-version": 2

--- a/versions/h-/hello-imgui.json
+++ b/versions/h-/hello-imgui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4b34e1f65c5c6269c656b4e523a253bb78edca85",
+      "git-tree": "78ac4b6bc7b6c824cb961ef178de22f621631b03",
       "version": "1.6.0",
       "port-version": 3
     },

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cecad336497c19491c07fead1897ac139a173ed2",
+      "version": "1.91.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "5f4112249c873fd337a417c75e45127362785b75",
       "version": "1.91.8",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
