### PR TITLE
[libxlsxwriter] add features

### DIFF
--- a/ports/libxlsxwriter/portfile.cmake
+++ b/ports/libxlsxwriter/portfile.cmake
@@ -7,6 +7,13 @@ vcpkg_from_github(
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/third_party/minizip")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    "dtoa"        USE_DTOA_LIBRARY
+    "openssl-md5" USE_OPENSSL_MD5
+    "mem-file"    USE_MEM_FILE
+)
+
 set(USE_WINDOWSSTORE OFF)
 if (VCPKG_TARGET_IS_UWP)
     set(USE_WINDOWSSTORE ON)
@@ -17,6 +24,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DUSE_SYSTEM_MINIZIP=1
         -DWINDOWSSTORE=${USE_WINDOWSSTORE}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/libxlsxwriter/vcpkg.json
+++ b/ports/libxlsxwriter/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libxlsxwriter",
   "version": "1.2.2",
+  "port-version": 1,
   "description": "Libxlsxwriter is a C library that can be used to write text, numbers, formulas and hyperlinks to multiple worksheets in an Excel 2007+ XLSX file.",
   "homepage": "https://github.com/jmcnamara/libxlsxwriter",
   "documentation": "https://libxlsxwriter.github.io",
@@ -12,5 +13,20 @@
       "host": true
     },
     "zlib"
-  ]
+  ],
+  "features": {
+    "dtoa": {
+      "description": "Use the Milo Yip DTOA library"
+    },
+    "mem-file": {
+      "description": "Use memory files instead of temp files",
+      "supports": "!windows"
+    },
+    "openssl-md5": {
+      "description": "Use Openssl MD5",
+      "dependencies": [
+        "openssl"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5598,7 +5598,7 @@
     },
     "libxlsxwriter": {
       "baseline": "1.2.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libxml2": {
       "baseline": "2.13.5",

--- a/versions/l-/libxlsxwriter.json
+++ b/versions/l-/libxlsxwriter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "abed9bed4b74d831df214261194dcbe19ccfa17b",
+      "version": "1.2.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "58ddcdb4a0fdcece46700e32b6ac1b75ba7e80f1",
       "version": "1.2.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

