### PR TITLE
[sdl3] update to 3.2.14

### DIFF
--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL
     REF "release-${VERSION}"
-    SHA512 30a5b4db62b4dc9e0034092d9b80ee5519bf24f02df17af5280242cf9a3151b39056d8181f047c7abc0aa47786c5bfe2688cf6f5b24f82a3684bdd9e4d03f5f1
+    SHA512 5d6f0b22c08357dccdc5ada486138b056ed8ce16573f0c60c5b17ada4bc39733aff8a12bc3b89d6a3aee923e1e490a3ab002aecaf41b3eef248080b2eb7e8a85
     HEAD_REF main
 )
 

--- a/ports/sdl3/vcpkg.json
+++ b/ports/sdl3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl3",
-  "version": "3.2.12",
+  "version": "3.2.14",
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
   "license": "Zlib AND MIT AND Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8533,7 +8533,7 @@
       "port-version": 11
     },
     "sdl3": {
-      "baseline": "3.2.12",
+      "baseline": "3.2.14",
       "port-version": 0
     },
     "sdl3-image": {

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4036f9ab31a96a110f90c2bb754ef1c0a938d160",
+      "version": "3.2.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "94603e8c3a997f197ba845be0ef4d1bc9f78f527",
       "version": "3.2.12",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/libsdl-org/SDL/releases/tag/release-3.2.14
