### PR TITLE
[frugally-deep] update to 0.18.0

### DIFF
--- a/ports/frugally-deep/portfile.cmake
+++ b/ports/frugally-deep/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Dobiasd/frugally-deep
     REF "v${VERSION}"
-    SHA512 45cbdaa0a1aaaadb7472e18f25ebfaca6a9c3398adf15eb4bc96d2f56c504411ccf8db95b1fece077607c99d77d2d8d149e7da312063db7abf74baeadf35bdc1
+    SHA512 948121dd6d9b6ea368f3ed9d85c33a2f6900e43f4b5e2954c59825477c483a12f8bac0f1b79717682866399e7b02f013a5f78e50e87085e7e031d1fbfd026fde
     HEAD_REF master
 )
 

--- a/ports/frugally-deep/vcpkg.json
+++ b/ports/frugally-deep/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "frugally-deep",
-  "version-semver": "0.16.3",
+  "version-semver": "0.18.0",
   "description": "Header-only library for using Keras models in C++.",
   "homepage": "https://github.com/Dobiasd/frugally-deep",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2977,7 +2977,7 @@
       "port-version": 0
     },
     "frugally-deep": {
-      "baseline": "0.16.3",
+      "baseline": "0.18.0",
       "port-version": 0
     },
     "fruit": {

--- a/versions/f-/frugally-deep.json
+++ b/versions/f-/frugally-deep.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8dccebffc7248e4fbf509607fcbf18598c7b4f1",
+      "version-semver": "0.18.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "06d571f30732cf13b18a03d5f4c57a2e2a7a42aa",
       "version-semver": "0.16.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Dobiasd/frugally-deep/releases/tag/v0.18.0
https://github.com/Dobiasd/frugally-deep/releases/tag/v0.17.1
https://github.com/Dobiasd/frugally-deep/releases/tag/v0.17.0
