### PR TITLE
[zziplib] update to 0.13.79

### DIFF
--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
     "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/zzipfseeko.pc"
     "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/zzipmmapped.pc"
     "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zzipfseeko.pc"

--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -31,13 +31,15 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/zziplib")
 vcpkg_fixup_pkgconfig()
 
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/zzipfseeko.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zzipfseeko.pc")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/zziplib.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zziplib.pc")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/zzipmmapped.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zzipmmapped.pc")
+
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
-    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/zzipfseeko.pc"
-    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/zzipmmapped.pc"
-    "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zzipfseeko.pc"
-    "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zzipmmapped.pc"
+    "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
 )
 
 file(STRINGS "${CURRENT_PACKAGES_DIR}/include/zzip/_config.h" have_stdint_h REGEX "^#define ZZIP_HAVE_STDINT_H 1")

--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 bed63fa7d430bd197bb70084f28ae6edc4c4120655b882bc8367f968b32c03340bb6d9bf1b14a5fcc5a1160d91ccf00e7b1131a4123da5d52233a84840ba8b7e
     PATCHES
         no-release-postfix.patch
+        revert-pkgconfig-path.patch
 )
 
 string(COMPARE EQUAL VCPKG_CRT_LINKAGE "static" MSVC_STATIC_RUNTIME)
@@ -31,15 +32,12 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/zziplib")
 vcpkg_fixup_pkgconfig()
 
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/zzipfseeko.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zzipfseeko.pc")
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/zziplib.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zziplib.pc")
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/zzipmmapped.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zzipmmapped.pc")
-
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
-    "${CURRENT_PACKAGES_DIR}/debug/share"
-    "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/zzipfseeko.pc"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/zzipmmapped.pc"
+    "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zzipfseeko.pc"
+    "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zzipmmapped.pc"
 )
 
 file(STRINGS "${CURRENT_PACKAGES_DIR}/include/zzip/_config.h" have_stdint_h REGEX "^#define ZZIP_HAVE_STDINT_H 1")

--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gdraheim/zziplib
     REF "v${VERSION}"
-    SHA512 e96771c310a1a9eb227027e8c2a495409c01dd273b483b3a04119d6a273cce7c88ba77c192fcde5e85d0a37c847a0df8e521f460d00920e62153400f0743ea78
+    SHA512 bed63fa7d430bd197bb70084f28ae6edc4c4120655b882bc8367f968b32c03340bb6d9bf1b14a5fcc5a1160d91ccf00e7b1131a4123da5d52233a84840ba8b7e
     PATCHES
         no-release-postfix.patch
 )

--- a/ports/zziplib/revert-pkgconfig-path.patch
+++ b/ports/zziplib/revert-pkgconfig-path.patch
@@ -1,0 +1,13 @@
+diff --git a/zzip/CMakeLists.txt b/zzip/CMakeLists.txt
+index 646903b..c300011 100644
+--- a/zzip/CMakeLists.txt
++++ b/zzip/CMakeLists.txt
+@@ -304,7 +304,7 @@ set(outdir ${CMAKE_CURRENT_BINARY_DIR})
+ 
+ if(ZZIP_PKGCONFIG)
+ install(FILES ${outdir}/zziplib.pc ${outdir}/zzipmmapped.pc ${outdir}/zzipfseeko.pc
+-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig" )
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" )
+ endif()
+ 
+ install(FILES ${libzzip_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )

--- a/ports/zziplib/vcpkg.json
+++ b/ports/zziplib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zziplib",
-  "version": "0.13.78",
+  "version": "0.13.79",
   "description": "library providing read access on ZIP-archives",
   "homepage": "https://github.com/gdraheim/zziplib",
   "license": "LGPL-2.0-or-later OR MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10417,7 +10417,7 @@
       "port-version": 0
     },
     "zziplib": {
-      "baseline": "0.13.78",
+      "baseline": "0.13.79",
       "port-version": 0
     }
   }

--- a/versions/z-/zziplib.json
+++ b/versions/z-/zziplib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c891bfe5dcf8f903a1bdc521dadabb1d3cbb680a",
+      "git-tree": "1c877d218b88327087916afa94f68fd0ba8fbc00",
       "version": "0.13.79",
       "port-version": 0
     },

--- a/versions/z-/zziplib.json
+++ b/versions/z-/zziplib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "32ae3c35970f49f048f4c809f9bfdd6ff08e137f",
+      "git-tree": "cf210348aa71a3a9adef2d84f7ea56e51627814d",
       "version": "0.13.79",
       "port-version": 0
     },

--- a/versions/z-/zziplib.json
+++ b/versions/z-/zziplib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cf210348aa71a3a9adef2d84f7ea56e51627814d",
+      "git-tree": "c891bfe5dcf8f903a1bdc521dadabb1d3cbb680a",
       "version": "0.13.79",
       "port-version": 0
     },

--- a/versions/z-/zziplib.json
+++ b/versions/z-/zziplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32ae3c35970f49f048f4c809f9bfdd6ff08e137f",
+      "version": "0.13.79",
+      "port-version": 0
+    },
+    {
       "git-tree": "0fc955f622b2ca33bbab5ce2276168eef784f14e",
       "version": "0.13.78",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/gdraheim/zziplib/releases/tag/v0.13.79
