### PR TITLE
[poco] Add more features for poco library

### DIFF
--- a/ports/3fd/vcpkg.json
+++ b/ports/3fd/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "3fd",
   "version": "2.6.3",
-  "port-version": 4,
+  "port-version": 5,
   "description": "C++ Framework For Fast Development",
   "supports": "windows & !static & !arm64",
   "dependencies": [
@@ -15,6 +15,11 @@
     },
     {
       "name": "poco",
+      "default-features": false,
+      "features": [
+        "data",
+        "odbc"
+      ],
       "platform": "windows"
     },
     "rapidxml",

--- a/ports/poco/0009-fix-zip-to-xml-dependency.patch
+++ b/ports/poco/0009-fix-zip-to-xml-dependency.patch
@@ -1,0 +1,22 @@
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e88e5612a..23b4c992f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -459,12 +459,12 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/ActiveRecord/Compiler AND ENABLE_ACTIVERECORD_CO
+ 	list(APPEND Poco_COMPONENTS "ActiveRecordCompiler")
+ endif()
+ 
+-if(EXISTS ${PROJECT_SOURCE_DIR}/SevenZip AND ENABLE_SEVENZIP AND ENABLE_XML)
++if(EXISTS ${PROJECT_SOURCE_DIR}/SevenZip AND ENABLE_SEVENZIP)
+ 	add_subdirectory(SevenZip)
+ 	list(APPEND Poco_COMPONENTS "SevenZip")
+ endif()
+ 
+-if(EXISTS ${PROJECT_SOURCE_DIR}/Zip AND ENABLE_ZIP AND ENABLE_XML)
++if(EXISTS ${PROJECT_SOURCE_DIR}/Zip AND ENABLE_ZIP)
+ 	add_subdirectory(Zip)
+ 	list(APPEND Poco_COMPONENTS "Zip")
+ endif()

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -15,6 +15,8 @@ vcpkg_from_github(
         0007-find-pcre2.patch
         # MSYS2 repo was used as a source. Thanks MSYS2 team: https://github.com/msys2/MINGW-packages/blob/6e7fba42b7f50e1111b7c0ef50048832243b0ac4/mingw-w64-poco/001-fix-build-on-mingw.patch
         0008-fix-mingw-compilation.patch
+        # Should be removed once https://github.com/pocoproject/poco/issues/4947 is resolved
+        0009-fix-zip-to-xml-dependency.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/Foundation/src/pcre2.h")
@@ -53,6 +55,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         odbc                    ENABLE_DATA_ODBC
         activerecord            ENABLE_ACTIVERECORD
         activerecord-compiler   ENABLE_ACTIVERECORD_COMPILER
+        sevenzip                ENABLE_SEVENZIP
+        cpp-parser              ENABLE_CPPPARSER
 )
 
 # POCO_ENABLE_NETSSL_WIN: 
@@ -82,7 +86,6 @@ vcpkg_cmake_configure(
         # Allow enabling and disabling components done via features
         -DPOCO_DISABLE_INTERNAL_OPENSSL=ON
         -DENABLE_APACHECONNECTOR=OFF
-        -DENABLE_CPPPARSER=OFF
         -DENABLE_DATA_MYSQL=${POCO_USE_MYSQL}
     MAYBE_UNUSED_VARIABLES # these are only used when if(MSVC)
         POCO_DISABLE_INTERNAL_OPENSSL

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -30,10 +30,29 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" POCO_MT)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        crypto      ENABLE_CRYPTO
-        netssl      ENABLE_NETSSL
-        pdf         ENABLE_PDF
-        postgresql  ENABLE_DATA_POSTGRESQL
+        crypto                  ENABLE_CRYPTO
+        netssl                  ENABLE_NETSSL
+        pdf                     ENABLE_PDF
+        postgresql              ENABLE_DATA_POSTGRESQL
+        encodings               ENABLE_ENCODINGS
+        encodings-compiler      ENABLE_ENCODINGS_COMPILER
+        xml                     ENABLE_XML
+        json                    ENABLE_JSON
+        mongodb                 ENABLE_MONGODB
+        redis                   ENABLE_REDIS
+        prometheus              ENABLE_PROMETHEUS
+        util                    ENABLE_UTIL
+        net                     ENABLE_NET
+        zip                     ENABLE_ZIP
+        pocodoc                 ENABLE_POCODOC
+        pagecompiler            ENABLE_PAGECOMPILER
+        pagecompiler-file2page  ENABLE_PAGECOMPILER_FILE2PAGE
+        jwt                     ENABLE_JWT
+        data                    ENABLE_DATA
+        sqlite                  ENABLE_DATA_SQLITE
+        odbc                    ENABLE_DATA_ODBC
+        activerecord            ENABLE_ACTIVERECORD
+        activerecord-compiler   ENABLE_ACTIVERECORD_COMPILER
 )
 
 # POCO_ENABLE_NETSSL_WIN: 
