### PR TITLE
[tesseract] update to 5.5.1

### DIFF
--- a/ports/tesseract/portfile.cmake
+++ b/ports/tesseract/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tesseract-ocr/tesseract
     REF "${VERSION}"
-    SHA512 206e7da2d28a6271217ff384b482aa45a50beee0c53327aa4fd3da7082dce83386c8b7600194cbc30282134013b6182a1bed9d128ed6378f2957d0b8d1770b2d
+    SHA512 37c9cc2ac1bcd26b783f76a0cd8ef266d2dd54746c73d983202d150bf885b50fd32d9f1745d1df65f4cddccd9fc24b1b871e8dea8dcba3454a27363297423cdd
     PATCHES
         fix_static_link_icu.patch
         fix-link-include-path.patch

--- a/ports/tesseract/vcpkg.json
+++ b/ports/tesseract/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tesseract",
-  "version": "5.5.0",
-  "port-version": 1,
+  "version": "5.5.1",
   "description": "An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.",
   "homepage": "https://github.com/tesseract-ocr/tesseract",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9257,8 +9257,8 @@
       "port-version": 0
     },
     "tesseract": {
-      "baseline": "5.5.0",
-      "port-version": 1
+      "baseline": "5.5.1",
+      "port-version": 0
     },
     "tevclient": {
       "baseline": "2023-12-04",

--- a/versions/t-/tesseract.json
+++ b/versions/t-/tesseract.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8ba16ca377162ad75388a69c6e023e950a985cc",
+      "version": "5.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3037e2bd6bed856d03266bdfa59f67884896f29c",
       "version": "5.5.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/tesseract-ocr/tesseract/releases/tag/5.5.1
