### PR TITLE
[lapack-reference] Fix building lapack with cblas on mingw

### DIFF
--- a/ports/lapack-reference/FindLAPACK.cmake
+++ b/ports/lapack-reference/FindLAPACK.cmake
@@ -466,13 +466,26 @@ if(BLAS_FOUND)
         "${BLAS_LIBRARIES}"
       )
     endif()
-    if(NOT LAPACK_LIBRARIES AND NOT WIN32)
+    if(NOT LAPACK_LIBRARIES)
       check_lapack_libraries(
         LAPACK_LIBRARIES
         LAPACK
         cheev
         ""
         "lapack;m;gfortran"
+        ""
+        ""
+        ""
+        "${BLAS_LIBRARIES}"
+      )
+    endif()
+	if(NOT LAPACK_LIBRARIES)
+      check_lapack_libraries(
+        LAPACK_LIBRARIES
+        LAPACK
+        cheev
+        ""
+        "lapack;m;gfortran;quadmath"
         ""
         ""
         ""

--- a/ports/lapack-reference/FindLAPACK.cmake
+++ b/ports/lapack-reference/FindLAPACK.cmake
@@ -479,7 +479,7 @@ if(BLAS_FOUND)
         "${BLAS_LIBRARIES}"
       )
     endif()
-	if(NOT LAPACK_LIBRARIES)
+    if(NOT LAPACK_LIBRARIES)
       check_lapack_libraries(
         LAPACK_LIBRARIES
         LAPACK

--- a/ports/lapack-reference/vcpkg.json
+++ b/ports/lapack-reference/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lapack-reference",
   "version": "3.11.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "LAPACK - Linear Algebra PACKage",
   "homepage": "https://netlib.org/lapack/",
   "license": "BSD-3-Clause-Open-MPI",

--- a/ports/lapack-reference/vcpkg.json
+++ b/ports/lapack-reference/vcpkg.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "vcpkg-gfortran",
-      "platform": "windows"
+      "platform": "windows & !mingw"
     }
   ],
   "default-features": [
@@ -32,7 +32,7 @@
           "features": [
             "noblas"
           ],
-          "platform": "!windows | !static"
+          "platform": "!windows | !static | mingw"
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4242,7 +4242,7 @@
     },
     "lapack-reference": {
       "baseline": "3.11.0",
-      "port-version": 6
+      "port-version": 7
     },
     "lastools": {
       "baseline": "2.0.3",

--- a/versions/l-/lapack-reference.json
+++ b/versions/l-/lapack-reference.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1931df5bc0ba3ba25311d7e9ea2849253c896a74",
+      "version": "3.11.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "c6447c2a6f70504bfbf20f2e649bcc17a6ce67de",
       "version": "3.11.0",
       "port-version": 6

--- a/versions/l-/lapack-reference.json
+++ b/versions/l-/lapack-reference.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "df7b913ccc2b5e9e0f519a9042a1cd011bbc72c2",
+      "git-tree": "03ec23ff643f6ac2f398923e46c0f68043ebf055",
       "version": "3.11.0",
       "port-version": 7
     },

--- a/versions/l-/lapack-reference.json
+++ b/versions/l-/lapack-reference.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1931df5bc0ba3ba25311d7e9ea2849253c896a74",
+      "git-tree": "df7b913ccc2b5e9e0f519a9042a1cd011bbc72c2",
       "version": "3.11.0",
       "port-version": 7
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.