### PR TITLE
[gtest] update to 1.17.0

### DIFF
--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/googletest
     REF "v${VERSION}"
-    SHA512 bec8dad2a5abbea8e9e5f0ceedd8c9dbdb8939e9f74785476b0948f21f5db5901018157e78387e106c6717326558d6642fc0e39379c62af57bf1205a9df8a18b
+    SHA512 0f57e9ef06925e5b7722df1eb92ef5850e8dce79220ea16a8aaff586a71c0b01460ef1713649ee24ffedb2e6ad5a51e9198c5a5ae1b2789e43feb1f494e7d45c
     HEAD_REF main
     PATCHES
         001-fix-UWP-death-test.patch

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gtest",
-  "version-semver": "1.16.0",
-  "port-version": 1,
+  "version-semver": "1.17.0",
   "description": "Google Testing and Mocking Framework",
   "homepage": "https://github.com/google/googletest",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3381,8 +3381,8 @@
       "port-version": 0
     },
     "gtest": {
-      "baseline": "1.16.0",
-      "port-version": 1
+      "baseline": "1.17.0",
+      "port-version": 0
     },
     "gtk": {
       "baseline": "4.16.3",

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8379b242dedcaefa81bebb7dc499cd6b62a740b4",
+      "version-semver": "1.17.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6f97e6a042f8662fe76d3905d82ac23a129695b1",
       "version-semver": "1.16.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/google/googletest/releases/tag/v1.17.0
