### PR TITLE
[openal-soft] Update to 1.24.3

### DIFF
--- a/ports/openal-soft/portfile.cmake
+++ b/ports/openal-soft/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcat/openal-soft
     REF ${VERSION}
-    SHA512 e0b1cb08fe65e71ffd49a1dd90a1b1d2119a1dd8e5d1e10850d6c5bf04eea3335cc3051636a0479617ee5af95536a09fcad2a80d8009a10bc1fbe35a42cfe611
+    SHA512 3eebd18de4984691136738e8fe5851ac5dbdc8f17916cc9dcc599bd3bafc400c9dad9dc88844a9b77b1e8e372a041af342421bdf23746dffe4760f8385bd1e53
     HEAD_REF master
 )
 

--- a/ports/openal-soft/vcpkg.json
+++ b/ports/openal-soft/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openal-soft",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "description": "OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.",
   "homepage": "https://github.com/kcat/openal-soft",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6753,7 +6753,7 @@
       "port-version": 0
     },
     "openal-soft": {
-      "baseline": "1.24.2",
+      "baseline": "1.24.3",
       "port-version": 0
     },
     "openblas": {

--- a/versions/o-/openal-soft.json
+++ b/versions/o-/openal-soft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f783908f96ce29c1b94aa4fb26ea8660168f6ac6",
+      "version": "1.24.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "368c76c235972804893059e75da4584486a8a0d0",
       "version": "1.24.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.