### PR TITLE
[libdshowcapture] Bump to 2025-02-08

### DIFF
--- a/ports/libdshowcapture/fix_build.patch
+++ b/ports/libdshowcapture/fix_build.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2c88ff6..ee1688b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,8 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Mo
+ 
+ option(BUILD_SHARED_LIBS "Build shared library" ON)
+ 
+-find_package(CXX11 REQUIRED)
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_FLAGS}")
++set(CMAKE_CXX_STANDARD 17)
+ 
+ if(${CMAKE_C_COMPILER_ID} MATCHES "Clang" OR ${CMAKE_CXX_COMPILER_ID} MATCHES
+                                              "Clang")
+diff --git a/source/dshow-formats.cpp b/source/dshow-formats.cpp
+index 4baf381..3f41a99 100644
+--- a/source/dshow-formats.cpp
++++ b/source/dshow-formats.cpp
+@@ -283,7 +283,7 @@ bool GetMediaTypeVFormat(const AM_MEDIA_TYPE &mt, VideoFormat &format)
+ 
+ 	/* raw formats */
+ 	if (mt.subtype == MEDIASUBTYPE_RGB24)
+-		format = VideoFormat::XRGB;
++		format = VideoFormat::RGB24;
+ 	else if (mt.subtype == MEDIASUBTYPE_RGB32)
+ 		format = VideoFormat::XRGB;
+ 	else if (mt.subtype == MEDIASUBTYPE_ARGB32)

--- a/ports/libdshowcapture/portfile.cmake
+++ b/ports/libdshowcapture/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_github(
     REPO elgatosf/capture-device-support
     REF fe9630974d47f51bf54826e72fb8b654e620aa93
     SHA512 971185ffaf0c5777c060d3cf49ee8f907aebc8191e3ada9c9f3c4c0d553c257d13e2828c991985b9d47a446d003b26664ecec2c18c0e6c66dfdba904baee0ae6
-    HEAD_REF master
+    HEAD_REF main
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/external/capture-device-support")

--- a/ports/libdshowcapture/portfile.cmake
+++ b/ports/libdshowcapture/portfile.cmake
@@ -1,10 +1,24 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO obsproject/libdshowcapture
-    REF cba07c63810f51a58f6fb7f2e3b0fb162b5a6313
-    SHA512 962f5886f637f06580db9b90d238cdb76976846c5b1d49112910fda0da689788abec1d1703aa4e91ee4be57f328eb8183c04f94119662e1243269ae66f023c84
+    REF 8878638324393815512f802640b0d5ce940161f1
+    SHA512 bbb9fa169bffce4f6405b8332524267f10b3e6e2dcaddcddf7ef73ffb7a6409ef4c6a13f599cab814cbf42c22690f9e24e988666886535ef9fdfb851fdb50a5c
+    HEAD_REF master
+    PATCHES
+        fix_build.patch
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH DEP_SOURCE_PATH
+    REPO elgatosf/capture-device-support
+    REF fe9630974d47f51bf54826e72fb8b654e620aa93
+    SHA512 971185ffaf0c5777c060d3cf49ee8f907aebc8191e3ada9c9f3c4c0d553c257d13e2828c991985b9d47a446d003b26664ecec2c18c0e6c66dfdba904baee0ae6
     HEAD_REF master
 )
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/external/capture-device-support")
+file(RENAME "${DEP_SOURCE_PATH}" "${SOURCE_PATH}/external/capture-device-support")
+file(REMOVE_RECURSE "${DEP_SOURCE_PATH}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libdshowcapture/vcpkg.json
+++ b/ports/libdshowcapture/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libdshowcapture",
-  "version": "0.6.0",
-  "port-version": 4,
+  "version-date": "2025-02-08",
   "description": "Free and Open Source C++11 Library for capturing DirectShow video/audio devices on windows.",
   "supports": "windows & !uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4569,8 +4569,8 @@
       "port-version": 0
     },
     "libdshowcapture": {
-      "baseline": "0.6.0",
-      "port-version": 4
+      "baseline": "2025-02-08",
+      "port-version": 0
     },
     "libdvdcss": {
       "baseline": "1.4.3",

--- a/versions/l-/libdshowcapture.json
+++ b/versions/l-/libdshowcapture.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4757e69e72aa5027b6f5dd33cdbe8fae00e2a11e",
+      "git-tree": "a565a559ce19c369eac9cafce3d55789b4b35989",
       "version-date": "2025-02-08",
       "port-version": 0
     },

--- a/versions/l-/libdshowcapture.json
+++ b/versions/l-/libdshowcapture.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4757e69e72aa5027b6f5dd33cdbe8fae00e2a11e",
+      "version-date": "2025-02-08",
+      "port-version": 0
+    },
+    {
       "git-tree": "df899babb69eb01159e5777fc4d4ef07a1570724",
       "version": "0.6.0",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
