### PR TITLE
[jemalloc] Fix exception specification error for hosts using musl libc

### DIFF
--- a/ports/jemalloc/fix-host-use-libc.patch
+++ b/ports/jemalloc/fix-host-use-libc.patch
@@ -1,0 +1,13 @@
+diff --git a/include/jemalloc/jemalloc_macros.h.in b/include/jemalloc/jemalloc_macros.h.in
+index ebb3137..05d996b 100644
+--- a/include/jemalloc/jemalloc_macros.h.in
++++ b/include/jemalloc/jemalloc_macros.h.in
+@@ -142,7 +142,7 @@
+ #  define JEMALLOC_COLD
+ #endif
+ 
+-#if (defined(__APPLE__) || defined(__FreeBSD__)) && !defined(JEMALLOC_NO_RENAME)
++#if (defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || (defined(__linux__) && !defined(__GLIBC__))) && !defined(JEMALLOC_NO_RENAME)
+ #  define JEMALLOC_SYS_NOTHROW
+ #else
+ #  define JEMALLOC_SYS_NOTHROW JEMALLOC_NOTHROW

--- a/ports/jemalloc/portfile.cmake
+++ b/ports/jemalloc/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-configure-ac.patch
         preprocessor.patch
+        fix-host-use-libc.patch # https://github.com/jemalloc/jemalloc/commit/45249cf5a9cfa13c2c62e68e272a391721523b4b
 )
 if(VCPKG_TARGET_IS_WINDOWS)
     set(opts "ac_cv_search_log=none required" "--without-private-namespace")

--- a/ports/jemalloc/vcpkg.json
+++ b/ports/jemalloc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "jemalloc",
   "version": "5.3.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "jemalloc is a general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support",
   "homepage": "https://jemalloc.net/",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3910,7 +3910,7 @@
     },
     "jemalloc": {
       "baseline": "5.3.0",
-      "port-version": 2
+      "port-version": 3
     },
     "jhasse-poly2tri": {
       "baseline": "2023-12-27",

--- a/versions/j-/jemalloc.json
+++ b/versions/j-/jemalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f72ec0f582114964b0cc3cff8c436e00e64da65",
+      "version": "5.3.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "c89a63053caf864aff15f36cf9fa0e6b2ded6bfc",
       "version": "5.3.0",
       "port-version": 2


### PR DESCRIPTION
Fixes #45007, apply the patch from upstream https://github.com/jemalloc/jemalloc/commit/45249cf5a9cfa13c2c62e68e272a391721523b4b to fix exception specification error for hosts using musl `libc`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
