### PR TITLE
[libxml2] update to 2.13.8

### DIFF
--- a/ports/libxml2/fix_ios_compilation.patch
+++ b/ports/libxml2/fix_ios_compilation.patch
@@ -1,26 +1,36 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0a279c8..8e771ee 100644
+index a48dbbfe..9f51cf6e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -136,7 +136,7 @@ if (NOT MSVC)
+@@ -136,7 +136,12 @@ if (NOT MSVC)
      check_include_files(fcntl.h HAVE_FCNTL_H)
      check_function_exists(fpclass HAVE_FPCLASS)
      check_function_exists(ftime HAVE_FTIME)
 -    check_function_exists(getentropy HAVE_GETENTROPY)
-+    check_symbol_exists(getentropy "sys/random.h" HAVE_GETENTROPY)
++    if (APPLE)
++        # In old macOS SDKs (ex: 10.15), sys/random.h fails to include header files it needs, so add them here.
++        check_symbol_exists(getentropy "Availability.h;stddef.h;sys/random.h" HAVE_GETENTROPY)
++    else()
++        check_symbol_exists(getentropy sys/random.h HAVE_GETENTROPY)
++    endif()
      check_function_exists(gettimeofday HAVE_GETTIMEOFDAY)
      check_library_exists(history append_history "" HAVE_LIBHISTORY)
      check_library_exists(readline readline "" HAVE_LIBREADLINE)
-@@ -149,7 +149,6 @@ if (NOT MSVC)
+@@ -149,12 +154,6 @@ if (NOT MSVC)
      check_function_exists(stat HAVE_STAT)
      check_include_files(stdint.h HAVE_STDINT_H)
      check_include_files(sys/mman.h HAVE_SYS_MMAN_H)
--    check_include_files(sys/random.h HAVE_SYS_RANDOM_H)
+-    if (APPLE)
+-        # In old macOS SDKs (ex: 10.15), sys/random.h fails to include header files it needs, so add them here.
+-        check_include_files("Availability.h;stddef.h;sys/random.h" HAVE_SYS_RANDOM_H)
+-    else()
+-        check_include_files(sys/random.h HAVE_SYS_RANDOM_H)
+-    endif()
      check_include_files(sys/select.h HAVE_SYS_SELECT_H)
      check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
      check_include_files(sys/stat.h HAVE_SYS_STAT_H)
 diff --git a/config.h.cmake.in b/config.h.cmake.in
-index 2f4aeba..79f1cdb 100644
+index 2f4aeba3..36c068fd 100644
 --- a/config.h.cmake.in
 +++ b/config.h.cmake.in
 @@ -69,9 +69,6 @@
@@ -34,10 +44,10 @@ index 2f4aeba..79f1cdb 100644
  #cmakedefine HAVE_SYS_SELECT_H 1
  
 diff --git a/configure.ac b/configure.ac
-index 48cd2f0..0f09c61 100644
+index 478bb4eb..ad49a9ac 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -304,7 +304,6 @@ AC_CHECK_HEADERS([stdint.h])
+@@ -305,7 +305,6 @@ AC_CHECK_HEADERS([stdint.h])
  AC_CHECK_HEADERS([fcntl.h unistd.h sys/stat.h])
  AC_CHECK_HEADERS([sys/mman.h])
  AC_CHECK_HEADERS([sys/time.h sys/timeb.h])
@@ -45,7 +55,7 @@ index 48cd2f0..0f09c61 100644
  AC_CHECK_HEADERS([dl.h dlfcn.h])
  AC_CHECK_HEADERS([glob.h])
  AM_CONDITIONAL(WITH_GLOB, test "$ac_cv_header_glob_h" = "yes")
