### PR TITLE
[ruckig] Update to 0.15.3

### DIFF
--- a/ports/ruckig/portfile.cmake
+++ b/ports/ruckig/portfile.cmake
@@ -2,14 +2,21 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pantor/ruckig
     REF "v${VERSION}"
-    SHA512 cd8e31d4cc41cf90a23095f39f58e7139ac12a34c7699f3274c6389916cbed56a6e8627facaf34e5a888d43b78e43cb01dce1cd1ef45201652d3ded917a80075
+    SHA512 5399e1f0c61c1c4d96a8a910e4b934b629c6302fd18fd609c7a8bc76156bf0f3f5197ff9e83ac0fc443083e40cc7208d9a2f09070f4f8ab4511f4a6566981b5d
     HEAD_REF main
+    PATCHES
+        third_party.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        cloud BUILD_CLOUD_CLIENT
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBUILD_CLOUD_CLIENT=OFF
+        ${FEATURE_OPTIONS}
         -DBUILD_TESTS=OFF
         -DBUILD_EXAMPLES=OFF
 )

--- a/ports/ruckig/third_party.patch
+++ b/ports/ruckig/third_party.patch
@@ -1,0 +1,47 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 701982a..3cedd7f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -46,10 +46,15 @@ endif()
+ 
+ if(BUILD_CLOUD_CLIENT)
+   target_sources(ruckig PRIVATE src/ruckig/cloud_client.cpp)
+-  target_include_directories(ruckig PUBLIC
+-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party>
+-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ruckig/third_party>
+-  )
++  find_package(nlohmann_json CONFIG REQUIRED)
++  find_package(httplib CONFIG REQUIRED)
++
++  target_link_libraries(ruckig PUBLIC nlohmann_json::nlohmann_json)
++  target_link_libraries(ruckig PRIVATE httplib::httplib)
++  #target_include_directories(ruckig PUBLIC
++  #  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party>
++  #  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ruckig/third_party>
++  #)
+   target_compile_definitions(ruckig PUBLIC WITH_CLOUD_CLIENT)
+ endif()
+ 
+@@ -130,9 +135,9 @@ include(CMakePackageConfigHelpers)
+ 
+ # Install headers
+ install(DIRECTORY include/ruckig DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+-if(BUILD_CLOUD_CLIENT)
+-  install(DIRECTORY third_party/httplib third_party/nlohmann DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ruckig/third_party)
+-endif()
++#if(BUILD_CLOUD_CLIENT)
++  #install(DIRECTORY third_party/httplib third_party/nlohmann DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ruckig/third_party)
++#endif()
+ 
+ # Install library
+ install(TARGETS ruckig
+diff --git a/src/ruckig/cloud_client.cpp b/src/ruckig/cloud_client.cpp
+index d5dc499..65ab347 100644
+--- a/src/ruckig/cloud_client.cpp
++++ b/src/ruckig/cloud_client.cpp
+@@ -1,4 +1,4 @@
+-#include <httplib/httplib.h>
++#include <httplib.h>
+ 
+ #include <ruckig/calculator_cloud.hpp>
+ 

--- a/ports/ruckig/vcpkg.json
+++ b/ports/ruckig/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ruckig",
-  "version": "0.14.0",
+  "version": "0.15.3",
   "description": "Ruckig generates trajectories on-the-fly, allowing robots and machines to react instantaneously to sensor input.",
   "homepage": "https://ruckig.com/",
   "license": "MIT",
@@ -14,5 +14,17 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "cloud"
+  ],
+  "features": {
+    "cloud": {
+      "description": "Build cloud client to calculate Ruckig Pro trajectories remotely",
+      "dependencies": [
+        "cpp-httplib",
+        "nlohmann-json"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8417,7 +8417,7 @@
       "port-version": 0
     },
     "ruckig": {
-      "baseline": "0.14.0",
+      "baseline": "0.15.3",
       "port-version": 0
     },
     "rxcpp": {

--- a/versions/r-/ruckig.json
+++ b/versions/r-/ruckig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "634f7ae551de76541aa80a69eb408245c8a86ca3",
+      "version": "0.15.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "830d50b509f03638a9066a73d0979eddac5acc68",
       "version": "0.14.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
