### PR TITLE
[DPP] Bump to version 10.1.2

### DIFF
--- a/ports/dpp/include.patch
+++ b/ports/dpp/include.patch
@@ -3,10 +3,10 @@ index f08acef0..61c98daa 100644
 --- a/src/dpp/socketengines/poll.cpp
 +++ b/src/dpp/socketengines/poll.cpp
 @@ -19,6 +19,7 @@
-*
-************************************************************************************/
+  *
+  ************************************************************************************/
 
 +#include <dpp/cluster.h>
-#include <dpp/socketengine.h>
-#include <dpp/exception.h>
-#include <vector>
+ #include <dpp/socketengine.h>
+ #include <dpp/exception.h>
+ #include <vector>

--- a/ports/dpp/include.patch
+++ b/ports/dpp/include.patch
@@ -1,13 +1,12 @@
-diff --git a/src/dpp/socketengine.cpp b/src/dpp/socketengine.cpp
-index 81c5fc92..025c534c 100644
---- a/src/dpp/socketengine.cpp
-+++ b/src/dpp/socketengine.cpp
-@@ -23,7 +23,7 @@
- #include <dpp/exception.h>
- #include <csignal>
- #include <memory>
--#include <sslclient.h>
-+#include <dpp/sslclient.h>
- #include <iostream>
- #include <dpp/cache.h>
- #include <dpp/cluster.h>
+diff --git a/src/dpp/socketengines/poll.cpp b/src/dpp/socketengines/poll.cpp
+index f08acef0..61c98daa 100644
+--- a/src/dpp/socketengines/poll.cpp
++++ b/src/dpp/socketengines/poll.cpp
+@@ -19,6 +19,7 @@
+*
+************************************************************************************/
+
++#include <dpp/cluster.h>
+#include <dpp/socketengine.h>
+#include <dpp/exception.h>
+#include <vector>

--- a/ports/dpp/portfile.cmake
+++ b/ports/dpp/portfile.cmake
@@ -8,12 +8,6 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
-    OPTIONS
-        -DCMAKE_CXX_STANDARD=20
-        -DCMAKE_CXX_STANDARD_REQUIRED=ON
-        -DDPP_BUILD_TEST=OFF
-        -DDPP_FORMATTERS=ON
-        -DDPP_NO_CORO=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/dpp/portfile.cmake
+++ b/ports/dpp/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_cmake_configure(
         -DCMAKE_CXX_STANDARD_REQUIRED=ON
         -DDPP_BUILD_TEST=OFF
         -DDPP_FORMATTERS=ON
-        -DDPP_NO_CORO=OFF    
+        -DDPP_NO_CORO=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/dpp/portfile.cmake
+++ b/ports/dpp/portfile.cmake
@@ -3,6 +3,8 @@ vcpkg_from_github(
     REPO brainboxdotcc/DPP
     REF "v${VERSION}"
     SHA512 3ebbe762cc8aaa606a5eaef06b9c2de7986decfe380f7348d5393a550af2d01ba7c6505271dad60e0fe0acb1904268eac5cf4981fe2f5042e06293aaa45ab523
+    PATCHES
+        "include.patch"
 )
 
 vcpkg_cmake_configure(

--- a/ports/dpp/portfile.cmake
+++ b/ports/dpp/portfile.cmake
@@ -8,6 +8,12 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DCMAKE_CXX_STANDARD=20
+        -DCMAKE_CXX_STANDARD_REQUIRED=ON
+        -DDPP_BUILD_TEST=OFF
+        -DDPP_FORMATTERS=ON
+        -DDPP_NO_CORO=OFF    
 )
 
 vcpkg_cmake_install()

--- a/ports/dpp/portfile.cmake
+++ b/ports/dpp/portfile.cmake
@@ -2,20 +2,12 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO brainboxdotcc/DPP
     REF "v${VERSION}"
-    SHA512 91c28f5ec96e3cb8312a01dffe03c0a4280d0499a310c594954ff1967d25f919805dfd069df2a77ad7e12d187438eba33763e433f8ed524ae48e73f976a5a2c7
-    PATCHES
-        "include.patch"
+    SHA512 3ebbe762cc8aaa606a5eaef06b9c2de7986decfe380f7348d5393a550af2d01ba7c6505271dad60e0fe0acb1904268eac5cf4981fe2f5042e06293aaa45ab523
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
-    OPTIONS
-        -DCMAKE_CXX_STANDARD=20
-        -DCMAKE_CXX_STANDARD_REQUIRED=ON
-        -DDPP_BUILD_TEST=OFF
-        -DDPP_FORMATTERS=ON
-        -DDPP_NO_CORO=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/dpp/vcpkg.json
+++ b/ports/dpp/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "dpp",
-  "version": "10.1.0",
-  "port-version": 1,
+  "version": "10.1.2",
   "description": "D++ Extremely Lightweight C++ Discord Library.",
   "homepage": "https://dpp.dev/",
   "license": "Apache-2.0",
-  "supports": "(windows & !uwp) | linux | osx",
+  "supports": "(windows & !static & !uwp) | linux | osx",
   "dependencies": [
     "nlohmann-json",
     "openssl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2409,8 +2409,8 @@
       "port-version": 0
     },
     "dpp": {
-      "baseline": "10.1.0",
-      "port-version": 1
+      "baseline": "10.1.2",
+      "port-version": 0
     },
     "draco": {
       "baseline": "1.5.7",

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a9391d3c2ec712899532847b6485a357cacd018c",
+      "git-tree": "b663e391a2941f4f8b3299da668d1dab03d00cbf",
       "version": "10.1.2",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "774c0c73ecff73448855becc9e920a9a4a957249",
+      "git-tree": "a9391d3c2ec712899532847b6485a357cacd018c",
       "version": "10.1.2",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b663e391a2941f4f8b3299da668d1dab03d00cbf",
+      "git-tree": "c45bee285c0342daed9b8dd3d2050010396f4677",
       "version": "10.1.2",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a9391d3c2ec712899532847b6485a357cacd018c",
+      "git-tree": "774c0c73ecff73448855becc9e920a9a4a957249",
       "version": "10.1.2",
       "port-version": 0
     },

--- a/versions/d-/dpp.json
+++ b/versions/d-/dpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9391d3c2ec712899532847b6485a357cacd018c",
+      "version": "10.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "90d85a80bd937f74482ee548ddb0e3bf890d7c38",
       "version": "10.1.0",
       "port-version": 1


### PR DESCRIPTION
**This PR updates DPP package to 10.1.2**

Our vcpkg update is built from our CI actions.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `Triplets are unchanged, baseline not updated.`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  `Yes`


