### PR TITLE
[sentry-native] update to 0.8.3

### DIFF
--- a/ports/sentry-native/fix-crashpad-wer.patch
+++ b/ports/sentry-native/fix-crashpad-wer.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2e8ffcd..81907b8 100644
+index 2873b3d..7ee1d78 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -423,7 +423,7 @@ if(SENTRY_BACKEND_CRASHPAD)
+@@ -488,7 +488,7 @@ if(SENTRY_BACKEND_CRASHPAD)
  	endif()
  	add_subdirectory(external/crashpad crashpad_build)
 
@@ -11,7 +11,7 @@ index 2e8ffcd..81907b8 100644
  		add_dependencies(sentry crashpad::wer)
  	endif()
 
-@@ -438,7 +438,9 @@ if(SENTRY_BACKEND_CRASHPAD)
+@@ -503,7 +503,9 @@ if(SENTRY_BACKEND_CRASHPAD)
  		set_property(TARGET crashpad_snapshot PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
  		set_property(TARGET crashpad_tools PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
  		set_property(TARGET crashpad_util PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
@@ -21,7 +21,7 @@ index 2e8ffcd..81907b8 100644
  		set_property(TARGET crashpad_zlib PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
  		set_property(TARGET mini_chromium PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
  	endif()
-@@ -455,7 +457,9 @@ if(SENTRY_BACKEND_CRASHPAD)
+@@ -520,7 +522,9 @@ if(SENTRY_BACKEND_CRASHPAD)
  		set_target_properties(crashpad_util PROPERTIES FOLDER ${SENTRY_FOLDER})
  		set_target_properties(crashpad_zlib PROPERTIES FOLDER ${SENTRY_FOLDER})
  		set_target_properties(mini_chromium PROPERTIES FOLDER ${SENTRY_FOLDER})
@@ -31,7 +31,7 @@ index 2e8ffcd..81907b8 100644
  	endif()
 
  	target_link_libraries(sentry PRIVATE
-@@ -465,7 +469,7 @@ if(SENTRY_BACKEND_CRASHPAD)
+@@ -530,7 +534,7 @@ if(SENTRY_BACKEND_CRASHPAD)
  	install(EXPORT crashpad_export NAMESPACE sentry_crashpad:: FILE sentry_crashpad-targets.cmake
  		DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
  	)
@@ -41,10 +41,10 @@ index 2e8ffcd..81907b8 100644
  			DESTINATION "${CMAKE_INSTALL_BINDIR}" OPTIONAL)
  		sentry_install(FILES $<TARGET_PDB_FILE:crashpad_wer>
 diff --git a/external/crashpad/handler/CMakeLists.txt b/external/crashpad/handler/CMakeLists.txt
-index 55d2e4a..b1c99ae 100644
+index 2247e2a..b89c570 100644
 --- a/external/crashpad/handler/CMakeLists.txt
 +++ b/external/crashpad/handler/CMakeLists.txt
-@@ -123,7 +123,7 @@ if(NOT IOS)
+@@ -126,7 +126,7 @@ if(NOT IOS)
      )
  endif()
 
@@ -54,10 +54,10 @@ index 55d2e4a..b1c99ae 100644
          win/wer/crashpad_wer.cc
          win/wer/crashpad_wer.h
 diff --git a/src/backends/sentry_backend_crashpad.cpp b/src/backends/sentry_backend_crashpad.cpp
-index 711dc57..4c1d473 100644
+index 9ddca42..4fa1e4e 100644
 --- a/src/backends/sentry_backend_crashpad.cpp
 +++ b/src/backends/sentry_backend_crashpad.cpp
-@@ -120,7 +120,7 @@ crashpad_backend_user_consent_changed(sentry_backend_t *backend)
+@@ -138,7 +138,7 @@ crashpad_backend_user_consent_changed(sentry_backend_t *backend)
      data->db->GetSettings()->SetUploadsEnabled(!sentry__should_skip_upload());
  }
 
@@ -66,8 +66,8 @@ index 711dc57..4c1d473 100644
  static void
  crashpad_register_wer_module(
      const sentry_path_t *absolute_handler_path, const crashpad_state_t *data)
-@@ -445,7 +445,7 @@ crashpad_backend_startup(
-         /* asynchronous_start */ false, attachments);
+@@ -483,7 +483,7 @@ crashpad_backend_startup(
+         options->crashpad_wait_for_upload);
      sentry_free(minidump_url);
 
 -#ifdef SENTRY_PLATFORM_WINDOWS

--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 a3790ab0dd0f12f8b63ac91fd78d468f772f0019598ea497a4d1d656dc26947b6fcedad74e7ee0e61fe6f78ed4b9fd5d4eb0f45271a9eba0943205e55ce971c4
+    SHA512 6317e30f15f87d92dcbec72cea0f61ded012c768c23a0ed2eaab4355e0264aefab4a16cec15628e0a1527a605e4edf5b168b701593d782fb6e515a05ac7215d1
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8457,7 +8457,7 @@
       "port-version": 1
     },
     "sentry-native": {
-      "baseline": "0.8.2",
+      "baseline": "0.8.3",
       "port-version": 0
     },
     "septag-dmon": {

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c429de056bcbe3b98988901c89f9f481d2d962b5",
+      "version": "0.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "f914767ccf5f2fa79b05cfa934d711316f938c53",
       "version": "0.8.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
