### PR TITLE
[whisper-cpp] add new port

### DIFF
--- a/ports/whisper-cpp/0001-ggml-alias.patch
+++ b/ports/whisper-cpp/0001-ggml-alias.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index be6db903..0419a8c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -132,7 +132,7 @@ if (NOT TARGET ggml)
+         if (NOT ggml_FOUND)
+             message(FATAL_ERROR "System-installed GGML library not found.")
+         endif()
+-        add_library(ggml ALIAS ggml::ggml)
++        add_library(ggml ALIAS ggml::all)
+     else()
+         add_subdirectory(ggml)
+     endif()

--- a/ports/whisper-cpp/portfile.cmake
+++ b/ports/whisper-cpp/portfile.cmake
@@ -1,0 +1,56 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ggml-org/whisper.cpp
+    REF v${VERSION}
+    SHA512 35efd976f60261e108972e3af7b322d723e36be30f5265db3be63752caaed0b52b9da3ece02975da2b83ff30f1eb32663e77fbaaf15f3037e35a525939071c0b
+    HEAD_REF master
+    PATCHES
+        0001-ggml-alias.patch
+)
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/ggml")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+      -DWHISPER_USE_SYSTEM_GGML=ON
+      -DWHISPER_CCACHE=OFF
+      -DWHISPER_BUILD_TESTS=OFF
+      -DWHISPER_BUILD_EXAMPLES=OFF
+      -DWHISPER_ALL_WARNINGS=OFF
+      ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME whisper CONFIG_PATH "lib/cmake/whisper")
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/whisper/whisper-config.cmake"
+        "set_and_check(WHISPER_BIN_DIR     \"${PACKAGE_PREFIX_DIR}/bin\")"
+        ""
+        IGNORE_UNCHANGED
+    )
+endif()
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/whisper/whisper-config.cmake"
+    "add_library(whisper UNKNOWN IMPORTED)"
+    "if (NOT TARGET whisper)
+    add_library(whisper UNKNOWN IMPORTED)
+endif()
+"
+)
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+file(INSTALL "${SOURCE_PATH}/models/convert-pt-to-ggml.py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/whisper-cpp/portfile.cmake
+++ b/ports/whisper-cpp/portfile.cmake
@@ -28,7 +28,7 @@ vcpkg_fixup_pkgconfig()
 
 if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/whisper/whisper-config.cmake"
-        "set_and_check(WHISPER_BIN_DIR     \"${PACKAGE_PREFIX_DIR}/bin\")"
+        "set_and_check(WHISPER_BIN_DIR     \"\${PACKAGE_PREFIX_DIR}/bin\")"
         ""
         IGNORE_UNCHANGED
     )

--- a/ports/whisper-cpp/vcpkg.json
+++ b/ports/whisper-cpp/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Port of OpenAI's Whisper model in C/C++",
   "homepage": "https://github.com/ggml-org/whisper.cpp",
   "license": "MIT",
-  "supports": "!android",
+  "supports": "!(arm64 & osx)",
   "dependencies": [
     "ggml",
     {

--- a/ports/whisper-cpp/vcpkg.json
+++ b/ports/whisper-cpp/vcpkg.json
@@ -1,19 +1,19 @@
 {
-    "name": "whisper-cpp",
-    "version": "1.7.5",
-    "description": "Port of OpenAI's Whisper model in C/C++",
-    "homepage": "https://github.com/ggml-org/whisper.cpp",
-    "license": "MIT",
-    "supports": "!android",
-    "dependencies": [
-      "ggml",
-      {
-        "name": "vcpkg-cmake",
-        "host": true
-      },
-      {
-        "name": "vcpkg-cmake-config",
-        "host": true
-      }
-    ]
-  }
+  "name": "whisper-cpp",
+  "version": "1.7.5",
+  "description": "Port of OpenAI's Whisper model in C/C++",
+  "homepage": "https://github.com/ggml-org/whisper.cpp",
+  "license": "MIT",
+  "supports": "!android",
+  "dependencies": [
+    "ggml",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/whisper-cpp/vcpkg.json
+++ b/ports/whisper-cpp/vcpkg.json
@@ -1,0 +1,19 @@
+{
+    "name": "whisper-cpp",
+    "version": "1.7.5",
+    "description": "Port of OpenAI's Whisper model in C/C++",
+    "homepage": "https://github.com/ggml-org/whisper.cpp",
+    "license": "MIT",
+    "supports": "!android",
+    "dependencies": [
+      "ggml",
+      {
+        "name": "vcpkg-cmake",
+        "host": true
+      },
+      {
+        "name": "vcpkg-cmake-config",
+        "host": true
+      }
+    ]
+  }

--- a/ports/whisper-cpp/vcpkg.json
+++ b/ports/whisper-cpp/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "Port of OpenAI's Whisper model in C/C++",
   "homepage": "https://github.com/ggml-org/whisper.cpp",
   "license": "MIT",
-  "supports": "!(arm64 & osx)",
   "dependencies": [
     "ggml",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10036,6 +10036,10 @@
       "baseline": "2019-08-13",
       "port-version": 2
     },
+    "whisper-cpp": {
+      "baseline": "1.7.5",
+      "port-version": 0
+    },
     "wiiuse": {
       "baseline": "0.15.6",
       "port-version": 0

--- a/versions/w-/whisper-cpp.json
+++ b/versions/w-/whisper-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4b89f5df77ff01026b6fbe7771705c69f1374ddf",
+      "version": "1.7.5",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/w-/whisper-cpp.json
+++ b/versions/w-/whisper-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4b89f5df77ff01026b6fbe7771705c69f1374ddf",
+      "git-tree": "56d6934e8229b0a208761f4743c51bbdfbc5ab17",
       "version": "1.7.5",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

