### PR TITLE
[nanoflann] Update to 1.7.1

### DIFF
--- a/ports/nanoflann/portfile.cmake
+++ b/ports/nanoflann/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jlblancoc/nanoflann
     REF "v${VERSION}"
-    SHA512 ec76fc6b300315e802ddbe774efadff582398cb89b5db2f76297dba50a0207ec837aa3ea520b0eb4a268f16c5c59afec41533933b5bddcf2fa4b4c9432e01ac4
+    SHA512 258b2145f2972f6e6cbfa524dfada15f6d66fd53ab81cd55924f159c6c05eb55c56426039bded0357ea707c34df3ca04fa4875a42baeecb5e6b5f4a57feac808
     HEAD_REF master
 )
 

--- a/ports/nanoflann/vcpkg.json
+++ b/ports/nanoflann/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoflann",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "nanoflann is a C++11 header-only library for building KD-Trees of datasets with different topologies: R2, R3 (point clouds), SO(2) and SO(3) (2D and 3D rotation groups).",
   "homepage": "https://github.com/jlblancoc/nanoflann",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6341,7 +6341,7 @@
       "port-version": 8
     },
     "nanoflann": {
-      "baseline": "1.7.0",
+      "baseline": "1.7.1",
       "port-version": 0
     },
     "nanogui": {

--- a/versions/n-/nanoflann.json
+++ b/versions/n-/nanoflann.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e3ae6ea902522d2b25af60d47bde944e7020361a",
+      "version": "1.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "fcd6fd4497c8562c547bf44921aff4ae32b64d17",
       "version": "1.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.