### PR TITLE
[gperf] Fix CMake 4.0 build

### DIFF
--- a/ports/gperf/CMakeLists.txt
+++ b/ports/gperf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(gperf LANGUAGES C CXX)
 
 include(CheckCXXSourceCompiles)

--- a/ports/gperf/vcpkg.json
+++ b/ports/gperf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gperf",
   "version": "3.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "GNU perfect hash function generator",
   "homepage": "https://www.gnu.org/software/gperf/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3266,7 +3266,7 @@
     },
     "gperf": {
       "baseline": "3.1",
-      "port-version": 6
+      "port-version": 7
     },
     "gperftools": {
       "baseline": "2.16",

--- a/versions/g-/gperf.json
+++ b/versions/g-/gperf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce0c8faaa002c19f8d96a64d4929439cab4570f2",
+      "version": "3.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "590e19515bff5b0abc6d9f73ba20a19a71555a32",
       "version": "3.1",
       "port-version": 6


### PR DESCRIPTION
Fixes #44187

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.