### PR TITLE
[godot-cpp] Upgrade to 4.4

### DIFF
--- a/ports/godot-cpp/packagable.patch
+++ b/ports/godot-cpp/packagable.patch
@@ -1,126 +1,151 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e715102..b000066 100644
+index 9e4b1f50..cb910688 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -37,7 +37,7 @@
- # Todo
- # Test build for Windows, Mac and mingw.
- 
--cmake_minimum_required(VERSION 3.13)
-+cmake_minimum_required(VERSION 3.19)
- project(godot-cpp LANGUAGES CXX)
- 
- option(GENERATE_TEMPLATE_GET_NODE "Generate a template version of the Node class's get_node." ON)
-@@ -65,9 +65,8 @@ if(NOT DEFINED BITS)
- endif()
- 
- # Input from user for GDExtension interface header and the API JSON file
--set(GODOT_GDEXTENSION_DIR "gdextension" CACHE STRING "")
-+set(GODOT_GDEXTENSION_DIR "${CMAKE_CURRENT_SOURCE_DIR}/gdextension" CACHE STRING "")
- set(GODOT_CUSTOM_API_FILE "" CACHE STRING "")
--
- set(GODOT_GDEXTENSION_API_FILE "${GODOT_GDEXTENSION_DIR}/extension_api.json")
- if (NOT "${GODOT_CUSTOM_API_FILE}" STREQUAL "")  # User-defined override.
- 	set(GODOT_GDEXTENSION_API_FILE "${GODOT_CUSTOM_API_FILE}")
-@@ -85,9 +84,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
- 	set(GODOT_COMPILE_FLAGS "/utf-8") # /GF /MP
- 
- 	if(CMAKE_BUILD_TYPE MATCHES Debug)
--		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /MDd") # /Od /RTC1 /Zi
-+		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /Od") # /Od /RTC1 /Zi
- 	else()
--		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /MD /O2") # /Oy /GL /Gy
-+		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /O2") # /Oy /GL /Gy
- 		STRING(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
- 		string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
- 	endif(CMAKE_BUILD_TYPE MATCHES Debug)
-@@ -117,7 +116,6 @@ else()
- endif()
- 
- # Generate source from the bindings file
--find_package(Python3 3.4 REQUIRED) # pathlib should be present
- if(GENERATE_TEMPLATE_GET_NODE)
- 	set(GENERATE_BINDING_PARAMETERS "True")
- else()
-@@ -183,9 +181,10 @@ if (GODOT_CPP_SYSTEM_HEADERS)
- endif ()
- 
- target_include_directories(${PROJECT_NAME} ${GODOT_CPP_SYSTEM_HEADERS_ATTRIBUTE} PUBLIC
--	include
--	${CMAKE_CURRENT_BINARY_DIR}/gen/include
--	${GODOT_GDEXTENSION_DIR}
-+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-+	$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/gen/include>
-+	$<BUILD_INTERFACE:${GODOT_GDEXTENSION_DIR}>
-+	$<INSTALL_INTERFACE:include>
- )
- 
- # Add the compile flags
-@@ -213,4 +212,8 @@ set_target_properties(${PROJECT_NAME}
- 		LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
- 		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
- 		OUTPUT_NAME "${OUTPUT_NAME}"
-+		EXPORT_NAME "cpp"
- )
+@@ -60,3 +60,38 @@ endif()
+ # USE_FOLDERS flag will organize godot-cpp targets under the subfolder
+ # 'godot-cpp'. This is enable by default from CMake version 3.26
+ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 +
 +
-+include("cmake/install.cmake")
-diff --git a/cmake/config.cmake b/cmake/config.cmake
-new file mode 100644
-index 0000000..bcddb3c
---- /dev/null
-+++ b/cmake/config.cmake
-@@ -0,0 +1 @@
-+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-godot-cpp-target.cmake")
-diff --git a/cmake/install.cmake b/cmake/install.cmake
-new file mode 100644
-index 0000000..f48ab5c
---- /dev/null
-+++ b/cmake/install.cmake
-@@ -0,0 +1,46 @@
 +
 +include("CMakePackageConfigHelpers")
 +include("GNUInstallDirs")
 +
-+install(TARGETS "godot-cpp"
-+	EXPORT "unofficial-godot-cpp-target"
-+	ARCHIVE
-+		DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++string(TOLOWER "godot-cpp.template_${CMAKE_BUILD_TYPE}" INSTALL_TARGET)
++install(TARGETS "${INSTALL_TARGET}"
++    EXPORT "unofficial-godot-cpp-config"
++    ARCHIVE
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 +)
++
 +install(
-+	DIRECTORY
-+		"${CMAKE_CURRENT_SOURCE_DIR}/include/"
-+		"${CMAKE_CURRENT_BINARY_DIR}/gen/include/"
-+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++    DIRECTORY
++        "${CMAKE_CURRENT_SOURCE_DIR}/include/"
++        "${CMAKE_CURRENT_BINARY_DIR}/gen/include/"
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++)
++install(FILES "${GODOTCPP_GDEXTENSION_DIR}/gdextension_interface.h"
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 +)
 +
-+install(FILES "${GODOT_GDEXTENSION_DIR}/gdextension_interface.h"
-+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++install(EXPORT "unofficial-godot-cpp-config"
++    NAMESPACE "unofficial::"
++    DESTINATION "${CMAKE_INSTALL_DATADIR}/unofficial-godot-cpp"
 +)
-+install(FILES "${GODOT_GDEXTENSION_API_FILE}"
-+	DESTINATION "${CMAKE_INSTALL_DATADIR}/godot-cpp"
-+)
-+
-+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake"
-+	RENAME "unofficial-godot-cpp-config.cmake"
-+	DESTINATION "${CMAKE_INSTALL_DATADIR}/unofficial-godot-cpp"
-+)
-+install(EXPORT "unofficial-godot-cpp-target"
-+	NAMESPACE "unofficial::godot::"
-+	DESTINATION "${CMAKE_INSTALL_DATADIR}/unofficial-godot-cpp"
-+)
-+
-+file(READ "${GODOT_GDEXTENSION_API_FILE}" GODOT_GDEXTENSION_API_JSON)
-+string(JSON GODOT_API_VERSION_MAJOR GET "${GODOT_GDEXTENSION_API_JSON}" "header" "version_major")
-+string(JSON GODOT_API_VERSION_MINOR GET "${GODOT_GDEXTENSION_API_JSON}" "header" "version_minor")
-+string(JSON GODOT_API_VERSION_PATCH GET "${GODOT_GDEXTENSION_API_JSON}" "header" "version_patch")
-+set(GODOT_API_VERSION "${GODOT_API_VERSION_MAJOR}.${GODOT_API_VERSION_MINOR}.${GODOT_API_VERSION_PATCH}")
-+unset(GODOT_GDEXTENSION_API_JSON)
 +
 +write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/unofficial-godot-cpp-config-version.cmake"
-+	VERSION "${GODOT_API_VERSION}"
-+	COMPATIBILITY SameMinorVersion
++    VERSION "4.4"
++    COMPATIBILITY "SameMinorVersion"
 +)
 +install(FILES "${CMAKE_CURRENT_BINARY_DIR}/unofficial-godot-cpp-config-version.cmake"
-+	DESTINATION "${CMAKE_INSTALL_DATADIR}/unofficial-godot-cpp"
++    DESTINATION "${CMAKE_INSTALL_DATADIR}/unofficial-godot-cpp"
 +)
+diff --git a/cmake/GodotCPPModule.cmake b/cmake/GodotCPPModule.cmake
+index ce087468..04b4679d 100644
+--- a/cmake/GodotCPPModule.cmake
++++ b/cmake/GodotCPPModule.cmake
+@@ -18,7 +18,6 @@ godot-cpp
+     include( GodotCPPModule )
+ 
+ ]=======================================================================]
+-find_package(Python3 3.4 REQUIRED) # pathlib should be present
+ 
+ #[[ Generate Trimmed API
+ 
+diff --git a/cmake/godotcpp.cmake b/cmake/godotcpp.cmake
+index c10d835d..cb2e8f70 100644
+--- a/cmake/godotcpp.cmake
++++ b/cmake/godotcpp.cmake
+@@ -105,7 +105,7 @@ function( godotcpp_options )
+     # Except for macos universal, which can be set by GODOTCPP_MACOS_UNIVERSAL=YES
+ 
+     # Input from user for GDExtension interface header and the API JSON file
+-    set( GODOTCPP_GDEXTENSION_DIR "gdextension" CACHE PATH
++    set( GODOTCPP_GDEXTENSION_DIR "${CMAKE_CURRENT_SOURCE_DIR}/gdextension" CACHE PATH
+             "Path to a custom directory containing GDExtension interface header and API JSON file ( /path/to/gdextension_dir )" )
+     set( GODOTCPP_CUSTOM_API_FILE "" CACHE FILEPATH
+             "Path to a custom GDExtension API JSON file (takes precedence over `GODOTCPP_GDEXTENSION_DIR`) ( /path/to/custom_api_file )")
+@@ -288,7 +288,8 @@ function( godotcpp_generate )
+     set( IS_DEV_BUILD "$<BOOL:${GODOTCPP_DEV_BUILD}>")
+ 
+     ### Define our godot-cpp library targets
+-    foreach ( TARGET_ALIAS template_debug template_release editor )
++    block()
++        string(TOLOWER "template_${CMAKE_BUILD_TYPE}" TARGET_ALIAS)
+         set( TARGET_NAME "godot-cpp.${TARGET_ALIAS}" )
+ 
+         # Generator Expressions that rely on the target
+@@ -307,7 +308,7 @@ function( godotcpp_generate )
+         )
+ 
+         # the godot-cpp.* library targets
+-        add_library( ${TARGET_NAME} STATIC EXCLUDE_FROM_ALL )
++        add_library( ${TARGET_NAME} STATIC )
+         add_library( godot-cpp::${TARGET_ALIAS} ALIAS ${TARGET_NAME} )
+ 
+         file( GLOB_RECURSE GODOTCPP_SOURCES LIST_DIRECTORIES NO CONFIGURE_DEPENDS src/*.cpp )
+@@ -319,9 +320,10 @@ function( godotcpp_generate )
+         )
+ 
+         target_include_directories( ${TARGET_NAME} ${GODOTCPP_SYSTEM_HEADERS_ATTRIBUTE} PUBLIC
+-                include
+-                ${CMAKE_CURRENT_BINARY_DIR}/gen/include
+-                ${GODOTCPP_GDEXTENSION_DIR}
++            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
++            "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/gen/include>"
++            "$<BUILD_INTERFACE:${GODOTCPP_GDEXTENSION_DIR}>"
++            "$<INSTALL_INTERFACE:include>"
+         )
+ 
+         set_target_properties( ${TARGET_NAME}
+@@ -348,6 +350,8 @@ function( godotcpp_generate )
+ 
+                 # Some IDE's respect this property to logically group targets
+                 FOLDER "godot-cpp"
++
++                EXPORT_NAME "godot::cpp"
+         )
+ 
+         if( CMAKE_SYSTEM_NAME STREQUAL Android )
+@@ -364,10 +368,9 @@ function( godotcpp_generate )
+             windows_generate()
+         endif ()
+ 
+-    endforeach ()
++    endblock()
+ 
+     # Added for backwards compatibility with prior cmake solution so that builds dont immediately break
+     # from a missing target.
+-    add_library( godot::cpp ALIAS godot-cpp.template_debug )
+ 
+ endfunction()
+diff --git a/cmake/web.cmake b/cmake/web.cmake
+index 996a1e52..170c6ac9 100644
+--- a/cmake/web.cmake
++++ b/cmake/web.cmake
+@@ -26,7 +26,6 @@ function( web_generate )
+             PUBLIC
+             -sSIDE_MODULE
+             -sSUPPORT_LONGJMP=wasm
+-            -fno-exceptions
+             $<${THREADS_ENABLED}:-sUSE_PTHREADS=1>
+     )
+ 
+diff --git a/cmake/windows.cmake b/cmake/windows.cmake
+index 8e37e7e4..02a24fde 100644
+--- a/cmake/windows.cmake
++++ b/cmake/windows.cmake
+@@ -60,9 +60,9 @@ function( windows_options )
+     message( STATUS "If not already cached, setting CMAKE_MSVC_RUNTIME_LIBRARY.\n"
+             "\tFor more information please read godot-cpp/cmake/windows.cmake")
+ 
+-    set( CMAKE_MSVC_RUNTIME_LIBRARY
+-            "MultiThreaded$<IF:$<BOOL:${GODOTCPP_DEBUG_CRT}>,DebugDLL,$<$<NOT:$<BOOL:${GODOTCPP_USE_STATIC_CPP}>>:DLL>>"
+-            CACHE STRING "Select the MSVC runtime library for use by compilers targeting the MSVC ABI.")
++    # set( CMAKE_MSVC_RUNTIME_LIBRARY
++    #         "MultiThreaded$<IF:$<BOOL:${GODOTCPP_DEBUG_CRT}>,DebugDLL,$<$<NOT:$<BOOL:${GODOTCPP_USE_STATIC_CPP}>>:DLL>>"
++    #         CACHE STRING "Select the MSVC runtime library for use by compilers targeting the MSVC ABI.")
+ endfunction()
+ 
+ 

--- a/ports/godot-cpp/portfile.cmake
+++ b/ports/godot-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "godotengine/godot-cpp"
     REF "godot-${VERSION}-stable"
-    SHA512 "4012e2c8cbdbccf5362b139a6318785af6e2cfdc99848734d5e3825afba8b8a46cdd7fff63887e2503cf3195efe79c0bd39a900b535322ab0fb51c3452dc07f5"
+    SHA512 "3c97d6f0bbd952977d8085483d538b650d44ee0f9c6d84215128d9702d071b23a91bacab3a5259320f89d11884b3a5d5b638bc757c11d7447c000223fa976de8"
     HEAD_REF "master"
     PATCHES
         "packagable.patch"

--- a/ports/godot-cpp/vcpkg.json
+++ b/ports/godot-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-cpp",
-  "version": "4.3",
+  "version": "4.4",
   "description": "C++ bindings for the Godot script API",
   "homepage": "https://github.com/godotengine/godot-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3245,7 +3245,7 @@
       "port-version": 9
     },
     "godot-cpp": {
-      "baseline": "4.3",
+      "baseline": "4.4",
       "port-version": 0
     },
     "google-cloud-cpp": {

--- a/versions/g-/godot-cpp.json
+++ b/versions/g-/godot-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "443011b5e26b9bce81dfa2a15dc2ca1c7962cad5",
+      "version": "4.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "561f56e438444e007a1b6abbcd77b33b6d64ff2c",
       "version": "4.3",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
~- [ ] The "supports" clause reflects platforms that may be fixed by this new version.~
~- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

