### PR TITLE
[luau] update to 0.678

### DIFF
--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 f36173635edb38fb1384f01b92e8b038f9e281568a5e3f3910735b4c29c14d518e2ab74bd7e834e90a2d703f82faedb9a0524d5f0be13c3acaa5eb189f320ba0
+    SHA512 cb335ac1af0ff6f6b5004be80c8e3109f700a9f935bcac06e02d12aed61d3e6a10cfc04bb04d6f92785b5a2dbff762494b729d564b6f6ffa30c7d7e6839634af
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.677",
+  "version": "0.678",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5881,7 +5881,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.677",
+      "baseline": "0.678",
       "port-version": 0
     },
     "luminoengine": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35e25cc71a55c44d073d601614d185f08a90aae3",
+      "version": "0.678",
+      "port-version": 0
+    },
+    {
       "git-tree": "acdebff3a330d7c3619beb4c8c173f84ece25d2a",
       "version": "0.677",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/luau-lang/luau/releases/tag/0.678
