### PR TITLE
[crossdb] add new port

### DIFF
--- a/ports/crossdb/portfile.cmake
+++ b/ports/crossdb/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO crossdb-org/crossdb
+    REF "${VERSION}"
+    SHA512 ad0d1c4eb02016d4d1eb8b8f3dbbacc800c1ac02a2fd39e832225e7d17d4f9938da4b49cd6ca226555819a17bb23cdf8c6d5945eeb612fe8e7e140eedd902d8f
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_copy_tools(TOOL_NAMES xdb-cli DESTINATION "${CURRENT_PACKAGES_DIR}/tools" AUTO_CLEAN)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/crossdb/usage
+++ b/ports/crossdb/usage
@@ -1,0 +1,6 @@
+The package crossdb can be used via CMake:
+
+    find_path(CROSSDB_INCLUDE_DIR crossdb.h)
+    find_library(CROSSDB_LIBRARY NAMES crossdb)
+    target_include_directories(main PRIVATE "${CROSSDB_INCLUDE_DIR}")
+    target_link_libraries(main PRIVATE "${CROSSDB_LIBRARY}")

--- a/ports/crossdb/vcpkg.json
+++ b/ports/crossdb/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Ultra High-performance Lightweight Embedded and Server OLTP RDBMS",
   "homepage": "https://github.com/crossdb-org/crossdb",
   "license": "MPL-2.0",
-  "supports": "!windows | mingw",
+  "supports": "(!windows | mingw) & !android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/crossdb/vcpkg.json
+++ b/ports/crossdb/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "crossdb",
+  "version": "0.14.0",
+  "description": "Ultra High-performance Lightweight Embedded and Server OLTP RDBMS",
+  "homepage": "https://github.com/crossdb-org/crossdb",
+  "license": "MPL-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/ports/crossdb/vcpkg.json
+++ b/ports/crossdb/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Ultra High-performance Lightweight Embedded and Server OLTP RDBMS",
   "homepage": "https://github.com/crossdb-org/crossdb",
   "license": "MPL-2.0",
+  "supports": "!windows | mingw",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2132,6 +2132,10 @@
       "baseline": "2023-03-30",
       "port-version": 0
     },
+    "crossdb": {
+      "baseline": "0.14.0",
+      "port-version": 0
+    },
     "crossguid": {
       "baseline": "2021-10-22",
       "port-version": 3

--- a/versions/c-/crossdb.json
+++ b/versions/c-/crossdb.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4e3339a53f4cc1cb54a204c763b32d64fe46d909",
+      "version": "0.14.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/crossdb.json
+++ b/versions/c-/crossdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4716c58d06a085047bd61677756c1c7e561b2fda",
+      "git-tree": "71458aa6539a1f36956b9fcc35ab3c0e35cc9f30",
       "version": "0.14.0",
       "port-version": 0
     }

--- a/versions/c-/crossdb.json
+++ b/versions/c-/crossdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4e3339a53f4cc1cb54a204c763b32d64fe46d909",
+      "git-tree": "4716c58d06a085047bd61677756c1c7e561b2fda",
       "version": "0.14.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/crossdb-org/crossdb
