### PR TITLE
[mfx-dispatch] Fix missing cstdint import using upstream's patch. (#4…

### DIFF
--- a/ports/mfx-dispatch/portfile.cmake
+++ b/ports/mfx-dispatch/portfile.cmake
@@ -1,3 +1,10 @@
+vcpkg_download_distfile(
+    MISSING_CSTDINT_IMPORT_PATCH
+    URLS https://github.com/lu-zero/mfx_dispatch/commit/d6241243f85a0d947bdfe813006686a930edef24.patch?full_index=1
+    FILENAME fix-missing-cstdint-import-d6241243f85a0d947bdfe813006686a930edef24.patch
+    SHA512 5d2ffc4ec2ba0e5859d01d2e072f75436ebc3e62e0f6580b5bb8b9f82fe588e7558a46a1fdfa0297a782c0eeb8f50322258d0dd9e41d927cc9be496727b61e44
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lu-zero/mfx_dispatch
@@ -7,6 +14,7 @@ vcpkg_from_github(
     PATCHES
         fix-unresolved-symbol.patch
         fix-pkgconf.patch
+        ${MISSING_CSTDINT_IMPORT_PATCH}
 )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/mfx-dispatch/vcpkg.json
+++ b/ports/mfx-dispatch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mfx-dispatch",
   "version": "1.35.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Open source Intel media sdk dispatcher",
   "homepage": "https://github.com/lu-zero/mfx_dispatch",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6014,7 +6014,7 @@
     },
     "mfx-dispatch": {
       "baseline": "1.35.1",
-      "port-version": 4
+      "port-version": 5
     },
     "mgnlibs": {
       "baseline": "2019-09-29",

--- a/versions/m-/mfx-dispatch.json
+++ b/versions/m-/mfx-dispatch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0001879960211c1331aa7b26c40e0fdd36cf5f47",
+      "version": "1.35.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "0e2d18fc6010dd23044bade1a855669f8e9c9c86",
       "version": "1.35.1",
       "port-version": 4


### PR DESCRIPTION
Fixes #44648.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.