### PR TITLE
[cudnn-frontend] Create a new port with v1.11.0 (devendors this from [libtorch])

### DIFF
--- a/ports/cudnn-frontend/portfile.cmake
+++ b/ports/cudnn-frontend/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIA/cudnn-frontend
+    REF "v${VERSION}"
+    SHA512 2d50fbedc1d2f488275aedce84893447a025d4c00b9e8609c4004b2eb0525480a348835d0e8b2784499d80d0c63d75bb1430741cb06c3652da8dd72b822489fa
+    HEAD_REF main
+)
+file(REMOVE_RECURSE "${SOURCE_PATH}/include/cudnn_frontend/thirdparty")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DCUDNN_FRONTEND_FETCH_PYBINDS_IN_CMAKE=OFF
+        -DCUDNN_FRONTEND_BUILD_TESTS=OFF
+        -DCUDNN_FRONTEND_BUILD_SAMPLES=OFF
+        -DCUDNN_FRONTEND_SKIP_JSON_LIB=OFF
+    MAYBE_UNUSED_VARIABLES
+        CUDNN_FRONTEND_FETCH_PYBINDS_IN_CMAKE
+)
+vcpkg_cmake_install()
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/cudnn_frontend_utils.h"
+    "\"cudnn_frontend/thirdparty/nlohmann/json.hpp\""
+    "<nlohmann/json.hpp>"
+)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/cudnn-frontend/portfile.cmake
+++ b/ports/cudnn-frontend/portfile.cmake
@@ -10,12 +10,9 @@ file(REMOVE_RECURSE "${SOURCE_PATH}/include/cudnn_frontend/thirdparty")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DCUDNN_FRONTEND_FETCH_PYBINDS_IN_CMAKE=OFF
         -DCUDNN_FRONTEND_BUILD_TESTS=OFF
         -DCUDNN_FRONTEND_BUILD_SAMPLES=OFF
         -DCUDNN_FRONTEND_SKIP_JSON_LIB=OFF
-    MAYBE_UNUSED_VARIABLES
-        CUDNN_FRONTEND_FETCH_PYBINDS_IN_CMAKE
 )
 vcpkg_cmake_install()
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/cudnn_frontend_utils.h"

--- a/ports/cudnn-frontend/portfile.cmake
+++ b/ports/cudnn-frontend/portfile.cmake
@@ -10,7 +10,6 @@ file(REMOVE_RECURSE "${SOURCE_PATH}/include/cudnn_frontend/thirdparty")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        ${FEATURE_OPTIONS}
         -DCUDNN_FRONTEND_FETCH_PYBINDS_IN_CMAKE=OFF
         -DCUDNN_FRONTEND_BUILD_TESTS=OFF
         -DCUDNN_FRONTEND_BUILD_SAMPLES=OFF

