### PR TITLE
[libjxl] Remove libm dependency when building with MSVC

### DIFF
--- a/ports/libjxl/msvc-remove-libm.patch
+++ b/ports/libjxl/msvc-remove-libm.patch
@@ -1,0 +1,24 @@
+--- a/lib/jxl.cmake	2024-11-26 05:02:35.000000000 -0800
++++ b/lib/jxl.cmake	2025-06-26 08:37:25.999263200 -0700
+@@ -269,12 +269,15 @@
+ set(JPEGXL_LIBRARY_REQUIRES
+     "libhwy libbrotlienc libbrotlidec libjxl_cms")
+ 
+-if (BUILD_SHARED_LIBS)
+-  set(JPEGXL_REQUIRES_TYPE "Requires.private")
+-  set(JPEGXL_PRIVATE_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
+-else()
+-  set(JPEGXL_REQUIRES_TYPE "Requires")
+-  set(JPEGXL_PUBLIC_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
++# MSVCRT bundles math functions
++if(NOT MSVC)
++    if (BUILD_SHARED_LIBS)
++      set(JPEGXL_REQUIRES_TYPE "Requires.private")
++      set(JPEGXL_PRIVATE_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
++    else()
++      set(JPEGXL_REQUIRES_TYPE "Requires")
++      set(JPEGXL_PUBLIC_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
++    endif()
+ endif()
+ 
+ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/jxl/libjxl.pc.in"

--- a/ports/libjxl/portfile.cmake
+++ b/ports/libjxl/portfile.cmake
@@ -6,7 +6,8 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         fix-dependencies.patch
-	avoid-exe-linker-flags.patch # https://github.com/libjxl/libjxl/pull/4229
+        avoid-exe-linker-flags.patch # https://github.com/libjxl/libjxl/pull/4229
+        msvc-remove-libm.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libjxl/vcpkg.json
+++ b/ports/libjxl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libjxl",
   "version-semver": "0.11.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "JPEG XL image format reference implementation",
   "homepage": "https://github.com/libjxl/libjxl",
   "license": "BSD-3-Clause",
@@ -17,6 +17,7 @@
   "features": {
     "tools": {
       "description": "Build user tools: cjxl and djxl",
+      "supports": "!uwp",
       "dependencies": [
         "giflib",
         "libjpeg-turbo",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4898,7 +4898,7 @@
     },
     "libjxl": {
       "baseline": "0.11.1",
-      "port-version": 1
+      "port-version": 2
     },
     "libkeyfinder": {
       "baseline": "2.2.8",

--- a/versions/l-/libjxl.json
+++ b/versions/l-/libjxl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ff477143618a294bb1f624cc075c4ea42059377",
+      "version-semver": "0.11.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "1f7903efa9347e989121781311287edb5f41592f",
       "version-semver": "0.11.1",
       "port-version": 1


### PR DESCRIPTION
This patches MSVC builds to not link with `libm`. Otherwise, when `NOT BUILD_SHARED_LIBS` is true, targets that depend on the libjxl target try to link with `m.lib`.

The following was the previous workaround I had to do before this fix:
```patch
diff --git a/Libraries/LibGfx/CMakeLists.txt b/Libraries/LibGfx/CMakeLists.txt
index 794271d014..2c55c49dfd 100644
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -137,6 +137,11 @@ endif()
 
 if (NOT ANDROID)
     pkg_check_modules(Jxl REQUIRED IMPORTED_TARGET libjxl)
+    if (MSVC)
+        get_target_property(LIBJXL_INTERFACE_LINK_LIBS PkgConfig::Jxl INTERFACE_LINK_LIBRARIES)
+        list(REMOVE_ITEM LIBJXL_INTERFACE_LINK_LIBS "m")
+        set_target_properties(PkgConfig::Jxl PROPERTIES INTERFACE_LINK_LIBRARIES "${LIBJXL_INTERFACE_LINK_LIBS}")
+    endif()
     target_link_libraries(LibGfx PRIVATE PkgConfig::Jxl)
 else()
     find_package(libjxl REQUIRED)

```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
