### PR TITLE
[gsl-lite, telnetpp] Update to v1.0.1 and v4.0.0, respectively

### DIFF
--- a/ports/gsl-lite/portfile.cmake
+++ b/ports/gsl-lite/portfile.cmake
@@ -31,4 +31,4 @@ file(INSTALL
     RENAME copyright
 )
 
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/gsl-lite/portfile.cmake
+++ b/ports/gsl-lite/portfile.cmake
@@ -14,12 +14,6 @@ vcpkg_cmake_config_fixup(
     CONFIG_PATH "share/cmake/gsl-lite"
 )
 
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/gsl-lite.hpp "#ifndef GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
-#define GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
-#pragma message(\"The header <gsl-lite.hpp> is deprecated and provided by Vcpkg for compatibility only; please include <gsl-lite/gsl-lite.hpp> instead.\")
-#include <gsl-lite/gsl-lite.hpp>
-#endif // GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED")
-
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/lib"
     "${CURRENT_PACKAGES_DIR}/debug"
@@ -31,4 +25,7 @@ file(INSTALL
     RENAME copyright
 )
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL
+    "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)

--- a/ports/gsl-lite/portfile.cmake
+++ b/ports/gsl-lite/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gsl-lite/gsl-lite
     REF "v${VERSION}"
-    SHA512 8215dc36418964b6c66f4bc8cd6f1eb39446e1563aaae3b015cb4f39bf2e5b69d34ef822cc0b4794a2ceef6944928543770727afcdc8060a6f61b548066d7c2b
+    SHA512 b872be42f8d17a55db61fd3862c4b4a9e095e77aeee8001e81b35c3597d3ed1e08edff6bb4e509b9b51fa7cdb09d313f4a7db538a2c3f19971fb4b6840efa42a
     HEAD_REF master
 )
 
@@ -11,13 +11,13 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
-    CONFIG_PATH "lib/cmake/gsl-lite"
+    CONFIG_PATH "share/cmake/gsl-lite"
 )
 
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/gsl-lite.hpp "#ifndef GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
 #define GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
-#pragma message(\"The header <gsl-lite.hpp> is deprecated and provided by Vcpkg for compatibility only; please include <gsl/gsl-lite.hpp> instead.\")
-#include <gsl/gsl-lite.hpp>
+#pragma message(\"The header <gsl-lite.hpp> is deprecated and provided by Vcpkg for compatibility only; please include <gsl-lite/gsl-lite.hpp> instead.\")
+#include <gsl-lite/gsl-lite.hpp>
 #endif // GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED")
 
 file(REMOVE_RECURSE
@@ -30,3 +30,5 @@ file(INSTALL
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     RENAME copyright
 )
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)

--- a/ports/gsl-lite/usage
+++ b/ports/gsl-lite/usage
@@ -1,0 +1,4 @@
+gsl-lite provides CMake targets:
+
+  find_package(gsl-lite CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE gsl-lite::gsl-lite)

