### PR TITLE
[unleash-client-cpp] Add port to vcpkg

### DIFF
--- a/ports/unleash-client-cpp/portfile.cmake
+++ b/ports/unleash-client-cpp/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO aruizs/unleash-client-cpp
+    REF "v${VERSION}"
+    SHA512 0ba3fa89bacfded6aaf54c5595ec4affc621563dc0b2b7917f5a444cb322336fa8c85ce236ef7ba3726edce778d00c6ad827b3a5bd3c4022898ae0eba872d869
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_REQUIRE_FIND_PACKAGE_cpr=ON
+        -DCMAKE_REQUIRE_FIND_PACKAGE_nlohmann_json=ON
+        -DENABLE_TESTING=OFF
+        -DENABLE_TEST_COVERAGE=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/unleash" PACKAGE_NAME "unleash")
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/unleash-client-cpp/usage
+++ b/ports/unleash-client-cpp/usage
@@ -1,0 +1,4 @@
+unleash-client-cpp provides a CMake target:
+
+  find_package(unleash CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE unleash::unleash)

--- a/ports/unleash-client-cpp/vcpkg.json
+++ b/ports/unleash-client-cpp/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "unleash-client-cpp",
+  "version": "1.3.0",
+  "description": "C++ client SDK for Unleash, an open-source feature flag management service.",
+  "homepage": "https://github.com/aruizs/unleash-client-cpp",
+  "license": "MIT",
+  "dependencies": [
+    "cpr",
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9588,6 +9588,10 @@
       "baseline": "2.3.11",
       "port-version": 2
     },
+    "unleash-client-cpp": {
+      "baseline": "1.3.0",
+      "port-version": 0
+    },
     "unordered-dense": {
       "baseline": "4.5.0",
       "port-version": 0

--- a/versions/u-/unleash-client-cpp.json
+++ b/versions/u-/unleash-client-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "cec80652193bc6f7319a057533e2471f46a278fa",
+      "version": "1.3.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