@@ -59,23 +78,11 @@ vcpkg_cmake_configure(
         # Define linking feature
         -DPOCO_MT=${POCO_MT}
         -DENABLE_TESTS=OFF
-        # Allow enabling and disabling components
-        -DENABLE_ENCODINGS=ON
-        -DENABLE_ENCODINGS_COMPILER=ON
-        -DENABLE_XML=ON
-        -DENABLE_JSON=ON
-        -DENABLE_MONGODB=ON
-        -DENABLE_REDIS=ON
-        -DENABLE_UTIL=ON
-        -DENABLE_NET=ON
-        -DENABLE_SEVENZIP=ON
-        -DENABLE_ZIP=ON
-        -DENABLE_CPPPARSER=ON
-        -DENABLE_POCODOC=ON
-        -DENABLE_PAGECOMPILER=ON
-        -DENABLE_PAGECOMPILER_FILE2PAGE=ON
+        -DENABLE_SAMPLES=OFF
+        # Allow enabling and disabling components done via features
         -DPOCO_DISABLE_INTERNAL_OPENSSL=ON
         -DENABLE_APACHECONNECTOR=OFF
+        -DENABLE_CPPPARSER=OFF
         -DENABLE_DATA_MYSQL=${POCO_USE_MYSQL}
     MAYBE_UNUSED_VARIABLES # these are only used when if(MSVC)
         POCO_DISABLE_INTERNAL_OPENSSL
@@ -87,7 +94,25 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 # Move apps to the tools folder
-vcpkg_copy_tools(TOOL_NAMES cpspc f2cpsp PocoDoc tec poco-arc AUTO_CLEAN)
+set(tools)
+if (ENABLE_PAGECOMPILER)
+    list(APPEND tools "cpspc")
+endif()
+if (ENABLE_PAGECOMPILER_FILE2PAGE)
+    list(APPEND tools "f2cpsp")
+endif()
+if (ENABLE_POCODOC)
+    list(APPEND tools "PocoDoc")
+endif()
+if (ENABLE_ENCODINGS_COMPILER)
+    list(APPEND tools "tec")
+endif()
+if (ENABLE_ACTIVERECORD_COMPILER)
+    list(APPEND tools "poco-arc")
+endif()
+if (tools)
+    vcpkg_copy_tools(TOOL_NAMES ${tools} AUTO_CLEAN)
+endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -44,6 +44,7 @@
     "activerecord": {
       "description": "Simple and lightweight object-relational mapping (ORM) framework built on top of the POCO Data",
       "dependencies": [
+        "expat",
         {
           "name": "poco",
           "default-features": false,
@@ -203,11 +204,31 @@
     "pdf": {
       "description": "Haru support for POCO",
       "dependencies": [
-        "libharu"
+        "libharu",
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "util",
+            "xml"
+          ]
+        }
       ]
     },
     "pocodoc": {
-      "description": "POCO documentation generator"
+      "description": "POCO documentation generator",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "data",
+            "sqlite",
+            "util",
+            "xml"
+          ]
+        }
+      ]
     },
     "postgresql": {
       "description": "PostgreSQL support for POCO",

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -1,15 +1,13 @@
 {
   "name": "poco",
   "version": "1.14.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.",
   "homepage": "https://github.com/pocoproject/poco",
   "license": "BSL-1.0",
   "supports": "!uwp",
   "dependencies": [
-    "expat",
     "pcre2",
-    "sqlite3",
     "utf8proc",
     {
       "name": "vcpkg-cmake",
@@ -21,24 +19,124 @@
     },
     "zlib"
   ],
+  "default-features": [
+    "activerecord",
+    "activerecord-compiler",
+    "data",
+    "encodings",
+    "encodings-compiler",
+    "json",
+    "jwt",
+    "mongodb",
+    "net",
+    "odbc",
+    "pagecompiler",
+    "pagecompiler-file2page",
+    "pocodoc",
+    "prometheus",
+    "redis",
+    "sqlite",
+    "util",
+    "xml",
+    "zip"
+  ],
   "features": {
+    "activerecord": {
+      "description": "Simple and lightweight object-relational mapping (ORM) framework built on top of the POCO Data",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "activerecord-compiler": {
+      "description": "Compiler for Simple and lightweight object-relational mapping (ORM) framework built on top of the POCO Data",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "util",
+            "xml"
+          ]
+        }
+      ]
+    },
     "crypto": {
       "description": "Crypto support",
       "dependencies": [
         "openssl"
       ]
     },
+    "data": {
+      "description": "Database abstraction layer for POCO"
+    },
+    "encodings": {
+      "description": "Encodings support for POCO"
+    },
+    "encodings-compiler": {
+      "description": "Compiler for encodings support for POCO"
+    },
+    "json": {
+      "description": "JSON support for POCO"
+    },
+    "jwt": {
+      "description": "JWT support for POCO",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "crypto",
+            "json"
+          ]
+        }
+      ]
+    },
     "mariadb": {
       "description": "MariaDB support for POCO",
       "dependencies": [
-        "libmariadb"
+        "libmariadb",
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "mongodb": {
+      "description": "MongoDB support for POCO",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "net"
+          ]
+        }
       ]
     },
     "mysql": {
       "description": "Mysql support for POCO",
       "dependencies": [
-        "libmysql"
+        "libmysql",
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "data"
+          ]
+        }
       ]
