### PR TITLE
[libde265] update to 1.0.16

### DIFF
--- a/ports/libde265/fix-interface-include.patch
+++ b/ports/libde265/fix-interface-include.patch
@@ -1,10 +1,10 @@
 diff --git a/libde265/CMakeLists.txt b/libde265/CMakeLists.txt
-index d0d6762..06e1660 100644
+index 9fa2837..d17097c 100644
 --- a/libde265/CMakeLists.txt
 +++ b/libde265/CMakeLists.txt
-@@ -114,7 +114,7 @@ endif()
+@@ -123,7 +123,7 @@ endif()
  
- add_library(de265 ${libde265_sources} ${ENCODER_OBJECTS} ${X86_OBJECTS})
+ add_library(de265 ${libde265_sources} ${libde265_public_headers} ${ENCODER_OBJECTS} ${X86_OBJECTS})
  target_link_libraries(de265 PRIVATE Threads::Threads)
 -target_include_directories(de265 PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 +target_include_directories(de265 PRIVATE $<BUILD_INTERFACE:${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}> PUBLIC $<INSTALL_INTERFACE:include>)

--- a/ports/libde265/portfile.cmake
+++ b/ports/libde265/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO strukturag/libde265
     REF "v${VERSION}"
-    SHA512 df380f1ea6345e20ed1f907df3c7cdaaac44358a6746e29e16699005783ce96524d30fec7bba457c9f9773a6373250aaaf0b9cd41224057b269798117964b8b5
+    SHA512 bda239b4827c81552855dc540724b74c86f6b02bcd0fe556650bc16d665a8eed1ddbde76ac0972d26b3002b14575bb9b6f70b367c39eb7de45c5c9df324e3d05
     HEAD_REF master
     PATCHES
         fix-interface-include.patch

--- a/ports/libde265/vcpkg.json
+++ b/ports/libde265/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libde265",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Open h.265 video codec implementation.",
   "homepage": "https://www.libde265.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4545,7 +4545,7 @@
       "port-version": 0
     },
     "libde265": {
-      "baseline": "1.0.15",
+      "baseline": "1.0.16",
       "port-version": 0
     },
     "libdeflate": {

--- a/versions/l-/libde265.json
+++ b/versions/l-/libde265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88fc0d2a520755fb90f5955bfbb720a8f6df3e3d",
+      "version": "1.0.16",
+      "port-version": 0
+    },
+    {
       "git-tree": "386663192fc988e45cc4c16378b3a5a0549a7366",
       "version": "1.0.15",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/strukturag/libde265/releases/tag/v1.0.16
