### PR TITLE
[joltphysics] Expose more Jolt options

### DIFF
--- a/ports/joltphysics/portfile.cmake
+++ b/ports/joltphysics/portfile.cmake
@@ -12,9 +12,15 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" USE_STATIC_CRT)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        debugrenderer       DEBUG_RENDERER_IN_DEBUG_AND_RELEASE
-        profiler            PROFILER_IN_DEBUG_AND_RELEASE
-        rtti                CPP_RTTI_ENABLED
+        asserts                     USE_ASSERTS
+        debugrenderer               DEBUG_RENDERER_IN_DEBUG_AND_RELEASE
+        disable-custom-allocator    DISABLE_CUSTOM_ALLOCATOR
+        double-precision            DOUBLE_PRECISION
+        exceptions                  CPP_EXCEPTIONS_ENABLED
+        disable-object-stream       ENABLE_OBJECT_STREAM
+        profiler                    PROFILER_IN_DEBUG_AND_RELEASE
+        rtti                        CPP_RTTI_ENABLED
+        std-vector                  USE_STD_VECTOR
 )
 
 vcpkg_cmake_configure(

--- a/ports/joltphysics/portfile.cmake
+++ b/ports/joltphysics/portfile.cmake
@@ -17,7 +17,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         disable-custom-allocator    DISABLE_CUSTOM_ALLOCATOR
         double-precision            DOUBLE_PRECISION
         exceptions                  CPP_EXCEPTIONS_ENABLED
-        disable-object-stream       ENABLE_OBJECT_STREAM
+        object-stream               ENABLE_OBJECT_STREAM
         profiler                    PROFILER_IN_DEBUG_AND_RELEASE
         rtti                        CPP_RTTI_ENABLED
         std-vector                  USE_STD_VECTOR

--- a/ports/joltphysics/vcpkg.json
+++ b/ports/joltphysics/vcpkg.json
@@ -35,7 +35,7 @@
       "description": "Enable C++ exceptions"
     },
     "object-stream": {
-      "description": "Enable support for serializing objects to a stream"
+      "description": "Compile the ObjectStream class and RTTI attribute information"
     },
     "profiler": {
       "description": "Enable the profiler in Debug and Release builds"

--- a/ports/joltphysics/vcpkg.json
+++ b/ports/joltphysics/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "joltphysics",
   "version": "5.3.0",
+  "port-version": 1,
   "description": "A multi core friendly rigid body physics and collision detection library suitable for games and VR applications",
   "homepage": "https://github.com/jrouwe/JoltPhysics",
   "license": "MIT",
@@ -14,15 +15,36 @@
       "host": true
     }
   ],
+  "default-features": [
+    "object-stream"
+  ],
   "features": {
+    "asserts": {
+      "description": "Enable asserts"
+    },
     "debugrenderer": {
       "description": "Enable debug renderer in Debug and Release builds"
+    },
+    "disable-custom-allocator": {
+      "description": "Disable support for a custom memory allocator"
+    },
+    "double-precision": {
+      "description": "Use double precision math"
+    },
+    "exceptions": {
+      "description": "Enable C++ exceptions"
+    },
+    "object-stream": {
+      "description": "Enable support for serializing objects to a stream"
     },
     "profiler": {
       "description": "Enable the profiler in Debug and Release builds"
     },
     "rtti": {
       "description": "Enable C++ RTTI"
+    },
+    "std-vector": {
+      "description": "Use std::vector instead of Jolt's own Array class"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3942,7 +3942,7 @@
     },
     "joltphysics": {
       "baseline": "5.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "josuttis-jthread": {
       "baseline": "2020-07-21",

--- a/versions/j-/joltphysics.json
+++ b/versions/j-/joltphysics.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2d908d611b7beef60683853edf96d106d7e0186e",
+      "git-tree": "63af833b12eec7bf7e7515915601248b5d39c77a",
       "version": "5.3.0",
       "port-version": 1
     },

--- a/versions/j-/joltphysics.json
+++ b/versions/j-/joltphysics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d908d611b7beef60683853edf96d106d7e0186e",
+      "version": "5.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "55cfea43bb342bd7123b209a28d8f02c117c39ab",
       "version": "5.3.0",
       "port-version": 0


### PR DESCRIPTION
## Description

This commit exposes more options of the JoltPhysics library via vcpkg features.

I originally only needed `exceptions` but figured I could take the time to add other missing features.

## Added features

Here are the added features:
- asserts: Enable asserts (USE_ASSERTS)
- disable-custom-allocator: Disable support for a custom memory allocator (DISABLE_CUSTOM_ALLOCATOR)
- double-precision: Use double precision math (DOUBLE_PRECISION)
- exceptions: Enable C++ exceptions (CPP_EXCEPTIONS_ENABLED)
- object-stream: Enable support for serializing objects to a stream (ENABLE_OBJECT_STREAM)
- std-vector: Use std::vector instead of Jolt's own Array class (USE_STD_VECTOR)

See Jolt's [CMakeLists.txt](https://github.com/jrouwe/JoltPhysics/blob/v5.3.0/Build/CMakeLists.txt) for the details of each feature.

I also added `object-stream` as default-feature, since Jolt's define it to ON by default at https://github.com/jrouwe/JoltPhysics/blob/0373ec0dd762e4bc2f6acdb08371ee84fa23c6db/Build/CMakeLists.txt#L102

## Checks
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~~SHA512s are updated for each updated download.~~
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
