### PR TITLE
[libmediainfo] update to 25.04

### DIFF
--- a/ports/libmediainfo/portfile.cmake
+++ b/ports/libmediainfo/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MediaArea/MediaInfoLib
     REF "v${MEDIAINFO_VERSION}"
-    SHA512 6ad4db0df7425b26a2555f379bbb01dbcdcc8c10bceec4ba97f732b181f2983ee61cc3a49a74c1763e58574e854dc21a031ff4fa1561278ce2c3e9b9e541e9fe
+    SHA512 b6a7482d7e7af7ceaf20dc1bdffeac2cf35ceea6f6a1311a8df4658940202cf190a599ba03a1e8d5dad2bd623263b55edd3b20ee0fce78ee1c4f938a014af3b4
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/libmediainfo/vcpkg.json
+++ b/ports/libmediainfo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmediainfo",
-  "version": "25.3",
+  "version": "25.4",
   "description": "Get most relevant technical and tag data from video and audio files",
   "homepage": "https://github.com/MediaArea/MediaInfoLib",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4917,7 +4917,7 @@
       "port-version": 0
     },
     "libmediainfo": {
-      "baseline": "25.3",
+      "baseline": "25.4",
       "port-version": 0
     },
     "libmem": {

--- a/versions/l-/libmediainfo.json
+++ b/versions/l-/libmediainfo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8acb5ace1a3ab7c3e7c32bfe3ed1ff7ec9d0bc9b",
+      "version": "25.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "079a991e7c8abd9a4ccdd69a03f5d4643afd4c5a",
       "version": "25.3",
       "port-version": 0


### PR DESCRIPTION
If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.