### PR TITLE
Decouple from system openssl configuration

### DIFF
--- a/ports/openssl/unix/portfile.cmake
+++ b/ports/openssl/unix/portfile.cmake
@@ -117,7 +117,7 @@ vcpkg_configure_make(
         "${SOURCE_PATH}/Configure"
         ${OPENSSL_ARCH}
         ${CONFIGURE_OPTIONS}
-        "--openssldir=/etc/ssl"
+        "--openssldir=etc/ssl"
         "--libdir=lib"
     OPTIONS_DEBUG
         --debug
@@ -137,9 +137,6 @@ elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/etc/ssl/misc")
 endif()
-
-file(TOUCH "${CURRENT_PACKAGES_DIR}/etc/ssl/certs/.keep")
-file(TOUCH "${CURRENT_PACKAGES_DIR}/etc/ssl/private/.keep")
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/etc"

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openssl",
   "version": "3.5.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6990,7 +6990,7 @@
     },
     "openssl": {
       "baseline": "3.5.0",
-      "port-version": 1
+      "port-version": 2
     },
     "opensubdiv": {
       "baseline": "3.5.0",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "303b55ed960245e2c6dddc316605a2623bf041ad",
+      "version": "3.5.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "6819498ce6c5c3e379b3ffbd2b5d93e3fc271933",
       "version": "3.5.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #46047

This will work if we leave `--prefix` unset, but OpenSSL recommends setting `--prefix` and `--openssldir` to the same location (and we do this in [the Windows portfile](https://github.com/microsoft/vcpkg/blob/6b973816fb727bd4b2d8c7865c499feeeba35e75/ports/openssl/windows/portfile.cmake#L81), so I explicitly included it.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
