### PR TITLE
[libtheora] Update cmake_minimum_required

### DIFF
--- a/ports/libtheora/CMakeLists.txt
+++ b/ports/libtheora/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.30)
 project(theora LANGUAGES C)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}")

--- a/ports/libtheora/vcpkg.json
+++ b/ports/libtheora/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtheora",
   "version-string": "1.2.0alpha1-20170719",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Theora is a free and open video compression format from the Xiph.org Foundation.",
   "homepage": "https://github.com/xiph/theora",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5282,7 +5282,7 @@
     },
     "libtheora": {
       "baseline": "1.2.0alpha1-20170719",
-      "port-version": 7
+      "port-version": 8
     },
     "libtins": {
       "baseline": "4.5",

--- a/versions/l-/libtheora.json
+++ b/versions/l-/libtheora.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "875c4b56b5fbda529ab8a2efb67209b35408134a",
+      "version-string": "1.2.0alpha1-20170719",
+      "port-version": 8
+    },
+    {
       "git-tree": "f6cc1235f841d9f9a7b7d1a278dc63b788c63659",
       "version-string": "1.2.0alpha1-20170719",
       "port-version": 7


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/44442#issuecomment-2735017195

Update `cmake_minimum_required` to 3.30 to fix.

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

### Test

The port installation tests pass with the following triplets:

* x64-linux (CMake 4.0.0-rc2)