### PR TITLE
[mpfr] update to 4.2.2

### DIFF
--- a/ports/mpfr/portfile.cmake
+++ b/ports/mpfr/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 vcpkg_download_distfile(ARCHIVE
     URLS "http://www.mpfr.org/mpfr-${VERSION}/mpfr-${VERSION}.tar.xz" "https://ftp.gnu.org/gnu/mpfr/mpfr-${VERSION}.tar.xz"
     FILENAME "mpfr-${VERSION}.tar.xz"
-    SHA512 bc68c0d755d5446403644833ecbb07e37360beca45f474297b5d5c40926df1efc3e2067eecffdf253f946288bcca39ca89b0613f545d46a9e767d1d4cf358475
+    SHA512 eb9e7f51b5385fb349cc4fba3a45ffdf0dd53be6dfc74932dc01258158a10514667960c530c47dd9dfc5aa18be2bd94859d80499844c5713710581e6ac6259a9
 )
 
 vcpkg_extract_source_archive(

--- a/ports/mpfr/vcpkg.json
+++ b/ports/mpfr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mpfr",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "The MPFR library is a C library for multiple-precision floating-point computations with correct rounding",
   "homepage": "https://www.mpfr.org",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6285,7 +6285,7 @@
       "port-version": 0
     },
     "mpfr": {
-      "baseline": "4.2.1",
+      "baseline": "4.2.2",
       "port-version": 0
     },
     "mpg123": {

--- a/versions/m-/mpfr.json
+++ b/versions/m-/mpfr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fbee25330fb33970c438f64e3401a6c27d14872c",
+      "version": "4.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d612486f81111c3f56a2ac56727dde81fda96f8e",
       "version": "4.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

---

GNU MPFR version 4.2.2 (released on 20 March 2025)

https://www.mpfr.org/mpfr-current/