### PR TITLE
[ms-gdk] Update for October 2024 Update 2

### DIFF
--- a/ports/ms-gdk/pfusage
+++ b/ports/ms-gdk/pfusage
@@ -1,0 +1,12 @@
+
+  find_package(playfab.services.c CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabServices)
+
+  find_package(playfab.multiplayer.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabMultiplayer)
+
+  find_package(playfab.party.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabParty)
+
+  find_package(playfab.partyxboxlive.cpp CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Xbox::PlayFabPartyLIVE)

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -1,4 +1,4 @@
-set(GDK_EDITION_NUMBER 241001)
+set(GDK_EDITION_NUMBER 241002)
 
 # The GDK contains a combination of static C++ libraries and DLL-based extension libraries.
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
@@ -6,7 +6,7 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"
     FILENAME "ms-gdk.${VERSION}.zip"
-    SHA512 47cd422fddce2594626c3c0319965a66bdd422dde79474d2ba1993feaeb9d7dadc684f7cd297d13e14fe526f06d64856f5de70b97242ba529777a3101423a3bc
+    SHA512 e9b40b1c904e1a082b0078f6d3654fad7f859f9676b169f2e2223b74b5d2546c69bd79c365d6f4b915fbe6a2afc1b664d2ce47c902b7fb59f9a038fe2a060f99
 )
 
 vcpkg_extract_source_archive(
@@ -15,10 +15,21 @@ vcpkg_extract_source_archive(
     NO_REMOVE_ONE_LEVEL
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        playfab BUILD_PLAYFAB_SERVICES
+)
+
 set(GRDK_PATH "${PACKAGE_PATH}/native/${GDK_EDITION_NUMBER}/GRDK")
+
+# We use the gameinput port instead
+file(REMOVE "${GRDK_PATH}/GameKit/Include/GameInput.h")
+file(REMOVE "${GRDK_PATH}/GameKit/Lib/amd64/GameInput.lib")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${GRDK_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
@@ -29,41 +40,39 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.libhttpclient)
 vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.services.api.c)
 vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.xcurl.api)
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.multiplayer.cpp)
-vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.party.cpp)
-vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.partyxboxlive.cpp)
-vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.services.c)
+set(LICENSE_FILES "${PACKAGE_PATH}/LICENSE.md")
 
-file(INSTALL "${PACKAGE_PATH}/native/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
-file(INSTALL "${PACKAGE_PATH}/native/bin/GameConfigEditorDependencies" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-file(REMOVE
-    "${CURRENT_PACKAGES_DIR}/debug/lib/Microsoft.Xbox.Services.142.GDK.C.lib"
-    "${CURRENT_PACKAGES_DIR}/debug/lib/Microsoft.Xbox.Services.142.GDK.C.pdb"
-    "${CURRENT_PACKAGES_DIR}/debug/lib/Microsoft.Xbox.Services.GDK.C.Thunks.lib"
-    "${CURRENT_PACKAGES_DIR}/debug/lib/Microsoft.Xbox.Services.GDK.C.Thunks.pdb"
-    )
-
-file(REMOVE
-    "${CURRENT_PACKAGES_DIR}/lib/Microsoft.Xbox.Services.142.GDK.C.debug.lib"
-    "${CURRENT_PACKAGES_DIR}/lib/Microsoft.Xbox.Services.142.GDK.C.debug.pdb"
-    "${CURRENT_PACKAGES_DIR}/lib/Microsoft.Xbox.Services.GDK.C.Thunks.debug.lib"
-    "${CURRENT_PACKAGES_DIR}/lib/Microsoft.Xbox.Services.GDK.C.Thunks.debug.pdb"
-    )
-
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
-vcpkg_install_copyright(FILE_LIST
-    "${PACKAGE_PATH}/LICENSE.md"
+list(APPEND LICENSE_FILES
     "${GRDK_PATH}/ExtensionLibraries/Xbox.LibHttpClient/Include/httpClient/ThirdPartyNotices.txt"
     "${GRDK_PATH}/ExtensionLibraries/Xbox.XCurl.API/Include/ThirdPartyNotices.txt"
     "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/cpprest/ThirdPartyNotices.txt"
     "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/pplx/ThirdPartyNotices.txt"
     "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-c/ThirdPartyNotices.txt"
     "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-cpp/ThirdPartyNotices.txt"
-    "${GRDK_PATH}/ExtensionLibraries/PlayFab.Multiplayer.Cpp/Include/NOTICE.txt"
-    "${GRDK_PATH}/ExtensionLibraries/PlayFab.Party.Cpp/Include/NOTICE.txt"
-    "${GRDK_PATH}/ExtensionLibraries/PlayFab.PartyXboxLive.Cpp/Include/NOTICE.txt"
 )
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+if("playfab" IN_LIST FEATURES)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.multiplayer.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.party.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.partyxboxlive.cpp)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.services.c)
+
+    list(APPEND LICENSE_FILES
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.Multiplayer.Cpp/Include/NOTICE.txt"
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.Party.Cpp/Include/NOTICE.txt"
+        "${GRDK_PATH}/ExtensionLibraries/PlayFab.PartyXboxLive.Cpp/Include/NOTICE.txt"
+    )
+
+    file(READ "${CMAKE_CURRENT_LIST_DIR}/pfusage" USAGE_CONTENT)
+    file(APPEND "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" ${USAGE_CONTENT})
+else()
+endif()
+
+file(INSTALL "${PACKAGE_PATH}/native/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+file(INSTALL "${PACKAGE_PATH}/native/bin/GameConfigEditorDependencies" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/ms-gdk/usage
+++ b/ports/ms-gdk/usage
@@ -14,15 +14,3 @@ The Microsoft GDK package provides CMake targets:
 
   find_package(xbox.game.chat.2.cpp.api CONFIG REQUIRED)
   target_link_libraries(main PRIVATE Xbox::GameChat2)
-
-  find_package(playfab.services.c CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE Xbox::PlayFabServices)
-
-  find_package(playfab.multiplayer.cpp CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE Xbox::PlayFabMultiplayer)
-
-  find_package(playfab.party.cpp CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE Xbox::PlayFabParty)
-
-  find_package(playfab.partyxboxlive.cpp CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE Xbox::PlayFabPartyLIVE)

--- a/ports/ms-gdk/vcpkg.json
+++ b/ports/ms-gdk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-gdk",
-  "version": "2410.1.1897",
+  "version": "2410.2.1916",
   "description": "Microsoft Game Development Kit (GDK)",
   "homepage": "https://aka.ms/gdkx",
   "documentation": "https://aka.ms/gamedevdocs",
@@ -15,5 +15,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "playfab": {
+      "description": "Include PlayFab Extension Libraries"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6293,7 +6293,7 @@
       "port-version": 1
     },
     "ms-gdk": {
-      "baseline": "2410.1.1897",
+      "baseline": "2410.2.1916",
       "port-version": 0
     },
     "ms-gdkx": {

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0535ef02e82f2357f1f1fc45d680246374a2f9df",
+      "version": "2410.2.1916",
+      "port-version": 0
+    },
+    {
       "git-tree": "55b2ad59e5cc59bb90a8a8eb259c0a93a84ece16",
       "version": "2410.1.1897",
       "port-version": 0


### PR DESCRIPTION
* Remove some workarounds from the port for issues fixed in the GDK's CMake files

* Added **playfab** feature to allow opt-in for the four Playfab Extension Libraries using new CMake build option in the GDK's files.

* gameinput v0 headers in the GDK are ignored in favor of using the gameinput port directly