### PR TITLE
[ctre] update to 3.10.0

### DIFF
--- a/ports/ctre/portfile.cmake
+++ b/ports/ctre/portfile.cmake
@@ -2,9 +2,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hanickadot/compile-time-regular-expressions
     REF "v${VERSION}"
-    SHA512 252f4e8c516be8b240e4907de2751e17c97cb0154e6b0104f743e3ac70d58bcced24068fdca8eb3b56e16f52cfcbe8d549140033c1f7cd36269b60a80e017046
+    SHA512 4bed66b8adbf1de4f73963370e8b210787ace2f50d956cac141f1353c6a4e0ed0dcd62eb61cf54ae3e64875752ffdc04b67985a25aa50a2a245bc9039ab39f46
     HEAD_REF main
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -13,8 +15,9 @@ vcpkg_cmake_configure(
         -DCTRE_BUILD_PACKAGE=OFF
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH "share/cmake/ctre")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/ctre")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ctre/vcpkg.json
+++ b/ports/ctre/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ctre",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "A Compile time PCRE (almost) compatible regular expression matcher",
   "homepage": "https://github.com/hanickadot/compile-time-regular-expressions",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2153,7 +2153,7 @@
       "port-version": 2
     },
     "ctre": {
-      "baseline": "3.9.0",
+      "baseline": "3.10.0",
       "port-version": 0
     },
     "ctstraffic": {

--- a/versions/c-/ctre.json
+++ b/versions/c-/ctre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "33e1d6f404d8374a60c29037b3b5b2516a73ca88",
+      "version": "3.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "46132b3dc836ad3d4bd3be6a83ecef318800e844",
       "version": "3.9.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/hanickadot/compile-time-regular-expressions/releases/tag/v3.10.0