### PR TITLE
[libmd] Add new port

### DIFF
--- a/ports/libmd/portfile.cmake
+++ b/ports/libmd/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_download_distfile(
+        LIBMD_ARCHIVE
+        URLS "https://archive.hadrons.org/software/libmd/libmd-1.1.0.tar.xz"
+        FILENAME "libmd-1.1.0.tar.xz"
+        SHA512 5d0da3337038e474fae7377bbc646d17214e72dc848a7aadc157f49333ce7b5ac1456e45d13674bd410ea08477c6115fc4282fed6c8e6a0bf63537a418c0df96
+)
+vcpkg_extract_source_archive(
+        SOURCE_PATH
+        ARCHIVE "${LIBMD_ARCHIVE}"
+)
+
+vcpkg_list(SET MAKE_OPTIONS)
+vcpkg_list(SET LIBMD_LINK_LIBRARIES)
+vcpkg_configure_make(
+        SOURCE_PATH "${SOURCE_PATH}"
+        AUTOCONFIG
+        OPTIONS
+            ${MAKE_OPTIONS}
+)
+vcpkg_install_make()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libmd/vcpkg.json
+++ b/ports/libmd/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "libmd",
+  "version": "1.1.0",
+  "description": "This library provides message digest functions found on BSD systems either on their libc (NetBSD, OpenBSD) or libmd (FreeBSD, DragonflyBSD, macOS, Solaris) libraries and lacking on others like GNU systems.",
+  "homepage": "https://www.hadrons.org/software/libmd",
+  "license": "BSD-3-Clause",
+  "supports": "!uwp & !windows",
+  "dependencies": [
+    "gettext",
+    {
+      "name": "libmd",
+      "platform": "linux"
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4916,6 +4916,10 @@
       "baseline": "1.12.2",
       "port-version": 0
     },
+    "libmd": {
+      "baseline": "1.1.0",
+      "port-version": 0
+    },
     "libmediainfo": {
       "baseline": "25.3",
       "port-version": 0

--- a/versions/l-/libmd.json
+++ b/versions/l-/libmd.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6844a522380be0a18dfea0ea3b70b1d7d32824e4",
+      "version": "1.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
> This library provides message digest functions found on BSD systems either on their libc (NetBSD, OpenBSD) or libmd (FreeBSD, DragonflyBSD, macOS, Solaris) libraries and lacking on others like GNU systems.

https://www.hadrons.org/software/libmd

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.