### PR TITLE
Exclude libdisasm CodeQL failures.

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,0 +1,3 @@
+path_classifiers:
+  library:
+    - "buildtrees/libdisasm/src/-87a041f03c.clean/libdisasm/ia32_insn.c"


### PR DESCRIPTION
It's probably a bad idea for people to use `libdisasm`; it's showing in our CodeQL scans because it's a dependency of `breakpad`, which I think is important to include in results because https://github.com/microsoft/vcpkg/blob/master/ports/breakpad/check_getcontext.cc exists.