### PR TITLE
[vcpkg baseline][qpid-proton] Update patch file

### DIFF
--- a/ports/qpid-proton/fix-dependencies.patch
+++ b/ports/qpid-proton/fix-dependencies.patch
@@ -70,6 +70,17 @@ index 2049fe9..3dc8a06 100644
    set(CONNECT_CONFIG_SRC src/connect_config.cpp)
    set(CONNECT_CONFIG_LIBS ${JsonCpp_LIBRARY})
  else()
+@@ -37,9 +37,9 @@ else()
+ endif()
+ 
+ # Check for OPENTELEMETRY-CPP for distributed tracing
+-find_package(opentelemetry-cpp)
+ option(ENABLE_OPENTELEMETRYCPP "Use opentelemetry for distributed tracing" ${OPENTELEMETRY-CPP_FOUND})
+ if (ENABLE_OPENTELEMETRYCPP)
++  find_package(opentelemetry-cpp)
+   include_directories(${OPENTELEMETRY_CPP_INCLUDE_DIRS})
+   set(TRACING_SRC src/tracing_opentelemetry.cpp src/tracing_stub.cpp)
+   set(TRACING_LIBS opentelemetry-cpp::trace)
 diff --git a/cpp/ProtonCppConfig.cmake.in b/cpp/ProtonCppConfig.cmake.in
 index aaa1bf9..e1be025 100644
 --- a/cpp/ProtonCppConfig.cmake.in

--- a/ports/qpid-proton/vcpkg.json
+++ b/ports/qpid-proton/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qpid-proton",
   "version": "0.38.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qpid Proton is a high-performance, lightweight messaging library.",
   "homepage": "https://github.com/apache/qpid-proton",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7630,7 +7630,7 @@
     },
     "qpid-proton": {
       "baseline": "0.38.0",
-      "port-version": 2
+      "port-version": 3
     },
     "qscintilla": {
       "baseline": "2.14.1",

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ea6c2164ee7fc53be914a5805ed90734cf85fd1",
+      "version": "0.38.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "2cf3ce91a7b7d428dece244d6626ebb67d03a37d",
       "version": "0.38.0",
       "port-version": 2


### PR DESCRIPTION
`qpid-proton` installation failed with following error in https://dev.azure.com/vcpkg/public/_build/results?buildId=116719&view=results
```
CMake Error at D:/installed/x64-windows-static-md/share/opentelemetry-cpp/find-package-support-functions.cmake:119 (if):
  if given arguments:
    "ZLIB" "IN_LIST" "COMPONENT_api_THIRDPARTY_DEPENDS"
  Unknown arguments specified
```
This issue is actually a usage bug introduced after the [update](https://github.com/microsoft/vcpkg/pull/45927) of `opentelemetry-cpp`. However, there is also an issue with `qpid-proton` itself. The `qpid-proton` package in vcpkg does not include `opentelemetry-cpp` as a dependency, and it also explicitly disables `opentelemetry-cpp` in the `portfile.cmake` (`-DENABLE_OPENTELEMETRYCPP=OFF`). However, `qpid-proton`’s `CMakeLists.txt` does not control `find_package(opentelemetry-cpp)` based on the `ENABLE_OPENTELEMETRYCPP` option; it calls it unconditionally. Therefore, I am currently updating the patch to make `find_package(opentelemetry-cpp)` be controlled by the `ENABLE_OPENTELEMETRYCPP` option.

As for the `opentelemetry-cpp` usage bug, it should be fixed in another pull request.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
