### PR TITLE
[gz-physics] fix dartsim features dependency

### DIFF
--- a/ports/gz-physics/vcpkg.json
+++ b/ports/gz-physics/vcpkg.json
@@ -1,13 +1,21 @@
 {
   "name": "gz-physics",
   "version": "8.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "component of Gazebo, provides an abstract physics interface designed to support simulation and rapid development of robot applications.",
   "homepage": "https://gazebosim.org/libs/physics",
   "license": "Apache-2.0",
   "dependencies": [
     "bullet3",
-    "dartsim",
+    {
+      "name": "dartsim",
+      "features": [
+        "collision-bullet",
+        "collision-ode",
+        "utils",
+        "utils-urdf"
+      ]
+    },
     "eigen3",
     "gz-cmake",
     "gz-common",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3458,7 +3458,7 @@
     },
     "gz-physics": {
       "baseline": "8.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "gz-physics6": {
       "baseline": "6.5.1",

--- a/versions/g-/gz-physics.json
+++ b/versions/g-/gz-physics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd8dc5f9e757558dcdfebcaf488883bd8c973a0f",
+      "version": "8.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "45bbc49168b3dde36bb6b3ab8ea8387505ee3fcb",
       "version": "8.0.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
