### PR TITLE
[liburing] Remove unnecessary license ()s around WITH.

### DIFF
--- a/ports/liburing/portfile.cmake
+++ b/ports/liburing/portfile.cmake
@@ -27,6 +27,10 @@ vcpkg_from_github(
 # https://github.com/axboe/liburing/blob/liburing-2.8/src/Makefile#L13
 set(ENV{CFLAGS} "$ENV{CFLAGS} -O3 -Wall -Wextra -fno-stack-protector")
 
+# without this calls to `realpath ${prefix}` inside the build system fail for the debug build if this is the first
+# library to be installed
+file(MAKE_DIRECTORY "${CURRENT_INSTALLED_DIR}/debug")
+
 # note: check ${SOURCE_PATH}/liburing.spec before updating configure options
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/liburing/vcpkg.json
+++ b/ports/liburing/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "liburing",
   "version": "2.9",
+  "port-version": 1,
   "description": "Linux-native io_uring I/O access library",
   "homepage": "https://github.com/axboe/liburing",
-  "license": "(MIT OR LGPL-2.1) AND (MIT OR (GPL-2.0 WITH Linux-syscall-note))",
+  "license": "(MIT OR LGPL-2.1) AND (MIT OR GPL-2.0 WITH Linux-syscall-note)",
   "supports": "linux"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5458,7 +5458,7 @@
     },
     "liburing": {
       "baseline": "2.9",
-      "port-version": 0
+      "port-version": 1
     },
     "libusb": {
       "baseline": "1.0.28",

--- a/versions/l-/liburing.json
+++ b/versions/l-/liburing.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4675d3fe3c7ddc63373181e2880a73656103ea40",
+      "git-tree": "795a24ada6a8adc1b5fff6efd2e6eb4a1db24b6e",
       "version": "2.9",
       "port-version": 1
     },

--- a/versions/l-/liburing.json
+++ b/versions/l-/liburing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4675d3fe3c7ddc63373181e2880a73656103ea40",
+      "version": "2.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "407de8efd734478970668239ff668e47ecf69735",
       "version": "2.9",
       "port-version": 0


### PR DESCRIPTION
The extra ()s around the 'WITH' are unnecessary and will be removed by a future version of `vcpkg format-manifest`.
