### PR TITLE
[cpptrace] update to 0.8.2

### DIFF
--- a/ports/cpptrace/portfile.cmake
+++ b/ports/cpptrace/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jeremy-rifkin/cpptrace
     REF "v${VERSION}"
-    SHA512 2148b6200ed6e1026858e2239b7cf468e0dbfbbb1ac1ae18c231ec95a12b6a4149a0c00e5475166f0d0c19e3263667c7f4ea7fde3bfbf0c21ba0f4a9ce8dbcbe
+    SHA512 5ab8415657eb72bffb2df673b55454d4bb0c04895ca62e9f4425e4cafb25d03820f4820800201c9ce1466bacf0ab488adf046b652fe8d113aa7748e24240190b
     HEAD_REF main
 )
 

--- a/ports/cpptrace/vcpkg.json
+++ b/ports/cpptrace/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpptrace",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Simple, portable, and self-contained stacktrace library for C++11 and newer",
   "homepage": "https://github.com/jeremy-rifkin/cpptrace",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2013,7 +2013,7 @@
       "port-version": 4
     },
     "cpptrace": {
-      "baseline": "0.8.1",
+      "baseline": "0.8.2",
       "port-version": 0
     },
     "cppunit": {

--- a/versions/c-/cpptrace.json
+++ b/versions/c-/cpptrace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8efffead0836127fbd64606ad51cf3c2a4b61b8",
+      "version": "0.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "31e43d5a874d751f9b2c9532e02b3f83cae515e4",
       "version": "0.8.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.