### PR TITLE
[ngtcp2] Re-added `libressl` feature

### DIFF
--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -9,6 +9,10 @@ vcpkg_from_github(
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC_LIB)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED_LIB)
 
+if("libressl" IN_LIST FEATURES)
+    list(APPEND FEATURES "openssl")
+endif()  
+
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         wolfssl  ENABLE_WOLFSSL

--- a/ports/ngtcp2/vcpkg.json
+++ b/ports/ngtcp2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ngtcp2",
   "version": "1.12.0",
+  "port-version": 1,
   "description": "ngtcp2 project is an effort to implement RFC9000 QUIC protocol.",
   "homepage": "https://github.com/ngtcp2/ngtcp2",
   "license": "MIT",
@@ -26,6 +27,12 @@
           "name": "shiftmedia-libgnutls",
           "platform": "windows & !mingw"
         }
+      ]
+    },
+    "libressl": {
+      "description": "Compile with libressl",
+      "dependencies": [
+        "libressl"
       ]
     },
     "openssl": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6542,7 +6542,7 @@
     },
     "ngtcp2": {
       "baseline": "1.12.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nifly": {
       "baseline": "1.0.0",

--- a/versions/n-/ngtcp2.json
+++ b/versions/n-/ngtcp2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b1a94323cfee6920cac7a82d21a4b52164446b4",
+      "version": "1.12.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "504d33e51bfe97e033e171a19c4994d93f11c9e9",
       "version": "1.12.0",
       "port-version": 0


### PR DESCRIPTION
`libressl` feature was removed by <https://github.com/microsoft/vcpkg/commit/7cd46ec6873c1325b541a068c8e4cdf54633dabe>.
ngtcp2 still supports libressl. Re-added it.
