### PR TITLE
[glib] update to 2.84.2

### DIFF
--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH "^([0-9]*[.][0-9]*)" GLIB_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(GLIB_ARCHIVE
     URLS "https://download.gnome.org/sources/glib/${GLIB_MAJOR_MINOR}/glib-${VERSION}.tar.xz"
     FILENAME "glib-${VERSION}.tar.xz"
-    SHA512 ee7f38a4726fd72e41ddb75c4933c7b1bb30935bb2fddc84902d0627a836af512534195132cc02e3d15f168fefc816576181a8d6e436472b582191437b79a456
+    SHA512 430928d7d7a442fc3927ca943f2569035fe8768768a0ebc6720ae1ef152b56fc5f8d4215d21b4828cc2f39a8632c907ed2c52a0c8566da1c533a2e049a1a121f
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glib",
-  "version": "2.84.1",
+  "version": "2.84.2",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -2133,6 +2133,7 @@ gegl(osx) = fail # meson bug on osx. See https://github.com/microsoft/vcpkg/issu
 geogram[graphics] = feature-fails # imgui not found. See https://github.com/microsoft/vcpkg/issues/32421
 ginkgo[openmp](osx) = feature-fails # No openmp on osx
 ginkgo[openmp](windows) = feature-fails # needs openmp 3.0 support but msvc only supports openmp 2.0
+glib[selinux]:x64-linux = feature-fails # CI machines don't have libselinux1-dev installed
 glib-networking[openssl, gnutls] = options # You have to select exactly one ssl backend
 google-cloud-cpp[storagetransfer](osx) = feature-fails # See https://github.com/microsoft/vcpkg/issues/32149
 graphviz(osx) = fail # CMake configure error. See https://github.com/microsoft/vcpkg/issues/44414

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3237,7 +3237,7 @@
       "port-version": 2
     },
     "glib": {
-      "baseline": "2.84.1",
+      "baseline": "2.84.2",
       "port-version": 0
     },
     "glib-networking": {

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53f4b36567d0b56a6a2828033b789121911a80c2",
+      "version": "2.84.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "8003b971cde2579c2eaf89b1e879f259176bbe25",
       "version": "2.84.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
