### PR TITLE
[fineftp] Update to 1.5.1

### DIFF
--- a/ports/fineftp/portfile.cmake
+++ b/ports/fineftp/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eclipse-ecal/fineftp-server
     REF "v${VERSION}"
-    SHA512 dcced2cf743434a55314ad661ca729efc1c4883ae0c0883335f43a12ed47568ebcb50d233dab8a1410bb526587b24f1cf19938241bf649cfe54b11ffe264124b
+    SHA512 10e6fe6724e1751cb72d212f5fc8053b9c715e79ab41b080beb35c3501377b9e8fd8137de0b30266709aa34432dfa4593026db1b04735f7c1a4dbde90763ea97
     HEAD_REF master
     PATCHES
         asio.patch

--- a/ports/fineftp/vcpkg.json
+++ b/ports/fineftp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "fineftp",
-  "version": "1.3.4",
+  "version": "1.5.1",
   "description": "FineFTP is a minimal FTP server library for Windows and Unix flavors.",
   "homepage": "https://github.com/eclipse-ecal/fineftp-server",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2801,7 +2801,7 @@
       "port-version": 2
     },
     "fineftp": {
-      "baseline": "1.3.4",
+      "baseline": "1.5.1",
       "port-version": 0
     },
     "fins": {

--- a/versions/f-/fineftp.json
+++ b/versions/f-/fineftp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d03fb60d6d482ea88aba0acfffb07b28abb0ef69",
+      "version": "1.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "379dd5cfe0c3cad96197e14aa9782daf51daca3d",
       "version": "1.3.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
This PR fixes the port's dependency on an older version of asio