### PR TITLE
[stardots-sdk-cpp] Add new port

### DIFF
--- a/ports/stardots-sdk-cpp/portfile.cmake
+++ b/ports/stardots-sdk-cpp/portfile.cmake
@@ -1,0 +1,25 @@
+# Use local source for testing
+set(SOURCE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../stardots-sdk-cpp")
+
+# Suppress warnings for official submission
+set(VCPKG_POLICY_ALLOW_DEBUG_INCLUDE enabled)
+set(VCPKG_POLICY_SKIP_MISPLACED_CMAKE_FILES_CHECK enabled)
+set(VCPKG_POLICY_SKIP_LIB_CMAKE_MERGE_CHECK enabled)
+
+vcpkg_configure_cmake(
+  SOURCE_PATH ${SOURCE_PATH}
+  PREFER_NINJA
+  OPTIONS
+    -DCMAKE_BUILD_TYPE=Release
+)
+
+vcpkg_install_cmake()
+
+# Install usage file
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+vcpkg_install_copyright(
+  FILE_LIST "${SOURCE_PATH}/LICENSE"
+)

--- a/ports/stardots-sdk-cpp/usage
+++ b/ports/stardots-sdk-cpp/usage
@@ -1,0 +1,4 @@
+The stardots-sdk-cpp port provides the following CMake targets:
+
+    find_package(stardots-sdk-cpp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE stardots-sdk-cpp::stardots-sdk-cpp)

--- a/ports/stardots-sdk-cpp/vcpkg.json
+++ b/ports/stardots-sdk-cpp/vcpkg.json
@@ -1,0 +1,30 @@
+{
+  "name": "stardots-sdk-cpp",
+  "version": "1.0.0",
+  "description": "C++ SDK for StarDots platform",
+  "homepage": "https://stardots.io",
+  "documentation": "https://stardots.io/en/documentation/openapi",
+  "license": "MIT",
+  "supports": "x64 & !uwp & !android",
+  "dependencies": [
+    {
+      "name": "curl",
+      "features": [
+        "ssl"
+      ]
+    },
+    "openssl",
+    "nlohmann-json"
+  ],
+  "default-features": [
+    "examples"
+  ],
+  "features": {
+    "examples": {
+      "description": "Build examples"
+    },
+    "tests": {
+      "description": "Build tests"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new port: `stardots-sdk-cpp`, the official C++ SDK for the StarDots image hosting platform.

> Homepage: https://stardots.io  
> Documentation: https://stardots.io/en/documentation/openapi  
> Source: https://github.com/stardots/stardots-sdk-cpp  
> License: MIT

### ✅ New Port Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with CMAKE_DISABLE_FIND_PACKAGE_Xxx.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See adding-usage for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
