### PR TITLE
[ankurvdev-embedresource] Update to v0.0.12

### DIFF
--- a/ports/ankurvdev-embedresource/portfile.cmake
+++ b/ports/ankurvdev-embedresource/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ankurvdev/embedresource
-    REF "67b3313c073d55f084369df92d202b23185a65cc"
-    SHA512 697f3aa9a7d47f03b18ebd7e305f19b05203fdc0a62e77fac52c8863306c7386e48dc86e3caca8ced8b0bf913fe039046ab9bebac596105d9773f468b50cab72
+    REF "v${VERSION}"
+    SHA512 3b19bd106b1840bb318799135cc31512c9713b6abe205c05e8f09b1d64b7b64b1f6a89bc091638b0336c6a779a5c89f6fba2ecdef6eb3783212d341f6b47a191
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/ankurvdev-embedresource/portfile.cmake
+++ b/ports/ankurvdev-embedresource/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ankurvdev/embedresource
     REF "v${VERSION}"
-    SHA512 3b19bd106b1840bb318799135cc31512c9713b6abe205c05e8f09b1d64b7b64b1f6a89bc091638b0336c6a779a5c89f6fba2ecdef6eb3783212d341f6b47a191
+    SHA512 0a26a0b554e743b4f4987c4414cfcca6d2207e8ac038a1701cdb5068ddc6cc9438deda8037ce93145c4f1434ae97d7737bbc875d7367aa14726fd16511e8421a
     HEAD_REF main)
 
 vcpkg_cmake_configure(

--- a/ports/ankurvdev-embedresource/portfile.cmake
+++ b/ports/ankurvdev-embedresource/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ankurvdev/embedresource
-    REF "v${VERSION}"
-    SHA512 90b4e40b84cd5b6de155a17890b5d8094cf772f56657230ad13a0c51a332e84fa4a38d8640a3890ae4b521a2eb897666d8c3f58e7cd9dc98e6eb3d55c84dfe44
+    REF "67b3313c073d55f084369df92d202b23185a65cc"
+    SHA512 697f3aa9a7d47f03b18ebd7e305f19b05203fdc0a62e77fac52c8863306c7386e48dc86e3caca8ced8b0bf913fe039046ab9bebac596105d9773f468b50cab72
     HEAD_REF main)
 
 vcpkg_cmake_configure(
@@ -15,12 +15,16 @@ vcpkg_copy_pdbs()
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-vcpkg_copy_tools(TOOL_NAMES embedresource AUTO_CLEAN)
+if(HOST_TRIPLET STREQUAL TARGET_TRIPLET) # Otherwise fails on wasm32-emscripten
+    vcpkg_copy_tools(TOOL_NAMES embedresource AUTO_CLEAN)
+else()
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+endif()
 
 file(READ "${CURRENT_PACKAGES_DIR}/share/embedresource/EmbedResourceConfig.cmake" config_contents)
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/embedresource/EmbedResourceConfig.cmake"
 "find_program(
-    EMBEDRESOURCE_EXECUTABLE embedresource
+    embedresource_EXECUTABLE embedresource
     PATHS
         \"\${CMAKE_CURRENT_LIST_DIR}/../../../${HOST_TRIPLET}/tools/${PORT}\"
     NO_DEFAULT_PATH

--- a/ports/ankurvdev-embedresource/vcpkg.json
+++ b/ports/ankurvdev-embedresource/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ankurvdev-embedresource",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Cross Platform Resource Embedding",
   "homepage": "https://github.com/ankurvdev/embedresource",
   "license": "BSD-3-Clause",

--- a/versions/a-/ankurvdev-embedresource.json
+++ b/versions/a-/ankurvdev-embedresource.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5de9a52fe766364a7e22874c3f854d03df4fbda2",
+      "version": "0.0.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "e8d07a71c677c057e726ccc85d3376da62eb28e2",
       "version": "0.0.11",
       "port-version": 0

--- a/versions/a-/ankurvdev-embedresource.json
+++ b/versions/a-/ankurvdev-embedresource.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5de9a52fe766364a7e22874c3f854d03df4fbda2",
+      "git-tree": "9704a7da260f41b8487527e7d321b4a29ad6b7bd",
       "version": "0.0.12",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -137,7 +137,7 @@
       "port-version": 10
     },
     "ankurvdev-embedresource": {
-      "baseline": "0.0.11",
+      "baseline": "0.0.12",
       "port-version": 0
     },
     "annoy": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.