### PR TITLE
[librecad] Add new port

### DIFF
--- a/ports/librecad/dependencies.patch
+++ b/ports/librecad/dependencies.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -22,10 +22,10 @@
+ set(CMAKE_AUTORCC ON)
+ add_compile_definitions(DWGSUPPORT)
+ add_compile_definitions(MUPARSER_STATIC)
+ 
+-find_package(Qt5 COMPONENTS Gui Core Widgets PrintSupport SVG REQUIRED)
+-find_package(Boost REQUIRED COMPONENTS)
++find_package(Qt5 COMPONENTS Gui Core Widgets PrintSupport Svg REQUIRED)
++find_package(Boost REQUIRED COMPONENTS numeric_ublas math)
+ 
+ #qt5_wrap_cpp(plugins/asciifile.cpp)
+ 
+ include_directories(${MIN_GW_PATH_PREFIX}\\include\\QtSvg)
+@@ -1040,5 +1040,6 @@
+         #        tools/ttf2lff/main.cpp )
+ )
+ 
+ 
+-target_link_libraries(LibreCAD Qt5::Core Qt5::Widgets Qt5::Gui Qt5::PrintSupport Qt5::Svg)
++target_link_libraries(LibreCAD Qt5::Core Qt5::Widgets Qt5::Gui Qt5::PrintSupport Qt5::Svg Boost::numeric_ublas Boost::math)
++install(TARGETS LibreCAD RUNTIME DESTINATION bin)

--- a/ports/librecad/portfile.cmake
+++ b/ports/librecad/portfile.cmake
@@ -1,0 +1,26 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO LibreCAD/LibreCAD
+    REF "v${VERSION}"
+    SHA512 c8c65f2e0405f8193c37ce0a5a395320635138967d4f948b516453f48d286fe9f4afee6ac9edd93690a5c9977b4c072c7319b5a95b81bca82ad055f332a7f064
+    HEAD_REF master
+    PATCHES
+        dependencies.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+vcpkg_copy_tools(
+    TOOL_NAMES LibreCAD
+    AUTO_CLEAN
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/librecad/vcpkg.json
+++ b/ports/librecad/vcpkg.json
@@ -1,0 +1,31 @@
+{
+  "name": "librecad",
+  "version-string": "2.2.1",
+  "description": "Cross-platform 2D CAD drawing tool.",
+  "homepage": "librecad.org/",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    "boost-ublas",
+    "boost-math",
+    {
+      "name": "qt5-base",
+      "default-features": false
+    },
+    {
+      "name": "qt5-svg",
+      "default-features": false
+    },
+    {
+      "name": "qt5-tools",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

