### PR TITLE
[zydis] Move tools to a feature

### DIFF
--- a/ports/zydis/portfile.cmake
+++ b/ports/zydis/portfile.cmake
@@ -1,4 +1,3 @@
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zyantific/zydis
@@ -7,10 +6,14 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         zycore.patch
-
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ZYDIS_BUILD_SHARED_LIB)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tool        ZYDIS_BUILD_TOOLS
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -20,15 +23,16 @@ vcpkg_cmake_configure(
         -DZYDIS_BUILD_DOXYGEN=OFF
         -DZYDIS_BUILD_EXAMPLES=OFF
         -DZYDIS_BUILD_TESTS=OFF
-    OPTIONS_DEBUG
-        -DZYDIS_BUILD_TOOLS=OFF
+        -DZYDIS_BUILD_TOOLS=${ZYDIS_BUILD_TOOLS}
 )
 
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/zydis)
 
-vcpkg_copy_tools(TOOL_NAMES ZydisDisasm ZydisInfo AUTO_CLEAN)
+if ("tool" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES ZydisDisasm ZydisInfo AUTO_CLEAN)
+endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/Zydis/Defines.h" "defined(ZYDIS_STATIC_BUILD)" "1")

--- a/ports/zydis/portfile.cmake
+++ b/ports/zydis/portfile.cmake
@@ -12,7 +12,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ZYDIS_BUILD_SHARED_LIB
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        tool        ZYDIS_BUILD_TOOLS
+        tools       ZYDIS_BUILD_TOOLS
 )
 
 vcpkg_cmake_configure(
@@ -30,7 +30,7 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/zydis)
 
-if ("tool" IN_LIST FEATURES)
+if ("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES ZydisDisasm ZydisInfo AUTO_CLEAN)
 endif()
 

--- a/ports/zydis/portfile.cmake
+++ b/ports/zydis/portfile.cmake
@@ -23,7 +23,7 @@ vcpkg_cmake_configure(
         -DZYDIS_BUILD_DOXYGEN=OFF
         -DZYDIS_BUILD_EXAMPLES=OFF
         -DZYDIS_BUILD_TESTS=OFF
-        -DZYDIS_BUILD_TOOLS=${ZYDIS_BUILD_TOOLS}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/zydis/portfile.cmake
+++ b/ports/zydis/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_cmake_configure(
         -DZYDIS_BUILD_DOXYGEN=OFF
         -DZYDIS_BUILD_EXAMPLES=OFF
         -DZYDIS_BUILD_TESTS=OFF
+    OPTIONS_RELEASE
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/zydis/portfile.cmake
+++ b/ports/zydis/portfile.cmake
@@ -23,8 +23,9 @@ vcpkg_cmake_configure(
         -DZYDIS_BUILD_DOXYGEN=OFF
         -DZYDIS_BUILD_EXAMPLES=OFF
         -DZYDIS_BUILD_TESTS=OFF
-    OPTIONS_RELEASE
         ${FEATURE_OPTIONS}
+    OPTIONS_DEBUG
+        -DZYDIS_BUILD_TOOLS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/zydis/vcpkg.json
+++ b/ports/zydis/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zydis",
   "version-semver": "4.1.1",
+  "port-version": 1,
   "description": "Fast and lightweight x86/x86-64 disassembler library.",
   "homepage": "https://zydis.re",
   "license": "MIT",
@@ -14,5 +15,10 @@
       "host": true
     },
     "zycore"
-  ]
+  ],
+  "features": {
+    "tool": {
+      "description": "Builds zydis executables"
+    }
+  }
 }

--- a/ports/zydis/vcpkg.json
+++ b/ports/zydis/vcpkg.json
@@ -17,7 +17,7 @@
     "zycore"
   ],
   "features": {
-    "tool": {
+    "tools": {
       "description": "Builds zydis executables"
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10538,7 +10538,7 @@
     },
     "zydis": {
       "baseline": "4.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "zyre": {
       "baseline": "2024-04-10",

--- a/versions/z-/zydis.json
+++ b/versions/z-/zydis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6fd0c91b9b437b8e8afb6a74f4d336cdaf6fe511",
+      "version-semver": "4.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "45ddfb739de0637d4c046d26dd91b88e6caef94e",
       "version-semver": "4.1.1",
       "port-version": 0

--- a/versions/z-/zydis.json
+++ b/versions/z-/zydis.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6fd0c91b9b437b8e8afb6a74f4d336cdaf6fe511",
+      "git-tree": "c421c36f5a8936ba875519a3a6e153f3073242fe",
       "version-semver": "4.1.1",
       "port-version": 1
     },

--- a/versions/z-/zydis.json
+++ b/versions/z-/zydis.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c421c36f5a8936ba875519a3a6e153f3073242fe",
+      "git-tree": "a9fcbe16a405f483fab0ad5ed02fa3d688c13927",
       "version-semver": "4.1.1",
       "port-version": 1
     },

--- a/versions/z-/zydis.json
+++ b/versions/z-/zydis.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a9fcbe16a405f483fab0ad5ed02fa3d688c13927",
+      "git-tree": "a2973c641a9b8cd585e093fa8949dd9f6f70c29a",
       "version-semver": "4.1.1",
       "port-version": 1
     },

--- a/versions/z-/zydis.json
+++ b/versions/z-/zydis.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a2973c641a9b8cd585e093fa8949dd9f6f70c29a",
+      "git-tree": "6851f43c4942dfc1a44c43336e8f2febf1775138",
       "version-semver": "4.1.1",
       "port-version": 1
     },


### PR DESCRIPTION
ZyDis tools were only built in Release despite being always copied, move them to a feature to allow enabling and disabling those and using custom configuration that doesn't support tools.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
