### PR TITLE
[libbsd] New port

### DIFF
--- a/ports/libbsd/portfile.cmake
+++ b/ports/libbsd/portfile.cmake
@@ -1,5 +1,5 @@
 if(VCPKG_TARGET_IS_LINUX)
-    message("${PORT} currently requires the following tools and libraries from the system package manager:\n    autoreconf\n    libudev\n\nThese can be installed on Ubuntu systems via apt-get install autoconf")
+    message("${PORT} currently requires the following tools and libraries from the system package manager:\n    autoreconf\n\nThis can be installed on Ubuntu systems via apt-get install autoconf")
 endif()
 
 vcpkg_download_distfile(
@@ -11,7 +11,6 @@ vcpkg_download_distfile(
 vcpkg_extract_source_archive(
         SOURCE_PATH
         ARCHIVE "${LIBBSD_ARCHIVE}"
-#        SOURCE_BASE "libbsd-0.12.2"
 )
 
 vcpkg_list(SET MAKE_OPTIONS)
@@ -28,4 +27,3 @@ vcpkg_fixup_pkgconfig()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/libbsd/portfile.cmake
+++ b/ports/libbsd/portfile.cmake
@@ -28,3 +28,4 @@ vcpkg_fixup_pkgconfig()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/libbsd/portfile.cmake
+++ b/ports/libbsd/portfile.cmake
@@ -1,0 +1,40 @@
+if(VCPKG_TARGET_IS_LINUX)
+    message("${PORT} currently requires the following tools and libraries from the system package manager:\n    autoreconf\n    libudev\n\nThese can be installed on Ubuntu systems via apt-get install autoconf")
+endif()
+
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL https://gitlab.freedesktop.org/libbsd/libbsd
+    REF 04a24db27ad1572f766bad772cdd9c146e6d9cf0
+    FETCH_REF "0.12.2"
+    HEAD_REF master
+)
+
+vcpkg_list(SET MAKE_OPTIONS)
+vcpkg_list(SET LIBBSD_LINK_LIBRARIES)
+vcpkg_execute_required_process(
+        COMMAND "./autogen"
+        WORKING_DIRECTORY "${SOURCE_PATH}"
+        LOGNAME "autoconf-${TARGET_TRIPLET}"
+)
+vcpkg_execute_required_process(
+        COMMAND "./configure"
+        WORKING_DIRECTORY "${SOURCE_PATH}"
+        LOGNAME "configure-${TARGET_TRIPLET}"
+)
+vcpkg_execute_required_process(
+        COMMAND "make"
+        WORKING_DIRECTORY "${SOURCE_PATH}"
+        LOGNAME "make-${TARGET_TRIPLET}"
+)
+#vcpkg_configure_make(
+#        SOURCE_PATH "${SOURCE_PATH}"
+#        AUTOCONFIG
+#        OPTIONS
+#            ${MAKE_OPTIONS}
+#)
+vcpkg_install_make()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libbsd/portfile.cmake
+++ b/ports/libbsd/portfile.cmake
@@ -17,13 +17,12 @@ vcpkg_extract_source_archive(
 
 vcpkg_list(SET MAKE_OPTIONS)
 vcpkg_list(SET LIBBSD_LINK_LIBRARIES)
-vcpkg_configure_make(
+vcpkg_make_configure(
         SOURCE_PATH "${SOURCE_PATH}"
-        AUTOCONFIG
-        OPTIONS
-            ${MAKE_OPTIONS}
+        AUTORECONF
+        LANGUAGES C
 )
-vcpkg_install_make()
+vcpkg_make_install()
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/libbsd/portfile.cmake
+++ b/ports/libbsd/portfile.cmake
@@ -1,6 +1,8 @@
 if(VCPKG_TARGET_IS_LINUX)
-    message("${PORT} currently requires the following tools and libraries from the system package manager:\n    autoreconf\n\nThis can be installed on Ubuntu systems via apt-get install autoconf")
-endif()
+    message("${PORT} currently requires the following tools and libraries from the system package manager:"
+            "\n    autoreconf libmd0\n\n"
+            "These can be installed on Ubuntu systems via apt-get install autoconf libmd0")
+endif(VCPKG_TARGET_IS_LINUX)
 
 vcpkg_download_distfile(
         LIBBSD_ARCHIVE

--- a/ports/libbsd/portfile.cmake
+++ b/ports/libbsd/portfile.cmake
@@ -2,39 +2,29 @@ if(VCPKG_TARGET_IS_LINUX)
     message("${PORT} currently requires the following tools and libraries from the system package manager:\n    autoreconf\n    libudev\n\nThese can be installed on Ubuntu systems via apt-get install autoconf")
 endif()
 
-vcpkg_from_git(
-    OUT_SOURCE_PATH SOURCE_PATH
-    URL https://gitlab.freedesktop.org/libbsd/libbsd
-    REF 04a24db27ad1572f766bad772cdd9c146e6d9cf0
-    FETCH_REF "0.12.2"
-    HEAD_REF master
+vcpkg_download_distfile(
+        LIBBSD_ARCHIVE
+        URLS "https://libbsd.freedesktop.org/releases/libbsd-0.12.2.tar.xz"
+        FILENAME "libbsd-0.12.2.tar.xz"
+        SHA512 ce43e4f0486d5f00d4a8119ee863eaaa2f968cae4aa3d622976bb31ad601dfc565afacef7ebade5eba33fff1c329b5296c6387c008d1e1805d878431038f8b21
+)
+vcpkg_extract_source_archive(
+        SOURCE_PATH
+        ARCHIVE "${LIBBSD_ARCHIVE}"
+#        SOURCE_BASE "libbsd-0.12.2"
 )
 
 vcpkg_list(SET MAKE_OPTIONS)
 vcpkg_list(SET LIBBSD_LINK_LIBRARIES)
-vcpkg_execute_required_process(
-        COMMAND "./autogen"
-        WORKING_DIRECTORY "${SOURCE_PATH}"
-        LOGNAME "autoconf-${TARGET_TRIPLET}"
+vcpkg_configure_make(
+        SOURCE_PATH "${SOURCE_PATH}"
+        AUTOCONFIG
+        OPTIONS
+            ${MAKE_OPTIONS}
 )
-vcpkg_execute_required_process(
-        COMMAND "./configure"
-        WORKING_DIRECTORY "${SOURCE_PATH}"
-        LOGNAME "configure-${TARGET_TRIPLET}"
-)
-vcpkg_execute_required_process(
-        COMMAND "make"
-        WORKING_DIRECTORY "${SOURCE_PATH}"
-        LOGNAME "make-${TARGET_TRIPLET}"
-)
-#vcpkg_configure_make(
-#        SOURCE_PATH "${SOURCE_PATH}"
-#        AUTOCONFIG
-#        OPTIONS
-#            ${MAKE_OPTIONS}
-#)
 vcpkg_install_make()
 
 vcpkg_fixup_pkgconfig()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libbsd/usage
+++ b/ports/libbsd/usage
@@ -1,5 +1,0 @@
-libbsd can be imported via CMake FindPkgConfig module:
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(libbsd REQUIRED IMPORTED_TARGET libbsd-0.12.2)
-
-    target_link_libraries(main PRIVATE PkgConfig::libbsd)

--- a/ports/libbsd/usage
+++ b/ports/libbsd/usage
@@ -1,0 +1,5 @@
+libbsd can be imported via CMake FindPkgConfig module:
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(libbsd REQUIRED IMPORTED_TARGET libbsd-0.12.2)
+
+    target_link_libraries(main PRIVATE PkgConfig::libbsd)

--- a/ports/libbsd/vcpkg.json
+++ b/ports/libbsd/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "libbsd",
+  "version": "0.12.2",
+  "description": "Utility functions from BSD systems",
+  "homepage": "https://libbsd.freedesktop.org",
+  "license": "BSD-3-Clause",
+  "supports": "!uwp & !windows"
+}

--- a/ports/libbsd/vcpkg.json
+++ b/ports/libbsd/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Utility functions from BSD systems",
   "homepage": "https://libbsd.freedesktop.org",
   "license": "BSD-3-Clause",
-  "supports": "!uwp & !windows",
+  "supports": "!uwp & !windows & !android",
   "dependencies": [
     "gettext"
   ]

--- a/ports/libbsd/vcpkg.json
+++ b/ports/libbsd/vcpkg.json
@@ -6,6 +6,10 @@
   "license": "BSD-3-Clause",
   "supports": "!uwp & !windows & !android",
   "dependencies": [
-    "gettext"
+    "gettext",
+    {
+      "name": "libmd",
+      "platform": "linux"
+    }
   ]
 }

--- a/ports/libbsd/vcpkg.json
+++ b/ports/libbsd/vcpkg.json
@@ -4,12 +4,22 @@
   "description": "Utility functions from BSD systems",
   "homepage": "https://libbsd.freedesktop.org",
   "license": "BSD-3-Clause",
-  "supports": "!uwp & !windows & !android",
+  "supports": "!uwp & !windows & !android & !linux",
   "dependencies": [
-    "gettext",
+    {
+      "name": "gettext",
+      "host": true,
+      "features": [
+        "tools"
+      ]
+    },
     {
       "name": "libmd",
       "platform": "linux"
+    },
+    {
+      "name": "vcpkg-make",
+      "host": true
     }
   ]
 }

--- a/ports/libbsd/vcpkg.json
+++ b/ports/libbsd/vcpkg.json
@@ -4,5 +4,8 @@
   "description": "Utility functions from BSD systems",
   "homepage": "https://libbsd.freedesktop.org",
   "license": "BSD-3-Clause",
-  "supports": "!uwp & !windows"
+  "supports": "!uwp & !windows",
+  "dependencies": [
+    "gettext"
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4452,6 +4452,10 @@
       "baseline": "1.0.0",
       "port-version": 4
     },
+    "libbsd": {
+      "baseline": "0.12.2",
+      "port-version": 0
+    },
     "libbson": {
       "baseline": "1.30.3",
       "port-version": 0

--- a/versions/l-/libbsd.json
+++ b/versions/l-/libbsd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4c1394eb7d01bec8307efa3de3e5239a47ec62ac",
+      "git-tree": "16c1663269cbd93f23753d8137c1fbfdfbc3a60a",
       "version": "0.12.2",
       "port-version": 0
     }

--- a/versions/l-/libbsd.json
+++ b/versions/l-/libbsd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c475cd50cbc5904e3c45a08c6d4caaa037c1619d",
+      "git-tree": "336b9adcd6be27ae69185fbd2fdd4f1686f12787",
       "version": "0.12.2",
       "port-version": 0
     }

--- a/versions/l-/libbsd.json
+++ b/versions/l-/libbsd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7f8fd4a41ebca60b3096de05ae45d23f00b255ad",
+      "git-tree": "4c1394eb7d01bec8307efa3de3e5239a47ec62ac",
       "version": "0.12.2",
       "port-version": 0
     }

--- a/versions/l-/libbsd.json
+++ b/versions/l-/libbsd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "336b9adcd6be27ae69185fbd2fdd4f1686f12787",
+      "git-tree": "09a9b9b95c3c2270964882285601632df540787d",
       "version": "0.12.2",
       "port-version": 0
     }

--- a/versions/l-/libbsd.json
+++ b/versions/l-/libbsd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "16c1663269cbd93f23753d8137c1fbfdfbc3a60a",
+      "git-tree": "c475cd50cbc5904e3c45a08c6d4caaa037c1619d",
       "version": "0.12.2",
       "port-version": 0
     }

--- a/versions/l-/libbsd.json
+++ b/versions/l-/libbsd.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7f8fd4a41ebca60b3096de05ae45d23f00b255ad",
+      "version": "0.12.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
> This library provides useful functions commonly found on BSD systems, and lacking on others like GNU systems, thus making it easier to port projects with strong BSD origins, without needing to embed the same code over and over again on each project.

https://libbsd.freedesktop.org

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.