### PR TITLE
[libsigcpp, glibmm, gsl] fix ports bugs

### DIFF
--- a/ports/glibmm/vcpkg.json
+++ b/ports/glibmm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "glibmm",
   "version": "2.80.1",
+  "port-version": 1,
   "description": "This is glibmm, a C++ API for parts of glib that are useful for C++.",
   "homepage": "https://www.gtkmm.org.",
   "license": "LGPL-2.1-or-later",
@@ -10,7 +11,7 @@
     "glib",
     "libffi",
     "libiconv",
-    "libsigcpp-3",
+    "libsigcpp",
     "pcre",
     {
       "name": "vcpkg-tool-meson",

--- a/ports/gsl/portfile.cmake
+++ b/ports/gsl/portfile.cmake
@@ -23,8 +23,13 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-
 vcpkg_fixup_pkgconfig()
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gsl.pc" "\${GSL_CBLAS_LIB}" "-lgsl \${GSL_CBLAS_LIB}")
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gsl.pc")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gsl.pc" "-lgslcblas" "-lgslcblasd")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gsl.pc" "\${GSL_CBLAS_LIB}" "-lgsld \${GSL_CBLAS_LIB}")
+endif()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/gsl/vcpkg.json
+++ b/ports/gsl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gsl",
   "version": "2.8",
+  "port-version": 1,
   "description": "The GNU Scientific Library is a numerical library for C and C++ programmers",
   "homepage": "https://www.gnu.org/software/gsl/",
   "license": "GPL-3.0-or-later",

--- a/ports/libsigcpp/fix_version.patch
+++ b/ports/libsigcpp/fix_version.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,9 +16,9 @@
+ 
+ cmake_minimum_required (VERSION 3.2)
+ 
+ set (SIGCXX_MAJOR_VERSION 3)
+-set (SIGCXX_MINOR_VERSION 4)
++set (SIGCXX_MINOR_VERSION 6)
+ set (SIGCXX_MICRO_VERSION 0)
+ 
+ set (SIGCXX_API_VERSION 3.0)
+ set (PACKAGE_VERSION ${SIGCXX_MAJOR_VERSION}.${SIGCXX_MINOR_VERSION}.${SIGCXX_MICRO_VERSION})

--- a/ports/libsigcpp/portfile.cmake
+++ b/ports/libsigcpp/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         disable_tests_enable_static_build.patch
         fix-shared-windows-build.patch
         fix_include_path.patch
+        fix_version.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/libsigcpp/vcpkg.json
+++ b/ports/libsigcpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsigcpp",
   "version": "3.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Typesafe callback framework for C++",
   "homepage": "https://libsigcplusplus.github.io/libsigcplusplus/",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3230,7 +3230,7 @@
     },
     "glibmm": {
       "baseline": "2.80.1",
-      "port-version": 0
+      "port-version": 1
     },
     "glm": {
       "baseline": "1.0.1",
@@ -3362,7 +3362,7 @@
     },
     "gsl": {
       "baseline": "2.8",
-      "port-version": 0
+      "port-version": 1
     },
     "gsl-lite": {
       "baseline": "0.42.0",
@@ -5242,7 +5242,7 @@
     },
     "libsigcpp": {
       "baseline": "3.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libsigcpp-3": {
       "baseline": "3.0.3",

--- a/versions/g-/glibmm.json
+++ b/versions/g-/glibmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d6c1e2f8d051288fce26c9294a15c89f3a56c3b",
+      "version": "2.80.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "a25c0ff9ecf2824710c645d6b236f10341ab68e6",
       "version": "2.80.1",
       "port-version": 0

--- a/versions/g-/gsl.json
+++ b/versions/g-/gsl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e842d0c0f2aa72b22baf30c1350f81fcc87591dc",
+      "version": "2.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "065963abda1b0c77fc000f1624636bc5aec7e876",
       "version": "2.8",
       "port-version": 0

--- a/versions/l-/libsigcpp.json
+++ b/versions/l-/libsigcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b48fe434789aee633527a307273c41f0b8be925",
+      "version": "3.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "7acf22cbf38c907f3309b3478dd61dd9ed7a78f0",
       "version": "3.6.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
