### PR TITLE
[elfutils] Update to 0.193, add to libcamera deps

### DIFF
--- a/ports/elfutils/link-libs.diff
+++ b/ports/elfutils/link-libs.diff
@@ -65,7 +65,7 @@ index 5363c02..045cde5 100644
 +++ b/libdw/Makefile.am
 @@ -110,7 +110,7 @@ libdw_so_LIBS = ../libebl/libebl_pic.a ../backends/libebl_backends_pic.a \
  		../libcpu/libcpu_pic.a libdw_pic.a ../libdwelf/libdwelf_pic.a \
- 		../libdwfl/libdwfl_pic.a
+ 		../libdwfl/libdwfl_pic.a ../libdwfl_stacktrace/libdwfl_stacktrace_pic.a
  libdw_so_DEPS = ../lib/libeu.a ../libelf/libelf.so
 -libdw_so_LDLIBS = $(libdw_so_DEPS) -ldl -lz $(argp_LDADD) $(fts_LIBS) $(obstack_LIBS) $(zip_LIBS) -pthread
 +libdw_so_LDLIBS = $(libdw_so_DEPS) -ldl $(ZLIB_LIBS) $(argp_LDADD) $(fts_LIBS) $(obstack_LIBS) $(zip_LIBS) -pthread
@@ -89,7 +89,7 @@ diff --git a/src/Makefile.am b/src/Makefile.am
 index 6bdf2df..2fd5b42 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -47,8 +47,8 @@ CLEANFILES += make-debug-archive
+@@ -54,8 +54,8 @@ CLEANFILES = $(bin_SCRIPTS) $(EXTRA_libar_a_DEPENDENCIES)
  
  if BUILD_STATIC
  libasm = ../libasm/libasm.a

--- a/ports/elfutils/portfile.cmake
+++ b/ports/elfutils/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://sourceware.org/pub/elfutils/${VERSION}/elfutils-${VERSION}.tar.bz2"
          "https://www.mirrorservice.org/sites/sourceware.org/pub/elfutils/${VERSION}/elfutils-${VERSION}.tar.bz2"
     FILENAME "elfutils-${VERSION}.tar.bz2"
-    SHA512 543188f5f2cfe5bc7955a878416c5f252edff9926754e5de0c6c57b132f21d9285c9b29e41281e93baad11d4ae7efbbf93580c114579c182103565fe99bd3909
+    SHA512 557e328e3de0d2a69d09c15a9333f705f3233584e2c6a7d3ce855d06a12dc129e69168d6be64082803630397bd64e1660a8b5324d4f162d17922e10ddb367d76
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/elfutils/portfile.cmake
+++ b/ports/elfutils/portfile.cmake
@@ -23,7 +23,9 @@ vcpkg_add_to_path(PREPEND "${BISON_DIR}")
 
 set(options "")
 
-if(NOT "libdebuginfod" IN_LIST FEATURES)
+if("libdebuginfod" IN_LIST FEATURES)
+    list(APPEND options "--enable-libdebuginfod=yes")
+else()
     list(APPEND options "--enable-libdebuginfod=no")
 endif()
 

--- a/ports/elfutils/rpath-link.diff
+++ b/ports/elfutils/rpath-link.diff
@@ -15,9 +15,9 @@ diff --git a/src/Makefile.am b/src/Makefile.am
 index 8e35512..33f7f4b 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -23,7 +23,7 @@ AM_CPPFLAGS += -I$(srcdir)/../libelf -I$(srcdir)/../libebl \
- 	    -I$(srcdir)/../libdw -I$(srcdir)/../libdwelf \
- 	    -I$(srcdir)/../libdwfl -I$(srcdir)/../libasm -I../debuginfod
+@@ -26,7 +26,7 @@ AM_CPPFLAGS += -I$(srcdir)/../libelf -I$(srcdir)/../libebl \
+ 	    -I$(srcdir)/../libdwfl -I$(srcdir)/../libdwfl_stacktrace \
+ 	    -I$(srcdir)/../libasm -I../debuginfod
  
 -AM_LDFLAGS = -Wl,-rpath-link,../libelf:../libdw $(STACK_USAGE_NO_ERROR)
 +AM_LDFLAGS = -Wl,-rpath-link,../libelf:../libdw:$(libdir) $(STACK_USAGE_NO_ERROR)

