### PR TITLE
[fluidsynth] Update to 2.4.5

### DIFF
--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FluidSynth/fluidsynth
     REF "v${VERSION}"
-    SHA512 a380bd710c4b7fe83fc6799c56f51c9d4c3d21516b9366f8381c7fdb899c195472fe4bded9c25ab9de9c76fc95a4e727a8b0305ab92b5ede025fd03585036aa3
+    SHA512 cf41eb338fccaafaa6961b8ca9eec6e8f0e35d25ec8f1d6f621fc73bd4b43b301dfe027db4252424118d1772568b949542820777a74b651a3f32c5028a34ed61
     HEAD_REF master
     PATCHES
         gentables.patch

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fluidsynth",
-  "version": "2.4.4",
-  "port-version": 1,
+  "version": "2.4.5",
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2881,8 +2881,8 @@
       "port-version": 0
     },
     "fluidsynth": {
-      "baseline": "2.4.4",
-      "port-version": 1
+      "baseline": "2.4.5",
+      "port-version": 0
     },
     "flux": {
       "baseline": "0.4.0",

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9bc8118eda57fe75d0995bf411c55f6ce67bcade",
+      "version": "2.4.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "f386155bd6f328d8c38ed1a95306d4522aa5481f",
       "version": "2.4.4",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.