### PR TITLE
[libavif] update to 1.3.0

### DIFF
--- a/ports/libavif/portfile.cmake
+++ b/ports/libavif/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AOMediaCodec/libavif
     REF "v${VERSION}"
-    SHA512 13eb641a17c59d70c465995dca6f921e7a40867053b8d8f0792a68aeaf9dde029daacc77df2049ebb8235ae3b1a35651f5b38a37914bdafe3b8884c64822b1e8
+    SHA512 a411579c851b7c46ddbd93c3549295e0901d822c817f5378b2c75b6a4f16eba1dffdf611bd1789dedeba776e701690a7437f9caeb9eb6dc382fc64935949dbf4
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/libavif/vcpkg.json
+++ b/ports/libavif/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libavif",
-  "version-semver": "1.2.1",
+  "version-semver": "1.3.0",
   "description": "Library for encoding and decoding AVIF files",
   "homepage": "https://github.com/AOMediaCodec/libavif",
   "license": "BSD-2-Clause AND Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4445,7 +4445,7 @@
       "port-version": 0
     },
     "libavif": {
-      "baseline": "1.2.1",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "libb2": {

--- a/versions/l-/libavif.json
+++ b/versions/l-/libavif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "537563c8e4d49831113d936162a6be1c5f8f9f2f",
+      "version-semver": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "86c42010735474826c9b00cd3026632e4e92bba8",
       "version-semver": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/AOMediaCodec/libavif/releases/tag/v1.3.0
