### PR TITLE
[directx12-agility] Updated for 1.615.1 release

### DIFF
--- a/ports/directx12-agility/portfile.cmake
+++ b/ports/directx12-agility/portfile.cmake
@@ -1,12 +1,12 @@
 set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
-set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled) # headers are provided by the directx-headers port
 set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
-set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled) # DX12 SDK Debug Layer is an extra DLL
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/${VERSION}"
     FILENAME "Microsoft.Direct3D.D3D12.${VERSION}.zip"
-    SHA512 7cf03deb15dcaf8f7e7619137b7a2ac5788146012efd472b165e3545d9d98851fd7169cc384b335f45e4293d2db6355e998a9e1d39cf93f88639547d2fc1baeb
+    SHA512 cee32540e7ffb7d29165974e2daf9bc067ff225fa201f58abd4bd841a3d6a5b6a90e98dddedc27b256168927bfb3b49a7a7963fd8e26cf136a25dbffb27e3f25
 )
 
 vcpkg_extract_source_archive(

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx12-agility",
-  "version": "1.615.0",
+  "version": "1.615.1",
   "description": "DirectX 12 Agility SDK",
   "homepage": "https://aka.ms/directx12agility",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2341,7 +2341,7 @@
       "port-version": 0
     },
     "directx12-agility": {
-      "baseline": "1.615.0",
+      "baseline": "1.615.1",
       "port-version": 0
     },
     "directxmath": {

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a388f09668eea6381c950cd90c1fd098b42fea1",
+      "version": "1.615.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6a1a6a22ca690ece83c21359c18de2a263347dae",
       "version": "1.615.0",
       "port-version": 0


### PR DESCRIPTION
No changes to the *directx-headers*, but the DLLs were updated for some bug fixes.
