### PR TITLE
[argtable3] update to 3.3.0

### DIFF
--- a/ports/argtable3/Fix-dependence-getopt.patch
+++ b/ports/argtable3/Fix-dependence-getopt.patch
@@ -1,10 +1,10 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 2e0b519..6b455dd 100644
+index 8ea5334..1ec6bbe 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -79,6 +79,11 @@ endif()
- add_library(${ARGTABLE3_PROJECT_NAME}::argtable3 ALIAS argtable3)
- target_include_directories(argtable3 PRIVATE ${PROJECT_SOURCE_DIR}/src)
+@@ -86,6 +86,11 @@ target_include_directories(argtable3 PUBLIC
+   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+ )
  
 +if(NOT ARGTABLE3_REPLACE_GETOPT)
 +  find_package(unofficial-getopt-win32 REQUIRED)
@@ -12,5 +12,5 @@ index 2e0b519..6b455dd 100644
 +endif()
 +
  set_target_properties(argtable3 PROPERTIES
-   VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
-   SOVERSION ${PROJECT_VERSION_MAJOR}
+   VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
+   SOVERSION "${PROJECT_VERSION_MAJOR}"

--- a/ports/argtable3/portfile.cmake
+++ b/ports/argtable3/portfile.cmake
@@ -31,6 +31,8 @@ elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT}")
     vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 endif()
 
+vcpkg_fixup_pkgconfig()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/argtable3/portfile.cmake
+++ b/ports/argtable3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO argtable/argtable3
     REF "v${VERSION}"
-    SHA512 623197142fd1749b2fd5bc3e51758ae49c58ec8699b6afa5ecb2d0199d98f9c05366f92c5169c8039b5c417f4774fb4a09c879a7b04ddbed9d5e43585692ed7f
+    SHA512 b434944f264d22e271415078b5bc6c80feb3ce508189f9b62ec292fa1c041de7cbeb6c2f4be7c59341cd189f346d8a52808b1676481fc29df92fbec12cb89b2a
     HEAD_REF master
     PATCHES Fix-dependence-getopt.patch
 )

--- a/ports/argtable3/vcpkg.json
+++ b/ports/argtable3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "argtable3",
-  "version-string": "3.2.2.f25c624",
+  "version-string": "3.3.0.116da6c",
   "description": "A single-file, ANSI C, command-line parsing library that parses GNU-style command-line options",
   "homepage": "https://www.argtable.org/",
   "license": "BSD-2-Clause-NetBSD AND TCL",

--- a/versions/a-/argtable3.json
+++ b/versions/a-/argtable3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8b50e26c42b6e3b28925b60626f1db2516e3a1a",
+      "version-string": "3.3.0.116da6c",
+      "port-version": 0
+    },
+    {
       "git-tree": "949eef38520716ab831bb7f008cce93b28af8f54",
       "version-string": "3.2.2.f25c624",
       "port-version": 0

--- a/versions/a-/argtable3.json
+++ b/versions/a-/argtable3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d8b50e26c42b6e3b28925b60626f1db2516e3a1a",
+      "git-tree": "b50840a1e4bb570697cad03f94145c0660b1e4ef",
       "version-string": "3.3.0.116da6c",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -233,7 +233,7 @@
       "port-version": 10
     },
     "argtable3": {
-      "baseline": "3.2.2.f25c624",
+      "baseline": "3.3.0.116da6c",
       "port-version": 0
     },
     "argumentum": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/argtable/argtable3/releases/tag/v3.3.0.116da6c
