### PR TITLE
[pulseaudio] Move gstreamer to feature

### DIFF
--- a/ports/pulseaudio/portfile.cmake
+++ b/ports/pulseaudio/portfile.cmake
@@ -46,8 +46,6 @@ vcpkg_configure_meson(
       -Dasyncns=disabled # requires port?
       -Davahi=disabled
       -Dbluez5=disabled
-      -Dbluez5-native-headset=false
-      -Dbluez5-ofono-headset=false
       -Dconsolekit=disabled
       -Ddbus=enabled
       -Delogind=disabled
@@ -57,15 +55,15 @@ vcpkg_configure_meson(
       -Dgtk=disabled
       -Dhal-compat=false
       -Dipv6=true
-      -Dopenssl=enabled
       -Djack=enabled # jack2?
       -Dlirc=enabled # does this need a port?
+      -Dopenssl=enabled
       -Dorc=enabled # does this need a port? "orc" ?
 
       -Dsoxr=enabled
       -Dspeex=enabled
       -Dsystemd=disabled
-      -Dtcpwrap=enabled # dito
+      -Dtcpwrap=disabled
       -Dudev=disabled # port ?
       -Dvalgrind=disabled
       -Dx11=disabled
@@ -93,7 +91,6 @@ if(NOT VCPKG_BUILD_TYPE)
 endif()
 vcpkg_copy_tools(TOOL_NAMES pacat pactl padsp pa-info pamon AUTO_CLEAN)
 
-# Handle copyright
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/pulseaudio/portfile.cmake
+++ b/ports/pulseaudio/portfile.cmake
@@ -58,7 +58,7 @@ vcpkg_configure_meson(
       -Djack=enabled # jack2?
       -Dlirc=enabled # does this need a port?
       -Dopenssl=enabled
-      -Dorc=enabled # does this need a port? "orc" ?
+      -Dorc=disabled # not port orc
 
       -Dsoxr=enabled
       -Dspeex=enabled

--- a/ports/pulseaudio/portfile.cmake
+++ b/ports/pulseaudio/portfile.cmake
@@ -24,6 +24,11 @@ else()
     -Doss-output=disabled
   )
 endif()
+if("gstreamer" IN_LIST FEATURES)
+  list(APPEND opts -Dgstreamer=enabled)
+else()
+  list(APPEND opts -Dgstreamer=disabled)
+endif()
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -49,7 +54,6 @@ vcpkg_configure_meson(
       -Dfftw=enabled
       -Dglib=enabled
       -Dgsettings=disabled
-      -Dgstreamer=enabled
       -Dgtk=disabled
       -Dhal-compat=false
       -Dipv6=true

--- a/ports/pulseaudio/vcpkg.json
+++ b/ports/pulseaudio/vcpkg.json
@@ -34,7 +34,6 @@
       "name": "openssl",
       "default-features": false
     },
-    "orc",
     "soxr",
     "speex",
     {

--- a/ports/pulseaudio/vcpkg.json
+++ b/ports/pulseaudio/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "PulseAudio is a sound server, originally created to overcome the limitations of the Enlightened Sound Daemon (EsounD)",
   "homepage": "https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/Community/",
   "license": null,
-  "supports": "!windows & !osx",
+  "supports": "!android & !osx & !windows",
   "dependencies": [
     {
       "name": "alsa",

--- a/ports/pulseaudio/vcpkg.json
+++ b/ports/pulseaudio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pulseaudio",
   "version": "17.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "PulseAudio is a sound server, originally created to overcome the limitations of the Enlightened Sound Daemon (EsounD)",
   "homepage": "https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/Community/",
   "license": null,
@@ -18,10 +18,6 @@
     "fftw3",
     {
       "name": "glib",
-      "default-features": false
-    },
-    {
-      "name": "gstreamer",
       "default-features": false
     },
     "jack2",
@@ -49,5 +45,19 @@
       "name": "vcpkg-tool-meson",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "gstreamer": {
+      "description": [
+        "Use GStreamer media-related functionality.",
+        "This feauture may cause dependency cycles with other libs used by gstreamer."
+      ],
+      "dependencies": [
+        {
+          "name": "gstreamer",
+          "default-features": false
+        }
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7502,7 +7502,7 @@
     },
     "pulseaudio": {
       "baseline": "17.0",
-      "port-version": 2
+      "port-version": 3
     },
     "pulzed-mini": {
       "baseline": "0.9.18",

--- a/versions/p-/pulseaudio.json
+++ b/versions/p-/pulseaudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c58fbd05348766e648cf082364375dace51d2337",
+      "version": "17.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "498d6911a860d3f86ec25caabd0f63f5180782a2",
       "version": "17.0",
       "port-version": 2

--- a/versions/p-/pulseaudio.json
+++ b/versions/p-/pulseaudio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c58fbd05348766e648cf082364375dace51d2337",
+      "git-tree": "4fbc8a0a9d91a869f066c9f07dd5d684e8392a71",
       "version": "17.0",
       "port-version": 3
     },


### PR DESCRIPTION
Allow to unbreak cycles in gstreamer dependencies, e.g. openal-soft, fluidsynth.

No feature test CI warnings.

Related PRs:

~~~mermaid
graph TD;
  fluidsynth_45364 --> gstreamer_45134;
  openal-soft_5356 --> gstreamer_45134;
  pulseaudio_45363 --> fluidsynth_45364;
  pulseaudio_45363 --> gstreamer_45134;
  pulseaudio_45363 --> openal-soft_5356;
  gstreamer_45134  --> gstreamer-update;
~~~