### PR TITLE
[arcticdb-sparrow] Update to 0.6.0

### DIFF
--- a/ports/arcticdb-sparrow/portfile.cmake
+++ b/ports/arcticdb-sparrow/portfile.cmake
@@ -1,12 +1,12 @@
 if(VCPKG_TARGET_IS_LINUX)
-    message("Warning: `sparrow` requires Clang18+ or GCC 12+ on Linux")
+    message("Warning: `sparrow` requires Clang18+ or GCC 11+ on Linux")
 endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO man-group/sparrow
     REF "${VERSION}"
-    SHA512 1e80792625589c72a8e83cabc603f0f4e08ce72c6ba9044e2191f197e7740ac40f7b714c5fe543a00417689e48c681d5ea4f81b87baf54695f3725acf1d3a0e3
+    SHA512 d97f37471812f5edbfbd407b831af95a624b46faa500a6eb46257af988414989af5e71671cbdc0a38a1a79404a6110894171d349621ce4bc73eb3590cb316575
     HEAD_REF main
 )
 

--- a/ports/arcticdb-sparrow/vcpkg.json
+++ b/ports/arcticdb-sparrow/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arcticdb-sparrow",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "C++20 idiomatic APIs for the Apache Arrow Columnar Format",
   "homepage": "https://github.com/man-group/sparrow",
   "license": "Apache-2.0",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -51,8 +51,6 @@ apr:arm64-android=fail
 apr:x64-android=fail
 apsi:arm-neon-android=fail
 apsi:x64-android=fail
-# arcticdb-sparrow requires gcc13 and clang17 or later. linux-x64 always fails because it uses gcc11.
-arcticdb-sparrow:x64-linux=fail
 # Broken with CUDA 12; needs update to 3.8.3 and https://github.com/arrayfire/arrayfire/issues/3349 fixed
 arrayfire:x64-linux=fail
 avro-c:arm-neon-android=fail

--- a/versions/a-/arcticdb-sparrow.json
+++ b/versions/a-/arcticdb-sparrow.json
@@ -3,7 +3,7 @@
     {
       "git-tree": "05dcd2be4c194527b5afda5fe4d043da4e6ea232",
       "version": "0.6.0",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "56a860246cba2159516ff5ad32f32f27cbbee598",

--- a/versions/a-/arcticdb-sparrow.json
+++ b/versions/a-/arcticdb-sparrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff116b16e368747cb09d784950a1cb9a1fb7d587",
+      "version": "0.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "56a860246cba2159516ff5ad32f32f27cbbee598",
       "version": "0.5.0",
       "port-version": 0

--- a/versions/a-/arcticdb-sparrow.json
+++ b/versions/a-/arcticdb-sparrow.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "ff116b16e368747cb09d784950a1cb9a1fb7d587",
+      "git-tree": "05dcd2be4c194527b5afda5fe4d043da4e6ea232",
       "version": "0.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     {
       "git-tree": "56a860246cba2159516ff5ad32f32f27cbbee598",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -194,7 +194,7 @@
     },
     "arcticdb-sparrow": {
       "baseline": "0.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "arcus": {
       "baseline": "4.10.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -194,7 +194,7 @@
     },
     "arcticdb-sparrow": {
       "baseline": "0.6.0",
-      "port-version": 1
+      "port-version": 0
     },
     "arcus": {
       "baseline": "4.10.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -193,7 +193,7 @@
       "port-version": 2
     },
     "arcticdb-sparrow": {
-      "baseline": "0.5.0",
+      "baseline": "0.6.0",
       "port-version": 0
     },
     "arcus": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.