### PR TITLE
[kf5-coreaddons] Depend only on qt5-base core feature

### DIFF
--- a/ports/kf5coreaddons/vcpkg.json
+++ b/ports/kf5coreaddons/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "kf5coreaddons",
   "version": "5.98.0",
+  "port-version": 1,
   "description": "Addons to QtCore",
   "homepage": "https://api.kde.org/frameworks/kcoreaddons/html/index.html",
   "dependencies": [
     "ecm",
-    "qt5-base",
+    {
+      "name": "qt5-base",
+      "default-features": false
+    },
     "qt5-tools",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4110,7 +4110,7 @@
     },
     "kf5coreaddons": {
       "baseline": "5.98.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5crash": {
       "baseline": "5.98.0",

--- a/versions/k-/kf5coreaddons.json
+++ b/versions/k-/kf5coreaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23bddb564943032879091136a89658442d8995d2",
+      "version": "5.98.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6ce923654b749eae794d954c9c0a05a089a49cbb",
       "version": "5.98.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.