### PR TITLE
[qt5-doc] WIP

### DIFF
--- a/ports/qt5-doc/vcpkg.json
+++ b/ports/qt5-doc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-doc",
   "version": "5.15.16",
+  "port-version": 1,
   "description": "The Qt documentation.",
   "license": null,
   "supports": "native",


### PR DESCRIPTION
To fix
~~~
make[2]: /mnt/vcpkg-ci/installed/x64-linux/tools/qt5/bin/qhelpgenerator: No such file or directory
make[2]: *** [Makefile:614: qch_docs] Error 127
make[1]: *** [Makefile:700: sub-doc-src-cmake-cmake-pro-qch_docs] Error 2
make: *** [Makefile:645: docs] Error 2
~~~