### PR TITLE
[qt-advanced-docking-system] add pdb copy

### DIFF
--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_cmake_configure(
         -DBUILD_STATIC=${BUILD_STATIC}
 )
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(PACKAGE_NAME "qtadvanceddocking-qt6" CONFIG_PATH "lib/cmake/qtadvanceddocking-qt6")
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/qtadvanceddocking-qt6/qtadvanceddocking-qt6Config.cmake"

--- a/ports/qt-advanced-docking-system/vcpkg.json
+++ b/ports/qt-advanced-docking-system/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt-advanced-docking-system",
   "version": "4.4.0",
+  "port-version": 1,
   "description": "Create customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio",
   "homepage": "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7562,7 +7562,7 @@
     },
     "qt-advanced-docking-system": {
       "baseline": "4.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qt3d": {
       "baseline": "6.8.3",

--- a/versions/q-/qt-advanced-docking-system.json
+++ b/versions/q-/qt-advanced-docking-system.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b360686d52733a11331ecfaa6adc482c54f9f2a",
+      "version": "4.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d0416590051af6df9d6aa0f1f1591b8b18ab0905",
       "version": "4.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.