### PR TITLE
[vcpkg baseline][bond] Add bond:x64-linux=fail

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -147,8 +147,8 @@ bond:arm-neon-android=fail
 bond:arm64-android=fail
 bond:arm64-osx=fail
 bond:x64-android=fail
-bond:x64-osx=fail
 bond:x64-linux=fail
+bond:x64-osx=fail
 # Conflicts with openssl
 boringssl:arm-neon-android=skip
 boringssl:arm64-android=skip

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -148,6 +148,7 @@ bond:arm64-android=fail
 bond:arm64-osx=fail
 bond:x64-android=fail
 bond:x64-osx=fail
+bond:x64-linux=fail
 # Conflicts with openssl
 boringssl:arm-neon-android=skip
 boringssl:arm64-android=skip


### PR DESCRIPTION
Port `bond:x64-linux` failed on https://dev.azure.com/vcpkg/public/_build/results?buildId=114224&view=results, due to missing tool `stack`, this failure is same with `x64-osx`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~

