### PR TITLE
[xtensor] update to 0.26.0

### DIFF
--- a/ports/xtensor/fix-find-tbb-and-install-destination.patch
+++ b/ports/xtensor/fix-find-tbb-and-install-destination.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7535649..5c93655 100644
+index c7ec920..6f46641 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -75,8 +75,8 @@ if(XTENSOR_USE_XSIMD)
@@ -13,16 +13,16 @@ index 7535649..5c93655 100644
      message(STATUS "Found intel TBB: ${TBB_INCLUDE_DIRS}")
  endif()
  
-@@ -261,7 +261,7 @@ export(EXPORT ${PROJECT_NAME}-targets
- install(FILES ${XTENSOR_HEADERS}
-         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xtensor)
+@@ -260,7 +260,7 @@ export(EXPORT ${PROJECT_NAME}-targets
+ install(DIRECTORY ${XTENSOR_INCLUDE_DIR}/xtensor
+         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  
 -set(XTENSOR_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}" CACHE
 +set(XTENSOR_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE
      STRING "install path for xtensorConfig.cmake")
  
  configure_package_config_file(${PROJECT_NAME}Config.cmake.in
-@@ -288,7 +288,7 @@ configure_file(${PROJECT_NAME}.pc.in
+@@ -287,7 +287,7 @@ configure_file(${PROJECT_NAME}.pc.in
                 "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
                  @ONLY)
  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"

--- a/ports/xtensor/portfile.cmake
+++ b/ports/xtensor/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xtensor
     REF "${VERSION}"
-    SHA512 d8ff5bdb2af66db5ba84cceb2e5138728b7e689b81d5aab904c4f5dfbebdcde67b8ecf38e69750edb85e30a6f45ce70ff618ca3d1a76f38a2b4013a6a6320de6
+    SHA512 9fe07376ef05d9822ffedba2804ef8af402e6560ca1424624bbfb220ef954b4f721d09c22dc045a76134a5856eccf97bfbe08450e5e70c58128583c9352afb5e
     HEAD_REF master
     PATCHES
         fix-find-tbb-and-install-destination.patch

--- a/ports/xtensor/vcpkg.json
+++ b/ports/xtensor/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xtensor",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "C++ tensors with broadcasting and lazy computing",
   "homepage": "https://github.com/xtensor-stack/xtensor",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10149,7 +10149,7 @@
       "port-version": 0
     },
     "xtensor": {
-      "baseline": "0.25.0",
+      "baseline": "0.26.0",
       "port-version": 0
     },
     "xtensor-blas": {

--- a/versions/x-/xtensor.json
+++ b/versions/x-/xtensor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "852e8a91b35bb4af715a8ba19a2b30b3bf74abc2",
+      "version": "0.26.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4f8e8bf52ae7f55b38fabb98423beafc361cff28",
       "version": "0.25.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/xtensor-stack/xtensor/releases/tag/0.26.0