### PR TITLE
[igraph] update to 0.10.16

### DIFF
--- a/ports/igraph/portfile.cmake
+++ b/ports/igraph/portfile.cmake
@@ -4,9 +4,9 @@
 #  - The release tarball contains pre-generated parser sources, which eliminates the dependency on bison/flex.
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/igraph/igraph/releases/download/0.10.15/igraph-0.10.15.tar.gz"
-    FILENAME "igraph-0.10.15.tar.gz"
-    SHA512 bf9f0f2f62618cf037bdbbf2e126d27ec4e45edfb65efcf26df3fc1fb71a3e1f05a8b9a62f972650d96daa1e7bd3f2a084fe39bbca42e808cc737165514276e0
+    URLS "https://github.com/igraph/igraph/releases/download/0.10.16/igraph-0.10.16.tar.gz"
+    FILENAME "igraph-0.10.16.tar.gz"
+    SHA512 f17b2777b8817618958f2b5505a8d066a45a25ac05ee646e3ae7e2e6d19c86d90aca3ad05866a03fb2545d21caa374d736f4f9b8c090c04da3bd88c632792fd8
 )
 
 vcpkg_extract_source_archive(

--- a/ports/igraph/vcpkg.json
+++ b/ports/igraph/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "igraph",
-  "version": "0.10.15",
-  "port-version": 1,
+  "version": "0.10.16",
   "description": "igraph is a C library for network analysis and graph theory, with an emphasis on efficiency portability and ease of use.",
   "homepage": "https://igraph.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3769,8 +3769,8 @@
       "port-version": 0
     },
     "igraph": {
-      "baseline": "0.10.15",
-      "port-version": 1
+      "baseline": "0.10.16",
+      "port-version": 0
     },
     "iir1": {
       "baseline": "1.9.5",

--- a/versions/i-/igraph.json
+++ b/versions/i-/igraph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d17d1792289749047af7ccab3672cc723d47373",
+      "version": "0.10.16",
+      "port-version": 0
+    },
+    {
       "git-tree": "0c766a667b2c2df17eddf1013712e87602e7dd73",
       "version": "0.10.15",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version. **no change needed**
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. **no change needed**
- [ ] Any patches that are no longer applied are deleted from the port's directory. **no change needed**
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


