### PR TITLE
[dartsim] remove freeglut dependency from osx

### DIFF
--- a/ports/dartsim/vcpkg.json
+++ b/ports/dartsim/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dartsim",
   "version": "6.15.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Dynamic Animation and Robotics Toolkit",
   "homepage": "https://dartsim.github.io/",
   "license": "BSD-2-Clause",
@@ -45,7 +45,10 @@
             "utils"
           ]
         },
-        "freeglut",
+        {
+          "name": "freeglut",
+          "platform": "!osx"
+        },
         "opengl"
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2222,7 +2222,7 @@
     },
     "dartsim": {
       "baseline": "6.15.0",
-      "port-version": 3
+      "port-version": 4
     },
     "dataframe": {
       "baseline": "3.5.0",

--- a/versions/d-/dartsim.json
+++ b/versions/d-/dartsim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "42f1f18c4f7de32f547eb03a55d669b8bb7fa16f",
+      "version": "6.15.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "afebd3545c9b535103677bc20adab17f8612f18d",
       "version": "6.15.0",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.