### PR TITLE
[libjxl] Avoid manipulating CMAKE_EXE_LINKER_FLAGS for linker checks

### DIFF
--- a/ports/libjxl/avoid-exe-linker-flags.patch
+++ b/ports/libjxl/avoid-exe-linker-flags.patch
@@ -1,0 +1,31 @@
+--- a/lib/jxl.cmake
++++ b/lib/jxl.cmake
+@@ -224,9 +224,9 @@ set_target_properties(jxl_dec PROPERTIES
+ # Check whether the linker support excluding libs
+ set(LINKER_EXCLUDE_LIBS_FLAG "-Wl,--exclude-libs=ALL")
+ include(CheckCSourceCompiles)
+-list(APPEND CMAKE_EXE_LINKER_FLAGS ${LINKER_EXCLUDE_LIBS_FLAG})
++list(APPEND CMAKE_REQUIRED_LINK_OPTIONS ${LINKER_EXCLUDE_LIBS_FLAG})
+ check_c_source_compiles("int main(){return 0;}" LINKER_SUPPORT_EXCLUDE_LIBS)
+-list(REMOVE_ITEM CMAKE_EXE_LINKER_FLAGS ${LINKER_EXCLUDE_LIBS_FLAG})
++list(REMOVE_ITEM CMAKE_REQUIRED_LINK_OPTIONS ${LINKER_EXCLUDE_LIBS_FLAG})
+ 
+ if(NOT BUILD_SHARED_LIBS)
+   target_compile_definitions(jxl PUBLIC -DJXL_STATIC_DEFINE)
+diff --git a/lib/jxl_cms.cmake b/lib/jxl_cms.cmake
+index 62d5b651fd5fcf25b8853a813f8e1c3098c2e93f..e23823c66d2b0d9c99138e52c44c7d3d02630a01 100644
+--- a/lib/jxl_cms.cmake
++++ b/lib/jxl_cms.cmake
+@@ -46,9 +46,9 @@ set_target_properties(jxl_cms PROPERTIES
+ # Check whether the linker support excluding libs
+ set(LINKER_EXCLUDE_LIBS_FLAG "-Wl,--exclude-libs=ALL")
+ include(CheckCSourceCompiles)
+-list(APPEND CMAKE_EXE_LINKER_FLAGS ${LINKER_EXCLUDE_LIBS_FLAG})
++list(APPEND CMAKE_REQUIRED_LINK_OPTIONS ${LINKER_EXCLUDE_LIBS_FLAG})
+ check_c_source_compiles("int main(){return 0;}" LINKER_SUPPORT_EXCLUDE_LIBS)
+-list(REMOVE_ITEM CMAKE_EXE_LINKER_FLAGS ${LINKER_EXCLUDE_LIBS_FLAG})
++list(REMOVE_ITEM CMAKE_REQUIRED_LINK_OPTIONS ${LINKER_EXCLUDE_LIBS_FLAG})
+ 
+ if(LINKER_SUPPORT_EXCLUDE_LIBS)
+   set_property(TARGET jxl_cms APPEND_STRING PROPERTY
+

--- a/ports/libjxl/portfile.cmake
+++ b/ports/libjxl/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         fix-dependencies.patch
+	avoid-exe-linker-flags.patch # https://github.com/libjxl/libjxl/pull/4229
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libjxl/vcpkg.json
+++ b/ports/libjxl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libjxl",
   "version-semver": "0.11.1",
+  "port-version": 1,
   "description": "JPEG XL image format reference implementation",
   "homepage": "https://github.com/libjxl/libjxl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4842,7 +4842,7 @@
     },
     "libjxl": {
       "baseline": "0.11.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libkeyfinder": {
       "baseline": "2.2.8",

--- a/versions/l-/libjxl.json
+++ b/versions/l-/libjxl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f7903efa9347e989121781311287edb5f41592f",
+      "version-semver": "0.11.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "1b18a67135031ccaa38f55a3f8c0a2dff6082754",
       "version-semver": "0.11.1",
       "port-version": 0


### PR DESCRIPTION
This patches the way the linker checks are done in libjxl to avoid
manipulating CMAKE_EXE_LINKER_FLAGS, and instead use
CMAKE_REQUIRED_LINK_OPTIONS as recommended in the docs. This avoids config
failures on macOS, where the -Wl,--exclude-libs flag is not supported,
when LDFLAGS contains flags that will cause the linker to fail when
-Wl,--exclude-libs=ALL is appended to it. This mostly happens with flags
such as -L/some/path.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


Upstream PR: https://github.com/libjxl/libjxl/pull/4229