### PR TITLE
[stdgpu] add new port

### DIFF
--- a/ports/stdgpu/Findthrust.cmake
+++ b/ports/stdgpu/Findthrust.cmake
@@ -1,0 +1,46 @@
+find_path(THRUST_INCLUDE_DIR
+          HINTS
+          "/usr/include"
+          "/usr/local/include"
+          "/usr/local/cuda/include"
+          NAMES
+          "thrust/version.h")
+
+if(THRUST_INCLUDE_DIR)
+    file(STRINGS "${THRUST_INCLUDE_DIR}/thrust/version.h"
+         THRUST_VERSION_STRING
+         REGEX "#define THRUST_VERSION[ \t]+[0-9]+")
+
+    if(THRUST_VERSION_STRING)
+        # Extract just the numeric version
+        string(REGEX MATCH "[0-9]+" THRUST_VERSION_NUM "${THRUST_VERSION_STRING}")
+        
+        if(THRUST_VERSION_NUM)
+            math(EXPR THRUST_VERSION_MAJOR "${THRUST_VERSION_NUM} / 100000")
+            math(EXPR THRUST_VERSION_MINOR "(${THRUST_VERSION_NUM} / 100) % 1000")
+            math(EXPR THRUST_VERSION_PATCH "${THRUST_VERSION_NUM} % 100")
+            set(THRUST_VERSION "${THRUST_VERSION_MAJOR}.${THRUST_VERSION_MINOR}.${THRUST_VERSION_PATCH}")
+        else()
+            set(THRUST_VERSION "2.0.0") # Fallback version
+        endif()
+    else()
+        set(THRUST_VERSION "2.0.0") # Fallback version
+    endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(thrust
+                                  REQUIRED_VARS THRUST_INCLUDE_DIR
+                                  VERSION_VAR THRUST_VERSION)
+
+
+if(thrust_FOUND)
+    add_library(thrust::thrust INTERFACE IMPORTED)
+    set_target_properties(thrust::thrust PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${THRUST_INCLUDE_DIR}")
+
+    mark_as_advanced(THRUST_INCLUDE_DIR
+                     THRUST_VERSION
+                     THRUST_VERSION_MAJOR
+                     THRUST_VERSION_MINOR
+                     THRUST_VERSION_PATCH)
+endif()

--- a/ports/stdgpu/fix-cuda-architectures.patch
+++ b/ports/stdgpu/fix-cuda-architectures.patch
@@ -1,0 +1,34 @@
+From 207ca5423c4d5b0cae2f77e8b755972be36e1095 Mon Sep 17 00:00:00 2001
+From: "sewon.jeon" <sewon.jeon@connecteve.com>
+Date: Wed, 18 Jun 2025 19:00:48 +0900
+Subject: [PATCH] Fix CUDA architecture detection for CI
+
+---
+ cmake/cuda/set_device_flags.cmake | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/cmake/cuda/set_device_flags.cmake b/cmake/cuda/set_device_flags.cmake
+index eba9845..dcae204 100644
+--- a/cmake/cuda/set_device_flags.cmake
++++ b/cmake/cuda/set_device_flags.cmake
+@@ -69,7 +69,16 @@ function(stdgpu_cuda_set_architecture_flags STDGPU_OUTPUT_DEVICE_COMPILE_AND_LIN
+     endforeach()
+ 
+     if(NOT STDGPU_CUDA_HAVE_SUITABLE_GPU)
+-        message(FATAL_ERROR "No CUDA-capable GPU detected")
++        if(DEFINED CMAKE_CUDA_ARCHITECTURES)
++            message(STATUS "No CUDA GPU detected, using user-provided architectures: ${CMAKE_CUDA_ARCHITECTURES}")
++            # Convert CMAKE_CUDA_ARCHITECTURES to stdgpu format
++            foreach(ARCH IN LISTS CMAKE_CUDA_ARCHITECTURES)
++                string(APPEND ${STDGPU_OUTPUT_DEVICE_COMPILE_AND_LINK_FLAGS} " --generate-code arch=compute_${ARCH},code=sm_${ARCH}")
++                message(STATUS "Enabled compilation for CC ${ARCH} (user-provided)")
++            endforeach()
++        else()
++            message(FATAL_ERROR "No CUDA-capable GPU detected and no CMAKE_CUDA_ARCHITECTURES provided")
++        endif()
+     endif()
+ 
+     # Make output variable visible
+-- 
+2.34.1
+

--- a/ports/stdgpu/portfile.cmake
+++ b/ports/stdgpu/portfile.cmake
@@ -47,6 +47,11 @@ if(STDGPU_BACKEND_OPENMP)
     endif()
 endif()
 
+# Check for HIP availability when using HIP backend
+if(STDGPU_BACKEND_HIP)
+    message(STATUS "HIP backend selected - requires ROCm/HIP SDK to be installed system-wide")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/stdgpu/portfile.cmake
+++ b/ports/stdgpu/portfile.cmake
@@ -37,7 +37,7 @@ elseif(BACKEND_COUNT GREATER 1)
     message(FATAL_ERROR "Multiple backends selected. Please enable only one backend feature: cuda, openmp, or hip")
 endif()
 
-# Check for thrust availability when using OpenMP backend
+# Check for thrust availability when using OpenMP backend (Linux only)
 if(STDGPU_BACKEND_OPENMP)
     if(NOT EXISTS "/usr/include/thrust/version.h" AND NOT EXISTS "/usr/local/cuda/include/thrust/version.h")
         message(FATAL_ERROR "The OpenMP backend requires thrust headers. Please install thrust first:\n"

--- a/ports/stdgpu/portfile.cmake
+++ b/ports/stdgpu/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 1.3.0
     SHA512 ea4999a28e3ee1eccb7ea3033b49ee783dfee9a577e3110ca210cf93f12242926182187e937cfa9b37465ea14e30880beca6a710446b13905d5d5872bdf31a19
     HEAD_REF master
+    PATCHES
+        fix-cuda-architectures.patch
 )
 
 # Copy our fixed Findthrust.cmake
@@ -54,7 +56,7 @@ endif()
 # Set CUDA architectures for CUDA backend to avoid GPU detection on CI
 if(STDGPU_BACKEND STREQUAL "STDGPU_BACKEND_CUDA")
     # Use a minimal set of common architectures that work on CI
-    set(CUDA_ARCH_OPTIONS -DCMAKE_CUDA_ARCHITECTURES=52)
+    set(CUDA_ARCH_OPTIONS -DCMAKE_CUDA_ARCHITECTURES=native)
 else()
     set(CUDA_ARCH_OPTIONS "")
 endif()

--- a/ports/stdgpu/portfile.cmake
+++ b/ports/stdgpu/portfile.cmake
@@ -11,17 +11,13 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/Findthrust.cmake" DESTINATION "${SOURCE_PAT
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        cuda    STDGPU_BACKEND_CUDA
         openmp  STDGPU_BACKEND_OPENMP
         hip     STDGPU_BACKEND_HIP
 )
 
-# Ensure exactly one backend is selected
+# Backend selection via vcpkg features only
 set(BACKEND_COUNT 0)
-if(STDGPU_BACKEND_CUDA)
-    math(EXPR BACKEND_COUNT "${BACKEND_COUNT} + 1")
-    set(STDGPU_BACKEND "STDGPU_BACKEND_CUDA")
-endif()
+
 if(STDGPU_BACKEND_OPENMP)
     math(EXPR BACKEND_COUNT "${BACKEND_COUNT} + 1")
     set(STDGPU_BACKEND "STDGPU_BACKEND_OPENMP")
@@ -32,16 +28,13 @@ if(STDGPU_BACKEND_HIP)
 endif()
 
 if(BACKEND_COUNT EQUAL 0)
-    # No backend selected, use CUDA as default
-    message(STATUS "No backend feature specified, using CUDA as default backend")
     set(STDGPU_BACKEND "STDGPU_BACKEND_CUDA")
-    set(BACKEND_COUNT 1)
 elseif(BACKEND_COUNT GREATER 1)
-    message(FATAL_ERROR "Multiple backends selected. Please enable only one backend feature: cuda, openmp, or hip")
+    message(FATAL_ERROR "Multiple backends selected. Please enable only one backend feature: openmp or hip")
 endif()
 
 # Check for thrust availability when using OpenMP backend (Linux only)
-if(STDGPU_BACKEND_OPENMP)
+if(STDGPU_BACKEND STREQUAL "STDGPU_BACKEND_OPENMP")
     if(NOT EXISTS "/usr/include/thrust/version.h" AND NOT EXISTS "/usr/local/cuda/include/thrust/version.h")
         message(FATAL_ERROR "The OpenMP backend requires thrust headers. Please install thrust first:\n"
                             "  - On Ubuntu/Debian: sudo apt-get install libthrust-dev\n"
@@ -51,7 +44,7 @@ if(STDGPU_BACKEND_OPENMP)
 endif()
 
 # Check for HIP availability when using HIP backend
-if(STDGPU_BACKEND_HIP)
+if(STDGPU_BACKEND STREQUAL "STDGPU_BACKEND_HIP")
     message(STATUS "HIP backend selected - requires ROCm/HIP SDK to be installed system-wide")
 endif()
 

--- a/ports/stdgpu/portfile.cmake
+++ b/ports/stdgpu/portfile.cmake
@@ -35,6 +35,9 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        # This is the crucial line to add.
+        # This will bypass the GPU auto-detection in stdgpu's build script.
+        -DCMAKE_CUDA_ARCHITECTURES=60;61;70;75;80;86
         -DSTDGPU_BACKEND=${STDGPU_BACKEND}
         -DSTDGPU_BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
         -DSTDGPU_BUILD_TESTS=OFF

--- a/ports/stdgpu/portfile.cmake
+++ b/ports/stdgpu/portfile.cmake
@@ -1,0 +1,70 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO stotko/stdgpu
+    REF 1.3.0
+    SHA512 ea4999a28e3ee1eccb7ea3033b49ee783dfee9a577e3110ca210cf93f12242926182187e937cfa9b37465ea14e30880beca6a710446b13905d5d5872bdf31a19
+    HEAD_REF master
+)
+
+# Copy our fixed Findthrust.cmake
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/Findthrust.cmake" DESTINATION "${SOURCE_PATH}/cmake/")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        cuda    STDGPU_BACKEND_CUDA
+        openmp  STDGPU_BACKEND_OPENMP
+        hip     STDGPU_BACKEND_HIP
+)
+
+# Ensure exactly one backend is selected
+set(BACKEND_COUNT 0)
+if(STDGPU_BACKEND_CUDA)
+    math(EXPR BACKEND_COUNT "${BACKEND_COUNT} + 1")
+    set(STDGPU_BACKEND "STDGPU_BACKEND_CUDA")
+endif()
+if(STDGPU_BACKEND_OPENMP)
+    math(EXPR BACKEND_COUNT "${BACKEND_COUNT} + 1")
+    set(STDGPU_BACKEND "STDGPU_BACKEND_OPENMP")
+endif()
+if(STDGPU_BACKEND_HIP)
+    math(EXPR BACKEND_COUNT "${BACKEND_COUNT} + 1")
+    set(STDGPU_BACKEND "STDGPU_BACKEND_HIP")
+endif()
+
+if(BACKEND_COUNT EQUAL 0)
+    message(FATAL_ERROR "No backend selected. Please enable at least one backend feature: cuda, openmp, or hip")
+elseif(BACKEND_COUNT GREATER 1)
+    message(FATAL_ERROR "Multiple backends selected. Please enable only one backend feature: cuda, openmp, or hip")
+endif()
+
+# Check for thrust availability when using OpenMP backend
+if(STDGPU_BACKEND_OPENMP)
+    if(NOT EXISTS "/usr/include/thrust/version.h" AND NOT EXISTS "/usr/local/cuda/include/thrust/version.h")
+        message(FATAL_ERROR "The OpenMP backend requires thrust headers. Please install thrust first:\n"
+                            "  - On Ubuntu/Debian: sudo apt-get install libthrust-dev\n"
+                            "  - Or install CUDA which includes thrust\n"
+                            "  - On other systems, install thrust manually")
+    endif()
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSTDGPU_BACKEND=${STDGPU_BACKEND}
+        -DSTDGPU_BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+        -DSTDGPU_BUILD_TESTS=OFF
+        -DSTDGPU_BUILD_EXAMPLES=OFF
+        -DSTDGPU_ENABLE_CONTRACT_CHECKS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/stdgpu)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_copy_pdbs()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/stdgpu/portfile.cmake
+++ b/ports/stdgpu/portfile.cmake
@@ -32,7 +32,10 @@ if(STDGPU_BACKEND_HIP)
 endif()
 
 if(BACKEND_COUNT EQUAL 0)
