### PR TITLE
[cpprestsdk] fix compilation of cpprestsdk on new MacOS

### DIFF
--- a/ports/cpprestsdk/chart_traits.patch
+++ b/ports/cpprestsdk/chart_traits.patch
@@ -1,0 +1,92 @@
+diff --git a/Release/include/cpprest/char_traits.h b/Release/include/cpprest/char_traits.h
+new file mode 100644
+index 0000000000..1e7d172bb0
+--- /dev/null
++++ b/Release/include/cpprest/char_traits.h
+@@ -0,0 +1,74 @@
++#include <cstdint>
++#include <cstring>
++#include <string>
++
++namespace std
++{
++template<>
++struct char_traits<uint8_t>
++{
++    using char_type = uint8_t;
++    using int_type = unsigned int;
++    using off_type = std::streamoff;
++    using pos_type = std::streampos;
++    using state_type = std::mbstate_t;
++
++    static void assign(char_type& c1, const char_type& c2) noexcept { c1 = c2; }
++
++    static bool eq(char_type c1, char_type c2) noexcept { return c1 == c2; }
++
++    static bool lt(char_type c1, char_type c2) noexcept { return c1 < c2; }
++
++    static int compare(const char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        return std::memcmp(s1, s2, n);
++    }
++
++    static std::size_t length(const char_type* s) noexcept
++    {
++        const char_type* p = s;
++        while (*p != 0)
++            ++p;
++        return p - s;
++    }
++
++    static const char_type* find(const char_type* s, std::size_t n, const char_type& a) noexcept
++    {
++        for (std::size_t i = 0; i < n; ++i)
++        {
++            if (eq(s[i], a))
++            {
++                return s + i;
++            }
++        }
++
++        return nullptr;
++    }
++
++    static char_type* move(char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        return static_cast<char_type*>(std::memmove(s1, s2, n));
++    }
++
++    static char_type* copy(char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        return static_cast<char_type*>(std::memcpy(s1, s2, n));
++    }
++
++    static char_type* assign(char_type* s, std::size_t n, char_type a) noexcept
++    {
++        std::fill_n(s, n, a);
++        return s;
++    }
++
++    static int_type not_eof(int_type c) noexcept { return c == eof() ? ~eof() : c; }
++
++    static char_type to_char_type(int_type c) noexcept { return static_cast<char_type>(c); }
++
++    static int_type to_int_type(char_type c) noexcept { return static_cast<int_type>(c); }
++
++    static bool eq_int_type(int_type c1, int_type c2) noexcept { return c1 == c2; }
++
++    static int_type eof() noexcept { return static_cast<int_type>(-1); }
++};
++} // namespace std
+diff --git a/Release/include/cpprest/streams.h b/Release/include/cpprest/streams.h
+index b6c3864028..e505c841ef 100644
+--- a/Release/include/cpprest/streams.h
++++ b/Release/include/cpprest/streams.h
+@@ -15,6 +15,7 @@
+ #ifndef CASA_STREAMS_H
+ #define CASA_STREAMS_H
+ 
++#include "cpprest/char_traits.h"
+ #include "cpprest/astreambuf.h"
+ #include <iosfwd>
+ #include <cstdio>

--- a/ports/cpprestsdk/chart_traits.patch
+++ b/ports/cpprestsdk/chart_traits.patch
@@ -1,9 +1,15 @@
 diff --git a/Release/include/cpprest/char_traits.h b/Release/include/cpprest/char_traits.h
 new file mode 100644
-index 0000000000..1e7d172bb0
+index 00000000..ba9ef01e
 --- /dev/null
 +++ b/Release/include/cpprest/char_traits.h
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,82 @@
++#pragma once
++
++#include <cstddef>
++
++#if (_LIBCPP_VERSION >= 190000)
++
 +#include <cstdint>
 +#include <cstring>
 +#include <string>
@@ -78,8 +84,10 @@ index 0000000000..1e7d172bb0
 +    static int_type eof() noexcept { return static_cast<int_type>(-1); }
 +};
 +} // namespace std
