### PR TITLE
[vcpkg baseline][duilib] fix include path

### DIFF
--- a/ports/duilib/fix-include-path.patch
+++ b/ports/duilib/fix-include-path.patch
@@ -1,0 +1,21 @@
+diff --git a/DuiLib/CMakeLists.txt b/DuiLib/CMakeLists.txt
+index 188f36f..5a679e9 100644
+--- a/DuiLib/CMakeLists.txt
++++ b/DuiLib/CMakeLists.txt
+@@ -41,11 +41,11 @@ file(GLOB DUILIB_UTILS_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/Utils/*.h")
+ file(GLOB DUILIB_CONTROL_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/Control/*.h")
+ file(GLOB DUILIB_LAYOUT_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/Layout/*.h")
+ 
+-install(FILES ${DUILIB_PUBLIC_HDRS}     DESTINATION include)
+-install(FILES ${DUILIB_CORE_HDRS}       DESTINATION include/Core)
+-install(FILES ${DUILIB_UTILS_HDRS}      DESTINATION include/Utils)
+-install(FILES ${DUILIB_CONTROL_HDRS}    DESTINATION include/Control)
+-install(FILES ${DUILIB_LAYOUT_HDRS}     DESTINATION include/Layout)
++install(FILES ${DUILIB_PUBLIC_HDRS}     DESTINATION include/duilib)
++install(FILES ${DUILIB_CORE_HDRS}       DESTINATION include/duilib/Core)
++install(FILES ${DUILIB_UTILS_HDRS}      DESTINATION include/duilib/Utils)
++install(FILES ${DUILIB_CONTROL_HDRS}    DESTINATION include/duilib/Control)
++install(FILES ${DUILIB_LAYOUT_HDRS}     DESTINATION include/duilib/Layout)
+ 
+ # Install binaries
+ install(

--- a/ports/duilib/fix-include-path.patch
+++ b/ports/duilib/fix-include-path.patch
@@ -1,7 +1,16 @@
 diff --git a/DuiLib/CMakeLists.txt b/DuiLib/CMakeLists.txt
-index 188f36f..5a679e9 100644
+index 188f36f..5c706fb 100644
 --- a/DuiLib/CMakeLists.txt
 +++ b/DuiLib/CMakeLists.txt
+@@ -30,7 +30,7 @@ add_library(duilib ${LINKAGE} ${Control_src} ${Core_src} ${Layout_src} ${Utils_s
+ 
+ add_definitions(-DUILIB_EXPORTS)
+ target_link_libraries(duilib comctl32 gdi32 user32)
+-target_include_directories(duilib PUBLIC $<INSTALL_INTERFACE:include>)
++target_include_directories(duilib PUBLIC $<INSTALL_INTERFACE:include/duilib>)
+ target_compile_definitions(duilib PRIVATE UILIB_EXPORTS)
+ set_target_properties(duilib PROPERTIES OUTPUT_NAME "duilib")
+ 
 @@ -41,11 +41,11 @@ file(GLOB DUILIB_UTILS_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/Utils/*.h")
  file(GLOB DUILIB_CONTROL_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/Control/*.h")
  file(GLOB DUILIB_LAYOUT_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/Layout/*.h")

--- a/ports/duilib/portfile.cmake
+++ b/ports/duilib/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         "fix-arm-build.patch"
         "fix-encoding.patch"
         "enable-static.patch"
+        "fix-include-path.patch"
 )
 
 vcpkg_cmake_configure(

--- a/ports/duilib/vcpkg.json
+++ b/ports/duilib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "duilib",
   "version-date": "2024-12-23",
+  "port-version": 1,
   "description": "Duilib is a free open source DirectUI interface library under Windows. It is widely accepted by major Internet companies due to its simple and easy to expand design and stable and efficient implementation. It is widely used in IM, video client, stock market software, navigation software, and mobile phone assistive software. Duilib is still evolving, and will continue to improve in many aspects such as documentation, examples, animations, and rendering engines.",
   "homepage": "https://github.com/duilib/duilib",
   "supports": "windows & !uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2470,7 +2470,7 @@
     },
     "duilib": {
       "baseline": "2024-12-23",
-      "port-version": 0
+      "port-version": 1
     },
     "dukglue": {
       "baseline": "2022-11-08",

--- a/versions/d-/duilib.json
+++ b/versions/d-/duilib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5a0a3a4ba5d47f55ef4f27563a084168d4e823a7",
+      "git-tree": "903e977ec675f37fce7a173a5ea8cb2e0bf0a310",
       "version-date": "2024-12-23",
       "port-version": 1
     },

--- a/versions/d-/duilib.json
+++ b/versions/d-/duilib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a0a3a4ba5d47f55ef4f27563a084168d4e823a7",
+      "version-date": "2024-12-23",
+      "port-version": 1
+    },
+    {
       "git-tree": "ecdf0937b94751b0c3392c02817c6b9238a3bfc7",
       "version-date": "2024-12-23",
       "port-version": 0


### PR DESCRIPTION
libosdp install failed with below error on [Pipelines - Run 20250418.1](https://dev.azure.com/vcpkg/public/_build/results?buildId=114841&view=results)

```
D:\b\libosdp\install-x64-windows-static-dbg-out.log
D:\installed\x64-windows-static\include\utils/utils.h(6): error C2061: syntax error: identifier 'DuiLib'
D:\installed\x64-windows-static\include\utils/utils.h(6): error C2059: syntax error: ';'
D:\installed\x64-windows-static\include\utils/utils.h(7): error C2449: found '{' at file scope (missing function header?)
D:\installed\x64-windows-static\include\utils/utils.h(283): error C2059: syntax error: '}'
D:\b\libosdp\src\v3.0.5-446f15bde5.clean\utils\src\disjoint_set.c(17): error C2037: left of 'max_nodes' specifies undefined struct/union 'disjoint_set'
D:\b\libosdp\src\v3.0.5-446f15bde5.clean\utils\src\disjoint_set.c(19): error C2037: left of 'parent' specifies undefined struct/union 'disjoint_set'
D:\b\libosdp\src\v3.0.5-446f15bde5.clean\utils\src\disjoint_set.c(20): error C2037: left of 'rank' specifies undefined struct/union 'disjoint_set'
```
This error is due to a conflict between the header file of `duilib` and `linosdp`. Add a patch and add the 'duilib/' to the installation path of the headers of `duilib`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
