### PR TITLE
[llnl-units] Minor changes

### DIFF
--- a/ports/llnl-units/portfile.cmake
+++ b/ports/llnl-units/portfile.cmake
@@ -21,15 +21,18 @@ vcpkg_cmake_configure(
         -DUNITS_BUILD_FUZZ_TARGETS=OFF
         -DLLNL-UNITS_ENABLE_ERROR_ON_WARNINGS=OFF
         -DLLNL-UNITS_ENABLE_EXTRA_COMPILER_WARNINGS=OFF
+    OPTIONS_DEBUG
+        -DUNITS_BUILD_CONVERTER_APP=OFF
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME llnl-units CONFIG_PATH lib/cmake/llnl-units)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/llnl-units)
 
 if("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES units_convert AUTO_CLEAN)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/llnl-units/usage
+++ b/ports/llnl-units/usage
@@ -1,4 +1,4 @@
 llnl-units provides CMake targets:
 
-    find_package(llnl-units CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE llnl-units::units)
+  find_package(llnl-units CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE llnl-units::units)

--- a/ports/llnl-units/vcpkg.json
+++ b/ports/llnl-units/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "llnl-units",
   "version": "0.13.1",
+  "port-version": 1,
   "description": "A run-time C++ library for working with units of measurement and conversions between them and with string representations of units and measurements",
   "homepage": "https://github.com/LLNL/units",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5710,7 +5710,7 @@
     },
     "llnl-units": {
       "baseline": "0.13.1",
-      "port-version": 0
+      "port-version": 1
     },
     "llvm": {
       "baseline": "18.1.6",

--- a/versions/l-/llnl-units.json
+++ b/versions/l-/llnl-units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "30421187cd028f08ac55f38e9440ad885e132852",
+      "version": "0.13.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e932658fccacda8567de8356c25fda00271707a2",
       "version": "0.13.1",
       "port-version": 0


### PR DESCRIPTION
FTR llnl-units avoids filesystem and cmake namespace clashes with port units (which is nholthaus-units) by using the `llnl-` prefix. But they can't be used together because they both use the `units::` C++ namespace and disagree at least on the definition of `unit::unit`:

~~~
/vcpkg/installed/x64-linux/include/units.h:819:54: error: ‘units::unit’ is not a template
  819 |         template <class, class, class, class> struct unit;
...
/vcpkg/installed/x64-linux/include/llnl-units/units_decl.hpp:606:7: note: previous declaration here
  606 | class unit {
      |       ^~~~
~~~

(From local test port.)