### PR TITLE
[sdl3-ttf] Update to 3.2.2

### DIFF
--- a/ports/sdl3-ttf/portfile.cmake
+++ b/ports/sdl3-ttf/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO  libsdl-org/SDL_ttf
-    REF "preview-${VERSION}"
-    SHA512 c6a2002d4a1227747a2986c257f3888ce4fc84b1c1d862142df5e2e7cbd9c9490c9c9b375dd16f8f0ecfc5313681d8cb5e267b907c0d52bd738a4c63695fd485 
+    REPO libsdl-org/SDL_ttf
+    REF "release-${VERSION}"
+    SHA512 b9adc28d584759b1cc1072d071caad95ade263a1fb24e294d66fc15e132d44bc62925875cb1f1b596089def9b47d7b73f42ffa4e120ee51982f993dc7a7d3bd7
     HEAD_REF main
 )
 

--- a/ports/sdl3-ttf/vcpkg.json
+++ b/ports/sdl3-ttf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl3-ttf",
-  "version": "3.1.0",
+  "version": "3.2.2",
   "description": "A library for rendering TrueType fonts with SDL",
   "homepage": "https://www.libsdl.org/projects/SDL_ttf/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8477,7 +8477,7 @@
       "port-version": 0
     },
     "sdl3-ttf": {
-      "baseline": "3.1.0",
+      "baseline": "3.2.2",
       "port-version": 0
     },
     "seacas": {

--- a/versions/s-/sdl3-ttf.json
+++ b/versions/s-/sdl3-ttf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98fed4df9ec2885f00d3d96669068b447296e240",
+      "version": "3.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e04f2a774fa7a6f4668b41641b077c4395e89b73",
       "version": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
