### PR TITLE
[vcpkg-tool-meson] Update to 1.8.2

### DIFF
--- a/ports/vcpkg-tool-meson/adjust-args.patch
+++ b/ports/vcpkg-tool-meson/adjust-args.patch
@@ -1,13 +1,13 @@
 diff --git a/mesonbuild/cmake/toolchain.py b/mesonbuild/cmake/toolchain.py
-index 7d73a7c..564e6de 100644
+index 11a00be5d..89ae490ff 100644
 --- a/mesonbuild/cmake/toolchain.py
 +++ b/mesonbuild/cmake/toolchain.py
-@@ -196,7 +196,7 @@ class CMakeToolchain:
+@@ -202,7 +202,7 @@ class CMakeToolchain:
      @staticmethod
      def is_cmdline_option(compiler: 'Compiler', arg: str) -> bool:
          if compiler.get_argument_syntax() == 'msvc':
 -            return arg.startswith('/')
-+            return arg.startswith(('/','-'))
++            return arg.startswith('/','-')
          else:
-             if compiler.exelist[0] == 'zig' and arg in {'ar', 'cc', 'c++', 'dlltool', 'lib', 'ranlib', 'objcopy', 'rc'}:
+             if os.path.basename(compiler.get_exe()) == 'zig' and arg in {'ar', 'cc', 'c++', 'dlltool', 'lib', 'ranlib', 'objcopy', 'rc'}:
                  return True

--- a/ports/vcpkg-tool-meson/adjust-args.patch
+++ b/ports/vcpkg-tool-meson/adjust-args.patch
@@ -7,7 +7,7 @@ index 11a00be5d..89ae490ff 100644
      def is_cmdline_option(compiler: 'Compiler', arg: str) -> bool:
          if compiler.get_argument_syntax() == 'msvc':
 -            return arg.startswith('/')
-+            return arg.startswith('/','-')
++            return arg.startswith(('/','-'))
          else:
              if os.path.basename(compiler.get_exe()) == 'zig' and arg in {'ar', 'cc', 'c++', 'dlltool', 'lib', 'ranlib', 'objcopy', 'rc'}:
                  return True

--- a/ports/vcpkg-tool-meson/fix-libcpp-enable-assertions.patch
+++ b/ports/vcpkg-tool-meson/fix-libcpp-enable-assertions.patch
@@ -1,0 +1,52 @@
+From a16ec8b0fb6d7035b669a13edd4d97ff0c307a0b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20D=C3=B8rum?= <martid0311@gmail.com>
+Date: Fri, 2 May 2025 10:56:28 +0200
+Subject: [PATCH] cpp: fix _LIBCPP_ENABLE_ASSERTIONS warning
+
+libc++ deprecated _LIBCPP_ENABLE_ASSERTIONS from version 18.
+However, the libc++ shipped with Apple Clang backported that
+deprecation in version 17 already,
+which is the version which Apple currently ships for macOS.
+This PR changes the _LIBCPP_ENABLE_ASSERTIONS deprecation check
+to use version ">=17" on Apple Clang.
+---
+ mesonbuild/compilers/cpp.py | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/mesonbuild/compilers/cpp.py b/mesonbuild/compilers/cpp.py
+index 01b9bb9fa34f..f7dc150e8608 100644
+--- a/mesonbuild/compilers/cpp.py
++++ b/mesonbuild/compilers/cpp.py
+@@ -311,6 +311,9 @@ def get_option_link_args(self, target: 'BuildTarget', env: 'Environment', subpro
+             return libs
+         return []
+ 
++    def is_libcpp_enable_assertions_deprecated(self) -> bool:
++        return version_compare(self.version, ">=18")
++
+     def get_assert_args(self, disable: bool, env: 'Environment') -> T.List[str]:
+         if disable:
+             return ['-DNDEBUG']
+@@ -323,7 +326,7 @@ def get_assert_args(self, disable: bool, env: 'Environment') -> T.List[str]:
+         if self.language_stdlib_provider(env) == 'stdc++':
+             return ['-D_GLIBCXX_ASSERTIONS=1']
+         else:
+-            if version_compare(self.version, '>=18'):
++            if self.is_libcpp_enable_assertions_deprecated():
+                 return ['-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST']
+             elif version_compare(self.version, '>=15'):
+                 return ['-D_LIBCPP_ENABLE_ASSERTIONS=1']
+@@ -343,7 +346,12 @@ class ArmLtdClangCPPCompiler(ClangCPPCompiler):
+ 
+ 
+ class AppleClangCPPCompiler(AppleCompilerMixin, AppleCPPStdsMixin, ClangCPPCompiler):
+-    pass
++    def is_libcpp_enable_assertions_deprecated(self) -> bool:
++        # Upstream libc++ deprecated _LIBCPP_ENABLE_ASSERTIONS
++        # in favor of _LIBCPP_HARDENING_MODE from version 18 onwards,
++        # but Apple Clang 17's libc++ has back-ported that change.
++        # See: https://github.com/mesonbuild/meson/issues/14440
++        return version_compare(self.version, ">=17")
+ 
+ 
+ class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):