-    message(FATAL_ERROR "No backend selected. Please enable at least one backend feature: cuda, openmp, or hip")
+    # No backend selected, use CUDA as default
+    message(STATUS "No backend feature specified, using CUDA as default backend")
+    set(STDGPU_BACKEND "STDGPU_BACKEND_CUDA")
+    set(BACKEND_COUNT 1)
 elseif(BACKEND_COUNT GREATER 1)
     message(FATAL_ERROR "Multiple backends selected. Please enable only one backend feature: cuda, openmp, or hip")
 endif()

--- a/ports/stdgpu/portfile.cmake
+++ b/ports/stdgpu/portfile.cmake
@@ -32,12 +32,18 @@ if(STDGPU_BACKEND STREQUAL "STDGPU_BACKEND_OPENMP")
 endif()
 
 
+# Set CUDA architectures for CUDA backend to avoid GPU detection on CI
+if(STDGPU_BACKEND STREQUAL "STDGPU_BACKEND_CUDA")
+    # Use a minimal set of common architectures that work on CI
+    set(CUDA_ARCH_OPTIONS -DCMAKE_CUDA_ARCHITECTURES=52)
+else()
+    set(CUDA_ARCH_OPTIONS "")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        # This is the crucial line to add.
-        # This will bypass the GPU auto-detection in stdgpu's build script.
-        -DCMAKE_CUDA_ARCHITECTURES=60;61;70;75;80;86
+        ${CUDA_ARCH_OPTIONS}
         -DSTDGPU_BACKEND=${STDGPU_BACKEND}
         -DSTDGPU_BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
         -DSTDGPU_BUILD_TESTS=OFF

