### PR TITLE
[aws-c-cal] Remove OpenSSL dependency from Windows and macOS.

### DIFF
--- a/ports/aws-c-cal/portfile.cmake
+++ b/ports/aws-c-cal/portfile.cmake
@@ -7,12 +7,16 @@ vcpkg_from_github(
     PATCHES remove-libcrypto-messages.patch
 )
 
+if (NOT (VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_OSX))
+    set(USE_OPENSSL ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common" # use extra cmake files
         -DBUILD_TESTING=FALSE
-        -DUSE_OPENSSL=ON
+        -DUSE_OPENSSL=${USE_OPENSSL}
 )
 
 vcpkg_cmake_install()

--- a/ports/aws-c-cal/vcpkg.json
+++ b/ports/aws-c-cal/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "aws-c-cal",
   "version": "0.8.8",
+  "port-version": 1,
   "description": "C99 wrapper for cryptography primitives.",
   "homepage": "https://github.com/awslabs/aws-c-cal",
   "license": "Apache-2.0",
   "dependencies": [
     "aws-c-common",
-    "openssl",
+    {
+      "name": "openssl",
+      "platform": "!windows & !osx"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/a-/aws-c-cal.json
+++ b/versions/a-/aws-c-cal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89bfec3f208df540aae6e782cc9e993b29580c5a",
+      "version": "0.8.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "b4f501b994ed102042e7d3ed48c41a5b49ea88e2",
       "version": "0.8.8",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -418,7 +418,7 @@
     },
     "aws-c-cal": {
       "baseline": "0.8.8",
-      "port-version": 0
+      "port-version": 1
     },
     "aws-c-common": {
       "baseline": "0.12.2",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Partially reverts #43559. Using system crypto libraries where available is better for security and results in compiling less code.

c.c. @fran6co