### PR TITLE
[minhook] fix usage

### DIFF
--- a/ports/minhook/fix-usage.patch
+++ b/ports/minhook/fix-usage.patch
@@ -1,0 +1,10 @@
+diff --git a/cmake/minhook-config.cmake.in b/cmake/minhook-config.cmake.in
+index 14e6463..28fa17c 100644
+--- a/cmake/minhook-config.cmake.in
++++ b/cmake/minhook-config.cmake.in
+@@ -36,4 +36,4 @@ set(MINHOOK_FOUND ON)
+ set_and_check(MINHOOK_INCLUDE_DIRS  "${PACKAGE_PREFIX_DIR}/include/")
+ set_and_check(MINHOOK_LIBRARY_DIRS  "${PACKAGE_PREFIX_DIR}/lib")
+  
+-include("${PACKAGE_PREFIX_DIR}/lib/minhook/minhook-targets.cmake")
++include("${CMAKE_CURRENT_LIST_DIR}/minhook-targets.cmake")

--- a/ports/minhook/portfile.cmake
+++ b/ports/minhook/portfile.cmake
@@ -14,6 +14,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 8a33233598b56ad9da44d22d470c2432f68364dac31bc719fcd6b085e681fa10ddd41865fbde056ee7f4e7a075cc135344b6bf444eadbd7e7314ee1bedfd89b5
     HEAD_REF master
+    PATCHES
+        fix-usage.patch
 )
 
 vcpkg_cmake_configure(

--- a/versions/m-/minhook.json
+++ b/versions/m-/minhook.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1d39d2cd5dbb40ee8a5a421c74eceee090c88618",
+      "git-tree": "f2e0ee0a631c02f725740c3267b05e3eb1cabdf3",
       "version": "1.3.4",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #45439 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.