### PR TITLE
[tree-sitter-c] update to 0.24.1

### DIFF
--- a/ports/tree-sitter-c/pkgconfig.diff
+++ b/ports/tree-sitter-c/pkgconfig.diff
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e6a23ee..f45024d 100644
+index 3771647..772f62a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -41,15 +41,15 @@ set_target_properties(tree-sitter-c
+@@ -45,16 +45,16 @@ set_target_properties(tree-sitter-c
                        SOVERSION "${TREE_SITTER_ABI_VERSION}.${PROJECT_VERSION_MAJOR}"
                        DEFINE_SYMBOL "")
  
@@ -13,8 +13,9 @@ index e6a23ee..f45024d 100644
  
 -include(GNUInstallDirs)
 -
- install(FILES bindings/c/tree-sitter-c.h
-         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter")
+ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bindings/c/tree_sitter"
+         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+         FILES_MATCHING PATTERN "*.h")
  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-c.pc"
 -        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig")
 +        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/ports/tree-sitter-c/portfile.cmake
+++ b/ports/tree-sitter-c/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tree-sitter/tree-sitter-c
     REF "v${VERSION}"
-    SHA512 76022e55c613901e6c58d08e425aa0d527027d0130ce6bed2c5f83cd9056a8bdfef7af73ccd5df056b03515a9a733d64759b37766ccaa994f757c8e5c51b9a74
+    SHA512 51cf052230ee835d4ae5e6c5adb24aeaeba3b4f106aceefaf4000bd0e57321946f1b3e3b0f9ea71d1c17a618604c6c7269c80c3ecc5ca17e22c883ff5ce4c304
     HEAD_REF master
     PATCHES
         pkgconfig.diff

--- a/ports/tree-sitter-c/vcpkg.json
+++ b/ports/tree-sitter-c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-c",
-  "version": "0.23.5",
+  "version": "0.24.1",
   "description": "C grammar for tree-sitter",
   "homepage": "https://github.com/tree-sitter/tree-sitter-c",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9493,7 +9493,7 @@
       "port-version": 0
     },
     "tree-sitter-c": {
-      "baseline": "0.23.5",
+      "baseline": "0.24.1",
       "port-version": 0
     },
     "tree-sitter-cli": {

--- a/versions/t-/tree-sitter-c.json
+++ b/versions/t-/tree-sitter-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b13d01b8c0207ecdb7ffdf988a4d6956dd7eeda5",
+      "version": "0.24.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c328547f974b97d7181e603d82c66c8cf34a4e2d",
       "version": "0.23.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/tree-sitter/tree-sitter-c/releases/tag/v0.24.1