### PR TITLE
[readerwriterqueue] update to 1.0.7

### DIFF
--- a/ports/readerwriterqueue/portfile.cmake
+++ b/ports/readerwriterqueue/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_cmake_configure(
 ) 
 
 vcpkg_cmake_install() 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake) 
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT}) 
 vcpkg_fixup_pkgconfig() 
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/readerwriterqueue/portfile.cmake
+++ b/ports/readerwriterqueue/portfile.cmake
@@ -1,12 +1,20 @@
-# header-only library
+set(VCPKG_BUILD_TYPE release) # header-only
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cameron314/readerwriterqueue
-    REF v1.0.6
-    SHA512 93606d8337ec6bb8aad23a40a7d5e685f8b97f6c75ca4a6b11947aaef02c2283648c5352d3c7f451006b2244ce45d0c04384ba0e1da8ac515ce7644f83f49f2c
+    REF "v${VERSION}"
+    SHA512 adabc72f94dd9d9fedda9d1123bc1496c19e667c911b17058407718c79337a2532f7510abbcc1b6d69fb4bf54df8765b6ac64925929ef676912a5285eacc07c5
     HEAD_REF master
 )
 
-file(GLOB HEADER_FILES ${SOURCE_PATH}/*.h)
-file(INSTALL ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+vcpkg_cmake_configure( 
+    SOURCE_PATH "${SOURCE_PATH}"
+) 
+
+vcpkg_cmake_install() 
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake) 
+vcpkg_fixup_pkgconfig() 
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/readerwriterqueue/vcpkg.json
+++ b/ports/readerwriterqueue/vcpkg.json
@@ -1,6 +1,16 @@
 {
   "name": "readerwriterqueue",
-  "version-semver": "1.0.6",
+  "version-semver": "1.0.7",
   "description": "A single-producer, single-consumer lock-free queue",
-  "homepage": "https://github.com/cameron314/readerwriterqueue"
+  "homepage": "https://github.com/cameron314/readerwriterqueue",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8081,7 +8081,7 @@
       "port-version": 0
     },
     "readerwriterqueue": {
-      "baseline": "1.0.6",
+      "baseline": "1.0.7",
       "port-version": 0
     },
     "readline": {

--- a/versions/r-/readerwriterqueue.json
+++ b/versions/r-/readerwriterqueue.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a5c9981dd59e415f207224199a1c9d9ac0b0e088",
+      "git-tree": "8dd55cc4a2c0b7fbcbcaa78a2520e1cf00c2d7b5",
       "version-semver": "1.0.7",
       "port-version": 0
     },

--- a/versions/r-/readerwriterqueue.json
+++ b/versions/r-/readerwriterqueue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5c9981dd59e415f207224199a1c9d9ac0b0e088",
+      "version-semver": "1.0.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae76a96e8113f07bd43b2d2239d06d542bb8b681",
       "version-semver": "1.0.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.