### PR TITLE
[ppqsort] add new port

### DIFF
--- a/ports/ppqsort/portfile.cmake
+++ b/ports/ppqsort/portfile.cmake
@@ -1,0 +1,40 @@
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO GabTux/PPQSort
+    REF "v${VERSION}"
+    SHA512 404621a489cc530170196dca317cabf35ecb2f93e10465474a5af1a4e79352433ca57711236f1cc08a359ae40294d9dd62feed42ec1f6890fa5139473997c29c
+    HEAD_REF master
+    PATCHES
+        remove-cpm.patch
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH PACKAGE_PROJECT_PATH
+    REPO TheLartians/PackageProject.cmake
+    REF "v1.11.1"
+    SHA512 cffd7b203c54f325b4604b909678425e0f63bed3f9d4fb5478b1eb885b532e682d3972595d0909ea2feb1aadd73736bd282931fa62fa47af27affb6b3f17a304
+    HEAD_REF master
+)
+file(RENAME "${PACKAGE_PROJECT_PATH}" "${SOURCE_PATH}/cmake/packageproject.cmake")
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        openmp PPQSORT_USE_OPENMP 
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/PPQSort-${VERSION}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ppqsort/remove-cpm.patch
+++ b/ports/ppqsort/remove-cpm.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ef7ff7a..d219662 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,10 +22,8 @@ endif()
+ # ---- Add dependencies via CPM ----
+ # see https://github.com/TheLartians/CPM.cmake for more info
+ 
+-include(cmake/CPM.cmake)
+-
+ # PackageProject.cmake will be used to make our target installable
+-CPMAddPackage("gh:TheLartians/PackageProject.cmake@1.11.1")
++add_subdirectory(cmake/packageproject.cmake)
+ 
+ # ---- Add source files ----
+ 

--- a/ports/ppqsort/vcpkg.json
+++ b/ports/ppqsort/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "ppqsort",
+  "version": "1.0.5",
+  "description": "a efficient implementation of parallel quicksort algorithm",
+  "homepage": "https://gabtux.github.io/PPQSort/",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "openmp": {
+      "description": "Build with openmp, otherwise use native threads"
+    }
+  }
+}

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -2189,6 +2189,7 @@ openvdb[ax] = feature-fails # ax requires llvm version <= 14. Work when using a 
 osgearth[tools](osx) = feature-fails # Undefined _NSSearchPathForDirectoriesInDomains
 pangolin[core,eigen,examples,ffmpeg,gui,jpeg,lz4,module,openexr,png,pybind11,realsense,test,tiff,tools,vars,video,zstd](!(arm & windows)) = combination-fails # see https://github.com/microsoft/vcpkg/issues/31304
 poco[core,mariadb,mysql] = options # You can not install mariadb and mysql at the same time
+ppqsort[openmp](osx) = feature-fails # No openmp on osx
 qt3d[animation] = options # is a requirement, see https://github.com/microsoft/vcpkg/issues/31336
 qt3d[extras] = options # is a requirement, see https://github.com/microsoft/vcpkg/issues/31336
 qt5compat[iconv](!uwp) = feature-fails # requires qtbase without icu

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7432,6 +7432,10 @@
       "baseline": "2020-07-03",
       "port-version": 2
     },
+    "ppqsort": {
+      "baseline": "1.0.5",
+      "port-version": 0
+    },
     "pprint": {
       "baseline": "2019-07-19",
       "port-version": 3

--- a/versions/p-/ppqsort.json
+++ b/versions/p-/ppqsort.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a61c8f3a9114caf6eff79a4304f382557e331d67",
+      "version": "1.0.5",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/GabTux/PPQSort/

PPQsort requires tracy/1.12.0. [ref](https://github.com/microsoft/vcpkg/pull/45820)
