### PR TITLE
[mysvac-jsonlib] Add new port.

### DIFF
--- a/ports/mysvac-jsonlib/portfile.cmake
+++ b/ports/mysvac-jsonlib/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Mysvac/cpp-jsonlib
+    REF "${VERSION}"
+    SHA512 ce4129ae8fcb4157e461be72b3da62f666d8e72456bfe26a90052c03eb4944e9e740474602fbc7b325f9814473b21238c5a61c0b51550460fe5c77e54e6cb583
+    HEAD_REF main
+)
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/mysvac-jsonlib/usage
+++ b/ports/mysvac-jsonlib/usage
@@ -1,0 +1,4 @@
+mysvac-jsonlib provides CMake targets:
+
+  find_package(mysvac-jsonlib CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE mysvac::jsonlib)

--- a/ports/mysvac-jsonlib/vcpkg.json
+++ b/ports/mysvac-jsonlib/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "mysvac-jsonlib",
+  "version": "1.0.0",
+  "description": "A C++ JSON library.",
+  "homepage": "https://github.com/Mysvac/cpp-jsonlib",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6352,6 +6352,10 @@
       "baseline": "9.1.0",
       "port-version": 4
     },
+    "mysvac-jsonlib": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "nameof": {
       "baseline": "0.10.4",
       "port-version": 0

--- a/versions/m-/mysvac-jsonlib.json
+++ b/versions/m-/mysvac-jsonlib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "25f44cd36c9488e85a655903f7e56c3aa3630ba3",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


