### PR TITLE
[cxxopts] update to 3.3.1

### DIFF
--- a/ports/cxxopts/portfile.cmake
+++ b/ports/cxxopts/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jarro2783/cxxopts
     REF "v${VERSION}"
-    SHA512 7841fb3e6c3c2a057917c962e29fc0090e6ed06f5515aaa5e2a868fef59071a9a99b74d81c32cf613ecf10a68a4d96d6ad07805f48c7c3951ded096a2317dc3d
+    SHA512 a22da1436a263d51aad2f542c2099f5b4fd1b02674716ff26d2f575786dcec4e97400edebf5577de95f3ae48c7c99be7be17d7a3de3e01a9f3612667e1547908
     HEAD_REF master
 )
 
@@ -16,7 +16,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/cxxopts)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/cxxopts)
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/cxxopts/portfile.cmake
+++ b/ports/cxxopts/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+set(VCPKG_BUILD_TYPE release) # header-only port
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/cxxopts/vcpkg.json
+++ b/ports/cxxopts/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cxxopts",
-  "version-semver": "3.2.1",
+  "version-semver": "3.3.1",
   "description": "This is a lightweight C++ option parser library, supporting the standard GNU style syntax for options",
   "homepage": "https://github.com/jarro2783/cxxopts",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2217,7 +2217,7 @@
       "port-version": 0
     },
     "cxxopts": {
-      "baseline": "3.2.1",
+      "baseline": "3.3.1",
       "port-version": 0
     },
     "cyclonedds": {

--- a/versions/c-/cxxopts.json
+++ b/versions/c-/cxxopts.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c788dfb65e15ad8ea0128d8b4e5c10a0237cf4e8",
+      "version-semver": "3.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ad8547da18ed18a0bd77925eafad7507430f383",
       "version-semver": "3.2.1",
       "port-version": 0

--- a/versions/c-/cxxopts.json
+++ b/versions/c-/cxxopts.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c788dfb65e15ad8ea0128d8b4e5c10a0237cf4e8",
+      "git-tree": "d24b1868232e29427a9fa9bf32b50aa4e2e322ee",
       "version-semver": "3.3.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/jarro2783/cxxopts/releases/tag/v3.3.1
