### PR TITLE
[ada-idna] add new port

### DIFF
--- a/ports/ada-idna/install.patch
+++ b/ports/ada-idna/install.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a1eda0c..af4079e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,8 +51,6 @@ else()
+   endif()
+ endif(BUILD_TESTING)
+ 
+-add_subdirectory(singleheader)
+-
+ add_library(ada-idna::ada-idna ALIAS ada-idna)
+ 
+ set_target_properties(
+@@ -83,3 +81,8 @@ install(
+   ARCHIVE COMPONENT ada-idna_development
+   INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+ )
++
++install(EXPORT ada-idna_targets
++    FILE unofficial-ada-idna-config.cmake
++    NAMESPACE unofficial::ada-idna::
++    DESTINATION share/unofficial-ada-idna)

--- a/ports/ada-idna/portfile.cmake
+++ b/ports/ada-idna/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ada-url/idna
+    REF "${VERSION}"
+    SHA512 d0176445c0f98f6adc399c4a853248bd4b34cae9d151baf85ee60d285ec0fab59adeb4b3997fca0e9554bc6781bb7b6ac9ce74e8e3f1f04e863ea15c6b61845e
+    HEAD_REF main
+    PATCHES
+        install.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DADA_IDNA_BENCHMARKS=OFF
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-ada-idna)
+
+vcpkg_install_copyright(
+    COMMENT "ada-idna is dual licensed under Apache-2.0 and MIT"
+    FILE_LIST
+       "${SOURCE_PATH}/LICENSE-APACHE"
+       "${SOURCE_PATH}/LICENSE-MIT"
+)

--- a/ports/ada-idna/portfile.cmake
+++ b/ports/ada-idna/portfile.cmake
@@ -18,6 +18,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-ada-idna)
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 vcpkg_install_copyright(
     COMMENT "ada-idna is dual licensed under Apache-2.0 and MIT"
     FILE_LIST

--- a/ports/ada-idna/vcpkg.json
+++ b/ports/ada-idna/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "ada-idna",
+  "version": "0.3.2",
+  "description": "C++ library implementing the to_ascii and to_unicode functions from the Unicode Technical Standard.",
+  "homepage": "https://github.com/ada-url/idna",
+  "license": "Apache-2.0 AND MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/ada-idna.json
+++ b/versions/a-/ada-idna.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c12db14f8a4050207284639a780ab1fd6ceddc80",
+      "git-tree": "08833326cf37f9782d88c2918e55ea31570647a1",
       "version": "0.3.2",
       "port-version": 0
     }

--- a/versions/a-/ada-idna.json
+++ b/versions/a-/ada-idna.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c12db14f8a4050207284639a780ab1fd6ceddc80",
+      "version": "0.3.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -36,6 +36,10 @@
       "baseline": "3.9.5",
       "port-version": 17
     },
+    "ada-idna": {
+      "baseline": "0.3.2",
+      "port-version": 0
+    },
     "ada-url": {
       "baseline": "3.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

