### PR TITLE
[minhook] fix build error on CMake 4.0

### DIFF
--- a/ports/minhook/fix-cmake-version.patch
+++ b/ports/minhook/fix-cmake-version.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index df947af..7be7630 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,7 +24,7 @@
+ #  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.0...3.5)
+ 
+ project(minhook LANGUAGES C)
+ 

--- a/ports/minhook/portfile.cmake
+++ b/ports/minhook/portfile.cmake
@@ -19,12 +19,13 @@ vcpkg_download_distfile(
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO TsudaKageyu/minhook
-    REF v1.3.3
+    REF "v${VERSION}"
     SHA512 9f10c92a926a06cde1e4092b664a3aab00477e8b9f20cee54e1d2b3747fad91043d199a2753f7e083497816bbefc5d75d9162d2098dd044420dbca555e80b060
     HEAD_REF master
     PATCHES
         "${CMAKE_SUPPORT_PATCH}"
         fix-usage.patch
+        fix-cmake-version.patch
 )
 
 vcpkg_cmake_configure(
@@ -37,4 +38,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/minhook)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/minhook/vcpkg.json
+++ b/ports/minhook/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "minhook",
   "version": "1.3.3",
-  "port-version": 4,
+  "port-version": 5,
   "description": "The Minimalistic x86/x64 API Hooking Library for Windows.",
   "homepage": "https://github.com/TsudaKageyu/minhook",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6046,7 +6046,7 @@
     },
     "minhook": {
       "baseline": "1.3.3",
-      "port-version": 4
+      "port-version": 5
     },
     "miniaudio": {
       "baseline": "0.11.22",

--- a/versions/m-/minhook.json
+++ b/versions/m-/minhook.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad027a206e91d0fbb6c7bcadfdf1cc17e2b79e26",
+      "version": "1.3.3",
+      "port-version": 5
+    },
+    {
       "git-tree": "c9751daba9242a47e7beb2e21a4211226aee316f",
       "version": "1.3.3",
       "port-version": 4


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/44516.
Build error on CMake 4.0:
```
CMake Error at CMakeLists.txt:27 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```
No feature needs to test.
Usage tested pass on `x64-windows`.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.