### PR TITLE
[crcpp] add new port

### DIFF
--- a/ports/crcpp/portfile.cmake
+++ b/ports/crcpp/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO d-bahr/CRCpp
+    REF "release-${VERSION}"
+    SHA512 61d6d4636cbf42752568900a1267336721836b80cbe99e1795c74be9fffd9d6368697182565beecf5b4050d649c7a77acbacfac2a20eff9de4073dab4ea073cf
+    HEAD_REF master
+)
+
+# header-only
+set(VCPKG_BUILD_TYPE "release")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCRCPP_BUILD_TESTS=OFF
+        -DCRCPP_BUILD_DOCS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/crcpp/portfile.cmake
+++ b/ports/crcpp/portfile.cmake
@@ -12,8 +12,8 @@ set(VCPKG_BUILD_TYPE "release")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DCRCPP_BUILD_TESTS=OFF
-        -DCRCPP_BUILD_DOCS=OFF
+        -DBUILD_TEST=OFF
+        -DBUILD_DOC=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/crcpp/vcpkg.json
+++ b/ports/crcpp/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "crcpp",
+  "version": "1.2.1.0",
+  "description": "Easy to use and fast C++ CRC library.",
+  "homepage": "https://github.com/d-bahr/CRCpp",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2116,6 +2116,10 @@
       "baseline": "1.1.2",
       "port-version": 2
     },
+    "crcpp": {
+      "baseline": "1.2.1.0",
+      "port-version": 0
+    },
     "crfsuite": {
       "baseline": "2020-08-27",
       "port-version": 1

--- a/versions/c-/crcpp.json
+++ b/versions/c-/crcpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "aa82e981dc452dbfaed61e21c0dc472f78debe7b",
+      "version": "1.2.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/crcpp.json
+++ b/versions/c-/crcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "aa82e981dc452dbfaed61e21c0dc472f78debe7b",
+      "git-tree": "907d42101b451a0e70ab9044b669bdf6ca687560",
       "version": "1.2.1.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/d-bahr/CRCpp

