### PR TITLE
[open62541] Remove amalgamation feature

### DIFF
--- a/ports/open62541/portfile.cmake
+++ b/ports/open62541/portfile.cmake
@@ -21,7 +21,6 @@ vcpkg_replace_string("${SOURCE_PATH}/tools/cmake/open62541Config.cmake.in" "find
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        amalgamation UA_ENABLE_AMALGAMATION
         diagnostics UA_ENABLE_DIAGNOSTICS
         discovery UA_ENABLE_DISCOVERY
         historizing UA_ENABLE_HISTORIZING

--- a/ports/open62541/vcpkg.json
+++ b/ports/open62541/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "open62541",
   "version": "1.3.15",
-  "port-version": 2,
+  "port-version": 3,
   "description": "open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.",
   "homepage": "https://open62541.org",
   "license": "MPL-2.0",
@@ -22,9 +22,6 @@
     "subscriptions-events"
   ],
   "features": {
-    "amalgamation": {
-      "description": "Concatenate the library to a single file open62541.h/.c"
-    },
     "diagnostics": {
       "description": "Enable diagnostics information exposed by the server",
       "dependencies": [

--- a/ports/qtopcua/fix-build.patch
+++ b/ports/qtopcua/fix-build.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/FindOpen62541.cmake b/cmake/FindOpen62541.cmake
-index b4fcea410..91958e554 100644
+index b4fcea4..67e180f 100644
 --- a/cmake/FindOpen62541.cmake
 +++ b/cmake/FindOpen62541.cmake
 @@ -21,6 +21,7 @@
@@ -10,19 +10,31 @@ index b4fcea410..91958e554 100644
  find_path(Open62541_INCLUDE_DIRS
      NAMES open62541.h
      HINTS "${OPEN62541_INCDIR}")
-@@ -46,6 +47,15 @@ if (Open62541_FOUND)
+@@ -46,6 +47,11 @@ if (Open62541_FOUND)
  endif()
  
  mark_as_advanced(Open62541_INCLUDE_DIRS Open62541_LIBRARIES)
-+else()
-+    find_package(open62541 CONFIG REQUIRED)
-+    if(NOT TARGET open62541)
-+        add_library(open62541 INTERFACE IMPORTED)
-+        set_property(TARGET open62541 APPEND PROPERTY
-+            INTERFACE_LINK_LIBRARIES open62541::open62541)
-+    endif()
-+    set(Open62541_FOUND ON)
++endif()
++find_package(Open62541 NAMES open62541)
++if(Open62541_FOUND AND TARGET open62541::open62541 AND NOT TARGET open62541)
++    add_library(open62541 ALIAS open62541::open62541)
 +endif()
  
  include(FeatureSummary)
  set_package_properties(Open62541 PROPERTIES
+diff --git a/src/plugins/opcua/open62541/qopen62541.h b/src/plugins/opcua/open62541/qopen62541.h
+index a4f63df..877888b 100644
+--- a/src/plugins/opcua/open62541/qopen62541.h
++++ b/src/plugins/opcua/open62541/qopen62541.h
+@@ -18,7 +18,10 @@
+ #pragma clang diagnostic ignored "-Wunused-parameter"
+ #endif
+ 
+-#include <open62541.h>
++#include <open62541/client.h>
++#include <open62541/client_config_default.h>
++#include <open62541/client_subscriptions.h>
++#include <open62541/server.h>
+ 
+ #if defined(_MSC_VER)
+ #pragma warning(pop)

--- a/ports/qtopcua/vcpkg.json
+++ b/ports/qtopcua/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtopcua",
   "version": "6.8.3",
+  "port-version": 1,
   "description": "The Qt OPC UA module implements a Qt API to interact with OPC UA on top of a 3rd party OPC UA stack.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -41,7 +42,6 @@
           "name": "open62541",
           "default-features": false,
           "features": [
-            "amalgamation",
             "historizing",
             "openssl"
           ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7850,7 +7850,7 @@
     },
     "qtopcua": {
       "baseline": "6.8.3",
-      "port-version": 0
+      "port-version": 1
     },
     "qtpositioning": {
       "baseline": "6.8.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6786,7 +6786,7 @@
     },
     "open62541": {
       "baseline": "1.3.15",
-      "port-version": 2
+      "port-version": 3
     },
     "open62541pp": {
       "baseline": "0.17.0",

--- a/versions/o-/open62541.json
+++ b/versions/o-/open62541.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7ed2cdee853c7b51d70e02cbf56b76d06b60652",
+      "version": "1.3.15",
+      "port-version": 3
+    },
+    {
       "git-tree": "b82eadc5a4096f707d0f1cfd7e6982f3cec1d04d",
       "version": "1.3.15",
       "port-version": 2

--- a/versions/q-/qtopcua.json
+++ b/versions/q-/qtopcua.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53f0e3d81d4a77abd47a4a1bf90458015c257cdc",
+      "version": "6.8.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "7a00f40ebed9f440209d4bd46f4a6892c38ed8d1",
       "version": "6.8.3",
       "port-version": 0


### PR DESCRIPTION
[Not recommended for installation](https://github.com/open62541/open62541/blob/3eed1a6d5c5b207c531b2d35ed88aa0a4a4541e5/CMakeLists.txt#L1653-L1657), and [entirely unsupported for installation](https://github.com/open62541/open62541/blob/2aa764b640c3f049e71e64661ff10eb1f513878c/CMakeLists.txt#L1494-L1496) in next minor version.
This also removes the convenient amalgamated open62541.h header, but https://github.com/open62541/open62541/pull/2292#discussion_r241106424.
For https://github.com/microsoft/vcpkg/pull/45011#issuecomment-2807316535.
