### PR TITLE
[inih] update to 59

### DIFF
--- a/ports/inih/portfile.cmake
+++ b/ports/inih/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO benhoyt/inih
     REF "r${VERSION}"
-    SHA512 d69f488299c1896e87ddd3dd20cd9db5848da7afa4c6159b8a99ba9a5d33f35cadfdb9f65d6f2fe31decdbadb8b43bf610ff2699df475e1f9ff045e343ac26ae
+    SHA512 cd5ee8796c1be1ff7f589069ec90fee6fc4464ae7b2f0b39600ab08cf01cda9e4c006aa1cba0ee3c78df0111de5da23fa314816bfd327e34211a0dfcfa1d993b
     HEAD_REF master
 )
 

--- a/ports/inih/vcpkg.json
+++ b/ports/inih/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "inih",
-  "version": "58",
+  "version": "59",
   "description": "Simple .INI file parser",
   "homepage": "https://github.com/benhoyt/inih",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3777,7 +3777,7 @@
       "port-version": 0
     },
     "inih": {
-      "baseline": "58",
+      "baseline": "59",
       "port-version": 0
     },
     "iniparser": {

--- a/versions/i-/inih.json
+++ b/versions/i-/inih.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7beabe1b3f67c1fe3dd3bf9461ec5f34bc627965",
+      "version": "59",
+      "port-version": 0
+    },
+    {
       "git-tree": "f86a866280aff2071eb313ff85cc1c5c7cabaeff",
       "version": "58",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/benhoyt/inih/releases/tag/r59
