### PR TITLE
[libunistd] New port

### DIFF
--- a/ports/libunistd/option-disble-subproject0.patch
+++ b/ports/libunistd/option-disble-subproject0.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b8be0bd..00dd987 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -40,11 +40,27 @@ if(NOT WIN32 AND NOT APPLE)
+ 	message("Linking rt pthread dl")
+ endif(NOT WIN32 AND NOT APPLE)
+ 
+-add_subdirectory(portable)
+-add_subdirectory(sqlite)
+-add_subdirectory(uuid)
+-add_subdirectory(regex)
+-add_subdirectory(xxhash)
++option(BUILD_PORTABLE "Build portable" ON)
++option(BUILD_SQLITE "Build sqlite" ON)
++option(BUILD_UUID "Build uuid" ON)
++option(BUILD_REGEX "Build regex" ON)
++option(BUILD_XXHASH "Build xxhash" ON)
++
++if (BUILD_PORTABLE)
++    add_subdirectory(portable)
++endif (BUILD_PORTABLE)
++if (BUILD_SQLITE)
++    add_subdirectory(sqlite)
++endif (BUILD_SQLITE)
++if (BUILD_UUID)
++    add_subdirectory(uuid)
++endif (BUILD_UUID)
++if (BUILD_REGEX)
++	add_subdirectory(regex)
++endif (BUILD_REGEX)
++if (BUILD_XXHASH)
++    add_subdirectory(xxhash)
++endif (BUILD_XXHASH)
+ if(WITH_TESTS)
+ add_subdirectory(test)
+ endif()

--- a/ports/libunistd/portfile.cmake
+++ b/ports/libunistd/portfile.cmake
@@ -1,10 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO            robinrowe/libunistd
+    REPO            SamuelMarks/libunistd
     REF             8ab9bd613b15302e767003ff1841acfad5d8ac97
     SHA512          802fde13d16ba17a221121fca3c63d2829b65f54a382428f385f273a5978162e61b412a872e1a3c2ddc69094fb23f39422e365357706ccd62b592fbb5da62ba2
-    HEAD_REF        master
-    PATCHES         option-disble-subproject0.patch
+    HEAD_REF        branch-opt
 )
 
 vcpkg_cmake_configure(

--- a/ports/libunistd/portfile.cmake
+++ b/ports/libunistd/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            robinrowe/libunistd
+    REF             8ab9bd613b15302e767003ff1841acfad5d8ac97
+    SHA512          802fde13d16ba17a221121fca3c63d2829b65f54a382428f385f273a5978162e61b412a872e1a3c2ddc69094fb23f39422e365357706ccd62b592fbb5da62ba2
+    HEAD_REF        master
+    PATCHES         option-disble-subproject0.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DWITH_TESTS=OFF
+        -DBUILD_SQLITE=OFF
+        -DBUILD_UUID=OFF
+        -DBUILD_REGEX=OFF
+        -DBUILD_XXHASH=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libunistd/usage
+++ b/ports/libunistd/usage
@@ -1,0 +1,4 @@
+libunistd provides CMake targets:
+
+    find_package(libunistd CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE libunistd)

--- a/ports/libunistd/vcpkg.json
+++ b/ports/libunistd/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libunistd",
+  "version-date": "2025-03-26",
+  "description": "lightweight Windows POSIX/Pthreads library implementation",
+  "homepage": "https://github.com/robinrowe/libunistd",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/libunistd/vcpkg.json
+++ b/ports/libunistd/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libunistd",
-  "version-date": "2025-03-26",
+  "version-date": "2025-06-09",
   "description": "lightweight Windows POSIX/Pthreads library implementation",
   "homepage": "https://github.com/robinrowe/libunistd",
   "license": "MIT",
+  "supports": "windows",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5456,6 +5456,10 @@
       "baseline": "0.4.0",
       "port-version": 0
     },
+    "libunistd": {
+      "baseline": "2025-03-26",
+      "port-version": 0
+    },
     "libunistring": {
       "baseline": "1.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5457,7 +5457,7 @@
       "port-version": 0
     },
     "libunistd": {
-      "baseline": "2025-03-26",
+      "baseline": "2025-06-09",
       "port-version": 0
     },
     "libunistring": {

--- a/versions/l-/libunistd.json
+++ b/versions/l-/libunistd.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f2ea7b140e9ddd8cea2ef977b2995dcd23562e90",
+      "version-date": "2025-03-26",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libunistd.json
+++ b/versions/l-/libunistd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ce9ace3bc4bd927ce2bb1c5e48dfcffddac3c6a",
+      "version-date": "2025-06-09",
+      "port-version": 0
+    },
+    {
       "git-tree": "f2ea7b140e9ddd8cea2ef977b2995dcd23562e90",
       "version-date": "2025-03-26",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


Windows only port. Just found this library that's been around for like, 23 years. https://github.com/robinrowe/libunistd

> Robin Rowe's libunistd is a lightweight Windows POSIX library that enables typical Linux C/C++ code to build in Windows Microsoft Visual Studio. If you're maintaining C++ code across Windows, Linux and MacOS you need a Windows POSIX library to make single codebase work. This is it.
>
> Libunistd supports all the common Linux POSIX calls, except fork(). Please don't fork. Use C++ standard threads or libunistd's POSIX pthreads instead.

Closes https://github.com/robinrowe/libunistd/issues/16

(WiP)