--- a/ports/cudnn-frontend/vcpkg.json
+++ b/ports/cudnn-frontend/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "cudnn-frontend",
+  "version-semver": "1.11.0",
+  "description": "cudnn_frontend provides a c++ wrapper for the cudnn backend API and samples on how to use it",
+  "homepage": "https://github.com/NVIDIA/cudnn-frontend",
+  "license": "MIT",
+  "dependencies": [
+    "cuda",
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/ports/libtorch/cmake-fixes.patch
+++ b/ports/libtorch/cmake-fixes.patch
@@ -136,7 +136,8 @@ index c3abce5..63f665f 100644
  # ---[ cuDNN
  if(USE_CUDNN)
 +  find_package(CUDNN REQUIRED)
-   set(CUDNN_FRONTEND_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/../third_party/cudnn_frontend/include)
+-  set(CUDNN_FRONTEND_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/../third_party/cudnn_frontend/include)
++  find_path(CUDNN_FRONTEND_INCLUDE_DIR NAMES cudnn_frontend.h REQUIRED)
    target_include_directories(torch::cudnn INTERFACE ${CUDNN_FRONTEND_INCLUDE_DIR})
 +  target_include_directories(torch::cudnn INTERFACE "${CUDNN_INCLUDE_DIR}")
  endif()
@@ -202,6 +203,27 @@ index c3abce5..63f665f 100644
  
  list(APPEND Caffe2_DEPENDENCY_LIBS fmt::fmt-header-only)
  set(BUILD_SHARED_LIBS ${TEMP_BUILD_SHARED_LIBS} CACHE BOOL "Build shared libs" FORCE)
+@@ -1388,16 +1388,16 @@ if(USE_DISTRIBUTED AND USE_TENSORPIPE)
+     endif()
+     set(TP_BUILD_LIBUV ON CACHE BOOL "" FORCE)
+     add_compile_options(-DTORCH_USE_LIBUV)
+-    include_directories(BEFORE SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../third_party/tensorpipe/third_party/libuv/include)
++    find_package(libuv CONFIG REQUIRED)
+     set(TP_STATIC_OR_SHARED STATIC CACHE STRING "" FORCE)
+ 
+     # Tensorpipe uses cuda_add_library
+     torch_update_find_cuda_flags()
+-    add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/tensorpipe)
++    find_package(unofficial-tensorpipe CONFIG REQUIRED)
+ 
+-    list(APPEND Caffe2_DEPENDENCY_LIBS tensorpipe)
++    list(APPEND Caffe2_DEPENDENCY_LIBS $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv> unofficial::tensorpipe::tensorpipe)
+     if(USE_CUDA)
+-      list(APPEND Caffe2_CUDA_DEPENDENCY_LIBS tensorpipe_cuda)
++      list(APPEND Caffe2_CUDA_DEPENDENCY_LIBS unofficial::tensorpipe::tensorpipe_cuda)
+     elseif(USE_ROCM)
+       message(WARNING "TensorPipe doesn't yet support ROCm")
+       # Not yet...
 diff --git a/cmake/Modules/FindLMDB.cmake b/cmake/Modules/FindLMDB.cmake
 index 2f0adb1..8a817fd 100644
 --- a/cmake/Modules/FindLMDB.cmake

--- a/ports/libtorch/cmake-fixes.patch
+++ b/ports/libtorch/cmake-fixes.patch
@@ -274,3 +274,24 @@ index 4d48c0f..ebdd39a 100644
    endif()
  endmacro()
  
+diff --git a/cmake/VulkanDependencies.cmake b/cmake/VulkanDependencies.cmake
+index 52de6a4..02dcff1 100644
+--- a/cmake/VulkanDependencies.cmake
++++ b/cmake/VulkanDependencies.cmake
+@@ -31,13 +31,15 @@ if(ANDROID)
+ 
+ else()
+   find_package(Vulkan)
++  find_package(VulkanHeaders)
++  find_package(VulkanMemoryAllocator CONFIG REQUIRED)
+ 
+   if(NOT Vulkan_FOUND)
+     message(FATAL_ERROR "USE_VULKAN requires either Vulkan installed on system path or environment var VULKAN_SDK set.")
+   endif()
+ 
+   list(APPEND Vulkan_INCLUDES ${Vulkan_INCLUDE_DIRS})
+-  list(APPEND Vulkan_LIBS ${Vulkan_LIBRARIES})
++  list(APPEND Vulkan_LIBS ${Vulkan_LIBRARIES} Vulkan::Headers GPUOpen::VulkanMemoryAllocator)
+ 
+   set(GOOGLE_SHADERC_INCLUDE_SEARCH_PATH ${Vulkan_INCLUDE_DIR})
+   set(GOOGLE_SHADERC_LIBRARY_SEARCH_PATH ${Vulkan_LIBRARY})

