### PR TITLE
[sqlcipher] Add support for static build on Windows

### DIFF
--- a/ports/sqlcipher/CMakeLists.txt
+++ b/ports/sqlcipher/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 project(sqlcipher C)
 
 find_package(OpenSSL REQUIRED)
-
-include_directories(. ${OPENSSL_INCLUDE_DIR})
 if(BUILD_SHARED_LIBS)
     if(UNIX)
         set(API "-DSQLITE_API=__attribute__((visibility(\"default\")))")
@@ -12,8 +10,6 @@ if(BUILD_SHARED_LIBS)
     else()
         message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")
     endif()
-else()
-    set(API "-DSQLITE_API=extern")
 endif()
 add_library(sqlcipher sqlite3.c)
 
@@ -37,7 +33,6 @@ if(WITH_JSON1)
     add_compile_definitions(SQLITE_ENABLE_JSON1)
 endif()
 
-
 if(WITH_FTS5)
     add_compile_definitions(SQLITE_ENABLE_FTS5)
 endif()
@@ -51,7 +46,7 @@ if (UNIX AND NOT APPLE)
     target_link_libraries(sqlcipher PRIVATE m)
 endif()
 
-target_link_libraries(sqlcipher PRIVATE ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries(sqlcipher PRIVATE OpenSSL::Crypto)
 
 if(CMAKE_SYSTEM_NAME MATCHES "WindowsStore")
     target_compile_definitions(sqlcipher PRIVATE -DSQLITE_OS_WINRT=1)

--- a/ports/sqlcipher/portfile.cmake
+++ b/ports/sqlcipher/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sqlcipher/sqlcipher
@@ -13,22 +11,18 @@ find_program(NMAKE nmake REQUIRED)
 
 # Find tclsh Executable needed for Amalgamation of SQLite
 file(GLOB TCLSH_CMD
-		${CURRENT_INSTALLED_DIR}/tools/tcl/bin/tclsh*${VCPKG_HOST_EXECUTABLE_SUFFIX}
+    ${CURRENT_INSTALLED_DIR}/tools/tcl/bin/tclsh*${VCPKG_HOST_EXECUTABLE_SUFFIX}
 )
 file(TO_NATIVE_PATH "${TCLSH_CMD}" TCLSH_CMD)
-file(TO_NATIVE_PATH "${SOURCE_PATH}" SOURCE_PATH_NAT)
 
 # Determine TCL version (e.g. [path]tclsh90sx.exe -> 90)
 string(REGEX REPLACE ^.*tclsh "" TCLVERSION ${TCLSH_CMD})
 string(REGEX REPLACE [A-Za-z]*${VCPKG_HOST_EXECUTABLE_SUFFIX}$ "" TCLVERSION ${TCLVERSION})
 
 list(APPEND NMAKE_OPTIONS
-		TCLSH_CMD="${TCLSH_CMD}"
-		TCLVERSION=${TCLVERSION}
-		ORIGINAL_SRC="${SOURCE_PATH_NAT}"
-		EXT_FEATURE_FLAGS=-DSQLITE_TEMP_STORE=2\ -DSQLITE_HAS_CODEC
-		LTLIBS=libcrypto.lib
-        LTLIBPATHS=/LIBPATH:"${CURRENT_INSTALLED_DIR}/lib/"
+    TCLSH_CMD="${TCLSH_CMD}"
+    TCLVERSION=${TCLVERSION}
+    EXT_FEATURE_FLAGS=-DSQLITE_TEMP_STORE=2\ -DSQLITE_HAS_CODEC
 )
 
 set(ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include;$ENV{INCLUDE}")
@@ -36,10 +30,10 @@ set(ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include;$ENV{INCLUDE}")
 # Creating amalgamation files
 message(STATUS "Pre-building ${TARGET_TRIPLET}")
 vcpkg_execute_required_process(
-	COMMAND ${NMAKE} -f Makefile.msc /A /NOLOGO clean tcl
-	${NMAKE_OPTIONS}
-	WORKING_DIRECTORY "${SOURCE_PATH}"
-	LOGNAME pre-build-${TARGET_TRIPLET}
+    COMMAND ${NMAKE} -f Makefile.msc /A /NOLOGO clean sqlite3.c
+    ${NMAKE_OPTIONS}
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME pre-build-${TARGET_TRIPLET}
 )
 message(STATUS "Pre-building ${TARGET_TRIPLET} done")
 
@@ -58,7 +52,9 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${FEATURE_OPTIONS} -DSQLCIPHER_VERSION=${VERSION}
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DSQLCIPHER_VERSION=${VERSION}
     OPTIONS_DEBUG
         -DSQLITE3_SKIP_TOOLS=ON
 )

--- a/ports/sqlcipher/vcpkg.json
+++ b/ports/sqlcipher/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "sqlcipher",
   "version": "4.6.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "SQLCipher extends the SQLite database library to add security enhancements that make it more suitable for encrypted local data storage.",
   "homepage": "https://www.zetetic.net/sqlcipher",
   "license": null,
-  "supports": "windows & !uwp & !static",
+  "supports": "windows & !uwp",
   "dependencies": [
     "openssl",
     "tcl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9006,7 +9006,7 @@
     },
     "sqlcipher": {
       "baseline": "4.6.1",
-      "port-version": 1
+      "port-version": 2
     },
     "sqlite-modern-cpp": {
       "baseline": "2023-12-03",

--- a/versions/s-/sqlcipher.json
+++ b/versions/s-/sqlcipher.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a11bc0fb6f797eb895de7c8a2e44ae84d085db6d",
+      "version": "4.6.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "11732bd26171c4420ce06505e0ab52dfb841714e",
       "version": "4.6.1",
       "port-version": 1


### PR DESCRIPTION
The previous build process was building the TCL target to get amalgamated `sqlite3.c` as a side effect, which was preventing static builds on Windows.

This change generates `sqlite3.c` directly, making the build more efficient and enabling both static and dynamic linkage options.

Fixes #42069. 

- [x] Changes comply with the [maintainer guide](https://github.com/MicrosoftDocs/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.