### PR TITLE
[hexl] update to 1.2.6

### DIFF
--- a/ports/hexl/portfile.cmake
+++ b/ports/hexl/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/hexl
     REF "v${VERSION}"
-    SHA512 1a5e42fdeac877f3b4ef87ab75ffa8280697e941d7a8f0f6dc8c5066f2dd405470530dfabdf12d846362bd3e7e6cd30fd1f11d8dd99bee5086d09371ba1da196
+    SHA512 11cfbfbea70d8bb70bb1d5c5d741c18ce87adc9d1904ca30f603cd878eb6b29be0eaf78ca76a05ed2bdacab0370f89494851309cff1e847488d28ca79b891bce
     HEAD_REF development
 )
 

--- a/ports/hexl/vcpkg.json
+++ b/ports/hexl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hexl",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Intel® HEXL is an open-source library which provides efficient implementations of integer arithmetic on Galois fields.",
   "homepage": "https://github.com/intel/hexl",
   "license": "Apache-2.0",

--- a/ports/hexl/vcpkg.json
+++ b/ports/hexl/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Intel® HEXL is an open-source library which provides efficient implementations of integer arithmetic on Galois fields.",
   "homepage": "https://github.com/intel/hexl",
   "license": "Apache-2.0",
-  "supports": "x64",
+  "supports": "x64 & !android",
   "dependencies": [
     "cpu-features",
     "easyloggingpp",

--- a/ports/hexl/vcpkg.json
+++ b/ports/hexl/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Intel® HEXL is an open-source library which provides efficient implementations of integer arithmetic on Galois fields.",
   "homepage": "https://github.com/intel/hexl",
   "license": "Apache-2.0",
-  "supports": "x64 & !android",
+  "supports": "x64",
   "dependencies": [
     "cpu-features",
     "easyloggingpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3633,7 +3633,7 @@
       "port-version": 0
     },
     "hexl": {
-      "baseline": "1.2.5",
+      "baseline": "1.2.6",
       "port-version": 0
     },
     "hffix": {

--- a/versions/h-/hexl.json
+++ b/versions/h-/hexl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "62863dbb94934895550cdb94dd278ac8d3577e51",
+      "git-tree": "c839f66be35d04f72df40d47e310c2318bdb7623",
       "version": "1.2.6",
       "port-version": 0
     },

--- a/versions/h-/hexl.json
+++ b/versions/h-/hexl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c839f66be35d04f72df40d47e310c2318bdb7623",
+      "git-tree": "62863dbb94934895550cdb94dd278ac8d3577e51",
       "version": "1.2.6",
       "port-version": 0
     },

--- a/versions/h-/hexl.json
+++ b/versions/h-/hexl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c839f66be35d04f72df40d47e310c2318bdb7623",
+      "version": "1.2.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "507c302772e728f454519b1c7eb2740414b11386",
       "version": "1.2.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/IntelLabs/hexl/releases/tag/v1.2.6