--- a/ports/stdgpu/portfile.cmake
+++ b/ports/stdgpu/portfile.cmake
@@ -27,13 +27,9 @@ if(STDGPU_BACKEND_OPENMP)
 endif()
 
 if(BACKEND_COUNT EQUAL 0)
-    # Default to OpenMP on Linux, error on other platforms
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        set(STDGPU_BACKEND "STDGPU_BACKEND_OPENMP")
-        message(STATUS "No backend specified, defaulting to OpenMP backend")
-    else()
-        message(FATAL_ERROR "No backend selected. Please specify cuda or openmp feature.")
-    endif()
+    # Default to CUDA backend when no features specified
+    set(STDGPU_BACKEND "STDGPU_BACKEND_CUDA")
+    message(STATUS "No backend specified, defaulting to CUDA backend")
 elseif(BACKEND_COUNT GREATER 1)
     message(FATAL_ERROR "Multiple backends selected. Please enable only one backend feature: cuda or openmp")
 endif()

--- a/ports/stdgpu/portfile.cmake
+++ b/ports/stdgpu/portfile.cmake
@@ -12,25 +12,13 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/Findthrust.cmake" DESTINATION "${SOURCE_PAT
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         openmp  STDGPU_BACKEND_OPENMP
-        hip     STDGPU_BACKEND_HIP
 )
 
