### PR TITLE
[libheif] Make gdk-pixbuf optional

### DIFF
--- a/ports/libheif/gdk-pixbuf.patch
+++ b/ports/libheif/gdk-pixbuf.patch
@@ -3,7 +3,8 @@ index eeb2727..20a6b16 100644
 --- "a/gdk-pixbuf/CMakeLists.txt"
 +++ "b/gdk-pixbuf/CMakeLists.txt"
 @@ -1,12 +1,9 @@
- if(UNIX OR MINGW)
+-if(UNIX OR MINGW)
++if(WITH_GDKPIXBUF2 AND (UNIX OR MINGW))
    find_package(PkgConfig)
 -  pkg_check_modules(GDKPIXBUF2 gdk-pixbuf-2.0)
 +  pkg_check_modules(GDKPIXBUF2 gdk-pixbuf-2.0 IMPORTED_TARGET)

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         jpeg        WITH_JPEG_DECODER
         jpeg        WITH_JPEG_ENCODER
         iso23001-17 WITH_UNCOMPRESSED_CODEC
+        gdk-pixbuf  WITH_GDKPIXBUF2
 )
 
 vcpkg_cmake_configure(

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,15 +1,12 @@
 {
   "name": "libheif",
   "version": "1.19.8",
+  "port-version": 1,
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",
   "supports": "!xbox",
   "dependencies": [
-    {
-      "name": "gdk-pixbuf",
-      "platform": "!windows"
-    },
     "libde265",
     {
       "name": "vcpkg-cmake",
@@ -29,6 +26,13 @@
       "license": "BSD-2-Clause",
       "dependencies": [
         "aom"
+      ]
+    },
+    "gdk-pixbuf": {
+      "description": "Plugin for gdk-pixbuf",
+      "supports": "!windows",
+      "dependencies": [
+        "gdk-pixbuf"
       ]
     },
     "hevc": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4770,7 +4770,7 @@
     },
     "libheif": {
       "baseline": "1.19.8",
-      "port-version": 0
+      "port-version": 1
     },
     "libhsplasma": {
       "baseline": "2024-03-07",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3818c7a07a9299759d1de597f0091d9f127b3d95",
+      "version": "1.19.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "12fbe980a14a9a302122f8b5df3916365c413fc7",
       "version": "1.19.8",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.