--- a/ports/elfutils/vcpkg.json
+++ b/ports/elfutils/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "elfutils",
-  "version": "0.192",
+  "version": "0.193",
   "description": "elfutils is a collection of utilities and libraries to read, create and modify ELF binary files, find and handle DWARF debug data, symbols, thread state and stacktraces for processes and core files on GNU/Linux.",
   "homepage": "https://sourceware.org/elfutils/",
   "license": null,

--- a/ports/elfutils/vcpkg.json
+++ b/ports/elfutils/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "elfutils is a collection of utilities and libraries to read, create and modify ELF binary files, find and handle DWARF debug data, symbols, thread state and stacktraces for processes and core files on GNU/Linux.",
   "homepage": "https://sourceware.org/elfutils/",
   "license": null,
-  "supports": "!windows",
+  "supports": "linux",
   "dependencies": [
     "bzip2",
     "liblzma",

--- a/ports/elfutils/vcpkg.json
+++ b/ports/elfutils/vcpkg.json
@@ -18,7 +18,8 @@
         {
           "name": "curl",
           "default-features": false
-        }
+        },
+        "json-c"
       ]
     },
     "nls": {

--- a/ports/libcamera/vcpkg.json
+++ b/ports/libcamera/vcpkg.json
@@ -1,11 +1,13 @@
 {
   "name": "libcamera",
   "version": "0.5.0",
+  "port-version": 1,
   "description": "A complex camera support library for Linux, Android, and ChromeOS",
   "homepage": "https://git.libcamera.org/libcamera/libcamera.git/",
   "license": "LGPL-2.1-or-later",
   "supports": "linux",
   "dependencies": [
+    "elfutils",
     "glib",
     "gstreamer",
     "libgnutls",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -297,12 +297,6 @@ ecal:x64-android=fail
 elfio:arm-neon-android=fail
 elfio:arm64-android=fail
 elfio:x64-android=fail
-# Checks for gnu extension so only works with gcc.
-elfutils:arm-neon-android=fail
-elfutils:arm64-android=fail
-elfutils:arm64-osx=fail
-elfutils:x64-android=fail
-elfutils:x64-osx=fail
 # clang rejects variable length arrays
 fbgemm:x64-android=fail
 # variable length arrays in C++ are a Clang extension

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -99,7 +99,6 @@ discord-rpc:x64-uwp=fail
 dmlc(uwp) = fail
 eastl:arm-uwp=fail
 ebml:arm-uwp=fail
-elfutils(osx) = fail # Checks for gnu extension so only works with gcc.
 epsilon(uwp)=fail
 faiss:arm64-windows=fail
 fastrtps:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4478,7 +4478,7 @@
     },
     "libcamera": {
       "baseline": "0.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libcanberra": {
       "baseline": "0.30",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2617,7 +2617,7 @@
       "port-version": 0
     },
     "elfutils": {
-      "baseline": "0.192",
+      "baseline": "0.193",
       "port-version": 0
     },
     "embree3": {

--- a/versions/e-/elfutils.json
+++ b/versions/e-/elfutils.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "892683d1c7f841e5322a26e85ddf3cbb84dd25e7",
+      "git-tree": "3fcfd684585a393d6f0bb2a7c63aabf48c61af4e",
       "version": "0.193",
       "port-version": 0
     },

--- a/versions/e-/elfutils.json
+++ b/versions/e-/elfutils.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "892683d1c7f841e5322a26e85ddf3cbb84dd25e7",
+      "version": "0.193",
+      "port-version": 0
+    },
+    {
       "git-tree": "773241ff69478469d2ae1bca47abdd22eafae484",
       "version": "0.192",
       "port-version": 0

--- a/versions/l-/libcamera.json
+++ b/versions/l-/libcamera.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4047f6b48f8dc0ae112f0f0682b12d88ee9269a0",
+      "version": "0.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "06606c46dc576d620d00cfeb75c68b16aea018a3",
       "version": "0.5.0",
       "port-version": 0


### PR DESCRIPTION
Fixe isses discovered by vcpkg.ci:
libcamera automatically picks libdw from elfutils. (Installation order problem.)
Undefined symbols while linking libdw from elfutils, even with all link libs from pkgconfig.