### PR TITLE
[opentelemetry-cpp-contrib-version] Update to 2025-04-15

### DIFF
--- a/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
@@ -4,9 +4,9 @@ function(clone_opentelemetry_cpp_contrib CONTRIB_SOURCE_PATH)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-telemetry/opentelemetry-cpp-contrib
-        REF 69b8a42741b7f7063ad063d7957f7bc97bf701a4
+        REF 12a60a7009c900797ca0609e9f611d640da4548e
         HEAD_REF main
-        SHA512 1db239ab73f7c4d8ba97d42dd9f97b728d18a9a3a2fad342fda66231f0144aae829d9ceebd584979acc026aa9f0ca7aac0b73aa4eff2fc2f1f059b0f53eaecd3
+        SHA512 b41f3ea435f47af086e6a1477fa3f77c6d2b3e7c04e08d559cb17c35365e17395c3ee8a795e22acd0315e261fdf5713be73997e15d8c83edf87fbc463c0a3449
     )
     set(${CONTRIB_SOURCE_PATH} ${SOURCE_PATH} CACHE INTERNAL "")
 endfunction()

--- a/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
@@ -4,9 +4,9 @@ function(clone_opentelemetry_cpp_contrib CONTRIB_SOURCE_PATH)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-telemetry/opentelemetry-cpp-contrib
-        REF 12a60a7009c900797ca0609e9f611d640da4548e
+        REF 6392b5ff2ebd134e3aa359adc97a2ed37888977c
         HEAD_REF main
-        SHA512 b41f3ea435f47af086e6a1477fa3f77c6d2b3e7c04e08d559cb17c35365e17395c3ee8a795e22acd0315e261fdf5713be73997e15d8c83edf87fbc463c0a3449
+        SHA512 8318031c203691e6fa4ffc363d3a37642b2705898bd25b23acd211489c2006c268c3e333c7bef8685d762a8b31b762b96f4d175f6edb9eaf29047852c568e31f
     )
     set(${CONTRIB_SOURCE_PATH} ${SOURCE_PATH} CACHE INTERNAL "")
 endfunction()

--- a/ports/opentelemetry-cpp-contrib-version/vcpkg.json
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp-contrib-version",
-  "version-date": "2025-04-02",
+  "version-date": "2025-04-15",
   "description": "This port manages the opentelemetry-cpp-version that will be used for opentelemetry-cpp",
   "homepage": "https://github.com/open-telemetry/opentelemetry-cpp-contrib",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6933,7 +6933,7 @@
       "port-version": 0
     },
     "opentelemetry-cpp-contrib-version": {
-      "baseline": "2025-04-02",
+      "baseline": "2025-04-15",
       "port-version": 0
     },
     "opentracing": {

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f314d39b193dc6cb3832e519b5705bcb493b7c85",
+      "version-date": "2025-04-12",
+      "port-version": 0
+    },
+    {
       "git-tree": "f5c77c975f7a824161b4fdf62cb3d0b8fb2428f3",
       "version-date": "2025-04-02",
       "port-version": 0

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "f314d39b193dc6cb3832e519b5705bcb493b7c85",
-      "version-date": "2025-04-12",
+      "version-date": "2025-04-15",
       "port-version": 0
     },
     {

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f314d39b193dc6cb3832e519b5705bcb493b7c85",
+      "git-tree": "ed3cde2d60d5eae17855cef965147a2bbb712b33",
       "version-date": "2025-04-15",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
