### PR TITLE
[lucocozz-cargs] New port at version 1.0.2

### DIFF
--- a/ports/lucocozz-cargs/portfile.cmake
+++ b/ports/lucocozz-cargs/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lucocozz/cargs
+    REF v${VERSION}
+    SHA512 40780e98a72fa225bdde62d45b349f558bfd32171f65393fdd8eb0da1566cb0c0083adbea620452a8bf8ff960898e216674612b94b2a556b07498a8fd7dd10d3
+    HEAD_REF main
+)
+
+set(OPTIONS "")
+if(NOT "regex" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Ddisable_regex=true)
+endif()
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${OPTIONS}
+        -Dbenchmarks=false
+        -Dexamples=false
+        -Dtests=false
+)
+
+vcpkg_install_meson()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/lucocozz-cargs/vcpkg.json
+++ b/ports/lucocozz-cargs/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "lucocozz-cargs",
+  "version": "1.0.2",
+  "description": "Modern C library for command-line argument parsing with an elegant, macro-based API",
+  "homepage": "https://github.com/lucocozz/cargs",
+  "license": "MIT",
+  "supports": "!windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "regex"
+  ],
+  "features": {
+    "regex": {
+      "description": "Enable regex validation support using PCRE2",
+      "dependencies": [
+        "pcre2"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5824,6 +5824,10 @@
       "baseline": "0.669",
       "port-version": 0
     },
+    "lucocozz-cargs": {
+      "baseline": "1.0.2",
+      "port-version": 0
+    },
     "luminoengine": {
       "baseline": "0.10.1",
       "port-version": 1

--- a/versions/l-/lucocozz-cargs.json
+++ b/versions/l-/lucocozz-cargs.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b124891a883f4602ca9781cafc4804e51c780a89",
+      "version": "1.0.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
# New port: lucocozz-cargs

- [x] Changes comply with the [[maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. PCRE2 dependency is properly handled via features.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says (1.0.2).
- [x] The license declaration in `vcpkg.json` matches what upstream says (MIT).
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source (GitHub repository).
- [ ] The generated "usage text" is accurate.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.

## Description

libcargs is a modern C library for command-line argument parsing with an elegant, macro-based API. It provides features subcommands, validation, and more, offering a more intuitive alternative to getopt and argp.

Key features:
- Automatic help generation
- Git-style nested subcommands
- Advanced validation with regex support
- Array and map (key-value) option types

## Testing

Tested on:
- Ubuntu 24.04 (GCC 13.3, Clang 18.1.3)
- macOS

All builds completed successfully with both regex and non-regex variants.