### PR TITLE
[cpp-exiftool] Add version 1.8.0

### DIFF
--- a/ports/cpp-exiftool/CMakeLists.txt
+++ b/ports/cpp-exiftool/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.21)
+project(cpp-exiftool LANGUAGES CXX)
+
+file(GLOB src_files "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB public_headers "${CMAKE_CURRENT_SOURCE_DIR}/inc/*.h")
+add_library(cpp-exiftool ${src_files})
+target_include_directories(cpp-exiftool
+                           PUBLIC
+                           "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>"
+                           "$<INSTALL_INTERFACE:include>")
+set_target_properties(cpp-exiftool PROPERTIES PUBLIC_HEADER "${public_headers}")
+
+install(TARGETS cpp-exiftool
+        EXPORT cpp-exiftool-targets
+        LIBRARY DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/cpp-exiftool)
+
+install(EXPORT cpp-exiftool-targets
+        FILE unofficial-cpp-exiftool-config.cmake
+        DESTINATION share/unofficial-cpp-exiftool
+        NAMESPACE unofficial::cpp-exiftool::)

--- a/ports/cpp-exiftool/portfile.cmake
+++ b/ports/cpp-exiftool/portfile.cmake
@@ -1,0 +1,14 @@
+vcpkg_download_distfile(
+    ARCHIVE
+    URLS "https://exiftool.org/cpp_exiftool/cpp_exiftool.tar.gz"
+    FILENAME "cpp_exiftool-${VERSION}.tar.gz"
+    SHA512 d362e622deeb2a04aa6d694e0c8ffabf610af30cb30c29430811e77b0faa86177fe3409ec228ead9af998a99eb6d3ffa601652c6128a96f20eb60a03e0f64292
+)
+vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-cpp-exiftool)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/README")

--- a/ports/cpp-exiftool/vcpkg.json
+++ b/ports/cpp-exiftool/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "cpp-exiftool",
+  "version": "1.8.0",
+  "description": "The C++ interface for exiftool provides the source code for a set of objects that allow C++ applications to easily leverage the full power of the exiftool application through a simple interface. This interface handles all the hard work of launching, monitoring, controlling, and communicating with an external exiftool process.",
+  "homepage": "https://exiftool.org/cpp_exiftool/",
+  "license": null,
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1912,6 +1912,10 @@
       "baseline": "V2.rc.08",
       "port-version": 0
     },
+    "cpp-exiftool": {
+      "baseline": "1.8.0",
+      "port-version": 0
+    },
     "cpp-httplib": {
       "baseline": "0.20.0",
       "port-version": 1

--- a/versions/c-/cpp-exiftool.json
+++ b/versions/c-/cpp-exiftool.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c5d61c5f3b1c617ea7a1a7924fadd5acf9df6d64",
+      "version": "1.8.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

# Note
* I have fixed review comments from my previous pull request that was reverted: https://github.com/microsoft/vcpkg/pull/44807
