### PR TITLE
[folly, fizz, wangle, proxygen, mvfst, fbthrift, cachelib] update to 03.24

### DIFF
--- a/ports/cachelib/portfile.cmake
+++ b/ports/cachelib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/CacheLib
     REF "v${VERSION}"
-    SHA512 9540feac162cd0104a1e324eb2b4635ba5257691a9653164d65bf4a46b87dffe4b12e3ce6bbe4930d24efbf1ebea965c8565fae01ce5de6c3734e4557b383228
+    SHA512 04e6d5823f46e248a6e52cb45bda36cdc838bc27febc1d5cdb65611289c27504b39c6095e7a4cb5c0a527d4db9713f1047345b9e24c08d4a1bbfb5851eeb5002
     HEAD_REF main
     PATCHES
         fix-build.patch

--- a/ports/cachelib/vcpkg.json
+++ b/ports/cachelib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cachelib",
-  "version-string": "2025.03.17.00",
+  "version-string": "2025.03.24.00",
   "description": "Pluggable caching engine to build and scale high performance cache services.",
   "homepage": "https://github.com/facebook/CacheLib",
   "license": "Apache-2.0",

--- a/ports/fbthrift/fix-bigobj.patch
+++ b/ports/fbthrift/fix-bigobj.patch
@@ -1,0 +1,15 @@
+diff --git a/thrift/compiler/generate/CMakeLists.txt b/thrift/compiler/generate/CMakeLists.txt
+index 180751b267..dfdf098267 100644
+--- a/thrift/compiler/generate/CMakeLists.txt
++++ b/thrift/compiler/generate/CMakeLists.txt
+@@ -45,6 +45,10 @@ add_library(compiler_generators STATIC ${GENERATOR_FILES}
+             ${CMAKE_CURRENT_BINARY_DIR}/templates.cc)
+ set_target_properties(compiler_generators PROPERTIES
+                       POSITION_INDEPENDENT_CODE "${BUILD_SHARED_LIBS}")
++if(MSVC)
++  set_target_properties(compiler_generators PROPERTIES
++                        COMPILE_FLAGS "/bigobj")
++endif()
+ target_link_libraries(
+   compiler_generators
+   compiler_ast

--- a/ports/fbthrift/portfile.cmake
+++ b/ports/fbthrift/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-deps.patch
         fix-test.patch
+        fix-bigobj.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/thrift/cmake/FindGMock.cmake")

--- a/ports/fbthrift/portfile.cmake
+++ b/ports/fbthrift/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/fbthrift
     REF "v${VERSION}"
-    SHA512 0d98e6aefbf6e2d5aa7358c7dbba66df2e3065eb7b6b2a0d49fa908ebd6ac30900ca486945bd624d0f9690b0eab65616559479412a3e4ec5e9aaf95c931b88a0
+    SHA512 a5344a1ee15d6a7fdcf1c6d558138d27ce5eaf51bcfefadb372d4f2cbc05828d63b00742dc936cf6b246486f180e5d1f1cd81a0fc76ff20448332d0a48195218
     HEAD_REF main
     PATCHES
         fix-deps.patch

--- a/ports/fbthrift/vcpkg.json
+++ b/ports/fbthrift/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fbthrift",
-  "version-string": "2025.03.10.00",
+  "version-string": "2025.03.24.00",
   "description": "Facebook's branch of Apache Thrift, including a new C++ server.",
   "homepage": "https://github.com/facebook/fbthrift",
   "license": "Apache-2.0",

--- a/ports/fizz/portfile.cmake
+++ b/ports/fizz/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebookincubator/fizz
     REF "v${VERSION}"
-    SHA512 effbe7c6ed1866683a73ce6ff480d6ff61f5621cef3c08ded464aa516b5d6a21e4c70c9ff95a8fe482fbfd46092b4d1b6a83d4580b1359a2aa33d41eab715fa9
+    SHA512 24b77048b06a0fc7bb82f48dbc06e847a35299ec1dda891c94f388cd638ccd11612870e518e059eb660363f6b517dae138469c4b36ca9a03e7d38087fd907818
     HEAD_REF main
     PATCHES
         fix-build.patch

--- a/ports/fizz/vcpkg.json
+++ b/ports/fizz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fizz",
-  "version-string": "2025.03.17.00",
+  "version-string": "2025.03.24.00",
   "description": "a TLS 1.3 implementation by Facebook",
   "homepage": "https://github.com/facebookincubator/fizz",
   "license": "BSD-3-Clause",

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/folly
     REF "v${VERSION}"
-    SHA512 947484e1ed0c166a861b40b25d6a29a893b305f1092bc1d1af224368c0b6384784913afceaeb0f52f37d6c10fb5bdf6c37688479264969d7cf516a53e2cc794f
+    SHA512 f63240c41b7c74b3db305a132bcd0a1ea02eeecaeb88d9b27b380526006f66fab93edb9bc5202214e6fc625509d55e93bb29b8a33a876f759b4781919b14e7c7
     HEAD_REF main
     PATCHES
         fix-windows-minmax.patch

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "folly",
-  "version-string": "2025.03.17.00",
-  "port-version": 1,
+  "version-string": "2025.03.24.00",
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "license": "Apache-2.0",

--- a/ports/mvfst/portfile.cmake
+++ b/ports/mvfst/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/mvfst
     REF "v${VERSION}"
-    SHA512 441bd1a9fa32ffd080f8e9d7c97367fd946ef79e95ed9b8dcd4db6d8ee0e66c395f5a3449e0def3b8afc9468aff36f1d9f74b21a50d819c4d694fa29d9f161ea
+    SHA512 b75f61dbbf27ee2b6b6833a4173388de72a9f1b2e6e844bc0ca7ef6b7fd07ae8a2bc4719dc9cbf0bfde6ddd9d289d8241b5f7bdc456dd1925f0a68359b45835a
     HEAD_REF main
 )
 

