### PR TITLE
[libuuid] Fix build with CMake 4.0

### DIFF
--- a/ports/libuuid/CMakeLists.txt
+++ b/ports/libuuid/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(libuuid C)
 
 configure_file(config.linux.h config.h COPYONLY)

--- a/ports/libuuid/CMakeLists.txt
+++ b/ports/libuuid/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.21)
 project(libuuid C)
 
 configure_file(config.linux.h config.h COPYONLY)

--- a/ports/libuuid/vcpkg.json
+++ b/ports/libuuid/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libuuid",
   "version": "1.0.3",
-  "port-version": 14,
+  "port-version": 15,
   "description": "Universally unique id library",
   "homepage": "https://sourceforge.net/projects/libuuid",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5398,7 +5398,7 @@
     },
     "libuuid": {
       "baseline": "1.0.3",
-      "port-version": 14
+      "port-version": 15
     },
     "libuv": {
       "baseline": "1.50.0",

--- a/versions/l-/libuuid.json
+++ b/versions/l-/libuuid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5291be55ef145322cdd8d8ad163908322fafe1c5",
+      "version": "1.0.3",
+      "port-version": 15
+    },
+    {
       "git-tree": "09be6774f518692bc418aa03623cc9dbc19e6516",
       "version": "1.0.3",
       "port-version": 14

--- a/versions/l-/libuuid.json
+++ b/versions/l-/libuuid.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5291be55ef145322cdd8d8ad163908322fafe1c5",
+      "git-tree": "21e17c7c38cd70cc7aa063860eb6717f61b3cbad",
       "version": "1.0.3",
       "port-version": 15
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fixes #44758