### PR TITLE
[ada-idna] update to 0.3.3

### DIFF
--- a/ports/ada-idna/portfile.cmake
+++ b/ports/ada-idna/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ada-url/idna
     REF "${VERSION}"
-    SHA512 d0176445c0f98f6adc399c4a853248bd4b34cae9d151baf85ee60d285ec0fab59adeb4b3997fca0e9554bc6781bb7b6ac9ce74e8e3f1f04e863ea15c6b61845e
+    SHA512 cc113fc1ea4602ea262658d17f57ca0ef1a7ce2ee0d02de5379e9c58a5ac6a3afa59d3d43336505d13e75a764da431a3db809962d077a9dc27b9e0fa672ee82e
     HEAD_REF main
     PATCHES
         install.patch

--- a/ports/ada-idna/vcpkg.json
+++ b/ports/ada-idna/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ada-idna",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "C++ library implementing the to_ascii and to_unicode functions from the Unicode Technical Standard.",
   "homepage": "https://github.com/ada-url/idna",
   "license": "Apache-2.0 AND MIT",

--- a/versions/a-/ada-idna.json
+++ b/versions/a-/ada-idna.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c74dda0a2da1ded40b16efad9c84ab361eb6980",
+      "version": "0.3.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "08833326cf37f9782d88c2918e55ea31570647a1",
       "version": "0.3.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -37,7 +37,7 @@
       "port-version": 17
     },
     "ada-idna": {
-      "baseline": "0.3.2",
+      "baseline": "0.3.3",
       "port-version": 0
     },
     "ada-url": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ada-url/idna/releases/tag/0.3.3
