### PR TITLE
[voro] Add new port

### DIFF
--- a/ports/voro/portfile.cmake
+++ b/ports/voro/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO chr1shr/voro
+    REF "2cb6cefc690be1c653bfb8e65559ee8441c0b21f"
+    SHA512 a22dcdb26ef85a9c75757182f07c0c391b9904a1b46b03e8be27a16e475a24ec9fd736a3964fa6022dc5dd545691f498c69f284a260a5724a1715fd347006efb
+    HEAD_REF dev
+)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+    -DVORO_BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+    -DVORO_BUILD_EXAMPLES=OFF
+    -DVORO_BUILD_CMD_LINE=OFF
+    -DVORO_ENABLE_DOXYGEN=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "VORO" CONFIG_PATH "lib/cmake/VORO")
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/man")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/voro/portfile.cmake
+++ b/ports/voro/portfile.cmake
@@ -1,4 +1,6 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -7,16 +9,19 @@ vcpkg_from_github(
     SHA512 a22dcdb26ef85a9c75757182f07c0c391b9904a1b46b03e8be27a16e475a24ec9fd736a3964fa6022dc5dd545691f498c69f284a260a5724a1715fd347006efb
     HEAD_REF dev
 )
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" VORO_BUILD_SHARED_LIBS)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-    -DVORO_BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-    -DVORO_BUILD_EXAMPLES=OFF
-    -DVORO_BUILD_CMD_LINE=OFF
-    -DVORO_ENABLE_DOXYGEN=OFF
+        -DVORO_BUILD_SHARED_LIBS=${VORO_BUILD_SHARED_LIBS}
+        -DVORO_BUILD_EXAMPLES=OFF
+        -DVORO_BUILD_CMD_LINE=OFF
+        -DVORO_ENABLE_DOXYGEN=OFF
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME "VORO" CONFIG_PATH "lib/cmake/VORO")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/VORO")
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/voro/vcpkg.json
+++ b/ports/voro/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "voro",
+  "version-date": "2024-09-11",
+  "description": "Voro++: a three-dimensional Voronoi cell library in C++.",
+  "homepage": "https://math.lbl.gov/voro++/",
+  "license": "BSD-3-Clause-LBNL",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9916,6 +9916,10 @@
       "baseline": "1.4.304.1",
       "port-version": 0
     },
+    "voro": {
+      "baseline": "2024-09-11",
+      "port-version": 0
+    },
     "vowpal-wabbit": {
       "baseline": "9.10.0",
       "port-version": 2

--- a/versions/v-/voro.json
+++ b/versions/v-/voro.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f5a98525bdcc1ca9eea8cf8ccff302b3d7f6fe8b",
+      "git-tree": "66156fb0c6f6385196504f59682b1dde4de3d660",
       "version-date": "2024-09-11",
       "port-version": 0
     }

--- a/versions/v-/voro.json
+++ b/versions/v-/voro.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f5a98525bdcc1ca9eea8cf8ccff302b3d7f6fe8b",
+      "version-date": "2024-09-11",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

---
> The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.

That's a rough one. The website and effective target is `voro++`, but the repository of the owner is named `voro`, while repology returns matches with (from most to least) voro++, voropp, voroxx. For now I set it to the same as the owner's repository name, but advice would be appreciated since vcpkg does not accept `+` in port name.

---

> The versioning scheme in `vcpkg.json` matches what upstream says

Not really, the last tag is from 2013 and did not have a CMake file then, so I set it to the current latest commit on master (from 09-2024)
