### PR TITLE
[tinycbor] update to 0.6.1

### DIFF
--- a/ports/tinycbor/portfile.cmake
+++ b/ports/tinycbor/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/tinycbor
-    REF v0.6.0
-    SHA512 af1ed05c03d3aed56e35fdcaad3235992f96b5043b594c0246e600e4b1f085df78c5345beaac8758c2b5db2952ab83997019de5940857eecb81d84b6fb642093
+    REF "v${VERSION}"
+    SHA512 7c7fff9c1e9a2f04a3bb0247b79723526685b2821df720d0211c8e86b1a516c955926b3668fa6dcdaaf6cb811aff238db39a9add1bc12a4d32f8a51741f3f2ce
     HEAD_REF master
 )
 

--- a/ports/tinycbor/vcpkg.json
+++ b/ports/tinycbor/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tinycbor",
-  "version-semver": "0.6.0",
-  "port-version": 1,
+  "version-semver": "0.6.1",
   "description": "Concise Binary Object Representation (CBOR) Library",
   "homepage": "https://github.com/intel/tinycbor",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9181,8 +9181,8 @@
       "port-version": 3
     },
     "tinycbor": {
-      "baseline": "0.6.0",
-      "port-version": 1
+      "baseline": "0.6.1",
+      "port-version": 0
     },
     "tinycthread": {
       "baseline": "2019-08-06",

--- a/versions/t-/tinycbor.json
+++ b/versions/t-/tinycbor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a4528b4d00b5960fd91dc8d7cde593224f343c11",
+      "version-semver": "0.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0579e95478ca32302fe6680fb0f953441d043a27",
       "version-semver": "0.6.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/intel/tinycbor/releases/tag/v0.6.1

This is probably the last version of requiring third-party CMakeLists.txt.
official CMakeLists.txt has been committed on upstream.
https://github.com/intel/tinycbor/commit/37d1a6dee358a991b87493fa198716c13facbffa