--- a/ports/mvfst/vcpkg.json
+++ b/ports/mvfst/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mvfst",
-  "version-string": "2025.03.17.00",
+  "version-string": "2025.03.24.00",
   "description": "mvfst (Pronounced move fast) is a client and server implementation of IETF QUIC protocol in C++ by Facebook.",
   "homepage": "https://github.com/facebook/mvfst",
   "license": "MIT",

--- a/ports/proxygen/portfile.cmake
+++ b/ports/proxygen/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/proxygen
     REF "v${VERSION}"
-    SHA512 3ca8ab0a710079dd49657c02a396c6209f8b9b03f6408b7c9890efa95a1a0a81cb3394d734f854dcd57743b0aa2f8550415cdb33c5a4541cb5de6b2f95368250
+    SHA512 01b81dbba8d0715b5f249c7899fb0bac476c7afe9de3c577d22a80054199abf5ce7e5465bd73e862a4ed34fa93eea9d0144475add07c11a23937da708208c07f
     HEAD_REF main
     PATCHES
         remove-register.patch

--- a/ports/proxygen/vcpkg.json
+++ b/ports/proxygen/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "proxygen",
-  "version-string": "2025.03.17.00",
+  "version-string": "2025.03.24.00",
   "description": "It comprises the core C++ HTTP abstractions used at Facebook.",
   "homepage": "https://github.com/facebook/proxygen",
   "license": "BSD-3-Clause",

--- a/ports/wangle/portfile.cmake
+++ b/ports/wangle/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/wangle
     REF "v${VERSION}"
-    SHA512 3e1f66af021e02c3292e2b0ad9cc5b35062862e7952a8a8d97acd15e89e7e65e291baab39ac1c2a3e767d90f94eb4dec74d401062dfcfc5a8d603f86ac7320a2
+    SHA512 8707e84ae49682ccdc8e8d038ae62c68cbb065f910d58839809326c3b0127b5df1d3e805ceac8240a6cae235ee8c0b1e1948a3da60e6403d58a0198369f296c0
     HEAD_REF main
     PATCHES
         fix-config-cmake.patch

