### PR TITLE
[simdutf] Update to 7.3.0

### DIFF
--- a/ports/simdutf/portfile.cmake
+++ b/ports/simdutf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO simdutf/simdutf
     REF "v${VERSION}"
-    SHA512 68505e423157d33076d76aecd416dadf28e5d0c5efff325bdeeaadd13877b9d7b8b3ceb7997bc4b705dbc037dce36f63ef54b348a5c37fdf8f17524819026249
+    SHA512 fc354abaf2233bbdc0d51b22b3e2ba8b68332c1d8d739381925259ee631ab7a0ffb0c92e978f746e5f7aa32c3ad800ce34bccd49446250f9f473af7c4dd9e9a3
     HEAD_REF master
 )
 

--- a/ports/simdutf/vcpkg.json
+++ b/ports/simdutf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdutf",
-  "version-semver": "7.1.0",
+  "version-semver": "7.3.0",
   "description": "Unicode validation and transcoding at billions of characters per second",
   "homepage": "https://github.com/simdutf/simdutf",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8705,7 +8705,7 @@
       "port-version": 0
     },
     "simdutf": {
-      "baseline": "7.1.0",
+      "baseline": "7.3.0",
       "port-version": 0
     },
     "simonbrunel-qtpromise": {

--- a/versions/s-/simdutf.json
+++ b/versions/s-/simdutf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7562f8d31560d98c51ae650af7de7c1afbde5c01",
+      "version-semver": "7.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "06d5ef07a7c69f6851180821b12248c01a44594d",
       "version-semver": "7.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
