### PR TITLE
[rmlui] Update to version 6.1 and add lottie plugin

### DIFF
--- a/ports/rmlui/add-itlib-and-robin-hood.patch
+++ b/ports/rmlui/add-itlib-and-robin-hood.patch
@@ -1,34 +1,42 @@
 diff --git a/Include/RmlUi/Config/Config.h b/Include/RmlUi/Config/Config.h
-index 15d984a3..019db32c 100644
+index 15d984a3..ee122353 100644
 --- a/Include/RmlUi/Config/Config.h
 +++ b/Include/RmlUi/Config/Config.h
-@@ -58,7 +58,7 @@
+@@ -56,9 +56,9 @@
+ 		#include <set>
+ 		#include <unordered_set>
  	#else
- 		#include "../Core/Containers/itlib/flat_map.hpp"
- 		#include "../Core/Containers/itlib/flat_set.hpp"
+-		#include "../Core/Containers/itlib/flat_map.hpp"
+-		#include "../Core/Containers/itlib/flat_set.hpp"
 -		#include "../Core/Containers/robin_hood.h"
++		#include <itlib/flat_map.hpp>
++		#include <itlib/flat_set.hpp>
 +		#include <robin_hood.h>
  	#endif // RMLUI_NO_THIRDPARTY_CONTAINERS
  
  namespace Rml {
 diff --git a/Source/Core/CMakeLists.txt b/Source/Core/CMakeLists.txt
-index c377ff49..7dff6a07 100644
+index 336ec979..c68131c8 100644
 --- a/Source/Core/CMakeLists.txt
 +++ b/Source/Core/CMakeLists.txt
-@@ -233,7 +233,6 @@ target_sources(rmlui_core PRIVATE
+@@ -239,9 +239,6 @@ target_sources(rmlui_core PRIVATE
+ 	"${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Colour.inl"
+ 	"${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/CompiledFilterShader.h"
  	"${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/ComputedValues.h"
- 	"${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Containers/itlib/flat_map.hpp"
- 	"${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Containers/itlib/flat_set.hpp"
+-	"${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Containers/itlib/flat_map.hpp"
+-	"${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Containers/itlib/flat_set.hpp"
 -	"${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Containers/robin_hood.h"
  	"${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Context.h"
  	"${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/ContextInstancer.h"
  	"${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/ConvolutionFilter.h"
-@@ -379,6 +378,9 @@ elseif(rmlui_core_TYPE STREQUAL "SHARED_LIBRARY")
+@@ -390,6 +387,11 @@ elseif(rmlui_core_TYPE STREQUAL "SHARED_LIBRARY")
  endif()
  unset(rmlui_core_TYPE)
  
 +find_path(ROBIN_HOOD_INCLUDE_DIR robin_hood.h)
 +target_include_directories(rmlui_core PUBLIC ${ROBIN_HOOD_INCLUDE_DIR})
++find_path(ITLIB_INCLUDE_DIRS "itlib/flat_map.hpp")
++target_include_directories(rmlui_core PUBLIC ${ITLIB_INCLUDE_DIRS})
 +
  if(RMLUI_FONT_ENGINE STREQUAL "freetype")
  	# Include the source files for the default font engine.

--- a/ports/rmlui/portfile.cmake
+++ b/ports/rmlui/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mikke89/RmlUi
     REF ${VERSION}
-    SHA512 46a8fef450ab6eaf6d4d6a2fff9b23dbe5a7ae81720cfa29f116f9454daca5fe80bef0b9981e037e6a42718a21361a0ca2380d0ebe33bf5e744aeecc033724b5
+    SHA512 44a336f1d1d17a71ffccf7456b44c76b9d5e590159f534a62e26378933cdcb4b78bdf5b0f9e9c3a7185c767accde1439f3cc6179b72a4c9901e36d738903a7f1
     HEAD_REF master
     PATCHES
         add-robin-hood.patch
@@ -13,6 +13,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         lua             RMLUI_LUA_BINDINGS
         svg             RMLUI_SVG_PLUGIN
+        lottie          RMLUI_LOTTIE_PLUGIN
 )
 
 if("freetype" IN_LIST FEATURES)

--- a/ports/rmlui/portfile.cmake
+++ b/ports/rmlui/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 44a336f1d1d17a71ffccf7456b44c76b9d5e590159f534a62e26378933cdcb4b78bdf5b0f9e9c3a7185c767accde1439f3cc6179b72a4c9901e36d738903a7f1
     HEAD_REF master
     PATCHES
-        add-robin-hood.patch
+        add-itlib-and-robin-hood.patch
         skip-custom-find-modules.patch
 )
 
@@ -22,8 +22,8 @@ else()
     set(RMLUI_FONT_ENGINE "none")
 endif()
 
-# Remove built-in header, instead we use vcpkg version (from robin-hood-hashing port)
-file(REMOVE "${SOURCE_PATH}/Include/RmlUi/Core/Containers/robin_hood.h")
+# Remove built-in third-party dependencies (itlib and robin-hood), instead we use vcpkg ports.
+file(REMOVE_RECURSE "${SOURCE_PATH}/Include/RmlUi/Core/Containers")
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
@@ -64,6 +64,5 @@ configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/
 vcpkg_install_copyright(
     FILE_LIST
     "${SOURCE_PATH}/LICENSE.txt"
-    "${SOURCE_PATH}/Include/RmlUi/Core/Containers/LICENSE.txt"
     "${SOURCE_PATH}/Source/Debugger/LICENSE.txt"
 )

--- a/ports/rmlui/vcpkg.json
+++ b/ports/rmlui/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rmlui",
-  "version": "6.0",
-  "port-version": 1,
+  "version": "6.1",
   "maintainers": "Michael R. P. Ragazzon <mikke89@users.noreply.github.com>",
   "description": "RmlUi is the C++ user interface library based on the HTML and CSS standards, designed as a complete solution for any project's interface needs.",
   "homepage": "https://github.com/mikke89/RmlUi",
@@ -29,6 +28,12 @@
           "name": "freetype",
           "default-features": false
         }
+      ]
+    },
+    "lottie": {
+      "description": "Enable plugin for lottie animations",
+      "dependencies": [
+        "rlottie"
       ]
     },
     "lua": {

--- a/ports/rmlui/vcpkg.json
+++ b/ports/rmlui/vcpkg.json
@@ -7,6 +7,7 @@
   "documentation": "https://mikke89.github.io/RmlUiDoc/",
   "license": "MIT",
   "dependencies": [
+    "itlib",
     "robin-hood-hashing",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8217,8 +8217,8 @@
       "port-version": 0
     },
     "rmlui": {
-      "baseline": "6.0",
-      "port-version": 1
+      "baseline": "6.1",
+      "port-version": 0
     },
     "rmqcpp": {
       "baseline": "1.0.0",

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f489fc5a69c8d87af3bbbca5997841ac4be4baff",
+      "git-tree": "5281bb2a2d009142e220adf95b86845d7d8dc073",
       "version": "6.1",
       "port-version": 0
     },

--- a/versions/r-/rmlui.json
+++ b/versions/r-/rmlui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f489fc5a69c8d87af3bbbca5997841ac4be4baff",
+      "version": "6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "fdd8836a66e7c33d1454a1a1376ad32bf78da5f1",
       "version": "6.0",
       "port-version": 1


### PR DESCRIPTION
Update library to the latest version: https://github.com/mikke89/RmlUi/releases/tag/6.1

Add the lottie plugin while we're at it, as the rlottie dependency is now available since #41890.