### PR TITLE
[python3] add debug tools

### DIFF
--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -212,6 +212,9 @@ if(VCPKG_TARGET_IS_WINDOWS)
 
         file(GLOB_RECURSE PYTHON_EXTENSIONS_DEBUG "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/*.pyd")
         file(COPY ${PYTHON_EXTENSIONS_DEBUG} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(COPY ${PYTHON_EXTENSIONS_DEBUG} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/tools/${PORT}/DLLs")
+        vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/debug/tools/${PORT}/DLLs")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/tools/${PORT}/DLLs/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_d.dll")
     endif()
 
     file(COPY "${SOURCE_PATH}/Include/" "${SOURCE_PATH}/PC/pyconfig.h"
@@ -219,6 +222,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
         FILES_MATCHING PATTERN *.h
     )
     file(COPY "${SOURCE_PATH}/Lib" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+    file(COPY "${SOURCE_PATH}/Lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/tools/${PORT}")
 
     # Remove any extension libraries and other unversioned binaries that could conflict with the python2 port.
     # You don't need to link against these anyway.
@@ -227,7 +231,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
         "${CURRENT_PACKAGES_DIR}/debug/lib/*.lib"
     )
     list(FILTER PYTHON_LIBS EXCLUDE REGEX [[python[0-9]*(_d)?\.lib$]])
-    file(GLOB PYTHON_INSTALLERS "${CURRENT_PACKAGES_DIR}/tools/${PORT}/wininst-*.exe")
+    file(GLOB PYTHON_INSTALLERS "${CURRENT_PACKAGES_DIR}/tools/${PORT}/wininst-*.exe" "${CURRENT_PACKAGES_DIR}/debug/tools/${PORT}/wininst-*.exe")
     file(REMOVE ${PYTHON_LIBS} ${PYTHON_INSTALLERS})
 
     # pkg-config files
@@ -240,9 +244,9 @@ if(VCPKG_TARGET_IS_WINDOWS)
 
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         make_python_pkgconfig(FILE python.pc INSTALL_ROOT "${CURRENT_PACKAGES_DIR}/debug"
-            EXEC_PREFIX "\${prefix}/../tools/${PORT}" INCLUDEDIR [[${prefix}/../include]] ABIFLAGS "_d")
+            EXEC_PREFIX "\${prefix}/../debug/tools/${PORT}" INCLUDEDIR [[${prefix}/../include]] ABIFLAGS "_d")
         make_python_pkgconfig(FILE python-embed.pc INSTALL_ROOT "${CURRENT_PACKAGES_DIR}/debug"
-            EXEC_PREFIX "\${prefix}/../tools/${PORT}" INCLUDEDIR [[${prefix}/../include]] ABIFLAGS "_d")
+            EXEC_PREFIX "\${prefix}/../debug/tools/${PORT}" INCLUDEDIR [[${prefix}/../include]] ABIFLAGS "_d")
     endif()
 
     vcpkg_fixup_pkgconfig()
@@ -304,6 +308,7 @@ else()
     vcpkg_install_make(ADD_BIN_TO_PATH INSTALL_TARGET altinstall)
 
     file(COPY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+    file(COPY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/tools/${PORT}")
 
     # Makefiles, c files, __pycache__, and other junk.
     file(GLOB PYTHON_LIB_DIRS LIST_DIRECTORIES true
@@ -401,6 +406,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
 else()
   vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/python3.${PYTHON_VERSION_MINOR}/distutils/command/build_ext.py" "'libs'" "'../../lib'")
   file(COPY_FILE "${CURRENT_PACKAGES_DIR}/tools/python3/python3.${PYTHON_VERSION_MINOR}" "${CURRENT_PACKAGES_DIR}/tools/python3/python3")
+  file(COPY_FILE "${CURRENT_PACKAGES_DIR}/debug/tools/python3/python3.${PYTHON_VERSION_MINOR}" "${CURRENT_PACKAGES_DIR}/debug/tools/python3/python3d")
 endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-port-config.cmake" @ONLY)

--- a/ports/python3/vcpkg-cmake-wrapper.cmake
+++ b/ports/python3/vcpkg-cmake-wrapper.cmake
@@ -62,12 +62,19 @@ if(_PythonFinder_WantLibs)
             PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/tools/python3"
             NO_DEFAULT_PATH
         )
+        find_program(
+            _@PythonFinder_PREFIX@_EXECUTABLE_DEBUG
+            NAMES "python_d" "python@PYTHON_VERSION_MAJOR@.@PYTHON_VERSION_MINOR@d"
+            PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/tools/python3"
+            NO_DEFAULT_PATH
+        )
     endif()
 
     # These are duplicated as normal variables to nullify FindPython's checksum verifications.
     set(_@PythonFinder_PREFIX@_INCLUDE_DIR "${_@PythonFinder_PREFIX@_INCLUDE_DIR}")
     set(_@PythonFinder_PREFIX@_LIBRARY_RELEASE "${_@PythonFinder_PREFIX@_LIBRARY_RELEASE}")
     set(_@PythonFinder_PREFIX@_LIBRARY_DEBUG "${_@PythonFinder_PREFIX@_LIBRARY_DEBUG}")
+    set(_@PythonFinder_PREFIX@_EXECUTABLE_DEBUG "${_@PythonFinder_PREFIX@_EXECUTABLE_DEBUG}")
 
     _find_package(${ARGS})
 

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "python3",
   "version": "3.11.11",
+  "port-version": 1,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7394,7 +7394,7 @@
     },
     "python3": {
       "baseline": "3.11.11",
-      "port-version": 0
+      "port-version": 1
     },
     "qca": {
       "baseline": "2.3.7",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70fa3c99bfb384f63efdaffc24f13e8ddf23adc4",
+      "version": "3.11.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "7aeb024f9b5e3927d3e37f145b85c85504bc51dd",
       "version": "3.11.11",
       "port-version": 0


### PR DESCRIPTION
Add debug tools installation.
Bind debug executable
Dependency: https://github.com/microsoft/vcpkg/pull/44288

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