-@@ -317,9 +316,7 @@ AH_VERBATIM([HAVE_MUNMAP_AFTER],[/* mmap() is no good without munmap() */
+@@ -318,9 +317,7 @@ AH_VERBATIM([HAVE_MUNMAP_AFTER],[/* mmap() is no good without munmap() */
  #  undef /**/ HAVE_MMAP
  #endif])
  
@@ -57,31 +67,32 @@ index 48cd2f0..0f09c61 100644
  dnl
  dnl Checks for inet libraries
 diff --git a/dict.c b/dict.c
-index 49e1c6b..46bb4d4 100644
+index a238cd9d..ce501cb5 100644
 --- a/dict.c
 +++ b/dict.c
-@@ -928,13 +928,11 @@ xmlDictQLookup(xmlDictPtr dict, const xmlChar *prefix, const xmlChar *name) {
-   #define WIN32_LEAN_AND_MEAN
+@@ -929,13 +929,11 @@ xmlDictQLookup(xmlDictPtr dict, const xmlChar *prefix, const xmlChar *name) {
    #include <windows.h>
    #include <bcrypt.h>
--#elif defined(HAVE_GETENTROPY)
-+#elif HAVE_GETENTROPY
-   #ifdef HAVE_UNISTD_H
-     #include <unistd.h>
-   #endif
--  #ifdef HAVE_SYS_RANDOM_H
--    #include <sys/random.h>
--  #endif
-+  #include <sys/random.h>
  #else
+-  #if defined(HAVE_GETENTROPY)
++  #if HAVE_GETENTROPY
+     #ifdef HAVE_UNISTD_H
+       #include <unistd.h>
+     #endif
+-    #ifdef HAVE_SYS_RANDOM_H
+-      #include <sys/random.h>
+-    #endif
++    #include <sys/random.h>
+   #endif
    #include <time.h>
  #endif
-@@ -965,7 +963,7 @@ xmlInitRandom(void) {
-                     "error code %lu\n", GetLastError());
-             abort();
-         }
--#elif defined(HAVE_GETENTROPY)
-+#elif HAVE_GETENTROPY
+@@ -969,7 +967,7 @@ xmlInitRandom(void) {
+ #else
+         int var;
+ 
+-#if defined(HAVE_GETENTROPY)
++#if HAVE_GETENTROPY
          while (1) {
              if (getentropy(globalRngState, sizeof(globalRngState)) == 0)
-                 break;
+                 return;
+

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -1,27 +1,13 @@
-vcpkg_download_distfile(FIX_COMPATIBILITY_PATCH
-    URLS https://github.com/GNOME/libxml2/commit/b347a008a745778630a9eb4fbd29694f3c135bfa.diff?full_index=1
-    FILENAME Fix-compatibility-in-package-version-file.patch
-    SHA512 7f5e5f53444c12924b0fefdf3013fa4dab76fb17f552dd827628739a6e65c9817ae7182e1817cea2317e2fc9b8a200ecce4f8cb5661a2614c0548a5b3e508b66
-)
-
-vcpkg_download_distfile(ADD_MISSING_BCRYPT_PATCH
-    URLS https://github.com/GNOME/libxml2/commit/fe1ee0f25f43e33a9981fd6fe7b0483a8c8b5e8d.diff?full_index=1
-    FILENAME Add-missing-Bcrypt-link.patch
-    SHA512 22bc2fe4c365a2c9991508484daa3d884ff91803df48b3847f71b2283e240ef3ce4fdc1d230932d837ff94dc02fc53e76e2e5a1c956ef037caacb13d8f9b3982
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/libxml2
     REF "v${VERSION}"
-    SHA512 dfe0529dd2fbb7dc9e79505b9c6ff7f29979fa4392d534c1b8859fa9934c2e7d4da3429265d718292056809a58080af32b130263625cdeb358123774c27da7c6
+    SHA512 6d32311feda4b415f50236dbc1b982094fafe46f86bb3f2ad21365183bd7e9011d00e12c0c23827daf851022a20c99f7cc646e5957a10946300bdc836f91f924
     HEAD_REF master
     PATCHES
         disable-docs.patch
         fix_cmakelist.patch
         fix_ios_compilation.patch
-        ${FIX_COMPATIBILITY_PATCH}
-        ${ADD_MISSING_BCRYPT_PATCH}
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxml2",
-  "version": "2.13.5",
-  "port-version": 2,
+  "version": "2.13.8",
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5605,8 +5605,8 @@
       "port-version": 1
     },
     "libxml2": {
-      "baseline": "2.13.5",
-      "port-version": 2
+      "baseline": "2.13.8",
+      "port-version": 0
     },
     "libxmlmm": {
       "baseline": "0.6.0",

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0ebad5d8133267fdd690fbc9b8c1e99f5e9f6c37",
+      "version": "2.13.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "90c8aae598f04d95b887f5bfd29e24ab1308bbfa",
       "version": "2.13.5",
       "port-version": 2


### PR DESCRIPTION
This is a work in progress PR. Please do not merge it into `master`.

The patches https://github.com/GNOME/libxml2/commit/b347a008a745778630a9eb4fbd29694f3c135bfa and https://github.com/GNOME/libxml2/commit/fe1ee0f25f43e33a9981fd6fe7b0483a8c8b5e8d are removed because they are already applied upstream in `2.13.6`.

There is a problem with the patch `fix_ios_compilation.patch` which was introduced to vcpkg by #42695. It conflicts with the upstream change https://github.com/GNOME/libxml2/commit/2617138d924e19211b530373162d93b8edc54eb8. Applying the patch mechanically makes little sense. The patch removes the line `check_include_files(sys/random.h HAVE_SYS_RANDOM_H)`, but nowadays this line is used only for non-Apple platforms.

I wonder if the patch is still required and if yes then what it should be. I have no access to iOS build environment and as I understand the vcpkg CI also doesn't check iOS-based triplets. Could someone test if this PR works for iOS? @nirvn

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
