### PR TITLE
[cl_cpp_wrapper] Replace ${slash} with a real dash

### DIFF
--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -50,10 +50,6 @@ else()
     list(APPEND OPTIONS -Dlzo=disabled)
 endif()
 
-if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-    set(ENV{CPP} "cl_cpp_wrapper")
-endif()
-
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/libx11/vcpkg.json
+++ b/ports/libx11/vcpkg.json
@@ -15,6 +15,10 @@
       "name": "libxslt",
       "host": true
     },
+    {
+      "name": "vcpkg-make",
+      "host": true
+    },
     "xcb",
     "xproto",
     "xtrans"

--- a/ports/vcpkg-make/wrappers/cl_cpp_wrapper
+++ b/ports/vcpkg-make/wrappers/cl_cpp_wrapper
@@ -2,22 +2,11 @@
 # cl_cpp_wrapper
 # Wrapper around MS's cl.exe to make it act more like Unix cpp
 
-PATH="$PATH:/usr/bin"
-
-case $MACHTYPE in
-    *-msys)
-        slash="-"
-        ;;
-    *)
-        slash="/"
-        ;;
-esac
-
 # prog specifies the program that should be run cl.exe
 prog=cl.exe
 debug=
-cppopt=("${slash}nologo")
-cppopt+=("${slash}E")
+cppopt=("-nologo")
+cppopt+=("-E")
 verbose=
 shared_index=-1
 
@@ -42,15 +31,10 @@ while test $# -gt 0; do
     -*)
         # Remaining '-' options are passed to the compiler
         if test x$optarg != x ; then
-            cppopt+=("${slash}${1:1}=$optarg")
+            cppopt+=("-${1:1}=$optarg")
         else
-            cppopt+=("${slash}${1:1}")
+            cppopt+=("-${1:1}")
         fi
-        ;;
-
-    /*)
-        # All '/' options are assumed to be for cpp and are passed through
-        cppopt+=("${slash}${1:1}")
         ;;
 
     *)
@@ -84,12 +68,21 @@ fi
 
 input_file="${file:-/proc/self/fd/0}"
 if [ "$input_file" == "/proc/self/fd/0" ]; then
+    #echo "STDIN"
     # CL does not support reading from STDIN so it is wrapped here. 
     tmpout=cpp_wrapper_$RANDOM.h
     /usr/bin/cp $input_file $tmpout
+    # from https://stackoverflow.com/questions/36313562/how-to-redirect-stdin-to-file-in-bash
+    #exec 3> cppstdtmp.h
+    #while IFS= read -r line; do
+    #  printf '%s' "$line"
+    #done
+    #exec 3<&-
+    #echo "$(</dev/stdin)" > cppstdtmp.h
     exec $prog ${cppopt[@]} $tmpout
     rm -f $tmpout
 else
+    #echo "FILE"
     exec $prog ${cppopt[@]} $input_file
 fi
 

--- a/scripts/buildsystems/make_wrapper/cl_cpp_wrapper
+++ b/scripts/buildsystems/make_wrapper/cl_cpp_wrapper
@@ -4,8 +4,8 @@
 
 PATH="$PATH:/usr/bin"
 
-case $MACHTYPE in
-    *-msys)
+case `uname -o` in
+    Msys)
         slash="-"
         ;;
     *)

--- a/scripts/buildsystems/make_wrapper/cl_cpp_wrapper
+++ b/scripts/buildsystems/make_wrapper/cl_cpp_wrapper
@@ -2,22 +2,11 @@
 # cl_cpp_wrapper
 # Wrapper around MS's cl.exe to make it act more like Unix cpp
 
-PATH="$PATH:/usr/bin"
-
-case `uname -o` in
-    Msys)
-        slash="-"
-        ;;
-    *)
-        slash="/"
-        ;;
-esac
-
 # prog specifies the program that should be run cl.exe
 prog=cl.exe
 debug=
-cppopt=("${slash}nologo")
-cppopt+=("${slash}E")
+cppopt=("-nologo")
+cppopt+=("-E")
 verbose=
 shared_index=-1
 
@@ -42,15 +31,10 @@ while test $# -gt 0; do
     -*)
         # Remaining '-' options are passed to the compiler
         if test x$optarg != x ; then
-            cppopt+=("${slash}${1:1}=$optarg")
+            cppopt+=("-${1:1}=$optarg")
         else
-            cppopt+=("${slash}${1:1}")
+            cppopt+=("-${1:1}")
         fi
-        ;;
-
-    /*)
-        # All '/' options are assumed to be for cpp and are passed through
-        cppopt+=("${slash}${1:1}")
         ;;
 
     *)


### PR DESCRIPTION
This is a simple PR that improve the detection of MSYS environement. I just download this script to `/usr/local/bin` to build library for my self-use.

In MSYS2, `$MACHTYPE` is `x86_64-pc-cygwin` instead of `x86_64-pc-msys2` in my machine.

A noticable thing is `uname -s` is `MINGW64_NT-10.0-19045` on MINGW64 environment, so I think it's the most convenient way to do that.