### PR TITLE
[redis-plus-plus] update to 1.3.14

### DIFF
--- a/ports/redis-plus-plus/portfile.cmake
+++ b/ports/redis-plus-plus/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sewenew/redis-plus-plus
     REF "${VERSION}"
-    SHA512 c2892ec1b2f242ee19c727cd9dd1bc4e08b9f515f5736bffee5b5a12a2f1b2eddec0ebeba7998a5abc5620bdff37b5d745abdf0d7586b89535ce0ae035988ef4
+    SHA512 62dbba8e641fbac71ea322e2f7766360c601959c371bfde2ab9cb0613f65eb42b442e76ef4130d64ece4058b4f4d7872503d4774a505ab0616955e95706143c8
     HEAD_REF master
     PATCHES
         fix-conversion.patch

--- a/ports/redis-plus-plus/vcpkg.json
+++ b/ports/redis-plus-plus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-plus-plus",
-  "version-semver": "1.3.13",
+  "version-semver": "1.3.14",
   "description": "This is a C++ client for Redis. It's based on hiredis, and written in C++ 11",
   "homepage": "https://github.com/sewenew/redis-plus-plus",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8069,7 +8069,7 @@
       "port-version": 0
     },
     "redis-plus-plus": {
-      "baseline": "1.3.13",
+      "baseline": "1.3.14",
       "port-version": 0
     },
     "refl-cpp": {

--- a/versions/r-/redis-plus-plus.json
+++ b/versions/r-/redis-plus-plus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9102faa25c41f356a5041677c48a2bf7549e5a62",
+      "version-semver": "1.3.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "91fb6d6b9e220a2a75c0df8572ef980fc2313dab",
       "version-semver": "1.3.13",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/sewenew/redis-plus-plus/releases/tag/1.3.14
