### PR TITLE
[libdmtx] Add new port

### DIFF
--- a/ports/libdmtx/001-cmake-add-install-target.patch
+++ b/ports/libdmtx/001-cmake-add-install-target.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6420a813c1..749bd8d680 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.5)
+ project(DMTX VERSION 0.7.5 LANGUAGES C)
+ 
+ # DMTX library
+@@ -26,3 +26,19 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+       add_subdirectory("test")
+     endif()
+ endif()
++
++# Add install rules
++if(DMTX_SHARED)
++  if(WIN32)
++    install(TARGETS dmtx
++            RUNTIME DESTINATION bin
++            ARCHIVE DESTINATION lib)
++  else()
++    install(TARGETS dmtx
++            LIBRARY DESTINATION lib)
++  endif()
++else()
++  install(TARGETS dmtx
++          ARCHIVE DESTINATION lib)
++endif()
++install(FILES "dmtx.h" "dmtxstatic.h" DESTINATION include)

--- a/ports/libdmtx/portfile.cmake
+++ b/ports/libdmtx/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/dmtx/libdmtx/archive/refs/tags/v0.7.7.tar.gz"
+    FILENAME "v0.7.7.tar.gz"
+    SHA512 802a697669afeb74da0cc3736fe7301fcc1653c1e3bebc343a8baf76e52226cc5509231519343267a92e22ebdfcc5b2825380339991340f054f0a6685d2ffcdc
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        001-cmake-add-install-target.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ..
+    OPTIONS_DEBUG
+        -DBUILD_TESTING=ON
+)
+
+set(VCPKG_POLICY_ALLOW_DEBUG_INCLUDE enabled)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libdmtx/vcpkg.json
+++ b/ports/libdmtx/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "libdmtx",
+  "version": "0.7.7",
+  "description": "Software library that enables programs to read and write Data Matrix barcodes of the modern ECC200 variety",
+  "homepage": "https://github.com/dmtx/libdmtx",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4520,6 +4520,10 @@
       "baseline": "0.24.3",
       "port-version": 0
     },
+    "libdmtx": {
+      "baseline": "0.7.7",
+      "port-version": 0
+    },
     "libdmx": {
       "baseline": "1.1.5",
       "port-version": 0

--- a/versions/l-/libdmtx.json
+++ b/versions/l-/libdmtx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2355c6d9951b9b34be9cbef758b59cb074067206",
+      "version": "0.7.7",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #44635

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
