### PR TITLE
[vcpkg baseline][workflow] Remove workflow:arm64-uwp from fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1182,7 +1182,6 @@ wordnet:arm64-android=fail
 wordnet:x64-android=fail
 workflow:arm-neon-android=fail
 workflow:arm64-android=fail
-workflow:arm64-uwp=fail
 workflow:x64-android=fail
 workflow:x64-uwp=fail
 wpilib:arm-neon-android=fail # requires full c++20 support


### PR DESCRIPTION
Port workflow passed on https://dev.azure.com/vcpkg/public/_build/results?buildId=113480&view=logs&j=f3185963-cf64-542d-738a-b43a7110d124&t=01fe6d08-3359-5d92-0c0d-59657c90ee82&l=34425

```log
PASSING, REMOVE FROM FAIL LIST: workflow:arm64-uwp (D:\a\_work\1\s\scripts\azure-pipelines/../ci.baseline.txt).
```