### PR TITLE
[systemc] Update to version 3.0.1

### DIFF
--- a/ports/systemc/portfile.cmake
+++ b/ports/systemc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO accellera-official/systemc
     REF "${VERSION}"
-    SHA512 3ef4b5e9c05b8d03e856598ddc27ad50a0a39a7f9334cd00faefeacdf954b6527104d3238c4e8bfa88c00dc382f4da5a50efbd845fe0b6cc2f5a025c993deefd
+    SHA512 baeadd0318b9ab47fc559a2ab6bd880ac506ac5d858cdcf081a7544ca01688f2e798549655ff7546d02feba120c084951f834b69678a0bb984299bff25a4e21b
     HEAD_REF main
     PATCHES
         install.patch
@@ -23,6 +23,7 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/SystemCTLM PACKAGE_NAME systemc
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/sysc/packages/boost")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/sysc/packages/qt/time")
 
 file(INSTALL "${SOURCE_PATH}/NOTICE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/systemc/vcpkg.json
+++ b/ports/systemc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "systemc",
-  "version": "2.3.4",
+  "version": "3.0.1",
   "description": "A set of C++ classes and macros which provide an event-driven simulation kernel in C++",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9081,7 +9081,7 @@
       "port-version": 2
     },
     "systemc": {
-      "baseline": "2.3.4",
+      "baseline": "3.0.1",
       "port-version": 0
     },
     "tabulate": {

--- a/versions/s-/systemc.json
+++ b/versions/s-/systemc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be257d75161eb8dbd41c9e63382afe974c96ee94",
+      "version": "3.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e23998a33f56dce22c979b493bc154ff60d87f8d",
       "version": "2.3.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.