### PR TITLE
[sfl] add new port

### DIFF
--- a/ports/sfl/portfile.cmake
+++ b/ports/sfl/portfile.cmake
@@ -1,0 +1,16 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO slavenf/sfl-library
+    REF "${VERSION}"
+    SHA512 9e6f140c7a235c3f7dd5c76843d8b0d8d0e22491eaef1c9936dc55e28fed1e66c15c1d5d1e55ce40799ca691069745efcb234448ca202e4430668dba03a6c054
+    HEAD_REF master
+)
+
+# header-only
+set(VCPKG_BUILD_TYPE "release")
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+
+vcpkg_cmake_install()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/sfl/vcpkg.json
+++ b/ports/sfl/vcpkg.json
@@ -8,10 +8,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ]
 }

--- a/ports/sfl/vcpkg.json
+++ b/ports/sfl/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "sfl",
+  "version": "1.9.2",
+  "description": "header-only C++11 library that offers several new or less-known containers",
+  "homepage": "https://github.com/slavenf/sfl-library",
+  "license": "Zlib",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8624,6 +8624,10 @@
       "baseline": "1.0.0",
       "port-version": 0
     },
+    "sfl": {
+      "baseline": "1.9.2",
+      "port-version": 0
+    },
     "sfml": {
       "baseline": "3.0.0",
       "port-version": 1

--- a/versions/s-/sfl.json
+++ b/versions/s-/sfl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7c75ae4d58df1de69a2a4623dfb2982ce5d61d55",
+      "version": "1.9.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/sfl.json
+++ b/versions/s-/sfl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7c75ae4d58df1de69a2a4623dfb2982ce5d61d55",
+      "git-tree": "b0571621408816c82df5cb412d06c549875ad9a4",
       "version": "1.9.2",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/slavenf/sfl-library/releases/tag/1.9.2