--- a/ports/wangle/vcpkg.json
+++ b/ports/wangle/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wangle",
-  "version-string": "2025.03.17.00",
+  "version-string": "2025.03.24.00",
   "description": "Wangle is a framework providing a set of common client/server abstractions for building services in a consistent, modular, and composable way.",
   "homepage": "https://github.com/facebook/wangle",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1489,7 +1489,7 @@
       "port-version": 0
     },
     "cachelib": {
-      "baseline": "2025.03.17.00",
+      "baseline": "2025.03.24.00",
       "port-version": 0
     },
     "caf": {
@@ -2753,7 +2753,7 @@
       "port-version": 1
     },
     "fbthrift": {
-      "baseline": "2025.03.10.00",
+      "baseline": "2025.03.24.00",
       "port-version": 0
     },
     "fcl": {
@@ -2805,7 +2805,7 @@
       "port-version": 0
     },
     "fizz": {
-      "baseline": "2025.03.17.00",
+      "baseline": "2025.03.24.00",
       "port-version": 0
     },
     "flagpp": {
@@ -2893,8 +2893,8 @@
       "port-version": 1
     },
     "folly": {
-      "baseline": "2025.03.17.00",
-      "port-version": 1
+      "baseline": "2025.03.24.00",
+      "port-version": 0
     },
     "font-chef": {
       "baseline": "1.1.0",
@@ -6313,7 +6313,7 @@
       "port-version": 7
     },
     "mvfst": {
-      "baseline": "2025.03.17.00",
+      "baseline": "2025.03.24.00",
       "port-version": 0
     },
     "mygui": {
@@ -7385,7 +7385,7 @@
       "port-version": 0
     },
     "proxygen": {
-      "baseline": "2025.03.17.00",
+      "baseline": "2025.03.24.00",
       "port-version": 0
     },
     "psimd": {
@@ -9833,7 +9833,7 @@
       "port-version": 0
     },
     "wangle": {
-      "baseline": "2025.03.17.00",
+      "baseline": "2025.03.24.00",
       "port-version": 0
     },
     "wasmedge": {

--- a/versions/c-/cachelib.json
+++ b/versions/c-/cachelib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5cbb937d535ab0ed567efdde1cb25570bf84bce8",
+      "version-string": "2025.03.24.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "eb2251db2f38706edfa1250ccbbdd8e6405eeb07",
       "version-string": "2025.03.17.00",
       "port-version": 0

--- a/versions/f-/fbthrift.json
+++ b/versions/f-/fbthrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "602ebedac1e10de4f294e32157356715e32bda13",
+      "version-string": "2025.03.24.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "02f04419fccae2a3136d5d32a0a697551ee9e001",
       "version-string": "2025.03.10.00",
       "port-version": 0

--- a/versions/f-/fbthrift.json
+++ b/versions/f-/fbthrift.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "602ebedac1e10de4f294e32157356715e32bda13",
+      "git-tree": "78140d4704d44a34fd70b422a9c2dec04ddfa5be",
       "version-string": "2025.03.24.00",
       "port-version": 0
     },

--- a/versions/f-/fizz.json
+++ b/versions/f-/fizz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e1fe8c6b35715ccad6ae70677930c2a17dec98b2",
+      "version-string": "2025.03.24.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "a15ca84af6ec93cabbb4450bcc50ae9b8a03dad3",
       "version-string": "2025.03.17.00",
       "port-version": 0

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "346d0cebb0e359797e02cbdd9e4183cf70d76356",
+      "version-string": "2025.03.24.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "6724c01126e4de2d5014252336e7e23109d4c33b",
       "version-string": "2025.03.17.00",
       "port-version": 1

--- a/versions/m-/mvfst.json
+++ b/versions/m-/mvfst.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "113925c56f3a97c74cdd5c0308f755470606bd15",
+      "version-string": "2025.03.24.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "d3c30aca4a96df939291cba0faef47243c3fc931",
       "version-string": "2025.03.17.00",
       "port-version": 0

--- a/versions/p-/proxygen.json
+++ b/versions/p-/proxygen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ccd9d1851f6ea1f3da13900d1c0346b10e319ca9",
+      "version-string": "2025.03.24.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "383fc68b483217fb26fca30a5639d0b76e26e766",
       "version-string": "2025.03.17.00",
       "port-version": 0

--- a/versions/w-/wangle.json
+++ b/versions/w-/wangle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "249d1481a62ef41643dec8a3a99b91dc9eed7bb8",
+      "version-string": "2025.03.24.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "beb38de84c1cc81c674ee506070180b3f8fefe3b",
       "version-string": "2025.03.17.00",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
