### PR TITLE
[vcpkg baseline][systemc] REMOVE FROM FAIL LIST

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1018,8 +1018,6 @@ suitesparse-graphblas:arm64-windows=fail
 suitesparse-graphblas:arm64-uwp=fail
 suitesparse-graphblas:x64-uwp=fail
 systemc:arm64-uwp=fail
-systemc:arm64-windows-static-md=fail
-systemc:arm64-windows=fail
 systemc:x64-uwp=fail
 teemo:x64-android=fail
 


### PR DESCRIPTION
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=114475&view=results
```
PASSING, REMOVE FROM FAIL LIST: systemc:arm64-windows (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: systemc:arm64-windows-static-md (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
```
Fixed in PR https://github.com/microsoft/vcpkg/pull/44876, so they are removed from `ci.baseline.txt`.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~