### PR TITLE
[audiofile] update to 1.1.3

### DIFF
--- a/ports/audiofile/portfile.cmake
+++ b/ports/audiofile/portfile.cmake
@@ -1,10 +1,11 @@
 # header-only library
+set(VCPKG_BUILD_TYPE release)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO adamstark/AudioFile
     REF "${VERSION}"
-    SHA512 ee8af7687fe420634ea8dacef7ecc0c4d3dd1de13c6131202710b3055fdc5ffb27ac1e8ff034690a3ce5d512b6182a788adfa5852a29ac532a08322b14083e8a
+    SHA512 a6fa2a9d7d7cd9f7e0ba96d073af79479dc8893aab68b0bcc5602aff0250a9ea707cf375166f9dc6411072496ae597c5a93bb7cebe21b9b89a8995a6e092659f
     HEAD_REF master
 )
 

--- a/ports/audiofile/vcpkg.json
+++ b/ports/audiofile/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "audiofile",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A simple header-only C++ library for reading and writing audio files.",
   "homepage": "https://github.com/adamstark/AudioFile",
   "license": "MIT",

--- a/versions/a-/audiofile.json
+++ b/versions/a-/audiofile.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a145e7e2504e717f32b5e051d237e2695a906a7",
+      "version": "1.1.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "af5b6cc47eba8f3330b4769643ec814da3be5983",
       "version": "1.1.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -369,7 +369,7 @@
       "port-version": 0
     },
     "audiofile": {
-      "baseline": "1.1.2",
+      "baseline": "1.1.3",
       "port-version": 0
     },
     "audit": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/adamstark/AudioFile?tab=readme-ov-file#113---31st-may-2025
