### PR TITLE
[ijg-libjpeg] update to 9f

### DIFF
--- a/ports/ijg-libjpeg/CMakeLists.txt
+++ b/ports/ijg-libjpeg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16)
 project(libjpeg LANGUAGES C)
 
 option(BUILD_EXECUTABLES OFF)

--- a/ports/ijg-libjpeg/portfile.cmake
+++ b/ports/ijg-libjpeg/portfile.cmake
@@ -10,9 +10,9 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 vcpkg_download_distfile(ARCHIVE
-    URLS        "http://www.ijg.org/files/jpegsr9e.zip"
-    FILENAME    "jpegsr9e.zip"
-    SHA512      db7a2fb44e5cc20d61956c46334948af034c07cdcc0d6e41d9bd4f6611c0fbed8943d0a05029ba1bfb9d993f4acd0df5e95d0bc1cfb5a889b86a55b6b75fdf64
+    URLS        "http://www.ijg.org/files/jpegsr${VERSION}.zip"
+    FILENAME    "jpegsr${VERSION}.zip"
+    SHA512      f43e7cab21fb60d41c7a6842f5859ebeac34267f985870d999cc2e7e9e90ee552d667f054c0f162ef5e5ebaab87e285631432a7ca8441ba9837c4caa4fdf51ac
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/ijg-libjpeg/vcpkg.json
+++ b/ports/ijg-libjpeg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ijg-libjpeg",
-  "version-string": "9e",
-  "port-version": 2,
+  "version-string": "9f",
   "description": "Independent JPEG Group's JPEG software",
   "homepage": "http://www.ijg.org/",
   "license": null,

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -158,7 +158,6 @@ ignition-msgs1:x64-uwp=fail
 ignition-msgs5:arm-uwp=fail
 ignition-msgs5:arm64-windows=fail
 ignition-msgs5:x64-uwp=fail
-ijg-libjpeg:x64-windows-static-md=fail
 intel-mkl:arm-uwp=fail
 intel-mkl:arm64-osx=fail
 intel-mkl:arm64-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3765,8 +3765,8 @@
       "port-version": 1
     },
     "ijg-libjpeg": {
-      "baseline": "9e",
-      "port-version": 2
+      "baseline": "9f",
+      "port-version": 0
     },
     "im3d": {
       "baseline": "2022-10-11",

--- a/versions/i-/ijg-libjpeg.json
+++ b/versions/i-/ijg-libjpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7f8d1987d79b0d6cb043fbe2b57482e63387f01",
+      "version-string": "9f",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a22e20a63c3679dab4839e7a87566b411cf023c",
       "version-string": "9e",
       "port-version": 2


### PR DESCRIPTION
This release mostly changes build scripts, changes in `*.h` and `*.c` seem minor and are mostly cleanups. `vcpkg` uses its own `CMakeLists.txt`, so little is changed for `vcpkg`.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
