### PR TITLE
[entt] update to 3.15.0

### DIFF
--- a/ports/entt/portfile.cmake
+++ b/ports/entt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO skypjack/entt
     REF "v${VERSION}"
-    SHA512 153cd353aa211a93c8f2f8650d55a0fd2ea9abb836386ef827285b6ab96ad680e92cac65c4b23db50c7882078d599200ac6a9eb3326a2a33160e62fc624202c7
+    SHA512 ab9ea213fdfedb7b51554b4adfdb07ec363482728f4e758ec002ea3cdbb2ff45bbfbd06f46db17a50d8ce14c6537ff7683efdb3102212f0c4ab674d18a5517a3
     HEAD_REF master
 )
 
@@ -12,6 +12,8 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DENTT_BUILD_TESTING=OFF
+        -DENTT_BUILD_DOCS=OFF
+        -DENTT_INSTALL=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/entt/vcpkg.json
+++ b/ports/entt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "entt",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "Gaming meets modern C++ - a fast and reliable entity-component system and much more",
   "homepage": "https://github.com/skypjack/entt",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2605,7 +2605,7 @@
       "port-version": 6
     },
     "entt": {
-      "baseline": "3.14.0",
+      "baseline": "3.15.0",
       "port-version": 0
     },
     "ereignis": {

--- a/versions/e-/entt.json
+++ b/versions/e-/entt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b27478e44a27785f939170cfb8c910d87194b289",
+      "version": "3.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2c9a2cb27bd1e5688b91c4ca0b4aedcc6f92e88f",
       "version": "3.14.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
