### PR TITLE
[opentelemetry-cpp-contrib-version] Update to 2025-05-21

### DIFF
--- a/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
@@ -4,9 +4,9 @@ function(clone_opentelemetry_cpp_contrib CONTRIB_SOURCE_PATH)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-telemetry/opentelemetry-cpp-contrib
-        REF dcff8837c588bbbb2ac8bc86842989e24a5eacff
+        REF bfbaf5e529b6c8a661971b6cc94fb09cf5cd148a
         HEAD_REF main
-        SHA512 506c9177c757ff7b832972bae4c822315d59991ae104e876104d4a06c238dde935b4bbef59b62c6fada220fcdf8c5315aa3dbecd62888b41d8d2f3e0730fdba8
+        SHA512 cdf550ad1d3c3dcae33f70a4747cd30d961f7b66a5ce1897aa6f6ab9cbc3a0e6ad46e134d8f32bc185c7bf4414b6aa6981cbd391336597cff03e2aeb4d1bb4d1
     )
     set(${CONTRIB_SOURCE_PATH} ${SOURCE_PATH} CACHE INTERNAL "")
 endfunction()

--- a/ports/opentelemetry-cpp-contrib-version/vcpkg.json
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp-contrib-version",
-  "version-date": "2025-05-12",
+  "version-date": "2025-05-21",
   "description": "This port manages the opentelemetry-cpp-version that will be used for opentelemetry-cpp",
   "homepage": "https://github.com/open-telemetry/opentelemetry-cpp-contrib",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7001,7 +7001,7 @@
       "port-version": 0
     },
     "opentelemetry-cpp-contrib-version": {
-      "baseline": "2025-05-12",
+      "baseline": "2025-05-21",
       "port-version": 0
     },
     "opentracing": {

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b5df75cfed7282f4c5170c38ec781f51823329fd",
+      "version-date": "2025-05-21",
+      "port-version": 0
+    },
+    {
       "git-tree": "075bc94351e727fb66b1b5fb920dddb4850b7a64",
       "version-date": "2025-05-12",
       "port-version": 0

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b5df75cfed7282f4c5170c38ec781f51823329fd",
+      "git-tree": "bf931db359775a6acff47624872daa8195cee8f4",
       "version-date": "2025-05-21",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
