### PR TITLE
[simd] update to 6.1.150

### DIFF
--- a/ports/simd/portfile.cmake
+++ b/ports/simd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ermig1979/Simd
     REF "v${VERSION}"
-    SHA512 a60cc7d351cd43a89349412ebf9acd91ce6da45ef9294ea73636d2880c824e8e0edb0ed40db73a3d3672d6e2256286fc35aa6007d64848cf5a5eb3e95a789518
+    SHA512 834d5b8962cc14e6b1025defbc896967959045762b8688ece66f6f2afabfc166b8135837bc86106d61bcda74e90f71dc08ff2dc1198217ba3c97a4fa4665a346
     HEAD_REF master
     PATCHES
         fix-platform-detection.patch

--- a/ports/simd/vcpkg.json
+++ b/ports/simd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simd",
-  "version": "6.1.149",
+  "version": "6.1.150",
   "description": "Simd image processing and machine learning library, designed for C and C++ programmers",
   "homepage": "https://github.com/ermig1979/Simd",
   "license": "MIT",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -475,6 +475,7 @@ shiva-sfml:x64-windows=fail
 shiva-sfml:x86-windows=fail
 signalrclient:arm-uwp=fail
 simbody:arm64-windows=fail
+simd(android)=fail
 sleef:x86-windows=fail
 slikenet:arm-uwp=fail
 slikenet:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8701,7 +8701,7 @@
       "port-version": 1
     },
     "simd": {
-      "baseline": "6.1.149",
+      "baseline": "6.1.150",
       "port-version": 0
     },
     "simde": {

--- a/versions/s-/simd.json
+++ b/versions/s-/simd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6219876d59911c225b7150305bb64d6af85eeea5",
+      "version": "6.1.150",
+      "port-version": 0
+    },
+    {
       "git-tree": "403851cb105fb0e91b3b4ee1f196933941d3f036",
       "version": "6.1.149",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ermig1979/Simd/releases/tag/v6.1.150
