### PR TITLE
[protobuf] Add patch to fix protobuf_generate CMake function on Windows

### DIFF
--- a/ports/protobuf/fix-protobuf-generate.patch
+++ b/ports/protobuf/fix-protobuf-generate.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/protobuf-generate.cmake b/cmake/protobuf-generate.cmake
-index 244407ee2..91bfff07a 100644
+index 244407ee2..7c007fe07 100644
 --- a/cmake/protobuf-generate.cmake
 +++ b/cmake/protobuf-generate.cmake
 @@ -1,4 +1,5 @@
@@ -8,36 +8,44 @@ index 244407ee2..91bfff07a 100644
    include(CMakeParseArguments)
  
    set(_options APPEND_PATH)
-@@ -100,6 +101,21 @@ function(protobuf_generate)
+@@ -100,6 +101,25 @@ function(protobuf_generate)
      set(_protobuf_include_path -I ${CMAKE_CURRENT_SOURCE_DIR})
    endif()
  
 +  # Use windows paths on protoc
 +  if(CMAKE_HOST_WIN32)
-+      foreach(_path ${_protobuf_include_path})
-+        if(NOT _path STREQUAL "-I")
-+          get_filename_component(_windows_path_include ${_path} ABSOLUTE)
++    foreach(_path ${_protobuf_include_path})
++      if(NOT _path STREQUAL "-I")
++        if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.19")
++          file(REAL_PATH "${_path}" _windows_path_include)
++        else()
++          get_filename_component(_windows_path_include "${_path}" ABSOLUTE)
 +          if(NOT _windows_path_include MATCHES "^[A-Za-z]:")
 +            set(_windows_path_include "$ENV{SYSTEMDRIVE}${_windows_path_include}")
 +          endif()
-+          list(APPEND _protobuf_proper_include_path -I ${_windows_path_include})
 +        endif()
-+      endforeach()
++        list(APPEND _protobuf_proper_include_path -I "${_windows_path_include}")
++      endif()
++    endforeach()
 +  else(CMAKE_HOST_WIN32)
-+      set(_protobuf_proper_include_path ${_protobuf_include_path})
++    set(_protobuf_proper_include_path "${_protobuf_include_path}")
 +  endif(CMAKE_HOST_WIN32)
 +
    set(_generated_srcs_all)
    foreach(_proto ${protobuf_generate_PROTOS})
      get_filename_component(_abs_file ${_proto} ABSOLUTE)
-@@ -146,10 +162,17 @@ function(protobuf_generate)
+@@ -146,10 +166,21 @@ function(protobuf_generate)
        set(_comment "${_comment}, plugin-options: ${_plugin_options}")
      endif()
  
 +    # Use windows paths on protoc
 +    if(CMAKE_HOST_WIN32)
 +      if(NOT _abs_file MATCHES "^[A-Za-z]:")
-+        set(_abs_file "$ENV{SYSTEMDRIVE}${_abs_file}")
++        if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.19")
++          file(REAL_PATH "${_abs_file}" _abs_file)
++        else()
++          set(_abs_file "$ENV{SYSTEMDRIVE}${_abs_file}")
++        endif()
 +      endif()
 +    endif(CMAKE_HOST_WIN32)
 +

--- a/ports/protobuf/fix-protobuf-generate.patch
+++ b/ports/protobuf/fix-protobuf-generate.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/protobuf-generate.cmake b/cmake/protobuf-generate.cmake
-index 244407ee2..7c007fe07 100644
+index 244407ee2..24652a1c0 100644
 --- a/cmake/protobuf-generate.cmake
 +++ b/cmake/protobuf-generate.cmake
 @@ -1,4 +1,5 @@
@@ -8,7 +8,7 @@ index 244407ee2..7c007fe07 100644
    include(CMakeParseArguments)
  
    set(_options APPEND_PATH)
-@@ -100,6 +101,25 @@ function(protobuf_generate)
+@@ -100,6 +101,18 @@ function(protobuf_generate)
      set(_protobuf_include_path -I ${CMAKE_CURRENT_SOURCE_DIR})
    endif()
  
@@ -16,14 +16,7 @@ index 244407ee2..7c007fe07 100644
 +  if(CMAKE_HOST_WIN32)
 +    foreach(_path ${_protobuf_include_path})
 +      if(NOT _path STREQUAL "-I")
