### PR TITLE
[vcpkg script] Fix -skipDependencyChecks flag ignored in bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -22,7 +22,7 @@ do
     elif [ "$var" = "-buildTests" ]; then
         echo "Warning: -buildTests no longer has any effect; ignored."
     elif [ "$var" = "-skipDependencyChecks" ]; then
-        vcpkgSkipDependencyChecks="OFF"
+        vcpkgSkipDependencyChecks="ON"
     elif [ "$var" = "-musl" ]; then
         vcpkgUseMuslC="ON"
     elif [ "$var" = "-help" -o "$var" = "--help" ]; then
@@ -70,7 +70,8 @@ fi
 vcpkgCheckRepoTool()
 {
     __tool=$1
-    if [ "$vcpkgSkipDependencyChecks" = "ON" ]; then
+    # Only perform dependency checks when they are not explicitly skipped.
+    if [ "$vcpkgSkipDependencyChecks" = "OFF" ]; then
         if ! command -v "$__tool" >/dev/null 2>&1 ; then
             echo "Could not find $__tool. Please install it (and other dependencies) with:"
             echo "On Debian and Ubuntu derivatives:"


### PR DESCRIPTION
### Fix: `-skipDependencyChecks` flag ignored in [bootstrap.sh](cci:7://file:///c:/Users/T2430514/Downloads/vcpkg/scripts/bootstrap.sh:0:0-0:0)

The `-skipDependencyChecks` option was ineffective:

* The flag set `vcpkgSkipDependencyChecks` to `OFF`, identical to its default.
* Dependency verification ran only when the variable was `ON`, the opposite of the intended logic.

This patch:

* Sets `vcpkgSkipDependencyChecks="ON"` when the flag is passed.
* Runs prerequisite checks only when `vcpkgSkipDependencyChecks` is **OFF**.

Users can now reliably bypass dependency checks, improving bootstrap success on constrained systems.