### PR TITLE
[plutovg] update to 1.0.0

### DIFF
--- a/ports/lunasvg/fix-plutovg.patch
+++ b/ports/lunasvg/fix-plutovg.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 08cee28..b72d704 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,7 +6,7 @@ set(LUNASVG_VERSION_MICRO 1)
+ 
+ project(lunasvg LANGUAGES CXX VERSION ${LUNASVG_VERSION_MAJOR}.${LUNASVG_VERSION_MINOR}.${LUNASVG_VERSION_MICRO})
+ 
+-find_package(plutovg 0.0.4 QUIET)
++find_package(plutovg 1.0.0 QUIET)
+ if(NOT plutovg_FOUND)
+     add_subdirectory(plutovg)
+ endif()

--- a/ports/lunasvg/portfile.cmake
+++ b/ports/lunasvg/portfile.cmake
@@ -4,6 +4,9 @@ vcpkg_from_github(
   REF "v${VERSION}"
   SHA512 6ea8ef74a18047e2714aacc6c162c42519246c38061290053461e7c5c0922234534a031bdb84eaff7bea46da4d8edd1e3cdd00d710c066600c9024fa2a134a03
   HEAD_REF master
+  PATCHES
+    # temporary patch. It should be removed once the new version of lunasvg is released.
+    fix-plutovg.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/lunasvg/vcpkg.json
+++ b/ports/lunasvg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "lunasvg",
   "version": "3.2.1",
+  "port-version": 1,
   "description": "lunasvg is a standalone SVG rendering library in C++",
   "homepage": "https://github.com/sammycage/lunasvg",
   "license": "MIT",

--- a/ports/plutosvg/fix-plutovg.patch
+++ b/ports/plutosvg/fix-plutovg.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ba7ccfa..538ec66 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,7 +6,7 @@ set(PLUTOSVG_VERSION_MICRO 6)
+ 
+ project(plutosvg LANGUAGES C VERSION ${PLUTOSVG_VERSION_MAJOR}.${PLUTOSVG_VERSION_MINOR}.${PLUTOSVG_VERSION_MICRO})
+ 
+-find_package(plutovg 0.0.4 QUIET)
++find_package(plutovg 1.0.0 QUIET)
+ if(NOT plutovg_FOUND)
+     add_subdirectory(plutovg)
+ endif()

--- a/ports/plutosvg/portfile.cmake
+++ b/ports/plutosvg/portfile.cmake
@@ -4,6 +4,9 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 f0f2251cfb91f48b125299ec910d64181f03c14e683e1d497e2aa3f17713f5c7848247e3b7bdb6cf0dee8d98a7d25e85f7fcc440cbe55401c16fe5d1f0df1a10
     HEAD_REF master
+    PATCHES
+        # temporary patch. It should be removed once the new version of plutosvg is released.
+        fix-plutovg.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/plutosvg/vcpkg.json
+++ b/ports/plutosvg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "plutosvg",
   "version": "0.0.6",
+  "port-version": 1,
   "description": "Tiny SVG rendering library in C",
   "homepage": "https://github.com/sammycage/plutosvg",
   "license": "MIT",

--- a/ports/plutovg/portfile.cmake
+++ b/ports/plutovg/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sammycage/plutovg
     REF "v${VERSION}"
-    SHA512 1abf7da813d00987dcf724c50e924659d76d49d13c9e37219ec151f3a7357501ae6b9c220613104623d9021db14eaa6c7cf81a79ecafd589eeaeab50a63f7031
-    HEAD_REF master
+    SHA512 4f472542686f9ee949e6cba621f338128aaaee25e2dfde848713333eedc6de4f896bb55aac4b8296bdada73ae3327da1fd06055ef93acc920ed55bf123731f74
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/plutovg/vcpkg.json
+++ b/ports/plutovg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "plutovg",
-  "version": "0.0.13",
-  "description": " Tiny 2D vector graphics library in C",
+  "version": "1.0.0",
+  "description": "Tiny 2D vector graphics library in C",
   "homepage": "https://github.com/sammycage/plutovg",
   "license": "MIT",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7205,7 +7205,7 @@
       "port-version": 0
     },
     "plutovg": {
-      "baseline": "0.0.13",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "pmdk": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5766,7 +5766,7 @@
     },
     "lunasvg": {
       "baseline": "3.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "luv": {
       "baseline": "1.44.2",
@@ -7202,7 +7202,7 @@
     },
     "plutosvg": {
       "baseline": "0.0.6",
-      "port-version": 0
+      "port-version": 1
     },
     "plutovg": {
       "baseline": "1.0.0",

--- a/versions/l-/lunasvg.json
+++ b/versions/l-/lunasvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e1e6ef5c64dc868a851d9d110d4daac385c97a8f",
+      "version": "3.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d1c821b610c0753096112912447ad4c993518b38",
       "version": "3.2.1",
       "port-version": 0

--- a/versions/p-/plutosvg.json
+++ b/versions/p-/plutosvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4dba94a01987e44d6ab5df6391088129b0f7cfd3",
+      "version": "0.0.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "55b280cc3b5a68ff88bc171e5048e695f31a4497",
       "version": "0.0.6",
       "port-version": 0

--- a/versions/p-/plutovg.json
+++ b/versions/p-/plutovg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3cd906777f0a1ec613f828469ce1f91a536c80ca",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1c5ca4f07afad9e4e0786c226e4135b4e20907b9",
       "version": "0.0.13",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
