### PR TITLE
[libdwarf] update to 2.0.0

### DIFF
--- a/ports/libdwarf/portfile.cmake
+++ b/ports/libdwarf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO davea42/libdwarf-code
     REF "v${VERSION}"
-    SHA512 f6e72c7dc1430d9f5bbd324632a9825cafcab9c9aad1302ac1b413cae674b6180ece957672b16e52bd2976fd3e7203e732db7d8a395aa0606dce159188988c2e
+    SHA512 2fb4a0e713f7e4f577bc360114e371ea3dfe77a0f14a757b9c4180391900e8ceb4d6c20afee759095adae4223eb16413a40f60a2c3fe17cb21ffc41bbc2e975b
     HEAD_REF main
     PATCHES
         include-dir.diff # avoid dwarf.h conflict with elfutils

--- a/ports/libdwarf/vcpkg.json
+++ b/ports/libdwarf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdwarf",
-  "version": "0.12.0",
+  "version": "2.0.0",
   "description": "A library for reading DWARF2 and later DWARF.",
   "homepage": "https://github.com/davea42/libdwarf-code",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4617,7 +4617,7 @@
       "port-version": 0
     },
     "libdwarf": {
-      "baseline": "0.12.0",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "libe57": {

--- a/versions/l-/libdwarf.json
+++ b/versions/l-/libdwarf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e482663130cf25a5a3b2cf2a055356b3e91854b2",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5b27b214c4cf4666cc12d6d1bb3387c6179ab250",
       "version": "0.12.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/davea42/libdwarf-code/releases/tag/v2.0.0