### PR TITLE
[mdl-sdk] Update to 2024.1.1.

### DIFF
--- a/ports/mdl-sdk/usage
+++ b/ports/mdl-sdk/usage
@@ -1,8 +1,8 @@
 mdl-sdk provides CMake targets:
 
   find_package(mdl CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE mdl::mdl_sdk)
+  target_include_directories(main PRIVATE $<TARGET_PROPERTY:mdl::mdl_sdk,INTERFACE_INCLUDE_DIRECTORIES>)
 
-  # Or if you want to use only the MDL Core library:
+  # Or if you want to use the MDL Core library:
   find_package(mdl CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE mdl::mdl_core)
+  target_include_directories(main PRIVATE $<TARGET_PROPERTY:mdl::mdl_core,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/ports/mdl-sdk/usage
+++ b/ports/mdl-sdk/usage
@@ -1,8 +1,8 @@
 mdl-sdk provides CMake targets:
 
   find_package(mdl CONFIG REQUIRED)
-  target_include_directories(main PRIVATE $<TARGET_PROPERTY:mdl::mdl_sdk,INTERFACE_INCLUDE_DIRECTORIES>)
+  target_link_libraries(main PRIVATE mdl::mdl_sdk)
 
-  # Or if you want to use the MDL Core library:
+  # Or if you want to use only the MDL Core library:
   find_package(mdl CONFIG REQUIRED)
-  target_include_directories(main PRIVATE $<TARGET_PROPERTY:mdl::mdl_core,INTERFACE_INCLUDE_DIRECTORIES>)
+  target_link_libraries(main PRIVATE mdl::mdl_core)

--- a/ports/mdl-sdk/vcpkg.json
+++ b/ports/mdl-sdk/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "mdl-sdk",
-  "version": "2024.1",
+  "version": "2024.1.1",
   "description": "NVIDIA Material Definition Language SDK",
   "homepage": "https://github.com/NVIDIA/MDL-SDK",
   "license": "BSD-3-Clause",
-  "supports": "!x86 & !(windows & (staticcrt | arm | uwp)) & !(osx & arm) & !android",
+  "supports": "!x86 & !(windows & (arm | uwp)) & !(osx & arm) & !android",
   "dependencies": [
     "boost-algorithm",
     "boost-core",

--- a/scripts/test_ports/vcpkg-ci-mdl-sdk/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-mdl-sdk/vcpkg.json
@@ -3,7 +3,6 @@
   "version-string": "ci",
   "description": "Port to force features of certain ports within CI",
   "license": "BSD-3-Clause",
-  "supports": "!(windows & static)",
   "dependencies": [
     {
       "name": "mdl-sdk",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6029,7 +6029,7 @@
       "port-version": 0
     },
     "mdl-sdk": {
-      "baseline": "2024.1",
+      "baseline": "2024.1.1",
       "port-version": 0
     },
     "mdns": {

--- a/versions/m-/mdl-sdk.json
+++ b/versions/m-/mdl-sdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7a8e776b76885bfb3395429aba33cc9566089bda",
+      "git-tree": "5618e7195ba1447ffd06b783c373b4353897d440",
       "version": "2024.1.1",
       "port-version": 0
     },

--- a/versions/m-/mdl-sdk.json
+++ b/versions/m-/mdl-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a8e776b76885bfb3395429aba33cc9566089bda",
+      "version": "2024.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8baaf1116f9d57fc31240c1e60e2a5280dcdc286",
       "version": "2024.1",
       "port-version": 0


### PR DESCRIPTION
Add support for more Windows triplets.
Update usage instructions.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
