### PR TITLE
[stc] add new port

### DIFF
--- a/ports/stc/portfile.cmake
+++ b/ports/stc/portfile.cmake
@@ -1,0 +1,17 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO stclib/STC
+    REF "v${VERSION}"
+    SHA512 99ac97d4849e548c54d564e822cec36be6436b976546af1e8f12757764831c14229f958e7064ab8802e74131831a0016cc28649df24088c415ab4cdc65dad076
+    HEAD_REF master
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_install_meson()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/stc/vcpkg.json
+++ b/ports/stc/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "stc",
+  "version": "5.0",
+  "description": "A modern, user friendly, generic, type-safe and fast C99 container library: String, Vector, Sorted and Unordered Map and Set, Deque, Forward List, Smart Pointers, Bitset and Random numbers.",
+  "homepage": "https://github.com/stclib/STC",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9012,6 +9012,10 @@
       "baseline": "2024-07-29",
       "port-version": 1
     },
+    "stc": {
+      "baseline": "5.0",
+      "port-version": 0
+    },
     "stdexec": {
       "baseline": "2024-06-16",
       "port-version": 2

--- a/versions/s-/stc.json
+++ b/versions/s-/stc.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fd30d036b28ed9e90fbf4085f80005d82aacd1a4",
+      "version": "5.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #45520 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.(no usage text)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.