### PR TITLE
[libgcrypt] update to 1.11.1

### DIFF
--- a/ports/libgcrypt/portfile.cmake
+++ b/ports/libgcrypt/portfile.cmake
@@ -4,19 +4,13 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/libgcrypt/libgcrypt-${VERSION}.tar.bz2"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-${VERSION}.tar.bz2"
     FILENAME "libgcrypt-${VERSION}.tar.bz2"
-    SHA512 8e093e69e3c45d30838625ca008e995556f0d5b272de1c003d44ef94633bcc0d0ef5d95e8725eb531bfafb4490ac273488633e0c801200d4666194f86c3e270e
-)
-vcpkg_download_distfile(osx_asm_patch
-    URLS "https://github.com/gpg/libgcrypt/commit/bb0895bbb7c6d2b9502cbbf03da14d4ecf27a183.patch?full_index=1"
-    FILENAME "libgcrypt-1.11.0-bb0895b.diff"
-    SHA512 dc9a0f0c13b08bdc6e28b966c61f5a8695bc58a7bf5ea5a8376f3b293bde729f485342eabbc84e78ab37afaf12ba1ac4385f0baff0f5f4b31bc1d3b764893522
+    SHA512 85846d62ce785e4250a2bf8a2b13ec24837e48ab8e10d537ad4a18d650d2cca747f82fd1501feab47ad3114b9593b36c9fa7a892f48139e2a71ef61295a47678
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${tarball}"
     PATCHES
         cross-tools.patch
-        "${osx_asm_patch}"
 )
 
 if(VCPKG_CROSSCOMPILING)

--- a/ports/libgcrypt/vcpkg.json
+++ b/ports/libgcrypt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgcrypt",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "A general purpose cryptographic library",
   "homepage": "https://gnupg.org/software/libgcrypt/index.html",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4745,7 +4745,7 @@
       "port-version": 0
     },
     "libgcrypt": {
-      "baseline": "1.11.0",
+      "baseline": "1.11.1",
       "port-version": 0
     },
     "libgd": {

--- a/versions/l-/libgcrypt.json
+++ b/versions/l-/libgcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "000d5027bec692e2f4bceaa4854acd5fa1d30774",
+      "version": "1.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7ef0287faf9a058810b2eb5378b3a66ea6adcf69",
       "version": "1.11.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->
