### PR TITLE
[lua] update to 5.4.8

### DIFF
--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.lua.org/ftp/lua-${VERSION}.tar.gz"
     FILENAME "lua-${VERSION}.tar.gz"
-    SHA512 98c5c8978dfdf867e37e9eb3b3ec83dee92d199243b5119505da83895e33f10d43c841be6a7d3b106daba8a0b2bd25fe099ebff8f87831dcc55c79c78b97d8b8
+    SHA512 875ad1f6df3ba63722b5069564c9d3a4057b4c3564c691061bb49cf6cdf5d2e303f05762bd46797b444aaf992c03021f423df142123eebf86751fd77edaf8060
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/lua/vcpkg.json
+++ b/ports/lua/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lua",
-  "version": "5.4.7",
+  "version": "5.4.8",
   "description": "A powerful, fast, lightweight, embeddable scripting language",
   "homepage": "https://www.lua.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5841,7 +5841,7 @@
       "port-version": 0
     },
     "lua": {
-      "baseline": "5.4.7",
+      "baseline": "5.4.8",
       "port-version": 0
     },
     "lua-compat53": {

--- a/versions/l-/lua.json
+++ b/versions/l-/lua.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "062ae235ae46d4bce8b00be2c74667e0763cc2c1",
+      "version": "5.4.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "97783a4c337df419c0a6a75e9599545c54259d86",
       "version": "5.4.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://www.lua.org/work/diffs-lua-5.4.7-lua-5.4.8.html