### PR TITLE
[mingw toolchain] Set target triple to `<arch>-w64-windows-gnu`

### DIFF
--- a/scripts/toolchains/mingw.cmake
+++ b/scripts/toolchains/mingw.cmake
@@ -39,7 +39,7 @@ if(NOT _VCPKG_MINGW_TOOLCHAIN)
     endif()
 
     foreach(lang C CXX)
-      set(CMAKE_${lang}_COMPILER_TARGET "${CMAKE_SYSTEM_PROCESSOR}-windows-gnu" CACHE STRING "")
+      set(CMAKE_${lang}_COMPILER_TARGET "${CMAKE_SYSTEM_PROCESSOR}-w64-windows-gnu" CACHE STRING "")
     endforeach()
 
     find_program(CMAKE_C_COMPILER "${CMAKE_SYSTEM_PROCESSOR}-w64-mingw32-gcc")


### PR DESCRIPTION
At some point, LLVM changed their mingw-w64 mode to use `<arch>-w64-windows-gnu` instead of `<arch>-windows-gnu`, this change reflects that. No difference for the GCC side since GCC doesn't use this variable.