### PR TITLE
[ztd-static-containers] Update hash

### DIFF
--- a/ports/ztd-static-containers/portfile.cmake
+++ b/ports/ztd-static-containers/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO soasis/static_containers
     REF e1a21217b6dba3028e6cc6bf0f9562972ea1c43d
-    SHA512 ec5b98e2282e72eb09617006afaf2522a471b6eb3928c90fb878c46b7453bb94ddafb19cb4738c5561905003d299bb23d15ebf71c555259b5e500594fbadd97f
+    SHA512 b108b1e206854ddb4ceed9780c89c8db717c87bd010ee5ff1f176b79a26192dcc46a68b3d9b254b469f3869ec46738c0aabb0ccf0621444bb50bee306bdbe2fc
     HEAD_REF main
     PATCHES fix-cmake.patch
 )

--- a/ports/ztd-static-containers/vcpkg.json
+++ b/ports/ztd-static-containers/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ztd-static-containers",
   "version-date": "2022-12-12",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Containers of fixed capacity",
   "homepage": "https://github.com/soasis/static_containers",
   "license": "CC0-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10486,7 +10486,7 @@
     },
     "ztd-static-containers": {
       "baseline": "2022-12-12",
-      "port-version": 1
+      "port-version": 2
     },
     "ztd-text": {
       "baseline": "2023-11-03",

--- a/versions/z-/ztd-static-containers.json
+++ b/versions/z-/ztd-static-containers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "956d123fc74f3b0661c3475de07e832f1aaf077e",
+      "version-date": "2022-12-12",
+      "port-version": 2
+    },
+    {
       "git-tree": "9178972642436ec0fdba9274b7107314d09df794",
       "version-date": "2022-12-12",
       "port-version": 1


### PR DESCRIPTION
Fixes #45846

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
