### PR TITLE
[signalsmith-dsp] Add port for Signalsmiths DSP library

### DIFF
--- a/ports/signalsmith-dsp/portfile.cmake
+++ b/ports/signalsmith-dsp/portfile.cmake
@@ -1,4 +1,4 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+set(VCPKG_BUILD_TYPE release)  # header-only
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/signalsmith-dsp/portfile.cmake
+++ b/ports/signalsmith-dsp/portfile.cmake
@@ -1,0 +1,14 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Signalsmith-Audio/dsp
+    REF "v${VERSION}"
+    SHA512 f69f513bedd004a7e581493cf375015066abe2f8aa320ec98748656f6810a81b0a6f0d5a53a3f4ac5436d4dd56a263eef622ba62ac644675671b335e1fb290c6
+    HEAD_REF main
+)
+
+file(GLOB_RECURSE SIGNALSMITH_DSP_HEADERS "${SOURCE_PATH}/*.h")
+file(INSTALL ${SIGNALSMITH_DSP_HEADERS} DESTINATION "${CURRENT_PACKAGES_DIR}/include/signalsmith-dsp")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/signalsmith-dsp/vcpkg.json
+++ b/ports/signalsmith-dsp/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "signalsmith-dsp",
+  "version-semver": "1.6.2",
+  "description": "Signalsmith Audio's C++ DSP support library ",
+  "homepage": "https://signalsmith-audio.co.uk/code/dsp/",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8708,6 +8708,10 @@
       "baseline": "1.0.0-beta1-9",
       "port-version": 6
     },
+    "signalsmith-dsp": {
+      "baseline": "1.6.2",
+      "port-version": 0
+    },
     "sigslot": {
       "baseline": "1.0.0",
       "port-version": 5

--- a/versions/s-/signalsmith-dsp.json
+++ b/versions/s-/signalsmith-dsp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "df63ae4a9be36339f56175a67195e3beda472878",
+      "version-semver": "1.6.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/signalsmith-dsp.json
+++ b/versions/s-/signalsmith-dsp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "df63ae4a9be36339f56175a67195e3beda472878",
+      "git-tree": "2a99c7b942fe97ae7f2f6698322e5130ffabb676",
       "version-semver": "1.6.2",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.

I could not find this library in repology, so I selected signalsmith-dsp as port name, as DSP-Library would be too generic and signalsmith-audio-dsp-library too long

- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.