### PR TITLE
[lief] update to 0.16.5

### DIFF
--- a/ports/lief/fix-vcpkg-includes.patch
+++ b/ports/lief/fix-vcpkg-includes.patch
@@ -24,19 +24,6 @@ index 8cbe7b2..994e9bf 100644
  
  
  #include "LIEF/PE/Builder.hpp"
-diff --git a/src/logging.cpp b/src/logging.cpp
-index 39936fe..f5e1345 100644
---- a/src/logging.cpp
-+++ b/src/logging.cpp
-@@ -20,7 +20,7 @@
- #include "logging.hpp"
- 
- #include "spdlog/spdlog.h"
--#include "spdlog/fmt/bundled/args.h"
-+#include <fmt/args.h>
- #include "spdlog/sinks/stdout_color_sinks.h"
- #include "spdlog/sinks/basic_file_sink.h"
- #include "spdlog/sinks/android_sink.h"
 diff --git a/src/utils.cpp b/src/utils.cpp
 index 0acbba1..b624a1d 100644
 --- a/src/utils.cpp

--- a/ports/lief/include-cstdint.patch
+++ b/ports/lief/include-cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/include/LIEF/PE/ResourceNode.hpp b/include/LIEF/PE/ResourceNode.hpp
+index 5f13b91..e94749c 100644
+--- a/include/LIEF/PE/ResourceNode.hpp
++++ b/include/LIEF/PE/ResourceNode.hpp
+@@ -18,6 +18,7 @@
+ #include <string>
+ #include <vector>
+ #include <memory>
++#include <cstdint>
+ 
+ #include "LIEF/Object.hpp"
+ #include "LIEF/visibility.h"

--- a/ports/lief/include-json-header.patch
+++ b/ports/lief/include-json-header.patch
@@ -1,0 +1,12 @@
+diff --git a/src/json_api.cpp b/src/json_api.cpp
+index e586ebb..8bab796 100644
+--- a/src/json_api.cpp
++++ b/src/json_api.cpp
+@@ -18,6 +18,7 @@
+ #include "LIEF/json.hpp"
+ 
+ #if defined(LIEF_JSON_SUPPORT)
++  #include "visitors/json.hpp"
+   #if defined(LIEF_PE_SUPPORT)
+     #include "PE/json_internal.hpp"
+   #endif

--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -36,7 +36,20 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "art"            LIEF_ART               # Build LIEF with ART module
 )
 
+set(extra_config)
+
+# set CMAKE_MSVC_RUNTIME_LIBRARY for dynamic linkage
+# https://github.com/lief-project/LIEF/blob/0.16.5/scripts/windows/package_sdk.py#L46-L63
+if(VCPKG_TARGET_IS_WINDOWS)
+    if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+        list(APPEND extra_config -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$$<$$<CONFIG:Debug>:Debug>DLL)
+    else()
+        list(APPEND extra_config -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$$<$$<CONFIG:Debug>:Debug>)
+    endif()
+endif()
+
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LIEF_FORCE_API_EXPORTS)
+list(APPEND extra_config -DLIEF_FORCE_API_EXPORTS=${LIEF_FORCE_API_EXPORTS})
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -54,7 +67,7 @@ vcpkg_cmake_configure(
         -DLIEF_OPT_EXTERNAL_EXPECTED=ON
         -DLIEF_DISABLE_FROZEN=OFF
         -DLIEF_DISABLE_EXCEPTIONS=OFF
-        -DLIEF_FORCE_API_EXPORTS=${LIEF_FORCE_API_EXPORTS}
+        ${extra_config}
 
         "-DLIEF_EXTERNAL_SPAN_DIR=${_VCPKG_INSTALLED_DIR}/${TARGET_TRIPLET}/include/tcb"
 )

--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -2,12 +2,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lief-project/LIEF
     REF ${VERSION}
-    SHA512 776d26bc5d8ec7bca823d1c0fc821b0efc2411976901e1fca0ffecbc64591798e9e21a483c1637e9877bdd921dc463ffaef4eeb6a76d9dd8463c97c5f50834d4
+    SHA512 6f9f879f21c9ef61315f133235517fbf1d9679846189d750068cb28e65325d1728924546c78105f7e6d5075e085206f3832f4210408a472557adb48a8429c822
     HEAD_REF master
     PATCHES
         fix-cmakelists.patch
         fix-liefconfig-cmake-in.patch
         fix-vcpkg-includes.patch
+        # Remove it when following issue will be solved. https://github.com/lief-project/LIEF/issues/1192
+        include-cstdint.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/third-party")

--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -36,6 +36,12 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "art"            LIEF_ART               # Build LIEF with ART module
 )
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(LIEF_FORCE_API_EXPORTS ON)
+else()
+    set(LIEF_FORCE_API_EXPORTS OFF)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -52,6 +58,7 @@ vcpkg_cmake_configure(
         -DLIEF_OPT_EXTERNAL_EXPECTED=ON
         -DLIEF_DISABLE_FROZEN=OFF
         -DLIEF_DISABLE_EXCEPTIONS=OFF
+        -DLIEF_FORCE_API_EXPORTS=${LIEF_FORCE_API_EXPORTS}
 
         "-DLIEF_EXTERNAL_SPAN_DIR=${_VCPKG_INSTALLED_DIR}/${TARGET_TRIPLET}/include/tcb"
 )

--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -10,6 +10,8 @@ vcpkg_from_github(
         fix-vcpkg-includes.patch
         # Remove it when following issue will be solved. https://github.com/lief-project/LIEF/issues/1192
         include-cstdint.patch
+        # Fix compilation error with lief[core,enable-json]
+        include-json-header.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/third-party")

--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -36,11 +36,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "art"            LIEF_ART               # Build LIEF with ART module
 )
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    set(LIEF_FORCE_API_EXPORTS ON)
-else()
-    set(LIEF_FORCE_API_EXPORTS OFF)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LIEF_FORCE_API_EXPORTS)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/lief/vcpkg.json
+++ b/ports/lief/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lief",
-  "version-semver": "0.16.1",
+  "version-semver": "0.16.5",
   "description": "LIEF - Library to Instrument Executable Formats",
   "homepage": "https://lief.quarkslab.com",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5657,7 +5657,7 @@
       "port-version": 0
     },
     "lief": {
-      "baseline": "0.16.1",
+      "baseline": "0.16.5",
       "port-version": 0
     },
     "lightgbm": {

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b6c60ebf773688825c88ffaac2f7bb7881742573",
+      "git-tree": "e3b3af6c742e5520d0791ec3e907ec87d54313fd",
       "version-semver": "0.16.5",
       "port-version": 0
     },

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "651ad117b10d34f5bf4978045e371bb78484404f",
+      "git-tree": "b6c60ebf773688825c88ffaac2f7bb7881742573",
       "version-semver": "0.16.5",
       "port-version": 0
     },

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e3b3af6c742e5520d0791ec3e907ec87d54313fd",
+      "git-tree": "18df6c7623bb06d13e6e6fcbc4c371bce33de2cf",
       "version-semver": "0.16.5",
       "port-version": 0
     },

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "18df6c7623bb06d13e6e6fcbc4c371bce33de2cf",
+      "git-tree": "ac7147823038642f77a7a0d44db35e821db4f877",
       "version-semver": "0.16.5",
       "port-version": 0
     },

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "651ad117b10d34f5bf4978045e371bb78484404f",
+      "version-semver": "0.16.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "c93d7992ef9c457a2e320a5f10df9e1dfae1407d",
       "version-semver": "0.16.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://lief.re/doc/stable/changelog.html#april-19th-2025
