### PR TITLE
[libvault] update to 0.63.0

### DIFF
--- a/ports/libvault/portfile.cmake
+++ b/ports/libvault/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            abedra/libvault
     REF "${VERSION}"
-    SHA512 20a7e8ae5bac5278ff2c9588d24f853b0c80169e008e930c390a78e15d18f36c68c2666a4c6c4aa263689d5b89a8c9945eead4d88087035fafb9865fcc3466ca
+    SHA512 dc3295acafd1f9038430d8df00e96feb2252db0350716bd8a32c33d06a462a7ceb2c920458ca23bd42f5c14384fa1078ab4f69ff0817aa96b4e16ce03ddeddc2
     PATCHES
         0001-fix-dependencies.patch
 )

--- a/ports/libvault/vcpkg.json
+++ b/ports/libvault/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libvault",
-  "version": "0.61.0",
+  "version": "0.63.0",
   "description": "A C++ library for Hashicorp Vault",
   "homepage": "https://github.com/abedra/libvault",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5505,7 +5505,7 @@
       "port-version": 1
     },
     "libvault": {
-      "baseline": "0.61.0",
+      "baseline": "0.63.0",
       "port-version": 0
     },
     "libvhdi": {

--- a/versions/l-/libvault.json
+++ b/versions/l-/libvault.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fce2a067e2d7973d339d9c7046ae568a2aaae87f",
+      "version": "0.63.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "dcdc4c8aa3972fd6419a4203105ac1d57444b30f",
       "version": "0.61.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/abedra/libvault/releases/tag/0.63.0
https://github.com/abedra/libvault/releases/tag/0.62.0
