### PR TITLE
[sqlitecpp] Upgrade to 3.3.3

### DIFF
--- a/ports/sqlitecpp/fix_dependency.patch
+++ b/ports/sqlitecpp/fix_dependency.patch
@@ -1,21 +1,21 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index df5693d..e5723d0 100644
+index 50362fb..5d7c22f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -295,9 +295,9 @@ else (SQLITECPP_INTERNAL_SQLITE)
+@@ -325,9 +325,9 @@ else (SQLITECPP_INTERNAL_SQLITE)
              target_link_libraries(SQLiteCpp PRIVATE ${sqlcipher_LIBRARY})
          endif()
      else()
 -        find_package (SQLite3 REQUIRED)
 +        find_package (unofficial-sqlite3 CONFIG)
-         message(STATUS "Link to sqlite3 system library")
+         message(STATUS "Link to sqlite3 system library ${SQLite3_VERSION}")
 -        target_link_libraries(SQLiteCpp PUBLIC SQLite::SQLite3)
 +        target_link_libraries(SQLiteCpp PRIVATE unofficial::sqlite3::sqlite3)
          if(SQLite3_VERSION VERSION_LESS "3.19")
              set_target_properties(SQLiteCpp PROPERTIES COMPILE_FLAGS "-DSQLITECPP_HAS_MEM_STRUCT")
          endif()
 diff --git a/cmake/SQLiteCppConfig.cmake.in b/cmake/SQLiteCppConfig.cmake.in
-index 2b48df4..d0feda9 100644
+index 7d0941c..d0feda9 100644
 --- a/cmake/SQLiteCppConfig.cmake.in
 +++ b/cmake/SQLiteCppConfig.cmake.in
 @@ -1,6 +1,6 @@

--- a/ports/sqlitecpp/portfile.cmake
+++ b/ports/sqlitecpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO "SRombauts/SQLiteCpp"
     REF ${VERSION}
     HEAD_REF master
-    SHA512 e65695765756570d3b2df9151c968f76d434b9ec1dbcffa71e6b58a0cad005dc60c03ac826269d0292ecda2ad2abfbf2acd1cb71fb11967f53ff58140ea133fd
+    SHA512 23193108faaca4c1c7b0a05178bfdbb772a4e14dc145af1b3a7b35efe05a94b07200bdd5551afde44ab5eb3c6aeabbd70cfb0d710dc2750a8280e06fba94c494
     PATCHES
         fix_dependency.patch
         add_runtime_destination.patch

--- a/ports/sqlitecpp/vcpkg.json
+++ b/ports/sqlitecpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlitecpp",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "SQLiteC++ (SQLiteCpp) is a smart and easy to use C++ SQLite3 wrapper.",
   "homepage": "https://github.com/SRombauts/SQLiteCpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8957,7 +8957,7 @@
       "port-version": 0
     },
     "sqlitecpp": {
-      "baseline": "3.3.2",
+      "baseline": "3.3.3",
       "port-version": 0
     },
     "sqlpp11": {

--- a/versions/s-/sqlitecpp.json
+++ b/versions/s-/sqlitecpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d0741a4558bd9187854a03140417fcdf2679941",
+      "version": "3.3.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "5ae20f010448408508d0ec198f3166f6f9794f69",
       "version": "3.3.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #45545
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
