### PR TITLE
[beman-exemplar] new port

### DIFF
--- a/ports/beman-exemplar/portfile.cmake
+++ b/ports/beman-exemplar/portfile.cmake
@@ -1,5 +1,10 @@
 # vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+# See:
+# https://github.com/bemanproject/exemplar/issues/161
+# https://github.com/bemanproject/exemplar/issues/163
+set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bemanproject/exemplar

--- a/ports/beman-exemplar/portfile.cmake
+++ b/ports/beman-exemplar/portfile.cmake
@@ -1,0 +1,29 @@
+# vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bemanproject/exemplar
+    REF "${VERSION}"
+    SHA512 492dea71e64f3ee08e502c8eda33697d30f9eb9c04f32b2e1f4ffad28a605448e47dd6242356033ce06fcc972d0816348d44cfb2bd0dead12dffffe3d9ab8e16
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "beman-exemplar"
+    CONFIG_PATH "lib/cmake/beman.exemplar"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Move LICENSE file to the correct location
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+# Copy usage file
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/beman-exemplar/portfile.cmake
+++ b/ports/beman-exemplar/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DCMAKE_CXX_STANDARD=17
         -DBEMAN_EXEMPLAR_BUILD_TESTS=OFF
         -DBEMAN_EXEMPLAR_BUILD_EXAMPLES=OFF
 )

--- a/ports/beman-exemplar/portfile.cmake
+++ b/ports/beman-exemplar/portfile.cmake
@@ -10,6 +10,9 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBEMAN_EXEMPLAR_BUILD_TESTS=OFF
+        -DBEMAN_EXEMPLAR_BUILD_EXAMPLES=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/beman-exemplar/portfile.cmake
+++ b/ports/beman-exemplar/portfile.cmake
@@ -15,15 +15,13 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME "beman-exemplar"
+    PACKAGE_NAME "beman.exemplar"
     CONFIG_PATH "lib/cmake/beman.exemplar"
 )
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Move LICENSE file to the correct location
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-# Copy usage file
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/beman-exemplar/usage
+++ b/ports/beman-exemplar/usage
@@ -1,0 +1,4 @@
+beman.exemplar provides CMake targets:
+
+find_package(beman::exemplar CONFIG REQUIRED)
+target_link_libraries(main PRIVATE beman::exemplar)

--- a/ports/beman-exemplar/usage
+++ b/ports/beman-exemplar/usage
@@ -1,4 +1,4 @@
 beman.exemplar provides CMake targets:
 
-find_package(beman::exemplar CONFIG REQUIRED)
-target_link_libraries(main PRIVATE beman::exemplar)
+  find_package(beman.exemplar CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE beman::exemplar)

--- a/ports/beman-exemplar/vcpkg.json
+++ b/ports/beman-exemplar/vcpkg.json
@@ -1,0 +1,18 @@
+{
+    "name": "beman-exemplar",
+    "version": "2.0.0",
+    "homepage": "https://github.com/bemanproject/exemplar",
+    "description": "A Beman Library Exemplar",
+    "license": "Apache-2.0",
+    "dependencies": [
+      {
+        "name": "vcpkg-cmake",
+        "host": true
+      },
+      {
+        "name": "vcpkg-cmake-config",
+        "host": true
+      },
+      "gtest"
+    ]
+  }

--- a/ports/beman-exemplar/vcpkg.json
+++ b/ports/beman-exemplar/vcpkg.json
@@ -5,7 +5,6 @@
   "homepage": "https://github.com/bemanproject/exemplar",
   "license": "Apache-2.0",
   "dependencies": [
-    "gtest",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/beman-exemplar/vcpkg.json
+++ b/ports/beman-exemplar/vcpkg.json
@@ -1,18 +1,18 @@
 {
-    "name": "beman-exemplar",
-    "version": "2.0.0",
-    "homepage": "https://github.com/bemanproject/exemplar",
-    "description": "A Beman Library Exemplar",
-    "license": "Apache-2.0",
-    "dependencies": [
-      {
-        "name": "vcpkg-cmake",
-        "host": true
-      },
-      {
-        "name": "vcpkg-cmake-config",
-        "host": true
-      },
-      "gtest"
-    ]
-  }
+  "name": "beman-exemplar",
+  "version": "2.0.0",
+  "description": "A Beman Library Exemplar",
+  "homepage": "https://github.com/bemanproject/exemplar",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "gtest",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/b-/beman-exemplar.json
+++ b/versions/b-/beman-exemplar.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5b217b690704b1e25d5c8005316945870b56adf9",
+      "version": "2.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -600,6 +600,10 @@
       "baseline": "4.6.2",
       "port-version": 0
     },
+    "beman-exemplar": {
+      "baseline": "2.0.0",
+      "port-version": 0
+    },
     "benchmark": {
       "baseline": "1.9.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

CC @bretbrownjr