### PR TITLE
[sol2] update to 3.5.0

### DIFF
--- a/ports/sol2/portfile.cmake
+++ b/ports/sol2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ThePhD/sol2
     REF "v${VERSION}"
-    SHA512 4404b124a4f331d77459c01a92cd73895301e7d3ef829a0285980f0138b9cc66782de3713d54f017d5aad7d8a11d23eeffbc5f3b39ccb4d4306a955711d385dd 
+    SHA512 5a6ec7e16dae05ad6abea02842f62db8f64935eda438d67b2c264cbee80cee6d82200bd060387c6df837fe9f212dbe22b2772af34df1ce8bd43296dd9429558d
     HEAD_REF develop
     PATCHES
         header-only.patch

--- a/ports/sol2/vcpkg.json
+++ b/ports/sol2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sol2",
-  "version": "3.3.1",
-  "description": "Sol v2.0 - a C++ <-> Lua API wrapper with advanced features and top notch performance - is here, and it's great",
+  "version": "3.5.0",
+  "description": "Sol3 (sol2 v3.0) - a C++ <-> Lua API wrapper with advanced features and top notch performance",
   "homepage": "https://github.com/ThePhD/sol2",
   "license": "MIT",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8685,7 +8685,7 @@
       "port-version": 0
     },
     "sol2": {
-      "baseline": "3.3.1",
+      "baseline": "3.5.0",
       "port-version": 0
     },
     "solid3": {

--- a/versions/s-/sol2.json
+++ b/versions/s-/sol2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1335e18b0ecb699219ed36d3cad23309181d34a7",
+      "version": "3.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "803f41c884606248b07d343e13716c1135da7957",
       "version": "3.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Latest release is still 3.3.0.
3.5.0 includes lots of improvements since 3.3.0.
No public release will be made until Luau is supported.

https://github.com/ThePhD/sol2/issues/1680
