### PR TITLE
[assimp] update to 6.0.2

### DIFF
--- a/ports/assimp/build_fixes.patch
+++ b/ports/assimp/build_fixes.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d45eb22..0b5da28 100644
+index cd8f515..da59d84 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -307,7 +307,6 @@ ELSEIF(MSVC)
+@@ -343,7 +343,6 @@ ELSEIF(MSVC)
    ENDIF()
    # supress warning for double to float conversion if Double precision is activated
    ADD_COMPILE_OPTIONS(/wd4244)
@@ -10,7 +10,7 @@ index d45eb22..0b5da28 100644
    # Allow user to disable PDBs
    if(ASSIMP_INSTALL_PDB)
      SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
-@@ -315,7 +314,7 @@ ELSEIF(MSVC)
+@@ -351,7 +350,7 @@ ELSEIF(MSVC)
    elseif((GENERATOR_IS_MULTI_CONFIG) OR (CMAKE_BUILD_TYPE MATCHES Release))
      message("-- MSVC PDB generation disabled. Release binary will not be debuggable.")
    endif()
@@ -19,25 +19,25 @@ index d45eb22..0b5da28 100644
      # Source code is encoded in UTF-8
      ADD_COMPILE_OPTIONS(/source-charset:utf-8)
    endif ()
-@@ -444,7 +442,7 @@ ENDIF()
+@@ -483,7 +482,7 @@ ENDIF()
  
  set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
  
 -IF(ASSIMP_HUNTER_ENABLED)
 +IF(0)
