### PR TITLE
[opentelemetry-cpp-contrib-version] Update to 2025-04-02

### DIFF
--- a/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
@@ -4,9 +4,9 @@ function(clone_opentelemetry_cpp_contrib CONTRIB_SOURCE_PATH)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-telemetry/opentelemetry-cpp-contrib
-        REF f5c979ce0f9d5a9f2dab4f856aaae2afa8fc758d
+        REF 69b8a42741b7f7063ad063d7957f7bc97bf701a4
         HEAD_REF main
-        SHA512 ba4513065a26871b73285fb06b935b28552978161cdacf21ad51a2344f48c20937713a9676320bdb20a01d86b8d0d6bcd810c14a153161317d9da4791590b736
+        SHA512 1db239ab73f7c4d8ba97d42dd9f97b728d18a9a3a2fad342fda66231f0144aae829d9ceebd584979acc026aa9f0ca7aac0b73aa4eff2fc2f1f059b0f53eaecd3
     )
     set(${CONTRIB_SOURCE_PATH} ${SOURCE_PATH} CACHE INTERNAL "")
 endfunction()

--- a/ports/opentelemetry-cpp-contrib-version/vcpkg.json
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp-contrib-version",
-  "version-date": "2025-02-03",
+  "version-date": "2025-04-02",
   "description": "This port manages the opentelemetry-cpp-version that will be used for opentelemetry-cpp",
   "homepage": "https://github.com/open-telemetry/opentelemetry-cpp-contrib",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6897,7 +6897,7 @@
       "port-version": 2
     },
     "opentelemetry-cpp-contrib-version": {
-      "baseline": "2025-02-03",
+      "baseline": "2025-04-02",
       "port-version": 0
     },
     "opentracing": {

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f5c77c975f7a824161b4fdf62cb3d0b8fb2428f3",
+      "version-date": "2025-04-02",
+      "port-version": 0
+    },
+    {
       "git-tree": "00df8641b92d650983ce0b70004b19ce03ada303",
       "version-date": "2025-02-03",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
