### PR TITLE
[box2d] Update to 3.1.0

### DIFF
--- a/ports/box2d/portfile.cmake
+++ b/ports/box2d/portfile.cmake
@@ -3,17 +3,23 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO erincatto/Box2D
-    REF 9ebbbcd960ad424e03e5de6e66a40764c16f51bc  #v2.4.1
-    SHA512 d9fa387ce893ed1fb73f80006491202f2624ef6d0fb37daf92fbd1a7f9071c84da45e4b418b333566435bbbdfd3d5f68a42dfca02416e9a3a2b4db039f1c6151
-    HEAD_REF master
+    REF 0f2b0246f39594e93fcc8dde0fe0bb1b20b403f9 #slightly past release v3.1.0
+    SHA512 595bb13f49b1c4287ff77a1fe78b9cf4767ddcd15524ab305c5767da3295fc0801b5c62574917e20b926a9947032bb55539c7c823dd9f8f7f02e9d24f6ec76a4
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBOX2D_BUILD_UNIT_TESTS=OFF
-        -DBOX2D_BUILD_TESTBED=OFF
+        -DBOX2D_SAMPLES=OFF
+        -DBOX2D_BENCHMARKS=OFF
+        -DBOX2D_DOCS=OFF
+        -DBOX2D_PROFILE=OFF
+        -DBOX2D_VALIDATE=OFF
+        -DBOX2D_UNIT_TESTS=OFF
+        -DBOX2D_COMPILE_WARNING_AS_ERROR=OFF
 )
+
 vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
@@ -22,4 +28,6 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/box2d)
 
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/box2d/portfile.cmake
+++ b/ports/box2d/portfile.cmake
@@ -1,4 +1,5 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+set(VCPKG_POLICY_SKIP_CRT_LINKAGE_CHECK enabled)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/box2d/usage
+++ b/ports/box2d/usage
@@ -1,0 +1,4 @@
+box2d provides CMake targets:
+
+    find_package(box2d CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE box2d::box2d)

--- a/ports/box2d/vcpkg.json
+++ b/ports/box2d/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "box2d",
-  "version-semver": "2.4.1",
-  "port-version": 3,
+  "version-semver": "3.1.0",
   "description": "An open source C++ engine for simulating rigid bodies in 2D",
   "homepage": "https://box2d.org",
   "supports": "!uwp",

--- a/versions/b-/box2d.json
+++ b/versions/b-/box2d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "22bc81626a1b05cf9ee28a774aa22b19cba79475",
+      "git-tree": "c77778007f66a7b591c14377c2848c4050ccf149",
       "version-semver": "3.1.0",
       "port-version": 0
     },

--- a/versions/b-/box2d.json
+++ b/versions/b-/box2d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22bc81626a1b05cf9ee28a774aa22b19cba79475",
+      "version-semver": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "bef68937d8b4101d0df330a399a7fc043f7ec5e5",
       "version-semver": "2.4.1",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1405,8 +1405,8 @@
       "port-version": 0
     },
     "box2d": {
-      "baseline": "2.4.1",
-      "port-version": 3
+      "baseline": "3.1.0",
+      "port-version": 0
     },
     "braft": {
       "baseline": "2021-26-04",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/41264

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

