### PR TITLE
[luau] update to  0.670

### DIFF
--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 eec53ad49d632d9c73eb8df497018c935c5e8b0a75be3c54608c4b0d11c59b47cb546db71c62eab1941974e97af3f8d009a0ac2b2cde933988fa27c1d6a28939
+    SHA512 130f2e4fc476cb837b78a158c837de6476d0f780a41248af60ddfabf34060ee031363099569fa8e9498ee2e5147f28c608383bd4cef1e0d35c4c4ac9ea09107a
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -16,7 +16,8 @@
   ],
   "features": {
     "tool": {
-      "description": "Builds luau executable"
+      "description": "Builds luau executable",
+      "supports": "!uwp"
     }
   }
 }

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.669",
+  "version": "0.670",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5821,7 +5821,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.669",
+      "baseline": "0.670",
       "port-version": 0
     },
     "luminoengine": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47ed517dd369b8d8bebb2b596ab07872755f7fcb",
+      "version": "0.670",
+      "port-version": 0
+    },
+    {
       "git-tree": "f22c8d5770eea6f4c79c14fa4fce37bac6fc13a1",
       "version": "0.669",
       "port-version": 0

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "47ed517dd369b8d8bebb2b596ab07872755f7fcb",
+      "git-tree": "f1b0e97fd8c7f55475522dd353b3545d84f994c8",
       "version": "0.670",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/luau-lang/luau/releases/tag/0.670
