### PR TITLE
[restinio] Update to 0.7.6

### DIFF
--- a/ports/restinio/portfile.cmake
+++ b/ports/restinio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stiffstream/restinio
     REF "v${VERSION}"
-    SHA512 f3562f6ce470ac43941c7cd42709c3e9b53d7bfc8b9763979579a4538b8d5eee9b59ab199da9a46e027dbfd04ada4fe4b635aabf8ba9f85bbfa2f6b49bf35b9a
+    SHA512 2ce55df175d7a92601c36e0a765366207853f9e5886d25765f56443a79feeefa56e61add11024f9595b8094e303574df853d6a10b8fbf0c3aa31729668c67471
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only

--- a/ports/restinio/vcpkg.json
+++ b/ports/restinio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "restinio",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "A header-only C++14 library that gives you an embedded HTTP/Websocket server targeted primarily for asynchronous processing of HTTP-requests.",
   "homepage": "https://github.com/Stiffstream/restinio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8161,7 +8161,7 @@
       "port-version": 0
     },
     "restinio": {
-      "baseline": "0.7.5",
+      "baseline": "0.7.6",
       "port-version": 0
     },
     "resultlib": {

--- a/versions/r-/restinio.json
+++ b/versions/r-/restinio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "31d51d5a606347c0f3d22c35da89d25026d95eec",
+      "version": "0.7.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "00a95df9c19ea20c8370814d26995a6f6ecc44ca",
       "version": "0.7.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- ~~[ ] The "supports" clause reflects platforms that may be fixed by this new version.~~
- ~~[ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- ~~[ ] Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
