### PR TITLE
[sqlite3] update to 3.49.2

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -67,6 +67,11 @@ if(NOT SQLITE3_SKIP_TOOLS)
         target_compile_definitions(sqlite3-bin PRIVATE SQLITE_HAVE_ZLIB)
     endif()
 
+    find_library(HAVE_LIBM m)
+    if(HAVE_LIBM)
+        target_link_libraries(sqlite3-bin PRIVATE m)
+    endif()
+
     install(TARGETS sqlite3-bin sqlite3
       RUNTIME DESTINATION bin
       LIBRARY DESTINATION lib

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -4,7 +4,7 @@ string(REGEX REPLACE "^([0-9]+),0*([0-9][0-9]),0*([0-9][0-9]),0*([0-9][0-9])," "
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sqlite.org/2025/sqlite-autoconf-${SQLITE_VERSION}.tar.gz"
     FILENAME "sqlite-autoconf-${SQLITE_VERSION}.zip"
-    SHA512 ace92f20fb13a28a8be0eb3560ebf79e71e882611108179b45abba6e77ec0964d75a96c1e187c0e5f883b83896fd44074ef244e1f589288b6354bc9db85223ca
+    SHA512 59bbed0f49bcc17abcc3ba180858c7a7128038e43fd0b24a786505f0223340f85eb956e64a2b66e245d0b8d0769daa5e4688ae4686c64fc8ff91c546acce0070
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite3",
-  "version": "3.49.1",
+  "version": "3.49.2",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://sqlite.org/",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8929,7 +8929,7 @@
       "port-version": 0
     },
     "sqlite3": {
-      "baseline": "3.49.1",
+      "baseline": "3.49.2",
       "port-version": 0
     },
     "sqlitecpp": {

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a703aa5e0c5f764b9d66a33de11c4a4242ae4c7c",
+      "version": "3.49.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "92c7e25e29daa51849b0f0b82bae84898ebb80d9",
       "version": "3.49.1",
       "port-version": 0

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a703aa5e0c5f764b9d66a33de11c4a4242ae4c7c",
+      "git-tree": "a337f5fe100f83026072765ea63a8776f984f6fd",
       "version": "3.49.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://sqlite.org/releaselog/3_49_2.html
