### PR TITLE
[tree-sitter-c] New port

### DIFF
--- a/ports/tree-sitter-c/avoid-cli.diff
+++ b/ports/tree-sitter-c/avoid-cli.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8ef5453..1f61a60 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,7 +17,7 @@ endif()
+ 
+ find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
+ 
+-add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
++add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c.unused"
+                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
+                    COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json
+                             --abi=${TREE_SITTER_ABI_VERSION}

--- a/ports/tree-sitter-c/pkgconfig.diff
+++ b/ports/tree-sitter-c/pkgconfig.diff
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e6a23ee..f45024d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,15 +41,15 @@ set_target_properties(tree-sitter-c
+                       SOVERSION "${TREE_SITTER_ABI_VERSION}.${PROJECT_VERSION_MAJOR}"
+                       DEFINE_SYMBOL "")
+ 
++include(GNUInstallDirs)
++
+ configure_file(bindings/c/tree-sitter-c.pc.in
+                "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-c.pc" @ONLY)
+ 
+-include(GNUInstallDirs)
+-
+ install(FILES bindings/c/tree-sitter-c.h
+         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter")
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-c.pc"
+-        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig")
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+ install(TARGETS tree-sitter-c
+         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+ 

--- a/ports/tree-sitter-c/portfile.cmake
+++ b/ports/tree-sitter-c/portfile.cmake
@@ -1,0 +1,43 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+# Don't change to vcpkg_from_github! The distfile includes a generated parser.c.
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/tree-sitter/tree-sitter-c/releases/download/v${VERSION}/tree-sitter-c.tar.gz"
+    FILENAME "tree-sitter-c-${VERSION}.tar.gz"
+    SHA512 03d28ceb90750e881633057c366091466c31a839b7479f08fd58c753a962782678a851c3da4063136727f5cd60e86af836f32fe219b07d480ea768f07c18c7e2
+)
+
+#[[ # Uses cmake -E tar ..., but fails to extract this file
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        ...
+)
+]]
+set(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src/v${VERSION}")
+file(REMOVE_RECURSE "${SOURCE_PATH}")
+file(MAKE_DIRECTORY "${SOURCE_PATH}")
+vcpkg_execute_in_download_mode(
+    COMMAND tar xzf "${ARCHIVE}"
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+)
+vcpkg_apply_patches(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PATCHES
+        avoid-cli.diff
+        pkgconfig.diff
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DTREE_SITTER_REUSE_ALLOCATOR=ON
+)
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tree-sitter-c/vcpkg.json
+++ b/ports/tree-sitter-c/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "tree-sitter-c",
+  "version": "0.23.5",
+  "description": "C grammar for tree-sitter",
+  "homepage": "https://github.com/tree-sitter/tree-sitter-c",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9380,6 +9380,10 @@
       "baseline": "0.25.1",
       "port-version": 0
     },
+    "tree-sitter-c": {
+      "baseline": "0.23.5",
+      "port-version": 0
+    },
     "treehh": {
       "baseline": "3.18",
       "port-version": 0


### PR DESCRIPTION
Proof of concept for https://github.com/microsoft/vcpkg/pull/44107#pullrequestreview-2724487305.
Using `parser.c` as released in distfiles. (Avoids (re)generating it with tree-sitter CLI which is a tool written in rust.)
The distfile cannot be extracted with `cmake -E tar`. Workaround is a direct call to tar.
The distfile doesn't include the optional `scanner.c` source.
