### PR TITLE
[audioengine] Update to 1.2

### DIFF
--- a/ports/audioengine/portfile.cmake
+++ b/ports/audioengine/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
    OUT_SOURCE_PATH SOURCE_PATH
    REPO Darkx32/AudioEngine
    REF "v${VERSION}"
-   SHA512 66d3fd1beacafd7269cd548d4f3d06e5a13fb1aa44559105c20348d0e3e9592bffa45b7327d787a63ce18fd3b4d6b1aa56dfca9dd48dd0b7514e9856eaa8572e
+   SHA512 3f2144ea2bd833c4f567e64a20c9411dca9d07a6a81ca236086d65b76c6b9e91937139b9f73fbc531fecb2f6327cd5d180887122053f91d0c33ef0c04aa9edcd
 )
 
 vcpkg_cmake_configure(

--- a/ports/audioengine/vcpkg.json
+++ b/ports/audioengine/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "audioengine",
-  "version": "1.1",
+  "version": "1.2",
   "description": "AudioEngine created using C++, FFMPEG and OpenAL for a student",
   "homepage": "https://github.com/Darkx32/AudioEngine",
   "license": "MIT",

--- a/versions/a-/audioengine.json
+++ b/versions/a-/audioengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "549344685167b21c2b2e9682178852c0ee8cba5a",
+      "version": "1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "45b274656b338d05a58f7ee5713f3c067c369b8c",
       "version": "1.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -361,7 +361,7 @@
       "port-version": 0
     },
     "audioengine": {
-      "baseline": "1.1",
+      "baseline": "1.2",
       "port-version": 0
     },
     "audiofile": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.