--- a/ports/gsl-lite/vcpkg.json
+++ b/ports/gsl-lite/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gsl-lite",
-  "version": "0.43.0",
-  "description": "A single-file header-only implementation of ISO C++ Guidelines Support Library (GSL) for C++98, C++11 and later.",
+  "version": "1.0.1",
+  "description": "ISO C++ Core Guidelines Library implementation for C++98, C++11 up",
   "homepage": "https://github.com/gsl-lite/gsl-lite/",
   "dependencies": [
     {

--- a/ports/gsl-lite/vcpkg.json
+++ b/ports/gsl-lite/vcpkg.json
@@ -3,6 +3,8 @@
   "version": "1.0.1",
   "description": "ISO C++ Core Guidelines Library implementation for C++98, C++11 up",
   "homepage": "https://github.com/gsl-lite/gsl-lite/",
+  "documentation": "https://gsl-lite.github.io/gsl-lite/",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/telnetpp/portfile.cmake
+++ b/ports/telnetpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KazDragon/telnetpp
-  REF "v${VERSION}"
-  SHA512 be0a4304846369f85fef68c9b468b720877a640f8fb32496cf56591da4bb515b9afa9ac4c4477b2275049c304bd17c84b8b82efd8af642c509df452fec9d0d8e
+  REF dec6d24c325a888f355c3e12b3a0f68ebe830a67
+  SHA512 dd2f9725042df285428018da0303f89779c66bd7ddda74de2de0e2af6dcbea3136bd5ef784501ec4ca6ccef3a4fa7df0e6bd982238e5bad45f2afbe1c82382e0
   HEAD_REF master
   PATCHES 
       fix-install-paths-v3.patch

--- a/ports/telnetpp/portfile.cmake
+++ b/ports/telnetpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KazDragon/telnetpp
-  REF dec6d24c325a888f355c3e12b3a0f68ebe830a67
-  SHA512 dd2f9725042df285428018da0303f89779c66bd7ddda74de2de0e2af6dcbea3136bd5ef784501ec4ca6ccef3a4fa7df0e6bd982238e5bad45f2afbe1c82382e0
+  REF "v${VERSION}"
+  SHA512 0ff458675a44462655ff3869ff1c3390eec9d594a57a9ed95fb18f9b627b740b4f4be5e1fee3a5b9558553a05aae33134f8f8d26a85b8e4d2e01a927a8337c32
   HEAD_REF master
   PATCHES 
       fix-install-paths-v3.patch

--- a/ports/telnetpp/vcpkg.json
+++ b/ports/telnetpp/vcpkg.json
@@ -4,6 +4,8 @@
   "port-version": 1,
   "description": "Telnet++ is an implementation of the Telnet Session Layer protocol using C++17",
   "homepage": "https://github.com/KazDragon/telnetpp",
+  "documentation": "https://kazdragon.github.io/telnetpp/",
+  "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
     "boost-algorithm",

--- a/ports/telnetpp/vcpkg.json
+++ b/ports/telnetpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "telnetpp",
   "version": "3.1.0",
+  "port-version": 1,
   "description": "Telnet++ is an implementation of the Telnet Session Layer protocol using C++17",
   "homepage": "https://github.com/KazDragon/telnetpp",
   "supports": "!uwp",

--- a/ports/telnetpp/vcpkg.json
+++ b/ports/telnetpp/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "name": "telnetpp",
-  "version": "3.1.0",
-  "port-version": 1,
-  "description": "Telnet++ is an implementation of the Telnet Session Layer protocol using C++17",
+  "version": "4.0.0",
+  "description": "A C++ library for interacting with Telnet streams",
   "homepage": "https://github.com/KazDragon/telnetpp",
   "documentation": "https://kazdragon.github.io/telnetpp/",
   "license": "MIT",
@@ -12,9 +11,9 @@
     "boost-container",
     "boost-exception",
     "boost-range",
+    "boost-scope-exit",
     "boost-signals2",
     "boost-variant",
-    "gsl-lite",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9234,7 +9234,7 @@
     },
     "telnetpp": {
       "baseline": "3.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tensorflow": {
       "baseline": "2.10.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9233,8 +9233,8 @@
       "port-version": 0
     },
     "telnetpp": {
-      "baseline": "3.1.0",
-      "port-version": 1
+      "baseline": "4.0.0",
+      "port-version": 0
     },
     "tensorflow": {
       "baseline": "2.10.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3377,7 +3377,7 @@
       "port-version": 1
     },
     "gsl-lite": {
-      "baseline": "0.43.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "gsoap": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9233,7 +9233,7 @@
       "port-version": 0
     },
     "telnetpp": {
-      "baseline": "4.0.0",
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "tensorflow": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9233,7 +9233,7 @@
       "port-version": 0
     },
     "telnetpp": {
-      "baseline": "3.1.0",
+      "baseline": "4.0.0",
       "port-version": 0
     },
     "tensorflow": {

--- a/versions/g-/gsl-lite.json
+++ b/versions/g-/gsl-lite.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e94ff642bb891b884c5703569ea4e30e0552e0d5",
+      "git-tree": "922b7507a2d375f67b8b62ee85199f4119ce5379",
       "version": "1.0.1",
       "port-version": 0
     },

--- a/versions/g-/gsl-lite.json
+++ b/versions/g-/gsl-lite.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "922b7507a2d375f67b8b62ee85199f4119ce5379",
+      "git-tree": "5ebd578544d2e91830408a72068304405a6c5ba8",
       "version": "1.0.1",
       "port-version": 0
     },

--- a/versions/g-/gsl-lite.json
+++ b/versions/g-/gsl-lite.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5ebd578544d2e91830408a72068304405a6c5ba8",
+      "git-tree": "90b6dc17af37c51707fc6b811c6fe4bbd5b0d3f6",
       "version": "1.0.1",
       "port-version": 0
     },

