### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_modified_ports.yml
+++ b/.github/workflows/test_modified_ports.yml
@@ -1,4 +1,6 @@
 name: Test Modified Ports
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/vcpkg/security/code-scanning/1](https://github.com/microsoft/vcpkg/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not appear to require write permissions based on the provided steps, we can set the permissions to `contents: read` at the root level of the workflow. This will apply the least privilege principle and ensure that the workflow only has the permissions it needs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
