### PR TITLE
[mzying2001-sw] update to 0.0.3

### DIFF
--- a/ports/mzying2001-sw/portfile.cmake
+++ b/ports/mzying2001-sw/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Mzying2001/sw
     REF ${VERSION}
-    SHA512 6dc02efc47fd979951eeb24f4ca85ed282265e2d48b321fc76b7c27ae562492d41b4a1176ce00f535c8f7647720dec975827628fd0a39cf9a340095a263e2181
+    SHA512 1e8e997ed0c6c95b7dbda92a81d87b488d0f7ba3ab251200b931fbdd4acd0140023aad52acdaa2394793ee31ebc164c322f285fdace082aafa4f904308d4eb42
     HEAD_REF main
 )
 
@@ -11,7 +11,11 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME sw
+    CONFIG_PATH share/mzying2001-sw
+)
 
 vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/LICENSE)
 

--- a/ports/mzying2001-sw/vcpkg.json
+++ b/ports/mzying2001-sw/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mzying2001-sw",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A C++ GUI framework for building Windows desktop applications.",
   "homepage": "https://github.com/Mzying2001/sw",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6461,7 +6461,7 @@
       "port-version": 0
     },
     "mzying2001-sw": {
-      "baseline": "0.0.2",
+      "baseline": "0.0.3",
       "port-version": 0
     },
     "nameof": {

--- a/versions/m-/mzying2001-sw.json
+++ b/versions/m-/mzying2001-sw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bad9b30e6e285fd754881af4041d1e22115cc18f",
+      "version": "0.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "c8c85f3a8a42d03f53278de9df06174d66f62be5",
       "version": "0.0.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.