### PR TITLE
Add features of i64 and fp64 for 64bit index and double precision

### DIFF
--- a/ports/metis/build-fixes.patch
+++ b/ports/metis/build-fixes.patch
@@ -81,7 +81,7 @@ index 7fef0e7..f8e5dcf 100644
   modifications on other architectures.
  --------------------------------------------------------------------------*/
 -//#define IDXTYPEWIDTH 32
-+#define IDXTYPEWIDTH 32
++#define IDXTYPEWIDTH @IDXWIDTH@
  
  
  /*--------------------------------------------------------------------------
@@ -90,7 +90,7 @@ index 7fef0e7..f8e5dcf 100644
     64 : double precission floating point (double)
  --------------------------------------------------------------------------*/
 -//#define REALTYPEWIDTH 32
-+#define REALTYPEWIDTH 32
++#define REALTYPEWIDTH @REALWIDTH@
  
  
  

--- a/ports/metis/portfile.cmake
+++ b/ports/metis/portfile.cmake
@@ -1,11 +1,29 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+if("i64" IN_LIST FEATURES)
+    set(IDXWIDTH 64)
+else()
+    set(IDXWIDTH 32)
+endif()
+
+if("fp64" IN_LIST FEATURES)
+    set(REALWIDTH 64)
+else()
+    set(REALWIDTH 32)
+endif()
+
+configure_file(
+    "${CURRENT_PORT_DIR}/build-fixes.patch"
+    "${CURRENT_BUILDTREES_DIR}/build-fixes-dynamic.patch"
+    @ONLY
+)
+
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO KarypisLab/METIS
     REF 94c03a6e2d1860128c2d0675cbbb86ad4f261256
     SHA512 9f24329fa0f0856d0b5d10a489574d857bc4538d9639055fc895363cf70aa37342eaf7bc08819500ff6d5b98a4aa99f4241880622b540d4c484ca19e693d3480
     PATCHES
-        build-fixes.patch
+        "${CURRENT_BUILDTREES_DIR}/build-fixes-dynamic.patch"
     )
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")

--- a/ports/metis/vcpkg.json
+++ b/ports/metis/vcpkg.json
@@ -14,5 +14,14 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "i64": {
+      "description": "Use 64-bit integer indices"
+    },
+    "fp64": {
+      "description": "Use 64-bit float point (double)"
+    }
+  },
+  "default-features": []
 }


### PR DESCRIPTION
# Add feature-based configuration support for METIS

This PR enhances the METIS port by adding feature-based control over index width and real type precision. Users can now select between:

​+ Index width: 32-bit (default) or 64-bit (i64)
+ ​Precision: Single-precision (default) or Double-precision (fp64)

# Changes
## 1. ​Feature definitions:

- Added `i64` for integer width control
- Added `fp64` for precision control

## 2. ​Dynamic configuration:

- Modified build-fixes.patch to use CMake variables instead of hardcoded values
- Added dynamic macro substitution via `metis.h`

## 3. ​Validation:

- Tested all feature combinations on x64-linux and x64-windows
- Verified header file outputs match selected features

# Usage Example
```bash
# 64-bit indices + single precision
vcpkg install metis[i64]

# Default configuration (32-bit + single precision)
vcpkg install metis
```

# Notes
+ Maintains backward compatibility through default features

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.