### PR TITLE
Add swig to Linux docker container, update and cleanup

### DIFF
--- a/scripts/azure-pipelines/android/Dockerfile
+++ b/scripts/azure-pipelines/android/Dockerfile
@@ -44,6 +44,10 @@ ENV APT_PACKAGES="$APT_PACKAGES libxext-dev libxfixes-dev libxrender-dev \
 ## PowerShell
 ENV APT_PACKAGES="$APT_PACKAGES powershell"
 
+# The BUILD_DATE argument forces cache invalidation so we get updated apt dependencies
+ARG BUILD_DATE
+RUN echo "Build date: ${BUILD_DATE}"
+
 RUN <<END_OF_SCRIPT bash
 set -e
 

--- a/scripts/azure-pipelines/android/azure-pipelines.yml
+++ b/scripts/azure-pipelines/android/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
   - name: ANDROID_DOCKER_IMAGE
     value: 'vcpkgandroidwus.azurecr.io/vcpkg-android:2025-04-08'
   - name: LINUX_DOCKER_IMAGE
-    value: 'vcpkgandroidwus.azurecr.io/vcpkg-linux:2025-04-17'
+    value: 'vcpkgandroidwus.azurecr.io/vcpkg-linux:2025-04-21'
   steps:
     # Note: /mnt is the Azure machines' temporary disk.
   - bash: |

--- a/scripts/azure-pipelines/android/azure-pipelines.yml
+++ b/scripts/azure-pipelines/android/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
   - name: ANDROID_DOCKER_IMAGE
     value: 'vcpkgandroidwus.azurecr.io/vcpkg-android:2025-04-08'
   - name: LINUX_DOCKER_IMAGE
-    value: 'vcpkgandroidwus.azurecr.io/vcpkg-linux:2025-04-08'
+    value: 'vcpkgandroidwus.azurecr.io/vcpkg-linux:2025-04-17'
   steps:
     # Note: /mnt is the Azure machines' temporary disk.
   - bash: |

--- a/scripts/azure-pipelines/linux/Dockerfile
+++ b/scripts/azure-pipelines/linux/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 # DisableDockerDetector "Used to build the container deployed to Azure Container Registry"
-FROM ubuntu:jammy-20250126
+FROM ubuntu:jammy-20250404
 ADD provision-image.sh /provision-image.sh
 RUN apt-get update && \
     apt-get install --no-install-recommends -y curl gnupg ca-certificates

--- a/scripts/azure-pipelines/linux/Dockerfile
+++ b/scripts/azure-pipelines/linux/Dockerfile
@@ -3,5 +3,8 @@
 FROM ubuntu:jammy-20250404
 ADD provision-image.sh /provision-image.sh
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y curl gnupg ca-certificates
+  apt-get install --no-install-recommends -y curl gnupg ca-certificates
+# The BUILD_DATE argument forces cache invalidation so we get updated apt dependencies
+ARG BUILD_DATE
+RUN echo "Build date: ${BUILD_DATE}"
 RUN chmod +x /provision-image.sh && /provision-image.sh

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
   - name: VCPKG_DOWNLOADS
     value: /mnt/vcpkg-ci/downloads
   - name: LINUX_DOCKER_IMAGE
-    value: 'vcpkgandroidwus.azurecr.io/vcpkg-linux:2025-03-12'
+    value: 'vcpkgandroidwus.azurecr.io/vcpkg-linux:2025-04-17'
   steps:
     # Note: /mnt is the Azure machines' temporary disk.
   - bash: |

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
   - name: VCPKG_DOWNLOADS
     value: /mnt/vcpkg-ci/downloads
   - name: LINUX_DOCKER_IMAGE
-    value: 'vcpkgandroidwus.azurecr.io/vcpkg-linux:2025-04-17'
+    value: 'vcpkgandroidwus.azurecr.io/vcpkg-linux:2025-04-21'
   steps:
     # Note: /mnt is the Azure machines' temporary disk.
   - bash: |

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -47,10 +47,8 @@ APT_PACKAGES="git curl zip unzip tar"
 
 ## essentials
 APT_PACKAGES="$APT_PACKAGES \
-  at \
   autoconf autoconf-archive \
   build-essential \
-  cifs-utils \
   cmake \
   gcc g++ gfortran \
   libnuma1 libnuma-dev \
@@ -63,11 +61,12 @@ APT_PACKAGES="$APT_PACKAGES \
   bison libbison-dev \
   flex \
   gperf \
-  meson \
   nasm \
   ninja-build \
-  pkg-config \ 
+  pkg-config \
+  python3 \
   ruby-full \
+  swig \
   yasm \
 "
 

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -45,14 +45,46 @@ apt-get -y upgrade
 ## vcpkg prerequisites
 APT_PACKAGES="git curl zip unzip tar"
 
-## common build dependencies
-APT_PACKAGES="$APT_PACKAGES at libxt-dev gperf libxaw7-dev cifs-utils \
-  build-essential g++ gfortran libx11-dev libxkbcommon-x11-dev libxi-dev \
-  libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxinerama-dev libxxf86vm-dev \
-  libxcursor-dev yasm libnuma1 libnuma-dev libtool-bin libltdl-dev \
-  flex bison libbison-dev autoconf libudev-dev libncurses5-dev libtool libxrandr-dev \
-  xutils-dev dh-autoreconf autoconf-archive libgles2-mesa-dev ruby-full \
-  pkg-config meson nasm cmake ninja-build"
+## essentials
+APT_PACKAGES="$APT_PACKAGES \
+  at \
+  autoconf autoconf-archive \
+  build-essential \
+  cifs-utils \
+  cmake \
+  gcc g++ gfortran \
+  libnuma1 libnuma-dev \
+  libtool libtool-bin libltdl-dev \
+  libudev-dev \
+"
+
+## vcpkg_find_acquire_program
+APT_PACKAGES="$APT_PACKAGES \
+  bison libbison-dev \
+  flex \
+  gperf \
+  meson \
+  nasm \
+  ninja-build \
+  pkg-config \ 
+  ruby-full \
+  yasm \
+"
+
+## mesa and X essentials
+APT_PACKAGES="$APT_PACKAGES \
+  mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev libgles2-mesa-dev \
+  libx11-dev \
+  libxaw7-dev \
+  libxcursor-dev \
+  libxi-dev \
+  libxinerama-dev \
+  libxkbcommon-x11-dev \
+  libxrandr-dev \
+  libxt-dev \
+  libxxf86vm-dev \
+  xutils-dev \
+"
 
 ## required by qt5-base
 APT_PACKAGES="$APT_PACKAGES libxext-dev libxfixes-dev libxrender-dev \

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -48,6 +48,7 @@ APT_PACKAGES="git curl zip unzip tar"
 ## essentials
 APT_PACKAGES="$APT_PACKAGES \
   autoconf autoconf-archive \
+  autopoint \
   build-essential \
   cmake \
   gcc g++ gfortran \


### PR DESCRIPTION
* Cleans up the list of packages to install at the top a bit, adding comments.
* Adds swig
* Adds explicit switches to build only one of the docker images.
* Changes cache invalidation mechanism when building the images to explicitly make the SHAs differ rather than trying to prune. (This fixes the image not actually being pruned if other tags still exist, and allows vcpkg devs to have previous versions available and still run the update script)
* Log out of the ACR we are using, not docker hub.