### PR TITLE
[fluidsynth] Fix variable in portfile.cmake not being escaped

### DIFF
--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -49,7 +49,7 @@ elseif(VCPKG_TARGET_IS_ANDROID)
 endif()
 
 foreach(_option IN LISTS OPTIONS_TO_ENABLE)
-    list(APPEND ENABLED_OPTIONS "-D{_option}:BOOL=ON")
+    list(APPEND ENABLED_OPTIONS "-D${_option}:BOOL=ON")
 endforeach()
     
 foreach(_option IN LISTS OPTIONS_TO_DISABLE IGNORED_OPTIONS)

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fluidsynth",
   "version": "2.4.4",
+  "port-version": 1,
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2870,7 +2870,7 @@
     },
     "fluidsynth": {
       "baseline": "2.4.4",
-      "port-version": 0
+      "port-version": 1
     },
     "flux": {
       "baseline": "0.4.0",

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f386155bd6f328d8c38ed1a95306d4522aa5481f",
+      "version": "2.4.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "dc86fe8f047486a6eef27e327b9823a90eb10393",
       "version": "2.4.4",
       "port-version": 0


### PR DESCRIPTION
This was outputting a literal string "{_option}" rather than escaping the variable.
Looks like a simple typo. OPTIONS_TO_ENABLE now matches OPTIONS_TO_DISABLE.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.