### PR TITLE
[thorvg] update to 0.15.11

### DIFF
--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO thorvg/thorvg
     REF "v${VERSION}"
-    SHA512 f0a1a049284db5945fc5562dd50009fdc29bae847ca8e1dff585c35dc0d6b827c8c5a888cb04d7b58765635409aca09824cd3f5a78dc28acfd25d57b7cebde4d
+    SHA512 f0810a4473fb46c589fb1c7eb3bdef39aea55dfea6136ffc7da8d493c63d78c4587d9fe2967ed04db3b41e1572cbddac8655c26c1dfe1548e966dcaf9dbee166
     HEAD_REF master
 )
 

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "thorvg",
-  "version": "0.15.9",
+  "version": "0.15.11",
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9137,7 +9137,7 @@
       "port-version": 2
     },
     "thorvg": {
-      "baseline": "0.15.9",
+      "baseline": "0.15.11",
       "port-version": 0
     },
     "threadpool": {

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "812f78403b4aecc0c771dee1f2a4f3875f399376",
+      "version": "0.15.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "138ac6d7589070c8a6804f804be2b44637ddd97c",
       "version": "0.15.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/thorvg/thorvg/releases/tag/v0.15.11
