### PR TITLE
[vcpkg-script] fix vcpkg bootstrap failing on Musl Arm64

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -101,9 +101,7 @@ ARCH="$(uname -m)"
 
 if [ -e /etc/alpine-release ]; then
     vcpkgUseSystem="ON"
-    if [ "$ARCH" = "x86_64" ]; then
-        vcpkgUseMuslC="ON"
-    fi
+    vcpkgUseMuslC="ON"
 fi
 
 if [ "$UNAME" = "OpenBSD" ]; then
@@ -181,7 +179,7 @@ if [ "$UNAME" = "Darwin" ]; then
     echo "Downloading vcpkg-macos..."
     vcpkgToolReleaseSha=$VCPKG_MACOS_SHA
     vcpkgToolName="vcpkg-macos"
-elif [ "$vcpkgUseMuslC" = "ON" ]; then
+elif [ "$vcpkgUseMuslC" = "ON" ] && [ "$ARCH" = "x86_64" ]; then
     echo "Downloading vcpkg-muslc..."
     vcpkgToolReleaseSha=$VCPKG_MUSLC_SHA
     vcpkgToolName="vcpkg-muslc"
@@ -189,7 +187,7 @@ elif [ "$ARCH" = "x86_64" ]; then
     echo "Downloading vcpkg-glibc..."
     vcpkgToolReleaseSha=$VCPKG_GLIBC_SHA
     vcpkgToolName="vcpkg-glibc"
-elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+elif [ "$vcpkgUseMuslC" = "OFF" ] && { [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; }; then
     echo "Downloading vcpkg-arm64-glibc..."
     vcpkgToolReleaseSha=$VCPKG_GLIBC_ARM64_SHA
     vcpkgToolName="vcpkg-glibc-arm64"


### PR DESCRIPTION
After #44587, Alpine Arm64 fails to bootstrap vcpkg because it tries to run the glibc binaries on the Musl runtime instead of building from the source. This fixes the issue, making sure the Arm64 binaries are only used on Glibc runtime

Here's the failure:
https://github.com/aminya/setup-cpp/actions/runs/14304315923/job/40084748302#step:6:474