### PR TITLE
[qlementine] Update to 1.2.2

### DIFF
--- a/ports/qlementine/portfile.cmake
+++ b/ports/qlementine/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oclero/qlementine
     REF "v${VERSION}"
-    SHA512 cc00e0260a41e32c50a9a6e808d50f3a05fa7bb1f557fadca1776dba98d1a1f3be7d040d6072425ccc95d0f98ae8401db7e450336d9ef5b07f1b21b1aae6abe2
+    SHA512 dcba4b7a29352533ad63b4de22ab40985e84d08d5ad87b22a061c9bc0ed4d52bcc0277ef3ad20db4291c4dd9480a170323f6343e818badc0361457fc9ec6d2f1
 )
 
 vcpkg_cmake_configure(

--- a/ports/qlementine/vcpkg.json
+++ b/ports/qlementine/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qlementine",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "Modern QStyle for desktop Qt6 applications.",
   "homepage": "https://github.com/oclero/qlementine/",
   "documentation": "https://oclero.github.io/qlementine/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7517,7 +7517,7 @@
       "port-version": 5
     },
     "qlementine": {
-      "baseline": "1.2.0",
+      "baseline": "1.2.2",
       "port-version": 0
     },
     "qlementine-icons": {

--- a/versions/q-/qlementine.json
+++ b/versions/q-/qlementine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "daf327968c9e65595a16ad730067e7380595de9d",
+      "version": "1.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "79e37ddc470dd9340b2c6ad8bf7047c14dd40c3c",
       "version": "1.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.