### PR TITLE
[tgui] Fix backend check

### DIFF
--- a/ports/tgui/portfile.cmake
+++ b/ports/tgui/portfile.cmake
@@ -1,5 +1,12 @@
-if(NOT "sdl2" IN_LIST FEATURES AND NOT "sfml" IN_LIST FEATURES)
-    message(FATAL_ERROR "At least one of the backend features must be selected: sdl2 sfml")
+
+set(BACKEND_LST "sfml" "sdl2" "sdl3" "raylib")
+foreach(BACKEND IN LISTS BACKEND_LST)
+    if(BACKEND IN_LIST FEATURES)
+        set(HAS_BACKEND ON)
+    endif()
+endforeach()
+if(NOT HAS_BACKEND)
+    message(FATAL_ERROR "At least one of the backend features must be selected: ${BACKEND_LST}")
 endif()
 
 if(VCPKG_TARGET_IS_ANDROID)

--- a/ports/tgui/vcpkg.json
+++ b/ports/tgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tgui",
   "version": "1.8.0",
+  "port-version": 1,
   "description": "TGUI is an easy to use, cross-platform, C++ GUI for SFML.",
   "homepage": "https://tgui.eu",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9130,7 +9130,7 @@
     },
     "tgui": {
       "baseline": "1.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "think-cell-range": {
       "baseline": "2023.1",

--- a/versions/t-/tgui.json
+++ b/versions/t-/tgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6390a7307153b8fc26cc25e685d298f65424fec",
+      "version": "1.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5cfc9daf9c0f559a1cf3e3e73dd3d0e67c12cd50",
       "version": "1.8.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
~- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
~- [ ] Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
