### PR TITLE
[doctest] Update 2.4.12

### DIFF
--- a/ports/doctest/portfile.cmake
+++ b/ports/doctest/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO doctest/doctest
     REF "v${VERSION}"
-    SHA512 04425686057079d3f1a6f767c487f1953050f553dbff9fc42b42dde1358fe26e46bf6219881bbfce625f15cb9c229474d82688120eb2cb2b1d8138db0cc91b3c
+    SHA512 d55aae632e6d66add7b65d0e97bde5063cdae7512836f278613af35957c62dbc6b0b0febbe2eb1eddd334a7a5343faca7357a2eeebbf1428cafffeb5d18e610c
     HEAD_REF master
 )
 

--- a/ports/doctest/vcpkg.json
+++ b/ports/doctest/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "doctest",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "The fastest feature-rich C++11/14/17/20 single-header testing framework",
   "homepage": "https://github.com/doctest/doctest",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2417,7 +2417,7 @@
       "port-version": 1
     },
     "doctest": {
-      "baseline": "2.4.11",
+      "baseline": "2.4.12",
       "port-version": 0
     },
     "double-conversion": {

--- a/versions/d-/doctest.json
+++ b/versions/d-/doctest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fcb90f044a88f9c4d3af9410dd6eba419ca36016",
+      "version": "2.4.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "619b544477f70ef777fcc294e0b31650e2bd4c05",
       "version": "2.4.11",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
// - [ ] The "supports" clause reflects platforms that may be fixed by this new version.
// - [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
// - [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Update to new version, since older version does not build with cmake 4.0.x anymore
see https://github.com/doctest/doctest/issues/854

