### PR TITLE
[lzo] Fix build issues with CMake 4.0

### DIFF
--- a/ports/lzo/cmake_minimum_required.patch
+++ b/ports/lzo/cmake_minimum_required.patch
@@ -1,0 +1,22 @@
+diff -Naur lzo-2.10.orig/CMakeLists.txt lzo-2.10/CMakeLists.txt
+--- lzo-2.10.orig/CMakeLists.txt	2017-03-01 20:54:14.000000000 +0100
++++ lzo-2.10/CMakeLists.txt	2025-04-03 14:47:42.849234478 +0200
+@@ -8,7 +8,7 @@
+ # All Rights Reserved.
+ #
+ 
+-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.4.3...4.0)
+ 
+ #
+ # simple usage example (Unix):
+@@ -56,9 +56,6 @@
+ if(NOT ENABLE_STATIC AND NOT ENABLE_SHARED)
+     set(ENABLE_STATIC ON)
+ endif()
+-if(ENABLE_SHARED AND WIN32)
+-    cmake_minimum_required(VERSION 3.4.3 FATAL_ERROR) # needed for WINDOWS_EXPORT_ALL_SYMBOLS
+-endif()
+ 
+ # install directories
+ if(NOT CMAKE_INSTALL_PREFIX)

--- a/ports/lzo/portfile.cmake
+++ b/ports/lzo/portfile.cmake
@@ -7,7 +7,9 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
-    PATCHES always_install_pc.patch
+    PATCHES
+      always_install_pc.patch
+      cmake_minimum_required.patch
 )
 
 set(LZO_STATIC OFF)

--- a/ports/lzo/vcpkg.json
+++ b/ports/lzo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lzo",
   "version": "2.10",
-  "port-version": 9,
+  "port-version": 10,
   "description": "Lossless data compression library",
   "homepage": "https://www.oberhumer.com/opensource/lzo/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5826,7 +5826,7 @@
     },
     "lzo": {
       "baseline": "2.10",
-      "port-version": 9
+      "port-version": 10
     },
     "lzokay": {
       "baseline": "2023-10-22",

--- a/versions/l-/lzo.json
+++ b/versions/l-/lzo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "94f5f7e6f69e4678c3d16bcfa9212e0b4b42c721",
+      "version": "2.10",
+      "port-version": 10
+    },
+    {
       "git-tree": "fcd8844a4e80d418bf894cf93a0453f067e404de",
       "version": "2.10",
       "port-version": 9


### PR DESCRIPTION
Since there seems to be no public repository for lzo, we need to use a local patch for now.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [N/A] SHA512s are updated for each updated download.
- [N/A] The "supports" clause reflects platforms that may be fixed by this new version.
- [N/A] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [N/A] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
