### PR TITLE
[exiftool] Add version 1.8.0

### DIFF
--- a/ports/exiftool/CMakeLists.txt
+++ b/ports/exiftool/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.20)
+project(exiftool LANGUAGES CXX)
+
+file(GLOB src_files "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB public_headers "${CMAKE_CURRENT_SOURCE_DIR}/inc/*.h")
+add_library(exiftool "${src_files}")
+target_include_directories(exiftool
+                           PUBLIC
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+                           $<INSTALL_INTERFACE:include/exiftool>)
+set_target_properties(exiftool PROPERTIES PUBLIC_HEADER "${public_headers}")
+install(TARGETS exiftool
+        EXPORT exiftool-targets
+        LIBRARY DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/exiftool)
+install(EXPORT exiftool-targets
+        DESTINATION share/exiftool
+        NAMESPACE exiftool::)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/exiftool-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/exiftool-config.cmake"
+  INSTALL_DESTINATION "share/exiftool"
+)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/exiftool-config.cmake"
+  DESTINATION "share/exiftool"
+)

--- a/ports/exiftool/exiftool-config.cmake.in
+++ b/ports/exiftool/exiftool-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/exiftool-targets.cmake")
+
+check_required_components(exiftool)

--- a/ports/exiftool/portfile.cmake
+++ b/ports/exiftool/portfile.cmake
@@ -1,0 +1,14 @@
+vcpkg_download_distfile(
+    ARCHIVE
+    URLS "http://exiftool.org/cpp_exiftool/cpp_exiftool.tar.gz"
+    FILENAME "cpp_exiftool-${VERSION}.tar.gz"
+    SHA512 d362e622deeb2a04aa6d694e0c8ffabf610af30cb30c29430811e77b0faa86177fe3409ec228ead9af998a99eb6d3ffa601652c6128a96f20eb60a03e0f64292)
+vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE ${ARCHIVE})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/exiftool-config.cmake.in DESTINATION ${SOURCE_PATH})
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_cmake_config_fixup()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/README")

--- a/ports/exiftool/vcpkg.json
+++ b/ports/exiftool/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "exiftool",
+  "version": "1.8.0",
+  "description": "The C++ interface for ExifTool provides the source code for a set of objects that allow C++ applications to easily leverage the full power of the exiftool application through a simple interface. This interface handles all the hard work of launching, monitoring, controlling, and communicating with an external exiftool process.",
+  "homepage": "https://exiftool.org/cpp_exiftool/",
+  "license": null,
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2644,6 +2644,10 @@
       "baseline": "0.7.0",
       "port-version": 8
     },
+    "exiftool": {
+      "baseline": "1.8.0",
+      "port-version": 0
+    },
     "exiv2": {
       "baseline": "0.28.5",
       "port-version": 0

--- a/versions/e-/exiftool.json
+++ b/versions/e-/exiftool.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b2cdc710a3ecedcc4f10272f4fa835b421ba60d3",
+      "version": "1.8.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

# TODO
* I need help with determining what license value to use for this component.
