### PR TITLE
[upa-url] update to 2.2.0

### DIFF
--- a/ports/upa-url/portfile.cmake
+++ b/ports/upa-url/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO upa-url/upa
   REF "v${VERSION}"
-  SHA512 26af05d36b1ae147594630a23d258ed55328940a23560afcbb31e132b2fa6360c16f4ff09568787d0d39b8a351cdb90dc4c5a0a237b782a743a343992ee7ca4f
+  SHA512 d998e8e61fe018035343e43d937bd673eb4eb5d609263c71eff916611651fa9192715ee1b6da1eeaeab46fa26b94cb57cb4384de9318e5b8e28be0dd90c89468
   HEAD_REF main
 )
 
@@ -13,6 +13,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(PACKAGE_NAME "upa" CONFIG_PATH "lib/cmake/upa")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/upa-url/vcpkg.json
+++ b/ports/upa-url/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "upa-url",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "description": "An implementation of the WHATWG URL Standard in C++",
   "homepage": "https://github.com/upa-url/upa",
   "documentation": "https://upa-url.github.io/docs/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9681,7 +9681,7 @@
       "port-version": 0
     },
     "upa-url": {
-      "baseline": "2.0.0",
+      "baseline": "2.2.0",
       "port-version": 0
     },
     "urdfdom": {

--- a/versions/u-/upa-url.json
+++ b/versions/u-/upa-url.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c26d8af0a25417dd9f57cbc39f6e49920c560a44",
+      "version": "2.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "bac0247f2b63a656c2d7915edcca519d55054d70",
       "version": "2.0.0",
       "port-version": 0


### PR DESCRIPTION
This version adds the ability to build as a shared library.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
