### PR TITLE
[libarchive] update to 3.7.8

### DIFF
--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libarchive/libarchive
     REF "v${VERSION}"
-    SHA512 95c6232d178b26daa0eeba43d64ea4235aa96fa279c85fff715ac5e6cc73b2e65f276770f91c3538cb8ca989380555169497628d73e120bfa52e12f657049ff0
+    SHA512 5ce1fb0b0108a1f5a1547fbecc261e0438b449eee7253eec0b66452462c052b09c8e6cccd0ed9e7fd0c55e5862b334519b17da4f72b1e0196e73bc90ad97c983
     HEAD_REF master
     PATCHES
         disable-warnings.patch

--- a/ports/libarchive/vcpkg.json
+++ b/ports/libarchive/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libarchive",
-  "version": "3.7.7",
-  "port-version": 2,
+  "version": "3.7.8",
   "description": "Library for reading and writing streaming archives",
   "homepage": "https://www.libarchive.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4361,8 +4361,8 @@
       "port-version": 5
     },
     "libarchive": {
-      "baseline": "3.7.7",
-      "port-version": 2
+      "baseline": "3.7.8",
+      "port-version": 0
     },
     "libaribcaption": {
       "baseline": "1.1.1",

--- a/versions/l-/libarchive.json
+++ b/versions/l-/libarchive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d5d16f1e8eb9f6ba74f92e564f62fa641eab589e",
+      "version": "3.7.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "273f56c8b692d2fb25364dd5b117f22449578ffe",
       "version": "3.7.7",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/libarchive/libarchive/releases/tag/v3.7.8