### PR TITLE
[cpp-lazy] add new port

### DIFF
--- a/ports/cpp-lazy/portfile.cmake
+++ b/ports/cpp-lazy/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Kaaserne/cpp-lazy
+    REF "${VERSION}"
+    SHA512 9ca34fc3c532602e1e92480080a020eb9f44de751159f9fd028552413f15f08f9705898eacb306668ab3cb243bb629b7f9e68078a0fcd882b886154b6bd69430
+    HEAD_REF master
+)
+
+# header-only
+set(VCPKG_BUILD_TYPE "release")
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME cpp-lazy CONFIG_PATH lib/cmake/cpp-lazy)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/cpp-lazy/vcpkg.json
+++ b/ports/cpp-lazy/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "cpp-lazy",
+  "version": "8.0.1",
+  "description": "C++11 (and onwards) library for lazy evaluation ",
+  "homepage": "https://github.com/Kaaserne/cpp-lazy",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1972,6 +1972,10 @@
       "baseline": "1.0.1",
       "port-version": 0
     },
+    "cpp-lazy": {
+      "baseline": "8.0.1",
+      "port-version": 0
+    },
     "cpp-netlib": {
       "baseline": "0.13.0",
       "port-version": 10

--- a/versions/c-/cpp-lazy.json
+++ b/versions/c-/cpp-lazy.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e5b9aeb15614e9ea580a39d803f09f561e6dd28f",
+      "version": "8.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Kaaserne/cpp-lazy