-# Backend selection via vcpkg features only
-set(BACKEND_COUNT 0)
-
+# Backend selection: CUDA (default) or OpenMP
 if(STDGPU_BACKEND_OPENMP)
-    math(EXPR BACKEND_COUNT "${BACKEND_COUNT} + 1")
     set(STDGPU_BACKEND "STDGPU_BACKEND_OPENMP")
-endif()
-if(STDGPU_BACKEND_HIP)
-    math(EXPR BACKEND_COUNT "${BACKEND_COUNT} + 1")
-    set(STDGPU_BACKEND "STDGPU_BACKEND_HIP")
-endif()
-
-if(BACKEND_COUNT EQUAL 0)
+else()
     set(STDGPU_BACKEND "STDGPU_BACKEND_CUDA")
-elseif(BACKEND_COUNT GREATER 1)
-    message(FATAL_ERROR "Multiple backends selected. Please enable only one backend feature: openmp or hip")
 endif()
 
 # Check for thrust availability when using OpenMP backend (Linux only)
@@ -43,10 +31,6 @@ if(STDGPU_BACKEND STREQUAL "STDGPU_BACKEND_OPENMP")
     endif()
 endif()
 
-# Check for HIP availability when using HIP backend
-if(STDGPU_BACKEND STREQUAL "STDGPU_BACKEND_HIP")
-    message(STATUS "HIP backend selected - requires ROCm/HIP SDK to be installed system-wide")
-endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/stdgpu/usage
+++ b/ports/stdgpu/usage
@@ -5,12 +5,14 @@ stdgpu provides CMake targets:
 
 Note: You must select exactly one backend when installing:
   - vcpkg install stdgpu          # CUDA backend (default)
