### PR TITLE
[simdutf] update to 7.3.2

### DIFF
--- a/ports/simdutf/portfile.cmake
+++ b/ports/simdutf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO simdutf/simdutf
     REF "v${VERSION}"
-    SHA512 3ac7d53044dc438cc1fce4f6c27a90f7a04ac814278cb1c7ebd17328569bf493ea814e0e4ad39ca98ffcaacdf34d5a6fc7691d7844008b35f6fde27b0d4efd1a
+    SHA512 6657af38a8f7565b0bd585921c141ce30f1f0073bd357eb4dcd72de1b44a89c0336d5f39645e5e75c68b4c2c85e251a16b835e7ac3d88d4fac0379d7f3dd879c
     HEAD_REF master
 )
 

--- a/ports/simdutf/vcpkg.json
+++ b/ports/simdutf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdutf",
-  "version-semver": "7.3.1",
+  "version-semver": "7.3.2",
   "description": "Unicode validation and transcoding at billions of characters per second",
   "homepage": "https://github.com/simdutf/simdutf",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8765,7 +8765,7 @@
       "port-version": 0
     },
     "simdutf": {
-      "baseline": "7.3.1",
+      "baseline": "7.3.2",
       "port-version": 0
     },
     "simonbrunel-qtpromise": {

--- a/versions/s-/simdutf.json
+++ b/versions/s-/simdutf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e52260bd1fffbb7cb71e2cbff0cde4267099bca",
+      "version-semver": "7.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c976fe63ec107b6b92f9eb5d940af5ec92b070bf",
       "version-semver": "7.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/simdutf/simdutf/releases/tag/v7.3.2
