### PR TITLE
[libwebm] update to 1.0.0.32

### DIFF
--- a/ports/libwebm/Fix-cmake.patch
+++ b/ports/libwebm/Fix-cmake.patch
@@ -1,13 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 85b2603..ebb3333 100644
+index 19852cd..8d803cf 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -5,9 +5,11 @@
- #  tree. An additional intellectual property rights grant can be found
- #  in the file PATENTS.  All contributing project authors may
- #  be found in the AUTHORS file in the root of the source tree.
--cmake_minimum_required(VERSION 3.2)
-+cmake_minimum_required(VERSION 3.5)
+@@ -8,6 +8,8 @@
+ cmake_minimum_required(VERSION 3.16)
  project(LIBWEBM CXX)
  
 +set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/ports/libwebm/portfile.cmake
+++ b/ports/libwebm/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/libwebm
     REF libwebm-${VERSION}
-    SHA512 d80ecb37d21586aeff14d0282dfbcde7c71644b6952d3f32f538c6e5eb6cfe835c0eb777d5c633070d796526fbc645b70741c2278c106fb74ed0705123b9a200
+    SHA512 9da60f3e7243fb78e0c02e0b6bf8e628552c5b54631960e34bacdf0349ce690984ff9432b8ffa495051858ecc2f4e4a4c1e0b290666058298abf94c3ad99670f
     HEAD_REF master
     PATCHES
         Fix-cmake.patch

--- a/ports/libwebm/vcpkg.json
+++ b/ports/libwebm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libwebm",
-  "version": "1.0.0.31",
-  "port-version": 1,
+  "version": "1.0.0.32",
   "description": "WebM File Parser",
   "homepage": "https://github.com/webmproject/libwebm",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5553,8 +5553,8 @@
       "port-version": 6
     },
     "libwebm": {
-      "baseline": "1.0.0.31",
-      "port-version": 1
+      "baseline": "1.0.0.32",
+      "port-version": 0
     },
     "libwebp": {
       "baseline": "1.5.0",

--- a/versions/l-/libwebm.json
+++ b/versions/l-/libwebm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a3d265a67c42bbc8e93d6263db699a73bea01b9",
+      "version": "1.0.0.32",
+      "port-version": 0
+    },
+    {
       "git-tree": "1cfbac17267892f7a391ad56353f624a80451f88",
       "version": "1.0.0.31",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/webmproject/libwebm/releases/tag/libwebm-1.0.0.32
