### PR TITLE
[fastcdr] update to v2.3.0

### DIFF
--- a/ports/fastcdr/portfile.cmake
+++ b/ports/fastcdr/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eProsima/Fast-CDR
     REF "v${VERSION}"
-    SHA512 93044a36bbef10fc5c52e9c1f86a73da022af1e10652db6e52ead0eea457d45cae5c456b276e034cfa8c2ff6bce41e52ca24031910a816d9871bf3e3c9d3a112
+    SHA512 9221820f4e503ddc083f3014abad99e018f7975592e6350fd4ecd8a881944342596f78dc88f1489a72d612e3050cbf70edf5aed69edc81f747faa35f7dee742a
     HEAD_REF master
     PATCHES
         pdb-file.patch

--- a/ports/fastcdr/vcpkg.json
+++ b/ports/fastcdr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastcdr",
-  "version-semver": "2.2.6",
+  "version-semver": "2.3.0",
   "description": "eProsima FastCDR is a C++ library that provides two serialization mechanisms. One is the standard CDR serialization mechanism, while the other is a faster implementation that modifies the standard.",
   "homepage": "https://github.com/eProsima/Fast-CDR",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2745,7 +2745,7 @@
       "port-version": 0
     },
     "fastcdr": {
-      "baseline": "2.2.6",
+      "baseline": "2.3.0",
       "port-version": 0
     },
     "fastcgi": {

--- a/versions/f-/fastcdr.json
+++ b/versions/f-/fastcdr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e6b7b4adc7d625ea1d5ea1263dda7e6d1b2ea2fa",
+      "version-semver": "2.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "42773e9d93aa714e419322815cf51d09e9237a18",
       "version-semver": "2.2.6",
       "port-version": 0


### PR DESCRIPTION
Fixes #45544 
Fixes #45779

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
