### PR TITLE
[apr] bump to 1.7.6

### DIFF
--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://archive.apache.org/dist/apr/apr-${VERSION}.tar.bz2"
+    URLS "https://downloads.apache.org/apr/apr-${VERSION}.tar.bz2"
     FILENAME "apr-${VERSION}.tar.bz2"
-    SHA512 d8a7553642da0c81261ac3992536efd9d43ecb9154934ef1a10ae808d6a3ce8198b40433091d3a6d04f61e67c59426fb5276193a37e810ae4bc74a8a10fb651b
+    SHA512 629b60680d1244641828019db903a1b199e8a19c8f27a5132b93faacb381ce561f88463345ab019258f1f1e8cfdf8aa986ac815153a8e7e04a22b3932f9fedd2
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/apr/vcpkg.json
+++ b/ports/apr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "apr",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "port-version": 2,
   "description": "The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.",
   "homepage": "https://apr.apache.org/",

--- a/ports/apr/vcpkg.json
+++ b/ports/apr/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "apr",
   "version": "1.7.6",
-  "port-version": 2,
   "description": "The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.",
   "homepage": "https://apr.apache.org/",
   "license": "Apache-2.0",

--- a/versions/a-/apr.json
+++ b/versions/a-/apr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e92a2673b91ca78ac5c9f310f2a68aa6d105770",
+      "version": "1.7.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "dfa11d3e5058b640b37c1a6845dbc2980496a7c8",
       "version": "1.7.5",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -173,8 +173,8 @@
       "port-version": 0
     },
     "apr": {
-      "baseline": "1.7.5",
-      "port-version": 2
+      "baseline": "1.7.6",
+      "port-version": 0
     },
     "apr-util": {
       "baseline": "1.6.3",


### PR DESCRIPTION
Note: the source website has been changed, because the new tar ball is not shown in the previous source (archive.a.o), but the downloads.a.o contains it, and also seems more recommended to use.