### PR TITLE
[lcms] Update to V2.17

### DIFF
--- a/ports/lcms/portfile.cmake
+++ b/ports/lcms/portfile.cmake
@@ -2,21 +2,14 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     set(SHARED_LIBRARY_PATCH "fix-shared-library.patch")
 endif()
 
-vcpkg_download_distfile(ADD_MISSING_EXPORT_PATCH
-    URLS https://github.com/mm2/Little-CMS/commit/f7b3c637c20508655f8b49935a4b556d52937b69.diff?full_index=1
-    FILENAME Add-missing-export.patch
-    SHA512 4a78f55c07fe5cef5fb9174d466672371283301df89e2825fc47d9fd4c526b291dce11d3896401a3284f4e2093e285c9e5ccbe0011e132576d189e70f66a1325
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mm2/Little-CMS
     REF "lcms${VERSION}"
-    SHA512 c0d857123a0168cb76b5944a20c9e3de1cbe74e2b509fb72a54f74543e9c173474f09d50c495b0a0a295a3c2b47c5fa54a330d057e1a59b5a7e36d3f5a7f81b2
+    SHA512 a7e15f9395eac15971dd6c9d8e33effaa2badc5cd8cfa6152d4b26d653a48ab91438a0f5a2b5faeea033d217f95e459f2659d27849fc110d0e0b5c427c7dcd79
     HEAD_REF master
     PATCHES
         ${SHARED_LIBRARY_PATCH}
-        ${ADD_MISSING_EXPORT_PATCH}
 )
 
 if("fastfloat" IN_LIST FEATURES)
@@ -39,7 +32,6 @@ vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${OPTIONS}
-        -Dsamples=false
 )
 vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()

--- a/ports/lcms/vcpkg.json
+++ b/ports/lcms/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lcms",
-  "version": "2.16",
+  "version": "2.17",
   "description": "Little CMS.",
   "homepage": "https://github.com/mm2/Little-CMS",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4297,7 +4297,7 @@
       "port-version": 7
     },
     "lcms": {
-      "baseline": "2.16",
+      "baseline": "2.17",
       "port-version": 0
     },
     "leaf": {

--- a/versions/l-/lcms.json
+++ b/versions/l-/lcms.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2e326389c873aa7ade1f31337e5df8627147147",
+      "version": "2.17",
+      "port-version": 0
+    },
+    {
       "git-tree": "781f8c60a57e793ac8b9800b3b7cfa6e46f75b44",
       "version": "2.16",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Add-missing-export patch is no longer needed as this is now in the LCMS repo and the samples option is no longer a valid meson option