### PR TITLE
[mimalloc] Export C++ linkage in pc file

### DIFF
--- a/ports/mimalloc/pkgconfig-cxx.diff
+++ b/ports/mimalloc/pkgconfig-cxx.diff
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5cc7ec5..578d235 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -680,8 +680,13 @@ endif()
+ 
+ 
+ # pkg-config file support
++set(mi_cxx_libraries "")
++if(MI_USE_CXX)
++  set(mi_cxx_libraries ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
++  list(REMOVE_ITEM mi_cxx_libraries ${CMAKE_C_IMPLICIT_LINK_LIBRARIES})
++endif()
+ set(mi_pc_libraries "")
+-foreach(item IN LISTS mi_libraries)
++foreach(item IN LISTS mi_libraries mi_cxx_libraries)
+   if(item MATCHES " *[-].*")
+     set(mi_pc_libraries "${mi_pc_libraries} ${item}")
+   else()

--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 55262050f63868e3029cd929a74d312dc0f34b606534b1d0b3735eecc8eed68aae97523a50228b4ac4044e1e03192f2909440e3a27607e2d364607ac0bda828f
     HEAD_REF master
+    PATCHES
+        pkgconfig-cxx.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mimalloc",
   "version": "2.2.3",
+  "port-version": 1,
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
   "license": "MIT",

--- a/scripts/test_ports/vcpkg-ci-mimalloc/vcpkg-tests.cmake
+++ b/scripts/test_ports/vcpkg-ci-mimalloc/vcpkg-tests.cmake
@@ -23,10 +23,8 @@ find_library(mimalloc_lib NAMES ${names} PATHS "${MIMALLOC_LIBRARY_DIR}" NO_DEFA
 
 pkg_check_modules(PC_MIMALLOC mimalloc IMPORTED_TARGET REQUIRED)
 
-if(EXPECTED_FAILURE_DUE_TO_CXX_LINKAGE_OF_MIMALLOC)
 add_executable(pkgconfig-override $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,main-override.c,main-override-static.c>)
 target_link_libraries(pkgconfig-override PRIVATE PkgConfig::PC_MIMALLOC)
-endif()
 
 if(BUILD_SHARED_LIBS OR NOT WIN32)
     add_executable(pkgconfig-override-cxx main-override.cpp)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6090,7 +6090,7 @@
     },
     "mimalloc": {
       "baseline": "2.2.3",
-      "port-version": 0
+      "port-version": 1
     },
     "mimicpp": {
       "baseline": "6",

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f3e2f01e16667452acf8006b384824da2cdfb98",
+      "version": "2.2.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "fb9693583cca76adeb691b9d6e0ab8f5a5f9982a",
       "version": "2.2.3",
       "port-version": 0


### PR DESCRIPTION
For https://github.com/microsoft/vcpkg/pull/44699#issuecomment-2766863693.

Add C++ link libs in pkgconfig file. (Established pattern in vcpkg to fix downstream usage in C projects.)