### PR TITLE
[level-zero] Update to 1.20.5

### DIFF
--- a/ports/level-zero/patches/spdlog_include.patch
+++ b/ports/level-zero/patches/spdlog_include.patch
@@ -1,0 +1,13 @@
+diff --git a/source/utils/CMakeLists.txt b/source/utils/CMakeLists.txt
+index b77f264..de3f74d 100644
+--- a/source/utils/CMakeLists.txt
++++ b/source/utils/CMakeLists.txt
+@@ -5,7 +5,7 @@ set(logging_files logging.h logging.cpp)
+ add_library(level_zero_utils STATIC ${logging_files})
+ 
+ if(SYSTEM_SPDLOG)
+-       target_link_libraries(level_zero_utils PUBLIC spdlog::spdlog)
++       target_link_libraries(level_zero_utils PUBLIC spdlog::spdlog_header_only)
+ else()
+        target_include_directories(level_zero_utils PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/spdlog_headers>)
+ endif()

--- a/ports/level-zero/portfile.cmake
+++ b/ports/level-zero/portfile.cmake
@@ -4,8 +4,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oneapi-src/level-zero
     REF "v${VERSION}"
-    SHA512 86bd21b034aaa4e0ce8f554a6563f41e622fcf39895c012dcc79d472e35f878dc759b103e9d2b7daac71e4943344a7afddd1f3c7ab889949b09b4cf8e0947589
+    SHA512 de83e691a8ef4f28fcd86aa919f8aae493b84c6b644b04efcc46cec405a3a0f3eab519ab78fda26d65161e8c6776723a090a412f24fa0564679d02258643f9d0
     HEAD_REF master
+    PATCHES
+        patches/spdlog_include.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/level-zero/vcpkg.json
+++ b/ports/level-zero/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "level-zero",
-  "version": "1.20.2",
+  "version": "1.20.5",
   "description": "oneAPI Level Zero Specification Headers and Loader.",
   "homepage": "https://github.com/oneapi-src/level-zero",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4321,7 +4321,7 @@
       "port-version": 0
     },
     "level-zero": {
-      "baseline": "1.20.2",
+      "baseline": "1.20.5",
       "port-version": 0
     },
     "leveldb": {

--- a/versions/l-/level-zero.json
+++ b/versions/l-/level-zero.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9979ff06cb5187169a02122503ddb9080c31fe11",
+      "version": "1.20.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "a590b375a98696f4eba3c57c66a11141c3c7a77e",
       "version": "1.20.2",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
