### PR TITLE
[spimpl] Add spimpl port

### DIFF
--- a/ports/spimpl/portfile.cmake
+++ b/ports/spimpl/portfile.cmake
@@ -6,8 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+file(INSTALL "${SOURCE_PATH}/spimpl.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-spimpl-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/spimpl.h")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "[*]/.*" "*/" REGEX)
 
-file(INSTALL "${SOURCE_PATH}/spimpl.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/spimpl")
-
-file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/spimpl/portfile.cmake
+++ b/ports/spimpl/portfile.cmake
@@ -1,0 +1,13 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO oliora/samples
+    REF 58dead450bdac418fc55dfc512b8411556f51c0e
+    SHA512 a244364c3a58cb75709861cc8637dadeada0fbb4bc5fc52886a61d52623b3dab75ed5ccd73bed1a4384f66753fc3fd16e8cafde925fce760add084b4fffeca97
+    HEAD_REF master
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/spimpl.h")
+
+file(INSTALL "${SOURCE_PATH}/spimpl.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/spimpl")
+
+file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/spimpl/unofficial-spimpl-config.cmake
+++ b/ports/spimpl/unofficial-spimpl-config.cmake
@@ -1,0 +1,7 @@
+add_library(unofficial::spimpl::spimpl INTERFACE IMPORTED)
+
+set_target_properties(
+  unofficial::spimpl::spimpl
+  PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../../include"
+)

--- a/ports/spimpl/unofficial-spimpl-config.cmake
+++ b/ports/spimpl/unofficial-spimpl-config.cmake
@@ -1,7 +1,8 @@
-add_library(unofficial::spimpl::spimpl INTERFACE IMPORTED)
-
-set_target_properties(
-  unofficial::spimpl::spimpl
-  PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../../include"
-)
+if(NOT TARGET unofficial::spimpl::spimpl)
+  add_library(unofficial::spimpl::spimpl INTERFACE IMPORTED)
+  set_target_properties(
+    unofficial::spimpl::spimpl
+    PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../../include"
+  )
+endif()

--- a/ports/spimpl/vcpkg.json
+++ b/ports/spimpl/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "spimpl",
+  "version": "1.2.0",
+  "description": "A single-header C++ library for PIMPLs without having to implement any special member functions.",
+  "homepage": "https://github.com/oliora/samples",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/spimpl/vcpkg.json
+++ b/ports/spimpl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "spimpl",
-  "version": "1.2.0",
+  "version-date": "2025-01-23",
   "description": "A single-header C++ library for PIMPLs without having to implement any special member functions.",
   "homepage": "https://github.com/oliora/samples",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8848,6 +8848,10 @@
       "baseline": "2.5.0",
       "port-version": 0
     },
+    "spimpl": {
+      "baseline": "1.2.0",
+      "port-version": 0
+    },
     "spine-runtimes": {
       "baseline": "4.1.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8849,7 +8849,7 @@
       "port-version": 0
     },
     "spimpl": {
-      "baseline": "1.2.0",
+      "baseline": "2025-01-23",
       "port-version": 0
     },
     "spine-runtimes": {

--- a/versions/s-/spimpl.json
+++ b/versions/s-/spimpl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6853f71520f2309ead2c9c30e66308b84acee681",
+      "git-tree": "7289ca47c23ec9ff71ba553afb89c1becec90adc",
       "version-date": "2025-01-23",
       "port-version": 0
     }

--- a/versions/s-/spimpl.json
+++ b/versions/s-/spimpl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6853f71520f2309ead2c9c30e66308b84acee681",
+      "version-date": "2025-01-23",
+      "port-version": 0
+    },
+    {
       "git-tree": "1129b511545a052580abd1630e4751d4093c8fe0",
       "version": "1.2.0",
       "port-version": 0

--- a/versions/s-/spimpl.json
+++ b/versions/s-/spimpl.json
@@ -4,11 +4,6 @@
       "git-tree": "6853f71520f2309ead2c9c30e66308b84acee681",
       "version-date": "2025-01-23",
       "port-version": 0
-    },
-    {
-      "git-tree": "1129b511545a052580abd1630e4751d4093c8fe0",
-      "version": "1.2.0",
-      "port-version": 0
     }
   ]
 }

--- a/versions/s-/spimpl.json
+++ b/versions/s-/spimpl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1129b511545a052580abd1630e4751d4093c8fe0",
+      "version": "1.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] ~~Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).~~
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] ~~The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
