### PR TITLE
[qtbase] update to 6.9.1

### DIFF
--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "qtbase",
-  "version": "6.8.3",
-  "port-version": 2,
+  "version": "6.9.1",
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7825,8 +7825,8 @@
       "port-version": 0
     },
     "qtbase": {
-      "baseline": "6.8.3",
-      "port-version": 2
+      "baseline": "6.9.1",
+      "port-version": 0
     },
     "qtcharts": {
       "baseline": "6.8.3",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa10678be1c5cb1eca1b97dac851243802c44592",
+      "version": "6.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c6fb64e484a6762f3ea271a486044c6fb0bca96f",
       "version": "6.8.3",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.