### PR TITLE
[ffmpeg] avformat_index_get_entry does not modify its stream argument

### DIFF
--- a/ports/ffmpeg/0044-add-const-for-avformat-index-get-entry.patch
+++ b/ports/ffmpeg/0044-add-const-for-avformat-index-get-entry.patch
@@ -1,0 +1,51 @@
+diff --git a/libavformat/avformat.h b/libavformat/avformat.h
+index f12fa7d904..a5e33cf6b4 100644
+--- a/libavformat/avformat.h
++++ b/libavformat/avformat.h
+@@ -2647,7 +2647,7 @@ int avformat_index_get_entries_count(const AVStream *st);
+  *       until any function that takes the stream or the parent AVFormatContext
+  *       as input argument is called.
+  */
+-const AVIndexEntry *avformat_index_get_entry(AVStream *st, int idx);
++const AVIndexEntry *avformat_index_get_entry(const AVStream *st, int idx);
+ 
+ /**
+  * Get the AVIndexEntry corresponding to the given timestamp.
+@@ -2664,7 +2664,7 @@ const AVIndexEntry *avformat_index_get_entry(AVStream *st, int idx);
+  *       until any function that takes the stream or the parent AVFormatContext
+  *       as input argument is called.
+  */
+-const AVIndexEntry *avformat_index_get_entry_from_timestamp(AVStream *st,
++const AVIndexEntry *avformat_index_get_entry_from_timestamp(const AVStream *st,
+                                                             int64_t wanted_timestamp,
+                                                             int flags);
+ /**
+diff --git a/libavformat/seek.c b/libavformat/seek.c
+index 3b1c75f1b1..9ac6ff8fd1 100644
+--- a/libavformat/seek.c
++++ b/libavformat/seek.c
+@@ -247,20 +247,20 @@ int avformat_index_get_entries_count(const AVStream *st)
+     return cffstream(st)->nb_index_entries;
+ }
+ 
+-const AVIndexEntry *avformat_index_get_entry(AVStream *st, int idx)
++const AVIndexEntry *avformat_index_get_entry(const AVStream *st, int idx)
+ {
+-    const FFStream *const sti = ffstream(st);
++    const FFStream *const sti = cffstream(st);
+     if (idx < 0 || idx >= sti->nb_index_entries)
+         return NULL;
+ 
+     return &sti->index_entries[idx];
+ }
+ 
+-const AVIndexEntry *avformat_index_get_entry_from_timestamp(AVStream *st,
++const AVIndexEntry *avformat_index_get_entry_from_timestamp(const AVStream *st,
+                                                             int64_t wanted_timestamp,
+                                                             int flags)
+ {
+-    const FFStream *const sti = ffstream(st);
++    const FFStream *const sti = cffstream(st);
+     int idx = ff_index_search_timestamp(sti->index_entries,
+                                         sti->nb_index_entries,
+                                         wanted_timestamp, flags);

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         0040-ffmpeg-add-av_stream_get_first_dts-for-chromium.patch # Do not remove this patch. It is required by chromium
         0041-add-const-for-opengl-definition.patch
         0043-fix-miss-head.patch
+        0044-add-const-for-avformat-index-get-entry.patch
 )
 
 if(SOURCE_PATH MATCHES " ")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "7.1.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2802,7 +2802,7 @@
     },
     "ffmpeg": {
       "baseline": "7.1.1",
-      "port-version": 2
+      "port-version": 3
     },
     "ffnvcodec": {
       "baseline": "12.2.72.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9568fdd2e753191a03b27c88ee351f280d270bad",
+      "version": "7.1.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "a1c3c785273a5cecf79a78a22ac58c6cb316ac6d",
       "version": "7.1.1",
       "port-version": 2


### PR DESCRIPTION
There is no reason to provide a mutable stream. Submitted upstream as a patch at 02/16/2023, but not yet applied (no response). When they merge it we can remove this patch.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