-   set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
-   set(CMAKE_CONFIG_TEMPLATE_FILE "cmake-modules/assimp-hunter-config.cmake.in")
-   set(NAMESPACE "${PROJECT_NAME}::")
-@@ -452,7 +450,7 @@ IF(ASSIMP_HUNTER_ENABLED)
-   set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
-   set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
+   SET(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
+   SET(CMAKE_CONFIG_TEMPLATE_FILE "cmake-modules/assimp-hunter-config.cmake.in")
+   SET(NAMESPACE "${PROJECT_NAME}::")
+@@ -491,7 +490,7 @@ IF(ASSIMP_HUNTER_ENABLED)
+   SET(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+   SET(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
  ELSE()
--  set(CONFIG_INSTALL_DIR "${ASSIMP_LIB_INSTALL_DIR}/cmake/assimp-${ASSIMP_VERSION_MAJOR}.${ASSIMP_VERSION_MINOR}")
+-  SET(CONFIG_INSTALL_DIR "${ASSIMP_LIB_INSTALL_DIR}/cmake/assimp-${ASSIMP_VERSION_MAJOR}.${ASSIMP_VERSION_MINOR}")
 +  set(CONFIG_INSTALL_DIR "${ASSIMP_LIB_INSTALL_DIR}/cmake/assimp")
-   set(CMAKE_CONFIG_TEMPLATE_FILE "cmake-modules/assimp-plain-config.cmake.in")
+   SET(CMAKE_CONFIG_TEMPLATE_FILE "cmake-modules/assimp-plain-config.cmake.in")
    string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWERCASE)
-   set(NAMESPACE "${PROJECT_NAME_LOWERCASE}::")
-@@ -502,7 +502,7 @@
+   SET(NAMESPACE "${PROJECT_NAME_LOWERCASE}::")
+@@ -506,7 +505,7 @@ set(INCLUDE_INSTALL_DIR "include")
  include(CMakePackageConfigHelpers)
  
  # Note: PROJECT_VERSION is used as a VERSION
@@ -46,7 +46,7 @@ index d45eb22..0b5da28 100644
  
  configure_package_config_file(
      ${CMAKE_CONFIG_TEMPLATE_FILE}
-@@ -496,14 +494,13 @@ ENDIF()
+@@ -535,14 +534,13 @@ ENDIF()
  
  # Search for external dependencies, and build them from source if not found
  # Search for zlib
@@ -57,15 +57,15 @@ index d45eb22..0b5da28 100644
 +  find_package(ZLIB REQUIRED)
  
    add_definitions(-DASSIMP_BUILD_NO_OWN_ZLIB)
-   set(ZLIB_FOUND TRUE)
--  set(ZLIB_LIBRARIES ZLIB::zlib)
--  set(ASSIMP_BUILD_MINIZIP TRUE)
+   SET(ZLIB_FOUND TRUE)
+-  SET(ZLIB_LIBRARIES ZLIB::zlib)
+-  SET(ASSIMP_BUILD_MINIZIP TRUE)
 +  set(ZLIB_LIBRARIES ZLIB::ZLIB)
 +  set(ASSIMP_BUILD_MINIZIP OFF)
  ELSE()
    # If the zlib is already found outside, add an export in case assimpTargets can't find it.
    IF( ZLIB_FOUND AND ASSIMP_INSTALL)
-@@ -547,13 +544,13 @@ ELSE()
+@@ -586,13 +584,13 @@ ELSE()
    INCLUDE_DIRECTORIES(${ZLIB_INCLUDE_DIR})
  ENDIF()
  
@@ -78,16 +78,15 @@ index d45eb22..0b5da28 100644
    IF( NOT BUILD_SHARED_LIBS )
 -    IF( NOT ASSIMP_BUILD_MINIZIP )
 +    IF( 0 )
-       use_pkgconfig(UNZIP minizip)
+       USE_PKGCONFIG(UNZIP minizip)
      ENDIF()
    ENDIF ()
 diff --git a/cmake-modules/assimp-plain-config.cmake.in b/cmake-modules/assimp-plain-config.cmake.in
-index 6551dcb..3064f70 100644
+index 6551dcb..718ac04 100644
 --- a/cmake-modules/assimp-plain-config.cmake.in
 +++ b/cmake-modules/assimp-plain-config.cmake.in
-@@ -1,5 +1,19 @@
+@@ -1,4 +1,17 @@
  @PACKAGE_INIT@
- 
 +include(CMakeFindDependencyMacro)
 +
 +if(NOT @BUILD_SHARED_LIBS@)
@@ -101,12 +100,11 @@ index 6551dcb..3064f70 100644
 +    find_dependency(utf8cpp CONFIG)
 +    find_dependency(ZLIB)
 +endif()
-+
+ 
  include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
  
- set(ASSIMP_ROOT_DIR ${PACKAGE_PREFIX_DIR})
 diff --git a/code/AssetLib/3MF/D3MFExporter.cpp b/code/AssetLib/3MF/D3MFExporter.cpp
-index 6c09f09..7b3410a 100644
+index 64b94e5..5951279 100644
 --- a/code/AssetLib/3MF/D3MFExporter.cpp
 +++ b/code/AssetLib/3MF/D3MFExporter.cpp
 @@ -57,7 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -119,7 +117,7 @@ index 6c09f09..7b3410a 100644
  
  namespace Assimp {
 diff --git a/code/AssetLib/Blender/BlenderTessellator.h b/code/AssetLib/Blender/BlenderTessellator.h
-index e43535f..a0104c1 100644
+index d6487cb..b56e271 100644
 --- a/code/AssetLib/Blender/BlenderTessellator.h
 +++ b/code/AssetLib/Blender/BlenderTessellator.h
 @@ -143,7 +143,7 @@ namespace Assimp
@@ -132,7 +130,7 @@ index e43535f..a0104c1 100644
  namespace Assimp
  {
 diff --git a/code/AssetLib/IFC/IFCGeometry.cpp b/code/AssetLib/IFC/IFCGeometry.cpp
-index d488b23..1a6c0c7 100644
+index d3666d5..795f366 100644
 --- a/code/AssetLib/IFC/IFCGeometry.cpp
 +++ b/code/AssetLib/IFC/IFCGeometry.cpp
 @@ -45,8 +45,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -146,21 +144,8 @@ index d488b23..1a6c0c7 100644
  
  #include <iterator>
  #include <memory>
-diff --git a/code/AssetLib/IFC/IFCLoader.cpp b/code/AssetLib/IFC/IFCLoader.cpp
-index 13ea2d4..aeeb311 100644
---- a/code/AssetLib/IFC/IFCLoader.cpp
-+++ b/code/AssetLib/IFC/IFCLoader.cpp
-@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- #ifdef ASSIMP_USE_HUNTER
- #include <minizip/unzip.h>
- #else
--#include <unzip.h>
-+#include <minizip/unzip.h>
- #endif
- #endif
- 
 diff --git a/code/AssetLib/IFC/IFCOpenings.cpp b/code/AssetLib/IFC/IFCOpenings.cpp
-index 1d37dd8..eadbc86 100644
+index 068ef40..be116f8 100644
 --- a/code/AssetLib/IFC/IFCOpenings.cpp
 +++ b/code/AssetLib/IFC/IFCOpenings.cpp
 @@ -47,8 +47,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -175,10 +160,10 @@ index 1d37dd8..eadbc86 100644
  #include <deque>
  #include <forward_list>
 diff --git a/code/AssetLib/MMD/MMDPmxParser.cpp b/code/AssetLib/MMD/MMDPmxParser.cpp
-index 5a3e61d..e444dc8 100644
+index 73d6b6c..27ebcd9 100644
 --- a/code/AssetLib/MMD/MMDPmxParser.cpp
 +++ b/code/AssetLib/MMD/MMDPmxParser.cpp
-@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  #include <utility>
  #include "MMDPmxParser.h"
  #include <assimp/StringUtils.h>
@@ -188,7 +173,7 @@ index 5a3e61d..e444dc8 100644
  
  namespace pmx
 diff --git a/code/AssetLib/SIB/SIBImporter.cpp b/code/AssetLib/SIB/SIBImporter.cpp
-index e55e675..fb1a12b 100644
+index 8e05846..dee6a5a 100644
 --- a/code/AssetLib/SIB/SIBImporter.cpp
 +++ b/code/AssetLib/SIB/SIBImporter.cpp
 @@ -56,7 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -201,10 +186,10 @@ index e55e675..fb1a12b 100644
  #include <assimp/scene.h>
  #include <assimp/DefaultLogger.hpp>
 diff --git a/code/AssetLib/STEPParser/STEPFileEncoding.cpp b/code/AssetLib/STEPParser/STEPFileEncoding.cpp
-index d7f512c..94275f1 100644
+index 7508e90..4b85c68 100644
 --- a/code/AssetLib/STEPParser/STEPFileEncoding.cpp
 +++ b/code/AssetLib/STEPParser/STEPFileEncoding.cpp
-@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   */
  #include "STEPFileEncoding.h"
  #include <assimp/fast_atof.h>
@@ -214,28 +199,26 @@ index d7f512c..94275f1 100644
  #include <memory>
  
 diff --git a/code/CMakeLists.txt b/code/CMakeLists.txt
-index 9b27086..b7c2ccb 100644
+index 8728188..3d82854 100644
 --- a/code/CMakeLists.txt
 +++ b/code/CMakeLists.txt
-@@ -1050,8 +1050,8 @@ ELSE() # IF (ASSIMP_BUILD_USD_IMPORTER)
+@@ -1116,8 +1116,7 @@ ELSE() # IF (ASSIMP_BUILD_USD_IMPORTER)
  ENDIF() # IF (ASSIMP_BUILD_USD_IMPORTER)
  
  # pugixml
 -IF(ASSIMP_HUNTER_ENABLED)
 -  hunter_add_package(pugixml)
 +IF(1)
-+  #hunter_add_package(pugixml)
    find_package(pugixml CONFIG REQUIRED)
  ELSEIF(NOT TARGET pugixml::pugixml)
    SET( Pugixml_SRCS
-@@ -1063,30 +1063,30 @@ ELSE()
+@@ -1130,30 +1129,27 @@ ELSEIF(NOT TARGET pugixml::pugixml)
  ENDIF()
  
  # utf8
 -IF(ASSIMP_HUNTER_ENABLED)
 -  hunter_add_package(utf8)
 +IF(1)
-+  #hunter_add_package(utf8)
    find_package(utf8cpp CONFIG REQUIRED)
  ELSE()
    INCLUDE_DIRECTORIES("../contrib/utf8cpp/source")
@@ -243,10 +226,10 @@ index 9b27086..b7c2ccb 100644
  
  # polyclipping
 -#IF(ASSIMP_HUNTER_ENABLED)
-+IF(1)
- #  hunter_add_package(polyclipping)
+-#  hunter_add_package(polyclipping)
 -#  find_package(polyclipping CONFIG REQUIRED)
 -#ELSE()
++IF(1)
 +  find_package(polyclipping CONFIG REQUIRED)
 +ELSE()
    SET( Clipper_SRCS
@@ -259,16 +242,16 @@ index 9b27086..b7c2ccb 100644
  
  # poly2tri
 -#IF(ASSIMP_HUNTER_ENABLED)
-+IF(1)
- #  hunter_add_package(poly2tri)
+-#  hunter_add_package(poly2tri)
 -#  find_package(poly2tri CONFIG REQUIRED)
 -#ELSE()
++IF(1)
 +  find_package(poly2tri CONFIG REQUIRED)
 +ELSE()
    SET( Poly2Tri_SRCS
      ../contrib/poly2tri/poly2tri/common/shapes.cc
      ../contrib/poly2tri/poly2tri/common/shapes.h
-@@ -1101,12 +1101,12 @@ ENDIF()
+@@ -1168,11 +1164,10 @@ ENDIF()
      ../contrib/poly2tri/poly2tri/sweep/sweep_context.h
    )
    SOURCE_GROUP( Contrib\\Poly2Tri FILES ${Poly2Tri_SRCS})
@@ -278,14 +261,11 @@ index 9b27086..b7c2ccb 100644
  # minizip/unzip
 -IF(ASSIMP_HUNTER_ENABLED)
 -  hunter_add_package(minizip)
--  find_package(minizip CONFIG REQUIRED)
 +IF(1)
-+  #hunter_add_package(minizip)
-+  find_package(unofficial-minizip CONFIG REQUIRED)
+   find_package(minizip CONFIG REQUIRED)
  ELSE()
    SET( unzip_SRCS
-     ../contrib/unzip/crypt.h
-@@ -1121,9 +1121,9 @@ ENDIF()
+@@ -1188,9 +1183,8 @@ ENDIF()
  # zip (https://github.com/kuba--/zip)
  separate_arguments(ASSIMP_EXPORTERS_LIST UNIX_COMMAND ${ASSIMP_EXPORTERS_ENABLED})
  IF(3MF IN_LIST ASSIMP_EXPORTERS_LIST)
@@ -293,12 +273,11 @@ index 9b27086..b7c2ccb 100644
 -    hunter_add_package(zip)
 -    find_package(zip CONFIG REQUIRED)
 +  IF(1)
-+    #hunter_add_package(zip)
 +    find_package(kubazip CONFIG REQUIRED)
    ELSE()
      SET( ziplib_SRCS
        ../contrib/zip/src/miniz.h
-@@ -1143,7 +1143,7 @@ IF(3MF IN_LIST ASSIMP_EXPORTERS_LIST)
+@@ -1210,7 +1204,7 @@ IF(3MF IN_LIST ASSIMP_EXPORTERS_LIST)
  ENDIF()
  
  # openddlparser
@@ -307,7 +286,7 @@ index 9b27086..b7c2ccb 100644
    hunter_add_package(openddlparser)
    find_package(openddlparser CONFIG REQUIRED)
  ELSE()
-@@ -1166,7 +1166,7 @@ ELSE()
+@@ -1233,7 +1227,7 @@ ELSE()
  ENDIF()
  
  # Open3DGC
@@ -316,7 +295,7 @@ index 9b27086..b7c2ccb 100644
    # Nothing to do, not available in Hunter yet.
  ELSE()
    SET ( open3dgc_SRCS
-@@ -1201,6 +1201,7 @@ ELSE()
+@@ -1268,6 +1262,7 @@ ELSE()
      ../contrib/Open3DGC/o3dgcVector.inl
    )
    SOURCE_GROUP( Contrib\\open3dgc FILES ${open3dgc_SRCS})
@@ -324,7 +303,7 @@ index 9b27086..b7c2ccb 100644
  ENDIF()
  
  # Check dependencies for glTF importer with Open3DGC-compression.
-@@ -1209,7 +1210,7 @@ ENDIF()
+@@ -1276,7 +1271,7 @@ ENDIF()
  IF (NOT WIN32)
    FIND_PACKAGE(RT QUIET)
  ENDIF ()
@@ -333,20 +312,19 @@ index 9b27086..b7c2ccb 100644
    SET( ASSIMP_IMPORTER_GLTF_USE_OPEN3DGC 1 )
    ADD_DEFINITIONS( -DASSIMP_IMPORTER_GLTF_USE_OPEN3DGC=1 )
  ELSE ()
-@@ -1219,9 +1220,10 @@ ELSE ()
+@@ -1286,9 +1281,9 @@ ELSE ()
  ENDIF ()
  
  # RapidJSON
 -IF(ASSIMP_HUNTER_ENABLED)
 -  hunter_add_package(RapidJSON)
 +IF(1)
-+  #hunter_add_package(RapidJSON)
    find_package(RapidJSON CONFIG REQUIRED)
 +  ADD_DEFINITIONS( -DRAPIDJSON_HAS_STDSTRING=1)
  ELSE()
    INCLUDE_DIRECTORIES("../contrib/rapidjson/include")
    ADD_DEFINITIONS( -DRAPIDJSON_HAS_STDSTRING=1)
-@@ -1232,9 +1234,8 @@ ELSE()
+@@ -1299,9 +1294,8 @@ ELSE()
  ENDIF()
  
  # stb
@@ -358,7 +336,7 @@ index 9b27086..b7c2ccb 100644
  ELSE()
    SET( stb_SRCS
      ../contrib/stb/stb_image.h
-@@ -1256,7 +1257,7 @@ IF( MSVC OR "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC") # clang with MSVC ABI
+@@ -1323,7 +1317,7 @@ IF( MSVC OR "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC") # clang with MSVC ABI
    ADD_DEFINITIONS( -D_CRT_SECURE_NO_WARNINGS )
  endif ()
  
@@ -367,7 +345,7 @@ index 9b27086..b7c2ccb 100644
    if (UNZIP_FOUND)
      SET (unzip_compile_SRCS "")
    else ()
-@@ -1310,7 +1311,7 @@ SET( assimp_src
+@@ -1379,7 +1373,7 @@ SET( assimp_src
  )
  ADD_DEFINITIONS( -DOPENDDLPARSER_BUILD )
  
@@ -376,7 +354,7 @@ index 9b27086..b7c2ccb 100644
    INCLUDE_DIRECTORIES(
        ${IRRXML_INCLUDE_DIR}
        ../contrib/openddlparser/include
-@@ -1412,21 +1413,25 @@ TARGET_INCLUDE_DIRECTORIES ( assimp PUBLIC
+@@ -1483,21 +1477,25 @@ TARGET_INCLUDE_DIRECTORIES ( assimp PUBLIC
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>
    $<INSTALL_INTERFACE:${ASSIMP_INCLUDE_INSTALL_DIR}>
@@ -412,12 +390,7 @@ index 9b27086..b7c2ccb 100644
    endif()
  
    if (ASSIMP_BUILD_DRACO)
-@@ -1515,13 +1515,13 @@
- if(ASSIMP_ANDROID_JNIIOSYSTEM)
-   set(ASSIMP_ANDROID_JNIIOSYSTEM_PATH port/AndroidJNI)
-   add_subdirectory(../${ASSIMP_ANDROID_JNIIOSYSTEM_PATH}/ ../${ASSIMP_ANDROID_JNIIOSYSTEM_PATH}/)
--  target_link_libraries(assimp android_jniiosystem)
-+  target_link_libraries(assimp PRIVATE android_jniiosystem)
+@@ -1520,9 +1518,9 @@ if(ASSIMP_ANDROID_JNIIOSYSTEM)
  endif()
  
  IF (ASSIMP_BUILD_NONFREE_C4D_IMPORTER)
@@ -430,7 +403,7 @@ index 9b27086..b7c2ccb 100644
  ENDIF ()
  
  if( MSVC )
-@@ -1491,13 +1494,13 @@ if (MINGW)
+@@ -1563,13 +1561,13 @@ if (MINGW)
      ARCHIVE_OUTPUT_NAME assimp
    )
    if (NOT BUILD_SHARED_LIBS)
@@ -446,7 +419,7 @@ index 9b27086..b7c2ccb 100644
  endif()
  
  SET_TARGET_PROPERTIES( assimp PROPERTIES
-@@ -1527,14 +1530,14 @@ ENDIF()
+@@ -1599,14 +1597,14 @@ ENDIF()
  
  # Build against external unzip, or add ../contrib/unzip so
  # assimp can #include "unzip.h"
@@ -464,7 +437,7 @@ index 9b27086..b7c2ccb 100644
      endif()
    else ()
      INCLUDE_DIRECTORIES("../")
-@@ -1543,7 +1546,7 @@ ENDIF()
+@@ -1615,7 +1613,7 @@ ENDIF()
  
  # Add RT-extension library for glTF importer with Open3DGC-compression.
  IF (RT_FOUND AND ASSIMP_IMPORTER_GLTF_USE_OPEN3DGC)
@@ -474,7 +447,7 @@ index 9b27086..b7c2ccb 100644
  
  IF(ASSIMP_INSTALL)
 diff --git a/code/Common/BaseImporter.cpp b/code/Common/BaseImporter.cpp
-index 5c70cc2..bbbaae0 100644
+index 1894ad8..bfc10c0 100644
 --- a/code/Common/BaseImporter.cpp
 +++ b/code/Common/BaseImporter.cpp
 @@ -354,7 +354,7 @@ std::string BaseImporter::GetExtension(const std::string &pFile) {
@@ -487,7 +460,7 @@ index 5c70cc2..bbbaae0 100644
  // ------------------------------------------------------------------------------------------------
  // Convert to UTF8 data
 diff --git a/code/Common/StbCommon.h b/code/Common/StbCommon.h
-index aef23ce..1b059ec 100644
+index 6cec216..3e3c05a 100644
 --- a/code/Common/StbCommon.h
 +++ b/code/Common/StbCommon.h
 @@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -509,7 +482,7 @@ index aef23ce..1b059ec 100644
  #if _MSC_VER
  #pragma warning(pop)
 diff --git a/code/Common/ZipArchiveIOSystem.cpp b/code/Common/ZipArchiveIOSystem.cpp
-index 23d7db1..8f9b9ef 100644
+index e2234e2..6258717 100644
 --- a/code/Common/ZipArchiveIOSystem.cpp
 +++ b/code/Common/ZipArchiveIOSystem.cpp
 @@ -54,7 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO assimp/assimp
     REF "v${VERSION}"
-    SHA512 6028ad18a27ab3f924ec0c3decae8cf2ba2d9c7b04677d71e258a1cf997e35279dc7cf235c32e1a16261e0e5fd1eea46aeeaac472d04358d73563b05cf32b708
+    SHA512 dc9637b183a1ab4c87d3548b1cacf4278fc5d30ffa4ca35436f94723c20b916932791e8e2c2f0d2a63786078457e61a42fb7aac8462551172f7f5bd2582ad9a9
     HEAD_REF master
     PATCHES
         build_fixes.patch

--- a/ports/assimp/vcpkg.json
+++ b/ports/assimp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "assimp",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "The Open Asset import library",
   "homepage": "https://github.com/assimp/assimp",
   "license": "BSD-3-Clause",

--- a/versions/a-/assimp.json
+++ b/versions/a-/assimp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d85ea7782956f46ad985b5888e21eb742526de8",
+      "version": "6.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae0bcfa4a9cf55854689cf1b68f337b4405e7b85",
       "version": "6.0.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -301,7 +301,7 @@
       "port-version": 0
     },
     "assimp": {
-      "baseline": "6.0.1",
+      "baseline": "6.0.2",
       "port-version": 0
     },
     "astr": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/assimp/assimp/releases/tag/v6.0.2

