### PR TITLE
[freeglut] Fix build with CMake4.0

### DIFF
--- a/ports/freeglut/cmake-version.patch
+++ b/ports/freeglut/cmake-version.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9a5fb2b..a9ddfea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-CMAKE_MINIMUM_REQUIRED(VERSION 3.1 FATAL_ERROR)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.1...3.5 FATAL_ERROR)
+ PROJECT(freeglut LANGUAGES C)
+ 
+ if (POLICY CMP0072)

--- a/ports/freeglut/portfile.cmake
+++ b/ports/freeglut/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         x11-dependencies-export.patch
         fix-debug-macro.patch
         windows-output-name.patch
+        cmake-version.patch
 )
 
 if(VCPKG_TARGET_IS_OSX)

--- a/ports/freeglut/vcpkg.json
+++ b/ports/freeglut/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "freeglut",
   "version": "3.6.0",
+  "port-version": 1,
   "description": "A free OpenGL utility toolkit, the open-sourced alternative to the GLUT library.",
   "homepage": "https://sourceforge.net/projects/freeglut/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2926,7 +2926,7 @@
     },
     "freeglut": {
       "baseline": "3.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "freeimage": {
       "baseline": "3.18.0",

--- a/versions/f-/freeglut.json
+++ b/versions/f-/freeglut.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b2ff4479793417da25f0324620f2ce3373de98b",
+      "version": "3.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "501dfdaa34842155768b87802ae16c0d99baa820",
       "version": "3.6.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/44195.
Error:
```
CMake Error at CMakeLists.txt:1 (CMAKE_MINIMUM_REQUIRED):
Compatibility with CMake < 3.5 has been removed from CMake.

Update the VERSION argument value. Or, use the ... syntax
to tell CMake that the project requires at least but has been updated
to work with policies introduced by or earlier.

Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
