### PR TITLE
Fix error in x_vcpkg_install_local_dependencies (#46061)

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -699,9 +699,10 @@ function(x_vcpkg_install_local_dependencies)
             set(component_param COMPONENT "${arg_COMPONENT}")
         endif()
 
+        set(allowed_target_types MODULE_LIBRARY SHARED_LIBRARY EXECUTABLE)
         foreach(target IN LISTS arg_TARGETS)
             get_target_property(target_type "${target}" TYPE)
-            if(NOT target_type STREQUAL "INTERFACE_LIBRARY")
+            if(target_type IN_LIST allowed_target_types)
                 install(CODE "message(\"-- Installing app dependencies for ${target}...\")
                     execute_process(COMMAND \"${Z_VCPKG_POWERSHELL_PATH}\" -noprofile -executionpolicy Bypass -file \"${Z_VCPKG_TOOLCHAIN_DIR}/msbuild/applocal.ps1\"
                         -targetBinary \"${arg_DESTINATION}/$<TARGET_FILE_NAME:${target}>\"


### PR DESCRIPTION
OBJECT_LIBARIES must be ignored in x_vcpkg_install_local_dependencies, because the generator expression $<TARGET_FILE_NAME:tgt> is invalid for them.

Fixes #46061.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
