### PR TITLE
Make feature-test nonfatal for now.

### DIFF
--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -149,11 +149,14 @@ if ($testFeatures) {
     if ($lastLastExitCode -ne 0)
     {
         Write-Host "##vso[task.setvariable variable=FAILURE_LOGS_EMPTY]$false"
-        Write-Error "vcpkg feature testing failed; this is usually a bug in one of the features in the port(s) edited in this pull request. Check for failure logs attached to the run in Azure Pipelines."
-        exit $lastLastExitCode
+        Write-Host "vcpkg feature testing failed; this is usually a bug in one of the features in the port(s) edited in this pull request. Check for failure logs attached to the run in Azure Pipelines."
+        Write-Host "This is not a fatal error for now while we improve the x-test-features experience, but you may wish to check the feature test results."
+        # exit $lastLastExitCode
     }
-
-    $knownFailuresFromArgs += "--known-failures-from=$knownFailingAbisFile"
+    else
+    {
+        $knownFailuresFromArgs += "--known-failures-from=$knownFailingAbisFile"
+    }
 }
 
 $ciBaselineFile = "$PSScriptRoot/../ci.baseline.txt"

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -149,7 +149,7 @@ if ($testFeatures) {
     if ($lastLastExitCode -ne 0)
     {
         Write-Host "##vso[task.setvariable variable=FAILURE_LOGS_EMPTY]$false"
-        Write-Host "vcpkg feature testing failed; this is usually a bug in one of the features in the port(s) edited in this pull request. Check for failure logs attached to the run in Azure Pipelines."
+        Write-Host "##vso[task.logissue type=warning]vcpkg feature testing failed; this is usually a bug in one of the features in the port(s) edited in this pull request. Check for failure logs attached to the run in Azure Pipelines."
         Write-Host "This is not a fatal error for now while we improve the x-test-features experience, but you may wish to check the feature test results."
         # exit $lastLastExitCode
     }


### PR DESCRIPTION
The feedback from contributors thus far is that they don't understand how to respond to feature-test failures, and resolving the fire hose of problems has left not enough time to actually fix the problems in the first place. As a result, we're leaving this testing on but no longer failing the run for now. Hopefully will turn back on in the next week or two.