### PR TITLE
[liblzma] update to 5.8.0

### DIFF
--- a/ports/liblzma/build-tools.patch
+++ b/ports/liblzma/build-tools.patch
@@ -1,6 +1,8 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 32506cd..0fbd454 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1484,7 +1484,7 @@ function(my_install_man COMPONENT SRC_FILE LINK_NAMES)
+@@ -1748,7 +1748,7 @@ function(my_install_man COMPONENT SRC_FILE LINK_NAMES)
      endif()
  endfunction()
  
@@ -9,10 +11,11 @@
  #############################################################################
  # libgnu (getopt_long)
  #############################################################################
-@@ -1982,6 +1982,7 @@ if(UNIX)
-     my_install_man(scripts_Documentation src/scripts/xzless.1 "${XZLESS_LINKS}")
+@@ -2415,7 +2415,7 @@ xzdiff, xzgrep, xzmore, xzless, and their symlinks" ON)
+                        src/scripts/xzless.1 "${XZLESS_LINKS}")
+     endif()
  endif()
- 
+-
 +endif()
  
  #############################################################################

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tukaani-project/xz
     REF "v${VERSION}"
-    SHA512 0f814f4282c87cb74a8383199c1e55ec1bf49519daaf07f7b376cb644770b75cc9257c809b661405fcfd6cda28c54d799c67eb9e169665c35b1b87529468085e
+    SHA512 32c65500ccb49f598d88bca27cdd7bff35b505f16736ed341797eb308dc7fc9f4b01a9c8cacbecd6480701a2f8427777d476504eced663fc4f8b161f0e16adec
     HEAD_REF master
     PATCHES
         build-tools.patch
@@ -46,7 +46,7 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
 endif()
 set(prefix "${CURRENT_INSTALLED_DIR}")
 configure_file("${SOURCE_PATH}/src/liblzma/liblzma.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/liblzma.pc" @ONLY)
-if (NOT VCPKG_BUILD_TYPE)
+if(NOT VCPKG_BUILD_TYPE)
   set(prefix "${CURRENT_INSTALLED_DIR}/debug")
   configure_file("${SOURCE_PATH}/src/liblzma/liblzma.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/liblzma.pc" @ONLY)
 endif()

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -27,6 +27,7 @@ vcpkg_cmake_configure(
         -DCREATE_LZMA_SYMLINKS=OFF
         -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=   # using flags from (vcpkg) toolchain
         -DENABLE_NLS=OFF # nls is not supported by this port, yet
+        -DXZ_NLS=OFF
     MAYBE_UNUSED_VARIABLES
         CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
         CREATE_XZ_SYMLINKS

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liblzma",
-  "version": "5.6.3",
+  "version": "5.8.0",
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4845,7 +4845,7 @@
       "port-version": 1
     },
     "liblzma": {
-      "baseline": "5.6.3",
+      "baseline": "5.8.0",
       "port-version": 0
     },
     "libmad": {

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6cea06a3efa0c3930e24262e4fea2620488e0b2",
+      "version": "5.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b5e5694620b41a4d668390e5d14fa2326e0afdc3",
       "version": "5.6.3",
       "port-version": 0

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "060a91b4cea690b93447c8761ca45deb8c3e17eb",
+      "git-tree": "d1fb572d9cdc913cb384d358e5746a669961b004",
       "version": "5.8.0",
       "port-version": 0
     },

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c6cea06a3efa0c3930e24262e4fea2620488e0b2",
+      "git-tree": "060a91b4cea690b93447c8761ca45deb8c3e17eb",
       "version": "5.8.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

