### PR TITLE
[manifold] update to 3.1.1

### DIFF
--- a/ports/manifold/portfile.cmake
+++ b/ports/manifold/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO elalish/manifold
     REF v${VERSION}
-    SHA512 58713ada383e87ee3bd518ffff2c0b048da684aec3442d2b1185dfa69f9e578985e6084eef00f3a2bc52d3ddf6a6d914c6e3cd5517a5b2ea1f4a12e5adb84870
+    SHA512 920e34f1cc5a34e8081d61a7c362cebca204f5adb8e8862b5f0f1e3fc28be4a3b0511fd84d8a6da486c1ff0696206a6c2f75f3f53d61a35a29f7564ece62717e
 )
 
 vcpkg_cmake_configure(

--- a/ports/manifold/vcpkg.json
+++ b/ports/manifold/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "manifold",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Geometry library for topological robustness.",
   "homepage": "https://github.com/elalish/manifold",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5965,7 +5965,7 @@
       "port-version": 0
     },
     "manifold": {
-      "baseline": "3.1.0",
+      "baseline": "3.1.1",
       "port-version": 0
     },
     "mapbox-geojson-cpp": {

--- a/versions/m-/manifold.json
+++ b/versions/m-/manifold.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d90185c8a01c5e020ea500cb0859004df5d1ed2",
+      "version": "3.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e868ce7f27a6cd67a20c56931594479cb9a2a84f",
       "version": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/elalish/manifold/releases/tag/v3.1.1
