### PR TITLE
[websocketpp] Add new port

### DIFF
--- a/ports/websocketpp/portfile.cmake
+++ b/ports/websocketpp/portfile.cmake
@@ -11,6 +11,9 @@ set(VCPKG_BUILD_TYPE release)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        BUILD_EXAMPLES=OFF
+        BUILD_TESTS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/websocketpp/portfile.cmake
+++ b/ports/websocketpp/portfile.cmake
@@ -16,9 +16,9 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH cmake/)
-vcpkg_cmake_config_fixup(PACKAGE_NAME websocketpp)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/websocketpp/)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 

--- a/ports/websocketpp/portfile.cmake
+++ b/ports/websocketpp/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH cmake/)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/websocketpp/)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/websocketpp/portfile.cmake
+++ b/ports/websocketpp/portfile.cmake
@@ -1,0 +1,23 @@
+#header-only lib
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO zaphoyd/websocketpp
+    REF 56123c87598f8b1dd471be83ca841ceae07f95ba
+    SHA512 f185a66e5a7c783254352a6ef87e2e559f681032b7368765d08393ed12bcae76825abed7dcaea73de09df644320409dad46279701f5f469520542a2c9b6a6163
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake/)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+

--- a/ports/websocketpp/portfile.cmake
+++ b/ports/websocketpp/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH cmake/)
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/websocketpp/)
+vcpkg_cmake_config_fixup(PACKAGE_NAME websocketpp)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/websocketpp/vcpkg.json
+++ b/ports/websocketpp/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "websocketpp",
+  "version": "0.8.2",
+  "description": "C++ websocket client/server library",
+  "homepage": "https://github.com/zaphoyd/websocketpp",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9926,7 +9926,7 @@
     },
     "websocketpp": {
       "baseline": "0.8.2",
-      "port-version": 4
+      "port-version": 0
     },
     "webthing-cpp": {
       "baseline": "1.2.0",

--- a/versions/w-/websocketpp.json
+++ b/versions/w-/websocketpp.json
@@ -21,7 +21,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "e47feb5d39196897070bb28f76d912ffadabef67",
+      "git-tree": "27766540851cdb5e5880b651dc44e3c42348880a",
       "version-string": "0.8.2",
       "port-version": 0
     },

--- a/versions/w-/websocketpp.json
+++ b/versions/w-/websocketpp.json
@@ -21,7 +21,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "5762be2278bbd39c646fa2b384561bbb740a9d0c",
+      "git-tree": "4675b010cbdb6ccfdee13edf7739610a04356244",
       "version-string": "0.8.2",
       "port-version": 0
     },

--- a/versions/w-/websocketpp.json
+++ b/versions/w-/websocketpp.json
@@ -21,7 +21,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "4675b010cbdb6ccfdee13edf7739610a04356244",
+      "git-tree": "e47feb5d39196897070bb28f76d912ffadabef67",
       "version-string": "0.8.2",
       "port-version": 0
     },

--- a/versions/w-/websocketpp.json
+++ b/versions/w-/websocketpp.json
@@ -21,7 +21,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "c717c6c7fe929ef1c9cc7b2250e78700326940c4",
+      "git-tree": "5762be2278bbd39c646fa2b384561bbb740a9d0c",
       "version-string": "0.8.2",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #44640 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines. (name matches the github repo, but repology appears to be down at the moment)
- [ ] ~~Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).~~
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
