### PR TITLE
[unqlite] update homepage

### DIFF
--- a/ports/unqlite/vcpkg.json
+++ b/ports/unqlite/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "unqlite",
   "version": "1.1.9",
-  "port-version": 2,
+  "port-version": 3,
   "description": "An embedded NoSQL, transactional database engine",
-  "homepage": "https://unqlite.org/",
+  "homepage": "https://unqlite.symisc.net/",
   "license": "BSD-2-Clause",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9566,7 +9566,7 @@
     },
     "unqlite": {
       "baseline": "1.1.9",
-      "port-version": 2
+      "port-version": 3
     },
     "unrar": {
       "baseline": "7.0.7",

--- a/versions/u-/unqlite.json
+++ b/versions/u-/unqlite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb78e8d71663d3695c0f418aa04cef0f8264b5f6",
+      "version": "1.1.9",
+      "port-version": 3
+    },
+    {
       "git-tree": "c553ddb0b70a37f30c5a61fca9c055cfebf345b0",
       "version": "1.1.9",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Currently, https://unqlite.org/ is no longer maintained.
It appears to be used for other purposes.
