### PR TITLE
[yalantinglibs] Fix download

### DIFF
--- a/ports/yalantinglibs/portfile.cmake
+++ b/ports/yalantinglibs/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_BUILD_TYPE release)  # header-only
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alibaba/yalantinglibs
-    REF "${VERSION}"
-    SHA512 df45fb79713b3999ccac67228c886017bd7b4088eeb48aa2334f4861caf38d4595076149ce3c5a40858cb6cb9f1ed2588c522cc70e591e66ac19c23ab812e75b
+    REF 75b2c25eb591e0ee6dd94e3c764f99af761fb6f1 # Use commit id to avoid target to multiple commits
+    SHA512 8a5e01414389084a856c1ce07ae07991ecfe24b61fef9629aff531d303fd9dbb0da4fca4cd259a757788815cd8f3039fd115d5a2548845438665f6baed89163c
     HEAD_REF main
 )
 

--- a/ports/yalantinglibs/vcpkg.json
+++ b/ports/yalantinglibs/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "yalantinglibs",
   "version": "0.4.0",
+  "port-version": 1,
   "description": "A Collection of C++20 libraries, include struct_pack, struct_json, struct_xml, struct_yaml, struct_pb, easylog, coro_rpc, coro_http and async_simple",
   "homepage": "https://github.com/alibaba/yalantinglibs",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10254,7 +10254,7 @@
     },
     "yalantinglibs": {
       "baseline": "0.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "yaml-cpp": {
       "baseline": "0.8.0",

--- a/versions/y-/yalantinglibs.json
+++ b/versions/y-/yalantinglibs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f82ff90e6d0979130f2e60e348f7a61a1c318c66",
+      "version": "0.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "18c61b804c7fba225b1db50253a9f003a34f1199",
       "version": "0.4.0",
       "port-version": 0


### PR DESCRIPTION
Use tag to download archive with url https://github.com/alibaba/yalantinglibs/archive/0.4.0.tar.gz will meet error:
```
the given path has multiple possibilities: #<Git::Ref:0x00007ff8e45b9c50>, #<Git::Ref:0x00007ff8e45b87b0>
```

So use commit id instead of version [0.4.0](https://github.com/alibaba/yalantinglibs/commit/75b2c25eb591e0ee6dd94e3c764f99af761fb6f1) to avoid this bug.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fixes https://github.com/microsoft/vcpkg/issues/45194