-+        if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.19")
-+          file(REAL_PATH "${_path}" _windows_path_include)
-+        else()
-+          get_filename_component(_windows_path_include "${_path}" ABSOLUTE)
-+          if(NOT _windows_path_include MATCHES "^[A-Za-z]:")
-+            set(_windows_path_include "$ENV{SYSTEMDRIVE}${_windows_path_include}")
-+          endif()
-+        endif()
++        get_filename_component(_windows_path_include "${_path}" REALPATH)
 +        list(APPEND _protobuf_proper_include_path -I "${_windows_path_include}")
 +      endif()
 +    endforeach()
@@ -34,19 +27,13 @@ index 244407ee2..7c007fe07 100644
    set(_generated_srcs_all)
    foreach(_proto ${protobuf_generate_PROTOS})
      get_filename_component(_abs_file ${_proto} ABSOLUTE)
-@@ -146,10 +166,21 @@ function(protobuf_generate)
+@@ -146,10 +159,15 @@ function(protobuf_generate)
        set(_comment "${_comment}, plugin-options: ${_plugin_options}")
      endif()
  
 +    # Use windows paths on protoc
 +    if(CMAKE_HOST_WIN32)
-+      if(NOT _abs_file MATCHES "^[A-Za-z]:")
-+        if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.19")
-+          file(REAL_PATH "${_abs_file}" _abs_file)
-+        else()
-+          set(_abs_file "$ENV{SYSTEMDRIVE}${_abs_file}")
-+        endif()
-+      endif()
++      get_filename_component(_abs_file "${_abs_file}" REALPATH)
 +    endif(CMAKE_HOST_WIN32)
 +
      add_custom_command(

--- a/ports/protobuf/fix-protobuf-generate.patch
+++ b/ports/protobuf/fix-protobuf-generate.patch
@@ -1,0 +1,30 @@
+diff --git a/cmake/protobuf-generate.cmake b/cmake/protobuf-generate.cmake
+index 244407ee2..90c82f6b3 100644
+--- a/cmake/protobuf-generate.cmake
++++ b/cmake/protobuf-generate.cmake
+@@ -146,6 +146,25 @@ function(protobuf_generate)
+       set(_comment "${_comment}, plugin-options: ${_plugin_options}")
+     endif()
+ 
++    # Use windows paths on protoc
++    if(WIN32)
++      if(NOT _abs_file MATCHES "^\\w")
++        set(_abs_file "C:${_abs_file}")
++      endif()
++      file(TO_NATIVE_PATH "${_abs_file}" _abs_file)
++
++        foreach(_path ${_protobuf_include_path})
++          if(NOT _path STREQUAL "-I")
++            if(NOT _path MATCHES "^\\w")
++              set(WINDOWS_PATH_INCLUDE "C:${_path}")
++            endif()
++            file(TO_NATIVE_PATH "${WINDOWS_PATH_INCLUDE}" WINDOWS_PATH_INCLUDE)
++            list(APPEND _protobuf_aux_include_path -I ${WINDOWS_PATH_INCLUDE})
++          endif()
++        endforeach()
++        set(_protobuf_include_path ${_protobuf_aux_include_path})
++    endif(WIN32)
++
+     add_custom_command(
+       OUTPUT ${_generated_srcs}
+       COMMAND ${protobuf_generate_PROTOC_EXE}

--- a/ports/protobuf/fix-protobuf-generate.patch
+++ b/ports/protobuf/fix-protobuf-generate.patch
@@ -8,14 +8,14 @@ index 244407ee2..90c82f6b3 100644
  
 +    # Use windows paths on protoc
 +    if(WIN32)
-+      if(NOT _abs_file MATCHES "^\\w")
++      if(NOT _abs_file MATCHES "^[A-Za-z]:")
 +        set(_abs_file "C:${_abs_file}")
 +      endif()
 +      file(TO_NATIVE_PATH "${_abs_file}" _abs_file)
 +
 +        foreach(_path ${_protobuf_include_path})
 +          if(NOT _path STREQUAL "-I")
-+            if(NOT _path MATCHES "^\\w")
++            if(NOT _path MATCHES "^[A-Za-z]:")
 +              set(WINDOWS_PATH_INCLUDE "C:${_path}")
 +            endif()
 +            file(TO_NATIVE_PATH "${WINDOWS_PATH_INCLUDE}" WINDOWS_PATH_INCLUDE)

--- a/ports/protobuf/fix-protobuf-generate.patch
+++ b/ports/protobuf/fix-protobuf-generate.patch
@@ -1,8 +1,37 @@
 diff --git a/cmake/protobuf-generate.cmake b/cmake/protobuf-generate.cmake
-index 244407ee2..90c82f6b3 100644
+index 244407ee2..b7a1a9e7e 100644
 --- a/cmake/protobuf-generate.cmake
 +++ b/cmake/protobuf-generate.cmake
-@@ -146,6 +146,25 @@ function(protobuf_generate)
+@@ -1,4 +1,5 @@
+ function(protobuf_generate)
++
+   include(CMakeParseArguments)
+ 
+   set(_options APPEND_PATH)
+@@ -100,6 +101,22 @@ function(protobuf_generate)
+     set(_protobuf_include_path -I ${CMAKE_CURRENT_SOURCE_DIR})
+   endif()
+ 
++  # Use windows paths on protoc
++  if(WIN32)
++      foreach(_path ${_protobuf_include_path})
++        if(NOT _path STREQUAL "-I")
++          get_filename_component(_windows_path_include ${_path} ABSOLUTE)
++          if(NOT _windows_path_include MATCHES "^[A-Za-z]:")
++            set(_windows_path_include "C:${_windows_path_include}")
++          endif()
++          file(TO_NATIVE_PATH "${_windows_path_include}" _windows_path_include)
++          list(APPEND _protobuf_proper_include_path -I ${_windows_path_include})
++        endif()
++      endforeach()
++  else(WIN32)
++      set(_protobuf_proper_include_path ${_protobuf_include_path})
++  endif(WIN32)
++
+   set(_generated_srcs_all)
+   foreach(_proto ${protobuf_generate_PROTOS})
+     get_filename_component(_abs_file ${_proto} ABSOLUTE)
+@@ -146,10 +163,18 @@ function(protobuf_generate)
        set(_comment "${_comment}, plugin-options: ${_plugin_options}")
      endif()
  
@@ -12,19 +41,13 @@ index 244407ee2..90c82f6b3 100644
 +        set(_abs_file "C:${_abs_file}")
 +      endif()
 +      file(TO_NATIVE_PATH "${_abs_file}" _abs_file)
-+
-+        foreach(_path ${_protobuf_include_path})
-+          if(NOT _path STREQUAL "-I")
-+            if(NOT _path MATCHES "^[A-Za-z]:")
-+              set(WINDOWS_PATH_INCLUDE "C:${_path}")
-+            endif()
-+            file(TO_NATIVE_PATH "${WINDOWS_PATH_INCLUDE}" WINDOWS_PATH_INCLUDE)
-+            list(APPEND _protobuf_aux_include_path -I ${WINDOWS_PATH_INCLUDE})
-+          endif()
-+        endforeach()
-+        set(_protobuf_include_path ${_protobuf_aux_include_path})
 +    endif(WIN32)
 +
      add_custom_command(
        OUTPUT ${_generated_srcs}
        COMMAND ${protobuf_generate_PROTOC_EXE}
+-      ARGS ${protobuf_generate_PROTOC_OPTIONS} --${protobuf_generate_LANGUAGE}_out ${_plugin_options}:${protobuf_generate_PROTOC_OUT_DIR} ${_plugin} ${_protobuf_include_path} ${_abs_file}
++      ARGS ${protobuf_generate_PROTOC_OPTIONS} --${protobuf_generate_LANGUAGE}_out ${_plugin_options}:${protobuf_generate_PROTOC_OUT_DIR} ${_plugin} ${_protobuf_proper_include_path} ${_abs_file}
+       DEPENDS ${_abs_file} ${protobuf_PROTOC_EXE} ${protobuf_generate_DEPENDENCIES}
+       COMMENT ${_comment}
+       VERBATIM )

--- a/ports/protobuf/fix-protobuf-generate.patch
+++ b/ports/protobuf/fix-protobuf-generate.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/protobuf-generate.cmake b/cmake/protobuf-generate.cmake
-index 244407ee2..b7a1a9e7e 100644
+index 244407ee2..91bfff07a 100644
 --- a/cmake/protobuf-generate.cmake
 +++ b/cmake/protobuf-generate.cmake
 @@ -1,4 +1,5 @@
@@ -8,40 +8,38 @@ index 244407ee2..b7a1a9e7e 100644
    include(CMakeParseArguments)
  
    set(_options APPEND_PATH)
-@@ -100,6 +101,22 @@ function(protobuf_generate)
+@@ -100,6 +101,21 @@ function(protobuf_generate)
      set(_protobuf_include_path -I ${CMAKE_CURRENT_SOURCE_DIR})
    endif()
  
 +  # Use windows paths on protoc
-+  if(WIN32)
++  if(CMAKE_HOST_WIN32)
 +      foreach(_path ${_protobuf_include_path})
 +        if(NOT _path STREQUAL "-I")
 +          get_filename_component(_windows_path_include ${_path} ABSOLUTE)
 +          if(NOT _windows_path_include MATCHES "^[A-Za-z]:")
-+            set(_windows_path_include "C:${_windows_path_include}")
++            set(_windows_path_include "$ENV{SYSTEMDRIVE}${_windows_path_include}")
 +          endif()
-+          file(TO_NATIVE_PATH "${_windows_path_include}" _windows_path_include)
 +          list(APPEND _protobuf_proper_include_path -I ${_windows_path_include})
 +        endif()
 +      endforeach()
-+  else(WIN32)
++  else(CMAKE_HOST_WIN32)
 +      set(_protobuf_proper_include_path ${_protobuf_include_path})
-+  endif(WIN32)
++  endif(CMAKE_HOST_WIN32)
 +
    set(_generated_srcs_all)
    foreach(_proto ${protobuf_generate_PROTOS})
      get_filename_component(_abs_file ${_proto} ABSOLUTE)
-@@ -146,10 +163,18 @@ function(protobuf_generate)
+@@ -146,10 +162,17 @@ function(protobuf_generate)
        set(_comment "${_comment}, plugin-options: ${_plugin_options}")
      endif()
  
 +    # Use windows paths on protoc
-+    if(WIN32)
++    if(CMAKE_HOST_WIN32)
 +      if(NOT _abs_file MATCHES "^[A-Za-z]:")
-+        set(_abs_file "C:${_abs_file}")
++        set(_abs_file "$ENV{SYSTEMDRIVE}${_abs_file}")
 +      endif()
-+      file(TO_NATIVE_PATH "${_abs_file}" _abs_file)
-+    endif(WIN32)
++    endif(CMAKE_HOST_WIN32)
 +
      add_custom_command(
        OUTPUT ${_generated_srcs}

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         fix-default-proto-file-path.patch
         fix-utf8-range.patch
         fix-install-dirs.patch
+        fix-protobuf-generate.patch
 )
 
 string(COMPARE EQUAL "${TARGET_TRIPLET}" "${HOST_TRIPLET}" protobuf_BUILD_PROTOC_BINARIES)

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "protobuf",
   "version": "5.29.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7494,7 +7494,7 @@
     },
     "protobuf": {
       "baseline": "5.29.3",
-      "port-version": 1
+      "port-version": 2
     },
     "protobuf-c": {
       "baseline": "1.5.2",

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1020e6e87d6a63311c6ebf7f7ec5124b9bf7be74",
+      "git-tree": "af924351754545fc1a8c6cc453190e6d75f08371",
       "version": "5.29.3",
       "port-version": 1
     },

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "538098b623c6a98560530ed1c88089708c32980d",
+      "git-tree": "39043fdcd5ca0a3eac41f3bb95dd59e2da4e5954",
       "version": "5.29.3",
       "port-version": 2
     },

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "af924351754545fc1a8c6cc453190e6d75f08371",
+      "git-tree": "2c8c3782e8dddbb033387ffea38b091c7d3c72be",
+      "version": "5.29.3",
+      "port-version": 2
+    },
+    {
+      "git-tree": "1020e6e87d6a63311c6ebf7f7ec5124b9bf7be74",
       "version": "5.29.3",
       "port-version": 1
     },

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39043fdcd5ca0a3eac41f3bb95dd59e2da4e5954",
+      "git-tree": "0ff416196355c97fcb3a9b2def1c63147f0555e3",
       "version": "5.29.3",
       "port-version": 2
     },

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2c8c3782e8dddbb033387ffea38b091c7d3c72be",
+      "git-tree": "538098b623c6a98560530ed1c88089708c32980d",
       "version": "5.29.3",
       "port-version": 2
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This PR introduces a new patch that fixes `protobuf_generate` CMake function. The function fails on windows because `protoc` compiler (on this `protobuf` 5.29.3 version) cannot handle *linux like paths*.

> **Note:**  the latest `protoc` sources solve this issue. This patch can be deleted on `protobuf` version upgrade.

> **Note:** because only a patch is added:
> + SHA512 for the sources keeps the same
> + Only `port-version` must be upgraded in the versioning framework.
