### PR TITLE
[itlib] add new port

### DIFF
--- a/ports/itlib/portfile.cmake
+++ b/ports/itlib/portfile.cmake
@@ -1,0 +1,13 @@
+# Header-only library
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO iboB/itlib
+  REF "v${VERSION}"
+  SHA512 2ab2b3395ad3f14ec01eaf7a4bf8740df4d3503c71bb150278359d0d6b3602e6569632709a5ce316af1798787aec6c869e44759b703aff8a1c924123be2a893c
+  HEAD_REF master
+)
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/include")
+file(INSTALL "${SOURCE_PATH}/include/itlib" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/itlib/vcpkg.json
+++ b/ports/itlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "itlib",
   "version": "1.11.7",
-  "description": "A collection of std-like single-header C++ libraries ",
+  "description": "A collection of std-like single-header C++ libraries.",
   "homepage": "https://github.com/iboB/itlib",
   "license": "MIT"
 }

--- a/ports/itlib/vcpkg.json
+++ b/ports/itlib/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "itlib",
+  "version": "1.11.7",
+  "description": "A collection of std-like single-header C++ libraries ",
+  "homepage": "https://github.com/iboB/itlib",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3864,6 +3864,10 @@
       "baseline": "5.4.0",
       "port-version": 2
     },
+    "itlib": {
+      "baseline": "1.11.7",
+      "port-version": 0
+    },
     "itpp": {
       "baseline": "4.3.1",
       "port-version": 12

--- a/versions/i-/itlib.json
+++ b/versions/i-/itlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0b4121aa217926b8a58244046d7fbd3429c6de0a",
+      "git-tree": "c175bd35a46f440955eb9e096eff569fbb9ad762",
       "version": "1.11.7",
       "port-version": 0
     }

--- a/versions/i-/itlib.json
+++ b/versions/i-/itlib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0b4121aa217926b8a58244046d7fbd3429c6de0a",
+      "version": "1.11.7",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
