### PR TITLE
[simonbrunel-qtpromise] Disable building unit tests

### DIFF
--- a/ports/simonbrunel-qtpromise/portfile.cmake
+++ b/ports/simonbrunel-qtpromise/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_cmake_configure(
     OPTIONS 
         -DQTPROMISE_HEADER_INSTALL_DESTINATION="${CURRENT_PACKAGES_DIR}/include/${PORT}"
         -DQTPROMISE_HEADER_INSTALL_COMPONENTS="Release"
+        -DSUBPROJECT=ON # do not build tests
 )
 vcpkg_cmake_install()
 

--- a/ports/simonbrunel-qtpromise/vcpkg.json
+++ b/ports/simonbrunel-qtpromise/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "simonbrunel-qtpromise",
   "version": "0.7.0",
+  "port-version": 1,
   "maintainers": "Simon Brunel",
   "description": "Promises/A+ implementation for Qt/C++",
   "homepage": "https://qtpromise.netlify.app/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8682,7 +8682,7 @@
     },
     "simonbrunel-qtpromise": {
       "baseline": "0.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "simple-fft": {
       "baseline": "2020-06-14",

--- a/versions/s-/simonbrunel-qtpromise.json
+++ b/versions/s-/simonbrunel-qtpromise.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c083f02dfead7a0ba83b43d5fbea8ec8bbed46e4",
+      "version": "0.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b416eec5f84996491c4656f6b01723453abac31f",
       "version": "0.7.0",
       "port-version": 0


### PR DESCRIPTION
`qtpromise`'s unit test directory structure is quite deep. Combined with a sufficiently long enough build folder path for the client project and Qt's `moc`, certain paths become so long that the compiler errors out. Disabling the tests makes the problem go away. ([And is good practice for ports anyway according to the Maintainer guide.](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md#do-not-build-testsdocsexamples-by-default))

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

