### PR TITLE
[libosmium] update to v2.22

### DIFF
--- a/ports/libosmium/portfile.cmake
+++ b/ports/libosmium/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO osmcode/libosmium
     REF "v${VERSION}"
-    SHA512 fb87d5ae37c6d864ba1b265bda8e8a213fe9714d4e3cc47bd87ec05d07b9007494d37752ec4223bc5a2d957eac090d752d71f1944cb5200ae3d4af8ac97b9e10
+    SHA512 0d2b5e8e316d05c8e2d05b58d1c79136b1d78fffb116cb39987d007a4c68b325d8d7551e4c55b67e5c46927c92df720a0360c9abbc8784b9af9f86846297dae2
 )
 
 vcpkg_cmake_configure(

--- a/ports/libosmium/vcpkg.json
+++ b/ports/libosmium/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libosmium",
-  "version-semver": "2.21.0",
+  "version-semver": "2.22.0",
   "description": "A fast and flexible C++ library for working with OpenStreetMap data",
   "homepage": "https://osmcode.org/libosmium/",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5073,7 +5073,7 @@
       "port-version": 1
     },
     "libosmium": {
-      "baseline": "2.21.0",
+      "baseline": "2.22.0",
       "port-version": 0
     },
     "libosmscout": {

--- a/versions/l-/libosmium.json
+++ b/versions/l-/libosmium.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04253d94a2d6a2c3a31db24a8d6ff3e8f747a5b2",
+      "version-semver": "2.22.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1521fd94a5060bf49f8aa9893bcea7daceb67093",
       "version-semver": "2.21.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
