### PR TITLE
Marzbanpp

### DIFF
--- a/ports/marzbanpp/portfile.cmake
+++ b/ports/marzbanpp/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO andrascii/marzbanpp
+    REF "1.0.1"
+    SHA512 8db3ca283d119efadf9f9ba5d573263c92402a2dda82683499918a5889ddff502a0bcff0658a26b927f2d3a373e42dbcf59cf7aad2fab6313210eb39fff78b00
+    HEAD_REF marzbanpp
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "marzbanpp")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/marzbanpp/usage
+++ b/ports/marzbanpp/usage
@@ -1,0 +1,5 @@
+marzbanpp provides CMake targets:
+
+    find_package(marzbanpp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE marzbanpp::marzbanpp)
+

--- a/ports/marzbanpp/vcpkg.json
+++ b/ports/marzbanpp/vcpkg.json
@@ -1,24 +1,24 @@
 {
   "name": "marzbanpp",
   "version": "1.0.1",
-  "homepage": "https://github.com/andrascii/marzbanpp",
   "description": "marzbanpp is the C++ library for interaction with Marzban through its REST API.",
+  "homepage": "https://github.com/andrascii/marzbanpp",
   "license": "MIT",
   "dependencies": [
-    {
-      "name" : "vcpkg-cmake",
-      "host" : true
-    },
-    {
-      "name" : "vcpkg-cmake-config",
-      "host" : true
-    },
+    "curl",
+    "cxxopts",
+    "date",
     "fmt",
+    "glaze",
     "gtest",
     "spdlog",
-    "date",
-    "cxxopts",
-    "glaze",
-    "curl"
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/marzbanpp/vcpkg.json
+++ b/ports/marzbanpp/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "marzbanpp",
+  "version": "1.0.1",
+  "homepage": "https://github.com/andrascii/marzbanpp",
+  "description": "marzbanpp is the C++ library for interaction with Marzban through its REST API.",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name" : "vcpkg-cmake",
+      "host" : true
+    },
+    {
+      "name" : "vcpkg-cmake-config",
+      "host" : true
+    },
+    "fmt",
+    "gtest",
+    "spdlog",
+    "date",
+    "cxxopts",
+    "glaze",
+    "curl"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5900,6 +5900,10 @@
       "baseline": "2023-06-28",
       "port-version": 0
     },
+    "marzbanpp": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "matchit": {
       "baseline": "1.0.1",
       "port-version": 0

--- a/versions/m-/marzbanpp.json
+++ b/versions/m-/marzbanpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "53180a9265ef139be99be2a1a37f49f923c0cda8",
+      "version": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [+] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [-] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [+] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [+] The versioning scheme in `vcpkg.json` matches what upstream says.
- [+] The license declaration in `vcpkg.json` matches what upstream says.
- [+] The installed as the "copyright" file matches what upstream says.
- [+] The source code of the component installed comes from an authoritative source.
- [+] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [+] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [+] Only one version is in the new port's versions file.
- [+] Only one version is added to each modified port's versions file.
