### PR TITLE
[fastlz] update minimum required cmake version

### DIFF
--- a/ports/fastlz/CMakeLists.txt
+++ b/ports/fastlz/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED ( VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED (VERSION 3.5)
 
 add_library (fastlz fastlz.c)
 

--- a/ports/fastlz/vcpkg.json
+++ b/ports/fastlz/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fastlz",
   "version-date": "2024-08-02",
+  "port-version": 1,
   "description": "A lightning-fast lossless compression library",
   "homepage": "https://github.com/ariya/FastLZ",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2734,7 +2734,7 @@
     },
     "fastlz": {
       "baseline": "2024-08-02",
-      "port-version": 0
+      "port-version": 1
     },
     "fastor": {
       "baseline": "0.6.4",

--- a/versions/f-/fastlz.json
+++ b/versions/f-/fastlz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63416a3bf2481c31bda4daef3370aa682282ab9e",
+      "version-date": "2024-08-02",
+      "port-version": 1
+    },
+    {
       "git-tree": "5a8f1e974f444b848e63429a21677172189e1836",
       "version-date": "2024-08-02",
       "port-version": 0


### PR DESCRIPTION
CMake 4.0 removes support from versions lower than 3.5. If user updates to 4.0 this port stops building.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