--- a/ports/vcpkg-tool-meson/portfile.cmake
+++ b/ports/vcpkg-tool-meson/portfile.cmake
@@ -9,6 +9,7 @@ set(patches
   adjust-python-dep.patch
   adjust-args.patch
   remove-freebsd-pcfile-specialization.patch
+  fix-libcpp-enable-assertions.patch # https://github.com/mesonbuild/meson/pull/14548, Remove in 1.8.3
 )
 set(scripts
   vcpkg-port-config.cmake

--- a/ports/vcpkg-tool-meson/remove-freebsd-pcfile-specialization.patch
+++ b/ports/vcpkg-tool-meson/remove-freebsd-pcfile-specialization.patch
@@ -1,15 +1,23 @@
 diff --git a/mesonbuild/modules/pkgconfig.py b/mesonbuild/modules/pkgconfig.py
-index cc0450a52..a4a46915d 100644
+index cc0450a52..13501466d 100644
 --- a/mesonbuild/modules/pkgconfig.py
 +++ b/mesonbuild/modules/pkgconfig.py
-@@ -703,8 +703,8 @@ class PkgConfigModule(NewExtensionModule):
+@@ -701,16 +701,8 @@ class PkgConfigModule(NewExtensionModule):
+         pcfile = filebase + '.pc'
+         pkgroot = pkgroot_name = kwargs['install_dir'] or default_install_dir
          if pkgroot is None:
-             m = state.environment.machines.host
-             if m.is_freebsd():
+-            m = state.environment.machines.host
+-            if m.is_freebsd():
 -                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('prefix'))), 'libdata', 'pkgconfig')
 -                pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
