### PR TITLE
[libarchive] Fix build with CMake 4.0

### DIFF
--- a/ports/libarchive/fix-cmake-version.patch
+++ b/ports/libarchive/fix-cmake-version.patch
@@ -1,0 +1,11 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6719a189..0fee41d5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ #
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)
+ if(APPLE AND CMAKE_VERSION VERSION_LESS "3.17.0")
+   message(WARNING "CMake>=3.17.0 required to make the generated shared library have the same Mach-O headers as autotools")
+ endif()

--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         fix-buildsystem.patch
         fix-cpu-set.patch
         fix-deps.patch
+        fix-cmake-version.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libarchive/vcpkg.json
+++ b/ports/libarchive/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libarchive",
   "version": "3.7.8",
+  "port-version": 1,
   "description": "Library for reading and writing streaming archives",
   "homepage": "https://www.libarchive.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4370,7 +4370,7 @@
     },
     "libarchive": {
       "baseline": "3.7.8",
-      "port-version": 0
+      "port-version": 1
     },
     "libaribcaption": {
       "baseline": "1.1.1",

--- a/versions/l-/libarchive.json
+++ b/versions/l-/libarchive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "986ee4246d15e74755d40ef9b4ffc2435dfba6e1",
+      "version": "3.7.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "d5d16f1e8eb9f6ba74f92e564f62fa641eab589e",
       "version": "3.7.8",
       "port-version": 0


### PR DESCRIPTION
This PR fixes the compilation of the libarchive port with CMake 4.0, which removed compatibility with versions of CMake older than 3.5. CMake 4.0 has been released as the new stable version today.

This issue was fixed two days ago in the upstream repo (https://github.com/libarchive/libarchive/commit/4237b476fd4ef4b2b5ebac55811d92e73aeb5257), but as vcpkg uses stable version releases of libarchive, the proposed patch might be reasonable until a new stable version of libarchive is released.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.