### PR TITLE
[wavpack] Test the fix for CMake

### DIFF
--- a/ports/wavpack/CheckLanguageX.cmake
+++ b/ports/wavpack/CheckLanguageX.cmake
@@ -1,0 +1,171 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file LICENSE.rst or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+CheckLanguage
+-------------
+
+This module provides the ``check_language()`` macro to check whether a language
+can be enabled using the :command:`enable_language` or :command:`project`
+commands.
+
+.. command:: check_language
+
+  .. code-block:: cmake
+
+    check_language(<lang>)
+
+  This macro attempts to enable the language ``<lang>`` in a test project and
+  records the results in the following cache variables:
+
+  :variable:`CMAKE_<LANG>_COMPILER`
+    If the language can be enabled, this variable is set to the compiler
+    that was found.  If the language cannot be enabled, this variable is
+    set to ``NOTFOUND``.
+
+    If this variable is already set, either explicitly or cached by
+    a previous call, the check is skipped.
+
+  :variable:`CMAKE_<LANG>_HOST_COMPILER`
+    This variable is set when ``<lang>`` is ``CUDA`` or ``HIP``.
+
+    If the check detects an explicit host compiler that is required for
+    compilation, this variable will be set to that compiler.
+    If the check detects that no explicit host compiler is needed,
+    this variable will be cleared.
+
+    If this variable is already set, its value is preserved only if
+    :variable:`CMAKE_<LANG>_COMPILER` is also set.
+    Otherwise, the check runs and overwrites
+    :variable:`CMAKE_<LANG>_HOST_COMPILER` with a new result.
+    Note that :variable:`CMAKE_<LANG>_HOST_COMPILER` documents it should
+    not be set without also setting
+    :variable:`CMAKE_<LANG>_COMPILER` to a NVCC compiler.
+
+  :variable:`CMAKE_<LANG>_PLATFORM <CMAKE_HIP_PLATFORM>`
+    This variable is set to the detected GPU platform when ``<lang>`` is ``HIP``.
+
+    If this variable is already set, its value is always preserved.  Only
+    compatible values will be considered for :variable:`CMAKE_<LANG>_COMPILER`.
+
+Examples
+^^^^^^^^
+
+This module is useful when a project does not always require a specific language
+but may need to enable it for certain parts.  The following example checks for
+the availability of the ``Fortran`` language and enables it if possible:
+
+.. code-block:: cmake
+
+  include(CheckLanguage)
+  check_language(Fortran)
+  if(CMAKE_Fortran_COMPILER)
+    enable_language(Fortran)
+  else()
+    message(STATUS "No Fortran support")
+  endif()
+#]=======================================================================]
+
+include_guard(GLOBAL)
+
+block(SCOPE_FOR POLICIES)
+cmake_policy(SET CMP0126 NEW)
+
+macro(check_language lang)
+  if(NOT DEFINED CMAKE_${lang}_COMPILER)
+    set(_desc "Looking for a ${lang} compiler")
+    message(CHECK_START "${_desc}")
+    file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/Check${lang})
+
+    set(_cl_languages ENABLED_LANGUAGES)
+    list(APPEND _cl_languages "${lang}")
+
+    set(extra_compiler_variables)
+    if("${lang}" MATCHES "^(CUDA|HIP)$" AND NOT CMAKE_GENERATOR MATCHES "Visual Studio")
+      set(extra_compiler_variables "set(CMAKE_${lang}_HOST_COMPILER \\\"\${CMAKE_${lang}_HOST_COMPILER}\\\")")
+    endif()
+
+    if("${lang}" STREQUAL "HIP")
+      list(APPEND extra_compiler_variables "set(CMAKE_${lang}_PLATFORM \\\"\${CMAKE_${lang}_PLATFORM}\\\")")
+    endif()
+
+    list(TRANSFORM extra_compiler_variables PREPEND "\"")
+    list(TRANSFORM extra_compiler_variables APPEND "\\n\"")
+    list(JOIN extra_compiler_variables "\n  " extra_compiler_variables)
+
+    set(_cl_content
+      "cmake_minimum_required(VERSION ${CMAKE_VERSION})
+set(CMAKE_MODULE_PATH \"${CMAKE_MODULE_PATH}\")
+project(Check${lang} ${_cl_languages})
+file(WRITE \"\${CMAKE_CURRENT_BINARY_DIR}/result.cmake\"
+  \"set(CMAKE_${lang}_COMPILER \\\"\${CMAKE_${lang}_COMPILER}\\\")\\n\"
+  ${extra_compiler_variables}
+  )"
+    )
+
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/Check${lang}/CMakeLists.txt"
+      "${_cl_content}")
+    if(CMAKE_GENERATOR_INSTANCE)
+      set(_D_CMAKE_GENERATOR_INSTANCE "-DCMAKE_GENERATOR_INSTANCE:INTERNAL=${CMAKE_GENERATOR_INSTANCE}")
+    else()
+      set(_D_CMAKE_GENERATOR_INSTANCE "")
+    endif()
+    if(CMAKE_GENERATOR MATCHES "^(Xcode$|Green Hills MULTI$|Visual Studio)")
+      set(_D_CMAKE_MAKE_PROGRAM "")
+    else()
+      set(_D_CMAKE_MAKE_PROGRAM "-DCMAKE_MAKE_PROGRAM:FILEPATH=${CMAKE_MAKE_PROGRAM}")
+    endif()
+    if(CMAKE_TOOLCHAIN_FILE)
+      set(_D_CMAKE_TOOLCHAIN_FILE "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_TOOLCHAIN_FILE}")
+    else()
+      set(_D_CMAKE_TOOLCHAIN_FILE "")
+    endif()
+    if(CMAKE_${lang}_PLATFORM)
+      set(_D_CMAKE_LANG_PLATFORM "-DCMAKE_${lang}_PLATFORM:STRING=${CMAKE_${lang}_PLATFORM}")
+    else()
+      set(_D_CMAKE_LANG_PLATFORM "")
+    endif()
+    execute_process(
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/Check${lang}
+      COMMAND ${CMAKE_COMMAND} . -G ${CMAKE_GENERATOR}
+                                 -A "${CMAKE_GENERATOR_PLATFORM}"
+                                 -T "${CMAKE_GENERATOR_TOOLSET}"
+                                 ${_D_CMAKE_GENERATOR_INSTANCE}
+                                 ${_D_CMAKE_MAKE_PROGRAM}
+                                 ${_D_CMAKE_TOOLCHAIN_FILE}
+                                 ${_D_CMAKE_LANG_PLATFORM}
+      OUTPUT_VARIABLE _cl_output
+      ERROR_VARIABLE _cl_output
+      RESULT_VARIABLE _cl_result
+      )
+    include(${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/Check${lang}/result.cmake OPTIONAL)
+    if(CMAKE_${lang}_COMPILER AND "${_cl_result}" STREQUAL "0")
+      message(CONFIGURE_LOG
+        "${_desc} passed with the following output:\n"
+        "${_cl_output}\n")
+      set(_CHECK_COMPILER_STATUS CHECK_PASS)
+    else()
+      set(CMAKE_${lang}_COMPILER NOTFOUND)
+      set(_CHECK_COMPILER_STATUS CHECK_FAIL)
+      message(CONFIGURE_LOG
+        "${_desc} failed with the following output:\n"
+        "${_cl_output}\n")
+    endif()
+    message(${_CHECK_COMPILER_STATUS} "${CMAKE_${lang}_COMPILER}")
+    set(CMAKE_${lang}_COMPILER "${CMAKE_${lang}_COMPILER}" CACHE FILEPATH "${lang} compiler")
+    mark_as_advanced(CMAKE_${lang}_COMPILER)
+
+    if(CMAKE_${lang}_HOST_COMPILER)
+      message(STATUS "Looking for a ${lang} host compiler - ${CMAKE_${lang}_HOST_COMPILER}")
+      set(CMAKE_${lang}_HOST_COMPILER "${CMAKE_${lang}_HOST_COMPILER}" CACHE FILEPATH "${lang} host compiler")
+      mark_as_advanced(CMAKE_${lang}_HOST_COMPILER)
+    endif()
+
+    if(CMAKE_${lang}_PLATFORM)
+      set(CMAKE_${lang}_PLATFORM "${CMAKE_${lang}_PLATFORM}" CACHE STRING "${lang} platform")
+      mark_as_advanced(CMAKE_${lang}_PLATFORM)
+    endif()
+  endif()
+endmacro()
+
+endblock()

--- a/ports/wavpack/enable-asm.diff
+++ b/ports/wavpack/enable-asm.diff
@@ -2,22 +2,15 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 03472d7..daca809 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1,6 +1,6 @@
- cmake_minimum_required(VERSION 3.2...3.10)
+@@ -33,10 +33,10 @@ endif()
  
--project(WavPack VERSION 5.8.1)
-+project(WavPack VERSION 5.8.1 LANGUAGES C CXX ASM)
+-include(CheckLanguage)
++include(cmake/CheckLanguageX.cmake)
  
- file(READ "${CMAKE_CURRENT_SOURCE_DIR}/configure.ac" CONFIGURE_AC)
- string(REGEX MATCH "LT_CURRENT=([0-9]+)" LT_CURRENT "${CONFIGURE_AC}")
-@@ -33,10 +33,6 @@ endif()
- 
- include(CheckLanguage)
- 
--check_language(ASM)
--if(CMAKE_ASM_COMPILER)
--  enable_language(ASM)
--endif()
+ check_language(ASM)
+ if(CMAKE_ASM_COMPILER)
+   enable_language(ASM)
+ endif()
  
  if(MSVC)
    if(WavPack_CPU_X86 OR WavPack_CPU_X64)

--- a/ports/wavpack/portfile.cmake
+++ b/ports/wavpack/portfile.cmake
@@ -1,16 +1,15 @@
 vcpkg_list(SET PATCHES)
 
-if (VCPKG_TARGET_IS_ANDROID)
-    vcpkg_list(APPEND PATCHES "enable-asm.diff")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dbry/WavPack
     REF ${VERSION}
     SHA512 bf833a4470625291a00022ae1a04ed1c6572a34c11b096bf3f4136066c77fde55c82994e8a3cee553c216539b7fdac996de9d97a5ddb7aed4904fee04d0df443
-    PATCHES ${PATCHES}
+    PATCHES enable-asm.diff
 )
+
+get_filename_component(absolute_path CheckLanguageX.cmake ABSOLUTE BASE_DIR "${CURRENT_PORT_DIR}")
+file(COPY_FILE "${absolute_path}" "${SOURCE_PATH}/cmake/CheckLanguageX.cmake")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/wavpack/vcpkg.json
+++ b/ports/wavpack/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wavpack",
   "version": "5.8.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "WavPack encode/decode library, command-line programs, and several plugins",
   "homepage": "https://github.com/dbry/WavPack",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9942,7 +9942,7 @@
     },
     "wavpack": {
       "baseline": "5.8.1",
-      "port-version": 1
+      "port-version": 2
     },
     "wayland": {
       "baseline": "1.23.1",

--- a/versions/w-/wavpack.json
+++ b/versions/w-/wavpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ddea1ac9f6aaddf7ece93645b500268cc6946c91",
+      "version": "5.8.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "bcdbba978c3ecf75e889f435ee0c002ce671ae54",
       "version": "5.8.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