-  - vcpkg install stdgpu[openmp]  # OpenMP backend
-  - vcpkg install stdgpu[hip]     # HIP backend (requires ROCm/HIP SDK)
+  - vcpkg install stdgpu[openmp]  # OpenMP backend (Linux only, requires thrust)
+  - vcpkg install stdgpu[hip]     # HIP backend (Linux only, requires ROCm/HIP SDK)
 
-Platform support: Linux and Windows only (macOS not supported)
+Platform support: 
+  - Windows x64 (not UWP/Xbox) - CUDA backend only
+  - Linux x64 and ARM64 - All backends
 
 Dependencies:
   - CUDA backend: Automatically installs CUDA via vcpkg
-  - OpenMP backend: Uses system OpenMP + thrust headers
-  - HIP backend: Requires ROCm/HIP SDK installed system-wide
+  - OpenMP backend: Requires system thrust headers (Linux only)
+  - HIP backend: Requires ROCm/HIP SDK installed system-wide (Linux only)

--- a/ports/stdgpu/usage
+++ b/ports/stdgpu/usage
@@ -1,0 +1,9 @@
+stdgpu provides CMake targets:
+
+    find_package(stdgpu REQUIRED)
+    target_link_libraries(main PRIVATE stdgpu::stdgpu)
+
+Note: You must select exactly one backend when installing:
+  - vcpkg install stdgpu[openmp]  # OpenMP backend (default)
+  - vcpkg install stdgpu[cuda]    # CUDA backend
+  - vcpkg install stdgpu[hip]     # HIP backend (experimental, Linux only)

--- a/ports/stdgpu/usage
+++ b/ports/stdgpu/usage
@@ -4,6 +4,10 @@ stdgpu provides CMake targets:
     target_link_libraries(main PRIVATE stdgpu::stdgpu)
 
 Installation:
-  - vcpkg install stdgpu          # OpenMP backend (default on Linux)
-  - vcpkg install stdgpu[cuda]    # CUDA backend
-  - vcpkg install stdgpu[openmp]  # OpenMP backend (explicit)
+  - vcpkg install stdgpu          # CUDA backend (default)
+  - vcpkg install stdgpu[cuda]    # CUDA backend (explicit)
+  - vcpkg install stdgpu[openmp]  # OpenMP backend (Linux only)
+
+Platform support:
+  - Windows x64 (not UWP/Xbox): CUDA backend only
+  - Linux x64/ARM64: Both CUDA and OpenMP backends

--- a/ports/stdgpu/usage
+++ b/ports/stdgpu/usage
@@ -4,5 +4,6 @@ stdgpu provides CMake targets:
     target_link_libraries(main PRIVATE stdgpu::stdgpu)
 
 Installation:
-  - vcpkg install stdgpu          # CUDA backend (default)
-  - vcpkg install stdgpu[openmp]  # OpenMP backend (Linux only)
+  - vcpkg install stdgpu          # OpenMP backend (default on Linux)
+  - vcpkg install stdgpu[cuda]    # CUDA backend
+  - vcpkg install stdgpu[openmp]  # OpenMP backend (explicit)

--- a/ports/stdgpu/usage
+++ b/ports/stdgpu/usage
@@ -3,16 +3,6 @@ stdgpu provides CMake targets:
     find_package(stdgpu REQUIRED)
     target_link_libraries(main PRIVATE stdgpu::stdgpu)
 
-Backend selection:
+Installation:
   - vcpkg install stdgpu          # CUDA backend (default)
   - vcpkg install stdgpu[openmp]  # OpenMP backend (Linux only)
-  - vcpkg install stdgpu[hip]     # HIP backend (Linux only, requires ROCm/HIP SDK)
-
-Platform support: 
-  - Windows x64 (not UWP/Xbox) - CUDA backend only
-  - Linux x64 and ARM64 - All backends
-
-Dependencies:
-  - CUDA backend: Automatically installs CUDA via vcpkg
-  - OpenMP backend: Requires system thrust headers (Linux only)
-  - HIP backend: Requires ROCm/HIP SDK installed system-wide (Linux only)

--- a/ports/stdgpu/usage
+++ b/ports/stdgpu/usage
@@ -4,8 +4,8 @@ stdgpu provides CMake targets:
     target_link_libraries(main PRIVATE stdgpu::stdgpu)
 
 Note: You must select exactly one backend when installing:
