### PR TITLE
[rapidcsv] update to 8.85

### DIFF
--- a/ports/rapidcsv/portfile.cmake
+++ b/ports/rapidcsv/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO d99kris/rapidcsv
     REF "v${VERSION}"
-    SHA512 8fb03ad7e3b53f01c568deb7705a7185a66cfc1eb0245b0165d580a8f60a8972197cd5eac3cda115d9bbb3c06c89de25a84acad62d13d6ffb366d3f1155a1b9c
+    SHA512 4545f6a92bc891ca64a0d3a2e988b60245fcc0e75a8489bf3ba9dbdd3451ce1e11d2355de9a5f9a26d7345dcb3c0a0c910b32c1d9713a3b1208f44a5e784db5f
     HEAD_REF master
 )
 

--- a/ports/rapidcsv/vcpkg.json
+++ b/ports/rapidcsv/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rapidcsv",
-  "version": "8.84",
+  "version": "8.85",
   "description": "Rapidcsv is a C++ header-only library for CSV parsing.",
   "homepage": "https://github.com/d99kris/rapidcsv/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7941,7 +7941,7 @@
       "port-version": 0
     },
     "rapidcsv": {
-      "baseline": "8.84",
+      "baseline": "8.85",
       "port-version": 0
     },
     "rapidfuzz": {

--- a/versions/r-/rapidcsv.json
+++ b/versions/r-/rapidcsv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0060200b211f8c9fb0024984ad5f161e4bbaf820",
+      "version": "8.85",
+      "port-version": 0
+    },
+    {
       "git-tree": "62b6074da263ca7864da9eb1e26d0ed4b9e00412",
       "version": "8.84",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/d99kris/rapidcsv/releases/tag/v8.85