++
++#endif // (_LIBCPP_VERSION >= 190000)
 diff --git a/Release/include/cpprest/streams.h b/Release/include/cpprest/streams.h
-index b6c3864028..e505c841ef 100644
+index b6c38640..704bfc92 100644
 --- a/Release/include/cpprest/streams.h
 +++ b/Release/include/cpprest/streams.h
 @@ -15,6 +15,7 @@

--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(PATCH_PR_1820
+    URLS https://github.com/microsoft/cpprestsdk/commit/396259a0f88e6f908c6d841f13c113d5f0d0ec26.patch
+    SHA512 2235feddc11633041eb27fadb154515c2270d2f187f3bab4cac3f0b73f7ff034a56d4540700ccae36be216f480915da5203b660f9401e371999dbce888a421bf
+    FILENAME char_traits.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/cpprestsdk
@@ -11,6 +17,7 @@ vcpkg_from_github(
         fix-clang-dllimport.patch # workaround for https://github.com/microsoft/cpprestsdk/issues/1710
         silence-stdext-checked-array-iterators-warning.patch
         fix-asio-error.patch
+        ${PATCH_PR_1820}
 )
 
 vcpkg_check_features(

--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -1,9 +1,3 @@
-vcpkg_download_distfile(PATCH_PR_1820
-    URLS https://github.com/microsoft/cpprestsdk/commit/396259a0f88e6f908c6d841f13c113d5f0d0ec26.patch
-    SHA512 2235feddc11633041eb27fadb154515c2270d2f187f3bab4cac3f0b73f7ff034a56d4540700ccae36be216f480915da5203b660f9401e371999dbce888a421bf
-    FILENAME char_traits.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/cpprestsdk
@@ -17,7 +11,7 @@ vcpkg_from_github(
         fix-clang-dllimport.patch # workaround for https://github.com/microsoft/cpprestsdk/issues/1710
         silence-stdext-checked-array-iterators-warning.patch
         fix-asio-error.patch
-        ${PATCH_PR_1820}
+        chart_traits.patch # remove after https://github.com/microsoft/cpprestsdk/pull/1820
 )
 
 vcpkg_check_features(

--- a/ports/cpprestsdk/vcpkg.json
+++ b/ports/cpprestsdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cpprestsdk",
   "version": "2.10.19",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "C++11 JSON, REST, and OAuth library",
     "The C++ REST SDK is a Microsoft project for cloud-based client-server communication in native code using a modern asynchronous C++ API design. This project aims to help C++ developers connect to and interact with services."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2022,7 +2022,7 @@
     },
     "cpprestsdk": {
       "baseline": "2.10.19",
-      "port-version": 3
+      "port-version": 4
     },
     "cppslippi": {
       "baseline": "1.4.3.16",

--- a/versions/c-/cpprestsdk.json
+++ b/versions/c-/cpprestsdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "86500cf9f3b462296cd78a268eb4b643424b44e4",
+      "git-tree": "b54e9d0973f60275791398089dacc24db2fef324",
       "version": "2.10.19",
       "port-version": 4
     },

--- a/versions/c-/cpprestsdk.json
+++ b/versions/c-/cpprestsdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b54e9d0973f60275791398089dacc24db2fef324",
+      "git-tree": "938096ad282071faff4b7b5746dd3193ad95c408",
       "version": "2.10.19",
       "port-version": 4
     },

--- a/versions/c-/cpprestsdk.json
+++ b/versions/c-/cpprestsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86500cf9f3b462296cd78a268eb4b643424b44e4",
+      "version": "2.10.19",
+      "port-version": 4
+    },
+    {
       "git-tree": "9f5e160191038cbbd2470e534c43f051c80e7d44",
       "version": "2.10.19",
       "port-version": 3


### PR DESCRIPTION
Cpprestsdk fails to compile on newer MacOS due to missing char_traits.
Fixes https://github.com/microsoft/vcpkg/issues/45131

This provides the fix from https://github.com/microsoft/cpprestsdk/pull/1820
Related to https://github.com/microsoft/cpprestsdk/issues/1812

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
