### PR TITLE
[ffnvcodec] Fix script path when building with minGW on Linux

### DIFF
--- a/ports/ffnvcodec/portfile.cmake
+++ b/ports/ffnvcodec/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
 # ====================================================
 
 # Windows
-if(VCPKG_TARGET_IS_WINDOWS)
+if(VCPKG_HOST_IS_WINDOWS)
     set(BUILD_SCRIPT ${CMAKE_CURRENT_LIST_DIR}\\build.sh)
     vcpkg_acquire_msys(MSYS_ROOT PACKAGES make pkg-config)
     set(BASH ${MSYS_ROOT}/usr/bin/bash.exe)

--- a/ports/ffnvcodec/vcpkg.json
+++ b/ports/ffnvcodec/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffnvcodec",
   "version": "12.2.72.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "FFmpeg version of Nvidia Codec SDK headers.",
   "homepage": "https://github.com/FFmpeg/nv-codec-headers",
   "supports": "linux | (!osx & !uwp & !(arm64 & windows))"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2790,7 +2790,7 @@
     },
     "ffnvcodec": {
       "baseline": "12.2.72.0",
-      "port-version": 1
+      "port-version": 2
     },
     "fftw3": {
       "baseline": "3.3.10",

--- a/versions/f-/ffnvcodec.json
+++ b/versions/f-/ffnvcodec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "098123f7c7c6eca1e98f934532f33b8a9c4d3fb1",
+      "version": "12.2.72.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "90afa3238f852b5b9bc8fee3e259b3a0f0fee91d",
       "version": "12.2.72.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #44912

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
