### PR TITLE
[vcpkg baseline] Remove non-existing port libpng-apng from ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -531,17 +531,6 @@ libopensp:arm-neon-android=fail
 libopensp:arm64-android=fail
 libopensp:x64-android=fail
 libp7client:x64-android=fail
-libpng-apng:arm64-uwp=skip
-libpng-apng:arm64-windows-static-md=skip
-libpng-apng:arm64-windows=skip
-libpng-apng:x64-linux=skip
-libpng-apng:x64-osx=skip
-libpng-apng:x64-uwp=skip
-libpng-apng:x64-windows-release=skip
-libpng-apng:x64-windows-static-md=skip
-libpng-apng:x64-windows-static=skip
-libpng-apng:x64-windows=skip
-libpng-apng:x86-windows=skip
 # The developer of libqcow does not offer stable release archives
 libqcow:arm-neon-android=skip
 libqcow:arm64-android=skip


### PR DESCRIPTION
The port `libpng-apng` doesn't exist at the moment. `apng` is a feature of `libpng`: `libpng[apng]`.
