### PR TITLE
[tinyxml2] update to 11.0.0

### DIFF
--- a/ports/tinyxml2/portfile.cmake
+++ b/ports/tinyxml2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO leethomason/tinyxml2
     REF "${VERSION}"
-    SHA512 acdd42c7431de65272fdcb2cdf64beb44efc97deffed45f9933453883182238a60071bec5dda2f87d166dd8455e8cd3118af6937ddd7c6abacafda2a060f6cc6
+    SHA512 8a6ddd48c96bc4287437d5b5ca62c131c4416c57310b664c9088ca9c1ac9f4d43d16c1bad03f82dc5588d9486752f510d631609a3930f1d4243f12184ad1c5f9
     HEAD_REF master
     PATCHES
         0001-fix-do-not-force-export-the-symbols-when-building-st.patch

--- a/ports/tinyxml2/vcpkg.json
+++ b/ports/tinyxml2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyxml2",
-  "version-semver": "10.1.0",
+  "version-semver": "11.0.0",
   "description": "A simple, small, efficient, C++ XML parser",
   "homepage": "https://github.com/leethomason/tinyxml2",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9261,7 +9261,7 @@
       "port-version": 10
     },
     "tinyxml2": {
-      "baseline": "10.1.0",
+      "baseline": "11.0.0",
       "port-version": 0
     },
     "tl-expected": {

--- a/versions/t-/tinyxml2.json
+++ b/versions/t-/tinyxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "642c5abe1171318729a73bdf95ce6c2ca58e079c",
+      "version-semver": "11.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8eb55bba03f65245ee1f2d9f90123662cbfcb36f",
       "version-semver": "10.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

There is the bug in the version number, not the code.
https://github.com/leethomason/tinyxml2/releases/tag/11.0.0
