### PR TITLE
[komihash] add new port

### DIFF
--- a/ports/komihash/portfile.cmake
+++ b/ports/komihash/portfile.cmake
@@ -1,0 +1,14 @@
+# Header-only library
+set(VCPKG_BUILD_TYPE "release")
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO avaneev/komihash
+  REF "${VERSION}"
+  SHA512 77d29bf1d428a5e42b348fd2bdc06977049b97ff5cda2f0d72dccf748d03ad73b3106fe9bd86dc1ad4f83e0e65600e684431082cf325796c64005f9531304772
+  HEAD_REF main
+)
+
+file(INSTALL "${SOURCE_PATH}/komihash.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/komihash/vcpkg.json
+++ b/ports/komihash/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "komihash",
+  "version": "5.27",
+  "description": "Very fast, high-quality hash function, discrete-incremental and streamed hashing-capable",
+  "homepage": "https://github.com/avaneev/komihash",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4308,6 +4308,10 @@
       "baseline": "1.1.0",
       "port-version": 1
     },
+    "komihash": {
+      "baseline": "5.27",
+      "port-version": 0
+    },
     "krabsetw": {
       "baseline": "4.3.2",
       "port-version": 0

--- a/versions/k-/komihash.json
+++ b/versions/k-/komihash.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2080bf24c141337f20244410b344aaf7b03684de",
+      "version": "5.27",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/avaneev/komihash