### PR TITLE
lief: update to 0.16.6

### DIFF
--- a/ports/lief/fix-vcpkg-includes.patch
+++ b/ports/lief/fix-vcpkg-includes.patch
@@ -24,19 +24,6 @@ index 8cbe7b2..994e9bf 100644
  
  
  #include "LIEF/PE/Builder.hpp"
-diff --git a/src/logging.cpp b/src/logging.cpp
-index 39936fe..f5e1345 100644
---- a/src/logging.cpp
-+++ b/src/logging.cpp
-@@ -20,7 +20,7 @@
- #include "logging.hpp"
- 
- #include "spdlog/spdlog.h"
--#include "spdlog/fmt/bundled/args.h"
-+#include <fmt/args.h>
- #include "spdlog/sinks/stdout_color_sinks.h"
- #include "spdlog/sinks/basic_file_sink.h"
- #include "spdlog/sinks/android_sink.h"
 diff --git a/src/utils.cpp b/src/utils.cpp
 index 0acbba1..b624a1d 100644
 --- a/src/utils.cpp

--- a/ports/lief/include-json.patch
+++ b/ports/lief/include-json.patch
@@ -1,0 +1,12 @@
+diff --git a/src/json_api.cpp b/src/json_api.cpp
+index e586ebb..8bab796 100644
+--- a/src/json_api.cpp
++++ b/src/json_api.cpp
+@@ -18,6 +18,7 @@
+ #include "LIEF/json.hpp"
+ 
+ #if defined(LIEF_JSON_SUPPORT)
++  #include "visitors/json.hpp"
+   #if defined(LIEF_PE_SUPPORT)
+     #include "PE/json_internal.hpp"
+   #endif

--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         fix-cmakelists.patch
         fix-liefconfig-cmake-in.patch
         fix-vcpkg-includes.patch
+        include-json.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/third-party")

--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lief-project/LIEF
     REF ${VERSION}
-    SHA512 776d26bc5d8ec7bca823d1c0fc821b0efc2411976901e1fca0ffecbc64591798e9e21a483c1637e9877bdd921dc463ffaef4eeb6a76d9dd8463c97c5f50834d4
+    SHA512 0e50fb5aba2d6cdf2eb653dd52d5f237a065d9f75c1b40e533bd14e300b7bb802f78308f4810b97efb87a40fc85626d7a2a2bd9ec557546c2ae98f5107fdeab0
     HEAD_REF master
     PATCHES
         fix-cmakelists.patch

--- a/ports/lief/vcpkg.json
+++ b/ports/lief/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lief",
-  "version-semver": "0.16.1",
+  "version-semver": "0.16.6",
   "description": "LIEF - Library to Instrument Executable Formats",
   "homepage": "https://lief.quarkslab.com",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5709,7 +5709,7 @@
       "port-version": 0
     },
     "lief": {
-      "baseline": "0.16.1",
+      "baseline": "0.16.6",
       "port-version": 0
     },
     "lightgbm": {

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "91c922d7b022897370a9acf8213e7d2cb4795403",
+      "version-semver": "0.16.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "c93d7992ef9c457a2e320a5f10df9e1dfae1407d",
       "version-semver": "0.16.1",
       "port-version": 0

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "91c922d7b022897370a9acf8213e7d2cb4795403",
+      "git-tree": "aa233279308ba07ca6429913b677a51c41793342",
       "version-semver": "0.16.6",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.