+  - vcpkg install stdgpu          # CUDA backend (default)
   - vcpkg install stdgpu[openmp]  # OpenMP backend
-  - vcpkg install stdgpu[cuda]    # CUDA backend  
   - vcpkg install stdgpu[hip]     # HIP backend (requires ROCm/HIP SDK)
 
 Platform support: Linux and Windows only (macOS not supported)

--- a/ports/stdgpu/usage
+++ b/ports/stdgpu/usage
@@ -4,6 +4,8 @@ stdgpu provides CMake targets:
     target_link_libraries(main PRIVATE stdgpu::stdgpu)
 
 Note: You must select exactly one backend when installing:
-  - vcpkg install stdgpu[openmp]  # OpenMP backend (default)
-  - vcpkg install stdgpu[cuda]    # CUDA backend
-  - vcpkg install stdgpu[hip]     # HIP backend (experimental, Linux only)
+  - vcpkg install stdgpu[openmp]  # OpenMP backend
+  - vcpkg install stdgpu[cuda]    # CUDA backend  
+  - vcpkg install stdgpu[hip]     # HIP backend (experimental)
+
+Platform support: Linux and Windows only (macOS not supported)

--- a/ports/stdgpu/usage
+++ b/ports/stdgpu/usage
@@ -6,6 +6,11 @@ stdgpu provides CMake targets:
 Note: You must select exactly one backend when installing:
   - vcpkg install stdgpu[openmp]  # OpenMP backend
   - vcpkg install stdgpu[cuda]    # CUDA backend  
-  - vcpkg install stdgpu[hip]     # HIP backend (experimental)
+  - vcpkg install stdgpu[hip]     # HIP backend (requires ROCm/HIP SDK)
 
 Platform support: Linux and Windows only (macOS not supported)
+
+Dependencies:
+  - CUDA backend: Automatically installs CUDA via vcpkg
+  - OpenMP backend: Uses system OpenMP + thrust headers
+  - HIP backend: Requires ROCm/HIP SDK installed system-wide

--- a/ports/stdgpu/usage
+++ b/ports/stdgpu/usage
@@ -3,9 +3,9 @@ stdgpu provides CMake targets:
     find_package(stdgpu REQUIRED)
     target_link_libraries(main PRIVATE stdgpu::stdgpu)
 
-Note: You must select exactly one backend when installing:
+Backend selection:
   - vcpkg install stdgpu          # CUDA backend (default)
-  - vcpkg install stdgpu[openmp]  # OpenMP backend (Linux only, requires thrust)
+  - vcpkg install stdgpu[openmp]  # OpenMP backend (Linux only)
   - vcpkg install stdgpu[hip]     # HIP backend (Linux only, requires ROCm/HIP SDK)
 
 Platform support: 

--- a/ports/stdgpu/vcpkg.json
+++ b/ports/stdgpu/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Open-source library providing generic GPU data structures for fast and reliable data management",
   "homepage": "https://github.com/stotko/stdgpu",
   "license": "Apache-2.0",
+  "supports": "!osx",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -23,7 +24,6 @@
     },
     "hip": {
       "description": "Build with experimental HIP backend",
-      "supports": "!windows",
       "dependencies": [
         "hip"
       ]

--- a/ports/stdgpu/vcpkg.json
+++ b/ports/stdgpu/vcpkg.json
@@ -16,19 +16,13 @@
       "host": true
     }
   ],
-  "default-features": [
-    "cuda"
-  ],
   "features": {
-    "cuda": {
-      "description": "Build with CUDA backend"
-    },
     "hip": {
       "description": "Build with experimental HIP backend (requires ROCm/HIP SDK installed)",
       "supports": "linux"
     },
     "openmp": {
-      "description": "Build with OpenMP backend (requires thrust headers, e.g., from CUDA installation or libthrust-dev package)",
+      "description": "Build with OpenMP backend",
       "supports": "linux"
     }
   }