+    },
+    "net": {
+      "description": "Network support for POCO"
     },
     "netssl": {
       "description": [
@@ -50,7 +148,49 @@
           "name": "poco",
           "default-features": false,
           "features": [
-            "crypto"
+            "crypto",
+            "net",
+            "util"
+          ]
+        }
+      ]
+    },
+    "odbc": {
+      "description": "ODBC support for POCO",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "pagecompiler": {
+      "description": "Command line tool that translates HTML files into C++ code",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "net",
+            "util",
+            "xml"
+          ]
+        }
+      ]
+    },
+    "pagecompiler-file2page": {
+      "description": "Command line tool that translates HTML files into C++ code",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "net",
+            "util",
+            "xml"
           ]
         }
       ]
@@ -61,11 +201,80 @@
         "libharu"
       ]
     },
+    "pocodoc": {
+      "description": "POCO documentation generator"
+    },
     "postgresql": {
       "description": "PostgreSQL support for POCO",
       "dependencies": [
-        "libpqxx"
+        "libpqxx",
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "data"
+          ]
+        }
       ]
+    },
+    "prometheus": {
+      "description": "Prometheus support for POCO",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "net"
+          ]
+        }
+      ]
+    },
+    "redis": {
+      "description": "Redis support for POCO",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "net"
+          ]
+        }
+      ]
+    },
+    "sqlite": {
+      "description": "SQLite support for POCO",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "data"
+          ]
+        },
+        "sqlite3"
+      ]
+    },
+    "util": {
+      "description": "Utility support library for POCO",
+      "dependencies": [
+        {
+          "name": "poco",
+          "default-features": false,
+          "features": [
+            "json",
+            "xml"
+          ]
+        }
+      ]
+    },
+    "xml": {
+      "description": "XML support for POCO",
+      "dependencies": [
+        "expat"
+      ]
+    },
+    "zip": {
+      "description": "Support for parsing and creating Zip files"
     }
   }
 }

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -46,6 +46,9 @@
         }
       ]
     },
