### PR TITLE
[libvpx] Fix build on systems where make is not gmake

### DIFF
--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -97,7 +97,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     message(STATUS "Generating MSBuild projects")
     vcpkg_execute_required_process(
         COMMAND
-            ${BASH} --noprofile --norc -c "make dist"
+            ${BASH} --noprofile --norc -c "gmake dist"
         WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tmp"
         LOGNAME generate-${TARGET_TRIPLET})
 
@@ -249,7 +249,7 @@ else()
         message(STATUS "Building libvpx for Release")
         vcpkg_execute_required_process(
             COMMAND
-                ${BASH} --noprofile --norc -c "make -j${VCPKG_CONCURRENCY}"
+                ${BASH} --noprofile --norc -c "gmake -j${VCPKG_CONCURRENCY}"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
             LOGNAME build-${TARGET_TRIPLET}-rel
         )
@@ -257,7 +257,7 @@ else()
         message(STATUS "Installing libvpx for Release")
         vcpkg_execute_required_process(
             COMMAND
-                ${BASH} --noprofile --norc -c "make install"
+                ${BASH} --noprofile --norc -c "gmake install"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
             LOGNAME install-${TARGET_TRIPLET}-rel
         )
@@ -283,7 +283,7 @@ else()
         message(STATUS "Building libvpx for Debug")
         vcpkg_execute_required_process(
             COMMAND
-                ${BASH} --noprofile --norc -c "make -j${VCPKG_CONCURRENCY}"
+                ${BASH} --noprofile --norc -c "gmake -j${VCPKG_CONCURRENCY}"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
             LOGNAME build-${TARGET_TRIPLET}-dbg
         )
@@ -291,7 +291,7 @@ else()
         message(STATUS "Installing libvpx for Debug")
         vcpkg_execute_required_process(
             COMMAND
-                ${BASH} --noprofile --norc -c "make install"
+                ${BASH} --noprofile --norc -c "gmake install"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
             LOGNAME install-${TARGET_TRIPLET}-dbg
         )

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libvpx",
   "version": "1.13.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5510,7 +5510,7 @@
     },
     "libvpx": {
       "baseline": "1.13.1",
-      "port-version": 4
+      "port-version": 5
     },
     "libwandio": {
       "baseline": "4.2.1",

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ef4b1c0e8a60dd13897c08e35f926f947528c49",
+      "version": "1.13.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "51aa3269c3e4839a7c789ba5e7f25e653ef65b27",
       "version": "1.13.1",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
