### PR TITLE
[ser20] Add new port

### DIFF
--- a/ports/ser20/copyright
+++ b/ports/ser20/copyright
@@ -1,2 +1,0 @@
-# Copyright (c) 2025 royjacobson
-# SPDX-License-Identifier: BSD-3-Clause

--- a/ports/ser20/copyright
+++ b/ports/ser20/copyright
@@ -1,0 +1,2 @@
+# Copyright (c) 2025 royjacobson
+# SPDX-License-Identifier: BSD-3-Clause

--- a/ports/ser20/portfile.cmake
+++ b/ports/ser20/portfile.cmake
@@ -7,8 +7,10 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS -DBUILD_TESTS=OFF
-            -DBUILD_SANDBOX=OFF
+    OPTIONS
+        -DBUILD_DOC=OFF
+        -DBUILD_SANDBOX=OFF
+        -DBUILD_TESTS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/ser20/portfile.cmake
+++ b/ports/ser20/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO royjacobson/ser20
+    REF v0.9.1
+    SHA512 3a9b796151d6fe48bf322758359ed6e39fa0025ada8fae0ca46177a986eb37c191fc014c5ad4776260aae4ed91c4d807a1b1175b7e13126a02fe7752314e3530
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS -DBUILD_TESTS=OFF
+            -DBUILD_SANDBOX=OFF
+)
+
+vcpkg_cmake_install()
+
+# Only run config fixup for release, not debug
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH lib/cmake/ser20
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST
+    ${SOURCE_PATH}/LICENSE
+    ${SOURCE_PATH}/include/ser20/external/LICENSE
+    ${SOURCE_PATH}/include/ser20/external/rapidjson/LICENSE
+    ${SOURCE_PATH}/include/ser20/external/rapidxml/license.txt
+)

--- a/ports/ser20/portfile.cmake
+++ b/ports/ser20/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO royjacobson/ser20
-    REF v0.9.1
+    REF "v${VERSION}"
     SHA512 3a9b796151d6fe48bf322758359ed6e39fa0025ada8fae0ca46177a986eb37c191fc014c5ad4776260aae4ed91c4d807a1b1175b7e13126a02fe7752314e3530
 )
 

--- a/ports/ser20/vcpkg.json
+++ b/ports/ser20/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "ser20",
+  "version": "0.9.1",
+  "description": "A C++20 serialization library (cereal fork) with modern meta-programming and optimizations.",
+  "homepage": "https://github.com/royjacobson/ser20",
+  "license": "BSD-3-Clause AND BSL-1.0 AND MIT AND Zlib",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8640,6 +8640,10 @@
       "baseline": "2.4.0",
       "port-version": 3
     },
+    "ser20": {
+      "baseline": "0.9.1",
+      "port-version": 0
+    },
     "serd": {
       "baseline": "0.32.4",
       "port-version": 0

--- a/versions/s-/ser20.json
+++ b/versions/s-/ser20.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "93fb45e74115109e1b6845fc92c2105af01e661f",
+      "git-tree": "9095fd260e3e16156d3d6badfd258aa6a7bfa093",
       "version": "0.9.1",
       "port-version": 0
     }

--- a/versions/s-/ser20.json
+++ b/versions/s-/ser20.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4ae4e514bd05d7394c04dbb76780eb0ff42ec648",
+      "version": "0.9.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/ser20.json
+++ b/versions/s-/ser20.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4ae4e514bd05d7394c04dbb76780eb0ff42ec648",
+      "git-tree": "93fb45e74115109e1b6845fc92c2105af01e661f",
       "version": "0.9.1",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.