### PR TITLE
[libnpy] Add new port

### DIFF
--- a/ports/libnpy/fix-install.patch
+++ b/ports/libnpy/fix-install.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 41ce88d..0a552b4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -120,15 +120,15 @@ target_compile_features(npy PRIVATE cxx_std_11)
+ 
+ # -------------------- INSTALL ------------------------------------
+ 
+-set(INSTALL_CONFIGDIR "cmake")
++set(INSTALL_CONFIGDIR "share/libnpy")
+ 
+ install(TARGETS npy 
+   EXPORT npy-targets
+-  ARCHIVE DESTINATION "build/native/lib"
+-  LIBRARY DESTINATION "build/native/lib"
++  ARCHIVE DESTINATION "lib"
++  LIBRARY DESTINATION "lib"
+ )
+ 
+-install(DIRECTORY include/ DESTINATION "build/native/include")
++install(DIRECTORY include/ DESTINATION "include")
+ 
+ install(EXPORT npy-targets
+   FILE
+@@ -166,14 +166,6 @@ export(PACKAGE npy)
+ 
+ # -------------------- Package ------------------------------------
+ 
+-set( PROJECT_FILES
+-  README.md
+-  CHANGELOG.md
+-)
+-
+-# copy these files into the root of the distribution zip
+-install( FILES ${PROJECT_FILES} DESTINATION "." )
+-
+ if( MSVC )
+   # NuGet files
+   set( LIBNPY_NUGET_NAME "npy-${SYSTEM_TOOLKIT}-${SYSTEM_BITS}-${CMAKE_BUILD_TYPE}" CACHE STRING "npy NuGet Name" FORCE )

--- a/ports/libnpy/portfile.cmake
+++ b/ports/libnpy/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO matajoh/libnpy
+    REF "v${VERSION}"
+    SHA512 88b39e5018fbe2ef8b8a40b01fb85beb5e9a25dccff6199924d6eb072f49972501c33a68e6af3e67bba34ae546c632176f86db7cc530e8314666cfee13297907
+    HEAD_REF main
+    PATCHES
+        fix-install.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLIBNPY_BUILD_TESTS=OFF
+	-DLIBNPY_BUILD_SAMPLES=OFF
+	-DLIBNPY_BUILD_DOCUMENTATION=OFF
+	-DLIBNPY_INCLUDE_CSHARP=OFF # when swig is added, this can be added as a feature
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libnpy/vcpkg.json
+++ b/ports/libnpy/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "libnpy",
+  "version": "1.5.3",
+  "description": "Multi-platform C++ library for reading and writing NPY and NPZ files, with an additional .NET interface",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5056,6 +5056,10 @@
       "baseline": "2021-11-03",
       "port-version": 0
     },
+    "libnpy": {
+      "baseline": "1.5.3",
+      "port-version": 0
+    },
     "libobfuscate": {
       "baseline": "2024-07-10",
       "port-version": 0

--- a/versions/l-/libnpy.json
+++ b/versions/l-/libnpy.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e51993c114abb8f798bb26c92b91604fb39df182",
+      "version": "1.5.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #45991 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.