### PR TITLE
[dlib] update to 19.24.9

### DIFF
--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO davisking/dlib
     REF "v${VERSION}"
-    SHA512 548f15fcd345a56b6e7a0a568fa7c694beeeda3b863492f59bdaa0b0e6d48b21d6705e2ac56a06f349aa26b0e9b79aa0a437870940170772b5b30cf35841cbb4
+    SHA512 8aef0e1e54093618e5246aa2418902681aeb4ffcaac734e523ee51cc2a4cbc3eefa78302a32b82550219a6d2cba997ea2ff10506310c1a4de8551a709579b5af
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/dlib/vcpkg.json
+++ b/ports/dlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dlib",
-  "version": "19.24.6",
+  "version": "19.24.9",
   "description": "Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++",
   "homepage": "https://github.com/davisking/dlib",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2413,7 +2413,7 @@
       "port-version": 0
     },
     "dlib": {
-      "baseline": "19.24.6",
+      "baseline": "19.24.9",
       "port-version": 0
     },
     "dlpack": {

--- a/versions/d-/dlib.json
+++ b/versions/d-/dlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f4abbb3aa13f22039b1859daf06cd940c7469a8",
+      "version": "19.24.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "5ec140618bd63da01f52b9904b02d03e8b6b1256",
       "version": "19.24.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/davisking/dlib/releases/tag/v19.24.9
https://github.com/davisking/dlib/releases/tag/v19.24.8
https://github.com/davisking/dlib/releases/tag/v19.24.7
