### PR TITLE
[cpp-httplib] update to 0.20.0

### DIFF
--- a/ports/cpp-httplib/fix-find-brotli.patch
+++ b/ports/cpp-httplib/fix-find-brotli.patch
@@ -23,8 +23,8 @@ index 0353b0c..5c0cd33 100644
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::encoder>
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::decoder>
 +		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::brotlicommon>
-+		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::brotliencoder>
-+		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::brotlidecoder>
++		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::brotlienc>
++		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::brotlidec>
  		$<$<BOOL:${HTTPLIB_IS_USING_ZLIB}>:ZLIB::ZLIB>
  		$<$<BOOL:${HTTPLIB_IS_USING_ZSTD}>:zstd::libzstd>
  		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::SSL>

--- a/ports/cpp-httplib/fix-find-brotli.patch
+++ b/ports/cpp-httplib/fix-find-brotli.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0353b0c..2dce6dd 100644
+index 0353b0c..5c0cd33 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -151,10 +151,10 @@ endif()
@@ -22,9 +22,9 @@ index 0353b0c..2dce6dd 100644
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::common>
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::encoder>
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::decoder>
-+		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::common>
-+		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::encoder>
-+		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::decoder>
++		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::brotlicommon>
++		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::brotliencoder>
++		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::brotlidecoder>
  		$<$<BOOL:${HTTPLIB_IS_USING_ZLIB}>:ZLIB::ZLIB>
  		$<$<BOOL:${HTTPLIB_IS_USING_ZSTD}>:zstd::libzstd>
  		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::SSL>
@@ -39,15 +39,17 @@ index 0353b0c..2dce6dd 100644
  	)
  
 diff --git a/cmake/httplibConfig.cmake.in b/cmake/httplibConfig.cmake.in
-index bf57364..00044f4 100644
+index bf57364..1c6fe62 100644
 --- a/cmake/httplibConfig.cmake.in
 +++ b/cmake/httplibConfig.cmake.in
-@@ -34,7 +34,7 @@ if(@HTTPLIB_IS_USING_BROTLI@)
+@@ -34,8 +34,8 @@ if(@HTTPLIB_IS_USING_BROTLI@)
  	# Note that the FindBrotli.cmake file is installed in the same dir as this file.
  	list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
  	set(BROTLI_USE_STATIC_LIBS @BROTLI_USE_STATIC_LIBS@)
 -	find_dependency(Brotli COMPONENTS common encoder decoder)
+-	set(httplib_Brotli_FOUND ${Brotli_FOUND})
 +	find_dependency(unofficial-brotli COMPONENTS common encoder decoder)
- 	set(httplib_Brotli_FOUND ${Brotli_FOUND})
++	set(httplib_Brotli_FOUND ${unofficial-brotli_FOUND})
  endif()
  
+ if(@HTTPLIB_IS_USING_ZSTD@)

--- a/ports/cpp-httplib/fix-find-brotli.patch
+++ b/ports/cpp-httplib/fix-find-brotli.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e27481b..51bfdf1 100644
+index 0353b0c..2dce6dd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -146,10 +146,10 @@ endif()
+@@ -151,10 +151,10 @@ endif()
  # This is so we can use our custom FindBrotli.cmake
  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
  if(HTTPLIB_REQUIRE_BROTLI)
@@ -15,20 +15,20 @@ index e27481b..51bfdf1 100644
  	set(HTTPLIB_IS_USING_BROTLI ${Brotli_FOUND})
  endif()
  
-@@ -223,9 +223,9 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
+@@ -236,9 +236,9 @@ target_link_libraries(${PROJECT_NAME} ${_INTERFACE_OR_PUBLIC}
  		# Needed for API from MacOS Security framework
  		"$<$<AND:$<PLATFORM_ID:Darwin>,$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>,$<BOOL:${HTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN}>>:-framework CoreFoundation -framework Security>"
  		# Can't put multiple targets in a single generator expression or it bugs out.
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::common>
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::encoder>
 -		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:Brotli::decoder>
-+		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::brotlicommon>
-+		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::brotlienc>
-+		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::brotlidec>
++		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::common>
++		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::encoder>
++		$<$<BOOL:${HTTPLIB_IS_USING_BROTLI}>:unofficial::brotli::decoder>
  		$<$<BOOL:${HTTPLIB_IS_USING_ZLIB}>:ZLIB::ZLIB>
+ 		$<$<BOOL:${HTTPLIB_IS_USING_ZSTD}>:zstd::libzstd>
  		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::SSL>
- 		$<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::Crypto>
-@@ -281,9 +281,6 @@ if(HTTPLIB_INSTALL)
+@@ -296,9 +296,6 @@ if(HTTPLIB_INSTALL)
  	install(FILES
  		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
  		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
@@ -39,15 +39,15 @@ index e27481b..51bfdf1 100644
  	)
  
 diff --git a/cmake/httplibConfig.cmake.in b/cmake/httplibConfig.cmake.in
-index 93dff32..8c6bc11 100644
+index bf57364..00044f4 100644
 --- a/cmake/httplibConfig.cmake.in
 +++ b/cmake/httplibConfig.cmake.in
-@@ -32,7 +32,7 @@ if(@HTTPLIB_IS_USING_BROTLI@)
+@@ -34,7 +34,7 @@ if(@HTTPLIB_IS_USING_BROTLI@)
  	# Note that the FindBrotli.cmake file is installed in the same dir as this file.
  	list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
  	set(BROTLI_USE_STATIC_LIBS @BROTLI_USE_STATIC_LIBS@)
 -	find_dependency(Brotli COMPONENTS common encoder decoder)
 +	find_dependency(unofficial-brotli COMPONENTS common encoder decoder)
+ 	set(httplib_Brotli_FOUND ${Brotli_FOUND})
  endif()
  
- # Mildly useful for end-users

--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yhirose/cpp-httplib
     REF "v${VERSION}"
-    SHA512 f30c0e9fa180b1ff22f9f297bbc755a4602ecb5f71a3b84ab47bb9d158c0aaf4aba6bc64e4aa31f2770c0b665a1b70c4691c9a9ff2cb5451198f38aa57eca61b
+    SHA512 a20d306bfc7b3749f67c3f213f410cf61e1d3896cb7b02582299af7a396731594d514680d8af54a48e1462223a30354446c7970dc38f68fb2f647c9d2e018581
     HEAD_REF master
     PATCHES
         fix-find-brotli.patch

--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-httplib",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1905,7 +1905,7 @@
       "port-version": 0
     },
     "cpp-httplib": {
-      "baseline": "0.19.0",
+      "baseline": "0.20.0",
       "port-version": 0
     },
     "cpp-ipc": {

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "26e5e028422b3fbcea8b3e40ba1379cfba19de15",
+      "git-tree": "ebecc0df2ab5dabc62a42cf17058e5995d2cfbb6",
       "version": "0.20.0",
       "port-version": 0
     },

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26e5e028422b3fbcea8b3e40ba1379cfba19de15",
+      "version": "0.20.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "edd8506c011b1758fb568ff0d63c472681326393",
       "version": "0.19.0",
       "port-version": 0

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ebecc0df2ab5dabc62a42cf17058e5995d2cfbb6",
+      "git-tree": "2cb1201ff0d73510fdaf89d9102f7f818fc74f78",
       "version": "0.20.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

