### PR TITLE
[ncurses] fix compilation error on gcc15

### DIFF
--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -37,8 +37,18 @@ if(VCPKG_TARGET_IS_MINGW)
     )
 endif()
 
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+
+# There are compilation errors on gcc 15. adding `-std=c17` to CFLAGS for workaround.
+# ref: https://gitlab.archlinux.org/archlinux/packaging/packages/ncurses/-/issues/3
+if(VCPKG_DETECTED_CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND VCPKG_DETECTED_CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
+    set(ENV{CFLAGS} "$ENV{CFLAGS} -std=c17")
+endif()
+
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
+    CONFIGURE_ENVIRONMENT_VARIABLES CFLAGS
     DETERMINE_BUILD_TRIPLET
     NO_ADDITIONAL_PATHS
     OPTIONS

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -1,9 +1,15 @@
 {
   "name": "ncurses",
   "version": "6.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Free software emulation of curses in System V Release 4.0, and more",
   "homepage": "https://invisible-island.net/ncurses/announce.html",
   "license": "MIT",
-  "supports": "!windows | mingw"
+  "supports": "!windows | mingw",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6514,7 +6514,7 @@
     },
     "ncurses": {
       "baseline": "6.4",
-      "port-version": 2
+      "port-version": 3
     },
     "ndis-driver-library": {
       "baseline": "1.2.0",

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b3a246cf66808e473b8cc1ff06e1a8a185b712d",
+      "version": "6.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "b32f25c6bd504d55b4d388c44e88a51a0870e7e9",
       "version": "6.4",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

There are compilation errors on gcc15.
It will be fixed by adding `-std=c17` to `CFLAGS`.

reference: https://gitlab.archlinux.org/archlinux/packaging/packages/ncurses/-/issues/3
