### PR TITLE
[pybind11] add patch to find python debug executable

### DIFF
--- a/ports/pybind11/fix-bind-python-debug.patch
+++ b/ports/pybind11/fix-bind-python-debug.patch
@@ -1,0 +1,39 @@
+diff --git a/tools/pybind11NewTools.cmake b/tools/pybind11NewTools.cmake
+index a8b0800b..96c69386 100644
+--- a/tools/pybind11NewTools.cmake
++++ b/tools/pybind11NewTools.cmake
+@@ -129,14 +129,21 @@ if(NOT _PYBIND11_CROSSCOMPILING)
+     unset(PYTHON_MODULE_EXTENSION CACHE)
+   endif()
+ 
+-  set(PYBIND11_PYTHON_EXECUTABLE_LAST
+-      "${${_Python}_EXECUTABLE}"
+-      CACHE INTERNAL "Python executable during the last CMake run")
++  if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND DEFINED ${_Python}_EXECUTABLE_DEBUG AND IS_EXECUTABLE ${${_Python}_EXECUTABLE_DEBUG})
++    set(PYBIND11_PYTHON_EXECUTABLE_LAST
++        "${${_Python}_EXECUTABLE_DEBUG}"
++        CACHE INTERNAL "Python executable during the last CMake run")
++  else()
++    set(PYBIND11_PYTHON_EXECUTABLE_LAST
++        "${${_Python}_EXECUTABLE}"
++        CACHE INTERNAL "Python executable during the last CMake run")
++  endif()
++
+ 
+   if(NOT DEFINED PYTHON_IS_DEBUG)
+     # Debug check - see https://stackoverflow.com/questions/646518/python-how-to-detect-debug-Interpreter
+     execute_process(
+-      COMMAND "${${_Python}_EXECUTABLE}" "-c"
++      COMMAND "${PYBIND11_PYTHON_EXECUTABLE_LAST}" "-c"
+               "import sys; sys.exit(hasattr(sys, 'gettotalrefcount'))"
+       RESULT_VARIABLE _PYTHON_IS_DEBUG)
+     set(PYTHON_IS_DEBUG
+@@ -149,7 +156,7 @@ if(NOT _PYBIND11_CROSSCOMPILING)
+   if(NOT DEFINED PYTHON_MODULE_EXTENSION OR NOT DEFINED PYTHON_MODULE_DEBUG_POSTFIX)
+     execute_process(
+       COMMAND
+-        "${${_Python}_EXECUTABLE}" "-c"
++        "${PYBIND11_PYTHON_EXECUTABLE_LAST}" "-c"
+         "import sys, importlib; s = importlib.import_module('distutils.sysconfig' if sys.version_info < (3, 10) else 'sysconfig'); print(s.get_config_var('EXT_SUFFIX') or s.get_config_var('SO'))"
+       OUTPUT_VARIABLE _PYTHON_MODULE_EXT_SUFFIX
+       ERROR_VARIABLE _PYTHON_MODULE_EXT_SUFFIX_ERR

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 497c25b33b09a9c42f67131ab82e35d689e8ce089dd7639be997305ff9a6d502447b79c824508c455d559e61f0186335b54dd2771d903a7c1621833930622d1a
     HEAD_REF master
+    PATCHES
+        fix-bind-python-debug.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pybind11",
   "version": "2.13.6",
+  "port-version": 1,
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7382,7 +7382,7 @@
     },
     "pybind11": {
       "baseline": "2.13.6",
-      "port-version": 0
+      "port-version": 1
     },
     "pystring": {
       "baseline": "1.1.4",

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d660a8d80170bb85b0b6ffa527866ce1a59eef2f",
+      "version": "2.13.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "61bb90b38540cad23b050fb28bbc5cfb83845e95",
       "version": "2.13.6",
       "port-version": 0


### PR DESCRIPTION
Add a patch to find debug python executable
Dependency: https://github.com/microsoft/vcpkg/pull/44614

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
