### PR TITLE
[intrusive-shared-ptr] update to 1.7

### DIFF
--- a/ports/intrusive-shared-ptr/portfile.cmake
+++ b/ports/intrusive-shared-ptr/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gershnik/intrusive_shared_ptr
     REF "v${VERSION}"
-    SHA512 cdbe6c7b8f35fc033c58ba4d7143b8f9434f75b0070ed302d62d43bdd14aac8840625f8de35815713c86f294c0b4b95cbed4af22fd76d2f6b4a9b5bee009992e
+    SHA512 0c76f04f9fec491cc8a1fc790248c3787b893459ca14cd1953fe1abe3cd5afd275627acac141bac3bc5f039a9e47448aafe246a5e7adb2aec5038057e5102fe8
     HEAD_REF master
 )
 

--- a/ports/intrusive-shared-ptr/vcpkg.json
+++ b/ports/intrusive-shared-ptr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "intrusive-shared-ptr",
-  "version": "1.6",
+  "version": "1.7",
   "description": "Intrusive reference counting smart pointer, highly configurable reference counted base class and various adapters. Also known as libisptr.",
   "homepage": "https://github.com/gershnik/intrusive_shared_ptr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3829,7 +3829,7 @@
       "port-version": 6
     },
     "intrusive-shared-ptr": {
-      "baseline": "1.6",
+      "baseline": "1.7",
       "port-version": 0
     },
     "io2d": {

--- a/versions/i-/intrusive-shared-ptr.json
+++ b/versions/i-/intrusive-shared-ptr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c2fe0a8f34302bd640aa224362b10ef4efeb872c",
+      "version": "1.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "612abe1e271ba72ee1e23bc9f910c934484248ba",
       "version": "1.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

