### PR TITLE
[openh264] Fix build on OpenBSD and FreeBSD

### DIFF
--- a/ports/openh264/add-openbsd-and-freebsd-to-meson.patch
+++ b/ports/openh264/add-openbsd-and-freebsd-to-meson.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index c604389e..a0dfd219 100644
+--- a/meson.build
++++ b/meson.build
+@@ -57,7 +57,7 @@ cpp_lib = '-lstdc++'
+ libm_dep = cpp.find_library('m', required : false)
+ deps += [libm_dep]
+ 
+-if ['linux', 'android', 'ios', 'darwin'].contains(system)
++if ['linux', 'freebsd', 'openbsd', 'android', 'ios', 'darwin'].contains(system)
+   asm_format32 = 'elf'
+   asm_format64 = 'elf64'
+   if ['ios', 'darwin'].contains(system)

--- a/ports/openh264/portfile.cmake
+++ b/ports/openh264/portfile.cmake
@@ -2,7 +2,9 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cisco/openh264
     REF v${VERSION}
-    SHA512 26a03acde7153a6b40b99f00641772433a244c72a3cc4bca6d903cf3b770174d028369a2fb73b2f0774e1124db0e269758eed6d88975347a815e0366c820d247 
+    SHA512 26a03acde7153a6b40b99f00641772433a244c72a3cc4bca6d903cf3b770174d028369a2fb73b2f0774e1124db0e269758eed6d88975347a815e0366c820d247
+    PATCHES
+        add-openbsd-and-freebsd-to-meson.patch
 )
 
 set(cxx_link_libraries "")

--- a/ports/openh264/vcpkg.json
+++ b/ports/openh264/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openh264",
   "version": "2.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenH264 is a codec library which supports H.264 encoding and decoding. It is suitable for use in real time applications such as WebRTC.",
   "homepage": "https://www.openh264.org/",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6918,7 +6918,7 @@
     },
     "openh264": {
       "baseline": "2.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "openigtlink": {
       "baseline": "3.0",

--- a/versions/o-/openh264.json
+++ b/versions/o-/openh264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "425ba93027a00f71a0d87da6ca0e752aedbba917",
+      "version": "2.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "f8a88fd9771af1e587d87d4ffe602916cfb75899",
       "version": "2.6.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
