### PR TITLE
[protobuf] Update to 6.31.1

### DIFF
--- a/ports/protobuf/fix-descriptor.patch
+++ b/ports/protobuf/fix-descriptor.patch
@@ -1,0 +1,44 @@
+diff --git a/src/google/protobuf/descriptor.cc b/src/google/protobuf/descriptor.cc
+index f97d206..9b9400d 100644
+--- a/src/google/protobuf/descriptor.cc
++++ b/src/google/protobuf/descriptor.cc
+@@ -4827,6 +4827,28 @@ class DescriptorBuilder {
+   void CheckVisibilityRulesVisit(const EnumDescriptor& enm,
+                                  const EnumDescriptorProto& proto,
+                                  VisibilityCheckerState& state);
++  void CheckVisibilityRulesVisit(const FileDescriptor&,
++                                 const FileDescriptorProto& proto,
++                                 VisibilityCheckerState& state) {}
++  void CheckVisibilityRulesVisit(const FieldDescriptor&,
++                                 const FieldDescriptorProto& proto,
++                                 VisibilityCheckerState& state) {}
++  void CheckVisibilityRulesVisit(const EnumValueDescriptor&,
++                                 const EnumValueDescriptorProto& proto,
++                                 VisibilityCheckerState& state) {}
++  void CheckVisibilityRulesVisit(const OneofDescriptor&,
++                                 const OneofDescriptorProto& proto,
++                                 VisibilityCheckerState& state) {}
++  void CheckVisibilityRulesVisit(const Descriptor::ExtensionRange&,
++                                 const DescriptorProto::ExtensionRange& proto,
++                                 VisibilityCheckerState& state) {}
++  void CheckVisibilityRulesVisit(const MethodDescriptor&,
++                                 const MethodDescriptorProto& proto,
++                                 VisibilityCheckerState& state) {}
++  void CheckVisibilityRulesVisit(const ServiceDescriptor&,
++                                 const ServiceDescriptorProto& proto,
++                                 VisibilityCheckerState& state) {}
++
+   bool IsEnumNamespaceMessage(const EnumDescriptor& enm) const;
+ 
+ 
+@@ -8378,9 +8400,7 @@ void DescriptorBuilder::CheckVisibilityRules(FileDescriptor* file,
+ 
+   // Build our state object so we can apply rules based on type.
+   internal::VisitDescriptors(
+-      *file, proto,
+-      [&](const auto& descriptor, const auto& proto)
+-          -> decltype(CheckVisibilityRulesVisit(descriptor, proto, state)) {
++      *file, proto, [&](const auto& descriptor, const auto& proto) {
+         CheckVisibilityRulesVisit(descriptor, proto, state);
+       });
+ 

--- a/ports/protobuf/fix-utf8-range.patch
+++ b/ports/protobuf/fix-utf8-range.patch
@@ -30,6 +30,29 @@ index 11c09b1bc..33ebac7cc 100644
  
 -target_link_libraries(libprotobuf PRIVATE utf8_validity)
 +target_link_libraries(libprotobuf PRIVATE utf8_range::utf8_validity)
+diff --git a/cmake/libupb.cmake b/cmake/libupb.cmake
+index 7476e56..a580361 100644
+--- a/cmake/libupb.cmake
++++ b/cmake/libupb.cmake
+@@ -37,4 +37,4 @@ set_target_properties(libupb PROPERTIES
+     VISIBILITY_INLINES_HIDDEN ON
+ )
+ add_library(protobuf::libupb ALIAS libupb)
+-target_link_libraries(libupb PRIVATE utf8_range)
++target_link_libraries(libupb PRIVATE utf8_range::utf8_range)
+diff --git a/cmake/upb_generators.cmake b/cmake/upb_generators.cmake
+index aad2765..187e3a6 100644
+--- a/cmake/upb_generators.cmake
++++ b/cmake/upb_generators.cmake
+@@ -16,7 +16,7 @@ foreach(generator upb upbdefs)
+   )
+   target_include_directories(protoc-gen-${generator} PRIVATE ${bootstrap_cmake_dir})
+   target_link_libraries(protoc-gen-${generator}
+-    utf8_validity
++    utf8_range::utf8_validity
+     ${protobuf_LIB_UPB}
+     ${protobuf_ABSL_USED_TARGETS}
+   )
 diff --git a/cmake/utf8_range.cmake b/cmake/utf8_range.cmake
 index f411a8c5b..21bf8235b 100644
 --- a/cmake/utf8_range.cmake

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protobuf",
-  "version": "5.29.3",
+  "version": "6.31.1",
   "port-version": 1,
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "protobuf",
   "version": "6.31.1",
-  "port-version": 1,
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/ports/utf8-range/fix-cmake.patch
+++ b/ports/utf8-range/fix-cmake.patch
@@ -1,8 +1,24 @@
 diff --git a/third_party/utf8_range/CMakeLists.txt b/third_party/utf8_range/CMakeLists.txt
-index 344952d38..dd855df17 100644
+index 8d50531..8b6f550 100644
 --- a/third_party/utf8_range/CMakeLists.txt
 +++ b/third_party/utf8_range/CMakeLists.txt
-@@ -63,6 +63,7 @@ if (utf8_range_ENABLE_INSTALL)
+@@ -47,15 +47,6 @@ endif (MSVC)
+ # A heavier-weight C++ wrapper that supports Abseil.
+ add_library (utf8_validity utf8_range.c)
+ 
+-set_target_properties(utf8_range PROPERTIES
+-  VERSION ${protobuf_VERSION}
+-  OUTPUT_NAME ${LIB_PREFIX}utf8_range
+-)
+-set_target_properties(utf8_validity PROPERTIES
+-  VERSION ${protobuf_VERSION}
+-  OUTPUT_NAME ${LIB_PREFIX}utf8_validity
+-)
+-
+ # Load Abseil dependency.
+ if (NOT TARGET absl::strings)
+   if (NOT ABSL_ROOT_DIR)
+@@ -98,6 +89,7 @@ if (utf8_range_ENABLE_INSTALL)
          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ports/utf8-range/portfile.cmake
+++ b/ports/utf8-range/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512 32a9ae3de113b8c94e2aed21ad8f58e5ed4419a6d4078e51f614f0fabbf3bfe6c4affc62c2c1326e030a54df0fdcc47bb715b45022191a363f17680ec651b68e
+    SHA512 9138ac1b1c248246ed9840ab3879a6e18da60c709454ede2cb8e45e66e949998ab6e2c8aba557f0bb0b650ec430caeb546695b23387321ced5bc288866e04ad7
     HEAD_REF main
     PATCHES
         fix-cmake.patch

--- a/ports/utf8-range/vcpkg.json
+++ b/ports/utf8-range/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "utf8-range",
-  "version": "5.29.3",
+  "version": "6.31.1",
   "description": "Fast UTF-8 validation with Range algorithm (NEON+SSE4+AVX2)",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7509,8 +7509,8 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "5.29.3",
-      "port-version": 1
+      "baseline": "6.31.1",
+      "port-version": 0
     },
     "protobuf-c": {
       "baseline": "1.5.2",
@@ -9737,7 +9737,7 @@
       "port-version": 4
     },
     "utf8-range": {
-      "baseline": "5.29.3",
+      "baseline": "6.31.1",
       "port-version": 0
     },
     "utf8h": {

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "059375f7b628da470faacaf79b9a0199a8a2b960",
+      "version": "6.31.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "1020e6e87d6a63311c6ebf7f7ec5124b9bf7be74",
       "version": "5.29.3",
       "port-version": 1

--- a/versions/u-/utf8-range.json
+++ b/versions/u-/utf8-range.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "72ce6429ec763395cf73aa1174638b7468ebe423",
+      "version": "6.31.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "67a0b0ded179b27dc30195bab68549fab519e1e2",
       "version": "5.29.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.