### PR TITLE
[libsrtp] update to 2.7.0

### DIFF
--- a/ports/libsrtp/portfile.cmake
+++ b/ports/libsrtp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cisco/libsrtp
     REF "v${VERSION}"
-    SHA512 bd679ab65ccf22ca30fe867b9649a0b84cfa6fad6e22eb10f081141632f6dd56479a04d525b865f11fd46007303ca211065d9c170e4820d6ea7055403702340a
+    SHA512 eb42cc1755acd5677351fc058e2f45314ba66b590bce80944ea12aa3780953ce4c1c6211979729304d753e6c0fd325647adafc38c20c6af8482ce6f552022896
     PATCHES
         fix-runtime-destination.patch
 )
@@ -16,7 +16,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DCMAKE_PROJECT_INCLUDE=${CMAKE_CURRENT_LIST_DIR}/cmake-project-include.cmake"
-        -DTEST_APPS=OFF
+        -DLIBSRTP_TEST_APPS=OFF
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/libsrtp/vcpkg.json
+++ b/ports/libsrtp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libsrtp",
-  "version": "2.5.0",
-  "port-version": 1,
+  "version": "2.7.0",
   "description": "This package provides an implementation of the Secure Real-time Transport Protocol (SRTP), the Universal Security Transform (UST), and a supporting cryptographic kernel.",
   "homepage": "https://github.com/cisco/libsrtp/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5261,8 +5261,8 @@
       "port-version": 0
     },
     "libsrtp": {
-      "baseline": "2.5.0",
-      "port-version": 1
+      "baseline": "2.7.0",
+      "port-version": 0
     },
     "libssh": {
       "baseline": "0.10.6",

--- a/versions/l-/libsrtp.json
+++ b/versions/l-/libsrtp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0f04591cad0e2ac930c04051a0f62a440dc8753c",
+      "version": "2.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "15577c99d2d078770d2e07d2bc8cce770797adb8",
       "version": "2.5.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/cisco/libsrtp/releases/tag/v2.7.0
