### PR TITLE
[celero] update to 2.9.1

### DIFF
--- a/ports/celero/portfile.cmake
+++ b/ports/celero/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DigitalInBlue/Celero
     REF "v${VERSION}"
-    SHA512 17bb1525b2e02a78739f2c530aa8453e07ca4c803568264aeb7d99f219244f361bcfd4f7e2bf13b3b06e5da0581a5abe93b94e8efda4dac6b092afa9e65cd1df
+    SHA512 18bd6443ff09e72dca0bf98d1bc0543c4839c18239b60c0c7a8bc30c67681b97fd23e8c8892b90a9f3a63a81ed6cac794fa63d58dd60f5daae9f48fc75c8a637
     HEAD_REF master
     PATCHES
         fix-bin-install-path.patch

--- a/ports/celero/vcpkg.json
+++ b/ports/celero/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "celero",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Celero is a modern cross-platform (Windows, Linux, MacOS) Microbenchmarking library for C++ 11 and later.",
   "homepage": "https://github.com/DigitalInBlue/Celero",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1609,7 +1609,7 @@
       "port-version": 0
     },
     "celero": {
-      "baseline": "2.9.0",
+      "baseline": "2.9.1",
       "port-version": 0
     },
     "cello": {

--- a/versions/c-/celero.json
+++ b/versions/c-/celero.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7ca88fba3bb0b175a1a6085104d2a9fc6601ddc",
+      "version": "2.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "1b4a2230664d3439e53d60370aa383ec540f6362",
       "version": "2.9.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/DigitalInBlue/Celero/releases/tag/v2.9.1
