### PR TITLE
[wt] update to 4.11.4

### DIFF
--- a/ports/wt/portfile.cmake
+++ b/ports/wt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO emweb/wt
     REF "${VERSION}"
-    SHA512 de1cf49e1b1d788841b1a87e6455bf5170ab857d0076ef7c60a5592bfb83bcdbc4621b23cac411f4b9dce2fd96b237fb4c80d854c195e575cf2e03515c399e3d
+    SHA512 e266e8333823a2960fe47645386dea6a9638a83caa4fdeee83af6bffd3e99ee43eb94d9c7afab6e4811a1c25d58df2f4c4f108308ba7f67e4359ed89f69ffd42
     HEAD_REF master
     PATCHES
         0005-XML_file_path.patch

--- a/ports/wt/vcpkg.json
+++ b/ports/wt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wt",
-  "version": "4.11.3",
+  "version": "4.11.4",
   "description": "Wt is a C++ library for developing web applications",
   "homepage": "https://github.com/emweb/wt",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10025,7 +10025,7 @@
       "port-version": 0
     },
     "wt": {
-      "baseline": "4.11.3",
+      "baseline": "4.11.4",
       "port-version": 0
     },
     "wtl": {

--- a/versions/w-/wt.json
+++ b/versions/w-/wt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1b4dabda2ea53169b5f2c5cb35f833eb461a7ae8",
+      "version": "4.11.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "3794e201631552d736199c750130dd00e711e44c",
       "version": "4.11.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/emweb/wt/releases/tag/4.11.4