--- a/versions/g-/gsl-lite.json
+++ b/versions/g-/gsl-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e94ff642bb891b884c5703569ea4e30e0552e0d5",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "1dec7fa87c2ead1a01cbf4ef58db83b0b645023e",
       "version": "0.43.0",
       "port-version": 0

--- a/versions/t-/telnetpp.json
+++ b/versions/t-/telnetpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "037d34be211605fcad95f52ae99cf45cd7f8cc46",
+      "version": "4.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "55b6d710fbf9e885674e8cef12749f7c24a66127",
       "version": "3.1.0",
       "port-version": 0

--- a/versions/t-/telnetpp.json
+++ b/versions/t-/telnetpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f2b41b8b502449fec14fd554cd7a41c82ecaacc",
+      "version": "3.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "55b6d710fbf9e885674e8cef12749f7c24a66127",
       "version": "3.1.0",
       "port-version": 0

--- a/versions/t-/telnetpp.json
+++ b/versions/t-/telnetpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f2b41b8b502449fec14fd554cd7a41c82ecaacc",
+      "git-tree": "cb4d68be7c984e3aa0c702ebec6b2fd07ec90557",
       "version": "3.1.0",
       "port-version": 1
     },

--- a/versions/t-/telnetpp.json
+++ b/versions/t-/telnetpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e050ac1225075c319464e07a081bc720f3f9b6c2",
+      "version": "4.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "55b6d710fbf9e885674e8cef12749f7c24a66127",
       "version": "3.1.0",
       "port-version": 0

--- a/versions/t-/telnetpp.json
+++ b/versions/t-/telnetpp.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "e050ac1225075c319464e07a081bc720f3f9b6c2",
-      "version": "4.0.0",
-      "port-version": 0
-    },
-    {
       "git-tree": "55b6d710fbf9e885674e8cef12749f7c24a66127",
       "version": "3.1.0",
       "port-version": 0

--- a/versions/t-/telnetpp.json
+++ b/versions/t-/telnetpp.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "cb4d68be7c984e3aa0c702ebec6b2fd07ec90557",
-      "version": "3.1.0",
-      "port-version": 1
-    },
-    {
       "git-tree": "55b6d710fbf9e885674e8cef12749f7c24a66127",
       "version": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

*gsl-lite* v1.0.1 [slightly improves backward compatibility](https://github.com/gsl-lite/gsl-lite/releases/tag/v1.0.1), making migration from v0.* a bit smoother.

As a major-version release, *gsl-lite* v1.0 [introduces some breaking changes](https://github.com/gsl-lite/gsl-lite/releases/tag/v1.0.0). This currently breaks [Telnet++](https://github.com/KazDragon/telnetpp), which in turn will break the Vcpkg integration tests.

I have submitted a [PR](https://github.com/KazDragon/telnetpp/pull/264) in the Telnet++ repository that upgrades the library to *gsl-lite* v1.0, making the required changes. However, because Telnet++'s Windows CI uses Vcpkg to obtain build dependencies, my PR currently fails the test suite because the latest *gsl-lite* version in Vcpkg currently is v0.43.0.

I'm not sure how to proceed here. What is the policy for releases with breaking changes? Can this PR be merged even if it (temporarily, hopefully) breaks another package? Do I need to provide a patch for the telnetpp package to make it work with the latest version of *gsl-lite*?