### PR TITLE
[openblas] update to 0.3.30

### DIFF
--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -44,6 +44,11 @@ if(VCPKG_TARGET_IS_EMSCRIPTEN)
     )
 endif()
 
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64" AND VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Android")
+    # Android ndk doesn't support AVX512
+    list(APPEND OPTIONS -DNO_AVX512=ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenMathLib/OpenBLAS
     REF "v${VERSION}"
-    SHA512 046316b4297460bffca09c890ecad17ea39d8b3db92ff445d03b547dd551663d37e40f38bce8ae11e2994374ff01e622b408da27aa8e40f4140185ee8f001a60
+    SHA512 c726ced2d3e6ebd3ddcd0b13c255bb43fae8c12d2aec15e9ef992b0bc7099996c02cd284ccaaa7b5fac3f23f280b098063dd60f521d97a68dc183ab192fcccdb
     HEAD_REF develop
     PATCHES
         disable-testing.diff

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openblas",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/OpenMathLib/OpenBLAS",
   "license": "BSD-3-Clause",

--- a/ports/openblas/win32-uwp.diff
+++ b/ports/openblas/win32-uwp.diff
@@ -21,10 +21,10 @@ index 2effbe0..538ede2 100644
      set(EXTRALIB "${EXTRALIB} -lpthread")
    endif ()
 diff --git a/cmake/system.cmake b/cmake/system.cmake
-index 683c318..eae7436 100644
+index 4eff967..c9c363c 100644
 --- a/cmake/system.cmake
 +++ b/cmake/system.cmake
-@@ -507,7 +507,7 @@ if (USE_SIMPLE_THREADED_LEVEL3)
+@@ -532,7 +532,7 @@ if (USE_SIMPLE_THREADED_LEVEL3)
    set(CCOMMON_OPT "${CCOMMON_OPT} -DUSE_SIMPLE_THREADED_LEVEL3")
  endif ()
  
@@ -33,7 +33,7 @@ index 683c318..eae7436 100644
  if (DEFINED MAX_STACK_ALLOC)
  if (NOT ${MAX_STACK_ALLOC} EQUAL 0)
  set(CCOMMON_OPT "${CCOMMON_OPT} -DMAX_STACK_ALLOC=${MAX_STACK_ALLOC}")
-@@ -516,7 +516,7 @@ else ()
+@@ -541,7 +541,7 @@ else ()
  set(CCOMMON_OPT "${CCOMMON_OPT} -DMAX_STACK_ALLOC=2048")
  endif ()
  endif ()
@@ -42,16 +42,7 @@ index 683c318..eae7436 100644
  if (DEFINED BLAS3_MEM_ALLOC_THRESHOLD)
  if (NOT ${BLAS3_MEM_ALLOC_THRESHOLD} EQUAL 32)
  set(CCOMMON_OPT "${CCOMMON_OPT} -DBLAS3_MEM_ALLOC_THRESHOLD=${BLAS3_MEM_ALLOC_THRESHOLD}")
-@@ -633,7 +633,7 @@ endif()
- set(LAPACK_FPFLAGS "${LAPACK_FPFLAGS} ${FPFLAGS}")
- 
- #Disable -fopenmp for LAPACK Fortran codes on Windows.
--if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-+if (WIN32)
-   set(FILTER_FLAGS "-fopenmp;-mp;-openmp;-xopenmp=parallel")
-   foreach (FILTER_FLAG ${FILTER_FLAGS})
-     string(REPLACE ${FILTER_FLAG} "" LAPACK_FFLAGS ${LAPACK_FFLAGS})
-@@ -665,11 +665,11 @@ if (INTERFACE64)
+@@ -693,11 +693,11 @@ if (INTERFACE64)
    set(LAPACK_CFLAGS "${LAPACK_CFLAGS} -DLAPACK_ILP64")
  endif ()
  

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6881,7 +6881,7 @@
       "port-version": 1
     },
     "openblas": {
-      "baseline": "0.3.29",
+      "baseline": "0.3.30",
       "port-version": 0
     },
     "opencascade": {

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ff3be04a9466a56fe1a434aab9d44dc338a5e396",
+      "git-tree": "e527f310bc3dbd3b2d853b1f3a3e5a47884ee53e",
       "version": "0.3.30",
       "port-version": 0
     },

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff3be04a9466a56fe1a434aab9d44dc338a5e396",
+      "version": "0.3.30",
+      "port-version": 0
+    },
+    {
       "git-tree": "3d3d198cfb372ccd328a36248c4c12fb7c6b3bb6",
       "version": "0.3.29",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/OpenMathLib/OpenBLAS/releases/tag/v0.3.30
