### PR TITLE
[mongoose] Add embedded filesystem feature

### DIFF
--- a/ports/mongoose/CMakeLists.txt
+++ b/ports/mongoose/CMakeLists.txt
@@ -5,6 +5,7 @@ project(mongoose C)
 include(GNUInstallDirs)
 
 option(ENABLE_SSL "Build with openssl support" OFF)
+option(ENABLE_PACK "Build pack for embedding read-only filesystems" OFF)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -12,13 +13,20 @@ add_library(mongoose mongoose.c)
 target_include_directories(mongoose PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 set_target_properties(mongoose PROPERTIES PUBLIC_HEADER mongoose.h)
 
+set(INSTALL_TARGETS mongoose)
+if (ENABLE_PACK)
+    add_executable(pack test/pack.c)
+    list(APPEND INSTALL_TARGETS pack)
+    target_compile_definitions(mongoose PRIVATE MG_ENABLE_PACKED_FS=1)
+endif()
+
 if (ENABLE_SSL)
     find_package(OpenSSL REQUIRED)
     target_compile_options(mongoose PRIVATE -DMG_ENABLE_SSL)
     target_link_libraries(mongoose PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 endif()
 
-install(TARGETS mongoose EXPORT unofficial-mongoose-config)
+install(TARGETS ${INSTALL_TARGETS} EXPORT unofficial-mongoose-config)
 
 install(
     EXPORT unofficial-mongoose-config

--- a/ports/mongoose/portfile.cmake
+++ b/ports/mongoose/portfile.cmake
@@ -38,6 +38,7 @@ find_dependency(OpenSSL)]])
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
 
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/mongoose/portfile.cmake
+++ b/ports/mongoose/portfile.cmake
@@ -13,6 +13,7 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         ssl ENABLE_SSL
+        pack ENABLE_PACK
 )
 
 vcpkg_cmake_configure(
@@ -24,6 +25,9 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT} CONFIG_PATH share/unofficial-${PORT})
+if ("pack" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES pack)
+endif()
 
 if("ssl" IN_LIST FEATURES)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-${PORT}-config.cmake"

--- a/ports/mongoose/vcpkg.json
+++ b/ports/mongoose/vcpkg.json
@@ -16,6 +16,9 @@
     }
   ],
   "features": {
+    "pack": {
+      "description": "Build pack for embedding read-only filesystems"
+    },
     "ssl": {
       "description": "Build with openssl",
       "dependencies": [

--- a/ports/mongoose/vcpkg.json
+++ b/ports/mongoose/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mongoose",
   "version": "7.18",
+  "port-version": 1,
   "description": "Embedded web server / embedded networking library",
   "homepage": "https://cesanta.com/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6294,7 +6294,7 @@
     },
     "mongoose": {
       "baseline": "7.18",
-      "port-version": 0
+      "port-version": 1
     },
     "monkeys-audio": {
       "baseline": "10.08",

--- a/versions/m-/mongoose.json
+++ b/versions/m-/mongoose.json
@@ -3,6 +3,11 @@
     {
       "git-tree": "4bdb887b1ae8053655bad57ad914db6370ac219f",
       "version": "7.18",
+      "port-version": 1
+    },
+    {
+      "git-tree": "0f42e6f030f8bf17df9ffca9d907cd2e529abf2c",
+      "version": "7.18",
       "port-version": 0
     },
     {

--- a/versions/m-/mongoose.json
+++ b/versions/m-/mongoose.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad0135dfc9f7b246a7b68c95f2a64b155383e0dd",
+      "git-tree": "cbd4b16233015998750ba5c6c036f40dcd6d1f7d",
       "version": "7.18",
       "port-version": 1
     },

--- a/versions/m-/mongoose.json
+++ b/versions/m-/mongoose.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "4bdb887b1ae8053655bad57ad914db6370ac219f",
+      "git-tree": "ad0135dfc9f7b246a7b68c95f2a64b155383e0dd",
       "version": "7.18",
       "port-version": 1
     },
     {
-      "git-tree": "0f42e6f030f8bf17df9ffca9d907cd2e529abf2c",
+      "git-tree": "4bdb887b1ae8053655bad57ad914db6370ac219f",
       "version": "7.18",
       "port-version": 0
     },

--- a/versions/m-/mongoose.json
+++ b/versions/m-/mongoose.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4bdb887b1ae8053655bad57ad914db6370ac219f",
+      "git-tree": "ad0135dfc9f7b246a7b68c95f2a64b155383e0dd",
       "version": "7.18",
       "port-version": 1
     },

--- a/versions/m-/mongoose.json
+++ b/versions/m-/mongoose.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad0135dfc9f7b246a7b68c95f2a64b155383e0dd",
+      "git-tree": "4bdb887b1ae8053655bad57ad914db6370ac219f",
       "version": "7.18",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #46243 

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
