### PR TITLE
Remove library type enforcement from Orocos KDL

### DIFF
--- a/ports/orocos-kdl/portfile.cmake
+++ b/ports/orocos-kdl/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 9774b76b755ea81168390643813789783f60d0b1cdb46cd250e3e0d27f75a6cf2fd3bfd2081c04e30a14ff4fc70d0080c9b43b82ee181c2dda82f23f052b338d
     HEAD_REF master
-    PATCHES export-include-dir.patch
+    PATCHES
+      export-include-dir.patch
+      remove-lib-type-enforcement.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/orocos-kdl/remove-lib-type-enforcement.patch
+++ b/ports/orocos-kdl/remove-lib-type-enforcement.patch
@@ -1,18 +1,21 @@
 diff --git a/orocos_kdl/src/CMakeLists.txt b/orocos_kdl/src/CMakeLists.txt
-index ca63079..276aad5 100644
+index ca63079..c85b00f 100644
 --- a/orocos_kdl/src/CMakeLists.txt
 +++ b/orocos_kdl/src/CMakeLists.txt
-@@ -8,9 +8,6 @@ FILE( GLOB UTIL_HPPS utilities/[^.]*.h utilities/[^.]*.hpp)
+@@ -6,12 +6,6 @@ FILE( GLOB UTIL_HPPS utilities/[^.]*.h utilities/[^.]*.hpp)
+ #In Windows (Visual Studio) it is necessary to specify the postfix
+ #of the debug library name and no symbols are exported by kdl,
  #so it is necessary to compile it as a static library
- IF(MSVC)
-     SET(CMAKE_DEBUG_POSTFIX "d")
+-IF(MSVC)
+-    SET(CMAKE_DEBUG_POSTFIX "d")
 -    SET(LIB_TYPE STATIC)
 -ELSE(MSVC)
 -    SET(LIB_TYPE SHARED)
- ENDIF(MSVC)
+-ENDIF(MSVC)
  
  CONFIGURE_FILE(config.h.in config.h @ONLY)
-@@ -55,7 +52,7 @@ IF(NOT (CMAKE_VERSION VERSION_LESS 2.8.12))
+ 
+@@ -55,7 +49,7 @@ IF(NOT (CMAKE_VERSION VERSION_LESS 2.8.12))
  ENDIF()
  #####end RPATH
  

--- a/ports/orocos-kdl/remove-lib-type-enforcement.patch
+++ b/ports/orocos-kdl/remove-lib-type-enforcement.patch
@@ -1,0 +1,23 @@
+diff --git a/orocos_kdl/src/CMakeLists.txt b/orocos_kdl/src/CMakeLists.txt
+index ca63079..276aad5 100644
+--- a/orocos_kdl/src/CMakeLists.txt
++++ b/orocos_kdl/src/CMakeLists.txt
+@@ -8,9 +8,6 @@ FILE( GLOB UTIL_HPPS utilities/[^.]*.h utilities/[^.]*.hpp)
+ #so it is necessary to compile it as a static library
+ IF(MSVC)
+     SET(CMAKE_DEBUG_POSTFIX "d")
+-    SET(LIB_TYPE STATIC)
+-ELSE(MSVC)
+-    SET(LIB_TYPE SHARED)
+ ENDIF(MSVC)
+ 
+ CONFIGURE_FILE(config.h.in config.h @ONLY)
+@@ -55,7 +52,7 @@ IF(NOT (CMAKE_VERSION VERSION_LESS 2.8.12))
+ ENDIF()
+ #####end RPATH
+ 
+-ADD_LIBRARY(orocos-kdl ${LIB_TYPE} ${KDL_SRCS} config.h)
++ADD_LIBRARY(orocos-kdl ${KDL_SRCS} config.h)
+ 
+ SET_TARGET_PROPERTIES( orocos-kdl PROPERTIES
+   SOVERSION "${KDL_VERSION_MAJOR}.${KDL_VERSION_MINOR}"


### PR DESCRIPTION
This PR adds a patch to remove library type enforcement on the upstream `CMakeLists.txt` file. Currently, the upstream forces to build static library of Orocos KDL if MSVC, otherwise forces shared library builds. With this change, it will be compatible with vcpkg triplet's choice via variable `VCPKG_LIBRARY_LINKAGE`.

For static library builds of Orocos KDL, the users might need to use the following:

```
# assuming "my-app" target is created using "add_executable(my-app ...)"
target_link_libraries(my-app Eigen3::Eigen orocos-kdl)
```

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
