### PR TITLE
[ripper37-libbase] Fix v1.1.0 port

### DIFF
--- a/ports/ripper37-libbase/01_patch_fix_curl_dep_linux.patch
+++ b/ports/ripper37-libbase/01_patch_fix_curl_dep_linux.patch
@@ -1,0 +1,46 @@
+﻿diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 545a5bd..1672c4f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -169,7 +169,7 @@ install(EXPORT libbase_targets
+ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
+ "include(CMakeFindDependencyMacro)\n"
+ "find_dependency(glog)\n"
+-"find_package(curl)\n"
++"find_package(CURL)\n"
+ "find_package(wxWidgets)\n"
+ "find_package(GTest)\n"
+ "find_package(benchmark)\n"
+diff --git a/examples/wxwidgets_integration/CMakeLists.txt b/examples/wxwidgets_integration/CMakeLists.txt
+index 8438903..4752036 100644
+--- a/examples/wxwidgets_integration/CMakeLists.txt
++++ b/examples/wxwidgets_integration/CMakeLists.txt
+@@ -1,3 +1,5 @@
++find_package(wxWidgets CONFIG REQUIRED)
++
+ add_executable(wxwidgets_integration_example WIN32 "")
+ 
+ target_compile_options(wxwidgets_integration_example
+@@ -9,6 +11,7 @@ target_link_libraries(wxwidgets_integration_example
+   PRIVATE
+     libbase
+     libbase_wx
++    wxWidgets::wxWidgets
+ )
+ 
+ target_sources(wxwidgets_integration_example
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 4b643b0..d677116 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -246,8 +246,8 @@ if(LIBBASE_BUILD_MODULE_WX)
+     libbase
+     Threads::Threads
+     glog::glog
+-    wx::core
+-    wx::base)
++    PRIVATE
++      wxWidgets::wxWidgets)
+ 
+   target_sources(libbase_wx
+     PRIVATE

--- a/ports/ripper37-libbase/portfile.cmake
+++ b/ports/ripper37-libbase/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 af360ec0c0181f711ee66fd7157d5e8dc38f5d78df97bce4ff4cb2c4d8ef270e76b0254be4f920eee74a0026845f805955a208b76f48ca38ba925169e4f05e03
     HEAD_REF master
+    PATCHES
+        01_patch_fix_curl_dep_linux.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/ripper37-libbase/vcpkg.json
+++ b/ports/ripper37-libbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ripper37-libbase",
   "version": "1.1.0",
+  "port-version": 1,
   "description": "Standalone reimplementation of //base module from Chromium",
   "homepage": "https://github.com/RippeR37/libbase",
   "documentation": "https://ripper37.github.io/libbase",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8202,7 +8202,7 @@
     },
     "ripper37-libbase": {
       "baseline": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "rivers": {
       "baseline": "2022-05-16",

--- a/versions/r-/ripper37-libbase.json
+++ b/versions/r-/ripper37-libbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27e047f1534c2f6fabafe1fda8ecb9dc3ae79b5c",
+      "version": "1.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3575b60fddfc5bdd583997b7d318d3038a5249e1",
       "version": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Added a patch to fix generated install file which mistakenly used `curl` instead of `CURL` name/path - which worked in my tests on Windows (case insensitive filesystem) but failed to work on other platforms.

This will be fixed and reworked/improved in future v1.1.1 of the lib, but for now lets fix the port for existing version.