### PR TITLE
[qtinterfaceframework] Bump jinja2 from 3.1.5 to 3.1.6

### DIFF
--- a/ports/qtinterfaceframework/requirements_minimal.txt
+++ b/ports/qtinterfaceframework/requirements_minimal.txt
@@ -3,7 +3,7 @@ argh==0.26.2
 click==6.7
 coloredlogs==10.0
 humanfriendly==4.15.1
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==2.1.5
 path.py==11.0.1
 PyYAML==6.0.1

--- a/ports/qtinterfaceframework/vcpkg.json
+++ b/ports/qtinterfaceframework/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtinterfaceframework",
   "version": "6.8.2",
+  "port-version": 1,
   "description": "The Qt Interface Framework module provides both the tools and the core APIs, for you to implement Middleware APIs, Middleware Back ends, and Middleware Services.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7738,7 +7738,7 @@
     },
     "qtinterfaceframework": {
       "baseline": "6.8.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtkeychain": {
       "baseline": "0.14.3",

--- a/versions/q-/qtinterfaceframework.json
+++ b/versions/q-/qtinterfaceframework.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "159bd50accf559e68a91b6bc925ddb6a182afb9f",
+      "version": "6.8.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "a596d24c714e517c2f6ba62229de8498dbc67751",
       "version": "6.8.2",
       "port-version": 0


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/security/dependabot/10

Close https://github.com/microsoft/vcpkg/pull/44476