### PR TITLE
[openimageio] Fix cmake option name.

### DIFF
--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -64,7 +64,7 @@ vcpkg_cmake_configure(
         -DUSE_TBB=OFF
         -DLINKSTATIC=OFF # LINKSTATIC breaks library lookup
         -DBUILD_MISSING_FMT=OFF
-        -DINTERNALIZE_FMT=OFF  # carry fmt's msvc utf8 usage requirements
+        -DOIIO_INTERNALIZE_FMT=OFF  # carry fmt's msvc utf8 usage requirements
         -DBUILD_MISSING_ROBINMAP=OFF
         -DBUILD_MISSING_DEPS=OFF
         -DSTOP_ON_WARNING=OFF
@@ -80,7 +80,6 @@ vcpkg_cmake_configure(
         BUILD_MISSING_DEPS
         BUILD_MISSING_FMT
         BUILD_MISSING_ROBINMAP
-        INTERNALIZE_FMT
         REQUIRED_DEPS
 )
 

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openimageio",
   "version": "3.0.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6854,7 +6854,7 @@
     },
     "openimageio": {
       "baseline": "3.0.1.0",
-      "port-version": 1
+      "port-version": 2
     },
     "openjpeg": {
       "baseline": "2.5.3",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6249bc4923c0145f06e54a49f685f06de819dacc",
+      "version": "3.0.1.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "cc63b8dfcea4e354d5b945aa08caa47895294e5f",
       "version": "3.0.1.0",
       "port-version": 1


### PR DESCRIPTION
The option INTERNALIZE_FMT was renamed to OIIO_INTERNALIZE_FMT with the 3.x release.

Fixes #44128.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.