### PR TITLE
[robin-hood-hashing] Add MIT license

### DIFF
--- a/ports/robin-hood-hashing/vcpkg.json
+++ b/ports/robin-hood-hashing/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "robin-hood-hashing",
   "version": "3.11.5",
+  "port-version": 1,
   "description": "Fast & memory efficient hashtable based on robin hood hashing for C++11/14/17/20",
   "homepage": "https://github.com/martinus/robin-hood-hashing",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8290,7 +8290,7 @@
     },
     "robin-hood-hashing": {
       "baseline": "3.11.5",
-      "port-version": 0
+      "port-version": 1
     },
     "robin-map": {
       "baseline": "1.4.0",

--- a/versions/r-/robin-hood-hashing.json
+++ b/versions/r-/robin-hood-hashing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "25ce100807060e0a7cf0c0f8f0bed52bca9a4ea8",
+      "version": "3.11.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "79b90adbe2f012facdd920fdb6454bc21c84399e",
       "version": "3.11.5",
       "port-version": 0


### PR DESCRIPTION
Minor change but as the library is deprecated no new real versions are expected. Tools using the license feature of vcpkg with this minor port update will not complain about license info missing.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.