### PR TITLE
[vcpkg baseline][vulkan-validationlayers] Passing remove form fail list

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1054,10 +1054,6 @@ vowpal-wabbit:x64-android=fail
 # vst3sdk CMake files work only with the GUI version of Xcode
 vst3sdk:arm64-osx=fail
 vst3sdk:x64-osx=fail
-vulkan-validationlayers:x64-windows-release=fail # VS2022 17.14.0 ICEs
-vulkan-validationlayers:x64-windows-static-md=fail
-vulkan-validationlayers:x64-windows-static=fail
-vulkan-validationlayers:x64-windows=fail
 wasmedge:arm-neon-android=fail
 # Collides with libpcap -> similar headers
 winpcap:x64-windows-release=skip


### PR DESCRIPTION
`vulkan-validationlayers` passing on https://dev.azure.com/vcpkg/public/_build/results?buildId=116953&view=results
```
PASSING, REMOVE FROM FAIL LIST: vulkan-validationlayers:x64-windows-release
PASSING, REMOVE FROM FAIL LIST: vulkan-validationlayers:x64-windows-static
```
`x64-windows-static-md` and `x64-windows` triplets are still running, I tested the results locally and they are passing as well.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [ ] ~The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.~
- [ ] ~Only one version is added to each modified port's versions file.~