### PR TITLE
[mongo-c-driver] [libbson] update to 1.30.2

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 4b3e8b109563b481d2cf1390f85ea902dcd60c8586bedb0b13b87e22e4ef7b927d46f60d1c49c08d96b8635106804df3fab4b178d2da98abbc5432193ac12e6f
+    SHA512 6dc763eccc844a52ce5982072cf6c2a31dbc2a3d899d86178fc0299dfb436fffe0b13e6c2d9f4d2cf090cedae179a1b2143225c598ec841479704a6be2340744
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.30.2",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
-  "license": null,
+  "license": "Apache-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.30.2",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
-  "license": "Apache-2.0",
+  "license": null,
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 4b3e8b109563b481d2cf1390f85ea902dcd60c8586bedb0b13b87e22e4ef7b927d46f60d1c49c08d96b8635106804df3fab4b178d2da98abbc5432193ac12e6f
+    SHA512 6dc763eccc844a52ce5982072cf6c2a31dbc2a3d899d86178fc0299dfb436fffe0b13e6c2d9f4d2cf090cedae179a1b2143225c598ec841479704a6be2340744
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
-  "license": null,
+  "license": "Apache-2.0",
   "supports": "!uwp",
   "dependencies": [
     "libbson",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4401,7 +4401,7 @@
       "port-version": 4
     },
     "libbson": {
-      "baseline": "1.30.1",
+      "baseline": "1.30.2",
       "port-version": 0
     },
     "libcaer": {
@@ -6125,7 +6125,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.30.1",
+      "baseline": "1.30.2",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c32dfb1db72f3037d20f6e09dcdf17a317a932e",
+      "version": "1.30.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "81b9e9670b2c55da5b1b455ef5e2da9eaed3aaf0",
       "version": "1.30.1",
       "port-version": 0

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f9aefd410dba8e8ba48396d0820fc4ef4ea03e3f",
+      "git-tree": "3c32dfb1db72f3037d20f6e09dcdf17a317a932e",
       "version": "1.30.2",
       "port-version": 0
     },

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3c32dfb1db72f3037d20f6e09dcdf17a317a932e",
+      "git-tree": "f9aefd410dba8e8ba48396d0820fc4ef4ea03e3f",
       "version": "1.30.2",
       "port-version": 0
     },

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "931c4f6b3a2dd5de7f08a4d75360c73c47a8590d",
+      "version": "1.30.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "83618522b95a73228624d60d2ae019480a6f3372",
       "version": "1.30.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
