### PR TITLE
[roaring] update to 4.3.2

### DIFF
--- a/ports/roaring/portfile.cmake
+++ b/ports/roaring/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RoaringBitmap/CRoaring
     REF "v${VERSION}"
-    SHA512 a4bf2a185b71be4854f4a7aba0cebbc511ad0c028c072b74b85c8f29aca2b5843fe75a70644b9e1480bd1537a8575ccae5d7487ec745b3a6ca6a7f0198c5c463
+    SHA512 8323fa32472f4c8ae697f83ada849caccecfcf0da6e9254507c5b4d28d0de43d3e31406c7fa3969beebb33276faec14ed180c714ba24a482cdcd03e99b22115e
     HEAD_REF master
 )
 

--- a/ports/roaring/vcpkg.json
+++ b/ports/roaring/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "roaring",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "A better compressed bitset in C (and C++)",
   "homepage": "https://github.com/RoaringBitmap/CRoaring",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8269,7 +8269,7 @@
       "port-version": 2
     },
     "roaring": {
-      "baseline": "4.3.1",
+      "baseline": "4.3.2",
       "port-version": 0
     },
     "robin-hood-hashing": {

--- a/versions/r-/roaring.json
+++ b/versions/r-/roaring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63ff08656106812679f0618de266b94bf115e353",
+      "version": "4.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "17a0eaa680d2956b2785f8857230b408cd25554a",
       "version": "4.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/RoaringBitmap/CRoaring/releases/tag/v4.3.2

There are very small fixes.
