### PR TITLE
[protopuf] update to 3.1.0

### DIFF
--- a/ports/protopuf/portfile.cmake
+++ b/ports/protopuf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PragmaTwice/protopuf
     REF "v${VERSION}"
-    SHA512 c74bd2bc6090fb1b09d697ff1c082028cb3bacbe7f18bb93afe8b323f8f140a3b6d1c79ac41d54cd06eb1132d97ddc61e1dd6c2e658368ac08f80c414eb779fd
+    SHA512 927fc531a72b34877c7b2dd171e2e873783ebb8a67567a9cca28ed258d8dca89695866b84bc64d71a18d38ba317a1e56f9cbdbbc83103892edff0da517006831
     HEAD_REF master
 )
 

--- a/ports/protopuf/vcpkg.json
+++ b/ports/protopuf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protopuf",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A little, highly templated, and protobuf-compatible serialization/deserialization library written in C++20",
   "homepage": "https://github.com/PragmaTwice/protopuf",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7453,7 +7453,7 @@
       "port-version": 0
     },
     "protopuf": {
-      "baseline": "3.0.0",
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "protozero": {

--- a/versions/p-/protopuf.json
+++ b/versions/p-/protopuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "33f01fc376ff87fba46c56ce662b43f1c9f2d3cc",
+      "version": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "81d04541581f77d3e71387de058cd91052486489",
       "version": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/PragmaTwice/protopuf/releases/tag/v3.1.0
