### PR TITLE
[opencv4] Fix pkgconfig file with freetype feature

### DIFF
--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -619,6 +619,11 @@ if (EXISTS "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/opencv4.pc")
     IGNORE_UNCHANGED
   )
   vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/opencv4.pc"
+    "-lharfbuzz::harfbuzz"
+    "-lharfbuzz"
+    IGNORE_UNCHANGED
+  )
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/opencv4.pc"
     "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/"
     "\${prefix}"
     IGNORE_UNCHANGED
@@ -649,6 +654,11 @@ if (EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/opencv4.pc")
   vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/opencv4.pc"
     "-lTesseract::libtesseract"
     "-ltesseract"
+    IGNORE_UNCHANGED
+  )
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/opencv4.pc"
+    "-lharfbuzz::harfbuzz"
+    "-lharfbuzz"
     IGNORE_UNCHANGED
   )
   vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/opencv4.pc"

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.11.0",
+  "port-version": 1,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6858,7 +6858,7 @@
     },
     "opencv4": {
       "baseline": "4.11.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d74f70567baa85f80998f0003431755de77bf9ff",
+      "git-tree": "0c08c3b4ab512c89cd865f5dbf4560c1109a7bc0",
       "version": "4.11.0",
       "port-version": 0
     },

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "0c08c3b4ab512c89cd865f5dbf4560c1109a7bc0",
+      "git-tree": "b688846a47f3610083dfd9aa65ca7f85b5b5b8e1",
+      "version": "4.11.0",
+      "port-version": 1
+    },
+    {
+      "git-tree": "d74f70567baa85f80998f0003431755de77bf9ff",
       "version": "4.11.0",
       "port-version": 0
     },


### PR DESCRIPTION
Running ```pkg-config -libs``` with the .pc file produced by the vcpkg opencv4 with the freetype feature enabled includes this problematic output: -lharfbuzz::harfbuzz which causes the linker to never find it because it's actually called libharfbuzz.a. This PR fixes the issue by changing the -lharfbuzz:harfbuzz to -lharfbuzz which will get the linker to properly find the libharfbuzz.a file.