### PR TITLE
[libxslt] update to 1.1.43

### DIFF
--- a/ports/libxslt/portfile.cmake
+++ b/ports/libxslt/portfile.cmake
@@ -1,14 +1,8 @@
-vcpkg_download_distfile(FIX_PACKAGE_VERSION_PATCH
-    URLS https://github.com/GNOME/libxslt/commit/7504032097712714aafe309d54f2ad57e3364bac.diff?full_index=1
-    FILENAME Fix-package-version.patch
-    SHA512 972921decf374fe8a4cad4e09890ce0d5961ee05e3c52d117c09fe8bde1a4540ebe212e767f8a95d281945240f29a90fd15e37104f45d47440032737d41dc8d0
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/libxslt
     REF "v${VERSION}"
-    SHA512 0974419e0eae3cd4070ca52341b3df2d1b873b30d0ede2143274fcd0ef8653d5ac55b5f0faad56d8cf60443fefb01c5f5ddecff4b7638ba28e450e88f1c3d3c4
+    SHA512 51d9e9586f78c5aa69ac67fac64b865625fefb16bf06f1f06dede0a57b3e382e78dea69145c7c0c59f06735b738bed209751e691dd9045c3cc33df096963f89d
     HEAD_REF master
     PATCHES
         python3.patch
@@ -16,7 +10,6 @@ vcpkg_from_github(
         libexslt-pkgconfig.patch
         fix-gcrypt-deps.patch
         skip-install-docs.patch
-        ${FIX_PACKAGE_VERSION_PATCH}
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libxslt/vcpkg.json
+++ b/ports/libxslt/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxslt",
-  "version": "1.1.42",
-  "port-version": 2,
+  "version": "1.1.43",
   "description": "Libxslt is a XSLT library implemented in C for XSLT 1.0 and most of EXSLT",
   "homepage": "https://github.com/GNOME/libxslt",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5649,8 +5649,8 @@
       "port-version": 0
     },
     "libxslt": {
-      "baseline": "1.1.42",
-      "port-version": 2
+      "baseline": "1.1.43",
+      "port-version": 0
     },
     "libxt": {
       "baseline": "1.3.0",

--- a/versions/l-/libxslt.json
+++ b/versions/l-/libxslt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb1445468e9d858f0ff63cc777b48e98c4d10a72",
+      "version": "1.1.43",
+      "port-version": 0
+    },
+    {
       "git-tree": "00e5829fca614f1b82dc9fa5439ef0a8d35d7cb4",
       "version": "1.1.42",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
