### PR TITLE
[sdformat] Remove ruby dep

### DIFF
--- a/ports/sdformat/portfile.cmake
+++ b/ports/sdformat/portfile.cmake
@@ -11,9 +11,6 @@ vcpkg_from_github(
         cmake-config.patch
 )
 
-# Ruby is required by the sdformat build process
-vcpkg_find_acquire_program(RUBY)
-
 # Python is required to generate the EmbeddedSdf.cc file, which contains all the supported SDF
 # descriptions in a map of strings. The parser.cc file uses EmbeddedSdf.hh.
 vcpkg_find_acquire_program(PYTHON3)
@@ -23,7 +20,6 @@ vcpkg_add_to_path("${PYTHON3_DIR}")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DRUBY=${RUBY}"
         -DBUILD_TESTING=OFF
         -DSKIP_PYBIND11=ON
         -DUSE_INTERNAL_URDF=OFF

--- a/ports/sdformat/vcpkg.json
+++ b/ports/sdformat/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdformat",
   "version": "15.1.1",
+  "port-version": 1,
   "description": "Simulation Description Format (SDF) parser and description files.",
   "homepage": "http://sdformat.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8378,7 +8378,7 @@
     },
     "sdformat": {
       "baseline": "15.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "sdformat13": {
       "baseline": "13.6.0",

--- a/versions/s-/sdformat.json
+++ b/versions/s-/sdformat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c2bdc4566609875e621f6c4426dcbf06643be25",
+      "version": "15.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "0e0f487e837716d50dec32e21e8a8c33a7269eb1",
       "version": "15.1.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
