### PR TITLE
[faudio] update to 25.04

### DIFF
--- a/ports/faudio/portfile.cmake
+++ b/ports/faudio/portfile.cmake
@@ -21,12 +21,12 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/FAudio)
+
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
-
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/FAudio)
 
 vcpkg_install_copyright(
     COMMENT "FAudio is licensed under the Zlib license."

--- a/ports/faudio/portfile.cmake
+++ b/ports/faudio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FNA-XNA/faudio
     REF "${VERSION}"
-    SHA512 f74282a7df749f50026bb07309ca20fb12b098cc24b003f8b93f4f6868a3d6f4343d4bd06b947b17d9ec6c1d08f88e477da259397d745f9cc41321f7c5722448
+    SHA512 191b4947c43161c74f32da0208d752f492bcc48eb4ce5bd94824fe541ce0446ff522bfed45fdde29eb05f6938ed814dba3bde31fd06abed4bccf6a79cf334eac
     HEAD_REF master
 )
 
@@ -21,7 +21,10 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/FAudio)
 

--- a/ports/faudio/vcpkg.json
+++ b/ports/faudio/vcpkg.json
@@ -1,13 +1,13 @@
 {
   "name": "faudio",
-  "version-string": "24.09",
+  "version-string": "25.04",
   "description": "FAudio - accuracy-focused XAudio reimplementation for open platforms",
   "homepage": "https://fna-xna.github.io/",
   "license": "Zlib",
   "supports": "!uwp",
   "dependencies": [
     {
-      "name": "sdl2",
+      "name": "sdl3",
       "default-features": false,
       "platform": "!windows"
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2761,7 +2761,7 @@
       "port-version": 0
     },
     "faudio": {
-      "baseline": "24.09",
+      "baseline": "25.04",
       "port-version": 0
     },
     "fawdlstty-libfv": {

--- a/versions/f-/faudio.json
+++ b/versions/f-/faudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1f2c655a55f5744753f6520f7e62c768d885b73",
+      "version-string": "25.04",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d83b0b0c608948eb8c4759723d63d2953fd4f6c",
       "version-string": "24.09",
       "port-version": 0

--- a/versions/f-/faudio.json
+++ b/versions/f-/faudio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f1f2c655a55f5744753f6520f7e62c768d885b73",
+      "git-tree": "55f4f0ecbe122330fbf7cb65e2cc4c6a39448620",
       "version-string": "25.04",
       "port-version": 0
     },


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.