### PR TITLE
[opentelemetry-cpp-contrib-version] Update to 2025-05-12

### DIFF
--- a/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
@@ -4,9 +4,9 @@ function(clone_opentelemetry_cpp_contrib CONTRIB_SOURCE_PATH)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-telemetry/opentelemetry-cpp-contrib
-        REF 6392b5ff2ebd134e3aa359adc97a2ed37888977c
+        REF dcff8837c588bbbb2ac8bc86842989e24a5eacff
         HEAD_REF main
-        SHA512 8318031c203691e6fa4ffc363d3a37642b2705898bd25b23acd211489c2006c268c3e333c7bef8685d762a8b31b762b96f4d175f6edb9eaf29047852c568e31f
+        SHA512 506c9177c757ff7b832972bae4c822315d59991ae104e876104d4a06c238dde935b4bbef59b62c6fada220fcdf8c5315aa3dbecd62888b41d8d2f3e0730fdba8
     )
     set(${CONTRIB_SOURCE_PATH} ${SOURCE_PATH} CACHE INTERNAL "")
 endfunction()

--- a/ports/opentelemetry-cpp-contrib-version/vcpkg.json
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp-contrib-version",
-  "version-date": "2025-04-15",
+  "version-date": "2025-05-12",
   "description": "This port manages the opentelemetry-cpp-version that will be used for opentelemetry-cpp",
   "homepage": "https://github.com/open-telemetry/opentelemetry-cpp-contrib",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6969,7 +6969,7 @@
       "port-version": 0
     },
     "opentelemetry-cpp-contrib-version": {
-      "baseline": "2025-04-15",
+      "baseline": "2025-05-12",
       "port-version": 0
     },
     "opentracing": {

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "075bc94351e727fb66b1b5fb920dddb4850b7a64",
+      "version-date": "2025-05-12",
+      "port-version": 0
+    },
+    {
       "git-tree": "ed3cde2d60d5eae17855cef965147a2bbb712b33",
       "version-date": "2025-04-15",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.