### PR TITLE
[luau] update to 0.672

### DIFF
--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 007f29fe42bce92211ebafda38cca0dd178daf4bfdf7f1139d2375ac9030861c353f38484b07241ce173dcf14b4fcf77db95bed38c6796de2d6604f0005e0615
+    SHA512 525e9819cb81eda7a3d8b76f7c06f0a7bdb14978f9908febb6172f4021dcdb714094617574dda630a7ff4b67063bf98e186f2f774d561f81a11f29f84e945ab7
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.671",
+  "version": "0.672",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5829,7 +5829,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.671",
+      "baseline": "0.672",
       "port-version": 0
     },
     "luminoengine": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54b66c957c5932c58b7b63a518a1621f5e7a9849",
+      "version": "0.672",
+      "port-version": 0
+    },
+    {
       "git-tree": "d7b7b09135751cb43e3a3d54dae01fd6e6ef7776",
       "version": "0.671",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/luau-lang/luau/releases/tag/0.672
