### PR TITLE
[cpp-jsonlib] Add new port

### DIFF
--- a/ports/cpp-jsonlib/portfile.cmake
+++ b/ports/cpp-jsonlib/portfile.cmake
@@ -1,4 +1,7 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -14,11 +17,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-
-vcpkg_cmake_config_fixup(PACKAGE_NAME "cpp-jsonlib")
+vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cpp-jsonlib/portfile.cmake
+++ b/ports/cpp-jsonlib/portfile.cmake
@@ -1,7 +1,4 @@
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-endif()
-
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/cpp-jsonlib/portfile.cmake
+++ b/ports/cpp-jsonlib/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Mysvac/cpp-jsonlib
+    REF "${VERSION}"
+    SHA512 b1f017d5ce5e3ea67640048fd5b84a9efe64d6cfc599696838af4d264d3638e2f52f58aec727d78a20dc1f2a9d076615c72956180b5bfd7a0c1a487cc264a319
+    HEAD_REF main
+)
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "cpp-jsonlib")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/cpp-jsonlib/usage
+++ b/ports/cpp-jsonlib/usage
@@ -1,0 +1,4 @@
+cpp-jsonlib provides CMake targets:
+
+find_package(cpp-jsonlib CONFIG REQUIRED)
+target_link_libraries(main PRIVATE jsonlib::jsonlib)

--- a/ports/cpp-jsonlib/usage
+++ b/ports/cpp-jsonlib/usage
@@ -1,4 +1,4 @@
 cpp-jsonlib provides CMake targets:
 
-find_package(cpp-jsonlib CONFIG REQUIRED)
-target_link_libraries(main PRIVATE jsonlib::jsonlib)
+  find_package(cpp-jsonlib CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE jsonlib::jsonlib)

--- a/ports/cpp-jsonlib/vcpkg.json
+++ b/ports/cpp-jsonlib/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "cpp-jsonlib",
+  "version": "2.0.0",
+  "description": "A C++ JSON library.",
+  "homepage": "https://github.com/Mysvac/cpp-jsonlib",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1916,6 +1916,10 @@
       "baseline": "1.3.0",
       "port-version": 0
     },
+    "cpp-jsonlib": {
+      "baseline": "2.0.0",
+      "port-version": 0
+    },
     "cpp-jwt": {
       "baseline": "2022-08-27",
       "port-version": 1

--- a/versions/c-/cpp-jsonlib.json
+++ b/versions/c-/cpp-jsonlib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d84f0133a5302e3b45b42691b68c4fc5ac9f69bf",
+      "version": "2.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add port.  "cpp-jsonlib" is a C++17 JSON parsing library with only about 1000 lines of code (excluding blank lines), compact structure, easy to use, and good performance.

<https://github.com/Mysvac/cpp-jsonlib>

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

