### PR TITLE
[ampl-asl] Update to 1.0.1

### DIFF
--- a/ports/ampl-asl/portfile.cmake
+++ b/ports/ampl-asl/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ampl/asl
-    REF 2f5d9de248c53a3063bba23af2013cd3db768bf8
-    SHA512 a551420f60b2419285195063fc42b208e59f076d1d00e4b90847c15613997ba35d319d57275687df37e74a7486420fec2cde7da71a6126802ed19a12dcb8ffdc
+    REF ae937db9bd1169ec2c4cb8d75196f67cdcb8041b
+    SHA512 7d0b2decb71397daa88ce328c23e782dab43b32fd6a51f031db8d4eed94abc6261892553faa990236a705a521de45c418261bbeba43f31bbee426c2c177af0cd
     HEAD_REF master
     PATCHES
         workaround-msvc-optimizer-ice.patch

--- a/ports/ampl-asl/vcpkg.json
+++ b/ports/ampl-asl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ampl-asl",
-  "version-date": "2024-02-01",
+  "version": "1.0.1",
   "description": "AMPL Solver Library",
   "homepage": "https://github.com/ampl/asl",
   "license": "BSD-3-Clause",

--- a/versions/a-/ampl-asl.json
+++ b/versions/a-/ampl-asl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb2f7378859875e2021f69f2ea1542d00a920270",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "af475f9134b986c7677f68e74b1658725d60b876",
       "version-date": "2024-02-01",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -113,7 +113,7 @@
       "port-version": 0
     },
     "ampl-asl": {
-      "baseline": "2024-02-01",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "ampl-mp": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.