### PR TITLE
[qt5-base] Move sqlite3 out of core feature

### DIFF
--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -14,6 +14,11 @@ endif()
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
+set(WITH_SQLITE3_PLUGIN OFF)
+if("sqlite3plugin" IN_LIST FEATURES)
+    set(WITH_SQLITE3_PLUGIN ON)
+endif()
+
 set(WITH_PGSQL_PLUGIN OFF)
 if("postgresqlplugin" IN_LIST FEATURES)
     set(WITH_PGSQL_PLUGIN ON)
@@ -112,7 +117,6 @@ list(APPEND CORE_OPTIONS
     -system-freetype
     -system-pcre
     -system-doubleconversion
-    -system-sqlite
     -system-harfbuzz
     -no-angle # Qt does not need to build angle. VCPKG will build angle!
     -no-glib
@@ -128,6 +132,11 @@ else()
     list(APPEND CORE_OPTIONS -dbus-runtime)
 endif()
 
+if(WITH_SQLITE3_PLUGIN)
+    list(APPEND CORE_OPTIONS -system-sqlite)
+else()
+    list(APPEND CORE_OPTIONS -no-sql-sqlite)
+endif()
 if(WITH_PGSQL_PLUGIN)
     list(APPEND CORE_OPTIONS -sql-psql)
 else()

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version": "5.15.16",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Qt Base provides the basic non-GUI functionality required by all Qt applications.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -37,7 +37,6 @@
       "host": true,
       "default-features": false
     },
-    "sqlite3",
     {
       "name": "vcpkg-cmake-get-vars",
       "host": true
@@ -81,6 +80,12 @@
       "description": "Build the sql plugin for connecting to postgresql databases",
       "dependencies": [
         "libpq"
+      ]
+    },
+    "sqlite3plugin": {
+      "description": "Build the sql plugin for connecting to sqlite3 databases",
+      "dependencies": [
+        "sqlite3"
       ]
     },
     "vulkan": {

--- a/ports/qt5-tools/vcpkg.json
+++ b/ports/qt5-tools/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-tools",
   "version": "5.15.16",
+  "port-version": 1,
   "description": "A collection of tools and utilities that come with the Qt framework to assist developers in the creation, management, and deployment of Qt applications.",
   "license": null,
   "dependencies": [
@@ -10,7 +11,10 @@
     },
     {
       "name": "qt5-base",
-      "default-features": false
+      "default-features": false,
+      "features": [
+        "sqlite3plugin"
+      ]
     },
     "qt5-declarative"
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7618,7 +7618,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.16",
-      "port-version": 3
+      "port-version": 4
     },
     "qt5-canvas3d": {
       "baseline": "0",
@@ -7734,7 +7734,7 @@
     },
     "qt5-tools": {
       "baseline": "5.15.16",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-translations": {
       "baseline": "5.15.16",

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "62edebec93307f1a16a04dac081974df32bdc337",
+      "version": "5.15.16",
+      "port-version": 4
+    },
+    {
       "git-tree": "242aac47d278fdbbdc38776f814ef4e0cb439083",
       "version": "5.15.16",
       "port-version": 3

--- a/versions/q-/qt5-tools.json
+++ b/versions/q-/qt5-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b361c851974436c968f0f17e7a7e544ab9f64cc",
+      "version": "5.15.16",
+      "port-version": 1
+    },
+    {
       "git-tree": "8c46478aa6df9dde8d3d78d2b5c5739f6337fa88",
       "version": "5.15.16",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.