### PR TITLE
[duckdb] add excel feature

### DIFF
--- a/ports/duckdb/excel-libname.patch
+++ b/ports/duckdb/excel-libname.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 29d069e..eb8d178 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,3 +1,4 @@
++
+ cmake_minimum_required(VERSION 2.8.12...3.29)
+ set(TARGET_NAME excel)
+ set(EXTENSION_NAME ${TARGET_NAME}_extension)
+@@ -6,7 +7,7 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
+ project(ExcelExtension)
+ 
+ # Dependencies from VCPKG
+-find_package(EXPAT REQUIRED)
++find_package(expat REQUIRED)
+ find_package(ZLIB REQUIRED)
+ find_package(minizip-ng CONFIG REQUIRED)
+ 
+@@ -23,9 +24,9 @@ set(PARAMETERS "-warnings")
+ build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES}
+                          ${NUMFORMAT_OBJECT_FILES})
+ 
+-target_link_libraries(${EXTENSION_NAME} EXPAT::EXPAT MINIZIP::minizip-ng
++target_link_libraries(${EXTENSION_NAME} expat::expat MINIZIP::minizip-ng
+                       ZLIB::ZLIB)
+-target_link_libraries(${LOADABLE_EXTENSION_NAME} EXPAT::EXPAT
++target_link_libraries(${LOADABLE_EXTENSION_NAME} expat::expat
+                       MINIZIP::minizip-ng ZLIB::ZLIB)
+ 
+ install(

--- a/ports/duckdb/extensions.patch
+++ b/ports/duckdb/extensions.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4496860..fdda539 100644
+index 4496860..e1f58c3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1257,7 +1257,14 @@ endforeach()
+@@ -1257,7 +1257,19 @@ endforeach()
  # Load extensions passed through cmake config var
  foreach(EXT IN LISTS BUILD_EXTENSIONS)
    if(NOT "${EXT}" STREQUAL "")
@@ -11,6 +11,11 @@ index 4496860..fdda539 100644
 +      duckdb_extension_load(${EXT} 
 +        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/httpfs
 +        INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/httpfs/extension/httpfs/include
++      )
++    elseif("${EXT}" STREQUAL "excel")
++      duckdb_extension_load(${EXT} 
++        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/excel
++        INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/excel/src/excel/include
 +      )
 +    else()
 +      duckdb_extension_load(${EXT})

--- a/ports/duckdb/extensions.patch
+++ b/ports/duckdb/extensions.patch
@@ -23,3 +23,22 @@ index 4496860..e1f58c3 100644
    endif()
  endforeach()
  
+diff --git a/DuckDBConfig.cmake.in b/DuckDBConfig.cmake.in
+index 7c5ce31..efb9ec3 100644
+--- a/DuckDBConfig.cmake.in
++++ b/DuckDBConfig.cmake.in
+@@ -10,6 +10,14 @@ if(NOT @WITH_INTERNAL_ICU@)
+     find_dependency(ICU COMPONENTS i18n uc)
+ endif()
+ 
++set(EXTENSION_LIST "@BUILD_EXTENSIONS@")
++list(FIND EXTENSION_LIST "excel" EXCEL_INDEX)
++
++if(EXCEL_INDEX GREATER_EQUAL 0)
++  find_dependency(expat CONFIG)
++  find_dependency(minizip-ng CONFIG)
++endif()
++
+ # Compute paths
+ get_filename_component(DuckDB_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ set(DuckDB_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     PATCHES
         bigobj.patch
         unvendor_icu_and_find_dependency.patch # https://github.com/duckdb/duckdb/pull/16176 + https://github.com/duckdb/duckdb/pull/16197
-        httpfs.patch
+        extensions.patch
         t-external-icu.patch # from https://github.com/duckdb/duckdb/pull/16676
         )
 
@@ -19,20 +19,32 @@ file(REMOVE_RECURSE
     "${SOURCE_PATH}/third_party/tpce-tool"
 )
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH DUCKDB_HTTPFS_SOURCE_PATH
-    REPO duckdb/duckdb_httpfs
-    REF 85ac4667bcb0d868199e156f8dd918b0278db7b9
-    SHA512 5790ed795d394dd1b512aac0d1f1dc5976588d93b34381cab1d78c256428f3047682c7b662b1c855d3b19a9dbf99a6c64f32152dba347c18f2a36e19bcc3c5df
-    HEAD_REF main
-)
+if("excel" IN_LIST FEATURES)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH DUCKDB_EXCCEL_SOURCE_PATH
+        REPO duckdb/duckdb-excel
+        REF f14e7c3beaf379c54b47b996aa896a1d814e1be8
+        SHA512 d2e97cfd59fc08d86f6e4a6fe35dc7dd6435ef1750b334d4b422555987d55eef67a9eb1b1859cacc46addd7a6f848de4e5e092d694fc4ccd7cf24fcf8298012e
+        HEAD_REF main
+    )
+    file(RENAME "${DUCKDB_EXCCEL_SOURCE_PATH}" "${SOURCE_PATH}/extension/excel")
+endif()
 
-file(RENAME "${DUCKDB_HTTPFS_SOURCE_PATH}" "${SOURCE_PATH}/extension/httpfs")
+if("httpfs" IN_LIST FEATURES)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH DUCKDB_HTTPFS_SOURCE_PATH
+        REPO duckdb/duckdb_httpfs
+        REF 85ac4667bcb0d868199e156f8dd918b0278db7b9
+        SHA512 5790ed795d394dd1b512aac0d1f1dc5976588d93b34381cab1d78c256428f3047682c7b662b1c855d3b19a9dbf99a6c64f32152dba347c18f2a36e19bcc3c5df
+        HEAD_REF main
+    )
+    file(RENAME "${DUCKDB_HTTPFS_SOURCE_PATH}" "${SOURCE_PATH}/extension/httpfs")
+endif()
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" DUCKDB_BUILD_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DUCKDB_BUILD_DYNAMIC)
 
-set(EXTENSION_LIST "autocomplete;httpfs;icu;json;tpcds;tpch")
+set(EXTENSION_LIST "autocomplete;excel;httpfs;icu;json;tpcds;tpch")
 set(BUILD_EXTENSIONS "")
 foreach(EXT ${EXTENSION_LIST})
     if(${EXT} IN_LIST FEATURES)

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
         unvendor_icu_and_find_dependency.patch # https://github.com/duckdb/duckdb/pull/16176 + https://github.com/duckdb/duckdb/pull/16197
         extensions.patch
         t-external-icu.patch # from https://github.com/duckdb/duckdb/pull/16676
-        )
+)
 
 # Remove vendored dependencies which are not properly namespaced
 file(REMOVE_RECURSE
@@ -26,6 +26,8 @@ if("excel" IN_LIST FEATURES)
         REF f14e7c3beaf379c54b47b996aa896a1d814e1be8
         SHA512 d2e97cfd59fc08d86f6e4a6fe35dc7dd6435ef1750b334d4b422555987d55eef67a9eb1b1859cacc46addd7a6f848de4e5e092d694fc4ccd7cf24fcf8298012e
         HEAD_REF main
+        PATCHES
+            excel-libname.patch
     )
     file(RENAME "${DUCKDB_EXCCEL_SOURCE_PATH}" "${SOURCE_PATH}/extension/excel")
 endif()

