### PR TITLE
[yasm] Fix the build error

### DIFF
--- a/ports/yasm/fix-arm-cross-build.patch
+++ b/ports/yasm/fix-arm-cross-build.patch
@@ -1,94 +1,104 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8df871c..2eafe3f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ PROJECT(yasm)
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.4)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+ if (COMMAND cmake_policy)
+     cmake_policy(SET CMP0003 NEW)
+ endif (COMMAND cmake_policy)
 diff --git a/cmake/modules/YasmMacros.cmake b/cmake/modules/YasmMacros.cmake
-index ab1be00..918f51b 100644
+index ab1be00..e6006b3 100644
 --- a/cmake/modules/YasmMacros.cmake
 +++ b/cmake/modules/YasmMacros.cmake
-@@ -58,7 +58,9 @@ macro (YASM_ADD_MODULE _module_NAME)
+@@ -58,31 +58,28 @@ macro (YASM_ADD_MODULE _module_NAME)
  endmacro (YASM_ADD_MODULE)
  
  macro (YASM_GENPERF _in_NAME _out_NAME)
-+    if (NOT _tmp_GENPERF_EXE)
-     get_target_property(_tmp_GENPERF_EXE genperf LOCATION)
-+    endif()
+-    get_target_property(_tmp_GENPERF_EXE genperf LOCATION)
      add_custom_command(
          OUTPUT ${_out_NAME}
-         COMMAND ${_tmp_GENPERF_EXE} ${_in_NAME} ${_out_NAME}
-@@ -68,7 +70,9 @@ macro (YASM_GENPERF _in_NAME _out_NAME)
+-        COMMAND ${_tmp_GENPERF_EXE} ${_in_NAME} ${_out_NAME}
+-        DEPENDS ${_tmp_GENPERF_EXE}
++        COMMAND $<TARGET_FILE:genperf> ${_in_NAME} ${_out_NAME}
++        DEPENDS genperf
+         MAIN_DEPENDENCY ${_in_NAME}
+         )
  endmacro (YASM_GENPERF)
  
  macro (YASM_RE2C _in_NAME _out_NAME)
-+    if (NOT _tmp_RE2C_EXE)
-     get_target_property(_tmp_RE2C_EXE re2c LOCATION)
-+    endif()
+-    get_target_property(_tmp_RE2C_EXE re2c LOCATION)
      add_custom_command(
          OUTPUT ${_out_NAME}
-         COMMAND ${_tmp_RE2C_EXE} ${ARGN} -o ${_out_NAME} ${_in_NAME}
-@@ -78,7 +82,9 @@ macro (YASM_RE2C _in_NAME _out_NAME)
+-        COMMAND ${_tmp_RE2C_EXE} ${ARGN} -o ${_out_NAME} ${_in_NAME}
+-        DEPENDS ${_tmp_RE2C_EXE}
++        COMMAND $<TARGET_FILE:re2c> ${ARGN} -o ${_out_NAME} ${_in_NAME}
++        DEPENDS re2c
+         MAIN_DEPENDENCY ${_in_NAME}
+         )
  endmacro (YASM_RE2C)
  
  macro (YASM_GENMACRO _in_NAME _out_NAME _var_NAME)
-+    if (NOT _tmp_GENMACRO_EXE)
-     get_target_property(_tmp_GENMACRO_EXE genmacro LOCATION)
-+    endif()
+-    get_target_property(_tmp_GENMACRO_EXE genmacro LOCATION)
      add_custom_command(
          OUTPUT ${_out_NAME}
-         COMMAND ${_tmp_GENMACRO_EXE} ${_out_NAME} ${_var_NAME} ${_in_NAME}
+-        COMMAND ${_tmp_GENMACRO_EXE} ${_out_NAME} ${_var_NAME} ${_in_NAME}
+-        DEPENDS ${_tmp_GENMACRO_EXE}
++        COMMAND $<TARGET_FILE:genmacro> ${_out_NAME} ${_var_NAME} ${_in_NAME}
++        DEPENDS genmacro
+         MAIN_DEPENDENCY ${_in_NAME}
+         )
+ endmacro (YASM_GENMACRO)
 diff --git a/modules/preprocs/nasm/CMakeLists.txt b/modules/preprocs/nasm/CMakeLists.txt
-index e10a9dd..e28ffbb 100644
+index e10a9dd..cac1588 100644
 --- a/modules/preprocs/nasm/CMakeLists.txt
 +++ b/modules/preprocs/nasm/CMakeLists.txt
-@@ -1,5 +1,8 @@
-+if (NOT _tmp_GENVERSION_EXE)
+@@ -1,9 +1,8 @@
  add_executable(genversion preprocs/nasm/genversion.c)
