### PR TITLE
[openssl] Backport a Windows crash fix patch for 3.5

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -7,6 +7,14 @@ if(VCPKG_TARGET_IS_EMSCRIPTEN)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
+# Download fix for cert store crash on Windows
+vcpkg_download_distfile(
+    CMAKE_SUPPORT_PATCH
+    URLS https://github.com/openssl/openssl/commit/2b5e7253b9a6a4cde64d3f2f22d71272f6ad32c5.patch?full_index=1
+    FILENAME windows/certstore-crash.patch
+    SHA512 a13054a457ee72fd3d1760810b5323d04be5aaf18f199824515ca596a72e98154ace4fefd747e32a7cc32c6e4ed2363b100bf65a729cf2361fcc76715d5b7cd1
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openssl/openssl
@@ -18,6 +26,7 @@ vcpkg_from_github(
         script-prefix.patch
         windows/install-layout.patch
         windows/install-pdbs.patch
+        windows/certstore-crash.patch
         unix/android-cc.patch
         unix/move-openssldir.patch
         unix/no-empty-dirs.patch

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -11,7 +11,7 @@ endif()
 vcpkg_download_distfile(
     WINDOWS_CRASH_PATCH
     URLS https://github.com/openssl/openssl/commit/2b5e7253b9a6a4cde64d3f2f22d71272f6ad32c5.patch?full_index=1
-    FILENAME windows/certstore-crash.patch
+    FILENAME openssl-certstore-crash-2b5e7253b9a6a4cde64d3f2f22d71272f6ad32c5.patch
     SHA512 a13054a457ee72fd3d1760810b5323d04be5aaf18f199824515ca596a72e98154ace4fefd747e32a7cc32c6e4ed2363b100bf65a729cf2361fcc76715d5b7cd1
 )
 

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -9,7 +9,7 @@ endif()
 
 # Download fix for cert store crash on Windows
 vcpkg_download_distfile(
-    CMAKE_SUPPORT_PATCH
+    WINDOWS_CRASH_PATCH
     URLS https://github.com/openssl/openssl/commit/2b5e7253b9a6a4cde64d3f2f22d71272f6ad32c5.patch?full_index=1
     FILENAME windows/certstore-crash.patch
     SHA512 a13054a457ee72fd3d1760810b5323d04be5aaf18f199824515ca596a72e98154ace4fefd747e32a7cc32c6e4ed2363b100bf65a729cf2361fcc76715d5b7cd1
@@ -26,7 +26,7 @@ vcpkg_from_github(
         script-prefix.patch
         windows/install-layout.patch
         windows/install-pdbs.patch
-        windows/certstore-crash.patch
+        "${WINDOWS_CRASH_PATCH}"
         unix/android-cc.patch
         unix/move-openssldir.patch
         unix/no-empty-dirs.patch

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openssl",
   "version": "3.5.0",
+  "port-version": 1,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6922,7 +6922,7 @@
     },
     "openssl": {
       "baseline": "3.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opensubdiv": {
       "baseline": "3.5.0",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cba3da237d6cda8f22a1f1b4fcac5ecf3dfd9655",
+      "git-tree": "6819498ce6c5c3e379b3ffbd2b5d93e3fc271933",
       "version": "3.5.0",
       "port-version": 1
     },

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e565e4a2590e7d6bd22c25671372a766e5809f7b",
+      "git-tree": "cba3da237d6cda8f22a1f1b4fcac5ecf3dfd9655",
       "version": "3.5.0",
       "port-version": 1
     },

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e565e4a2590e7d6bd22c25671372a766e5809f7b",
+      "version": "3.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7558a3501e44a455ac8fcbe14b622503eb9574ee",
       "version": "3.5.0",
       "port-version": 0


### PR DESCRIPTION
Backport a [crash](https://github.com/openssl/openssl/issues/27355) fix patch for OpenSSL 3.5.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.