### PR TITLE
[podofo] Update to 1.0.1

### DIFF
--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO podofo/podofo
     REF "${VERSION}"
-    SHA512 ab6975270f47d584ba8a8259bb5fe7edbaa8ae29dc0d9311685eab6f0923c62a895f3e42926608d8a7d93ddd23aad8f335aa6dbfb2fa3a115d2a5dcec50ff66c
+    SHA512 ecb351c379791a012509b92e337763874154469460bf7ff2cca435f0c92d951f037adef79b74c7b01a65ef89513fe94939b52395aa79dca55fc9fb5d8419460b
     PATCHES
         dependencies.diff
 )

--- a/ports/podofo/vcpkg.json
+++ b/ports/podofo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "podofo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "PoDoFo is a library to work with the PDF file format",
   "homepage": "https://github.com/podofo/podofo",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7389,7 +7389,7 @@
       "port-version": 2
     },
     "podofo": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "poissonrecon": {

--- a/versions/p-/podofo.json
+++ b/versions/p-/podofo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e54b2e8cda1b5c9087281265579cb9bbc96d269d",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f330f6f38e957896d09c8e1ee07c7d336b4246d3",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
@ceztko The 1.0.1 release notes mention a point which was resolved already with 1.0.0 (based on rc1):
"https://github.com/podofo/podofo/issues/256" (!) (with https://github.com/podofo/podofo/pull/258).
