### PR TITLE
[blosc] Fix build with CMake 4.0

### DIFF
--- a/ports/blosc/0002-fix-CMake-version.patch
+++ b/ports/blosc/0002-fix-CMake-version.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b91a101..ed77f03 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -72,10 +72,8 @@
+ #    DEV: static includes blosc.a and blosc.h
+ 
+ 
+-cmake_minimum_required(VERSION 2.8.12)
+-if(NOT CMAKE_VERSION VERSION_LESS 3.3)
+-    cmake_policy(SET CMP0063 NEW)
+-endif()
++# Recent versions of cmake dropped compatibility with < 3.5
++cmake_minimum_required(VERSION 3.5)
+ 
+ # parse the full version numbers from blosc.h
+ file(READ ${CMAKE_CURRENT_SOURCE_DIR}/blosc/blosc.h _blosc_h_contents)

--- a/ports/blosc/portfile.cmake
+++ b/ports/blosc/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
       0001-fix-CMake-config.patch
+      0002-fix-CMake-version.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BLOSC_STATIC)

--- a/ports/blosc/vcpkg.json
+++ b/ports/blosc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "blosc",
   "version": "1.21.6",
+  "port-version": 1,
   "description": "A blocking, shuffling and loss-less compression library that can be faster than `memcpy()`",
   "homepage": "https://github.com/Blosc/c-blosc",
   "license": "BSD-3-Clause",

--- a/versions/b-/blosc.json
+++ b/versions/b-/blosc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69bd15f3b0c382c30634dec7f4a52bec5e3a0047",
+      "version": "1.21.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "864998aec116af2c008676f9e3be350be747654d",
       "version": "1.21.6",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -726,7 +726,7 @@
     },
     "blosc": {
       "baseline": "1.21.6",
-      "port-version": 0
+      "port-version": 1
     },
     "blpapi": {
       "baseline": "3.25.1",


### PR DESCRIPTION
This PR fixes the compilation of the blosc port with CMake 4.0, which removed compatibility with versions of CMake older than 3.5. This issue was fixed four days ago in the upstream repo (https://github.com/Blosc/c-blosc/commit/051b9d2cb9437e375dead8574f66d80ebce47bee), but as vcpkg uses stable version releases of blosc, the proposed patch (which is exactly identical to the commit in the upstream repo) might be reasonable until a new stable version of blosc is released.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.