### PR TITLE
[gsl-lite] Update to v1.0.0

### DIFF
--- a/ports/gsl-lite/portfile.cmake
+++ b/ports/gsl-lite/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gsl-lite/gsl-lite
     REF "v${VERSION}"
-    SHA512 8215dc36418964b6c66f4bc8cd6f1eb39446e1563aaae3b015cb4f39bf2e5b69d34ef822cc0b4794a2ceef6944928543770727afcdc8060a6f61b548066d7c2b
+    SHA512 375ba0ba1ce2323d6918949c0a616500b3f666e3ec4d7046b41105b813f45c041787fd08f3a61498928edd304899e616ce950ff4be77b1119adc40ddacdc95e3
     HEAD_REF master
 )
 
@@ -11,13 +11,13 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
-    CONFIG_PATH "lib/cmake/gsl-lite"
+    CONFIG_PATH "share/cmake/gsl-lite"
 )
 
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/gsl-lite.hpp "#ifndef GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
 #define GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
-#pragma message(\"The header <gsl-lite.hpp> is deprecated and provided by Vcpkg for compatibility only; please include <gsl/gsl-lite.hpp> instead.\")
-#include <gsl/gsl-lite.hpp>
+#pragma message(\"The header <gsl-lite.hpp> is deprecated and provided by Vcpkg for compatibility only; please include <gsl-lite/gsl-lite.hpp> instead.\")
+#include <gsl-lite/gsl-lite.hpp>
 #endif // GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED")
 
 file(REMOVE_RECURSE
@@ -30,3 +30,5 @@ file(INSTALL
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     RENAME copyright
 )
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)

--- a/ports/gsl-lite/usage
+++ b/ports/gsl-lite/usage
@@ -1,0 +1,4 @@
+gsl-lite provides CMake targets:
+
+  find_package(gsl-lite CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE gsl-lite::gsl-lite)

--- a/ports/gsl-lite/vcpkg.json
+++ b/ports/gsl-lite/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gsl-lite",
-  "version": "0.43.0",
-  "description": "A single-file header-only implementation of ISO C++ Guidelines Support Library (GSL) for C++98, C++11 and later.",
+  "version": "1.0.0",
+  "description": "ISO C++ Core Guidelines Library implementation for C++98, C++11 up",
   "homepage": "https://github.com/gsl-lite/gsl-lite/",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3377,7 +3377,7 @@
       "port-version": 1
     },
     "gsl-lite": {
-      "baseline": "0.43.0",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "gsoap": {

--- a/versions/g-/gsl-lite.json
+++ b/versions/g-/gsl-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dea13a0b59dfa942c508ccf78903f2f84c5d5dd3",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1dec7fa87c2ead1a01cbf4ef58db83b0b645023e",
       "version": "0.43.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
