### PR TITLE
[magic-args] add new port

### DIFF
--- a/ports/magic-args/portfile.cmake
+++ b/ports/magic-args/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO fredemmott/magic_args
+    REF "v${VERSION}"
+    SHA512 028800e35321bcee19b72933715a4a7c1b21e71cd77be86c08101a4971df892800ae18ece9e8ee155f1a2b570ecd7c3b8b6d6236bf2d4e4262c467cde8d71756
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DBUILD_EXAMPLES=FF
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/magic-args/vcpkg.json
+++ b/ports/magic-args/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "magic-args",
+  "version": "0.2",
+  "description": "Ease-of-use-first argument parsing for C++23",
+  "homepage": "https://github.com/fredemmott/magic_args",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/ports/magic-args/vcpkg.json
+++ b/ports/magic-args/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Ease-of-use-first argument parsing for C++23",
   "homepage": "https://github.com/fredemmott/magic_args",
   "license": "MIT",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -625,6 +625,8 @@ llvm:x64-android=fail
 log4cplus:arm64-uwp=fail
 log4cplus:x64-uwp=fail
 log4cpp:x64-linux=fail # dynamic exception specifications
+# magic-args requires C++23. linux-x64 always fails because it uses gcc11.
+magic-args:x64-linux=fail
 magma:x64-linux=fail
 marzbanpp:x64-linux=fail # triplet supported but vcpkg toolchain is too old (requires GCC 12+/Clang 19+)
 mchehab-zbar:arm-neon-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5944,6 +5944,10 @@
       "baseline": "1.5.0",
       "port-version": 0
     },
+    "magic-args": {
+      "baseline": "0.2",
+      "port-version": 0
+    },
     "magic-enum": {
       "baseline": "0.9.7",
       "port-version": 1

--- a/versions/m-/magic-args.json
+++ b/versions/m-/magic-args.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8ebca2a87d4c3877810a9981f88781f69b62469f",
+      "version": "0.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/m-/magic-args.json
+++ b/versions/m-/magic-args.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8ebca2a87d4c3877810a9981f88781f69b62469f",
+      "git-tree": "1e011d2b457562168ac4745873d81727d3f40f69",
       "version": "0.2",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/fredemmott/magic_args/releases/tag/v0.2