--- a/ports/libtorch/portfile.cmake
+++ b/ports/libtorch/portfile.cmake
@@ -55,14 +55,7 @@ vcpkg_from_github(
 )
 file(COPY "${src_kineto}/" DESTINATION "${SOURCE_PATH}/third_party/kineto")
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH src_cudnn
-    REPO NVIDIA/cudnn-frontend # new port ?
-    REF 12f35fa2be5994c1106367cac2fba21457b064f4
-    SHA512 a7e4bf58f82ca0b767df35da1b3588e2639ea2ef22ed0c47e989fb4cde5a28b0605b228b42fcaefbdf721bfbb91f2a9e7d41352ff522bd80b63db6d27e44ec20
-    HEAD_REF main
-)
-file(COPY "${src_cudnn}/" DESTINATION "${SOURCE_PATH}/third_party/cudnn_frontend")
+file(REMOVE_RECURSE "${SOURCE_PATH}/third_party/cudnn_frontend")
 
 
 file(REMOVE

--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtorch",
   "version": "2.1.2",
-  "port-version": 12,
+  "port-version": 13,
   "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
   "homepage": "https://pytorch.org/",
   "license": null,
@@ -61,8 +61,16 @@
       "dependencies": [
         "cuda",
         "cudnn",
+        "cudnn-frontend",
         "magma",
-        "nvidia-cutlass"
+        "nvidia-cutlass",
+        {
+          "name": "tensorpipe",
+          "features": [
+            "cuda"
+          ],
+          "platform": "linux"
+        }
       ]
     },
     "dist": {

--- a/ports/libtorch/vcpkg.json
+++ b/ports/libtorch/vcpkg.json
@@ -134,6 +134,7 @@
       "description": "Build with Vulkan GPU backend",
       "dependencies": [
         "vulkan",
+        "vulkan-headers",
         "vulkan-loader",
         "vulkan-memory-allocator"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2184,6 +2184,10 @@
       "baseline": "7.6.5",
       "port-version": 15
     },
+    "cudnn-frontend": {
+      "baseline": "1.11.0",
+      "port-version": 0
+    },
     "cunit": {
       "baseline": "2.1.3",
       "port-version": 8

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5422,7 +5422,7 @@
     },
     "libtorch": {
       "baseline": "2.1.2",
-      "port-version": 12
+      "port-version": 13
     },
     "libtorrent": {
       "baseline": "2.0.11",

--- a/versions/c-/cudnn-frontend.json
+++ b/versions/c-/cudnn-frontend.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c3ebf5417c6de8d678a863dbcc2fd3b02203b358",
+      "version-semver": "1.11.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/cudnn-frontend.json
+++ b/versions/c-/cudnn-frontend.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c3ebf5417c6de8d678a863dbcc2fd3b02203b358",
+      "git-tree": "a0af3784645571fc4e16fcd6b13917d52fd4c864",
       "version-semver": "1.11.0",
       "port-version": 0
     }

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1b7ca410abf13543ee7065ca84c66a50375c058",
+      "version": "2.1.2",
+      "port-version": 13
+    },
+    {
       "git-tree": "42cff2032d0a7670edde067c822897cc6be1cf85",
       "version": "2.1.2",
       "port-version": 12

--- a/versions/l-/libtorch.json
+++ b/versions/l-/libtorch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b1b7ca410abf13543ee7065ca84c66a50375c058",
+      "git-tree": "37f4998f3d5c2fdf47df34c6aca8f2e01d7faf11",
       "version": "2.1.2",
       "port-version": 13
     },


### PR DESCRIPTION

Maybe we can name this port [`nvidia-cudnn-frontend`](https://repology.org/project/nvidia-cudnn-frontend/versions) like `nvidia-cutlass`. [`cudnn-frontend`](https://repology.org/project/cudnn-frontend/versions) also exists in https://repology.org/.

- Cherrypick some commits of https://github.com/microsoft/vcpkg/pull/36850 to follow the maintainer guideline
- `libtorch` was using this repository

```log
Computing installation plan...
The following packages are already installed:
    cudnn-frontend:x64-windows@1.11.0
cudnn-frontend:x64-windows is already installed
Total install time: 1.01 ms
cudnn-frontend is header-only and can be used from CMake via:

  find_path(CUDNN_FRONTEND_INCLUDE_DIRS "cudnn_backend_base.h")
  target_include_directories(main PRIVATE ${CUDNN_FRONTEND_INCLUDE_DIRS})   

```

## References

- https://github.com/NVIDIA/cudnn-frontend/releases/tag/v1.11.0
- https://github.com/luncliff/vcpkg-registry/pull/347

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
