### PR TITLE
[tbb] Force TBB as dynamic library

### DIFF
--- a/ports/tbb/portfile.cmake
+++ b/ports/tbb/portfile.cmake
@@ -1,6 +1,10 @@
 
 set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
 
+# TBB static library is strongly not recommended
+# It can result in thread oversubscription and crash at exit in case TBB is used in multiple shared libraries
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oneapi-src/oneTBB

--- a/ports/tbb/vcpkg.json
+++ b/ports/tbb/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "tbb",
   "version": "2022.0.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Intel's Threading Building Blocks.",
   "homepage": "https://github.com/oneapi-src/oneTBB",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9110,7 +9110,7 @@
     },
     "tbb": {
       "baseline": "2022.0.0",
-      "port-version": 2
+      "port-version": 3
     },
     "tcb-span": {
       "baseline": "2022-06-15",

--- a/versions/t-/tbb.json
+++ b/versions/t-/tbb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ffa58b53207469b7ee8169b724e923604531fcb",
+      "version": "2022.0.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "7ba5ca689237e53e47f3c9375736ebf901e919ef",
       "version": "2022.0.0",
       "port-version": 2


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
