### PR TITLE
[xlnt] Update to version 1.6.1

### DIFF
--- a/ports/xlnt/portfile.cmake
+++ b/ports/xlnt/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xlnt-community/xlnt
     REF "v${VERSION}"
-    SHA512 1051c2af1d37f3b0122a89fba2cb43d5779a3b8012cc978a5366e6ab721dc067819a6d301e0ebe214a1b0bac0281c8e1b7f56bfa5f41ec80dbf88d0cbaaaeb05
+    SHA512 2d016416447b56c3902fc86c0441fd1d10cb86c3a542a2a38929e32f8f55470c33e4a3938f9c47b1a672ac4d6784a981c4738a61fd076622a2baa64dbc632810
     HEAD_REF master
     PATCHES
         fix-not-found-include.patch

--- a/ports/xlnt/vcpkg.json
+++ b/ports/xlnt/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "xlnt",
-  "version": "1.6.0",
-  "description": "Cross-platform user-friendly xlsx library for C++11 (and above)",
+  "version": "1.6.1",
+  "description": "Cross-platform user-friendly xlsx (Microsoft Excel®) library for C++11 (and above)",
   "homepage": "https://github.com/xlnt-community/xlnt",
-  "license": "MIT OR BSD-3-Clause OR BSD-2-Clause OR LGPL-3.0-only OR BSL-1.0",
+  "documentation": "https://xlnt-community.gitbook.io/xlnt",
+  "license": "MIT AND BSD-3-Clause AND BSD-2-Clause",
   "dependencies": [
     "fast-float",
     "fmt",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10169,7 +10169,7 @@
       "port-version": 3
     },
     "xlnt": {
-      "baseline": "1.6.0",
+      "baseline": "1.6.1",
       "port-version": 0
     },
     "xlsxio": {

--- a/versions/x-/xlnt.json
+++ b/versions/x-/xlnt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c28a307d002509a5664301322ebc75024146b299",
+      "version": "1.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4f4ec481bbcbc1fef452d156abf7d8539ce5e08b",
       "version": "1.6.0",
       "port-version": 0


### PR DESCRIPTION
Corrected license information: main library is licensed under MIT, but some dependencies are licensed under BSD / BSL instead.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.