### PR TITLE
[ocilib] update to 4.8.0

### DIFF
--- a/ports/ocilib/portfile.cmake
+++ b/ports/ocilib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vrogier/ocilib
     REF "v${VERSION}"
-    SHA512 8a2c716ceba5c941d2f55ca99ba2b563bc754f2e7a8b6632421a62b3b2a298afb9a05ae13a1997995cea811c36f737ae1e0e5c676d72f573dbebc7f5073c8206
+    SHA512 1205f333fa7fa6c813dfbb93fefcec5203110ee0dc1c5d52b4f67df9e8fd5894b94e1f0f87cff79f6ad1d33dffbc9faa6535b7bf81ab36bb742cb4fd2dc5d966
     HEAD_REF master
     PATCHES fix-DisableWC4191.patch
 )

--- a/ports/ocilib/vcpkg.json
+++ b/ports/ocilib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ocilib",
-  "version": "4.7.7",
+  "version": "4.8.0",
   "description": "OCILIB is an open source and cross platform Oracle Driver that delivers efficient access to Oracle databases.",
   "homepage": "https://vrogier.github.io/ocilib/",
   "license": "Apache-2.0",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -348,7 +348,6 @@ numactl:x86-windows=fail
 ocilib:arm-uwp=fail
 ocilib:arm64-windows=fail
 ocilib:x64-uwp=fail
-ocilib:x64-windows-static-md=fail
 octave(android)=skip
 octomap:arm-uwp=fail
 octomap:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6757,7 +6757,7 @@
       "port-version": 3
     },
     "ocilib": {
-      "baseline": "4.7.7",
+      "baseline": "4.8.0",
       "port-version": 0
     },
     "octave": {

--- a/versions/o-/ocilib.json
+++ b/versions/o-/ocilib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3413a12ca6828dfd67aaa62d603f433953fd9c1",
+      "version": "4.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2a231543a140111ad3ac6261b1f9563ef0d158a6",
       "version": "4.7.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/vrogier/ocilib/releases/tag/v4.8.0