--- a/ports/duckdb/t-external-icu.patch
+++ b/ports/duckdb/t-external-icu.patch
@@ -10,7 +10,7 @@ index 2e5270e..7c5ce31 100644
 +    find_dependency(ICU COMPONENTS i18n uc data)
  endif()
  
- # Compute paths
+ set(EXTENSION_LIST "@BUILD_EXTENSIONS@")
 diff --git a/extension/icu/CMakeLists.txt b/extension/icu/CMakeLists.txt
 index b5585e4..e3ae9cf 100644
 --- a/extension/icu/CMakeLists.txt

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "duckdb",
   "version": "1.2.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "High-performance in-process analytical database system",
   "homepage": "https://duckdb.org",
   "license": "MIT",
@@ -19,6 +19,9 @@
   "features": {
     "autocomplete": {
       "description": "Statically link the autocomplete extension into DuckDB"
+    },
+    "excel": {
+      "description": "Statically link the excel extension into DuckDB"
     },
     "httpfs": {
       "description": "Statically link the httpfs extension into DuckDB",

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -21,7 +21,11 @@
       "description": "Statically link the autocomplete extension into DuckDB"
     },
     "excel": {
-      "description": "Statically link the excel extension into DuckDB"
+      "description": "Statically link the excel extension into DuckDB",
+      "dependencies": [
+        "expat",
+        "minizip-ng"
+      ]
     },
     "httpfs": {
       "description": "Statically link the httpfs extension into DuckDB",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2438,7 +2438,7 @@
     },
     "duckdb": {
       "baseline": "1.2.1",
-      "port-version": 1
+      "port-version": 2
     },
     "duckx": {
       "baseline": "1.2.2",

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce323a2e879243c2e6895fc08b3e42d283d734aa",
+      "git-tree": "a73d82bd1b2428f2811dee2ff2f2a618889f6b60",
       "version": "1.2.1",
       "port-version": 2
     },

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce323a2e879243c2e6895fc08b3e42d283d734aa",
+      "version": "1.2.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "95e99c85866fb18cb5494092ea09a224200e7a9e",
       "version": "1.2.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

