### PR TITLE
[fpzip] add new port

### DIFF
--- a/ports/fpzip/portfile.cmake
+++ b/ports/fpzip/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO LLNL/fpzip
+    REF "${VERSION}"
+    SHA512 1f37687cbd668a9ab14dad4511f94ede6bd527add5616430a5322ed9620b092bec5d8c286248e8244e8df5053d327bc9ad6cac6820f54d946e43b6d0f8e7174f
+    HEAD_REF develop
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        pic    FPZIP_ENABLE_PIC
+	cmdutils BUILD_UTILITIES
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fpzip/vcpkg.json
+++ b/ports/fpzip/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "fpzip",
+  "version": "1.3.0",
+  "description": "Lossless compressor of multidimensional floating-point arrays",
+  "homepage": "http://fpzip.llnl.gov/",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cmdutils": {
+      "description": "Build command-line tools"
+    },
+    "pic": {
+      "description": "Position Independent Code support. Always enabled when building shared libs."
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2956,6 +2956,10 @@
       "baseline": "2021-02-21",
       "port-version": 2
     },
+    "fpzip": {
+      "baseline": "1.3.0",
+      "port-version": 0
+    },
     "freealut": {
       "baseline": "1.1.0",
       "port-version": 4

--- a/versions/f-/fpzip.json
+++ b/versions/f-/fpzip.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6d69b0be7b2f52ff81f8b945c3a75b9622c99945",
+      "version": "1.3.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #45583 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. (no usage text)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
