### PR TITLE
[libunwind] update to 1.8.2

### DIFF
--- a/ports/libunwind/portfile.cmake
+++ b/ports/libunwind/portfile.cmake
@@ -1,22 +1,11 @@
-vcpkg_download_distfile(libunwind
-    URLS "https://github.com/dotnet/runtime/commit/d63c235756d4c46b061bd503a2c47207df6b3324.diff?full_index=1"
-    FILENAME "libunwind.diff"
-    SHA512 268af5d4aa3bec16e34c50024c0a3662e9a6fa7d273bb405c25f02066100e6bcbb9a68bd10556e3f420d983b586dac856fc45dbd182798889e5542217f953b27
-)
-
-file(READ "${libunwind}" contents)
-string(REPLACE "/src/native/external/libunwind" "" contents "${contents}")
-file(WRITE "${CURRENT_BUILDTREES_DIR}/src/libunwind.diff" "${contents}")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "libunwind/libunwind"
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 dd8332b7a2cbabb4716c01feea422f83b4a7020c1bee20551de139c3285ea0e0ceadfa4171c6f5187448c8ddc53e0ec4728697d0a985ee0c3ff4835b94f6af6f
+    SHA512 50bb802a821939d38e38ce9f906934eea6a4e815f9401c18d5de6205ae0b5c7594e94d37bbf8f9da4012c0adebac208077548771d21bb89a4dedeb27645ceb25
     PATCHES
         liblzma.diff
-        "${CURRENT_BUILDTREES_DIR}/src/libunwind.diff"
 )
 
 vcpkg_find_acquire_program(PKGCONFIG)

--- a/ports/libunwind/vcpkg.json
+++ b/ports/libunwind/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libunwind",
-  "version": "1.8.1",
-  "port-version": 3,
+  "version": "1.8.2",
   "description": "Unix libray for portable stack unwinding",
   "homepage": "https://www.nongnu.org/libunwind",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5449,8 +5449,8 @@
       "port-version": 0
     },
     "libunwind": {
-      "baseline": "1.8.1",
-      "port-version": 3
+      "baseline": "1.8.2",
+      "port-version": 0
     },
     "liburcu": {
       "baseline": "0.15.2",

--- a/versions/l-/libunwind.json
+++ b/versions/l-/libunwind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff02fab09a333c0389d4335a69f8ff48e8f53a92",
+      "version": "1.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "535c5df0f63ffbfd8bb48e564758d20e2bad192c",
       "version": "1.8.1",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/libunwind/libunwind/releases/tag/v1.8.2

dotnet patch seems to be merged at https://github.com/libunwind/libunwind/commit/e97c9ef82f8b48d0c7f713be4fa7b15e634d76b8
