### PR TITLE
[qtbase] add feature "shared-mime-info" 

### DIFF
--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -29,6 +29,10 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     list(APPEND ${PORT}_PATCHES env.patch)
 endif()
 
+if("shared-mime-info" IN_LIST FEATURES)
+    list(APPEND ${PORT}_PATCHES use-shared-mime-info.patch)
+endif()
+
 list(APPEND ${PORT}_PATCHES 
         dont_force_cmakecache_latest.patch
     )

--- a/ports/qtbase/use-shared-mime-info.patch
+++ b/ports/qtbase/use-shared-mime-info.patch
@@ -1,0 +1,31 @@
+ src/corelib/mimetypes/mimetypes_resources.cmake | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/corelib/mimetypes/mimetypes_resources.cmake b/src/corelib/mimetypes/mimetypes_resources.cmake
+index 1bec50e4..d4d54763 100644
+--- a/src/corelib/mimetypes/mimetypes_resources.cmake
++++ b/src/corelib/mimetypes/mimetypes_resources.cmake
+@@ -7,17 +7,17 @@
+ # file with the same information
+ 
+ set(corelib_mimetypes_resource_file
+-    "${CMAKE_CURRENT_LIST_DIR}/3rdparty/tika-mimetypes.xml"
++    "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/mime/packages/freedesktop.org.xml"
+ )
+ 
+ function(corelib_add_mimetypes_resources target)
+     set(source_file "${corelib_mimetypes_resource_file}")
+     set_source_files_properties("${source_file}"
+-        PROPERTIES QT_RESOURCE_ALIAS "tika-mimetypes.xml"
++        PROPERTIES QT_RESOURCE_ALIAS "freedesktop.org.xml"
+     )
+     qt_internal_add_resource(${target} "mimetypes"
+         PREFIX
+-            "/qt-project.org/qmime/tika/packages"
++            "/qt-project.org/qmime/packages"
+         FILES
+             "${source_file}"
+     )
+-- 
+2.34.1
+

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.8.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -402,6 +402,12 @@
     "securetransport": {
       "description": "Enable Secure Transport",
       "supports": "ios | osx"
+    },
+    "shared-mime-info": {
+      "description": "Use GPL licensed shared-mime-info port from freedesktop.org",
+      "dependencies": [
+        "shared-mime-info"
+      ]
     },
     "sql": {
       "description": "Qt Sql",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7698,7 +7698,7 @@
     },
     "qtbase": {
       "baseline": "6.8.2",
-      "port-version": 1
+      "port-version": 2
     },
     "qtcharts": {
       "baseline": "6.8.2",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a146d4ea52111f036f5c746695fc74df54ce4b5f",
+      "version": "6.8.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "744273bb84e2107bb024f6d32e5c03890b4c4f2d",
       "version": "6.8.2",
       "port-version": 1


### PR DESCRIPTION
.. to use GPL licensed shared-mime-info port from freedesktop.org

Qt has recently changed to the Apache silenced tika-mimetypes
Up to Qt 6.7.2 the MIME type reference from freedesktop.org have been used on Windows and a fallback on macOS. Linux still uses the sytem provided freedesktop.org version. Since this introduces inconsistent behavior across different platforms. The new feature introduced here allows to build with the "shared-mime-info" which will be introduced here: 
https://github.com/microsoft/vcpkg/pull/44341

This PR follows the suggestion from the Qt commit message: 
https://github.com/qt/qtbase/commit/ed2f80b75db66fc7e3c3b0ce8e3125a146c29402

> GPL-compatible projects which provide self-contained binaries can use this to provide a copy of freedesktop.org.xml that will be used instead of the TIKA mimetypes.

It is a fix for these upstream bugs: 
https://bugreports.qt.io/browse/QTBUG-131109
https://bugreports.qt.io/browse/QTBUG-133916

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.