### PR TITLE
[winsparkle] update to 0.9.0

### DIFF
--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/vslavik/winsparkle/releases/download/v${VERSION}/WinSparkle-${VERSION}.zip"
     FILENAME "winsparkle-v${VERSION}.zip"
-    SHA512 5ed99a73541f5a590f20ff1e7953284ca00da15df388319b3a96e87c69bb99aaeb5d5eb5e814a6245cf2e4389e0eb5a53ff8657d3eb0717e35f8fe526be911dc
+    SHA512 c970512979eb03a6659c18468c5a272a5f0ef4ef4a431189b1896c0578aac4985b0a4b06b64462bffef2c288df92ce3a546d11a460d7ba54e58fcef71710da82
 )
 
 vcpkg_extract_source_archive(

--- a/ports/winsparkle/vcpkg.json
+++ b/ports/winsparkle/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "winsparkle",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "WinSparkle is an easy-to-use software update library for Windows developers.",
   "homepage": "https://winsparkle.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9969,7 +9969,7 @@
       "port-version": 5
     },
     "winsparkle": {
-      "baseline": "0.8.3",
+      "baseline": "0.9.0",
       "port-version": 0
     },
     "wintoast": {

--- a/versions/w-/winsparkle.json
+++ b/versions/w-/winsparkle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74d27e5112613236a8065a6ac1b5e1cd13b963b6",
+      "version": "0.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d1defb75e4741ef2b57c225fe729abca3974a0b5",
       "version": "0.8.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.