### PR TITLE
[commata] add new port

### DIFF
--- a/ports/commata/portfile.cmake
+++ b/ports/commata/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
   HEAD_REF master
 )
 
-file(GLOB COMMATA_INCLUDES "${SOURCE_PATH}/include/commata/*")
-file(INSTALL ${COMMATA_INCLUDES} DESTINATION "${CURRENT_PACKAGES_DIR}/include/commata")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/include")
+file(INSTALL "${SOURCE_PATH}/include/commata" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/commata/portfile.cmake
+++ b/ports/commata/portfile.cmake
@@ -1,0 +1,13 @@
+# Header-only library
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO furfurylic/commata
+  REF "v${VERSION}"
+  SHA512 5ce3028b7bb854ce51d6cc7683b71a90e3758a7ceae03f1fba4fbfaa9b324907163f23e6330e87dc902a25fc2901f05c55be1aca34ada208b88898f1800e8858
+  HEAD_REF master
+)
+
+file(GLOB COMMATA_INCLUDES "${SOURCE_PATH}/include/commata/*")
+file(INSTALL ${COMMATA_INCLUDES} DESTINATION "${CURRENT_PACKAGES_DIR}/include/commata")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/commata/vcpkg.json
+++ b/ports/commata/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "commata",
+  "version": "1.1.0",
+  "description": "Just another header-only C++17 CSV parser.",
+  "homepage": "https://github.com/furfurylic/commata",
+  "license": "Unlicense"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1832,6 +1832,10 @@
       "baseline": "2022-03-20",
       "port-version": 0
     },
+    "commata": {
+      "baseline": "1.1.0",
+      "port-version": 0
+    },
     "comms": {
       "baseline": "5.2.7",
       "port-version": 0

--- a/versions/c-/commata.json
+++ b/versions/c-/commata.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ac0f3364646d88c2e233aa303c531ea9452771cd",
+      "version": "1.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/commata.json
+++ b/versions/c-/commata.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ac0f3364646d88c2e233aa303c531ea9452771cd",
+      "git-tree": "35b980f43ea98217041e031d275d0cc552c61d8b",
       "version": "1.1.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/furfurylic/commata
