### PR TITLE
[vk-bootstrap] Bump version to 1.4.312

### DIFF
--- a/ports/vk-bootstrap/portfile.cmake
+++ b/ports/vk-bootstrap/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO charles-lunarg/vk-bootstrap
     REF "v${VERSION}"
-    SHA512 f925665b1d7a1c5069ca2cb6786f537bcc4b3060757db50d931091dc37ff4ef3b73b1b3adf0da84c256979fd780a2f6203de3299f634292600dcee925b9a5091
+    SHA512 d55752fbaa84ecf8c674eb9c8639553db2631024797e62b807078c95601dd711263381443d52ddd2ef6635d61ffcacd39650aa638363cf1d124ff0a37010c2d9
     HEAD_REF master
     PATCHES
         fix-targets.patch

--- a/ports/vk-bootstrap/vcpkg.json
+++ b/ports/vk-bootstrap/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vk-bootstrap",
-  "version": "1.3.279",
+  "version": "1.4.312",
   "port-version": 1,
   "description": "Vulkan bootstraping library",
   "homepage": "https://github.com/charles-lunarg/vk-bootstrap",

--- a/ports/vk-bootstrap/vcpkg.json
+++ b/ports/vk-bootstrap/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vk-bootstrap",
   "version": "1.4.312",
-  "port-version": 1,
   "description": "Vulkan bootstraping library",
   "homepage": "https://github.com/charles-lunarg/vk-bootstrap",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9793,8 +9793,8 @@
       "port-version": 0
     },
     "vk-bootstrap": {
-      "baseline": "1.3.279",
-      "port-version": 1
+      "baseline": "1.4.312",
+      "port-version": 0
     },
     "vkfft": {
       "baseline": "1.2.31",

--- a/versions/v-/vk-bootstrap.json
+++ b/versions/v-/vk-bootstrap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "568c66b9021388111729f9ce67d6b860b1b00b06",
+      "version": "1.4.312",
+      "port-version": 0
+    },
+    {
       "git-tree": "33aa9fad865d5e7536507780f794845077d75a9c",
       "version": "1.3.279",
       "port-version": 1


### PR DESCRIPTION
Fixes #45005

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
