### PR TITLE
[libvpl] Add new port

### DIFF
--- a/ports/libvpl/portfile.cmake
+++ b/ports/libvpl/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO intel/libvpl
+    REF "c45b5d786bf7cdabbe49ff1bab78693ad78feb78"
+    SHA512 36f8817ae37013058753ae56383d9301c8214472e0b83d903e68b3aefa7d258510f5ed9f72f2ec15da74467797d3ccefc4cfa52f9eaff502a967b6ef7bc67536
+    HEAD_REF cmake-libvpl
+    PATCHES
+        vpl_config_cmake.patch
+)
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+    -DBUILD_EXPERIMENTAL=ON
+    -DINSTALL_EXAMPLES=OFF
+    -DBUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH  "lib/cmake/vpl"
+PACKAGE_NAME VPL)
+
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+#file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake")
+#file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/libvpl/usage
+++ b/ports/libvpl/usage
@@ -1,0 +1,5 @@
+if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+ set(CMAKE_LIBRARY_ARCHITECTURE x86)
+endif()
+find_package(VPL REQUIRED)
+target_link_libraries(${TARGET} VPL::dispatcher)

--- a/ports/libvpl/vcpkg.json
+++ b/ports/libvpl/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Intel VPL Dispatcher",
   "homepage": "https://github.com/intel/libvpl",
   "license": "MIT",
-  "supports": "windows",
+  "supports": "windows & (x64 | x86)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libvpl/vcpkg.json
+++ b/ports/libvpl/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Intel VPL Dispatcher",
   "homepage": "https://github.com/intel/libvpl",
   "license": "MIT",
-  "supports": "windows & (x64 | x86)",
+  "supports": "windows & !uwp & (x64 | x86)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libvpl/vcpkg.json
+++ b/ports/libvpl/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libvpl",
+  "version": "2.15.0",
+  "description": "Intel VPL Dispatcher",
+  "homepage": "https://github.com/intel/libvpl",
+  "license": "MIT",
+  "supports": "windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/libvpl/vpl_config_cmake.patch
+++ b/ports/libvpl/vpl_config_cmake.patch
@@ -1,0 +1,22 @@
+diff --git a/libvpl/cmake/VPLConfig.cmake.in b/libvpl/cmake/VPLConfig.cmake.in
+index 7a60974..e1d316c 100644
+--- a/libvpl/cmake/VPLConfig.cmake.in
++++ b/libvpl/cmake/VPLConfig.cmake.in
+@@ -18,13 +18,13 @@ get_filename_component(_vpl_config_file
+                        "${CMAKE_CURRENT_LIST_DIR}/VPLConfig.cmake" REALPATH)
+ get_filename_component(_vpl_config_dir "${_vpl_config_file}" DIRECTORY)
+ get_filename_component(_vpl_install_prefix
+-                       "${_vpl_config_dir}/@cmake_rel_prefix@" REALPATH)
++                       "${_vpl_config_dir}/../../../" REALPATH)
+ 
+-get_filename_component(VPL_LIB_DIR "${_vpl_config_dir}/@cmake_rel_libdir@"
++get_filename_component(VPL_LIB_DIR "${_vpl_config_dir}/../../lib"
+                        ABSOLUTE)
+-get_filename_component(VPL_INCLUDE_DIR "${_vpl_config_dir}/@cmake_rel_incdir@"
++get_filename_component(VPL_INCLUDE_DIR "${_vpl_config_dir}/../../include"
+                        ABSOLUTE)
+-get_filename_component(VPL_BIN_DIR "${_vpl_config_dir}/@cmake_rel_bindir@"
++get_filename_component(VPL_BIN_DIR "${_vpl_config_dir}/../../bin"
+                        ABSOLUTE)
+ 
+ if(CMAKE_SYSTEM_NAME MATCHES Windows)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5508,6 +5508,10 @@
       "baseline": "1.3.7",
       "port-version": 4
     },
+    "libvpl": {
+      "baseline": "2.15.0",
+      "port-version": 0
+    },
     "libvpx": {
       "baseline": "1.13.1",
       "port-version": 5

--- a/versions/l-/libvpl.json
+++ b/versions/l-/libvpl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3d3eccdd6d6e3a7db283f008fd7da165cd5fdeb3",
+      "git-tree": "33baa68253869749b0f63f7c2e112db9acdd81e9",
       "version": "2.15.0",
       "port-version": 0
     }

--- a/versions/l-/libvpl.json
+++ b/versions/l-/libvpl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "22013f5cf69ba122dc86c11236d595c53dd7cc24",
+      "git-tree": "3d3eccdd6d6e3a7db283f008fd7da165cd5fdeb3",
       "version": "2.15.0",
       "port-version": 0
     }

--- a/versions/l-/libvpl.json
+++ b/versions/l-/libvpl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "10e0bca6d1cdecd481639b861078485443833124",
+      "git-tree": "22013f5cf69ba122dc86c11236d595c53dd7cc24",
       "version": "2.15.0",
       "port-version": 0
     }

--- a/versions/l-/libvpl.json
+++ b/versions/l-/libvpl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "10e0bca6d1cdecd481639b861078485443833124",
+      "version": "2.15.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
