### PR TITLE
[level-zero] update to 1.22.4, support static build

### DIFF
--- a/ports/level-zero/portfile.cmake
+++ b/ports/level-zero/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oneapi-src/level-zero

--- a/ports/level-zero/portfile.cmake
+++ b/ports/level-zero/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSYSTEM_SPDLOG=ON
+        -DMSVC_BUILD_L0_DYNAMIC_VCRUNTIME=ON
         ${BUILD_STATIC}
 )
 

--- a/ports/level-zero/portfile.cmake
+++ b/ports/level-zero/portfile.cmake
@@ -4,16 +4,21 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oneapi-src/level-zero
     REF "v${VERSION}"
-    SHA512 de83e691a8ef4f28fcd86aa919f8aae493b84c6b644b04efcc46cec405a3a0f3eab519ab78fda26d65161e8c6776723a090a412f24fa0564679d02258643f9d0
+    SHA512 db480ff4b282918bed4d232c53c7fd8e9d2efd3e1351614cef91bae760f7e5811734700a7622e91e1e75df3fd79c91558d18d7a61cdbd2404c04454f216f6533
     HEAD_REF master
     PATCHES
         patches/spdlog_include.patch
 )
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(BUILD_STATIC "-DBUILD_STATIC=ON")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSYSTEM_SPDLOG=ON
+        ${BUILD_STATIC}
 )
 
 vcpkg_cmake_install()

--- a/ports/level-zero/vcpkg.json
+++ b/ports/level-zero/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "level-zero",
-  "version": "1.20.5",
+  "version": "1.22.4",
   "description": "oneAPI Level Zero Specification Headers and Loader.",
   "homepage": "https://github.com/oneapi-src/level-zero",
   "license": "MIT",
-  "supports": "x64 & !static & (linux | (windows & !uwp))",
+  "supports": "x64 & (linux | (windows & !uwp))",
   "dependencies": [
     "spdlog",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4397,7 +4397,7 @@
       "port-version": 0
     },
     "level-zero": {
-      "baseline": "1.20.5",
+      "baseline": "1.22.4",
       "port-version": 0
     },
     "leveldb": {

--- a/versions/l-/level-zero.json
+++ b/versions/l-/level-zero.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "251ed52720d2860aaca4dfad86f77056f010911f",
+      "version": "1.22.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "9979ff06cb5187169a02122503ddb9080c31fe11",
       "version": "1.20.5",
       "port-version": 0

--- a/versions/l-/level-zero.json
+++ b/versions/l-/level-zero.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "40b78e9908c3fc5a0a6cc38d97a069102f3f2ee9",
+      "git-tree": "12d50bc8f1af8b7cf4b9732e94e1067a7c8d54f1",
       "version": "1.22.4",
       "port-version": 0
     },

--- a/versions/l-/level-zero.json
+++ b/versions/l-/level-zero.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "251ed52720d2860aaca4dfad86f77056f010911f",
+      "git-tree": "40b78e9908c3fc5a0a6cc38d97a069102f3f2ee9",
       "version": "1.22.4",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/oneapi-src/level-zero/releases/tag/v1.22.4
