### PR TITLE
[libflac] update to 1.5.0

### DIFF
--- a/ports/libflac/android-cmake.diff
+++ b/ports/libflac/android-cmake.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9396130..11ef59d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -122,7 +122,7 @@ else()
+ endif()
+ 
+ 
+-if(ANDROID AND CMAKE_SYSTEM_VERSION VERSION_LESS 24 AND (CMAKE_SYSTEM_PROCESSOR MATCHES "i686" OR CMAKE_SYSTEM_PROCESSOR MATCHES "armv7-a"))
++if(ANDROID AND ANDROID_NATIVE_API_LEVEL VERSION_LESS "24" AND (CMAKE_SYSTEM_PROCESSOR MATCHES "i686" OR CMAKE_SYSTEM_PROCESSOR MATCHES "armv7-a"))
+     # fseeko/ftello may link, but it's not usable before Android API 24 on 32-bit Android
+     # https://android.googlesource.com/platform/bionic/+/main/docs/32-bit-abi.md
+     message(STATUS "Disabling fseeko/ftello for 32-bit Android before API 24")

--- a/ports/libflac/fix-find-threads.patch
+++ b/ports/libflac/fix-find-threads.patch
@@ -1,0 +1,15 @@
+diff --git a/flac-config.cmake.in b/flac-config.cmake.in
+index bcafc4c8..dcf299dd 100644
+--- a/flac-config.cmake.in
++++ b/flac-config.cmake.in
+@@ -5,6 +5,10 @@ if(NOT TARGET Ogg::ogg)
+     find_dependency(Ogg)
+ endif()
+ 
++if (@ENABLE_MULTITHREADING@)
++    find_dependency(Threads)
++endif()
++
+ include("${CMAKE_CURRENT_LIST_DIR}/targets.cmake")
+ 
+ if(TARGET FLAC::FLAC)

--- a/ports/libflac/portfile.cmake
+++ b/ports/libflac/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 c8e119462205cfd8bbe22b0aff112625d3e51ca11de97e4de06a46fb43a0768d7ec9c245b299b09b7aa4d811c6fc7b57856eaa1c217e82cca9b3ad1c0e545cbe
     HEAD_REF master
     PATCHES
+        android-cmake.diff
         fix-compile-options.patch
         fix-find-threads.patch
 )

--- a/ports/libflac/portfile.cmake
+++ b/ports/libflac/portfile.cmake
@@ -2,10 +2,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiph/flac
     REF "${VERSION}"
-    SHA512 3571467a1d557bc03eade2ae9bb1a72fd94a89222e6ad9563078d646aac0b65ed1c3d829fb45dd3a6cdca806f7ba3b6393f0ce6571b43651959acaa1c2106396
+    SHA512 c8e119462205cfd8bbe22b0aff112625d3e51ca11de97e4de06a46fb43a0768d7ec9c245b299b09b7aa4d811c6fc7b57856eaa1c217e82cca9b3ad1c0e545cbe
     HEAD_REF master
     PATCHES
         fix-compile-options.patch
+        fix-find-threads.patch
 )
 
 if("asm" IN_LIST FEATURES)
@@ -18,6 +19,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         asm WITH_ASM
         stack-protector WITH_STACK_PROTECTOR
+        multithreading ENABLE_MULTITHREADING
 )
 
 vcpkg_cmake_configure(
@@ -65,7 +67,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/flac.pc" " -lm" "")
 
     if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/flac.pc")
-       vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/flac.pc" " -lm" "")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/flac.pc" " -lm" "")
     endif()
 endif()
 

--- a/ports/libflac/vcpkg.json
+++ b/ports/libflac/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libflac",
-  "version": "1.4.3",
-  "port-version": 2,
+  "version": "1.5.0",
   "description": "Library for manipulating FLAC files",
   "homepage": "https://xiph.org/flac/",
   "license": "BSD-3-Clause",
@@ -26,6 +25,9 @@
     "asm": {
       "description": "Use any assembly optimization routines",
       "supports": "x86"
+    },
+    "multithreading": {
+      "description": "Enable multithreading if pthreads is available"
     },
     "stack-protector": {
       "description": "Build with stack smashing protection",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4649,8 +4649,8 @@
       "port-version": 1
     },
     "libflac": {
-      "baseline": "1.4.3",
-      "port-version": 2
+      "baseline": "1.5.0",
+      "port-version": 0
     },
     "libfontenc": {
       "baseline": "1.1.4",

--- a/versions/l-/libflac.json
+++ b/versions/l-/libflac.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c76fc9ad7eff17572099bfc170a9d66335a8a74",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a92a3397dfb70e6eec94fab7b3665a1288d9f7bd",
       "version": "1.4.3",
       "port-version": 2

--- a/versions/l-/libflac.json
+++ b/versions/l-/libflac.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8c76fc9ad7eff17572099bfc170a9d66335a8a74",
+      "git-tree": "1b83f01536820e062681fe33109e44bb3f597aca",
       "version": "1.5.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.