### PR TITLE
[openh264] fix cmake get vars dependency

### DIFF
--- a/ports/openh264/vcpkg.json
+++ b/ports/openh264/vcpkg.json
@@ -10,6 +10,10 @@
       "host": true
     },
     {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
+    {
       "name": "vcpkg-tool-meson",
       "host": true
     }

--- a/ports/openh264/vcpkg.json
+++ b/ports/openh264/vcpkg.json
@@ -7,10 +7,6 @@
   "license": "BSD-2-Clause",
   "dependencies": [
     {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
       "name": "vcpkg-cmake-get-vars",
       "host": true
     },

--- a/ports/openh264/vcpkg.json
+++ b/ports/openh264/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openh264",
   "version": "2.6.0",
+  "port-version": 1,
   "description": "OpenH264 is a codec library which supports H.264 encoding and decoding. It is suitable for use in real time applications such as WebRTC.",
   "homepage": "https://www.openh264.org/",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6806,7 +6806,7 @@
     },
     "openh264": {
       "baseline": "2.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openigtlink": {
       "baseline": "3.0",

--- a/versions/o-/openh264.json
+++ b/versions/o-/openh264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e9401f0aa9371bbdd2d2c0bbfe25f085249481d3",
+      "version": "2.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "23e2f38c48eac134b4d1184e67d1c1f7cf542b51",
       "version": "2.6.0",
       "port-version": 0

--- a/versions/o-/openh264.json
+++ b/versions/o-/openh264.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e9401f0aa9371bbdd2d2c0bbfe25f085249481d3",
+      "git-tree": "f8a88fd9771af1e587d87d4ffe602916cfb75899",
       "version": "2.6.0",
       "port-version": 1
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
~- [ ] SHA512s are updated for each updated download.~
~- [ ] The "supports" clause reflects platforms that may be fixed by this new version.~
~- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
~- [ ] Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
