### PR TITLE
[libwebsockets] Update to 4.3.5

### DIFF
--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO warmcat/libwebsockets
-    REF 4415e84c095857629863804e941b9e1c2e9347ef # v4.3.3
-    SHA512 11aed4ce06af0ef94ce3eaaf32cc2b5735be140dfcda1768cc8ccb0ed97c7bc7bdbb1b2718c6d6ef6a9058de208ba94cae85eedc1c597656300a4181060e31ff 
+    REF "v${VERSION}"
+    SHA512 629a4fe6b0c8f6b4a1d38128201f5a856bdcf8a33923120c24ceb8d7f7602906608ef4e289e98b66bb94633ed95f5901e2e46d8214dcc61cf276cc975b9d7134
     HEAD_REF master
     PATCHES
         fix-dependency-libuv.patch

--- a/ports/libwebsockets/vcpkg.json
+++ b/ports/libwebsockets/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libwebsockets",
-  "version-semver": "4.3.3",
-  "port-version": 1,
+  "version-semver": "4.3.5",
   "description": "Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.",
   "homepage": "https://github.com/warmcat/libwebsockets",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5485,8 +5485,8 @@
       "port-version": 0
     },
     "libwebsockets": {
-      "baseline": "4.3.3",
-      "port-version": 1
+      "baseline": "4.3.5",
+      "port-version": 0
     },
     "libx11": {
       "baseline": "1.8.1",

--- a/versions/l-/libwebsockets.json
+++ b/versions/l-/libwebsockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bcfd145aab2118e3871111c7294ef657656a390f",
+      "version-semver": "4.3.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "68b66d2cf7613db48230bbfe150b1702e9a52397",
       "version-semver": "4.3.3",
       "port-version": 1


### PR DESCRIPTION
Fixes #45162 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.