### PR TITLE
[icu] Added workaround for cross-compiling for arm64-linux on x64-linux

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -63,6 +63,12 @@ elseif(VCPKG_CROSSCOMPILING)
     # convert to unix path
     string(REGEX REPLACE "^([a-zA-Z]):/" "/\\1/" _VCPKG_TOOL_PATH "${TOOL_PATH}")
     list(APPEND CONFIGURE_OPTIONS "--with-cross-build=${_VCPKG_TOOL_PATH}")
+
+    # Workaround for cross-compiling for arm64-linux on x64-linux
+    if(HOST_TRIPLET STREQUAL "x64-linux" AND TARGET_TRIPLET STREQUAL "arm64-linux")
+        # autoconf "host" corresponds to cmake/vcpkg "target", cf. https://www.gnu.org/software/autoconf/manual/autoconf-2.71/html_node/Hosts-and-Cross_002dCompilation.html
+        list(APPEND CONFIGURE_OPTIONS "--host=aarch64-linux-gnu")
+    endif()
 endif()
 
 vcpkg_make_configure(

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "icu",
   "version": "74.2",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3666,7 +3666,7 @@
     },
     "icu": {
       "baseline": "74.2",
-      "port-version": 5
+      "port-version": 6
     },
     "ideviceinstaller": {
       "baseline": "2023-07-21",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c1880ed73c508847ddcd7135f0f0fd08c691b8e8",
+      "version": "74.2",
+      "port-version": 6
+    },
+    {
       "git-tree": "91b03be43850140e64dba01dcadc8b3f73b1083b",
       "version": "74.2",
       "port-version": 5


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [N/A] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [N/A] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
