### PR TITLE
[ada-url] update to 3.2.2

### DIFF
--- a/ports/ada-url/portfile.cmake
+++ b/ports/ada-url/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ada-url/ada
     REF "v${VERSION}"
-    SHA512 2fc437fcb4bf18d8218b7d353cefa83bc77d484d8cab995aeaed42050c7f1f013ff0fe2ca6b5216f58c319dbedeb14c8969d59b1c794c75ee5c44789f5232d48
+    SHA512 dd9f74ce795a105a3fa989015fe915c246716b052b5e8f3f28eb83652da96610b4c1e7297c5757b8f5e3fa6f1737f44ae184795cd45106a84ca9bcfb558e825d
     HEAD_REF main
     PATCHES
         no-cpm.patch

--- a/ports/ada-url/vcpkg.json
+++ b/ports/ada-url/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ada-url",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "WHATWG-compliant and fast URL parser written in modern C++",
   "homepage": "https://ada-url.com/",
   "license": "MIT OR Apache-2.0",

--- a/versions/a-/ada-url.json
+++ b/versions/a-/ada-url.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "79ebef636dc01be75318d3dcb1417d7f9d803222",
+      "version": "3.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "03a88e9522fc4ee160fac9d1cf44c6a0be6db081",
       "version": "3.2.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -37,7 +37,7 @@
       "port-version": 17
     },
     "ada-url": {
-      "baseline": "3.2.1",
+      "baseline": "3.2.2",
       "port-version": 0
     },
     "ade": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ada-url/ada/releases/tag/v3.2.2
