### PR TITLE
[unicorn] update to 2.1.3

### DIFF
--- a/ports/unicorn/fix-build.patch
+++ b/ports/unicorn/fix-build.patch
@@ -11,12 +11,3 @@ index 3fcde11..1acc0b5 100644
              message(FATAL_ERROR "please set the runtime library via either CMAKE_C_FLAGS or CMAKE_MSVC_RUNTIME_LIBRARY, not both")
          endif()
  
-@@ -1486,7 +1486,7 @@ if(UNICORN_BUILD_TESTS)
- endif()
- 
- 
--if(UNICORN_INSTALL AND NOT MSVC)
-+if(UNICORN_INSTALL)
-     include("GNUInstallDirs")
-     file(GLOB UNICORN_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/unicorn/*.h)
-     if (BUILD_SHARED_LIBS)

--- a/ports/unicorn/fix-msvc-shared.patch
+++ b/ports/unicorn/fix-msvc-shared.patch
@@ -1,26 +1,24 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1acc0b5..a4b70d4 100644
+index aa94074..3471cc4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1427,9 +1427,8 @@ endif()
- if (BUILD_SHARED_LIBS)
-     if (MSVC)
-         # Avoid the import lib built by MVSC clash with our archive.
--        set_target_properties(unicorn PROPERTIES ARCHIVE_OUTPUT_NAME "unicorn-import")
-+        set_target_properties(unicorn PROPERTIES ARCHIVE_OUTPUT_NAME "unicorn")
-     endif()
--    bundle_static_library(unicorn_static unicorn_archive unicorn)
- else()
-     # Rename the "static" lib to avoid filename clash.
-     set_target_properties(unicorn PROPERTIES OUTPUT_NAME "unicorn-static")
-@@ -1496,7 +1495,9 @@ if(UNICORN_INSTALL)
+@@ -1447,9 +1447,8 @@ if (UNICORN_LEGACY_STATIC_ARCHIVE)
+     if (BUILD_SHARED_LIBS)
+         if (MSVC)
+             # Avoid the import lib built by MVSC clash with our archive.
+-            set_target_properties(unicorn PROPERTIES ARCHIVE_OUTPUT_NAME "unicorn-import")
++            set_target_properties(unicorn PROPERTIES ARCHIVE_OUTPUT_NAME "unicorn")
+         endif()
+-        bundle_static_library(unicorn_static unicorn_archive unicorn)
+     else()
+         # Rename the "static" lib to avoid filename clash.
+         set_target_properties(unicorn PROPERTIES OUTPUT_NAME "unicorn-static")
+@@ -1517,7 +1517,7 @@ if(UNICORN_INSTALL)
              LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
          )
      endif()
--    install(FILES $<TARGET_FILE:unicorn_archive> DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+    if(NOT(BUILD_SHARED_LIBS))
-+        install(FILES $<TARGET_FILE:unicorn_archive> DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+    endif()
-     install(FILES ${UNICORN_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/unicorn)
-     if (ATOMIC_LINKAGE_FIX)
-         set(ATOMIC_LINK_PKG_CONFIG " -latomic")
+-    if (UNICORN_LEGACY_STATIC_ARCHIVE)
++    if (NOT(BUILD_SHARED_LIBS))
+         install(FILES $<TARGET_FILE:unicorn_archive> DESTINATION ${CMAKE_INSTALL_LIBDIR})
+         install(FILES $<TARGET_FILE_DIR:unicorn_archive>/$<TARGET_PROPERTY:unicorn_archive,SYMLINK_NAME> DESTINATION ${CMAKE_INSTALL_LIBDIR})
+     endif()

--- a/ports/unicorn/portfile.cmake
+++ b/ports/unicorn/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO unicorn-engine/unicorn
     REF "${VERSION}"
-    SHA512 d6184b87a0fb729397ec2ac2cb8bfd9d10c9d4276e49efa681c66c7c54d1a325305a920332a708e68989cc299d0d1a543a1ceeaf552a9b44ec93084f7bf85ef2
+    SHA512 49aa53cd981e88857cf579010e3e86a6808fbfc9723fbf73c3d5bcebf945c5d78ffcdf426a4bbcd06b13337a3a0ce76bce8815497e3521023ae432a053d3e4bb
     HEAD_REF master
     PATCHES
         fix-build.patch

--- a/ports/unicorn/vcpkg.json
+++ b/ports/unicorn/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "unicorn",
-  "version": "2.1.1",
+  "version": "2.1.3",
   "description": "Unicorn is a lightweight multi-platform, multi-architecture CPU emulator framework",
   "homepage": "https://github.com/unicorn-engine/unicorn",
   "license": "GPL-2.0-only",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -550,7 +550,6 @@ torch-th:x64-uwp=fail
 torch-th:x64-windows-static=fail
 treehopper:x64-linux=fail
 treehopper:x64-windows-static=fail
-unicorn:x64-windows-static-md=fail
 unicorn-lib:arm-uwp=fail
 unicorn-lib:x64-uwp=fail
 unittest-cpp:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9549,7 +9549,7 @@
       "port-version": 0
     },
     "unicorn": {
-      "baseline": "2.1.1",
+      "baseline": "2.1.3",
       "port-version": 0
     },
     "unicorn-lib": {

--- a/versions/u-/unicorn.json
+++ b/versions/u-/unicorn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "798ab1504a56c7ac87dff423f3e87a666d0e6e16",
+      "version": "2.1.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "0fcc1642b22d697846278397e4993b115a0514b6",
       "version": "2.1.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/45202

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.