### PR TITLE
[directx12-agility] Update to 1.616.1

### DIFF
--- a/ports/directx12-agility/portfile.cmake
+++ b/ports/directx12-agility/portfile.cmake
@@ -6,7 +6,7 @@ set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled) # DX12 SDK Debug Layer i
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/${VERSION}"
     FILENAME "Microsoft.Direct3D.D3D12.${VERSION}.zip"
-    SHA512 86205bc36e612c77128417dbb45db8dca86e95a6a489982273b3764e5f6c3050ac7abac5b1c7289ca0feffa1e24fb78f395809f7e32f8d6c1077212a6d6d7789
+    SHA512 fc8df2a625540a453b41d56f380f07d5ea8c1261169b9b0e5c78575f1e0417dad94534598b51701f590260070d48ad414d300f859f3257f36e3ce1256482c774
 )
 
 vcpkg_extract_source_archive(

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx12-agility",
-  "version": "1.616.0",
+  "version": "1.616.1",
   "description": "DirectX 12 Agility SDK",
   "homepage": "https://aka.ms/directx12agility",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2369,7 +2369,7 @@
       "port-version": 0
     },
     "directx12-agility": {
-      "baseline": "1.616.0",
+      "baseline": "1.616.1",
       "port-version": 0
     },
     "directxmath": {

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52d4fc49901daf74acdced516451fcc9b6c8ed19",
+      "version": "1.616.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0dd3590b1d86940aa8b24505e59f44cf7bb932d4",
       "version": "1.616.0",
       "port-version": 0


### PR DESCRIPTION
Update for bug fix in `Microsoft.Direct3D.D3D12`. No changes to DirectX-Headers.
