### PR TITLE
[zookeeper] Update to 3.8.4

### DIFF
--- a/ports/zkpp/CMakeLists.txt
+++ b/ports/zkpp/CMakeLists.txt
@@ -88,7 +88,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 # External Libraries                                                           #
 ################################################################################
 
-find_package(zookeeper REQUIRED)
+find_package(unofficial-zookeeper REQUIRED)
 
 
 build_module(NAME zkpp
@@ -97,7 +97,7 @@ build_module(NAME zkpp
             )
 
 target_include_directories(zkpp PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
-target_link_libraries(zkpp PRIVATE zookeeper::zookeeper)
+target_link_libraries(zkpp PRIVATE unofficial::zookeeper::zookeeper)
 
 install(TARGETS zkpp
     EXPORT zkpp

--- a/ports/zkpp/portfile.cmake
+++ b/ports/zkpp/portfile.cmake
@@ -15,11 +15,10 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
-
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
-vcpkg_cmake_config_fixup()
-vcpkg_copy_pdbs()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/zkpp/vcpkg.json
+++ b/ports/zkpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zkpp",
   "version": "0.2.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A ZooKeeper client for C++.",
   "homepage": "https://github.com/tgockel/zookeeper-cpp",
   "supports": "!windows",

--- a/ports/zookeeper/cmake.patch
+++ b/ports/zookeeper/cmake.patch
@@ -1,74 +1,56 @@
 diff --git a/zookeeper-client/zookeeper-client-c/CMakeLists.txt b/zookeeper-client/zookeeper-client-c/CMakeLists.txt
-index 24a5a1b..40fa67e 100644
+index ccba3ee..14384c0 100644
 --- a/zookeeper-client/zookeeper-client-c/CMakeLists.txt
 +++ b/zookeeper-client/zookeeper-client-c/CMakeLists.txt
-@@ -147,13 +147,15 @@ endforeach()
- include(CheckStructHasMember)
- check_struct_has_member("struct sockaddr_in6" sin6_addr "netinet/in.h" ZOO_IPV6_ENABLED)
- 
-+include(GNUInstallDirs)
-+
- # configure
- configure_file(cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/config.h)
- 
+@@ -169,7 +169,11 @@ configure_file(cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/config.h)
  # hashtable library
  set(hashtable_sources src/hashtable/hashtable_itr.c src/hashtable/hashtable.c)
  add_library(hashtable STATIC ${hashtable_sources})
 -target_include_directories(hashtable PUBLIC include)
-+target_include_directories(hashtable PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
++target_include_directories(hashtable PUBLIC
++  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++  $<INSTALL_INTERFACE:include>
++)
++set_target_properties(hashtable PROPERTIES OUTPUT_NAME zookeeper_hashtable)
  target_link_libraries(hashtable PUBLIC $<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:FreeBSD>>:m>)
  
  # zookeeper library
-@@ -176,11 +178,16 @@ if(WIN32)
+@@ -196,7 +200,12 @@ if(WIN32)
  endif()
  
  add_library(zookeeper STATIC ${zookeeper_sources})
 -target_include_directories(zookeeper PUBLIC include ${CMAKE_CURRENT_BINARY_DIR}/include generated)
 +target_include_directories(zookeeper PUBLIC
-+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 +  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++  $<INSTALL_INTERFACE:include>
 +  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/generated>)
-+
++  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/generated>
++)
  target_link_libraries(zookeeper PUBLIC
--  hashtable
+   hashtable
    $<$<PLATFORM_ID:Linux>:rt> # clock_gettime
--  $<$<PLATFORM_ID:Windows>:ws2_32>) # Winsock 2.0
-+  $<$<PLATFORM_ID:Windows>:ws2_32> # Winsock 2.0
-+  PRIVATE hashtable)
- 
- if(WANT_SYNCAPI AND NOT WIN32)
-   find_package(Threads REQUIRED)
-@@ -189,7 +196,7 @@ endif()
- 
- # cli executable
- add_executable(cli src/cli.c)
--target_link_libraries(cli zookeeper)
-+target_link_libraries(cli PRIVATE zookeeper)
- 
- # load_gen executable
- if(WANT_SYNCAPI AND NOT WIN32)
-@@ -247,3 +254,23 @@ if(WANT_CPPUNIT)
+@@ -291,3 +300,24 @@ if(WANT_CPPUNIT)
      "ZKROOT=${CMAKE_CURRENT_SOURCE_DIR}/../.."
      "CLASSPATH=$CLASSPATH:$CLOVER_HOME/lib/clover*.jar")
  endif()
 +
-+
-+target_compile_definitions(zookeeper PRIVATE _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
-+target_compile_definitions(cli PRIVATE _CRT_SECURE_NO_WARNINGS)
++if(WIN32)
++  target_compile_definitions(zookeeper PRIVATE _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
++  target_compile_definitions(cli PRIVATE _CRT_SECURE_NO_WARNINGS)
++endif()
 +
 +file(GLOB ZOOKEEPER_HEADERS include/*.h)
-+
 +install(FILES ${ZOOKEEPER_HEADERS} generated/zookeeper.jute.h DESTINATION include/zookeeper)
 +
 +install(TARGETS zookeeper hashtable
-+    EXPORT zookeeperConfig
++    EXPORT unofficial-zookeeperTargets
 +    RUNTIME DESTINATION bin
 +    ARCHIVE DESTINATION lib
 +    LIBRARY DESTINATION lib
 +)
-+install(EXPORT zookeeperConfig
-+  FILE zookeeperConfig.cmake
-+  NAMESPACE zookeeper::
-+  DESTINATION "${CMAKE_INSTALL_PREFIX}/share/zookeeper"
++install(EXPORT unofficial-zookeeperTargets
++  NAMESPACE unofficial::zookeeper::
++  DESTINATION share/unofficial-zookeeper
 +)
++configure_file("${CMAKE_CURRENT_SOURCE_DIR}/unofficial-zookeeperConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/unofficial-zookeeperConfig.cmake" @ONLY)
++install(FILES "${CMAKE_CURRENT_BINARY_DIR}/unofficial-zookeeperConfig.cmake" DESTINATION share/unofficial-zookeeper)

--- a/ports/zookeeper/portfile.cmake
+++ b/ports/zookeeper/portfile.cmake
@@ -1,38 +1,77 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://archive.apache.org/dist/zookeeper/zookeeper-3.5.6/apache-zookeeper-3.5.6.tar.gz"
-    FILENAME "zookeeper-3.5.6.tar.gz"
-    SHA512 7f45817cbbc42aec5a7817fa2ae99656128e666dc58ace23d86bcfc5ca0dc49e418d1a7d1f082ad80ccb916f9f1b490167d16f836886af1a56fbcf720ad3b9d0
-)
+string(REGEX REPLACE "^([0-9]+[.][0-9]+[.][0-9]+)[.]([0-9]+)\$" "\\1-\\2" VERSION "${VERSION}")
 
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO apache/zookeeper
+    REF "release-${VERSION}"
+    SHA512 98e42f35dd369e322439d87d0f7da13b78eaeb092f259c0eca9e5bd4971e297b9bbf5a3292b4f9e4e5a5f5f7f4e637774f175d0d68fcc07c9733471ba9d9ba1b
+    HEAD_REF master
     PATCHES
         cmake.patch
         win32.patch
 )
+file(COPY "${CURRENT_PORT_DIR}/unofficial-zookeeperConfig.cmake" DESTINATION "${SOURCE_PATH}/zookeeper-client/zookeeper-client-c")
+
+# We must run the jute generator which is made from Java sources.
+# We fetch it as JAR from the latest matching binary release of zookeeper.
+string(REPLACE "3.9.4-0" "3.9.3" jute_release "${VERSION}")
+vcpkg_download_distfile(
+    zookeeper_bin_archive
+    URLS "https://dlcdn.apache.org/zookeeper/zookeeper-${jute_release}/apache-zookeeper-${jute_release}-bin.tar.gz"
+    FILENAME "apache-zookeeper-${jute_release}-bin.tar.gz"
+    SHA512 d44d870c1691662efbf1a8baf1859c901b820dc5ff163b36e81beb27b6fbf3cd31b5f1f075697edaaf6d3e7a4cb0cc92f924dcff64b294ef13d535589bdaf143
+)
+vcpkg_extract_source_archive(
+    zookeeper_jute_path
+    ARCHIVE "${zookeeper_bin_archive}"
+)
+string(APPEND zookeeper_jute_path "/lib/zookeeper-jute-${jute_release}.jar")
+
+block(SCOPE_FOR VARIABLES)
+    # Do not warn about FindJava.cmake accessing WIN32
+    set(Z_VCPKG_BACKCOMPAT_MESSAGE_LEVEL "TRACE")
+    set(WIN32 "${CMAKE_HOST_WIN32}")
+    find_package(Java COMPONENTS Runtime REQUIRED)
+
+    # cf. zookeeper-jute/pom.xml > "generate-C-Jute"
+    file(MAKE_DIRECTORY "${SOURCE_PATH}/zookeeper-client/zookeeper-client-c/generated")
+    vcpkg_execute_required_process(
+        COMMAND "${Java_JAVA_EXECUTABLE}"
+            -classpath "${zookeeper_jute_path}"
+            org.apache.jute.compiler.generated.Rcc
+            -l c
+            "${SOURCE_PATH}/zookeeper-jute/src/main/resources/zookeeper.jute"
+        WORKING_DIRECTORY "${SOURCE_PATH}/zookeeper-client/zookeeper-client-c/generated"
+        LOGNAME "generate-C-Jute"
+    )
+endblock()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        sync WANT_SYNCAPI
+        openssl WITH_OPENSSL
+        openssl VCPKG_LOCK_FIND_PACKAGE_OpenSSL
+        sync    WANT_SYNCAPI
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/zookeeper-client/zookeeper-client-c"
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
+        -DTHREADS_PREFER_PTHREAD_FLAG=ON
         -DWANT_CPPUNIT=OFF
+        -DWITH_CYRUS_SASL=OFF
         ${FEATURE_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        THREADS_PREFER_PTHREAD_FLAG
+        VCPKG_LOCK_FIND_PACKAGE_OpenSSL
 )
 
 vcpkg_cmake_install()
-
-vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-zookeeper)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/zookeeper-client/zookeeper-client-c/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_copy_pdbs()
+file(COPY "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/zookeeper-client/zookeeper-client-c/LICENSE")

--- a/ports/zookeeper/portfile.cmake
+++ b/ports/zookeeper/portfile.cmake
@@ -2,12 +2,15 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 string(REGEX REPLACE "^([0-9]+[.][0-9]+[.][0-9]+)[.]([0-9]+)\$" "\\1-\\2" VERSION "${VERSION}")
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO apache/zookeeper
-    REF "release-${VERSION}"
-    SHA512 98e42f35dd369e322439d87d0f7da13b78eaeb092f259c0eca9e5bd4971e297b9bbf5a3292b4f9e4e5a5f5f7f4e637774f175d0d68fcc07c9733471ba9d9ba1b
-    HEAD_REF master
+vcpkg_download_distfile(
+    zookeeper_src_archive
+    URLS "https://dlcdn.apache.org/zookeeper/stable/apache-zookeeper-${VERSION}.tar.gz"
+    FILENAME "apache-zookeeper-${VERSION}.tar.gz"
+    SHA512 78d909c92b3709cc2112d1b8df9ef006f78a81ee0aa1b6b6400b8fea771ebaafc03cde497c6080e3fd924b75facb28420c4970885914e5dc9cd47cd761e96dd4
+)
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${zookeeper_src_archive}"
     PATCHES
         cmake.patch
         win32.patch
@@ -16,18 +19,17 @@ file(COPY "${CURRENT_PORT_DIR}/unofficial-zookeeperConfig.cmake" DESTINATION "${
 
 # We must run the jute generator which is made from Java sources.
 # We fetch it as JAR from the latest matching binary release of zookeeper.
-string(REPLACE "3.9.4-0" "3.9.3" jute_release "${VERSION}")
 vcpkg_download_distfile(
     zookeeper_bin_archive
-    URLS "https://dlcdn.apache.org/zookeeper/zookeeper-${jute_release}/apache-zookeeper-${jute_release}-bin.tar.gz"
-    FILENAME "apache-zookeeper-${jute_release}-bin.tar.gz"
-    SHA512 d44d870c1691662efbf1a8baf1859c901b820dc5ff163b36e81beb27b6fbf3cd31b5f1f075697edaaf6d3e7a4cb0cc92f924dcff64b294ef13d535589bdaf143
+    URLS "https://dlcdn.apache.org/zookeeper/stable/apache-zookeeper-${VERSION}-bin.tar.gz"
+    FILENAME "apache-zookeeper-${VERSION}-bin.tar.gz"
+    SHA512 4d85d6f7644d5f36d9c4d65e78bd662ab35ebe1380d762c24c12b98af029027eee453437c9245dbdf2b9beb77cd6b690b69e26f91cf9d11b0a183a979c73fa43
 )
 vcpkg_extract_source_archive(
     zookeeper_jute_path
     ARCHIVE "${zookeeper_bin_archive}"
 )
-string(APPEND zookeeper_jute_path "/lib/zookeeper-jute-${jute_release}.jar")
+string(APPEND zookeeper_jute_path "/lib/zookeeper-jute-${VERSION}.jar")
 
 block(SCOPE_FOR VARIABLES)
     # Do not warn about FindJava.cmake accessing WIN32

--- a/ports/zookeeper/unofficial-zookeeperConfig.cmake
+++ b/ports/zookeeper/unofficial-zookeeperConfig.cmake
@@ -1,0 +1,8 @@
+include(CMakeFindDependencyMacro)
+if("@WANT_SYNCAPI@" AND NOT WIN32)
+    find_dependency(Threads)
+endif()
+if("@WITH_OPENSSL@")
+    find_dependency(OpenSSL)
+endif()
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-zookeeperTargets.cmake")

--- a/ports/zookeeper/usage
+++ b/ports/zookeeper/usage
@@ -1,0 +1,4 @@
+zookeeper provides CMake targets:
+
+  find_package(unofficial-zookeeper CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE unofficial::zookeeper::zookeeper)

--- a/ports/zookeeper/vcpkg.json
+++ b/ports/zookeeper/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "zookeeper",
-  "version": "3.5.6",
-  "port-version": 1,
+  "version": "3.9.4.0",
   "description": "ZooKeeper C bindings",
   "homepage": "https://github.com/apache/zookeeper",
   "license": "BSD-3-Clause",
@@ -15,10 +14,13 @@
       "host": true
     }
   ],
-  "default-features": [
-    "sync"
-  ],
   "features": {
+    "openssl": {
+      "description": "Enable OpenSSL support",
+      "dependencies": [
+        "openssl"
+      ]
+    },
     "sync": {
       "description": "ZooKeeper with the sync API"
     }

--- a/ports/zookeeper/vcpkg.json
+++ b/ports/zookeeper/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zookeeper",
-  "version": "3.9.4.0",
+  "version": "3.8.4",
   "description": "ZooKeeper C bindings",
   "homepage": "https://github.com/apache/zookeeper",
   "license": "BSD-3-Clause",

--- a/ports/zookeeper/win32.patch
+++ b/ports/zookeeper/win32.patch
@@ -1,8 +1,8 @@
 diff --git a/zookeeper-client/zookeeper-client-c/src/zk_log.c b/zookeeper-client/zookeeper-client-c/src/zk_log.c
-index 436485e..1902b09 100644
+index 79ebd61..2f9d018 100644
 --- a/zookeeper-client/zookeeper-client-c/src/zk_log.c
 +++ b/zookeeper-client/zookeeper-client-c/src/zk_log.c
-@@ -108,8 +108,11 @@ static const char* time_now(char* now_str){
+@@ -108,7 +108,11 @@ static const char* time_now(char* now_str){
      gettimeofday(&tv,0);
  
      now = tv.tv_sec;
@@ -10,16 +10,15 @@ index 436485e..1902b09 100644
 +    localtime_s(&lt, &now);
 +#else
      localtime_r(&now, &lt);
--
 +#endif
-     // clone the format used by log4j ISO8601DateFormat
-     // specifically: "yyyy-MM-dd HH:mm:ss,SSS"
  
+     // clone the format used by logback ISO8601DateFormat
+     // specifically: "yyyy-MM-dd HH:mm:ss,SSS"
 diff --git a/zookeeper-client/zookeeper-client-c/src/zookeeper.c b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
-index 25baa9c..96ed379 100644
+index 74b0471..e9cd44b 100644
 --- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
 +++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
-@@ -90,6 +90,7 @@
+@@ -100,6 +100,7 @@
  #define EAI_ADDRFAMILY WSAEINVAL /* is this still needed? */
  #define EHOSTDOWN EPIPE
  #define ESTALE ENODEV

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1076,6 +1076,19 @@ yajl:x64-android=fail
 zeroc-ice:arm-neon-android=fail
 zeroc-ice:arm64-android=fail
 zeroc-ice:x64-android=fail
+# Needs Java runtime
+zookeeper:arm64-osx=fail
+zookeeper:arm64-uwp=fail
+zookeeper:arm64-windows-static-md=fail
+zookeeper:arm64-windows=fail
+zookeeper:x64-linux=fail
+zookeeper:x64-osx=fail
+zookeeper:x64-uwp=fail
+zookeeper:x64-windows-release=fail
+zookeeper:x64-windows-static-md=fail
+zookeeper:x64-windows-static=fail
+zookeeper:x64-windows=fail
+zookeeper:x86-windows=fail
 zyre:arm64-windows-static-md=fail
 zyre:x64-windows-static-md=fail
 
@@ -1312,3 +1325,6 @@ vcpkg-ci-wxwidgets:x64-windows-static-md=pass
 vcpkg-ci-wxwidgets:x64-windows-static=pass
 vcpkg-ci-wxwidgets:x64-windows=pass
 vcpkg-ci-wxwidgets:x86-windows=pass
+zookeeper:arm-neon-android=pass
+zookeeper:arm64-android=pass
+zookeeper:x64-android=pass

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -573,6 +573,19 @@ z3:arm-uwp=fail
 z3:x64-uwp=fail
 zeroc-ice(uwp)=fail # ZeroC doesn't provide ARM tagets in project files.
 zint:x64-osx=fail
+# Needs Java runtime
+zookeeper:arm64-osx=fail
+zookeeper:arm64-uwp=fail
+zookeeper:arm64-windows-static-md=fail
+zookeeper:arm64-windows=fail
+zookeeper:x64-linux=fail
+zookeeper:x64-osx=fail
+zookeeper:x64-uwp=fail
+zookeeper:x64-windows-release=fail
+zookeeper:x64-windows-static-md=fail
+zookeeper:x64-windows-static=fail
+zookeeper:x64-windows=fail
+zookeeper:x86-windows=fail
 zyre:x64-windows-static-md=fail
 
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10422,7 +10422,7 @@
     },
     "zkpp": {
       "baseline": "0.2.3",
-      "port-version": 3
+      "port-version": 4
     },
     "zlib": {
       "baseline": "1.3.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10441,8 +10441,8 @@
       "port-version": 0
     },
     "zookeeper": {
-      "baseline": "3.5.6",
-      "port-version": 1
+      "baseline": "3.9.4.0",
+      "port-version": 0
     },
     "zopfli": {
       "baseline": "1.0.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10441,7 +10441,7 @@
       "port-version": 0
     },
     "zookeeper": {
-      "baseline": "3.9.4.0",
+      "baseline": "3.8.4",
       "port-version": 0
     },
     "zopfli": {

--- a/versions/z-/zkpp.json
+++ b/versions/z-/zkpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce87f456b26d4e19568b3dcc97e2862e2ee796d8",
+      "version": "0.2.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "4d52d577d20e234d6076c5d3b768849c0279fa54",
       "version": "0.2.3",
       "port-version": 3

--- a/versions/z-/zookeeper.json
+++ b/versions/z-/zookeeper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e05e475f4bff9321f648b3600a601a3853b25c7",
+      "version": "3.9.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cddd556547f1e8fef18c115b551f0ba9b5428def",
       "version": "3.5.6",
       "port-version": 1

--- a/versions/z-/zookeeper.json
+++ b/versions/z-/zookeeper.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "9e05e475f4bff9321f648b3600a601a3853b25c7",
-      "version": "3.9.4.0",
+      "git-tree": "4ccb6991bb5bf41c030df4c0e6b371e3d2fd6136",
+      "version": "3.8.4",
       "port-version": 0
     },
     {


### PR DESCRIPTION
This port was outdated. 3.8.4 is the recommended stable release on https://dlcdn.apache.org/zookeeper/ and has no CVE documented on repology.org.
Updating despite the following limitations:

 - Upstream expects building everything of zookeeper with maven, and they generate some C sources during the build. We don't have maven available, and without maven we can't easily boostrap the generator which is written in Java.
   Mitigated by downloading a release tarball which contains a precompiled JAR featuring the generator.
 - The release tarball are only avaiblable for one patch release of a given minor version. (Cf. https://dlcdn.apache.org/zookeeper/.) The port cannot be built without the cached asset once upstream updates the tarball. But this is known from some other ports (e.g. live555).
 - Most CI images do not have Java, so it is only tested on Android in current CI. 

Adding an openssl feature for security.

Making the sync feature non-default.

Upstream zookeeper-cpp aka port zkpp hasn't been updated in four years. The release is six years old. Applying only minimal maintenance.
