### PR TITLE
[ryml][c4core] update to 0.9.0, 0.2.6

### DIFF
--- a/ports/c4core/portfile.cmake
+++ b/ports/c4core/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/c4core
     REF "v${VERSION}"
-    SHA512 14cd0afbe5c1907ae150fa916354bfb16849d8faadd569b26d4ca05d425d78a12b2af51a49301c1bcad18b840fa46ba1076fcdd5f5baf07677ec0ced4a9b23de
+    SHA512 027312776141bb93ba96a37190d2ed28a16985390d28dcdec69db1bca198d786633b30ffc66c11c7a05518a7c1d11cd310f650a112f436da4cfd099f03b74691
     HEAD_REF master
     PATCHES
         disable-cpack.patch

--- a/ports/c4core/vcpkg.json
+++ b/ports/c4core/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c4core",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Library of low-level C++ utilities",
   "homepage": "https://github.com/biojppm/c4core",
   "license": "MIT",

--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -10,14 +10,14 @@ vcpkg_from_github(
     PATCHES cmake-fix.patch
 )
 
-set(CM_COMMIT_HASH e87e11f1a10af8aab4e0ceaade0bc7807f207eb1)
+set(CM_COMMIT_HASH fe41e86552046c3df9ba73a40bf3d755df028c1e)
 
 # Get cmake scripts for rapidyaml
 vcpkg_download_distfile(
     CMAKE_ARCHIVE
     URLS "https://github.com/biojppm/cmake/archive/${CM_COMMIT_HASH}.zip"
     FILENAME "cmake-${CM_COMMIT_HASH}.zip"
-    SHA512 a5e161d975fa071b79e3a652c537572d73df59e0fe80e849276959b2a771c82568d7b7621076805ae3ed375301f59224b33c712bd31e9b2df1121d12609d900c
+    SHA512 7292f9856d9c41581f2731e73fdf08880e0f4353b757da38a13ec89b62c5c8cb52b9efc1a9ff77336efa0b6809727c17649e607d8ecacc965a9b2a7a49925237
 )
 
 vcpkg_extract_source_archive(

--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -5,19 +5,19 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/rapidyaml
     REF "v${VERSION}"
-    SHA512 964b17d43c2d8e0f820eaabb19aae594886c4b83668913f1ecf66581ed5c5ee0294551400d24926bcde90f34e1e6b8517761d0a8c8c51e53bd5336761e6d77b4
+    SHA512 f7e635ca2faf83ac83bfbbc4e6ea8ec65c8aa495664e6475e3670b235f6dfa0610399cee05c291b0583abb7a81d8142a3505df12eca062dd06c232f4c5fa252f
     HEAD_REF master
     PATCHES cmake-fix.patch
 )
 
-set(CM_COMMIT_HASH fe41e86552046c3df9ba73a40bf3d755df028c1e)
+set(CM_COMMIT_HASH e87e11f1a10af8aab4e0ceaade0bc7807f207eb1)
 
 # Get cmake scripts for rapidyaml
 vcpkg_download_distfile(
     CMAKE_ARCHIVE
     URLS "https://github.com/biojppm/cmake/archive/${CM_COMMIT_HASH}.zip"
     FILENAME "cmake-${CM_COMMIT_HASH}.zip"
-    SHA512 7292f9856d9c41581f2731e73fdf08880e0f4353b757da38a13ec89b62c5c8cb52b9efc1a9ff77336efa0b6809727c17649e607d8ecacc965a9b2a7a49925237
+    SHA512 a5e161d975fa071b79e3a652c537572d73df59e0fe80e849276959b2a771c82568d7b7621076805ae3ed375301f59224b33c712bd31e9b2df1121d12609d900c
 )
 
 vcpkg_extract_source_archive(

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ryml",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Rapid YAML library",
   "homepage": "https://github.com/biojppm/rapidyaml",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1481,7 +1481,7 @@
       "port-version": 0
     },
     "c4core": {
-      "baseline": "0.2.5",
+      "baseline": "0.2.6",
       "port-version": 0
     },
     "c89stringutils": {
@@ -8313,7 +8313,7 @@
       "port-version": 2
     },
     "ryml": {
-      "baseline": "0.8.0",
+      "baseline": "0.9.0",
       "port-version": 0
     },
     "ryu": {

--- a/versions/c-/c4core.json
+++ b/versions/c-/c4core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c6944f18c1c3263b0360dbab29544e752d2d7d1",
+      "version": "0.2.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "65a14492c99ee904e56fc2b74182c2f7b5db3b73",
       "version": "0.2.5",
       "port-version": 0

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "50c535ac5f4bc532f1b00cc561d4d4c7f997e5cb",
+      "git-tree": "714fd320270b1be1c0af06b08a06dfd50b2f7293",
       "version": "0.9.0",
       "port-version": 0
     },

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50c535ac5f4bc532f1b00cc561d4d4c7f997e5cb",
+      "version": "0.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ea4ece3aece3ddc82a5655cdf0fbc78ad4fea8f9",
       "version": "0.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/biojppm/rapidyaml/releases/tag/v0.9.0
https://github.com/biojppm/c4core/releases/tag/v0.2.6

