### PR TITLE
[tracy] update to 0.12.1

### DIFF
--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -1,18 +1,11 @@
-vcpkg_download_distfile(PATCH_MISSING_CHRONO_INCLUDE
-    URLS https://github.com/wolfpld/tracy/commit/50ff279aaddfd91dc3cdcfd5b7aec3978e63da25.diff?full_index=1
-    SHA512 f9594297ea68612b68bd631497cd312ea01b34280a0f098de0d2b99810149345251a8985a6430337d0b55d2f181ceac10d563b64cfe48f78959f79ec7a6ea3b5
-    FILENAME wolfpld-tracy-PR982.diff
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfpld/tracy
     REF "v${VERSION}"
-    SHA512 d3d99284e3c3172236c3f02b3bc52df111ef650fb8609e54fb3302ece28e55a06cd16713ed532f1e1aad66678ff09639dfc7e01a1e96880fb923b267a1b1b79b
+    SHA512 991ac48a00943b349b1bed9110fa7886d1378bf4e0f488b214aca244db988a9c39bfb8b4df6e60cea604fbb5d43120d6be68a0fcfbf41300547a4726a62a98d3
     HEAD_REF master
     PATCHES
         build-tools.patch
-		"${PATCH_MISSING_CHRONO_INCLUDE}"
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -40,6 +33,10 @@ vcpkg_cmake_configure(
     OPTIONS
         -DDOWNLOAD_CAPSTONE=OFF
         -DLEGACY=ON
+        -DCPM_LOCAL_PACKAGES_ONLY=ON
+        -DCPM_DONT_UPDATE_MODULE_PATH=ON
+        -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+        -DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS
         ${FEATURE_OPTIONS}
     OPTIONS_RELEASE
         ${TOOLS_OPTIONS}
@@ -49,7 +46,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(PACKAGE_NAME Tracy)
+vcpkg_cmake_config_fixup(PACKAGE_NAME Tracy CONFIG_PATH lib/cmake/Tracy)
 
 function(tracy_copy_tool tool_name tool_dir)
     vcpkg_copy_tools(

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tracy",
-  "version": "0.11.1",
-  "port-version": 2,
+  "version": "0.12.1",
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",
@@ -43,10 +42,13 @@
         },
         "freetype",
         "glfw3",
+        "nativefiledialog-extended",
+        "ppqsort",
         {
           "name": "tbb",
           "platform": "!windows"
-        }
+        },
+        "zstd"
       ]
     },
     "crash-handler": {
@@ -74,10 +76,13 @@
         },
         "freetype",
         "glfw3",
+        "nativefiledialog-extended",
+        "ppqsort",
         {
           "name": "tbb",
           "platform": "!windows"
-        }
+        },
+        "zstd"
       ]
     },
     "on-demand": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9545,8 +9545,8 @@
       "port-version": 4
     },
     "tracy": {
-      "baseline": "0.11.1",
-      "port-version": 2
+      "baseline": "0.12.1",
+      "port-version": 0
     },
     "transwarp": {
       "baseline": "2.2.3",

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c08676db2358b84e0f243871fb9daba36caeee54",
+      "version": "0.12.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff802e1b85c20b5f276c4b82aaa60fc933444ab2",
       "version": "0.11.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.