### PR TITLE
[libtcod] update to 2.0.0

### DIFF
--- a/ports/libtcod/portfile.cmake
+++ b/ports/libtcod/portfile.cmake
@@ -1,15 +1,15 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libtcod/libtcod
-    REF 1.24.0
-    SHA512 21aae343297ea4aefb89f3bc8fd06c7059e4f59dc34c26ef294f4211873f29bf26b5c600746db8af7eda9e9f5ab270bfd862ab34ae3c409051dcad6bb219df8a
+    REF ${VERSION}
+    SHA512 252e939fc632d648dc0048a61d5488b9e301d6829f2576b28c9eeee35c501a9271ff3c5c4127397aeafc029139f7d9286e8ac8291c6247f6336ee83adf6600d4
     HEAD_REF main
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     INVERTED_FEATURES
         "png" CMAKE_DISABLE_FIND_PACKAGE_lodepng-c
-        "sdl" CMAKE_DISABLE_FIND_PACKAGE_SDL2
+        "sdl" CMAKE_DISABLE_FIND_PACKAGE_SDL3
         "threads" CMAKE_DISABLE_FIND_PACKAGE_Threads
         "unicode" CMAKE_DISABLE_FIND_PACKAGE_utf8proc
         "unicode" CMAKE_DISABLE_FIND_PACKAGE_unofficial-utf8proc
@@ -21,7 +21,7 @@ vcpkg_cmake_configure(
     OPTIONS
         ${FEATURE_OPTIONS}
         -DCMAKE_INSTALL_INCLUDEDIR=${CURRENT_PACKAGES_DIR}/include
-        -DLIBTCOD_SDL2=find_package
+        -DLIBTCOD_SDL3=find_package
         -DLIBTCOD_ZLIB=find_package
         -DLIBTCOD_LODEPNG=find_package
         -DLIBTCOD_UTF8PROC=vcpkg

--- a/ports/libtcod/vcpkg.json
+++ b/ports/libtcod/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtcod",
-  "version": "1.24.0",
+  "version-semver": "2.0.0",
   "maintainers": "Kyle Benesch <4b796c65+github@gmail.com>",
   "description": "Common algorithms and tools for roguelikes.",
   "homepage": "https://github.com/libtcod/libtcod",
@@ -31,9 +31,9 @@
       ]
     },
     "sdl": {
-      "description": "Support for SDL2 windows and events with the libtcod context.",
+      "description": "Support for SDL windows and events with the libtcod context.",
       "dependencies": [
-        "sdl2"
+        "sdl3"
       ]
     },
     "threads": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5277,7 +5277,7 @@
       "port-version": 1
     },
     "libtcod": {
-      "baseline": "1.24.0",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "libtess2": {

--- a/versions/l-/libtcod.json
+++ b/versions/l-/libtcod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85c28d28469962d3d266a29568ed79e1456cc845",
+      "version-semver": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae0678aa4f8c3675932de4d2e8986f4a5ca7d30e",
       "version": "1.24.0",
       "port-version": 0


### PR DESCRIPTION
Libtcod now depends on SDL3 instead of SDL2

Versions since 2.0 are API compatible (symver)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
