### PR TITLE
[libigl] update to 2.6.0

### DIFF
--- a/ports/libigl/dependencies.patch
+++ b/ports/libigl/dependencies.patch
@@ -67,7 +67,7 @@ index 79c2126..6d06775 100644
  
  # 5. Unit tests
 diff --git a/cmake/igl/modules/imgui.cmake b/cmake/igl/modules/imgui.cmake
-index d7ffb9d..6152756 100644
+index d7ffb9d..f331854 100644
 --- a/cmake/igl/modules/imgui.cmake
 +++ b/cmake/igl/modules/imgui.cmake
 @@ -14,14 +14,12 @@ file(GLOB SRC_FILES "${libigl_SOURCE_DIR}/include/igl/opengl/glfw/imgui/*.cpp")
@@ -84,9 +84,8 @@ index d7ffb9d..6152756 100644
      igl::core
      igl::glfw
      imgui::imgui
--    imguizmo::imguizmo
+     imguizmo::imguizmo
 -    igl::imgui_fonts
-+    imguizmo::imguizmo
  )
 diff --git a/cmake/igl/modules/opengl.cmake b/cmake/igl/modules/opengl.cmake
 index 4580c03..dfadb38 100644
@@ -114,16 +113,3 @@ index 3763b77..31ab979 100644
  target_link_libraries(igl_xml ${IGL_SCOPE}
      igl::core
      tinyxml2::tinyxml2
-diff --git a/cmake/recipes/external/comiso.cmake b/cmake/recipes/external/comiso.cmake
-index d2879cb..5a0bd58 100644
---- a/cmake/recipes/external/comiso.cmake
-+++ b/cmake/recipes/external/comiso.cmake
-@@ -11,7 +11,7 @@ FetchContent_Declare(
-     GIT_TAG 536440e714f412e7ef6c0b96b90ba37b1531bb39
- )
- 
--include(eigen)
-+find_package(Eigen3 CONFIG REQUIRED)
- 
- FetchContent_MakeAvailable(comiso)
- 

--- a/ports/libigl/portfile.cmake
+++ b/ports/libigl/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libigl/libigl
     REF  "v${VERSION}"
-    SHA512 39b92ec4c2479a3c0a8e99b2890643c9d76a7e5b61b485c1a3a5f5abff1da4e62b67b879dbcf6e18a43f98172fc9f87f0a6c92b99e2a1900e6f1d2e809899b11
+    SHA512 7c6ae5b94020a01df5d6d0a358592293595d8d8bf04bf42e6acc09bcd6ed012071069373a71ed6f24ce878aa79447dd189b42bc8a3a70819ef05dccc60a2cf68
     HEAD_REF master
     PATCHES
         dependencies.patch
@@ -37,8 +37,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         imgui           LIBIGL_IMGUI
         opengl          LIBIGL_OPENGL
         xml             LIBIGL_XML
-        # Features removed: missing binary libs / separate ports
-        comiso          LIBIGL_COPYLEFT_COMISO
         predicates      LIBIGL_PREDICATES
         tetgen          LIBIGL_COPYLEFT_TETGEN
         triangle        LIBIGL_RESTRICTED_TRIANGLE

--- a/ports/libigl/vcpkg.json
+++ b/ports/libigl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libigl",
-  "version": "2.5.0",
-  "port-version": 2,
+  "version": "2.6.0",
   "description": "libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.",
   "homepage": "https://github.com/libigl/libigl",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4833,8 +4833,8 @@
       "port-version": 2
     },
     "libigl": {
-      "baseline": "2.5.0",
-      "port-version": 2
+      "baseline": "2.6.0",
+      "port-version": 0
     },
     "libilbc": {
       "baseline": "3.0.4",

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b47fec68bb327d7372d5a8d2c5418482fc60fdf",
+      "version": "2.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "97c212824af2073c76a3437ffad728205eba3ce7",
       "version": "2.5.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/libigl/libigl/releases/tag/v2.6.0
