### PR TITLE
[blake3] update to version 1.8.1

### DIFF
--- a/ports/blake3/portfile.cmake
+++ b/ports/blake3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BLAKE3-team/BLAKE3
     REF "${VERSION}"
-    SHA512 6d4778f9384a168faa5e1437a5b5b95706e4cfdbf102d944f83f8ef5535c64adf54a85feb409e0db1bf231bf6d83fc66bc5a7e53e099183d5b11e4825e012d7e
+    SHA512 a47ab31ae96d54884f8377e831028e3b503009bf89ac5a4383b83d3fe1cca5c99eefb7486fba9c7f459a7dbbad15754d1354f4e20e7bb0bb63a9e06ee8ce3507
     HEAD_REF main
     PATCHES
         fix-windows-arm-build-error.patch
@@ -10,6 +10,9 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/c"
+    OPTIONS
+        -DBLAKE3_FETCH_TBB=OFF
+        -DBLAKE3_EXAMPLES=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/blake3/portfile.cmake
+++ b/ports/blake3/portfile.cmake
@@ -8,9 +8,16 @@ vcpkg_from_github(
         fix-windows-arm-build-error.patch
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS BLAKE3_FEATURE_OPTIONS
+    FEATURES
+        tbb BLAKE3_USE_TBB
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/c"
     OPTIONS
+        ${BLAKE3_FEATURE_OPTIONS}
         -DBLAKE3_FETCH_TBB=OFF
         -DBLAKE3_EXAMPLES=OFF
 )

--- a/ports/blake3/vcpkg.json
+++ b/ports/blake3/vcpkg.json
@@ -13,5 +13,16 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tbb": {
+      "description": "Enable TBB multi-threading API support",
+      "dependencies": [
+        {
+          "name": "tbb",
+          "default-features": false
+        }
+      ]
+    }
+  }
 }

--- a/ports/blake3/vcpkg.json
+++ b/ports/blake3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "blake3",
-  "version": "1.7.0",
+  "version": "1.8.1",
   "description": "BLAKE3 cryptographic hash function.",
   "homepage": "https://github.com/BLAKE3-team/BLAKE3",
   "license": "CC0-1.0 OR Apache-2.0",

--- a/versions/b-/blake3.json
+++ b/versions/b-/blake3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ffbeed13f05feae7a0d28ed51efe781c9a84c0fd",
+      "version": "1.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff114b5f63e1e75a4db88a9390b5c0bd7f8ccf81",
       "version": "1.7.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -701,7 +701,7 @@
       "port-version": 0
     },
     "blake3": {
-      "baseline": "1.7.0",
+      "baseline": "1.8.1",
       "port-version": 0
     },
     "blas": {


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
