### PR TITLE
[BitSerializer] Update to v0.80

### DIFF
--- a/ports/bitserializer/portfile.cmake
+++ b/ports/bitserializer/portfile.cmake
@@ -1,17 +1,14 @@
-# All components of BitSerializer is "header only" except CSV archive
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
+# All BitSerializer components are "header only" except for CSV and MsgPack archives
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PavelKisliak/BitSerializer
-    REF v0.75
-    SHA512 ae31f17a0b4e488892f676eafe94e2d43a381153b9179891a9d3a6380c7b3f12d29bc20b7be270a71305bc7c27b08395f6aa8a8be26c52934e148e7140d34d21
+    REF v0.80
+    SHA512 43d0bbfeefaf303d20c2bf0534b7fab7bcb8508999ff346c7978b67aa8103a2fc7423d306d15cbd9824921c7055221ef2f8ad9cd2564ef7e032157ab9bb8e041
     HEAD_REF master
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        "cpprestjson-archive"  BUILD_CPPRESTJSON_ARCHIVE
         "rapidjson-archive"    BUILD_RAPIDJSON_ARCHIVE
         "pugixml-archive"      BUILD_PUGIXML_ARCHIVE
         "rapidyaml-archive"    BUILD_RAPIDYAML_ARCHIVE

--- a/ports/bitserializer/usage
+++ b/ports/bitserializer/usage
@@ -3,7 +3,6 @@ BitSerializer provides CMake targets:
     find_package(bitserializer CONFIG REQUIRED)
     # Link only archives which you are specified in the features list when install
     target_link_libraries(main PRIVATE
-        BitSerializer::cpprestjson-archive
         BitSerializer::rapidjson-archive
         BitSerializer::pugixml-archive
         BitSerializer::rapidyaml-archive

--- a/ports/bitserializer/vcpkg.json
+++ b/ports/bitserializer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "bitserializer",
-  "version": "0.75",
-  "description": "C++ 17 library for serialization to JSON, XML, YAML, CSV, MsgPack",
+  "version": "0.80",
+  "description": "Multi-format serialization library (JSON, XML, YAML, CSV, MsgPack)",
   "homepage": "https://github.com/PavelKisliak/BitSerializer",
   "license": "MIT",
   "dependencies": [
@@ -15,12 +15,6 @@
     }
   ],
   "features": {
-    "cpprestjson-archive": {
-      "description": "Module for support JSON (implementation based on the CppRestSDK library)",
-      "dependencies": [
-        "cpprestsdk"
-      ]
-    },
     "csv-archive": {
       "description": "Module for support CSV"
     },

--- a/versions/b-/bitserializer.json
+++ b/versions/b-/bitserializer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d77ff6e6a9d473e6928683064e88b307a581555d",
+      "version": "0.80",
+      "port-version": 0
+    },
+    {
       "git-tree": "905079d1cc6608e221aea9d68c19adcfa15b6f97",
       "version": "0.75",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -693,7 +693,7 @@
       "port-version": 0
     },
     "bitserializer": {
-      "baseline": "0.75",
+      "baseline": "0.80",
       "port-version": 0
     },
     "bitsery": {


### PR DESCRIPTION
New version of BitSerializer 0.80 has been released ([Release notes](https://github.com/PavelKisliak/BitSerializer/releases)).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
