### PR TITLE
[duckdb] update to 1.2.2

### DIFF
--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO duckdb/duckdb
         REF v${VERSION}
-        SHA512 7e2ec4f6d6be6d500b148bd845cc51fe8985190eed8ab6f6fe79012c216cad5592ab3329e2df6b091abcc6ea8937d66f47272baead798c7d711e5d73aa9ffaa7
+        SHA512 d9b4cdc798212ddeb518d9c1d8a6640423ac05f9e8ce99855f96c63778a6757079da37fed17ad8ec131b3f28a9f89c3580d2bbacad03d7607d9d9150347f4903
         HEAD_REF main
     PATCHES
         bigobj.patch

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "port-version": 2,
   "description": "High-performance in-process analytical database system",
   "homepage": "https://duckdb.org",

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "duckdb",
   "version": "1.2.2",
-  "port-version": 2,
   "description": "High-performance in-process analytical database system",
   "homepage": "https://duckdb.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2453,8 +2453,8 @@
       "port-version": 0
     },
     "duckdb": {
-      "baseline": "1.2.1",
-      "port-version": 2
+      "baseline": "1.2.2",
+      "port-version": 0
     },
     "duckx": {
       "baseline": "1.2.2",

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8b6cea8eac3a4cf5e3555de679e598d1fa924ae5",
+      "version": "1.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a73d82bd1b2428f2811dee2ff2f2a618889f6b60",
       "version": "1.2.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/duckdb/duckdb/releases/tag/v1.2.2
