### PR TITLE
[gul17] Add new port

### DIFF
--- a/ports/gul17/portfile.cmake
+++ b/ports/gul17/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gul-cpp/gul17
-    REF v25.4.1
+    REF "v${VERSION}"
     SHA512 afb4cddfe50da000880c51cded6961ae9720152a67a7440612ccf324ff7af646476ff0d1a287f14ad36b95d5cecc17be239f487e281d80b4a9ac1813d2f46f76
     HEAD_REF main
 )

--- a/ports/gul17/portfile.cmake
+++ b/ports/gul17/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
 )
 
 vcpkg_configure_meson(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS -Dtests=false
 )
 

--- a/ports/gul17/portfile.cmake
+++ b/ports/gul17/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gul-cpp/gul17
+    REF v25.4.1
+    SHA512 afb4cddfe50da000880c51cded6961ae9720152a67a7440612ccf324ff7af646476ff0d1a287f14ad36b95d5cecc17be239f487e281d80b4a9ac1813d2f46f76
+    HEAD_REF main
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS -Dtests=false
+)
+
+vcpkg_install_meson()
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+# Install copyright file
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license.txt")

--- a/ports/gul17/vcpkg.json
+++ b/ports/gul17/vcpkg.json
@@ -6,7 +6,7 @@
     "GUL17 contains often-used utility functions and types that form the foundation for other libraries and programs.",
     "It provides basic functionality that is not available in the C++17 standard library, including some backports from later versions of the standard."
   ],
-  "homepage": "https://github.desy.de/gul-cpp/gul17.git",
+  "homepage": "https://github.com/gul-cpp/gul17",
   "documentation": "https://gul-cpp.github.io/gul17/",
   "license": "LGPL-2.1-or-later",
   "supports": "!uwp & !xbox",

--- a/ports/gul17/vcpkg.json
+++ b/ports/gul17/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "gul17",
+  "version": "25.4.1",
+  "description": [
+    "General Utility Library for C++17.",
+    "GUL17 contains often-used utility functions and types that form the foundation for other libraries and programs.",
+    "It provides basic functionality that is not available in the C++17 standard library, including some backports from later versions of the standard."
+  ],
+  "homepage": "https://github.desy.de/gul-cpp/gul17.git",
+  "documentation": "https://gul-cpp.github.io/gul17/",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!uwp & !xbox",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3424,6 +3424,10 @@
       "baseline": "2.11.2",
       "port-version": 0
     },
+    "gul17": {
+      "baseline": "25.4.1",
+      "port-version": 0
+    },
     "gumbo": {
       "baseline": "0.12.3",
       "port-version": 0

--- a/versions/g-/gul17.json
+++ b/versions/g-/gul17.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7e763b0ef21b65b6499159ed68b51d94896e3f72",
+      "git-tree": "90e599aea40004f3731f537c34aff934b5295ed5",
       "version": "25.4.1",
       "port-version": 0
     }

--- a/versions/g-/gul17.json
+++ b/versions/g-/gul17.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7e763b0ef21b65b6499159ed68b51d94896e3f72",
+      "version": "25.4.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines. – *Well, kind of. GUL17 is a new sister/successor library to GUL14. Both will continue to exist in their own right for projects tied to a certain C++ standard.*