### PR TITLE
[signalsmith-stretch] Add new port

### DIFF
--- a/ports/signalsmith-stretch/portfile.cmake
+++ b/ports/signalsmith-stretch/portfile.cmake
@@ -1,0 +1,26 @@
+set(VCPKG_BUILD_TYPE release)  # header-only
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Signalsmith-Audio/signalsmith-stretch
+    REF "${VERSION}"
+    SHA512 cc014fcd64a3bd04a4d389a2b2cbc63025d8672d54eafb5f5bdf03428246581ecf57006f6ced38b608e50afa59cfaf5a92693ce234537ca8e92f4d3b75193568
+    HEAD_REF main
+)
+
+file(REMOVE_RECURSE
+    "${SOURCE_PATH}/cmd"
+    "${SOURCE_PATH}/dsp"
+    "${SOURCE_PATH}/web"
+)
+
+# Adjust include path to the VCPKG port signalsmith-dsp
+file(READ "${SOURCE_PATH}/signalsmith-stretch.h" _header_content)
+string(REPLACE "#include \"dsp/spectral.h\"" "#include <signalsmith-dsp/spectral.h>" _header_content "${_header_content}")
+string(REPLACE "#include \"dsp/delay.h\"" "#include <signalsmith-dsp/delay.h>" _header_content "${_header_content}")
+string(REPLACE "#include \"dsp/perf.h\"" "#include <signalsmith-dsp/perf.h>" _header_content "${_header_content}")
+file(WRITE "${SOURCE_PATH}/signalsmith-stretch.h" "${_header_content}")
+
+file(INSTALL "${SOURCE_PATH}/signalsmith-stretch.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/signalsmith-stretch")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/signalsmith-stretch/vcpkg.json
+++ b/ports/signalsmith-stretch/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "signalsmith-stretch",
-  "version-semver": "1.1.0",
+  "version": "1.1.0",
   "description": "C++ polyphonic pitch/time library",
   "homepage": "https://signalsmith-audio.co.uk/code/stretch/",
   "license": "MIT",

--- a/ports/signalsmith-stretch/vcpkg.json
+++ b/ports/signalsmith-stretch/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "signalsmith-stretch",
+  "version-semver": "1.1.0",
+  "description": "C++ polyphonic pitch/time library",
+  "homepage": "https://signalsmith-audio.co.uk/code/stretch/",
+  "license": "MIT",
+  "dependencies": [
+    "signalsmith-dsp"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8728,6 +8728,10 @@
       "baseline": "1.6.2",
       "port-version": 0
     },
+    "signalsmith-stretch": {
+      "baseline": "1.1.0",
+      "port-version": 0
+    },
     "sigslot": {
       "baseline": "1.0.0",
       "port-version": 5

--- a/versions/s-/signalsmith-stretch.json
+++ b/versions/s-/signalsmith-stretch.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e030a3fdbfa34386d47d445d3ccd7c7d45186b30",
+      "version-semver": "1.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/signalsmith-stretch.json
+++ b/versions/s-/signalsmith-stretch.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "e030a3fdbfa34386d47d445d3ccd7c7d45186b30",
-      "version-semver": "1.1.0",
+      "git-tree": "5b7dedca8595df5e0b457a38b267d42886fd97f0",
+      "version": "1.1.0",
       "port-version": 0
     }
   ]


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.

Not existing yet on repology

- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.