### PR TITLE
[arcticdb-sparrow] Update 0.8.0

### DIFF
--- a/ports/arcticdb-sparrow/portfile.cmake
+++ b/ports/arcticdb-sparrow/portfile.cmake
@@ -1,12 +1,12 @@
 if(VCPKG_TARGET_IS_LINUX)
-    message("Warning: `sparrow` requires Clang18+ or GCC 11+ on Linux")
+    message("Warning: `sparrow` requires Clang18+ or GCC 11.2+ on Linux")
 endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO man-group/sparrow
     REF "${VERSION}"
-    SHA512 aca5a46fd5275743a5a56aeb06b4cf15531866a340b6d54815f1c4773dfeca29256e756c9f3c2117b035c7f2ec2a03d13575123cd02fc01562e8193c246cf347
+    SHA512 59d8bdd9513b0510e6cbe9bc5285a80232916e8b157545234dab6b700a5aca3f493ce6a7672ccf340c571d88e33253212c0183153ba1cd2e5628f806c65298e2
     HEAD_REF main
 )
 

--- a/ports/arcticdb-sparrow/vcpkg.json
+++ b/ports/arcticdb-sparrow/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arcticdb-sparrow",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "C++20 idiomatic APIs for the Apache Arrow Columnar Format",
   "homepage": "https://github.com/man-group/sparrow",
   "license": "Apache-2.0",

--- a/versions/a-/arcticdb-sparrow.json
+++ b/versions/a-/arcticdb-sparrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3d3c8182f1cbfdb5136017147e8e1fd1203985fe",
+      "git-tree": "30468c0fba66aa929725dcd33694197a6296d238",
       "version": "0.8.0",
       "port-version": 0
     },

--- a/versions/a-/arcticdb-sparrow.json
+++ b/versions/a-/arcticdb-sparrow.json
@@ -2,6 +2,11 @@
   "versions": [
     {
       "git-tree": "3d3c8182f1cbfdb5136017147e8e1fd1203985fe",
+      "version": "0.8.0",
+      "port-version": 0
+    },
+    {
+      "git-tree": "3d3c8182f1cbfdb5136017147e8e1fd1203985fe",
       "version": "0.7.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -197,7 +197,7 @@
       "port-version": 2
     },
     "arcticdb-sparrow": {
-      "baseline": "0.7.0",
+      "baseline": "0.8.0",
       "port-version": 0
     },
     "arcus": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.