### PR TITLE
[octave] add new features

### DIFF
--- a/ports/octave/portfile.cmake
+++ b/ports/octave/portfile.cmake
@@ -37,6 +37,12 @@ if(VCPKG_HOST_IS_OSX)
     message("${PORT} currently requires the following programs from the system package manager:\n    gsed\n\nIt can be installed with brew gnu-sed")
 endif()
 
+if("arpack" IN_LIST FEATURES)
+    set(ARPACK_OPTION "yes")
+else()
+    set(ARPACK_OPTION "no")
+endif()
+
 if("bz2" IN_LIST FEATURES)
     set(BZ2_OPTION "yes")
 else()
@@ -101,6 +107,13 @@ else()
     set(UMFPACK_OPTION "no")
 endif()
 
+if("spqr" IN_LIST FEATURES)
+    set(SPQR_OPTION "yes")
+    set(SUITESPARSECONFIG_OPTION "yes")
+else()
+    set(SPQR_OPTION "no")
+endif()
+
 if("hdf5" IN_LIST FEATURES)
     set(HDF5_OPTION "yes")
 else()
@@ -125,6 +138,12 @@ else()
     set(FREETYPE_OPTION "no")
 endif()
 
+if("portaudio" IN_LIST FEATURES)
+    set(PORTAUDIO_OPTION "yes")
+else()
+    set(PORTAUDIO_OPTION "no")
+endif()
+
 vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/fltk")
 
 vcpkg_configure_make(
@@ -137,7 +156,7 @@ vcpkg_configure_make(
     --enable-lib-visibility-flags
     --enable-relocate-all
     --with-amd=${AMD_OPTION}
-    --with-arpack=no
+    --with-arpack=${ARPACK_OPTION}
     --with-bz2=${BZ2_OPTION}
     --with-camd=${CAMD_OPTION}
     --with-ccolamd=${CCOLAMD_OPTION}
@@ -155,14 +174,14 @@ vcpkg_configure_make(
     --with-klu=${KLU_OPTION}
     --with-magick=no
     --with-opengl # yes
-    --with-portaudio=no
+    --with-portaudio=${PORTAUDIO_OPTION}
     --with-pcre2 # yes
     --with-qhull_r=no
     --with-qrupdate=no
     --with-qscintilla=no
     --with-qt=no
     --with-sndfile # yes
-    --with-spqr=no
+    --with-spqr=${SPQR_OPTION}
     --with-suitesparseconfig=${SUITESPARSECONFIG_OPTION}
     --with-sundials_ida=no
     --with-sundials_nvecserial=no

--- a/ports/octave/vcpkg.json
+++ b/ports/octave/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "octave",
   "version": "9.4.0",
+  "port-version": 1,
   "description": "High-level interpreted language, primarily intended for numerical computations.",
   "homepage": "https://octave.org/",
   "documentation": "https://docs.octave.org/latest/",
@@ -23,6 +24,15 @@
       "dependencies": [
         {
           "name": "suitesparse-amd",
+          "default-features": false
+        }
+      ]
+    },
+    "arpack": {
+      "description": "arpack support",
+      "dependencies": [
+        {
+          "name": "arpack-ng",
           "default-features": false
         }
       ]
@@ -122,6 +132,24 @@
       "dependencies": [
         {
           "name": "suitesparse-klu",
+          "default-features": false
+        }
+      ]
+    },
+    "portaudio": {
+      "description": "portaudio support",
+      "dependencies": [
+        {
+          "name": "portaudio",
+          "default-features": false
+        }
+      ]
+    },
+    "spqr": {
+      "description": "suitesparse-spqr support",
+      "dependencies": [
+        {
+          "name": "suitesparse-spqr",
           "default-features": false
         }
       ]

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -359,6 +359,7 @@ ocilib:arm-uwp=fail
 ocilib:arm64-windows=fail
 ocilib:x64-uwp=fail
 ocilib:x64-windows-static-md=fail
+octave(android)=skip
 octomap:arm-uwp=fail
 octomap:x64-uwp=fail
 ode:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6730,7 +6730,7 @@
     },
     "octave": {
       "baseline": "9.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "octomap": {
       "baseline": "1.10.0",

--- a/versions/o-/octave.json
+++ b/versions/o-/octave.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13966ab545f9fb8a762797820f973bfa2773bc6e",
+      "version": "9.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5d8f8dbd764cc7e0a6599ff4ed9aff9fd59b7efe",
       "version": "9.4.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
