### PR TITLE
[Ocilib] update to 4.7.7

### DIFF
--- a/ports/ocilib/portfile.cmake
+++ b/ports/ocilib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vrogier/ocilib
     REF "v${VERSION}"
-    SHA512 5982b17d04ebbcb281848a998b3f2f35c5a83bc6d14cd6fecb8eef695300b577fb8dcc1377e9a8827587ac06d58441328cb0d55b19ae65788c2fce8da7ce702a
+    SHA512 8a2c716ceba5c941d2f55ca99ba2b563bc754f2e7a8b6632421a62b3b2a298afb9a05ae13a1997995cea811c36f737ae1e0e5c676d72f573dbebc7f5073c8206
     HEAD_REF master
     PATCHES fix-DisableWC4191.patch
 )

--- a/ports/ocilib/vcpkg.json
+++ b/ports/ocilib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ocilib",
-  "version": "4.7.6",
+  "version": "4.7.7",
   "description": "OCILIB is an open source and cross platform Oracle Driver that delivers efficient access to Oracle databases.",
   "homepage": "https://vrogier.github.io/ocilib/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6661,7 +6661,7 @@
       "port-version": 3
     },
     "ocilib": {
-      "baseline": "4.7.6",
+      "baseline": "4.7.7",
       "port-version": 0
     },
     "octave": {

--- a/versions/o-/ocilib.json
+++ b/versions/o-/ocilib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a231543a140111ad3ac6261b1f9563ef0d158a6",
+      "version": "4.7.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "8b2fb9dbc546b1b9853f48e5bd9ed971d791c730",
       "version": "4.7.6",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
