### PR TITLE
[bootstrap-vcpkg.sh] Do not download tool on Android

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -101,6 +101,7 @@ vcpkgCheckRepoTool tar
 
 UNAME="$(uname)"
 ARCH="$(uname -m)"
+OS="$(uname -o)"
 
 if [ -e /etc/alpine-release ]; then
     vcpkgUseSystem="ON"
@@ -197,7 +198,7 @@ elif [ "$UNAME" = "Linux" ] && [ "$ARCH" = "x86_64" ]; then
     echo "Downloading vcpkg-glibc..."
     vcpkgToolReleaseSha=$VCPKG_GLIBC_SHA
     vcpkgToolName="vcpkg-glibc"
-elif [ "$UNAME" = "Linux" ] && [ "$vcpkgUseMuslC" = "OFF" ] && { [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; }; then
+elif [ "$OS" != "Android" ] && [ "$UNAME" = "Linux" ] && [ "$vcpkgUseMuslC" = "OFF" ] && { [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; }; then
     echo "Downloading vcpkg-arm64-glibc..."
     vcpkgToolReleaseSha=$VCPKG_GLIBC_ARM64_SHA
     vcpkgToolName="vcpkg-glibc-arm64"


### PR DESCRIPTION
The `vcpkg` can work ([1](https://github.com/microsoft/vcpkg-tool/pull/497), [2](https://termux.dev/)) on `Android`, but currently downloaded binaries for it is wrong.

In my case `UNAME` is `Linux` and `ARCH` is `aarch64`.