### PR TITLE
[cpp-httplib] Support Zstandard(zstd) feature in v0.20.0

### DIFF
--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         brotli  HTTPLIB_REQUIRE_BROTLI
         openssl HTTPLIB_REQUIRE_OPENSSL
         zlib    HTTPLIB_REQUIRE_ZLIB
+        zstd    HTTPLIB_REQUIRE_ZSTD
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port
@@ -24,6 +25,7 @@ vcpkg_cmake_configure(
     -DHTTPLIB_USE_OPENSSL_IF_AVAILABLE=OFF
     -DHTTPLIB_USE_ZLIB_IF_AVAILABLE=OFF
     -DHTTPLIB_USE_BROTLI_IF_AVAILABLE=OFF
+    -DHTTPLIB_USE_ZSTD_IF_AVAILABLE=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cpp-httplib",
   "version": "0.20.0",
+  "port-version": 1,
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",
@@ -34,6 +35,12 @@
       "description": "Enables gzip compression support using zlib",
       "dependencies": [
         "zlib"
+      ]
+    },
+    "zstd": {
+      "description": "Enables zstd support",
+      "dependencies": [
+        "zstd"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1906,7 +1906,7 @@
     },
     "cpp-httplib": {
       "baseline": "0.20.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cpp-ipc": {
       "baseline": "1.3.0",

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "504cadb74ace89d1afed1c10afceebf046baae28",
+      "version": "0.20.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2cb1201ff0d73510fdaf89d9102f7f818fc74f78",
       "version": "0.20.0",
       "port-version": 0


### PR DESCRIPTION
### Changes

* https://github.com/yhirose/cpp-httplib/releases/tag/v0.20.0 includes `zstd` support
   * https://github.com/yhirose/cpp-httplib/pull/2088
   * https://github.com/microsoft/vcpkg/pull/44474

Because of the default option `HTTPLIB_USE_ZSTD_IF_AVAILABLE`,  
the CMake target `httplib::httplib` will cause link dependency error when `zstd` port is already installed.

```log
CMake Error at /home/runner/work/.../x64-linux/share/httplib/httplibTargets.cmake:60 (set_target_properties):
  The link interface of target "httplib::httplib" contains:

    zstd::libzstd

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

```


### Related Works

I encountered this error on my vcpkg-registry.

* https://github.com/luncliff/vcpkg-registry/pull/338


### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
