### PR TITLE
[argtable3] update to 3.3.1

### DIFF
--- a/ports/argtable3/portfile.cmake
+++ b/ports/argtable3/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS "https://github.com/argtable/argtable3/releases/download/v${VERSION}/argtable-v${VERSION}.zip"
     FILENAME "argtable-v${VERSION}.zip"
-    SHA512 5591d510a1c739148aa356e5fa9827e037c4a0f1d171453635fad0cca4030d1fa3cce1e50671a944d12abfd4793df1f5cd1125825a23c63e54e9362def56e9f9
+    SHA512 cdcb67f6d56ef4a02254cd210c035d2b037bd2844a3b14c261500eecd307ca9ab40c6cfa753aa32d4873773ddadc708966fb0772478e575d134399bd4743869f
 )
 
 vcpkg_extract_source_archive(

--- a/ports/argtable3/vcpkg.json
+++ b/ports/argtable3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "argtable3",
-  "version-string": "3.3.0.116da6c",
-  "port-version": 1,
+  "version": "3.3.1",
   "description": "A single-file, ANSI C, command-line parsing library that parses GNU-style command-line options",
   "homepage": "https://www.argtable.org/",
   "license": "BSD-3-Clause AND TCL",

--- a/versions/a-/argtable3.json
+++ b/versions/a-/argtable3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3de7f101097015a6bc35dfb30dbca11d3644433e",
+      "version": "3.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0057e71075971fe4287766bf35b3cb3a3bc7ff01",
       "version-string": "3.3.0.116da6c",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -233,8 +233,8 @@
       "port-version": 10
     },
     "argtable3": {
-      "baseline": "3.3.0.116da6c",
-      "port-version": 1
+      "baseline": "3.3.1",
+      "port-version": 0
     },
     "argumentum": {
       "baseline": "0.3.2",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/argtable/argtable3/releases/tag/v3.3.1
