### PR TITLE
[meshoptimizer] update to 0.24

### DIFF
--- a/ports/meshoptimizer/fix-cmake.patch
+++ b/ports/meshoptimizer/fix-cmake.patch
@@ -1,8 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9e0beed..fce83c7 100644
+index 9e0beed..d28a04c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -141,9 +141,8 @@ if(MESHOPT_BUILD_GLTFPACK)
+@@ -137,13 +137,12 @@ if(MESHOPT_BUILD_GLTFPACK)
+         target_compile_definitions(gltfpack PRIVATE WITH_BASISU)
+         set_source_files_properties(gltf/basisenc.cpp gltf/basislib.cpp PROPERTIES INCLUDE_DIRECTORIES ${BASISU_PATH})
+ 
+-        if(NOT MSVC AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
++        if(NOT MSVC AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
              set_source_files_properties(gltf/basislib.cpp PROPERTIES COMPILE_OPTIONS -msse4.1)
          endif()
  

--- a/ports/meshoptimizer/fix-threads.patch
+++ b/ports/meshoptimizer/fix-threads.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9e0beed..fce83c7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -141,9 +141,8 @@ if(MESHOPT_BUILD_GLTFPACK)
+             set_source_files_properties(gltf/basislib.cpp PROPERTIES COMPILE_OPTIONS -msse4.1)
+         endif()
+ 
+-        if(UNIX)
+-            target_link_libraries(gltfpack pthread)
+-        endif()
++        find_package(Threads REQUIRED)
++        target_link_libraries(gltfpack Threads::Threads)
+     endif()
+ endif()
+ 

--- a/ports/meshoptimizer/portfile.cmake
+++ b/ports/meshoptimizer/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeux/meshoptimizer
     REF v${VERSION}
-    SHA512 f2f1d951bfb5c9b51d1a8485b3ce5e6ba4b5d3475fbefb0129fd54ce6dfaaeb923ad03c603733ba3865cb7ff6516da92ccdf326e5d672ef2114f515fd3582395
+    SHA512 d8342aadd48c0f51aa014ba56ff4c97f4780194eabf78d8a867876fb49f5d103597748ec4aa3613e236e2c42c5ca58d46a9ad3b7c458de5e1f01546d9951bfb4
     HEAD_REF master
 )
 
@@ -14,8 +14,8 @@ if ("gltfpack" IN_LIST FEATURES)
   vcpkg_from_github(
       OUT_SOURCE_PATH BASISU_PATH
       REPO zeux/basis_universal
-      REF 91ca86492bc046bf1d096067a1adcd2309e13dd2
-      SHA512 fe80533db60b40cdc72a64f766c2447ce5c923d84467a926c2e8af4ec42e278d9fa9823b41b3fc7d9b740dd2d41d2f606f0f9990f94d2398f253bc86350a4287
+      REF 88e813c46b3ff42e56ef947b3fa11eeee7a504b0
+      SHA512 cc9e4dbaed556fac30f4426ead9c8fb018ca8540bd1188849a90396192e410a5fdc6f38edbad07d2615583fbdfe01a79989d426caed7614d38b93731bbe3d4ae
       HEAD_REF gltfpack
   )
 endif()

--- a/ports/meshoptimizer/portfile.cmake
+++ b/ports/meshoptimizer/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 d8342aadd48c0f51aa014ba56ff4c97f4780194eabf78d8a867876fb49f5d103597748ec4aa3613e236e2c42c5ca58d46a9ad3b7c458de5e1f01546d9951bfb4
     HEAD_REF master
     PATCHES
-      fix-threads.patch
+      fix-cmake.patch
 )
 
 # If we want basisu support in gltfpack we need a particular fork of basisu

--- a/ports/meshoptimizer/portfile.cmake
+++ b/ports/meshoptimizer/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v${VERSION}
     SHA512 d8342aadd48c0f51aa014ba56ff4c97f4780194eabf78d8a867876fb49f5d103597748ec4aa3613e236e2c42c5ca58d46a9ad3b7c458de5e1f01546d9951bfb4
     HEAD_REF master
+    PATCHES
+      fix-threads.patch
 )
 
 # If we want basisu support in gltfpack we need a particular fork of basisu

--- a/ports/meshoptimizer/vcpkg.json
+++ b/ports/meshoptimizer/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "meshoptimizer",
-  "version": "0.23",
+  "version": "0.24",
   "description": "Mesh optimization library that makes meshes smaller and faster to render",
   "homepage": "https://github.com/zeux/meshoptimizer",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6117,7 +6117,7 @@
       "port-version": 6
     },
     "meshoptimizer": {
-      "baseline": "0.23",
+      "baseline": "0.24",
       "port-version": 0
     },
     "metis": {

--- a/versions/m-/meshoptimizer.json
+++ b/versions/m-/meshoptimizer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "039137b31ceb05bb719c7c788aa07c51a7b5223d",
+      "version": "0.24",
+      "port-version": 0
+    },
+    {
       "git-tree": "60127d521117d7e21408ea9ee5a0f8aca4b1d31d",
       "version": "0.23",
       "port-version": 0

--- a/versions/m-/meshoptimizer.json
+++ b/versions/m-/meshoptimizer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc9da2cb38ce03ffec29328de970d70611b13aef",
+      "git-tree": "6d163a87dea85bb49a94a99015678f3b4cb0a185",
       "version": "0.24",
       "port-version": 0
     },

--- a/versions/m-/meshoptimizer.json
+++ b/versions/m-/meshoptimizer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "039137b31ceb05bb719c7c788aa07c51a7b5223d",
+      "git-tree": "bc9da2cb38ce03ffec29328de970d70611b13aef",
       "version": "0.24",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/zeux/meshoptimizer/releases/tag/v0.24
