### PR TITLE
[ffmpeg] Fix build on OpenBSD and FreeBSD

### DIFF
--- a/ports/ffmpeg/build.sh.in
+++ b/ports/ffmpeg/build.sh.in
@@ -85,6 +85,15 @@ else
     OPTIONS_x86_64="${OPTIONS_x86}"
 fi
 
+case "@VCPKG_CMAKE_SYSTEM_NAME@" in
+    FreeBSD|OpenBSD)
+        MAKE_BINARY="gmake"
+        ;;
+    *)
+        MAKE_BINARY="make"
+        ;;
+esac
+
 build_ffmpeg() {
     # extract build architecture
     BUILD_ARCH=$1
@@ -102,11 +111,11 @@ build_ffmpeg() {
 
     echo "=== BUILDING ==="
 
-    make -j${JOBS} V=1
+    $MAKE_BINARY -j${JOBS} V=1
 
     echo "=== INSTALLING ==="
 
-    make install
+    $MAKE_BINARY install
 }
 
 cd "$PATH_TO_BUILD_DIR"
@@ -115,7 +124,7 @@ if [ $OSX_ARCH_COUNT -gt 0 ]; then
     for ARCH in $OSX_ARCHS; do
         echo "=== CLEANING FOR $ARCH ==="
 
-        make clean && make distclean
+        $MAKE_BINARY clean && $MAKE_BINARY distclean
 
         build_ffmpeg $ARCH --extra-cflags=-arch --extra-cflags=$ARCH --extra-ldflags=-arch --extra-ldflags=$ARCH
 

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "7.1.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2842,7 +2842,7 @@
     },
     "ffmpeg": {
       "baseline": "7.1.1",
-      "port-version": 2
+      "port-version": 3
     },
     "ffnvcodec": {
       "baseline": "12.2.72.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66b79b494da2724cb74dec6995e3f41fd2a8e85e",
+      "version": "7.1.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "a1c3c785273a5cecf79a78a22ac58c6cb316ac6d",
       "version": "7.1.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
