### PR TITLE
[deniskovalchuk-libftp] update to 1.5.0

### DIFF
--- a/ports/deniskovalchuk-libftp/portfile.cmake
+++ b/ports/deniskovalchuk-libftp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO deniskovalchuk/libftp
         REF "v${VERSION}"
-        SHA512 c0fe6f174d0bcb200f7b3a933671f5b6ab63599ba9c7a4cadd2219866d246c0ab11bb9c9bfdfe6bf9adfebb9132c2378c7912cb7cb80489e29c05c9710e839c3
+        SHA512 34e3abdbe5fbc9e422f58e50f5a6f276ffbd3abf8d2c419c294e4e7ea36fb42dbdf15dff3c3a3d9e1c7ca7164e7f6fdc77f12f722c6002294a77e46fa61e3122
         HEAD_REF master
 )
 

--- a/ports/deniskovalchuk-libftp/vcpkg.json
+++ b/ports/deniskovalchuk-libftp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "deniskovalchuk-libftp",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "maintainers": "Denis Kovalchuk <denis.kovalchuk.main@gmail.com>",
   "description": "A cross-platform FTP/FTPS client library based on Boost.Asio.",
   "homepage": "https://github.com/deniskovalchuk/libftp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2321,7 +2321,7 @@
       "port-version": 0
     },
     "deniskovalchuk-libftp": {
-      "baseline": "1.4.1",
+      "baseline": "1.5.0",
       "port-version": 0
     },
     "detours": {

--- a/versions/d-/deniskovalchuk-libftp.json
+++ b/versions/d-/deniskovalchuk-libftp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e64ccf32dc088e13d253b443cb7fbb3272a3982b",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2dc10866ab80c071876660752ac03872f0488f00",
       "version": "1.4.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/deniskovalchuk/libftp/releases/tag/v1.5.0
