### PR TITLE
[calceph] update to version 4.0.5

### DIFF
--- a/ports/calceph/portfile.cmake
+++ b/ports/calceph/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-${VERSION}.tar.gz"
     FILENAME "calceph-${VERSION}.tar.gz"
-    SHA512 81cddae9fa0d06758dbbb5fae486bd64eb087dc2ebf2d7b17fa89b6689b86e0e84d1412e6852e980ebed00a4c84a3b1b4ac00b89021f6d0bb2f370a98a6dad25
+    SHA512 d3f17a302dafee243a3c7698dd5b7e67550ba070cd3217c399e2cee5f90486d2be394ddcfe6dcc1b72f980e212d19bda50c4057fca05b032f6558794f191935a
 )
 
 vcpkg_extract_source_archive(

--- a/ports/calceph/vcpkg.json
+++ b/ports/calceph/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "calceph",
-  "version": "4.0.4",
-  "port-version": 1,
+  "version": "4.0.5",
   "description": "C library to access the binary planetary ephemeris files.",
   "homepage": "https://www.imcce.fr/inpop/calceph/",
   "documentation": "https://calceph.imcce.fr/docs/latest/html/c/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1529,8 +1529,8 @@
       "port-version": 0
     },
     "calceph": {
-      "baseline": "4.0.4",
-      "port-version": 1
+      "baseline": "4.0.5",
+      "port-version": 0
     },
     "camport3": {
       "baseline": "1.6.2",

--- a/versions/c-/calceph.json
+++ b/versions/c-/calceph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae8ec7f572521c80b20f83cc1af30788205fa320",
+      "version": "4.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "ddfc19ed3c74649c11532a77211a3fe38c199365",
       "version": "4.0.4",
       "port-version": 1


### PR DESCRIPTION

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
