### PR TITLE
[xaudio2redist, directxtk, directxtk12] Updated for ARM64 support

### DIFF
--- a/ports/directxtk/XAudio2Redist-ARM64.patch
+++ b/ports/directxtk/XAudio2Redist-ARM64.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1eb47e1..e23817e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -196,10 +196,6 @@ if(MINGW)
+   set(BUILD_XAUDIO_WIN8 OFF)
+ endif()
+ 
+-if(${DIRECTX_ARCH} MATCHES "^arm")
+-  set(BUILD_XAUDIO_REDIST OFF)
+-endif()
+-
+ if(WINDOWS_STORE
+    OR BUILD_XAUDIO_WIN10 OR BUILD_XAUDIO_WIN8
+    OR BUILD_XAUDIO_REDIST)
+-- 
+2.49.0.windows.1
+

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -10,6 +10,8 @@ vcpkg_from_github(
     REF ${DIRECTXTK_TAG}
     SHA512 b19291021a338291cde5cee4f9d001309f1503448895d2ec2199901c5993ca5efd719283bc6bdc3d0ee262ae13907ae55995d7df404200c5b860e9e1643d2b0a
     HEAD_REF main
+    PATCHES
+      XAudio2Redist-ARM64.patch
 )
 
 vcpkg_check_features(

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "directxtk",
   "version-date": "2025-03-20",
+  "port-version": 1,
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",

--- a/ports/directxtk12/XAudio2Redist-ARM64.patch
+++ b/ports/directxtk12/XAudio2Redist-ARM64.patch
@@ -1,0 +1,27 @@
+From 1ab7a33d32380b00aab3a78c92091d42ec7da6a2 Mon Sep 17 00:00:00 2001
+From: Chuck Walbourn <chuckw@microsoft.com>
+Date: Fri, 11 Apr 2025 15:15:17 -0700
+Subject: [PATCH] XAudio2Redist now supports ARM64
+
+---
+ CMakeLists.txt | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e5cead7..d49f8c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -213,10 +213,6 @@ if(MINGW)
+   set(BUILD_XAUDIO_WIN10 OFF)
+ endif()
+ 
+-if(${DIRECTX_ARCH} MATCHES "^arm")
+-  set(BUILD_XAUDIO_REDIST OFF)
+-endif()
+-
+ if(WINDOWS_STORE
+    OR BUILD_XAUDIO_WIN10 OR BUILD_XAUDIO_WIN8
+    OR BUILD_XAUDIO_REDIST)
+-- 
+2.49.0.windows.1
+

--- a/ports/directxtk12/XAudio2Redist-ARM64.patch
+++ b/ports/directxtk12/XAudio2Redist-ARM64.patch
@@ -1,12 +1,3 @@
-From 1ab7a33d32380b00aab3a78c92091d42ec7da6a2 Mon Sep 17 00:00:00 2001
-From: Chuck Walbourn <chuckw@microsoft.com>
-Date: Fri, 11 Apr 2025 15:15:17 -0700
-Subject: [PATCH] XAudio2Redist now supports ARM64
-
----
- CMakeLists.txt | 4 ----
- 1 file changed, 4 deletions(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index e5cead7..d49f8c2 100644
 --- a/CMakeLists.txt

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF ${DIRECTXTK_TAG}
     SHA512 d6071bd9493f69357dd5a0c2020a9e78154619dc443e6bdd2e1498ceff0650655c67798968a15377a8904d00e06220ae86fe94d01f7f8afb202bee3d4361a163
     HEAD_REF main
+    PATCHES
+      XAudio2Redist-ARM64.patch
 )
 
 vcpkg_check_features(

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "directxtk12",
   "version-date": "2025-03-20",
+  "port-version": 1,
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",

--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -4,7 +4,7 @@ set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.XAudio2.Redist/${VERSION}"
     FILENAME "xaudio2redist.${VERSION}.zip"
-    SHA512 d9db1e64d31926af252f196238f9793710b53c894c47f2936c5fe3b7d37297711fe293d44f36da189bb6ee34855698569bc51a69cb03d81a49ff3c167cec43b9
+    SHA512 2d2a605cda22d2c6e7918d52cb673cb0b4f4e7c2b4b6ee3e1f988431f5cb6f945a17988574e0faca9465fc4370b222e9e8e23215525f3d6b5c276b1e3dc4476e
 )
 
 vcpkg_extract_source_archive(
@@ -13,10 +13,10 @@ vcpkg_extract_source_archive(
     NO_REMOVE_ONE_LEVEL
 )
 
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-    set(XAUDIO_ARCH x86)
+if(VCPKG_TARGET_ARCHITECTURE MATCHES "arm64|arm64ec")
+    set(XAUDIO_ARCH arm64)
 else()
-    set(XAUDIO_ARCH x64)
+    set(XAUDIO_ARCH ${VCPKG_TARGET_ARCHITECTURE})
 endif()
 
 file(GLOB HEADER_FILES "${PACKAGE_PATH}/build/native/include/*.h")

--- a/ports/xaudio2redist/vcpkg.json
+++ b/ports/xaudio2redist/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "xaudio2redist",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Redistributable version of XAudio 2.9 for Windows 7 SP1 or later",
   "homepage": "https://aka.ms/XAudio2Redist",
   "documentation": "https://aka.ms/XAudio2Redist",
   "license": null,
-  "supports": "windows & !arm & !uwp & !xbox"
+  "supports": "windows & !arm32 & !uwp & !xbox"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10097,7 +10097,7 @@
       "port-version": 2
     },
     "xaudio2redist": {
-      "baseline": "1.2.12",
+      "baseline": "1.2.13",
       "port-version": 0
     },
     "xbitmaps": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2354,11 +2354,11 @@
     },
     "directxtk": {
       "baseline": "2025-03-20",
-      "port-version": 0
+      "port-version": 1
     },
     "directxtk12": {
       "baseline": "2025-03-20",
-      "port-version": 0
+      "port-version": 1
     },
     "dirent": {
       "baseline": "1.25",

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aca1303014bb7b7eb7cf15dcb39367f1ce3f5a7a",
+      "version-date": "2025-03-20",
+      "port-version": 1
+    },
+    {
       "git-tree": "8a796db7cafe8fe0923c9e7dc161edbd77806734",
       "version-date": "2025-03-20",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e0768ed3ea0d2bd0463db355b7c269602de664f7",
+      "git-tree": "417e5eec5f78609b98f0a80ec7338f0745d958f9",
       "version-date": "2025-03-20",
       "port-version": 1
     },

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e0768ed3ea0d2bd0463db355b7c269602de664f7",
+      "version-date": "2025-03-20",
+      "port-version": 1
+    },
+    {
       "git-tree": "8ace684e1940e573914a40d0e21eacded29902f5",
       "version-date": "2025-03-20",
       "port-version": 0

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50b145268b8556817f0ee77897f61ebfc1363ccd",
+      "version": "1.2.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "b57c853317fd34f7f9fb87c4b2d137540bb04415",
       "version": "1.2.12",
       "port-version": 0


### PR DESCRIPTION
Updates XAudio2Redist port for 1.2.13 release which adds ARM64 binaries.

Also updates directxtk, directxtk12 to use ARM64 Xaudio2redist when requested.

