### PR TITLE
[clipper2] update to 1.5.4

### DIFF
--- a/ports/clipper2/portfile.cmake
+++ b/ports/clipper2/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AngusJohnson/Clipper2
     REF "Clipper2_${VERSION}"
-    SHA512 a56f1bf28a9baf8cbcf42d63e4c73f8b4a01eac9edfb59dafb752f67af7873bb46a256fc26f7bb839ee7051db69efb9a1c21c54b358cf55c84c4b137f7f2d804
+    SHA512 39153f35630ddc455ad4955a8b9b35f05bf3fad2a33c6e7232300b674a5172794a57c7bd18f96dd0a90d4607a44ecb32c92b0cacc7060d840d568032efaddf19
     HEAD_REF main
 )
 

--- a/ports/clipper2/vcpkg.json
+++ b/ports/clipper2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "clipper2",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Polygon Clipping and Offsetting",
   "homepage": "http://www.angusj.com/clipper2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1765,7 +1765,7 @@
       "port-version": 2
     },
     "clipper2": {
-      "baseline": "1.5.3",
+      "baseline": "1.5.4",
       "port-version": 0
     },
     "clockutils": {

--- a/versions/c-/clipper2.json
+++ b/versions/c-/clipper2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efcc6cdefc2176e0bdcc990d41d0d43601d20e20",
+      "version": "1.5.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "e45ff52cd2f4a804672f9a7ef670232396a34dac",
       "version": "1.5.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/AngusJohnson/Clipper2/releases/tag/Clipper2_1.5.4
