### PR TITLE
[librdkafka] update to 2.10.0

### DIFF
--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO confluentinc/librdkafka
     REF "v${VERSION}"
-    SHA512 2e4d13d601ea1894edcace2051aa4284ba17306d3f19971734f05d0fcef413b29961b3f701da1b6517e23930bd53034c75ee25c696ac1da7e6b7051cc8ed61eb
+    SHA512 0ded25a7a9786cc82aaae33e50280437718ac2f6ffe11a8d2af78f999c5af82398e8f1adc332f0cfa37f548209d4e0f26de80e115ad696b45fe5117f03f89b63
     HEAD_REF master
     PATCHES
         lz4.patch

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "librdkafka",
-  "version": "2.8.0",
+  "version": "2.10.0",
   "description": "The Apache Kafka C/C++ library",
   "homepage": "https://github.com/confluentinc/librdkafka",
   "license": null,

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -25,6 +25,7 @@
     },
     "sasl": {
       "description": "Build with sasl/gssapi",
+      "supports": "linux | osx | (x64 & windows & !static & !uwp)",
       "dependencies": [
         "cyrus-sasl"
       ]

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -25,7 +25,6 @@
     },
     "sasl": {
       "description": "Build with sasl/gssapi",
-      "supports": "linux | osx | (x64 & windows & !static & !uwp)",
       "dependencies": [
         "cyrus-sasl"
       ]

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -236,6 +236,7 @@ libopusenc:x64-uwp=fail
 libosip2:x64-windows-static-md=fail
 libplist:x64-windows-static=fail
 libqcow=skip # The developer of libqcow does not offer stable release archives
+librdkafka[sasl](android | (windows & (static | arm | x86))) = cascade
 libsoundio:arm-uwp=fail
 libsoundio:arm64-windows=fail
 libsoundio:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5165,7 +5165,7 @@
       "port-version": 0
     },
     "librdkafka": {
-      "baseline": "2.8.0",
+      "baseline": "2.10.0",
       "port-version": 0
     },
     "libredwg": {

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6c961a70b13917b5470f6889721c14910faace69",
+      "version": "2.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f611ff6cdc918a78f0a863518124593f4ea08a15",
       "version": "2.8.0",
       "port-version": 0

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "897d5dfc6fdbdfcb865f6f82ceb4ba14878b731e",
+      "git-tree": "6c961a70b13917b5470f6889721c14910faace69",
       "version": "2.10.0",
       "port-version": 0
     },

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6c961a70b13917b5470f6889721c14910faace69",
+      "git-tree": "897d5dfc6fdbdfcb865f6f82ceb4ba14878b731e",
       "version": "2.10.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/confluentinc/librdkafka/releases/tag/v2.10.0
https://github.com/confluentinc/librdkafka/releases/tag/v2.9.0
