### PR TITLE
[wxwidgets] update to 3.2.7.

### DIFF
--- a/ports/wxwidgets/install-layout.patch
+++ b/ports/wxwidgets/install-layout.patch
@@ -1,16 +1,3 @@
-diff --git a/build/cmake/functions.cmake b/build/cmake/functions.cmake
-index 7d3f88d..576a28c 100644
---- a/build/cmake/functions.cmake
-+++ b/build/cmake/functions.cmake
-@@ -453,7 +453,7 @@ macro(wx_add_library name)
-             # configure puts the .dll in the bin directory
-             set(runtime_dir "bin")
-         else()
--            set(runtime_dir "lib")
-+            set(runtime_dir "bin")
-         endif()
-         wx_install(TARGETS ${name}
-             EXPORT wxWidgetsTargets
 diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
 index e76dff6..eb4edc0 100644
 --- a/build/cmake/init.cmake

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wxWidgets/wxWidgets
     REF "v${VERSION}"
-    SHA512 0834cb1f4f2e294b721abeef659f696156b9a7474a6a770197f2295a598cce5547671634036a96739b063bb6482f5cb0092b5f704dc5ceb1c002c4e1782df197
+    SHA512 5b41f550d1c774f5a83497eb2cb11b37c34113eedeb4f39e9c6328c7f4d32ba2ad4ac5acc22366e82bd1eb4e60ef21ef7651029e556d53e3fe1e3591afd4b8f9
     HEAD_REF master
     PATCHES
         install-layout.patch
@@ -43,6 +43,14 @@ else()
     list(APPEND OPTIONS -DwxUSE_WEBREQUEST_CURL=ON)
 endif()
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+        list(APPEND OPTIONS -DwxBUILD_USE_STATIC_RUNTIME=OFF)
+    else()
+        list(APPEND OPTIONS -DwxBUILD_USE_STATIC_RUNTIME=ON)
+    endif()
+endif()
+
 vcpkg_find_acquire_program(PKGCONFIG)
 
 # This may be set to ON by users in a custom triplet.
@@ -75,6 +83,7 @@ vcpkg_cmake_configure(
         -DwxUSE_UIACTIONSIMULATOR=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_GSPELL=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_MSPACK=ON
+        -DwxBUILD_INSTALL_RUNTIME_DIR:PATH=bin
         ${OPTIONS}
         "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
         # The minimum cmake version requirement for Cotire is 2.8.12.
@@ -187,6 +196,12 @@ if("example" IN_LIST FEATURES)
 endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
+
+file(REMOVE "${CURRENT_PACKAGES_DIR}/wxwidgets.props")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/wxwidgets.props")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/build")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/build")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/docs/licence.txt")

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "wxwidgets",
-  "version": "3.2.6",
-  "port-version": 1,
+  "version": "3.2.7",
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10017,8 +10017,8 @@
       "port-version": 0
     },
     "wxwidgets": {
-      "baseline": "3.2.6",
-      "port-version": 1
+      "baseline": "3.2.7",
+      "port-version": 0
     },
     "wyhash": {
       "baseline": "2023-12-03",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e6c4ce438368254868d52c9ca2629efd426a6b0b",
+      "version": "3.2.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "ed83e68a98eae31bd305924cc58ebff0d259b8e6",
       "version": "3.2.6",
       "port-version": 1


### PR DESCRIPTION
This fixes #44770.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
