### PR TITLE
[protobuf-c] update to 1.5.2

### DIFF
--- a/ports/protobuf-c/portfile.cmake
+++ b/ports/protobuf-c/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protobuf-c/protobuf-c
     REF v${VERSION}
-    SHA512 009b8f45aade52cccf3177de88a5357c72b1626b8d07acee17da5ad1ed0e9f6a2e24d921e673b14323331e3b25fe2556f49b437d5e071e77c385efdd72ea5fe3
+    SHA512 c95ec5fa4d3531fb83c9db95968e62a60c5e16cb10fb390067eca35ccb9e0c65c1e667bbdc9b7aa3b8f6cf012b09a189d6833534d2a28e390f01ae0d12052a47
     HEAD_REF master
     PATCHES
         fix-crt-linkage.patch

--- a/ports/protobuf-c/vcpkg.json
+++ b/ports/protobuf-c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protobuf-c",
-  "version-semver": "1.5.1",
+  "version-semver": "1.5.2",
   "description": "This is protobuf-c, a C implementation of the Google Protocol Buffers data serialization format.",
   "homepage": "https://github.com/protobuf-c/protobuf-c",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7409,7 +7409,7 @@
       "port-version": 0
     },
     "protobuf-c": {
-      "baseline": "1.5.1",
+      "baseline": "1.5.2",
       "port-version": 0
     },
     "protopuf": {

--- a/versions/p-/protobuf-c.json
+++ b/versions/p-/protobuf-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a5526d64380105999487389877a8101b9e406d0",
+      "version-semver": "1.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a97149a961559d53832ac0d240bd6a7baed7863c",
       "version-semver": "1.5.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/protobuf-c/protobuf-c/releases/tag/v1.5.2