--- a/ports/stdgpu/vcpkg.json
+++ b/ports/stdgpu/vcpkg.json
@@ -1,0 +1,36 @@
+{
+  "name": "stdgpu",
+  "version": "1.3.0",
+  "description": "Open-source library providing generic GPU data structures for fast and reliable data management",
+  "homepage": "https://github.com/stotko/stdgpu",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [],
+  "features": {
+    "cuda": {
+      "description": "Build with CUDA backend",
+      "dependencies": [
+        "cuda"
+      ]
+    },
+    "hip": {
+      "description": "Build with experimental HIP backend",
+      "dependencies": [
+        "hip"
+      ],
+      "supports": "!windows"
+    },
+    "openmp": {
+      "description": "Build with OpenMP backend (requires thrust headers, e.g., from CUDA installation or libthrust-dev package)"
+    }
+  }
+}

--- a/ports/stdgpu/vcpkg.json
+++ b/ports/stdgpu/vcpkg.json
@@ -17,10 +17,6 @@
     }
   ],
   "features": {
-    "hip": {
-      "description": "Build with experimental HIP backend (requires ROCm/HIP SDK installed)",
-      "supports": "linux"
-    },
     "openmp": {
       "description": "Build with OpenMP backend",
       "supports": "linux"

--- a/ports/stdgpu/vcpkg.json
+++ b/ports/stdgpu/vcpkg.json
@@ -6,7 +6,6 @@
   "license": "Apache-2.0",
   "supports": "(windows & x64 & !uwp & !xbox) | (linux & x64) | (linux & arm64)",
   "dependencies": [
-    "cuda",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -16,10 +15,22 @@
       "host": true
     }
   ],
+  "default-features": [
+    "openmp"
+  ],
   "features": {
+    "cuda": {
+      "description": "Build with CUDA backend",
+      "dependencies": [
+        "cuda"
+      ]
+    },
     "openmp": {
-      "description": "Build with OpenMP backend",
-      "supports": "linux"
+      "description": "Build with OpenMP backend (default)",
+      "supports": "linux",
+      "dependencies": [
+        "cuda"
+      ]
     }
   }
 }

--- a/ports/stdgpu/vcpkg.json
+++ b/ports/stdgpu/vcpkg.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "supports": "(windows & x64 & !uwp & !xbox) | (linux & x64) | (linux & arm64)",
   "dependencies": [
+    "cuda",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -20,10 +21,7 @@
   ],
   "features": {
     "cuda": {
-      "description": "Build with CUDA backend",
-      "dependencies": [
-        "cuda"
-      ]
+      "description": "Build with CUDA backend"
     },
     "hip": {
       "description": "Build with experimental HIP backend (requires ROCm/HIP SDK installed)",

--- a/ports/stdgpu/vcpkg.json
+++ b/ports/stdgpu/vcpkg.json
@@ -14,7 +14,6 @@
       "host": true
     }
   ],
-  "default-features": [],
   "features": {
     "cuda": {
       "description": "Build with CUDA backend",
@@ -24,10 +23,10 @@
     },
     "hip": {
       "description": "Build with experimental HIP backend",
+      "supports": "!windows",
       "dependencies": [
         "hip"
-      ],
-      "supports": "!windows"
+      ]
     },
     "openmp": {
       "description": "Build with OpenMP backend (requires thrust headers, e.g., from CUDA installation or libthrust-dev package)"

--- a/ports/stdgpu/vcpkg.json
+++ b/ports/stdgpu/vcpkg.json
@@ -15,6 +15,9 @@
       "host": true
     }
   ],
+  "default-features": [
+    "cuda"
+  ],
   "features": {
     "cuda": {
       "description": "Build with CUDA backend",

--- a/ports/stdgpu/vcpkg.json
+++ b/ports/stdgpu/vcpkg.json
@@ -23,10 +23,7 @@
       ]
     },
     "hip": {
-      "description": "Build with experimental HIP backend",
-      "dependencies": [
-        "hip"
-      ]
+      "description": "Build with experimental HIP backend (requires ROCm/HIP SDK installed)"
     },
     "openmp": {
       "description": "Build with OpenMP backend (requires thrust headers, e.g., from CUDA installation or libthrust-dev package)"

--- a/ports/stdgpu/vcpkg.json
+++ b/ports/stdgpu/vcpkg.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "supports": "(windows & x64 & !uwp & !xbox) | (linux & x64) | (linux & arm64)",
   "dependencies": [
+    "cuda",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -16,21 +17,15 @@
     }
   ],
   "default-features": [
-    "openmp"
+    "cuda"
   ],
   "features": {
     "cuda": {
-      "description": "Build with CUDA backend",
-      "dependencies": [
-        "cuda"
-      ]
+      "description": "Build with CUDA backend"
     },
     "openmp": {
-      "description": "Build with OpenMP backend (default)",
-      "supports": "linux",
-      "dependencies": [
-        "cuda"
-      ]
+      "description": "Build with OpenMP backend (Linux only)",
+      "supports": "linux"
     }
   }
 }

