### PR TITLE
[sqlite3] Update to version 3.50.1

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -50,7 +50,7 @@ if(SQLITE_ENABLE_ICU)
     find_package(ICU COMPONENTS uc i18n data REQUIRED)
     target_link_libraries(sqlite3 PRIVATE ICU::uc ICU::i18n ICU::data)
 
-    string(APPEND PKGCONFIG_REQUIRES_PRIVATE " icu-uc icu-i18n icu-data")
+    string(APPEND PKGCONFIG_REQUIRES_PRIVATE " icu-uc icu-i18n")
 endif()
 
 if(NOT SQLITE3_SKIP_TOOLS)

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -55,6 +55,9 @@ endif()
 
 if(NOT SQLITE3_SKIP_TOOLS)
     add_executable(sqlite3-bin shell.c)
+    if(SQLITE_ENABLE_ICU)
+        set_property(TARGET sqlite3-bin PROPERTY LINKER_LANGUAGE CXX)
+    endif()
     set_target_properties(sqlite3-bin PROPERTIES
         OUTPUT_NAME sqlite3
         PDB_NAME "sqlite3${CMAKE_EXECUTABLE_SUFFIX}.pdb"
@@ -76,12 +79,6 @@ if(NOT SQLITE3_SKIP_TOOLS)
         # Assuming ICU components uc and i18n are already found by find_package(ICU ...)
         # Link the ICU libraries to the executable
         target_link_libraries(sqlite3-bin PRIVATE ICU::uc ICU::i18n)
-
-        # IMPORTANT: Link the C++ standard library.
-        # Since sqlite3-bin is a C executable but links to C++ libraries (ICU),
-        # it needs to explicitly link the C++ runtime.
-        # CXX_STANDARD_LIBRARY is a portable way to do this in CMake.
-        target_link_libraries(sqlite3-bin PRIVATE CXX_STANDARD_LIBRARY)
     endif()
 
     install(TARGETS sqlite3-bin sqlite3

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -75,9 +75,7 @@ if(NOT SQLITE3_SKIP_TOOLS)
 
     if(SQLITE_ENABLE_ICU)
         target_link_libraries(sqlite3-bin PRIVATE ICU::uc ICU::i18n)
-        set_target_properties(sqlite3-bin PROPERTIES
-            LINK_EXECUTABLE "${CMAKE_CXX_COMPILER}"
-        )
+        set_property(TARGET sqlite3-bin PROPERTY LINKER_LANGUAGE CXX)
     endif()
 
     install(TARGETS sqlite3-bin sqlite3

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -9,8 +9,7 @@ set(PKGCONFIG_LIBS_PRIVATE "")
 set(PKGCONFIG_REQUIRES_PRIVATE "")
 
 # Renamed the main sqlite3 library target to 'libsqlite3' to avoid LNK1149 error on Windows.
-# Explicitly set as STATIC, which is common for Vcpkg's default triplet linkage.
-add_library(libsqlite3 STATIC sqlite3.c sqlite3.rc)
+add_library(libsqlite3 sqlite3.c sqlite3.rc)
 
 target_include_directories(libsqlite3 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include>)
 
@@ -52,24 +51,10 @@ if(SQLITE_ENABLE_ICU)
     # Find ICU components uc (common) and i18n (internationalization).
     # The 'data' component often doesn't create a findable 'ICU::data' imported target
     # in some Vcpkg configurations, so we will find its library file directly.
-    find_package(ICU COMPONENTS uc i18n REQUIRED)
-
-    # Manually find the icudata library file, which is often a separate static archive.
-    # VCPKG_ROOT_DIR and VCPKG_TARGET_TRIPLET are Vcpkg-specific variables.
-    find_library(ICUDATA_LIBRARY NAMES icudata
-                 PATHS ${VCPKG_ROOT_DIR}/installed/${VCPKG_TARGET_TRIPLET}/lib
-                       ${VCPKG_ROOT_DIR}/installed/${VCPKG_TARGET_TRIPLET}/debug/lib
-                 NO_DEFAULT_PATH)
-
-    if(NOT ICUDATA_LIBRARY)
-        # This error indicates a problem with the ICU installation or Vcpkg environment
-        # if the data library cannot be found.
-        message(FATAL_ERROR "ICU data library (libicudata) not found for linking. "
-                            "It should be installed by the ICU vcpkg port.")
-    endif()
+    find_package(ICU COMPONENTS uc i18n data REQUIRED)
 
     # Link the main libsqlite3 with ICU components and the explicitly found icudata library.
-    target_link_libraries(libsqlite3 PRIVATE ICU::uc ICU::i18n ${ICUDATA_LIBRARY})
+    target_link_libraries(libsqlite3 PRIVATE ICU::uc ICU::i18n ICU::data)
 
     # Update pkgconfig requires: Exclude "icu-data" because the ICU vcpkg port
     # typically does not provide an 'icu-data.pc' file, which would cause pkg-config validation errors.
@@ -103,7 +88,7 @@ if(NOT SQLITE3_SKIP_TOOLS)
         target_link_libraries(sqlite3-bin PRIVATE
             ICU::i18n        # Depends on ICU::uc
             ICU::uc          # Depends on icudata
-            ${ICUDATA_LIBRARY} # Explicitly found icudata library path
+            ICU::data        # Explicitly found icudata library path
         )
         set_property(TARGET sqlite3-bin PROPERTY LINKER_LANGUAGE CXX)
     endif()

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(sqlite3 C)
+project(sqlite3 C CXX)
 
 option(WITH_ZLIB "Build sqlite3 with zlib support" OFF)
 option(SQLITE3_SKIP_TOOLS "Disable build sqlite3 executable" OFF)

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -54,10 +54,17 @@ if(SQLITE_ENABLE_ICU)
 endif()
 
 if(NOT SQLITE3_SKIP_TOOLS)
-    add_executable(sqlite3-bin shell.c)
+    # Define the sources for the executable
+    set(SQLITE3_BIN_SOURCES shell.c)
+
     if(SQLITE_ENABLE_ICU)
-        set_property(TARGET sqlite3-bin PROPERTY LINKER_LANGUAGE CXX)
+        # This will automatically make the executable target a C++ target,
+        # ensuring the C++ linker and its standard library are used.
+        set_source_files_properties(${SQLITE3_BIN_SOURCES} PROPERTIES LANGUAGE CXX)
     endif()
+
+    add_executable(sqlite3-bin ${SQLITE3_BIN_SOURCES})
+
     set_target_properties(sqlite3-bin PROPERTIES
         OUTPUT_NAME sqlite3
         PDB_NAME "sqlite3${CMAKE_EXECUTABLE_SUFFIX}.pdb"
@@ -76,8 +83,8 @@ if(NOT SQLITE3_SKIP_TOOLS)
     endif()
 
     if(SQLITE_ENABLE_ICU)
-        # Assuming ICU components uc and i18n are already found by find_package(ICU ...)
-        # Link the ICU libraries to the executable
+        # Now that sqlite3-bin is implicitly a C++ target, it will link against ICU
+        # and automatically pull in the C++ standard library.
         target_link_libraries(sqlite3-bin PRIVATE ICU::uc ICU::i18n)
     endif()
 

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(sqlite3 C)
+project(sqlite3 C CXX)
 
 option(WITH_ZLIB "Build sqlite3 with zlib support" OFF)
 option(SQLITE3_SKIP_TOOLS "Disable build sqlite3 executable" OFF)
@@ -74,9 +74,10 @@ if(NOT SQLITE3_SKIP_TOOLS)
     endif()
 
     if(SQLITE_ENABLE_ICU)
-        # Now that sqlite3-bin is implicitly a C++ target, it will link against ICU
-        # and automatically pull in the C++ standard library.
         target_link_libraries(sqlite3-bin PRIVATE ICU::uc ICU::i18n)
+        set_target_properties(sqlite3-bin PROPERTIES
+            LINK_EXECUTABLE "${CMAKE_CXX_COMPILER}"
+        )
     endif()
 
     install(TARGETS sqlite3-bin sqlite3

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -48,9 +48,9 @@ endif()
 
 if(SQLITE_ENABLE_ICU)
     find_package(ICU COMPONENTS uc i18n REQUIRED)
-    target_link_libraries(sqlite3 PRIVATE ICU::uc ICU::i18n)
+    target_link_libraries(sqlite3 PRIVATE ICU::uc ICU::i18n ICU::data)
 
-    string(APPEND PKGCONFIG_REQUIRES_PRIVATE " icu-uc icu-i18n")
+    string(APPEND PKGCONFIG_REQUIRES_PRIVATE " icu-uc icu-i18n icu-data")
 endif()
 
 if(NOT SQLITE3_SKIP_TOOLS)
@@ -74,7 +74,7 @@ if(NOT SQLITE3_SKIP_TOOLS)
     endif()
 
     if(SQLITE_ENABLE_ICU)
-        target_link_libraries(sqlite3-bin PRIVATE ICU::uc ICU::i18n)
+        target_link_libraries(sqlite3-bin PRIVATE ICU::uc ICU::i18n ICU::data)
         set_property(TARGET sqlite3-bin PROPERTY LINKER_LANGUAGE CXX)
     endif()
 

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -8,12 +8,14 @@ option(SQLITE3_SKIP_TOOLS "Disable build sqlite3 executable" OFF)
 set(PKGCONFIG_LIBS_PRIVATE "")
 set(PKGCONFIG_REQUIRES_PRIVATE "")
 
-add_library(sqlite3 sqlite3.c sqlite3.rc)
+# Renamed the main sqlite3 library target to 'libsqlite3' to avoid LNK1149 error on Windows.
+# Explicitly set as STATIC, which is common for Vcpkg's default triplet linkage.
+add_library(libsqlite3 STATIC sqlite3.c sqlite3.rc)
 
-target_include_directories(sqlite3 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include>)
+target_include_directories(libsqlite3 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include>)
 
 target_compile_definitions(
-    sqlite3
+    libsqlite3
     PRIVATE
         $<$<CONFIG:Debug>:SQLITE_DEBUG=1>
         $<$<CONFIG:Debug>:SQLITE_ENABLE_SELECTTRACE>
@@ -23,15 +25,15 @@ target_compile_definitions(
 
 if (BUILD_SHARED_LIBS)
     if (WIN32)
-        target_compile_definitions(sqlite3 PRIVATE "SQLITE_API=__declspec(dllexport)")
+        target_compile_definitions(libsqlite3 PRIVATE "SQLITE_API=__declspec(dllexport)")
     else()
-        target_compile_definitions(sqlite3 PRIVATE "SQLITE_API=__attribute__((visibility(\"default\")))")
+        target_compile_definitions(libsqlite3 PRIVATE "SQLITE_API=__attribute__((visibility(\"default\")))")
     endif()
 endif()
 
 if (NOT WIN32)
     find_package(Threads REQUIRED)
-    target_link_libraries(sqlite3 PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+    target_link_libraries(libsqlite3 PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
     string(APPEND PKGCONFIG_LIBS_PRIVATE " -pthread")
     foreach(LIB IN LISTS CMAKE_DL_LIBS)
         string(APPEND PKGCONFIG_LIBS_PRIVATE " -l${LIB}")
@@ -40,16 +42,37 @@ if (NOT WIN32)
     if(SQLITE_ENABLE_FTS5 OR SQLITE_ENABLE_MATH_FUNCTIONS)
         find_library(HAVE_LIBM m)
         if(HAVE_LIBM)
-            target_link_libraries(sqlite3 PRIVATE m)
+            target_link_libraries(libsqlite3 PRIVATE m)
             string(APPEND PKGCONFIG_LIBS_PRIVATE " -lm")
         endif()
     endif()
 endif()
 
 if(SQLITE_ENABLE_ICU)
-    find_package(ICU COMPONENTS uc i18n data REQUIRED)
-    target_link_libraries(sqlite3 PRIVATE ICU::uc ICU::i18n ICU::data)
+    # Find ICU components uc (common) and i18n (internationalization).
+    # The 'data' component often doesn't create a findable 'ICU::data' imported target
+    # in some Vcpkg configurations, so we will find its library file directly.
+    find_package(ICU COMPONENTS uc i18n REQUIRED)
 
+    # Manually find the icudata library file, which is often a separate static archive.
+    # VCPKG_ROOT_DIR and VCPKG_TARGET_TRIPLET are Vcpkg-specific variables.
+    find_library(ICUDATA_LIBRARY NAMES icudata
+                 PATHS ${VCPKG_ROOT_DIR}/installed/${VCPKG_TARGET_TRIPLET}/lib
+                       ${VCPKG_ROOT_DIR}/installed/${VCPKG_TARGET_TRIPLET}/debug/lib
+                 NO_DEFAULT_PATH)
+
+    if(NOT ICUDATA_LIBRARY)
+        # This error indicates a problem with the ICU installation or Vcpkg environment
+        # if the data library cannot be found.
+        message(FATAL_ERROR "ICU data library (libicudata) not found for linking. "
+                            "It should be installed by the ICU vcpkg port.")
+    endif()
+
+    # Link the main libsqlite3 with ICU components and the explicitly found icudata library.
+    target_link_libraries(libsqlite3 PRIVATE ICU::uc ICU::i18n ${ICUDATA_LIBRARY})
+
+    # Update pkgconfig requires: Exclude "icu-data" because the ICU vcpkg port
+    # typically does not provide an 'icu-data.pc' file, which would cause pkg-config validation errors.
     string(APPEND PKGCONFIG_REQUIRES_PRIVATE " icu-uc icu-i18n")
 endif()
 
@@ -61,7 +84,7 @@ if(NOT SQLITE3_SKIP_TOOLS)
         PDB_NAME "sqlite3${CMAKE_EXECUTABLE_SUFFIX}.pdb"
     )
 
-    target_link_libraries(sqlite3-bin PRIVATE sqlite3)
+    target_link_libraries(sqlite3-bin PRIVATE libsqlite3)
     if (WITH_ZLIB)
         find_package(ZLIB REQUIRED)
         target_link_libraries(sqlite3-bin PRIVATE ZLIB::ZLIB)
@@ -74,11 +97,18 @@ if(NOT SQLITE3_SKIP_TOOLS)
     endif()
 
     if(SQLITE_ENABLE_ICU)
-        target_link_libraries(sqlite3-bin PRIVATE ICU::uc ICU::i18n ICU::data)
+        # Link ICU libraries for the executable.
+        # For static builds on Linux/macOS, link order can be critical for ICU: i18n -> uc -> data.
+        # For MSVC, the order is less strict due to its linker's behavior.
+        target_link_libraries(sqlite3-bin PRIVATE
+            ICU::i18n        # Depends on ICU::uc
+            ICU::uc          # Depends on icudata
+            ${ICUDATA_LIBRARY} # Explicitly found icudata library path
+        )
         set_property(TARGET sqlite3-bin PROPERTY LINKER_LANGUAGE CXX)
     endif()
 
-    install(TARGETS sqlite3-bin sqlite3
+    install(TARGETS sqlite3-bin libsqlite3
       RUNTIME DESTINATION bin
       LIBRARY DESTINATION lib
       ARCHIVE DESTINATION lib
@@ -86,7 +116,7 @@ if(NOT SQLITE3_SKIP_TOOLS)
 endif()
 
 install(
-    TARGETS sqlite3
+    TARGETS libsqlite3
     EXPORT unofficial-sqlite3-targets
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(sqlite3 C CXX)
+project(sqlite3 C)
 
 option(WITH_ZLIB "Build sqlite3 with zlib support" OFF)
 option(SQLITE3_SKIP_TOOLS "Disable build sqlite3 executable" OFF)
@@ -54,16 +54,7 @@ if(SQLITE_ENABLE_ICU)
 endif()
 
 if(NOT SQLITE3_SKIP_TOOLS)
-    # Define the sources for the executable
-    set(SQLITE3_BIN_SOURCES shell.c)
-
-    if(SQLITE_ENABLE_ICU)
-        # This will automatically make the executable target a C++ target,
-        # ensuring the C++ linker and its standard library are used.
-        set_source_files_properties(${SQLITE3_BIN_SOURCES} PROPERTIES LANGUAGE CXX)
-    endif()
-
-    add_executable(sqlite3-bin ${SQLITE3_BIN_SOURCES})
+    add_executable(sqlite3-bin shell.c)
 
     set_target_properties(sqlite3-bin PROPERTIES
         OUTPUT_NAME sqlite3

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -47,7 +47,7 @@ if (NOT WIN32)
 endif()
 
 if(SQLITE_ENABLE_ICU)
-    find_package(ICU COMPONENTS uc i18n REQUIRED)
+    find_package(ICU COMPONENTS uc i18n data REQUIRED)
     target_link_libraries(sqlite3 PRIVATE ICU::uc ICU::i18n ICU::data)
 
     string(APPEND PKGCONFIG_REQUIRES_PRIVATE " icu-uc icu-i18n icu-data")

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -72,6 +72,18 @@ if(NOT SQLITE3_SKIP_TOOLS)
         target_link_libraries(sqlite3-bin PRIVATE m)
     endif()
 
+    if(SQLITE_ENABLE_ICU)
+        # Assuming ICU components uc and i18n are already found by find_package(ICU ...)
+        # Link the ICU libraries to the executable
+        target_link_libraries(sqlite3-bin PRIVATE ICU::uc ICU::i18n)
+
+        # IMPORTANT: Link the C++ standard library.
+        # Since sqlite3-bin is a C executable but links to C++ libraries (ICU),
+        # it needs to explicitly link the C++ runtime.
+        # CXX_STANDARD_LIBRARY is a portable way to do this in CMake.
+        target_link_libraries(sqlite3-bin PRIVATE CXX_STANDARD_LIBRARY)
+    endif()
+
     install(TARGETS sqlite3-bin sqlite3
       RUNTIME DESTINATION bin
       LIBRARY DESTINATION lib

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -4,7 +4,7 @@ string(REGEX REPLACE "^([0-9]+),0*([0-9][0-9]),0*([0-9][0-9]),0*([0-9][0-9])," "
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sqlite.org/2025/sqlite-autoconf-${SQLITE_VERSION}.tar.gz"
     FILENAME "sqlite-autoconf-${SQLITE_VERSION}.zip"
-    SHA512 59bbed0f49bcc17abcc3ba180858c7a7128038e43fd0b24a786505f0223340f85eb956e64a2b66e245d0b8d0769daa5e4688ae4686c64fc8ff91c546acce0070
+    SHA512 0526bab596282a93a1588e11c53662b3f4b17c32d5a5be25d99cca48307934c127cc39750448aceb8321af98683409b011a55bd8b5b157fe262ad437a793e672
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite3",
-  "version": "3.49.2",
+  "version": "3.50.1",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://sqlite.org/",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9001,7 +9001,7 @@
       "port-version": 0
     },
     "sqlite3": {
-      "baseline": "3.49.2",
+      "baseline": "3.50.1",
       "port-version": 0
     },
     "sqlitecpp": {

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f5c33057f5f35d3b241e7a6feb4c548217096e16",
+      "git-tree": "22ff93b96650101bf2a03484a220368d7b97b14a",
       "version": "3.50.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cf7683cc356680f7873db92893b4a0f0b95bafc6",
+      "git-tree": "a090c390b075e31a4ec2c6047a7b2cec346bc910",
       "version": "3.50.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "979e9a12787378f949f67d693cca253e15f182cc",
+      "git-tree": "7c5e4653758e69f2041fe13b581cd4dd2d7ca50e",
       "version": "3.50.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a03b6bf150e9e2622173ba87b0b3e137a3abe136",
+      "git-tree": "979e9a12787378f949f67d693cca253e15f182cc",
       "version": "3.50.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a090c390b075e31a4ec2c6047a7b2cec346bc910",
+      "git-tree": "5890ad2202a2cc60dfc83afd0da98287832d04e6",
       "version": "3.50.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a8c73803c4409a57e3388680899fa087f890dd45",
+      "git-tree": "759ae1ab46d74c535fcd26ef62bfc09a59b06215",
       "version": "3.50.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e2f0b0348c51867a42b5ae6d50bee74d55fbc8be",
+      "git-tree": "cf7683cc356680f7873db92893b4a0f0b95bafc6",
       "version": "3.50.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7c5e4653758e69f2041fe13b581cd4dd2d7ca50e",
+      "git-tree": "f5c33057f5f35d3b241e7a6feb4c548217096e16",
       "version": "3.50.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b1da1dc62e02ea28a9e5558c11b44bbf9433d8f3",
+      "git-tree": "a8c73803c4409a57e3388680899fa087f890dd45",
       "version": "3.50.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7b4df6b2fd485828db4e3ed0bde08316ccd72bfd",
+      "git-tree": "a03b6bf150e9e2622173ba87b0b3e137a3abe136",
       "version": "3.50.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b4df6b2fd485828db4e3ed0bde08316ccd72bfd",
+      "version": "3.50.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a337f5fe100f83026072765ea63a8776f984f6fd",
       "version": "3.49.2",
       "port-version": 0

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "759ae1ab46d74c535fcd26ef62bfc09a59b06215",
+      "git-tree": "e2f0b0348c51867a42b5ae6d50bee74d55fbc8be",
       "version": "3.50.1",
       "port-version": 0
     },

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "22ff93b96650101bf2a03484a220368d7b97b14a",
+      "git-tree": "b1da1dc62e02ea28a9e5558c11b44bbf9433d8f3",
       "version": "3.50.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.