+    "cpp-parser": {
+      "description": "POCO C++ parser"
+    },
     "crypto": {
       "description": "Crypto support",
       "dependencies": [
@@ -201,6 +204,7 @@
           "name": "poco",
           "default-features": false,
           "features": [
+            "cpp-parser",
             "data",
             "sqlite",
             "util",
@@ -245,6 +249,9 @@
           ]
         }
       ]
+    },
+    "sevenzip": {
+      "description": "Support for parsing and creating 7Zip files"
     },
     "sqlite": {
       "description": "SQLite support for POCO",

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -157,6 +157,7 @@
     },
     "odbc": {
       "description": "ODBC support for POCO",
+      "supports": "windows | osx | linux",
       "dependencies": [
         {
           "name": "poco",
@@ -164,6 +165,10 @@
           "features": [
             "data"
           ]
+        },
+        {
+          "name": "unixodbc",
+          "platform": "osx | linux"
         }
       ]
     },

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -19,27 +19,6 @@
     },
     "zlib"
   ],
-  "default-features": [
-    "activerecord",
-    "activerecord-compiler",
-    "data",
-    "encodings",
-    "encodings-compiler",
-    "json",
-    "jwt",
-    "mongodb",
-    "net",
-    "odbc",
-    "pagecompiler",
-    "pagecompiler-file2page",
-    "pocodoc",
-    "prometheus",
-    "redis",
-    "sqlite",
-    "util",
-    "xml",
-    "zip"
-  ],
   "features": {
     "activerecord": {
       "description": "Simple and lightweight object-relational mapping (ORM) framework built on top of the POCO Data",

--- a/versions/3-/3fd.json
+++ b/versions/3-/3fd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc015ca2306c3d177cf011b7bb54d5181d62b0e9",
+      "version": "2.6.3",
+      "port-version": 5
+    },
+    {
       "git-tree": "81e9fd75ff6a4fee6ab7a5d4d09e7e3a735fbaaa",
       "version": "2.6.3",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7318,7 +7318,7 @@
     },
     "poco": {
       "baseline": "1.14.1",
-      "port-version": 1
+      "port-version": 2
     },
     "podofo": {
       "baseline": "0.10.4",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2,7 +2,7 @@
   "default": {
     "3fd": {
       "baseline": "2.6.3",
-      "port-version": 4
+      "port-version": 5
     },
     "7zip": {
       "baseline": "24.09",

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2390096a6727fcecb4e1f0a5b7a0d3f819078eea",
+      "git-tree": "1b7c8e1c9662ffc308a12a2382fdbd3ac105801c",
       "version": "1.14.1",
       "port-version": 2
     },

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a942e8baf38b8986cb7f9ef3d31ea4276cbff610",
+      "git-tree": "1d974af566ef870752864dcde0462e9905dc5887",
       "version": "1.14.1",
       "port-version": 2
     },

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1d974af566ef870752864dcde0462e9905dc5887",
+      "git-tree": "2390096a6727fcecb4e1f0a5b7a0d3f819078eea",
       "version": "1.14.1",
       "port-version": 2
     },

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "49c78c4b9236fae1d6356073003db4b967fd5539",
+      "git-tree": "a942e8baf38b8986cb7f9ef3d31ea4276cbff610",
       "version": "1.14.1",
       "port-version": 2
     },

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49c78c4b9236fae1d6356073003db4b967fd5539",
+      "version": "1.14.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "0fbc74c0a62a6b1b4240b30a3594245ee187fbe9",
       "version": "1.14.1",
       "port-version": 1


### PR DESCRIPTION
Fixes #44825.
Adds following features to Poco:
- activerecord          
- activerecord-compiler 
- cpp-parser
- data                  
- encodings             
- encodings-compiler    
- json                  
- jwt                   
- mongodb               
- net                   
- odbc                  
- pagecompiler          
- pagecompiler-file2page
- pocodoc               
- prometheus            
- redis   
- sevenzip              
- sqlite                
- util                  
- xml                   
- zip                   

All newly added features are made default features to preserver backward compatibility (`vcpkg install poco` before and after this PR will do the same thing).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



