### PR TITLE
[zookeeper] update to 3.9.3

### DIFF
--- a/ports/zookeeper/portfile.cmake
+++ b/ports/zookeeper/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://archive.apache.org/dist/zookeeper/zookeeper-3.5.6/apache-zookeeper-3.5.6.tar.gz"
-    FILENAME "zookeeper-3.5.6.tar.gz"
-    SHA512 7f45817cbbc42aec5a7817fa2ae99656128e666dc58ace23d86bcfc5ca0dc49e418d1a7d1f082ad80ccb916f9f1b490167d16f836886af1a56fbcf720ad3b9d0
+    URLS "https://archive.apache.org/dist/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3.tar.gz"
+    FILENAME "zookeeper-3.9.3.tar.gz"
+    SHA512 77a8ffdc9e48f6e293ee5fde0dee73ffcdd1a4f1e554b4282ce403ffb09ff145b40987c272dec751993a83a5430972e0a535d18fa9818d6c84a69bfda8a03d216
 )
 
 vcpkg_extract_source_archive(

--- a/ports/zookeeper/portfile.cmake
+++ b/ports/zookeeper/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3.tar.gz"
     FILENAME "zookeeper-3.9.3.tar.gz"
-    SHA512 77a8ffdc9e48f6e293ee5fde0dee73ffcdd1a4f1e554b4282ce403ffb09ff145b40987c272dec751993a83a5430972e0a535d18fa9818d6c84a69bfda8a03d216
+    SHA512 7a8ffdc9e48f6e293ee5fde0dee73ffcdd1a4f1e554b4282ce403ffb09ff145b40987c272dec751993a83a5430972e0a535d18fa9818d6c84a69bfda8a03d216
 )
 
 vcpkg_extract_source_archive(

--- a/ports/zookeeper/vcpkg.json
+++ b/ports/zookeeper/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "zookeeper",
   "version": "3.9.3",
-  "port-version": 1,
   "description": "ZooKeeper C bindings",
   "homepage": "https://github.com/apache/zookeeper",
   "license": "BSD-3-Clause",

--- a/ports/zookeeper/vcpkg.json
+++ b/ports/zookeeper/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zookeeper",
-  "version": "3.5.6",
+  "version": "3.9.3",
   "port-version": 1,
   "description": "ZooKeeper C bindings",
   "homepage": "https://github.com/apache/zookeeper",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10409,7 +10409,7 @@
       "port-version": 0
     },
     "zookeeper": {
-      "baseline": "3.5.6",
+      "baseline": "3.9.3",
       "port-version": 1
     },
     "zopfli": {

--- a/versions/z-/zookeeper.json
+++ b/versions/z-/zookeeper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26dd7ff0304925de3becf0100253c4f73da49c84",
+      "version": "3.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "cddd556547f1e8fef18c115b551f0ba9b5428def",
       "version": "3.5.6",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [x ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ x] SHA512s are updated for each updated download.
- [ x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ x] Any patches that are no longer applied are deleted from the port's directory.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
