### PR TITLE
[benchmark] Update to 1.9.3

### DIFF
--- a/ports/benchmark/portfile.cmake
+++ b/ports/benchmark/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/benchmark
     REF "v${VERSION}"
-    SHA512 64e964f02c118935305ca3e7d3f732f2e093f927371bd1729467f6cb75dc0c42492f9f02c3191e3d8affdc9bab2e66becf10bd4250b768854074bf69efa7e4f2
+    SHA512 bd1bc103c89ec74a7dfdb09aa4b308496f79ccfe0a728e31eed2814b9ff0f19aa930c58827d044dac07e2e776f990f74ebc4c7cd9c86b37871f8868e1581d4e1
     HEAD_REF main
 )
 
@@ -11,6 +11,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DBENCHMARK_ENABLE_TESTING=OFF
         -DBENCHMARK_INSTALL_DOCS=OFF
+        -DBENCHMARK_ENABLE_WERROR=OFF # see https://github.com/google/benchmark/issues/1982
         -Werror=old-style-cast
 )
 

--- a/ports/benchmark/vcpkg.json
+++ b/ports/benchmark/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$comment": "https://github.com/google/benchmark/issues/661 describes the missing UWP support upstream",
   "name": "benchmark",
-  "version-semver": "1.9.2",
+  "version-semver": "1.9.3",
   "description": "A library to benchmark code snippets, similar to unit tests.",
   "homepage": "https://github.com/google/benchmark",
   "license": "Apache-2.0",

--- a/versions/b-/benchmark.json
+++ b/versions/b-/benchmark.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3a256d0d1a010a427fc54e8a53f8c033cdc8517e",
+      "version-semver": "1.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "f0945f588c31355ecc557e8fb01d72968f47d8d0",
       "version-semver": "1.9.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -621,7 +621,7 @@
       "port-version": 0
     },
     "benchmark": {
-      "baseline": "1.9.2",
+      "baseline": "1.9.3",
       "port-version": 0
     },
     "bento4": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.