### PR TITLE
[xaudio2redist] update for 1.2.12 release

### DIFF
--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -4,7 +4,7 @@ set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.XAudio2.Redist/${VERSION}"
     FILENAME "xaudio2redist.${VERSION}.zip"
-    SHA512 5eae9c94710ba6e51045e6f9dbe381bdfe76184a4272f561976582e8f585ef8343df9f6eaa2d391bfda06796000bc13ccb0f5bf112d7f2c7865f75ab0e89ab56
+    SHA512 d9db1e64d31926af252f196238f9793710b53c894c47f2936c5fe3b7d37297711fe293d44f36da189bb6ee34855698569bc51a69cb03d81a49ff3c167cec43b9
 )
 
 vcpkg_extract_source_archive(

--- a/ports/xaudio2redist/vcpkg.json
+++ b/ports/xaudio2redist/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "xaudio2redist",
-  "version": "1.2.11",
-  "port-version": 4,
+  "version": "1.2.12",
   "description": "Redistributable version of XAudio 2.9 for Windows 7 SP1 or later",
   "homepage": "https://aka.ms/XAudio2Redist",
   "documentation": "https://aka.ms/XAudio2Redist",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10089,8 +10089,8 @@
       "port-version": 2
     },
     "xaudio2redist": {
-      "baseline": "1.2.11",
-      "port-version": 4
+      "baseline": "1.2.12",
+      "port-version": 0
     },
     "xbitmaps": {
       "baseline": "1.1.2",

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b57c853317fd34f7f9fb87c4b2d137540bb04415",
+      "version": "1.2.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "a92fe4e38d46aa663e8ce588def6df3ce53cbdd5",
       "version": "1.2.11",
       "port-version": 4


### PR DESCRIPTION
The latest release of the Microsoft.XAudio2.Redist now includes 384k support for Windows 11.