### PR TITLE
Baseline proxygen:x64-linux.

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -823,6 +823,7 @@ popsift:x64-windows-release=fail
 popsift:x64-windows-static-md=fail
 popsift:x64-windows-static=fail
 popsift:x64-windows=fail
+proxygen:x64-linux=fail
 python2:arm-neon-android=fail
 python2:arm64-android=fail
 python2:x64-android=fail


### PR DESCRIPTION
Baseline issue for more than a month (as far back as https://dev.azure.com/vcpkg/public/_build/results?buildId=113027&view=logs&j=f79cfdd7-47a8-597f-8f57-dc3e21a8f2ad&t=4f03addf-ef5a-50a2-71be-19894d9df4e3 ) showing up in several PRs.
