### PR TITLE
[libdmtx] Correct all errors encountered during of #44636

### DIFF
--- a/ports/libdmtx/001-cmake-add-install-target.patch
+++ b/ports/libdmtx/001-cmake-add-install-target.patch
@@ -8,23 +8,14 @@ index 6420a813c1..749bd8d680 100644
  project(DMTX VERSION 0.7.5 LANGUAGES C)
  
  # DMTX library
-@@ -26,3 +26,19 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+@@ -26,3 +26,10 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
        add_subdirectory("test")
      endif()
  endif()
 +
 +# Add install rules
-+if(DMTX_SHARED)
-+  if(WIN32)
-+    install(TARGETS dmtx
-+            RUNTIME DESTINATION bin
-+            ARCHIVE DESTINATION lib)
-+  else()
-+    install(TARGETS dmtx
-+            LIBRARY DESTINATION lib)
-+  endif()
-+else()
-+  install(TARGETS dmtx
-+          ARCHIVE DESTINATION lib)
-+endif()
-+install(FILES "dmtx.h" "dmtxstatic.h" DESTINATION include)
++install(TARGETS dmtx
++        RUNTIME DESTINATION bin
++        ARCHIVE DESTINATION lib
++        LIBRARY DESTINATION lib)
++install(FILES "dmtx.h" DESTINATION include)

--- a/ports/libdmtx/portfile.cmake
+++ b/ports/libdmtx/portfile.cmake
@@ -1,28 +1,20 @@
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/dmtx/libdmtx/archive/refs/tags/v0.7.7.tar.gz"
-    FILENAME "v0.7.7.tar.gz"
-    SHA512 802a697669afeb74da0cc3736fe7301fcc1653c1e3bebc343a8baf76e52226cc5509231519343267a92e22ebdfcc5b2825380339991340f054f0a6685d2ffcdc
-)
-
-vcpkg_extract_source_archive_ex(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
+    REPO dmtx/libdmtx
+    REF v0.7.7
+    SHA512 802a697669afeb74da0cc3736fe7301fcc1653c1e3bebc343a8baf76e52226cc5509231519343267a92e22ebdfcc5b2825380339991340f054f0a6685d2ffcdc
     PATCHES
         001-cmake-add-install-target.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        ..
-    OPTIONS_DEBUG
-        -DBUILD_TESTING=ON
 )
-
-set(VCPKG_POLICY_ALLOW_DEBUG_INCLUDE enabled)
 
 vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libdmtx/portfile.cmake
+++ b/ports/libdmtx/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dmtx/libdmtx
-    REF v0.7.7
+    REF v${VERSION}
     SHA512 802a697669afeb74da0cc3736fe7301fcc1653c1e3bebc343a8baf76e52226cc5509231519343267a92e22ebdfcc5b2825380339991340f054f0a6685d2ffcdc
     PATCHES
         001-cmake-add-install-target.patch

--- a/ports/libdmtx/vcpkg.json
+++ b/ports/libdmtx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdmtx",
   "version": "0.7.7",
+  "port-version": 1,
   "description": "Software library that enables programs to read and write Data Matrix barcodes of the modern ECC200 variety",
   "homepage": "https://github.com/dmtx/libdmtx",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4522,7 +4522,7 @@
     },
     "libdmtx": {
       "baseline": "0.7.7",
-      "port-version": 0
+      "port-version": 1
     },
     "libdmx": {
       "baseline": "1.1.5",

--- a/versions/l-/libdmtx.json
+++ b/versions/l-/libdmtx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b017a8fe4d91a1e8a7694fdf7cf5bcfba22fac2b",
+      "version": "0.7.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "2355c6d9951b9b34be9cbef758b59cb074067206",
       "version": "0.7.7",
       "port-version": 0

--- a/versions/l-/libdmtx.json
+++ b/versions/l-/libdmtx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b017a8fe4d91a1e8a7694fdf7cf5bcfba22fac2b",
+      "git-tree": "83a83dba48ce7d0cd1d96808eac90a50a7c2d472",
       "version": "0.7.7",
       "port-version": 1
     },


### PR DESCRIPTION
- migrate to vcpkg_from_github
- Remove unused OPTIONS in vcpkg_cmake_configure
- Remove set(VCPKG_POLICY_ALLOW_DEBUG_INCLUDE enabled) from portfile and remove directory instead

Fix #44636
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.