### PR TITLE
[open62541pp] Update to version 0.18.0

### DIFF
--- a/ports/open62541pp/portfile.cmake
+++ b/ports/open62541pp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open62541pp/open62541pp
     REF "v${VERSION}"
-    SHA512 a4f5fc0f52a2df59962a5f9b32781970dc537369c3219ad752c369713ab936356ffe83815745b119da92ce7b36301c8daae22c342bb29daf3f51c5364b35a7d0
+    SHA512 944fefff9e184c6092554c1e513c409f509ffd18b88eade9bcfd0752406edb9f59fe388f45054577a7aaab5d4c4ce01e3a108e4a7b13a42e41fff43dec6ac8e5
     HEAD_REF master
 )
 
@@ -10,9 +10,15 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
 vcpkg_add_to_path("${PYTHON3_DIR}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        nodesetloader UAPP_ENABLE_NODESETLOADER
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DUAPP_INTERNAL_OPEN62541=OFF
 )
 

--- a/ports/open62541pp/portfile.cmake
+++ b/ports/open62541pp/portfile.cmake
@@ -10,15 +10,9 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
 vcpkg_add_to_path("${PYTHON3_DIR}")
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        nodesetloader UAPP_ENABLE_NODESETLOADER
-)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        ${FEATURE_OPTIONS}
         -DUAPP_INTERNAL_OPEN62541=OFF
 )
 

--- a/ports/open62541pp/vcpkg.json
+++ b/ports/open62541pp/vcpkg.json
@@ -14,13 +14,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "nodesetloader": {
-      "description": "Load `NodeSet2.xml` files at runtime (uses libxml2)",
-      "dependencies": [
-        "libxml2"
-      ]
-    }
-  }
+  ]
 }

--- a/ports/open62541pp/vcpkg.json
+++ b/ports/open62541pp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "open62541pp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "C++ wrapper of the open62541 OPC UA library",
   "homepage": "https://open62541pp.github.io",
   "license": "MPL-2.0",
@@ -14,5 +14,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "nodesetloader": {
+      "description": "Load `NodeSet2.xml` files at runtime (uses libxml2)",
+      "dependencies": [
+        "libxml2"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6721,7 +6721,7 @@
       "port-version": 2
     },
     "open62541pp": {
-      "baseline": "0.17.0",
+      "baseline": "0.18.0",
       "port-version": 0
     },
     "openal-soft": {

--- a/versions/o-/open62541pp.json
+++ b/versions/o-/open62541pp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "82e6bcd880dcdc3ac023339778867d124bc1d404",
+      "git-tree": "9b0682353d17f8756a69dcee0866829dc1bbfe15",
       "version": "0.18.0",
       "port-version": 0
     },

--- a/versions/o-/open62541pp.json
+++ b/versions/o-/open62541pp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82e6bcd880dcdc3ac023339778867d124bc1d404",
+      "version": "0.18.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cb4a588b3707bbb0f6e95396d0d079ccdeefdfb6",
       "version": "0.17.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.