### PR TITLE
[hexi] add new port

### DIFF
--- a/ports/hexi/portfile.cmake
+++ b/ports/hexi/portfile.cmake
@@ -1,0 +1,13 @@
+# Header-only library
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO EmberEmu/Hexi
+  REF "v${VERSION}"
+  SHA512 00292cdbdb78da204577e49f2517ceeabca6a636a670944b234342dea49548311481ad096d6e9423fc0f0956f8d644162f447595269ecef1c6e6242a2c0c9588
+  HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/single_include/hexi.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/hexi")
+file(INSTALL "${SOURCE_PATH}/single_include/hexi_fwd.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/hexi")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE" "${SOURCE_PATH}/LICENSE-MIT")

--- a/ports/hexi/vcpkg.json
+++ b/ports/hexi/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "hexi",
+  "version": "1.3.1",
+  "description": "Header-only, lightweight C++ library for binary streaming & serialization.",
+  "homepage": "https://github.com/EmberEmu/Hexi",
+  "license": "MIT OR Apache-2.0"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3580,6 +3580,10 @@
       "baseline": "1.6.0",
       "port-version": 3
     },
+    "hexi": {
+      "baseline": "1.3.1",
+      "port-version": 0
+    },
     "hexl": {
       "baseline": "1.2.5",
       "port-version": 0

--- a/versions/h-/hexi.json
+++ b/versions/h-/hexi.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c76e1b961fc7cc8c6db639a22339b20d3cf89f7b",
+      "version": "1.3.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
