### PR TITLE
[nanojsonc] Update to 1.3.0

### DIFF
--- a/ports/nanojsonc/portfile.cmake
+++ b/ports/nanojsonc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-source-patterns/nanojsonc
         REF "${VERSION}"
-        SHA512 eb913fb0df2d12e599e48eb55497b6445321cf7835e9aed9837c9c605b7641dc614edbffd3f543cf3ded8a75794175d3eb151008d4e12916dee7b21a47a5c4f9
+        SHA512 f1f52358bdff604104dd315584eef922f9533fbb9b235297f8a77f8edf0e5380c2f1170b8d1e069010acd128aa65325e9a8e2306fda6883629d9cec87f8d6632
         HEAD_REF main
 )
 

--- a/ports/nanojsonc/portfile.cmake
+++ b/ports/nanojsonc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-source-patterns/nanojsonc
         REF "${VERSION}"
-        SHA512 f1f52358bdff604104dd315584eef922f9533fbb9b235297f8a77f8edf0e5380c2f1170b8d1e069010acd128aa65325e9a8e2306fda6883629d9cec87f8d6632
+        SHA512 cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
         HEAD_REF main
 )
 

--- a/ports/nanojsonc/portfile.cmake
+++ b/ports/nanojsonc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-source-patterns/nanojsonc
         REF "${VERSION}"
-        SHA512 a79d4bbaf800dcc894df487cf375edb1db1d7e5e3d4c4444f24b80751a718c81cc867eb4890a1b364aed9f93296ee798aa361e24eb7c02627e98dcae5c073880
+        SHA512 eb913fb0df2d12e599e48eb55497b6445321cf7835e9aed9837c9c605b7641dc614edbffd3f543cf3ded8a75794175d3eb151008d4e12916dee7b21a47a5c4f9
         HEAD_REF main
 )
 

--- a/ports/nanojsonc/portfile.cmake
+++ b/ports/nanojsonc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-source-patterns/nanojsonc
         REF "${VERSION}"
-        SHA512 <correct_sha512_hash_for_nanojsonc_v1.3.0_release_archive>
+        SHA512 cee89262ae3403ae110aeddeb15d839033fb9ab698d5315df693b7abd05ce893b3dbd603237afdd6cb2d8a46a0a8794043f680343720a834969357e89e64929f
         HEAD_REF main
 )
 

--- a/ports/nanojsonc/portfile.cmake
+++ b/ports/nanojsonc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-source-patterns/nanojsonc
         REF "${VERSION}"
-        SHA512 cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
+        SHA512 <correct_sha512_hash_for_nanojsonc_v1.3.0_release_archive>
         HEAD_REF main
 )
 

--- a/ports/nanojsonc/vcpkg.json
+++ b/ports/nanojsonc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanojsonc",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "maintainers": "Saad Shams",
   "description": "Event-Driven JSON Parser for C",
   "homepage": "https://github.com/open-source-patterns/nanojsonc",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6517,7 +6517,7 @@
       "port-version": 5
     },
     "nanojsonc": {
-      "baseline": "1.2.0",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "nanomsg": {

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "679fe1b8cbd17de6b07ce2ead713580e606eb839",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "27de8e0e27fd55a6b832e79a6472c59fbb018829",
       "version": "1.2.0",
       "port-version": 0

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ae7407df9be871323c859ac0dd1079e83e08b3de",
+      "git-tree": "c705e388aa87750c7d1e36c5e5bf44de5329c1d2",
       "version": "1.3.0",
       "port-version": 0
     },

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -6,7 +6,7 @@
       "port-version": 0
     },
     {
-      "git-tree": "27de8e0e27fd55a6b832e79a6472c59fbb018829",
+      "git-tree": "41dc847f236000b8a703cf452d37ae36c39ec155",
       "version": "1.2.0",
       "port-version": 0
     },

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "679fe1b8cbd17de6b07ce2ead713580e606eb839",
+      "git-tree": "ae7407df9be871323c859ac0dd1079e83e08b3de",
       "version": "1.3.0",
       "port-version": 0
     },

--- a/versions/n-/nanojsonc.json
+++ b/versions/n-/nanojsonc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "41dc847f236000b8a703cf452d37ae36c39ec155",
+      "git-tree": "27de8e0e27fd55a6b832e79a6472c59fbb018829",
       "version": "1.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
version 1.3.0

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

 If this PR updates an existing port, please uncomment and fill out this checklist:

- [ x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x ] SHA512s are updated for each updated download.
- [x ] The "supports" clause reflects platforms that may be fixed by this new version.
- [x ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ x] Any patches that are no longer applied are deleted from the port's directory.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
