### PR TITLE
[vladimirshaleev-ipaddress] Update to 1.2.0

### DIFF
--- a/ports/vladimirshaleev-ipaddress/portfile.cmake
+++ b/ports/vladimirshaleev-ipaddress/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vladimirshaleev/ipaddress
     REF "v${VERSION}"
-    SHA512 a8ab2dc8563ff08a5afbe6d2157502b26a5d13f29d00ab3354b812ad4cb9e35cdc89cb26e4920929ced7d063ae2ad5aa79d30a4623409f65c76971ecbbcd5bfc
+    SHA512 cc6b2e6dc72a8ac7d1c847e87294381026a584388a53a4d2583c04050e30b152b4b740dca3e809ae3541c380590553ec0934ff3e3b15bd0ba3ac297b5de30fb7
     HEAD_REF main
 )
 

--- a/ports/vladimirshaleev-ipaddress/vcpkg.json
+++ b/ports/vladimirshaleev-ipaddress/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "vladimirshaleev-ipaddress",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A library for working and manipulating IPv4/IPv6 addresses and networks in modern C++.",
-  "homepage": "https://vladimirshaleev.github.io/ipaddress/",
+  "homepage": "https://github.com/VladimirShaleev/ipaddress",
+  "documentation": "https://vladimirshaleev.github.io/ipaddress/",
   "license": "MIT",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9833,7 +9833,7 @@
       "port-version": 0
     },
     "vladimirshaleev-ipaddress": {
-      "baseline": "1.1.0",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "vlfeat": {

--- a/versions/v-/vladimirshaleev-ipaddress.json
+++ b/versions/v-/vladimirshaleev-ipaddress.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "299f4c427540d14b6d8c4551f865e2ebce1eed39",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c4a128002e94b71cf2620c07f47b0380b3888802",
       "version": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
Hey everyone! Port update

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/VladimirShaleev/ipaddress/releases/tag/v1.2.0