### PR TITLE
Stardots sdk cpp

### DIFF
--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9072,6 +9072,10 @@
       "baseline": "2023-06-24",
       "port-version": 0
     },
+    "stardots-sdk-cpp": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "starlink-ast": {
       "baseline": "9.2.12",
       "port-version": 0

--- a/versions/s-/stardots-sdk-cpp.json
+++ b/versions/s-/stardots-sdk-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3b991d264ed9c469b194b7ca071b95da1f718ab2",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a new port: `stardots-sdk-cpp`, the official C++ SDK for the StarDots image hosting platform.

> Homepage: https://stardots.io  
> Documentation: https://stardots.io/en/documentation/openapi  
> Source: https://github.com/stardots/stardots-sdk-cpp  
> License: MIT

### ✅ New Port Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with CMAKE_DISABLE_FIND_PACKAGE_Xxx.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See adding-usage for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
