### PR TITLE
[libmypaint] Disable introspection.

### DIFF
--- a/ports/libmypaint/portfile.cmake
+++ b/ports/libmypaint/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         --disable-i18n
+        --disable-introspection
         --with-glib
 )
 

--- a/ports/libmypaint/vcpkg.json
+++ b/ports/libmypaint/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmypaint",
   "version": "1.6.1",
+  "port-version": 1,
   "description": "Brush library used by MyPaint",
   "homepage": "mypaint.org",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5010,7 +5010,7 @@
     },
     "libmypaint": {
       "baseline": "1.6.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libmysofa": {
       "baseline": "1.3.2",

--- a/versions/l-/libmypaint.json
+++ b/versions/l-/libmypaint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7abe278c8100389dac2602a26cb641fe28f9f990",
+      "version": "1.6.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "abd548dd40da39a6509ed1efde4325add5c109fa",
       "version": "1.6.1",
       "port-version": 0


### PR DESCRIPTION
Fixes build error when auto-enabled after installing gobject-introspection (vcpkg.ci).