### PR TITLE
[livepp] Add preference files support and documentation link

### DIFF
--- a/ports/livepp/global_preferences.json
+++ b/ports/livepp/global_preferences.json
@@ -1,0 +1,61 @@
+{
+    "HotReload": {
+        "clearLog": false,
+        "deletePatchFiles": true,
+        "hotReloadShortcutModifiers": 3,
+        "hotReloadShortcutVirtualKeyCode": 122,
+        "loadIncompleteCompilands ": false,
+        "loadIncompleteModules": false,
+        "timeout": 3000
+    },
+    "HotRestart": {
+        "hotRestartShortcutModifiers": 3,
+        "hotRestartShortcutVirtualKeyCode": 82,
+        "timeout": 10000
+    },
+    "IDE": {
+        "keepBreakpointsEnabled": false,
+        "showModalDialog": false,
+        "toggleOptimizationsShortcutModifiers": 3,
+        "toggleOptimizationsShortcutVirtualKeyCode": 79
+    },
+    "Licensing": {
+        "enableLicenseExpirationWarning": true,
+        "licenseExpirationWarningDays": 14
+    },
+    "Logging": {
+        "colorError": -65536,
+        "colorInfo": -1,
+        "colorPanic": -11141121,
+        "colorPlatform": -88543,
+        "colorSuccess": -16711936,
+        "colorTimeAndDate": -6250336,
+        "colorWarning": -256,
+        "enableWordWrap": false,
+        "font": "Courier New,10,-1,2,400,0,0,0,0,0,0,0,0,0,0,1",
+        "printTimestamps": true,
+        "verbosity": 0
+    },
+    "Network": {
+        "hostOrIP": "127.0.0.1",
+        "port": 12216,
+        "timeout": 2000
+    },
+    "Notifications": {
+        "areEnabled": true,
+        "focusType": 0,
+        "playSoundOnError": false,
+        "playSoundOnSuccess": false,
+        "soundOnError": "",
+        "soundOnSuccess": ""
+    },
+    "UI": {
+        "initialState": 0,
+        "language": 65535,
+        "showAnimatedIcon": true,
+        "showColorizedIcon": true,
+        "showErrorOnVersionMismatch": true,
+        "showTaskBarProgress": true,
+        "style": 1
+    }
+}

--- a/ports/livepp/portfile.cmake
+++ b/ports/livepp/portfile.cmake
@@ -28,4 +28,6 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/global_preferences_override.json")
     file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/global_preferences_override.json" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/Broker")
 endif()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/EULA/LPP_EULA.pdf")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" [[As of 2025-06-14, this software is bound by the "END USER LICENSE AGREEMENT" PDF located at
+https://liveplusplus.tech/downloads/LPP_EULA.pdf
+]])

--- a/ports/livepp/portfile.cmake
+++ b/ports/livepp/portfile.cmake
@@ -20,4 +20,12 @@ file(INSTALL "${SOURCE_PATH}/CLI" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${P
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-${PORT}Config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/global_preferences.json" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/Broker")
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/global_preferences_default.json")
+    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/global_preferences_default.json" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/Broker")
+endif()
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/global_preferences_override.json")
+    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/global_preferences_override.json" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/Broker")
+endif()
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/EULA/LPP_EULA.pdf")

--- a/ports/livepp/vcpkg.json
+++ b/ports/livepp/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "livepp",
   "version-semver": "2.9.2",
+  "port-version": 1,
   "description": "Hot-reload for C & C++ transforms workflows and decreases iteration times.",
   "homepage": "https://liveplusplus.tech/",
+  "documentation": "https://liveplusplus.tech/docs/documentation.html",
   "license": null,
   "supports": "windows"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5754,7 +5754,7 @@
     },
     "livepp": {
       "baseline": "2.9.2",
-      "port-version": 0
+      "port-version": 1
     },
     "llama-cpp": {
       "baseline": "4743",

--- a/versions/l-/livepp.json
+++ b/versions/l-/livepp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff14f8ab9286cbedcc04abf39b88fc8535523e41",
+      "version-semver": "2.9.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "b622803217418d154f870d806cad009b81928f6d",
       "version-semver": "2.9.2",
       "port-version": 0

--- a/versions/l-/livepp.json
+++ b/versions/l-/livepp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ff14f8ab9286cbedcc04abf39b88fc8535523e41",
+      "git-tree": "04318b1e123339dcde888da24bed6e3620b974f2",
       "version-semver": "2.9.2",
       "port-version": 1
     },


### PR DESCRIPTION
For various technical reasons [detailled here](https://github.com/MolecularMatters/lpp_public/issues/21#issuecomment-2968236982), Live++ must store its preferences files in its installation directory. This is an issue for the vcpkg port because user settings are erased every time the port is reinstalled or updated.

This PR is an attempt to approve the situation by providing a way for users to specify their own config files. It adds the default global_preferences.json file generated by Live++ and install it in the correct location. Users who wish to keep their settings can create an overlay port and replace the global_preferences.json file with their customized version. While not ideal, I believe this is still better than having no support for restoring user settings at all.

Live++ supports two other settings files (see the [documentation](https://liveplusplus.tech/docs/documentation.html#global_preferences)): global_preferences_default.json and global_preferences_override.json. These files are optional and can be used for advanced configuration control. This PR does not include them, but users can add them to the port, and if they do, they will be detected and installed as well.

I also added a link to Live++ documentation in the control file.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