--- a/ports/stdgpu/vcpkg.json
+++ b/ports/stdgpu/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Open-source library providing generic GPU data structures for fast and reliable data management",
   "homepage": "https://github.com/stotko/stdgpu",
   "license": "Apache-2.0",
-  "supports": "!osx",
+  "supports": "(windows & x64 & !uwp & !xbox) | (linux & x64) | (linux & arm64)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -26,10 +26,12 @@
       ]
     },
     "hip": {
-      "description": "Build with experimental HIP backend (requires ROCm/HIP SDK installed)"
+      "description": "Build with experimental HIP backend (requires ROCm/HIP SDK installed)",
+      "supports": "linux"
     },
     "openmp": {
-      "description": "Build with OpenMP backend (requires thrust headers, e.g., from CUDA installation or libthrust-dev package)"
+      "description": "Build with OpenMP backend (requires thrust headers, e.g., from CUDA installation or libthrust-dev package)",
+      "supports": "linux"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9072,6 +9072,10 @@
       "baseline": "2024-06-16",
       "port-version": 2
     },
+    "stdgpu": {
+      "baseline": "1.3.0",
+      "port-version": 0
+    },
     "stduuid": {
       "baseline": "1.2.3",
       "port-version": 0

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "88ef92ed86c5358042b6c33a3865b629540c055e",
+      "git-tree": "3d6979f2a66f8bb1e1d84e46ec4f8d2a66a7c373",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3d6979f2a66f8bb1e1d84e46ec4f8d2a66a7c373",
+      "git-tree": "91bf7ff28afbc8246ff2b67f3e965b8ca29e1d64",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ec76a71fb7e9f6ee706bb2433c991a328f738750",
+      "git-tree": "6e8308b9e06fd6ae402f38d9e4a4c29ccddcc59b",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2cfa0bff09f0512db277e83721f1efcd13d056fa",
+      "git-tree": "ec76a71fb7e9f6ee706bb2433c991a328f738750",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2c4ee5411745e06d48debb6e431b021e27034697",
+      "git-tree": "88ef92ed86c5358042b6c33a3865b629540c055e",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6e8308b9e06fd6ae402f38d9e4a4c29ccddcc59b",
+      "git-tree": "09cb68e6b8816a87bd087264fcb7c6059c1707c4",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2022dbe95a78a0d86de95b3e10dbda6dbbaed095",
+      "git-tree": "6da74d173a2ef31239fe722f8f78b915c9fd7a7c",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6da74d173a2ef31239fe722f8f78b915c9fd7a7c",
+      "git-tree": "2cfa0bff09f0512db277e83721f1efcd13d056fa",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "25974efe57814dcde289ffdb127d5f83271af6f4",
+      "git-tree": "74826eb77a47168ae915991b01426ac2b3e3a08d",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2caeae7794c0d081ad9df6e2b2b7a2217429720a",
+      "git-tree": "0821c7d16d56b4dd171cac66e58dc09a7b4c3ad7",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "74826eb77a47168ae915991b01426ac2b3e3a08d",
+      "git-tree": "21f30edcd56d0c24623555d4a79306c199562f87",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d573c36b5079419ad41eda58941cd19d7c6b84c9",
+      "git-tree": "2c4ee5411745e06d48debb6e431b021e27034697",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2caeae7794c0d081ad9df6e2b2b7a2217429720a",
+      "version": "1.3.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "21f30edcd56d0c24623555d4a79306c199562f87",
+      "git-tree": "2022dbe95a78a0d86de95b3e10dbda6dbbaed095",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0821c7d16d56b4dd171cac66e58dc09a7b4c3ad7",
+      "git-tree": "25974efe57814dcde289ffdb127d5f83271af6f4",
       "version": "1.3.0",
       "port-version": 0
     }

--- a/versions/s-/stdgpu.json
+++ b/versions/s-/stdgpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "09cb68e6b8816a87bd087264fcb7c6059c1707c4",
+      "git-tree": "d573c36b5079419ad41eda58941cd19d7c6b84c9",
       "version": "1.3.0",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

