### PR TITLE
[vcpkg baseline][yara] Update to 4.5.4

### DIFF
--- a/ports/yara/portfile.cmake
+++ b/ports/yara/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO VirusTotal/yara
   REF "v${VERSION}"
-  SHA512 761f3930117c35d87b0e3be1a5d61a6887006470fdf578164feb1bd56a96b2d85770ab7c3a21258a2781ff3327cb705942f4f0eb959cff4b210f0c7fbec1fc30
+  SHA512 b1da40636f9e55bb07cc911479e6dfa8dc7a4fa3f6b9f10b9f669d741d7af51a1d31e044f9842ec3ab9c6ac9788fbdb89a1686c9e3f22f68d1f9e5fb3db22167
   HEAD_REF master
   PATCHES
     # Module elf request new library tlshc(https://github.com/avast/tlshc), the related upstream PR: https://github.com/VirusTotal/yara/pull/1624.

--- a/ports/yara/vcpkg.json
+++ b/ports/yara/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "yara",
-  "version": "4.5.2",
-  "port-version": 1,
+  "version": "4.5.4",
   "description": "The pattern matching swiss knife",
   "homepage": "https://github.com/VirusTotal/yara",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10345,8 +10345,8 @@
       "port-version": 3
     },
     "yara": {
-      "baseline": "4.5.2",
-      "port-version": 1
+      "baseline": "4.5.4",
+      "port-version": 0
     },
     "yas": {
       "baseline": "7.1.0",

--- a/versions/y-/yara.json
+++ b/versions/y-/yara.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "87f57135883f8bed5a44b56f1477d83021258d5c",
+      "version": "4.5.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "72d184511e1157046d782b018a9d4461cbbf1e48",
       "version": "4.5.2",
       "port-version": 1


### PR DESCRIPTION
`yara` installation failed with the following error in in https://dev.azure.com/vcpkg/public/_build/results?buildId=116145&view=results
```
error: open_for_read("VirusTotal-yara-v4.5.2.tar.gz.8720.part"): invalid argument
error: open_for_read("VirusTotal-yara-v4.5.2.tar.gz.8720.part"): invalid argument
CMake Error at scripts/cmake/vcpkg_download_distfile.cmake:136 (message):
  Download failed, halting portfile.
```
This issue occurred because the file at [https://github.com/VirusTotal/yara/archive/refs/tags/v4.5.2.tar.gz](https://github.com/VirusTotal/yara/archive/refs/tags/v4.5.2.tar.gz) was automatically deleted by antivirus software.
Among the latest five tags of `yara`, only the file for version `4.5.2` triggers this behavior, while the others can be downloaded normally.
Therefore, I have updated the port to the latest version `4.5.4`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
