### PR TITLE
[vcpkg baseline][workflow] Remove workflow:x64-uwp from fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1094,7 +1094,6 @@ wordnet:x64-android=fail
 workflow:arm-neon-android=fail
 workflow:arm64-android=fail
 workflow:x64-android=fail
-workflow:x64-uwp=fail
 wpilib:arm-neon-android=fail # requires full c++20 support
 wpilib:arm64-android=fail # requires full c++20 support
 wpilib:x64-android=fail # requires full c++20 support


### PR DESCRIPTION
Port workflow passed on https://dev.azure.com/vcpkg/public/_build/results?buildId=113596&view=logs&j=afe306fb-88a0-5d5e-2934-71aa01507316&t=e596b5c6-3571-5ae5-2def-425822b5308e&l=35125

```log
PASSING, REMOVE FROM FAIL LIST: workflow:x64-uwp (D:\a\_work\1\s\scripts\azure-pipelines/../ci.baseline.txt).
```