### PR TITLE
[wavpack] Support Android.

### DIFF
--- a/ports/wavpack/enable-asm.diff
+++ b/ports/wavpack/enable-asm.diff
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 03472d7..daca809 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ cmake_minimum_required(VERSION 3.2...3.10)
+ 
+-project(WavPack VERSION 5.8.1)
++project(WavPack VERSION 5.8.1 LANGUAGES C CXX ASM)
+ 
+ file(READ "${CMAKE_CURRENT_SOURCE_DIR}/configure.ac" CONFIGURE_AC)
+ string(REGEX MATCH "LT_CURRENT=([0-9]+)" LT_CURRENT "${CONFIGURE_AC}")
+@@ -33,10 +33,6 @@ endif()
+ 
+ include(CheckLanguage)
+ 
+-check_language(ASM)
+-if(CMAKE_ASM_COMPILER)
+-  enable_language(ASM)
+-endif()
+ 
+ if(MSVC)
+   if(WavPack_CPU_X86 OR WavPack_CPU_X64)

--- a/ports/wavpack/portfile.cmake
+++ b/ports/wavpack/portfile.cmake
@@ -1,4 +1,4 @@
-set(PATCHES)
+vcpkg_list(SET PATCHES)
 
 if (VCPKG_TARGET_IS_ANDROID)
     vcpkg_list(APPEND PATCHES "enable-asm.diff")

--- a/ports/wavpack/portfile.cmake
+++ b/ports/wavpack/portfile.cmake
@@ -1,8 +1,15 @@
+set(PATCHES)
+
+if (VCPKG_TARGET_IS_ANDROID)
+    vcpkg_list(APPEND PATCHES "enable-asm.diff")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dbry/WavPack
     REF ${VERSION}
     SHA512 bf833a4470625291a00022ae1a04ed1c6572a34c11b096bf3f4136066c77fde55c82994e8a3cee553c216539b7fdac996de9d97a5ddb7aed4904fee04d0df443
+    PATCHES ${PATCHES}
 )
 
 vcpkg_cmake_configure(

--- a/ports/wavpack/vcpkg.json
+++ b/ports/wavpack/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "wavpack",
   "version": "5.8.1",
+  "port-version": 1,
   "description": "WavPack encode/decode library, command-line programs, and several plugins",
   "homepage": "https://github.com/dbry/WavPack",
   "license": "BSD-3-Clause",
-  "supports": "!android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9942,7 +9942,7 @@
     },
     "wavpack": {
       "baseline": "5.8.1",
-      "port-version": 0
+      "port-version": 1
     },
     "wayland": {
       "baseline": "1.23.1",

--- a/versions/w-/wavpack.json
+++ b/versions/w-/wavpack.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "34ca2a988b98e7c4c51a4d3c662343e8b5f744af",
+      "git-tree": "bcdbba978c3ecf75e889f435ee0c002ce671ae54",
       "version": "5.8.1",
       "port-version": 1
     },

--- a/versions/w-/wavpack.json
+++ b/versions/w-/wavpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34ca2a988b98e7c4c51a4d3c662343e8b5f744af",
+      "version": "5.8.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e796b0ad9586b22d5a4b9c88d5fb1cc3f4eaf360",
       "version": "5.8.1",
       "port-version": 0


### PR DESCRIPTION
This works around what appears to be a CMake bug where when the ASM language isn't requested in the project() call it uses the host's C compiler as the assembler rather than the target's C compiler, causing Android specific settings intended for clang to be passed to gcc.

See https://github.com/microsoft/vcpkg/pull/45135#issuecomment-2819707073