-+                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('libdir'))), 'pkgconfig')
-+                pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
-             elif m.is_haiku():
-                 pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
-                 pkgroot_name = os.path.join('{prefix}', 'develop', 'lib', 'pkgconfig')
+-            elif m.is_haiku():
+-                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
+-                pkgroot_name = os.path.join('{prefix}', 'develop', 'lib', 'pkgconfig')
+-            else:
+-                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('libdir'))), 'pkgconfig')
+-                pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
++            pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('libdir'))), 'pkgconfig')
++            pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
+         relocatable = state.get_option('pkgconfig.relocatable')
+         self._generate_pkgconfig_file(state, deps, subdirs, name, description, url,
+                                       version, pcfile, conflicts, variables,

--- a/ports/vcpkg-tool-meson/remove-freebsd-pcfile-specialization.patch
+++ b/ports/vcpkg-tool-meson/remove-freebsd-pcfile-specialization.patch
@@ -1,14 +1,15 @@
 diff --git a/mesonbuild/modules/pkgconfig.py b/mesonbuild/modules/pkgconfig.py
-index 1bdf829..5f1bfd9 100644
+index cc0450a52..a4a46915d 100644
 --- a/mesonbuild/modules/pkgconfig.py
 +++ b/mesonbuild/modules/pkgconfig.py
-@@ -701,6 +701,9 @@ class PkgConfigModule(NewExtensionModule):
-         pcfile = filebase + '.pc'
-         pkgroot = pkgroot_name = kwargs['install_dir'] or default_install_dir
+@@ -703,8 +703,8 @@ class PkgConfigModule(NewExtensionModule):
          if pkgroot is None:
-+            pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(OptionKey('libdir'))), 'pkgconfig')
-+            pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
-+        elif False:
-             if mesonlib.is_freebsd():
-                 pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(OptionKey('prefix'))), 'libdata', 'pkgconfig')
-                 pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
+             m = state.environment.machines.host
+             if m.is_freebsd():
+-                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('prefix'))), 'libdata', 'pkgconfig')
+-                pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
++                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('libdir'))), 'pkgconfig')
++                pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
+             elif m.is_haiku():
+                 pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
+                 pkgroot_name = os.path.join('{prefix}', 'develop', 'lib', 'pkgconfig')

--- a/ports/vcpkg-tool-meson/vcpkg-port-config.cmake
+++ b/ports/vcpkg-tool-meson/vcpkg-port-config.cmake
@@ -14,7 +14,7 @@ set(ref "${program_version}")
 set(path_to_search "${DOWNLOADS}/tools/meson-${program_version}-${meson_short_hash}")
 set(download_urls "https://github.com/mesonbuild/meson/archive/${ref}.tar.gz")
 set(download_filename "meson-${ref}.tar.gz")
-set(download_sha512 91ddf5421f2808f9f011c2d7f5f2cf9767cf26128821251bae454fc9f36b986ec19d7713b0a938abaaa6300b7f9f06491a91da42080e3811f5271076669da400)
+set(download_sha512 bd2e65f0863d9cb974e659ff502d773e937b8a60aaddfd7d81e34cd2c296c8e82bf214d790ac089ba441543059dfc2677ba95ed51f676df9da420859f404a907)
 
 find_program(SCRIPT_MESON NAMES ${search_names} PATHS "${path_to_search}" NO_DEFAULT_PATH) # NO_DEFAULT_PATH due top patching
 

--- a/ports/vcpkg-tool-meson/vcpkg.json
+++ b/ports/vcpkg-tool-meson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-tool-meson",
-  "version": "1.7.2",
+  "version": "1.8.2",
   "description": "Meson build system",
   "homepage": "https://github.com/mesonbuild/meson",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9881,7 +9881,7 @@
       "port-version": 1
     },
     "vcpkg-tool-meson": {
-      "baseline": "1.7.2",
+      "baseline": "1.8.2",
       "port-version": 0
     },
     "vcpkg-tool-mozbuild": {

--- a/versions/v-/vcpkg-tool-meson.json
+++ b/versions/v-/vcpkg-tool-meson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b52ae3558515a282bf3587897afd734a2fe609c9",
+      "version": "1.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "f0eaf59cb8c65aaf2fa2c1ea4a5ab75a5c04d727",
       "version": "1.7.2",
       "port-version": 0

--- a/versions/v-/vcpkg-tool-meson.json
+++ b/versions/v-/vcpkg-tool-meson.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b52ae3558515a282bf3587897afd734a2fe609c9",
+      "git-tree": "16211ff367256ac4de00202528439fcdd5dd316f",
       "version": "1.8.2",
       "port-version": 0
     },

--- a/versions/v-/vcpkg-tool-meson.json
+++ b/versions/v-/vcpkg-tool-meson.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "16211ff367256ac4de00202528439fcdd5dd316f",
+      "git-tree": "5f3a62a7394feefdd42a9e7c57aa459f1c80f353",
       "version": "1.8.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.