### PR TITLE
[angle] Fix Windows port

### DIFF
--- a/ports/angle/cmake-buildsystem/PlatformWin.cmake
+++ b/ports/angle/cmake-buildsystem/PlatformWin.cmake
@@ -9,8 +9,8 @@ list(APPEND ANGLE_DEFINITIONS
 
 # We're targeting Windows 10 which will have DirectX 11
 list(APPEND ANGLE_SOURCES
-    ${_d3d11_backend_sources}
-    ${_d3d_shared_sources}
+    ${d3d11_backend_sources}
+    ${d3d_shared_sources}
 
     ${angle_translator_hlsl_sources}
 
@@ -25,11 +25,12 @@ list(APPEND ANGLE_DEFINITIONS
     "-DANGLE_PRELOADED_D3DCOMPILER_MODULE_NAMES={ \"d3dcompiler_47.dll\", \"d3dcompiler_46.dll\", \"d3dcompiler_43.dll\" }"
 )
 
-list(APPEND ANGLEGLESv2_LIBRARIES dxguid dxgi)
+# https://issues.angleproject.org/issues/345274916
+list(APPEND ANGLEGLESv2_LIBRARIES dxguid dxgi synchronization)
 
 if(NOT angle_is_winuwp) # vcpkg EDIT: Exclude DirectX 9 on UWP
     # DirectX 9 support should be optional but ANGLE will not compile without it
-    list(APPEND ANGLE_SOURCES ${_d3d9_backend_sources})
+    list(APPEND ANGLE_SOURCES ${d3d9_backend_sources})
     list(APPEND ANGLE_DEFINITIONS ANGLE_ENABLE_D3D9)
     list(APPEND ANGLEGLESv2_LIBRARIES d3d9)
 endif()
@@ -52,7 +53,7 @@ if(USE_OPENGL)
 
     if(USE_ANGLE_EGL OR ENABLE_WEBGL)
         list(APPEND ANGLE_SOURCES
-            ${_gl_backend_sources}
+            ${gl_backend_sources}
 
             ${libangle_gl_egl_dl_sources}
             ${libangle_gl_egl_sources}

--- a/ports/angle/portfile.cmake
+++ b/ports/angle/portfile.cmake
@@ -147,7 +147,11 @@ function(checkout_in_path PATH URL REF)
         URL "${URL}"
         REF "${REF}"
     )
-    file(RENAME "${DEP_SOURCE_PATH}" "${PATH}")
+    if (WIN32)
+        file(COPY "${DEP_SOURCE_PATH}/" DESTINATION "${PATH}")
+    else()
+        file(RENAME "${DEP_SOURCE_PATH}" "${PATH}")
+    endif()
     file(REMOVE_RECURSE "${DEP_SOURCE_PATH}")
 endfunction()
 

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_5414",
-  "port-version": 10,
+  "port-version": 11,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ea68c4d81529edb62fbd7604c382a966812ef32",
+      "version-string": "chromium_5414",
+      "port-version": 11
+    },
+    {
       "git-tree": "025eefba308651be2ae69502477d1201dfdf04ea",
       "version-string": "chromium_5414",
       "port-version": 10

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -138,7 +138,7 @@
     },
     "angle": {
       "baseline": "chromium_5414",
-      "port-version": 10
+      "port-version": 11
     },
     "ankurvdev-embedresource": {
       "baseline": "0.0.12",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

