### PR TITLE
[vcpkg baseline] [proxygen] Fix ci pipeline error

### DIFF
--- a/ports/proxygen/fix-include-not-declared.patch
+++ b/ports/proxygen/fix-include-not-declared.patch
@@ -1,0 +1,13 @@
+diff --git a/proxygen/lib/CMakeLists.txt b/proxygen/lib/CMakeLists.txt
+index 7f25b20..c7a2958 100644
+--- a/proxygen/lib/CMakeLists.txt
++++ b/proxygen/lib/CMakeLists.txt
+@@ -4,6 +4,8 @@
+ # This source code is licensed under the BSD-style license found in the
+ # LICENSE file in the root directory of this source tree.
+ 
++add_compile_options(-DFOLLY_WITH_LIBURING=1)
++
+ file(
+     MAKE_DIRECTORY
+     ${PROXYGEN_GENERATED_ROOT}/proxygen/lib/http

--- a/ports/proxygen/fix-include-not-declared.patch
+++ b/ports/proxygen/fix-include-not-declared.patch
@@ -6,7 +6,7 @@ index 7f25b20..c7a2958 100644
  # This source code is licensed under the BSD-style license found in the
  # LICENSE file in the root directory of this source tree.
  
-+add_compile_options(-DFOLLY_WITH_LIBURING=1)
++add_compile_options(-DFOLLY_HAS_LIBURING=1)
 +
  file(
      MAKE_DIRECTORY

--- a/ports/proxygen/portfile.cmake
+++ b/ports/proxygen/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         remove-register.patch
         fix-zstd-zlib-dependency.patch
         fix-dependency.patch
+        fix-include-not-declared.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/proxygen/vcpkg.json
+++ b/ports/proxygen/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "proxygen",
   "version-string": "2025.03.24.00",
+  "port-version": 1,
   "description": "It comprises the core C++ HTTP abstractions used at Facebook.",
   "homepage": "https://github.com/facebook/proxygen",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7398,7 +7398,7 @@
     },
     "proxygen": {
       "baseline": "2025.03.24.00",
-      "port-version": 0
+      "port-version": 1
     },
     "psimd": {
       "baseline": "2021-02-21",

--- a/versions/p-/proxygen.json
+++ b/versions/p-/proxygen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "efb07fb5194de61755dd144bf1ec2e9b48c0a81d",
+      "git-tree": "42f108329c3fde7bc791c29bf68f9d68271e8d72",
       "version-string": "2025.03.24.00",
       "port-version": 1
     },

--- a/versions/p-/proxygen.json
+++ b/versions/p-/proxygen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efb07fb5194de61755dd144bf1ec2e9b48c0a81d",
+      "version-string": "2025.03.24.00",
+      "port-version": 1
+    },
+    {
       "git-tree": "ccd9d1851f6ea1f3da13900d1c0346b10e319ca9",
       "version-string": "2025.03.24.00",
       "port-version": 0


### PR DESCRIPTION
`proxygen` failed on due to `folly` on https://dev.azure.com/vcpkg/public/_build/results?buildId=113831&view=results.

Due to  `folly::PollIoBackend` is defined in https://github.com/facebook/folly/blob/fc12d7fed8c86e9bca19cf410022c9cabe7644aa/folly/io/async/IoUringBackend.h#L1208, but https://github.com/facebook/folly/blob/fc12d7fed8c86e9bca19cf410022c9cabe7644aa/folly/io/async/IoUringBackend.h#L51 requires
`#if FOLLY_HAS_LIBURING` and `#define FOLLY_HAS_LIBURING 1`, add the compile option `-DFOLLY_HAS_LIBURING=1`
Fix the following error:
````
/mnt/vcpkg-ci/b/proxygen/src/5.03.17.00-a54dcea8d5.clean/proxygen/lib/services/WorkerThread.cpp:33:14: error: ‘folly::PollIoBackend’ has not been declared

````

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
