### PR TITLE
[intx] add new port

### DIFF
--- a/ports/intx/portfile.cmake
+++ b/ports/intx/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO chfast/intx
+    REF "v${VERSION}"
+    SHA512 e1126f79cda6455aae4c04bed8deb91be4f47a6ab545a50b840f9f4df5e2d0c36be4e35e5576767b971903522ea8e37490db78efe08a85dbaadf2a396196fba6
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+    -DINTX_INSTALL=ON
+    -DINTX_TESTING=OFF
+    -DINTX_BENCHMARKING=OFF
+    -DINtX_FUZZING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME intx CONFIG_PATH lib/cmake/intx)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/intx/vcpkg.json
+++ b/ports/intx/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "intx",
+  "version": "0.13.0",
+  "description": "Extended precision integer C++ library ",
+  "homepage": "https://github.com/chfast/intx",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3860,6 +3860,10 @@
       "baseline": "1.9",
       "port-version": 0
     },
+    "intx": {
+      "baseline": "0.13.0",
+      "port-version": 0
+    },
     "io2d": {
       "baseline": "2020-09-14",
       "port-version": 5

--- a/versions/i-/intx.json
+++ b/versions/i-/intx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a106d9ba0c1aab6ce89de83f96bc36493d6a5275",
+      "version": "0.13.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/chfast/intx/releases/tag/v0.13.0
