### PR TITLE
[wavpack] Fix building for *-mingw-* triplets

### DIFF
--- a/ports/wavpack/portfile.cmake
+++ b/ports/wavpack/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_list(SET PATCHES)
 
-if (VCPKG_TARGET_IS_ANDROID)
+if (VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_MINGW)
     vcpkg_list(APPEND PATCHES "enable-asm.diff")
 endif()
 

--- a/ports/wavpack/vcpkg.json
+++ b/ports/wavpack/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wavpack",
   "version": "5.8.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "WavPack encode/decode library, command-line programs, and several plugins",
   "homepage": "https://github.com/dbry/WavPack",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10074,7 +10074,7 @@
     },
     "wavpack": {
       "baseline": "5.8.1",
-      "port-version": 1
+      "port-version": 2
     },
     "wayland": {
       "baseline": "1.23.1",

--- a/versions/w-/wavpack.json
+++ b/versions/w-/wavpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b603a10c5e86fb4292408142d35f904b1e9d4e75",
+      "version": "5.8.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "bcdbba978c3ecf75e889f435ee0c002ce671ae54",
       "version": "5.8.1",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

The patch that was added in #45182 is seemingly also needed for mingw.

The reason is the same as Android: `/usr/bin/cc` gets picked up as the ASM compiler by `check_language` and is unable to assemble the ASM sources.

---

<details><summary>Full failure logs</summary>

Package: wavpack:x86-mingw-dynamic@5.8.1#1

**Host Environment**

- Host: arm64-osx
- Compiler: GNU 15.1.0
-    vcpkg-tool version: 2025-06-02-145689e84b7637525510e2c9b4ee603fda046b56
    vcpkg-scripts version: 0cf34c184c 2025-06-20 (2 days ago)

**To Reproduce**

`vcpkg install wavpack:x86-mingw-dynamic`

**Failure logs**

```
-- Using cached dbry-WavPack-5.8.1.tar.gz
-- Cleaning sources at $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean. Use --editable to skip cleaning for the packages you specify.
-- Extracting source $VCPKG_ROOT/downloads/dbry-WavPack-5.8.1.tar.gz
-- Using source at $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean
-- Found external ninja('1.13.0').
-- Configuring x86-mingw-dynamic
-- Building x86-mingw-dynamic-dbg
CMake Error at scripts/cmake/vcpkg_execute_build_process.cmake:134 (message):
    Command failed: /opt/homebrew/bin/cmake --build . --config Debug --target install -- -v -j11
    Working Directory: $VCPKG_ROOT/buildtrees/wavpack/x86-mingw-dynamic-dbg
    See logs for more information:
      $VCPKG_ROOT/buildtrees/wavpack/install-x86-mingw-dynamic-dbg-out.log

Call Stack (most recent call first):
  installed/arm64-osx/share/vcpkg-cmake/vcpkg_cmake_build.cmake:74 (vcpkg_execute_build_process)
  installed/arm64-osx/share/vcpkg-cmake/vcpkg_cmake_install.cmake:16 (vcpkg_cmake_build)
  ports/wavpack/portfile.cmake:25 (vcpkg_cmake_install)
  scripts/ports.cmake:206 (include)



```

$VCPKG_ROOT/buildtrees/wavpack/install-x86-mingw-dynamic-dbg-out.log

```
Change Dir: '$VCPKG_ROOT/buildtrees/wavpack/x86-mingw-dynamic-dbg'

Run Build Command(s): /opt/homebrew/bin/ninja -v -v -j11 install
[1/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/decorr_utils.c.obj -MF CMakeFiles/wavpack.dir/src/decorr_utils.c.obj.d -o CMakeFiles/wavpack.dir/src/decorr_utils.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/decorr_utils.c
[2/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/entropy_utils.c.obj -MF CMakeFiles/wavpack.dir/src/entropy_utils.c.obj.d -o CMakeFiles/wavpack.dir/src/entropy_utils.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/entropy_utils.c
[3/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/open_legacy.c.obj -MF CMakeFiles/wavpack.dir/src/open_legacy.c.obj.d -o CMakeFiles/wavpack.dir/src/open_legacy.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/open_legacy.c
[4/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/open_raw.c.obj -MF CMakeFiles/wavpack.dir/src/open_raw.c.obj.d -o CMakeFiles/wavpack.dir/src/open_raw.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/open_raw.c
[5/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/open_filename.c.obj -MF CMakeFiles/wavpack.dir/src/open_filename.c.obj.d -o CMakeFiles/wavpack.dir/src/open_filename.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/open_filename.c
[6/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/pack_dns.c.obj -MF CMakeFiles/wavpack.dir/src/pack_dns.c.obj.d -o CMakeFiles/wavpack.dir/src/pack_dns.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_dns.c
[7/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/common_utils.c.obj -MF CMakeFiles/wavpack.dir/src/common_utils.c.obj.d -o CMakeFiles/wavpack.dir/src/common_utils.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/common_utils.c
[8/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/extra1.c.obj -MF CMakeFiles/wavpack.dir/src/extra1.c.obj.d -o CMakeFiles/wavpack.dir/src/extra1.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/extra1.c
[9/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/extra2.c.obj -MF CMakeFiles/wavpack.dir/src/extra2.c.obj.d -o CMakeFiles/wavpack.dir/src/extra2.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/extra2.c
[10/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/open_utils.c.obj -MF CMakeFiles/wavpack.dir/src/open_utils.c.obj.d -o CMakeFiles/wavpack.dir/src/open_utils.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/open_utils.c
[11/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/pack.c.obj -MF CMakeFiles/wavpack.dir/src/pack.c.obj.d -o CMakeFiles/wavpack.dir/src/pack.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack.c
[12/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/tags.c.obj -MF CMakeFiles/wavpack.dir/src/tags.c.obj.d -o CMakeFiles/wavpack.dir/src/tags.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/tags.c
[13/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/pack_floats.c.obj -MF CMakeFiles/wavpack.dir/src/pack_floats.c.obj.d -o CMakeFiles/wavpack.dir/src/pack_floats.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_floats.c
[14/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/read_words.c.obj -MF CMakeFiles/wavpack.dir/src/read_words.c.obj.d -o CMakeFiles/wavpack.dir/src/read_words.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/read_words.c
[15/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/tag_utils.c.obj -MF CMakeFiles/wavpack.dir/src/tag_utils.c.obj.d -o CMakeFiles/wavpack.dir/src/tag_utils.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/tag_utils.c
[16/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/unpack_floats.c.obj -MF CMakeFiles/wavpack.dir/src/unpack_floats.c.obj.d -o CMakeFiles/wavpack.dir/src/unpack_floats.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_floats.c
[17/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/unpack_seek.c.obj -MF CMakeFiles/wavpack.dir/src/unpack_seek.c.obj.d -o CMakeFiles/wavpack.dir/src/unpack_seek.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_seek.c
[18/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/unpack.c.obj -MF CMakeFiles/wavpack.dir/src/unpack.c.obj.d -o CMakeFiles/wavpack.dir/src/unpack.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack.c
[19/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/unpack_utils.c.obj -MF CMakeFiles/wavpack.dir/src/unpack_utils.c.obj.d -o CMakeFiles/wavpack.dir/src/unpack_utils.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_utils.c
[20/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/write_words.c.obj -MF CMakeFiles/wavpack.dir/src/write_words.c.obj.d -o CMakeFiles/wavpack.dir/src/write_words.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/write_words.c
[21/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/pack_utils.c.obj -MF CMakeFiles/wavpack.dir/src/pack_utils.c.obj.d -o CMakeFiles/wavpack.dir/src/pack_utils.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_utils.c
[22/28] /opt/homebrew/bin/i686-w64-mingw32-gcc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fdiagnostics-color=always -Wall -MD -MT CMakeFiles/wavpack.dir/src/pack_dsd.c.obj -MF CMakeFiles/wavpack.dir/src/pack_dsd.c.obj.d -o CMakeFiles/wavpack.dir/src/pack_dsd.c.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_dsd.c
[23/28] /usr/bin/cc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fPIC -Wall -MD -MT CMakeFiles/wavpack.dir/src/unpack_x86.S.obj -MF CMakeFiles/wavpack.dir/src/unpack_x86.S.obj.d -o CMakeFiles/wavpack.dir/src/unpack_x86.S.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S
FAILED: [code=1] CMakeFiles/wavpack.dir/src/unpack_x86.S.obj 
/usr/bin/cc -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include -g -fPIC -Wall -MD -MT CMakeFiles/wavpack.dir/src/unpack_x86.S.obj -MF CMakeFiles/wavpack.dir/src/unpack_x86.S.obj.d -o CMakeFiles/wavpack.dir/src/unpack_x86.S.obj -c $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:9:9: error: unknown directive
        .intel_syntax noprefix
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:70:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push ebp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:71:13: error: invalid operand for instruction
        mov ebp, esp
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:72:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push ebx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:73:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push esi
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:74:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push edi
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:76:26: error: unexpected token in argument list
        mov edx, [ebp+8] # copy delta from dpp to top of stack
                         ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:77:13: error: invalid operand for instruction
        mov eax, [edx+4]
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:78:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push eax
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:80:27: error: unexpected token in argument list
        mov edi, [ebp+12] # edi = buffer
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:81:27: error: unexpected token in argument list
        mov eax, [ebp+16] # get sample_count and divide by 8
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:82:13: error: invalid operand for instruction
        shl eax, 3
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:83:17: error: unexpected token in argument list
        jz done # exit now if there's nothing to do
                ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:85:22: error: unexpected token in argument list
        add eax, edi # else add to buffer point to make eptr
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:86:13: error: invalid operand for instruction
        mov esi, eax
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:88:26: error: unexpected token in argument list
        mov eax, [ebp+8] # get term from dpp and vector appropriately
                         ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:89:13: error: invalid operand for instruction
        mov eax, [eax]
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:90:13: error: invalid operand for instruction
        cmp eax, 17
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:91:9: error: unrecognized instruction mnemonic
        je term_17_entry
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:92:13: error: invalid operand for instruction
        cmp eax, 18
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:93:9: error: unrecognized instruction mnemonic
        je term_18_entry
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:94:13: error: invalid operand for instruction
        cmp eax, -1
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:95:9: error: unrecognized instruction mnemonic
        je term_minus_1_entry
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:96:13: error: invalid operand for instruction
        cmp eax, -2
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:97:9: error: unrecognized instruction mnemonic
        je term_minus_2_entry
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:98:13: error: invalid operand for instruction
        cmp eax, -3
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:99:9: error: unrecognized instruction mnemonic
        je term_minus_3_entry
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:117:27: error: unexpected token in argument list
        imul ebx, eax, -8 # set ebx to term * -8 for decorrelation index
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:118:13: error: invalid operand for instruction
        mov eax, 512
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:119:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movd mm7, eax
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:120:28: error: unexpected token in argument list
        punpckldq mm7, mm7 # mm7 = round (512)
                           ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:121:26: error: unexpected token in argument list
        mov edx, [ebp+8] # edx = *dpp
                         ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:122:13: error: invalid operand for instruction
        mov eax, [edx+4]
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:123:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movd mm6, eax
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:124:28: error: unexpected token in argument list
        punpckldq mm6, mm6 # mm6 = delta (0-7)
                           ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:125:25: error: unexpected token in argument list
        mov eax, 0xFFFF # mask high weights to zero for PMADDWD
                        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:126:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movd mm5, eax
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:127:28: error: unexpected token in argument list
        punpckldq mm5, mm5 # mm5 = weight mask 0x0000FFFF0000FFFF
                           ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:128:27: error: unexpected token in argument list
        pand mm5, [edx+8] # mm5 = weight_AB masked to 16 bits
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:129:23: error: unexpected token in argument list
        pxor mm4, mm4 # mm4 = zero (for pcmpeqd)
                      ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:130:9: error: unrecognized instruction mnemonic, did you mean: cmp?
        jmp default_term_loop
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:134:29: error: unexpected token in argument list
        movq mm3, [edi+ebx] # mm3 = sam_AB
                            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:135:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movq mm1, mm3
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:136:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movq mm0, mm3
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/unpack_x86.S:137:9: error: unrecognized instruction mnemonic, did you mean: add?
        paddd mm1, mm1
        ^
...
Skipped 10533 lines
...
                         ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1482:13: error: invalid operand for instruction
        mov ebx, edx
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1483:9: error: unrecognized instruction mnemonic, did you mean: fmul, mul, pmul?
        imul edx, ebp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1484:9: error: unrecognized instruction mnemonic
        jo 1f
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1485:9: error: unrecognized instruction mnemonic, did you mean: adr, asr, lsr, msr, sri, str, xar?
        sar edx, 10
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1486:9: error: unrecognized instruction mnemonic
        lodsd
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1487:13: error: invalid operand for instruction
        mov ecx, eax
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1488:9: error: unrecognized instruction mnemonic, did you mean: b, dsb, esb, isb, pssbb, sb, sbc, ssbb, sub, tsb?
        sbb eax, edx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1489:9: error: unrecognized instruction mnemonic, did you mean: cmp?
        jmp 2f
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1490:8: error: invalid operand for instruction
1: mov eax, ebx
       ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1491:9: error: unrecognized instruction mnemonic, did you mean: fmul, mul, pmul?
        imul ebp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1492:13: error: invalid operand for instruction
        shl edx, 22
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1493:9: error: unrecognized instruction mnemonic, did you mean: asr, lsr, msr, rshrn, shl, shrn, shrn2, sri, srshr, sshr, str, urshr, ushr?
        shr eax, 10
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1494:22: error: unexpected token in argument list
        adc edx, eax # edx = apply_weight (sam_A)
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1495:9: error: unrecognized instruction mnemonic
        lodsd
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1496:13: error: invalid operand for instruction
        mov ecx, eax
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1497:13: error: invalid operand for instruction
        sub eax, edx
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1498:4: error: unrecognized instruction mnemonic
2: stosd
   ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1499:9: error: unrecognized instruction mnemonic
        je 3f
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1500:9: error: unrecognized instruction mnemonic, did you mean: tst?
        test ebx, ebx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1501:9: error: unrecognized instruction mnemonic
        je 3f
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1502:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror, xar?
        xor eax, ebx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1503:9: error: unrecognized instruction mnemonic
        cdq
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1504:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror, xar?
        xor ebp, edx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1505:13: error: invalid operand for instruction
        add ebp, [esp]
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1506:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror, xar?
        xor ebp, edx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1507:8: error: invalid operand for instruction
3: add [esp+4], ebp
       ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1508:13: error: invalid operand for instruction
        cmp esi, [esp+8]
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1509:9: error: unrecognized instruction mnemonic
        jnz mono_term_17_loop
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1510:9: error: unrecognized instruction mnemonic, did you mean: cmp?
        jmp mono_term_1718_exit
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1515:9: error: unrecognized instruction mnemonic, did you mean: mla?
        lea edx, [ecx+ecx*2]
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1516:13: error: invalid operand for instruction
        sub edx, [esi-8]
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1517:9: error: unrecognized instruction mnemonic, did you mean: adr, asr, lsr, msr, sri, str, xar?
        sar edx, 1
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1518:22: error: unexpected token in argument list
        mov ebx, edx # ebx = sam_A
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1519:9: error: unrecognized instruction mnemonic, did you mean: fmul, mul, pmul?
        imul edx, ebp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1520:9: error: unrecognized instruction mnemonic
        jo 1f
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1521:9: error: unrecognized instruction mnemonic, did you mean: adr, asr, lsr, msr, sri, str, xar?
        sar edx, 10
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1522:9: error: unrecognized instruction mnemonic
        lodsd
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1523:13: error: invalid operand for instruction
        mov ecx, eax
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1524:9: error: unrecognized instruction mnemonic, did you mean: b, dsb, esb, isb, pssbb, sb, sbc, ssbb, sub, tsb?
        sbb eax, edx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1525:9: error: unrecognized instruction mnemonic, did you mean: cmp?
        jmp 2f
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1526:8: error: invalid operand for instruction
1: mov eax, ebx
       ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1527:9: error: unrecognized instruction mnemonic, did you mean: fmul, mul, pmul?
        imul ebp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1528:13: error: invalid operand for instruction
        shl edx, 22
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1529:9: error: unrecognized instruction mnemonic, did you mean: asr, lsr, msr, rshrn, shl, shrn, shrn2, sri, srshr, sshr, str, urshr, ushr?
        shr eax, 10
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1530:22: error: unexpected token in argument list
        adc edx, eax # edx = apply_weight (sam_A)
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1531:9: error: unrecognized instruction mnemonic
        lodsd
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1532:13: error: invalid operand for instruction
        mov ecx, eax
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1533:13: error: invalid operand for instruction
        sub eax, edx
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1534:4: error: unrecognized instruction mnemonic
2: stosd
   ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1535:9: error: unrecognized instruction mnemonic
        je 3f
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1536:9: error: unrecognized instruction mnemonic, did you mean: tst?
        test ebx, ebx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1537:9: error: unrecognized instruction mnemonic
        je 3f
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1538:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror, xar?
        xor eax, ebx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1539:9: error: unrecognized instruction mnemonic
        cdq
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1540:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror, xar?
        xor ebp, edx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1541:13: error: invalid operand for instruction
        add ebp, [esp]
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1542:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror, xar?
        xor ebp, edx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1543:8: error: invalid operand for instruction
3: add [esp+4], ebp
       ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1544:13: error: invalid operand for instruction
        cmp esi, [esp+8]
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1545:9: error: unrecognized instruction mnemonic
        jnz mono_term_18_loop
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1548:22: error: unexpected token in argument list
        mov ecx, ebp # ecx = weight
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1549:26: error: unexpected token in argument list
        mov eax, [esp+4] # eax = weight sum
                         ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1550:27: error: unexpected token in argument list
        lea ebp, [esp+24] # restore ebp (we've pushed 6 DWORDS)
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1551:27: error: unexpected token in argument list
        mov edx, [ebp+16] # edx = *dpp
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1552:26: error: unexpected token in argument list
        mov [edx+8], ecx # put weight back
                         ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1553:27: error: unexpected token in argument list
        mov [edx+88], eax # put dpp->sum_A back
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1554:26: error: unexpected token in argument list
        mov eax, [esi-4] # dpp->samples_A [0] = bptr [-1]
                         ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1555:13: error: invalid operand for instruction
        mov [edx+16], eax
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1556:26: error: unexpected token in argument list
        mov eax, [esi-8] # dpp->samples_A [1] = bptr [-2]
                         ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1557:13: error: invalid operand for instruction
        mov [edx+20], eax
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1560:21: error: unexpected token in argument list
        add esp, 12 # deallocate stack space
                    ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1561:17: error: unexpected token in argument list
        pop edi # pop saved registers & return
                ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1562:9: error: unrecognized instruction mnemonic, did you mean: nop?
        pop esi
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1563:9: error: unrecognized instruction mnemonic, did you mean: nop?
        pop ebx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1564:9: error: unrecognized instruction mnemonic, did you mean: nop?
        pop ebp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1600:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push ebp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1601:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push ebx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1602:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push esi
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1603:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push edi
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1605:22: error: unexpected token in argument list
        xor ebx, ebx # clear magnitude accumulator
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1606:27: error: unexpected token in argument list
        mov edi, [esp+20] # edi = buffer pointer
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1608:27: error: unexpected token in argument list
        mov eax, [esp+24] # eax = count
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1609:13: error: invalid operand for instruction
        and eax, 7
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1610:22: error: unexpected token in argument list
        mov ecx, eax # ecx = leftover samples to "manually" scan at end
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1612:27: error: unexpected token in argument list
        mov eax, [esp+24] # eax = count
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1613:20: error: unexpected token in argument list
        shr eax, 3 # eax = num of loops to process mmx (8 samples/loop)
                   ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1614:20: error: unexpected token in argument list
        shl eax, 5 # eax = num of bytes to process mmx (32 bytes/loop)
                   ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1615:18: error: unexpected token in argument list
        jz nommx # jump around if no mmx loops to do (< 8 samples)
                 ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1617:23: error: unexpected token in argument list
        pxor mm0, mm0 # clear dual magnitude accumulator
                      ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1618:22: error: unexpected token in argument list
        add eax, edi # esi = termination buffer pointer for mmx loop
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1619:13: error: invalid operand for instruction
        mov esi, eax
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1620:9: error: unrecognized instruction mnemonic, did you mean: cmp?
        jmp mmxlp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1624:24: error: unexpected token in argument list
mmxlp: movq mm1, [edi] # get stereo samples in mm1 & mm2
                       ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1625:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movq mm2, mm1
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1626:23: error: unexpected token in argument list
        psrad mm1, 31 # mm1 = sign (mm2)
                      ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1627:23: error: unexpected token in argument list
        pxor mm1, mm2 # mm1 = absolute magnitude, or into result
                      ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1628:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror?
        por mm0, mm1
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1630:27: error: unexpected token in argument list
        movq mm1, [edi+8] # do it again with 6 more samples
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1631:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movq mm2, mm1
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1632:9: error: unrecognized instruction mnemonic
        psrad mm1, 31
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1633:9: error: unrecognized instruction mnemonic
        pxor mm1, mm2
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1634:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror?
        por mm0, mm1
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1636:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movq mm1, [edi+16]
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1637:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movq mm2, mm1
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1638:9: error: unrecognized instruction mnemonic
        psrad mm1, 31
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1639:9: error: unrecognized instruction mnemonic
        pxor mm1, mm2
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1640:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror?
        por mm0, mm1
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1642:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movq mm1, [edi+24]
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1643:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movq mm2, mm1
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1644:9: error: unrecognized instruction mnemonic
        psrad mm1, 31
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1645:9: error: unrecognized instruction mnemonic
        pxor mm1, mm2
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1646:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror?
        por mm0, mm1
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1648:13: error: invalid operand for instruction
        add edi, 32
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1649:13: error: invalid operand for instruction
        cmp edi, esi
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1650:9: error: unrecognized instruction mnemonic
        jnz mmxlp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1652:23: error: unexpected token in argument list
        movd eax, mm0 # ebx = "or" of high and low mm0
                      ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1653:9: error: unrecognized instruction mnemonic
        punpckhdq mm0, mm0
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1654:9: error: unrecognized instruction mnemonic, did you mean: fmov, mov, movi, movk, movn, movz, smov, umov?
        movd ebx, mm0
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1655:9: error: unrecognized instruction mnemonic, did you mean: br, eor, eor3, orn, orr, ror, rorv?
        or ebx, eax
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1656:9: error: unrecognized instruction mnemonic
        emms
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1658:21: error: unexpected token in argument list
nommx: and ecx, ecx # any leftover samples to do?
                    ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1659:9: error: unrecognized instruction mnemonic
        jz noleft
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1661:13: error: invalid operand for instruction
leftlp: mov eax, [edi]
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1662:9: error: unrecognized instruction mnemonic
        cdq
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1663:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror, xar?
        xor eax, edx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1664:9: error: unrecognized instruction mnemonic, did you mean: br, eor, eor3, orn, orr, ror, rorv?
        or ebx, eax
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1665:13: error: invalid operand for instruction
        add edi, 4
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1666:9: error: unrecognized instruction mnemonic
        loop leftlp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1668:22: error: unexpected token in argument list
noleft: mov eax, ebx # move magnitude to eax for return
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1669:9: error: unrecognized instruction mnemonic, did you mean: nop?
        pop edi
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1670:9: error: unrecognized instruction mnemonic, did you mean: nop?
        pop esi
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1671:9: error: unrecognized instruction mnemonic, did you mean: nop?
        pop ebx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1672:9: error: unrecognized instruction mnemonic, did you mean: nop?
        pop ebp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1724:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push ebp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1725:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push ebx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1726:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push esi
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1727:9: error: unrecognized instruction mnemonic, did you mean: ushl, ushr?
        push edi
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1728:9: error: unrecognized instruction mnemonic, did you mean: cls, clz, ld1, ld2, ld3, ld4, ldp, ldr?
        cld
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1734:20: error: unexpected token in argument list
        call nexti # push address of nexti (return address)
                   ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1735:16: error: unexpected token in argument list
nexti: pop ebp # pop address of nexti into ebp
               ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1736:22: error: unexpected token in argument list
        sub ebp, 266 # offset to log2_table, should be (nexti - log2_table)
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1738:27: error: unexpected token in argument list
        mov esi, [esp+20] # esi = sample source pointer
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1739:22: error: unexpected token in argument list
        xor edi, edi # edi = 0 (accumulator)
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1740:27: error: unexpected token in argument list
        mov ebx, [esp+24] # ebx = num_samples
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1741:23: error: unexpected token in argument list
        test ebx, ebx # exit now if none, sum = 0
                      ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1742:9: error: unrecognized instruction mnemonic
        jz normal_exit
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1744:27: error: unexpected token in argument list
        mov eax, [esp+28] # eax = limit
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1745:23: error: unexpected token in argument list
        test eax, eax # we have separate loops for limit and no limit
                      ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1746:9: error: unrecognized instruction mnemonic
        jz no_limit_loop
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1747:9: error: unrecognized instruction mnemonic, did you mean: cmp?
        jmp limit_loop
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1752:24: error: unexpected token in argument list
        mov eax, [esi] # get next sample into eax
                       ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1753:19: error: unexpected token in argument list
        cdq # edx = sign of sample (for abs)
                  ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1754:13: error: invalid operand for instruction
        add esi, 4
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1755:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror, xar?
        xor eax, edx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1756:13: error: invalid operand for instruction
        sub eax, edx
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1757:16: error: unexpected token in argument list
        je L40 # skip if sample was zero
               ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1758:22: error: unexpected token in argument list
        mov edx, eax # move to edx and apply rounding
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1759:9: error: unrecognized instruction mnemonic, did you mean: asr, lsr, msr, rshrn, shl, shrn, shrn2, sri, srshr, sshr, str, urshr, ushr?
        shr eax, 9
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1760:13: error: invalid operand for instruction
        add edx, eax
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1761:22: error: unexpected token in argument list
        bsr ecx, edx # ecx = MSB set in sample (0 - 31)
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1762:26: error: unexpected token in argument list
        lea eax, [ecx+1] # eax = number used bits in sample (1 - 32)
                         ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1763:20: error: unexpected token in argument list
        sub ecx, 8 # ecx = shift right amount (-8 to 23)
                   ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1764:21: error: unexpected token in argument list
        ror edx, cl # use rotate to do "signed" shift
                    ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1765:20: error: unexpected token in argument list
        shl eax, 8 # move nbits to integer portion of log
                   ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1766:23: error: unexpected token in argument list
        movzx edx, dl # dl = mantissa, look up log fraction in table
                      ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1767:27: error: unexpected token in argument list
        mov al, [ebp+edx] # eax = combined integer and fraction for full log
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1768:22: error: unexpected token in argument list
        add edi, eax # add to running sum and compare to limit
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1769:13: error: invalid operand for instruction
        cmp eax, [esp+28]
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1770:9: error: unrecognized instruction mnemonic
        jge limit_exceeded
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1771:17: error: unexpected token in argument list
L40: sub ebx, 1 # loop back if more samples
                ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1772:9: error: unrecognized instruction mnemonic, did you mean: neg?
        jne limit_loop
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1773:9: error: unrecognized instruction mnemonic, did you mean: cmp?
        jmp normal_exit
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1778:24: error: unexpected token in argument list
        mov eax, [esi] # get next sample into eax
                       ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1779:19: error: unexpected token in argument list
        cdq # edx = sign of sample (for abs)
                  ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1780:13: error: invalid operand for instruction
        add esi, 4
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1781:9: error: unrecognized instruction mnemonic, did you mean: eor, orn, orr, ror, xar?
        xor eax, edx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1782:13: error: invalid operand for instruction
        sub eax, edx
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1783:16: error: unexpected token in argument list
        je L45 # skip if sample was zero
               ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1784:22: error: unexpected token in argument list
        mov edx, eax # move to edx and apply rounding
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1785:9: error: unrecognized instruction mnemonic, did you mean: asr, lsr, msr, rshrn, shl, shrn, shrn2, sri, srshr, sshr, str, urshr, ushr?
        shr eax, 9
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1786:13: error: invalid operand for instruction
        add edx, eax
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1787:22: error: unexpected token in argument list
        bsr ecx, edx # ecx = MSB set in sample (0 - 31)
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1788:26: error: unexpected token in argument list
        lea eax, [ecx+1] # eax = number used bits in sample (1 - 32)
                         ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1789:20: error: unexpected token in argument list
        sub ecx, 8 # ecx = shift right amount (-8 to 23)
                   ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1790:21: error: unexpected token in argument list
        ror edx, cl # use rotate to do "signed" shift
                    ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1791:20: error: unexpected token in argument list
        shl eax, 8 # move nbits to integer portion of log
                   ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1792:23: error: unexpected token in argument list
        movzx edx, dl # dl = mantissa, look up log fraction in table
                      ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1793:27: error: unexpected token in argument list
        mov al, [ebp+edx] # eax = combined integer and fraction for full log
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1794:22: error: unexpected token in argument list
        add edi, eax # add to running sum
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1795:17: error: unexpected token in argument list
L45: sub ebx, 1 # loop back if more samples
                ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1796:9: error: unrecognized instruction mnemonic, did you mean: neg?
        jne no_limit_loop
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1797:9: error: unrecognized instruction mnemonic, did you mean: cmp?
        jmp normal_exit
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1800:21: error: unexpected token in argument list
        mov edi, -1 # -1 return means log limit exceeded
                    ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1802:22: error: unexpected token in argument list
        mov eax, edi # move sum accumulator into eax for return
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1803:9: error: unrecognized instruction mnemonic, did you mean: nop?
        pop edi
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1804:9: error: unrecognized instruction mnemonic, did you mean: nop?
        pop esi
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1805:9: error: unrecognized instruction mnemonic, did you mean: nop?
        pop ebx
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1806:9: error: unrecognized instruction mnemonic, did you mean: nop?
        pop ebp
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1815:23: error: unexpected token in argument list
        pushfd # save eflags
                      ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1816:23: error: unexpected token in argument list
        pushfd # push another copy
                      ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1817:19: error: unexpected token in argument list
        xor dword ptr [esp], 0x200000 # toggle ID bit on stack & pop it back into eflags
                  ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1818:9: error: unrecognized instruction mnemonic
        popfd
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1819:24: error: unexpected token in argument list
        pushfd # store possibly modified eflags
                       ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1820:17: error: unexpected token in argument list
        pop eax # and pop back into eax
                ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1821:24: error: unexpected token in argument list
        xor eax, [esp] # compare to original pushed eflags
                       ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1822:25: error: unexpected token in argument list
        popfd # restore original eflags
                        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1823:27: error: unexpected token in argument list
        and eax, 0x200000 # eax = 1 if eflags ID bit was changeable
                          ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1824:19: error: unexpected token in argument list
        jz oldcpu # return zero if CPUID is not available (wow!)
                  ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1826:18: error: unexpected token in argument list
        push ebx # we must save ebx
                 ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1827:20: error: unexpected token in argument list
        mov eax, 1 # do cpuid (1) to get features into edx
                   ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1828:9: error: unrecognized instruction mnemonic
        cpuid
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1829:22: error: unexpected token in argument list
        mov eax, edx # copy into eax for shift
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1830:25: error: unexpected token in argument list
        mov cl, [esp+8] # get parameter and shift that bit index into LSB
                        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1831:9: error: unrecognized instruction mnemonic, did you mean: adr, asr, lsr, msr, sri, str, xar?
        sar eax, cl
        ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1832:13: error: invalid operand for instruction
        and eax, 1
            ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1833:17: error: unexpected token in argument list
        pop ebx # restore ebx and return 0 or 1
                ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1835:22: error: unexpected token in argument list
oldcpu: ret # return value in eax
                     ^
$VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/src/pack_x86.S:1836:1: error: unmatched .ifs or .elses

^
[26/28] /opt/homebrew/bin/i686-w64-mingw32-windres -O coff -DENABLE_DSD -DENABLE_THREADS -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X86 -D_FILE_OFFSET_BITS=64 -Dwavpack_EXPORTS -I $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/include  $VCPKG_ROOT/buildtrees/wavpack/src/5.8.1-9968a5852c.clean/wavpackdll/wavpackdll.rc CMakeFiles/wavpack.dir/wavpackdll/wavpackdll.rc.res
ninja: build stopped: subcommand failed.
```
</details>

