### PR TITLE
[vcpkg baseline][libheif] REMOVE FROM FAIL LIST

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -513,9 +513,7 @@ libhdfs3:arm64-osx=fail
 libhdfs3:x64-android=fail
 libhdfs3:x64-linux=fail
 libhdfs3:x64-osx=fail
-libheif:arm-neon-android=fail
 libheif:arm64-android=fail
-libheif:x64-android=fail
 # 120 min build time for libjxl arm64-uwp-rel, reason unknown
 libjxl:arm64-uwp=skip
 liblo:arm64-uwp=fail


### PR DESCRIPTION
Passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=115482&view=results
```
PASSING, REMOVE FROM FAIL LIST: libheif:arm-neon-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
PASSING, REMOVE FROM FAIL LIST: libheif:x64-android (/vcpkg/scripts/azure-pipelines/../ci.baseline.txt).
```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~