### PR TITLE
[woff2] Fix gcc 15 missing header issue

### DIFF
--- a/ports/woff2/0002-stdint-include.patch
+++ b/ports/woff2/0002-stdint-include.patch
@@ -1,0 +1,13 @@
+diff --git a/include/woff2/output.h b/include/woff2/output.h
+index dc78ccf..b12d538 100644
+--- a/include/woff2/output.h
++++ b/include/woff2/output.h
+@@ -9,6 +9,8 @@
+ #ifndef WOFF2_WOFF2_OUT_H_
+ #define WOFF2_WOFF2_OUT_H_
+ 
++#include <stdint.h>
++
+ #include <algorithm>
+ #include <cstring>
+ #include <memory>

--- a/ports/woff2/portfile.cmake
+++ b/ports/woff2/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
   HEAD_REF master
   PATCHES
     0001-unofficial-brotli.patch
+    0002-stdint-include.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/woff2/vcpkg.json
+++ b/ports/woff2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "woff2",
   "version": "1.0.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": "font compression reference code",
   "dependencies": [
     "brotli",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10038,7 +10038,7 @@
     },
     "woff2": {
       "baseline": "1.0.2",
-      "port-version": 4
+      "port-version": 5
     },
     "wolf-midi": {
       "baseline": "1.0.1",

--- a/versions/w-/woff2.json
+++ b/versions/w-/woff2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a12f112e02313670c8e24d72d72a83ce74521b4",
+      "version": "1.0.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "fbd2207ad0ad1e7e52b421b86f96deff9ed7ec65",
       "version": "1.0.2",
       "port-version": 4


### PR DESCRIPTION
GCC 15 reduced some transitive includes in libstdc++, so `stdint.h` is no longer being pulled in to woff2's `output.h`, causing a compile error on its use of `uint8_t`.

There is an open pull request with the fix (https://github.com/google/woff2/pull/176), but upstream maintainers haven't responded to it; let's patch it ourselves.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
