### PR TITLE
[sdl1] fix linking warning LNK4099

### DIFF
--- a/ports/sdl1/SDL.vcxproj.in
+++ b/ports/sdl1/SDL.vcxproj.in
@@ -140,7 +140,7 @@
       <PrecompiledHeaderOutputFile>.\Debug/SDL.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <ResourceCompile>
@@ -177,7 +177,7 @@
       <PrecompiledHeaderOutputFile>.\Debug/SDL.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <ResourceCompile>
@@ -214,7 +214,7 @@
       <PrecompiledHeaderOutputFile>.\Debug/SDL.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <ResourceCompile>

--- a/ports/sdl1/vcpkg.json
+++ b/ports/sdl1/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl1",
   "version": "1.2.15",
-  "port-version": 20,
+  "port-version": 21,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8350,7 +8350,7 @@
     },
     "sdl1": {
       "baseline": "1.2.15",
-      "port-version": 20
+      "port-version": 21
     },
     "sdl1-mixer": {
       "baseline": "2023-03-25",

--- a/versions/s-/sdl1.json
+++ b/versions/s-/sdl1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a56a739ee46255d64f35c8c07fd40165bbfdc5f",
+      "version": "1.2.15",
+      "port-version": 21
+    },
+    {
       "git-tree": "43661d95f373c57cac7a2d85c00dbc7e077edf67",
       "version": "1.2.15",
       "port-version": 20


### PR DESCRIPTION
Previously linking with SDL.lib produced multiple LNK4099 warnings.

I noticed that SDLmain.lib from the same package used /Z7 debug information format. This commit changes SDL.lib to use /Z7 too.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