-+install(TARGETS genversion RUNTIME DESTINATION bin)
- get_target_property(_tmp_GENVERSION_EXE genversion LOCATION)
-+endif()
+-get_target_property(_tmp_GENVERSION_EXE genversion LOCATION)
  add_custom_command(
      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version.mac
-     COMMAND ${_tmp_GENVERSION_EXE} ${CMAKE_CURRENT_BINARY_DIR}/version.mac
+-    COMMAND ${_tmp_GENVERSION_EXE} ${CMAKE_CURRENT_BINARY_DIR}/version.mac
+-    DEPENDS ${_tmp_GENVERSION_EXE}
++    COMMAND $<TARGET_FILE:genversion> ${CMAKE_CURRENT_BINARY_DIR}/version.mac
++    DEPENDS genversion
+     )
+ 
+ YASM_GENMACRO(
+@@ -23,3 +22,4 @@ YASM_ADD_MODULE(preproc_nasm
+     preprocs/nasm/nasm-eval.c
+     )
+ 
++install(TARGETS genversion RUNTIME DESTINATION bin)
 diff --git a/tools/genmacro/CMakeLists.txt b/tools/genmacro/CMakeLists.txt
-index 27ba599..0168494 100644
+index 27ba599..edf31d8 100644
 --- a/tools/genmacro/CMakeLists.txt
 +++ b/tools/genmacro/CMakeLists.txt
-@@ -1,3 +1,7 @@
-+if (NOT _tmp_GENMACRO_EXE)
+@@ -1,3 +1,5 @@
  add_executable(genmacro
      genmacro.c
      )
 +
 +install(TARGETS genmacro RUNTIME DESTINATION bin)
-+endif()
-\ No newline at end of file
 diff --git a/tools/genperf/CMakeLists.txt b/tools/genperf/CMakeLists.txt
-index 6f50989..87d19bc 100644
+index 6f50989..5228d47 100644
 --- a/tools/genperf/CMakeLists.txt
 +++ b/tools/genperf/CMakeLists.txt
-@@ -1,3 +1,4 @@
-+if (NOT _tmp_GENPERF_EXE)
- add_executable(genperf
-     genperf.c
-     perfect.c
-@@ -6,3 +7,6 @@ add_executable(genperf
+@@ -6,3 +6,5 @@ add_executable(genperf
      ../../libyasm/xstrdup.c
      )
  set_target_properties(genperf PROPERTIES COMPILE_FLAGS -DYASM_LIB_DECL=)
 +
 +install(TARGETS genperf RUNTIME DESTINATION bin)
-+endif()
-\ No newline at end of file
 diff --git a/tools/re2c/CMakeLists.txt b/tools/re2c/CMakeLists.txt
-index 7125d49..f2f1a40 100644
+index 7125d49..0b212d4 100644
 --- a/tools/re2c/CMakeLists.txt
 +++ b/tools/re2c/CMakeLists.txt
-@@ -1,3 +1,4 @@
-+if (NOT _tmp_RE2C_EXE)
- add_executable(re2c
-     main.c
-     code.c
-@@ -9,3 +10,6 @@ add_executable(re2c
+@@ -9,3 +9,5 @@ add_executable(re2c
      substr.c
      translate.c
      )
 +
 +install(TARGETS re2c RUNTIME DESTINATION bin)
-+endif()
-\ No newline at end of file

--- a/ports/yasm/portfile.cmake
+++ b/ports/yasm/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         add-feature-tools.patch
-        fix-arm-cross-build.patch
+        fix-arm-cross-build.patch # https://github.com/yasm/yasm/pull/286
         fix-overlay-pdb.patch
 )
 
@@ -19,21 +19,10 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
 vcpkg_add_to_path("${PYTHON3_DIR}")
 
-set(HOST_TOOLS_OPTIONS "")
-if (VCPKG_CROSSCOMPILING)
-    list(APPEND HOST_TOOLS_OPTIONS
-        "-D_tmp_RE2C_EXE=${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}/re2c${VCPKG_HOST_EXECUTABLE_SUFFIX}"
-        "-D_tmp_GENPERF_EXE=${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}/genperf${VCPKG_HOST_EXECUTABLE_SUFFIX}"
-        "-D_tmp_GENMACRO_EXE=${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}/genmacro${VCPKG_HOST_EXECUTABLE_SUFFIX}"
-        "-D_tmp_GENVERSION_EXE=${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}/genversion${VCPKG_HOST_EXECUTABLE_SUFFIX}"
-    )
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
-        ${HOST_TOOLS_OPTIONS}
         "-DPYTHON_EXECUTABLE=${PYTHON3}"
         -DENABLE_NLS=OFF
         -DYASM_BUILD_TESTS=OFF
@@ -64,4 +53,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 configure_file("${CURRENT_PORT_DIR}/vcpkg-port-config.cmake.in"
     "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-port-config.cmake" @ONLY)
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/yasm/vcpkg.json
+++ b/ports/yasm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "yasm",
   "version": "1.3.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Yasm is a complete rewrite of the NASM assembler under the new BSD License.",
   "homepage": "https://github.com/yasm/yasm",
   "license": "BSD-2-Clause OR BSD-3-Clause OR Artistic-1.0 OR GPL-2.0-only OR LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10250,7 +10250,7 @@
     },
     "yasm": {
       "baseline": "1.3.0",
-      "port-version": 6
+      "port-version": 7
     },
     "yasm-tool": {
       "baseline": "2021-12-14",

--- a/versions/y-/yasm.json
+++ b/versions/y-/yasm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ef6923ea084e2b12ecb1389c7c5bb447c0283e6",
+      "version": "1.3.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "cd30518fa90953d3fa7cc1c0096bf628d2b457be",
       "version": "1.3.0",
       "port-version": 6


### PR DESCRIPTION
Fixes #44941, the upstream fix PR: https://github.com/yasm/yasm/pull/286.
Fix the following errors:
```
CMake Error at cmake/modules/YasmMacros.cmake:74 (get_target_property):
  The LOCATION property may not be read from target "re2c".  Use the target
  name directly with add_custom_command, or use the generator expression
  $<TARGET_FILE>, as appropriate.
```

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
