### PR TITLE
[ports/zip] New port

### DIFF
--- a/ports/zip/CMakeLists.txt
+++ b/ports/zip/CMakeLists.txt
@@ -10,39 +10,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
 
-set(Header_Files "src/zip.h" "src/miniz.h")
-source_group("Header Files" FILES "${Header_Files}")
+add_subdirectory(src)
 
-set(Source_Files "src/zip.c")
-source_group("Source Files" FILES "${Source_Files}")
-
-add_library("${PROJECT_NAME}" "${Header_Files}" "${Source_Files}")
-
-include(GNUInstallDirs)
-target_include_directories(
-        "${PROJECT_NAME}"
-        PRIVATE
-        "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>"
-        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-)
-
-# find_package(miniz CONFIG REQUIRED)
-# target_link_libraries("${PROJECT_NAME}" PRIVATE miniz::miniz)
-
-set_target_properties("${PROJECT_NAME}" PROPERTIES LINKER_LANGUAGE C)
-
-#######################################
-# Export / installation configuration #
-#######################################
-
-set_property(TARGET "${PROJECT_NAME}" PROPERTY VERSION "${${PROJECT_NAME}_VERSION}")
-set_property(TARGET "${PROJECT_NAME}" PROPERTY SOVERSION "${${PROJECT_NAME}_VERSION_MAJOR}")
-
-install(TARGETS ${LIBRARY_NAME}
-        EXPORT "${PROJECT_NAME}Targets"
-        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-
-install(FILES ${Header_Files}
-        TYPE "INCLUDE")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/${PROJECT_NAME}Config.cmake"
+        DESTINATION share/${PROJECT_NAME})

--- a/ports/zip/CMakeLists.txt
+++ b/ports/zip/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.19)
+project(zip VERSION "2025.06.13" LANGUAGES C)
+
+set(HOMEPAGE_URL "https://github.com/kuba--/${PROJECT_NAME}")
+set(DESCRIPTION "A portable, simple zip library written in C")
+
+set(CMAKE_C_STANDARD 90)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
+
+set(Header_Files "src/zip.h" "src/miniz.h")
+source_group("Header Files" FILES "${Header_Files}")
+
+set(Source_Files "src/zip.c")
+source_group("Source Files" FILES "${Source_Files}")
+
+add_library("${PROJECT_NAME}" "${Header_Files}" "${Source_Files}")
+
+include(GNUInstallDirs)
+target_include_directories(
+        "${PROJECT_NAME}"
+        PRIVATE
+        "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>"
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+
+# find_package(miniz CONFIG REQUIRED)
+# target_link_libraries("${PROJECT_NAME}" PRIVATE miniz::miniz)
+
+set_target_properties("${PROJECT_NAME}" PROPERTIES LINKER_LANGUAGE C)
+
+#######################################
+# Export / installation configuration #
+#######################################
+
+set_property(TARGET "${PROJECT_NAME}" PROPERTY VERSION "${${PROJECT_NAME}_VERSION}")
+set_property(TARGET "${PROJECT_NAME}" PROPERTY SOVERSION "${${PROJECT_NAME}_VERSION_MAJOR}")
+
+install(TARGETS ${LIBRARY_NAME}
+        EXPORT "${PROJECT_NAME}Targets"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
+install(FILES ${Header_Files}
+        TYPE "INCLUDE")

--- a/ports/zip/portfile.cmake
+++ b/ports/zip/portfile.cmake
@@ -9,13 +9,21 @@ vcpkg_from_github(
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt"
      DESTINATION "${SOURCE_PATH}")
 
+file(COPY
+        "${CMAKE_CURRENT_LIST_DIR}/src/CMakeLists.txt"
+        "${CMAKE_CURRENT_LIST_DIR}/src/${PORT}Config.cmake"
+        DESTINATION "${SOURCE_PATH}/src")
+
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
 
-# file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/src/${PORT}Config.cmake"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/zip/portfile.cmake
+++ b/ports/zip/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kuba--/zip
+    REF a0fcdbf0fae4ebba741cc41cd1b286e52f3e3424
+    SHA512 23db0c92893a07de786c6520425de8373f4642f8438248cb1e8ffca6668b73032e666cbb5175cf0f2cc06dd913cc1a76a6eac6bd7b0be355a146f4a865cd7568
+    HEAD_REF master
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt"
+     DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+
+vcpkg_cmake_install()
+
+# file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/zip/src/CMakeLists.txt
+++ b/ports/zip/src/CMakeLists.txt
@@ -1,0 +1,36 @@
+set(Header_Files "zip.h" "miniz.h")
+source_group("Header Files" FILES "${Header_Files}")
+
+set(Source_Files "zip.c")
+source_group("Source Files" FILES "${Source_Files}")
+
+add_library("${PROJECT_NAME}" "${Header_Files}" "${Source_Files}")
+
+include(GNUInstallDirs)
+target_include_directories(
+        "${PROJECT_NAME}"
+        PRIVATE
+        "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>"
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+
+# find_package(miniz CONFIG REQUIRED)
+# target_link_libraries("${PROJECT_NAME}" PRIVATE miniz::miniz)
+
+set_target_properties("${PROJECT_NAME}" PROPERTIES LINKER_LANGUAGE C)
+
+#######################################
+# Export / installation configuration #
+#######################################
+
+set_property(TARGET "${PROJECT_NAME}" PROPERTY VERSION "${${PROJECT_NAME}_VERSION}")
+set_property(TARGET "${PROJECT_NAME}" PROPERTY SOVERSION "${${PROJECT_NAME}_VERSION_MAJOR}")
+
+install(TARGETS ${LIBRARY_NAME}
+        EXPORT "${PROJECT_NAME}Targets"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
+install(FILES ${Header_Files}
+        TYPE "INCLUDE")

--- a/ports/zip/src/zipConfig.cmake
+++ b/ports/zip/src/zipConfig.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/zipTargets.cmake)

--- a/ports/zip/usage
+++ b/ports/zip/usage
@@ -1,0 +1,4 @@
+zip provides CMake targets:
+
+  find_package(zip CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE zip)

--- a/ports/zip/vcpkg.json
+++ b/ports/zip/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "zip",
+  "version-date": "2025-06-13",
+  "description": "A portable, simple zip library written in C",
+  "homepage": "https://github.com/kuba--/zip",
+  "license": "MIT",
+  "dependencies": [
+    "miniz",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10456,6 +10456,10 @@
       "baseline": "2.15.0",
       "port-version": 0
     },
+    "zip": {
+      "baseline": "2025-06-13",
+      "port-version": 0
+    },
     "zix": {
       "baseline": "0.6.2",
       "port-version": 0

--- a/versions/z-/zip.json
+++ b/versions/z-/zip.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "12003ef1600b6ac4174b6029e841747c808f5779",
+      "git-tree": "aa95460f15d8bdb3cee5a23ac0b615e7ba21e26b",
       "version-date": "2025-06-13",
       "port-version": 0
     }

--- a/versions/z-/zip.json
+++ b/versions/z-/zip.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "12003ef1600b6ac4174b6029e841747c808f5779",
+      "version-date": "2025-06-13",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
> A portable, simple zip library written in C

https://github.com/kuba--/zip

---

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.