### PR TITLE
[liblzma] update to 5.8.1

### DIFF
--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tukaani-project/xz
     REF "v${VERSION}"
-    SHA512 32c65500ccb49f598d88bca27cdd7bff35b505f16736ed341797eb308dc7fc9f4b01a9c8cacbecd6480701a2f8427777d476504eced663fc4f8b161f0e16adec
+    SHA512 2f51fb316adb2962e0f2ef6ccc8b544cdc45087b9ad26dcd33f2025784be56578ab937c618e5826b2220b49b79b8581dcb8c6d43cd50ded7ad9de9fe61610f46
     HEAD_REF master
     PATCHES
         build-tools.patch

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liblzma",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4861,7 +4861,7 @@
       "port-version": 1
     },
     "liblzma": {
-      "baseline": "5.8.0",
+      "baseline": "5.8.1",
       "port-version": 0
     },
     "libmad": {

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "55eb3803f1d0388aebca8fd293963721bbf0092c",
+      "version": "5.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d1fb572d9cdc913cb384d358e5746a669961b004",
       "version": "5.8.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #44846

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
