### PR TITLE
[rnnoise] add new port

### DIFF
--- a/ports/rnnoise/portfile.cmake
+++ b/ports/rnnoise/portfile.cmake
@@ -1,0 +1,35 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO xiph/rnnoise
+    REF "v${VERSION}"
+    SHA512 0f7de78494e0f2421c09871e9328437b64d021fd046c2198b836e84028995b43a56d113fb5ebc0bd76c1cb308a9cc53f67d6de5c1f67281248af492eab534bbc
+    HEAD_REF main
+)
+
+vcpkg_download_distfile(
+    MODEL_PATH
+    URLS https://media.xiph.org/rnnoise/models/rnnoise_data-0a8755f8e2d834eff6a54714ecc7d75f9932e845df35f8b59bc52a7cfe6e8b37.tar.gz
+    FILENAME rnnoise_data-0a8755f8e2d834eff6a54714ecc7d75f9932e845df35f8b59bc52a7cfe6e8b37.tar.gz
+    SHA512 b327d2fc5095be9ed66c5246a86b1a1ce180e9de875c4e5e8778f975560d1f035da40a8686dc1c3fd91c8e709be65d2638eccaa9f866b6f3d85f8d0d16bd2184
+)
+
+vcpkg_extract_archive(
+    ARCHIVE "${MODEL_PATH}"
+    DESTINATION "${SOURCE_PATH}/modeldata"
+)
+file(COPY "${SOURCE_PATH}/modeldata/src/rnnoise_data.c" DESTINATION "${SOURCE_PATH}/src/")
+file(COPY "${SOURCE_PATH}/modeldata/src/rnnoise_data.h" DESTINATION "${SOURCE_PATH}/src/")
+file(COPY "${SOURCE_PATH}/modeldata/src/rnnoise_data_little.c" DESTINATION "${SOURCE_PATH}/src/")
+file(COPY "${SOURCE_PATH}/modeldata/src/rnnoise_data_little.h" DESTINATION "${SOURCE_PATH}/src/")
+file(COPY "${SOURCE_PATH}/modeldata/models/rnnoise10Ga_12.pth" DESTINATION "${SOURCE_PATH}/models/")
+file(COPY "${SOURCE_PATH}/modeldata/models/rnnoise10Gb_15.pth" DESTINATION "${SOURCE_PATH}/models/")
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+)
+
+vcpkg_make_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/rnnoise/portfile.cmake
+++ b/ports/rnnoise/portfile.cmake
@@ -31,5 +31,8 @@ vcpkg_make_configure(
 
 vcpkg_make_install()
 
+vcpkg_fixup_pkgconfig()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/rnnoise/vcpkg.json
+++ b/ports/rnnoise/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "rnnoise",
   "version": "0.2",
   "description": "Recurrent neural network for audio noise reduction",
-  "license": "BSD-3-Clause",
+  "license": "BSD-3-Clause AND CC0-1.0",
   "supports": "!windows & !arm",
   "dependencies": [
     {

--- a/ports/rnnoise/vcpkg.json
+++ b/ports/rnnoise/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "0.2",
   "description": "Recurrent neural network for audio noise reduction",
   "license": "BSD-3-Clause",
-  "supports": "!windows",
+  "supports": "!windows & !arm",
   "dependencies": [
     {
       "name": "vcpkg-make",

--- a/ports/rnnoise/vcpkg.json
+++ b/ports/rnnoise/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "rnnoise",
+  "version": "0.2",
+  "description": "Recurrent neural network for audio noise reduction",
+  "license": "BSD-3-Clause",
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}

--- a/ports/rnnoise/vcpkg.json
+++ b/ports/rnnoise/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "0.2",
   "description": "Recurrent neural network for audio noise reduction",
   "license": "BSD-3-Clause",
-  "supports": "linux",
+  "supports": "!windows",
   "dependencies": [
     {
       "name": "vcpkg-make",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8268,6 +8268,10 @@
       "baseline": "1.0.0",
       "port-version": 2
     },
+    "rnnoise": {
+      "baseline": "0.2",
+      "port-version": 0
+    },
     "roaring": {
       "baseline": "4.3.2",
       "port-version": 0

--- a/versions/r-/rnnoise.json
+++ b/versions/r-/rnnoise.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7d56aea1d7d2e92ad84975280217155032cea85b",
+      "git-tree": "5c128ff85a49eae57b76ea255258c9931ef3e425",
       "version": "0.2",
       "port-version": 0
     }

--- a/versions/r-/rnnoise.json
+++ b/versions/r-/rnnoise.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c74bb5f01ece66efcf08a996b4f4a134a0ec17d1",
+      "git-tree": "fa7f8fa88d5b38da496c4472d6f8386ef90bf5bf",
       "version": "0.2",
       "port-version": 0
     }

--- a/versions/r-/rnnoise.json
+++ b/versions/r-/rnnoise.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c74bb5f01ece66efcf08a996b4f4a134a0ec17d1",
+      "version": "0.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/r-/rnnoise.json
+++ b/versions/r-/rnnoise.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fa7f8fa88d5b38da496c4472d6f8386ef90bf5bf",
+      "git-tree": "7d56aea1d7d2e92ad84975280217155032cea85b",
       "version": "0.2",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.