### PR TITLE
[vanillapdf] Add new port

### DIFF
--- a/ports/vanillapdf/portfile.cmake
+++ b/ports/vanillapdf/portfile.cmake
@@ -1,12 +1,3 @@
-# Vanilla.PDF vcpkg portfile
-# https://github.com/vanillapdf/vanillapdf
-#
-# Maintainer: Juraj Zikmund <jzikmund@vanillapdf.com>
-# License: Apache-2.0
-#
-# This portfile builds Vanilla.PDF, a cross-platform SDK for creating and modifying PDF documents.
-# It supports both static and shared builds via the standard CMake `BUILD_SHARED_LIBS` option.
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vanillapdf/vanillapdf

--- a/ports/vanillapdf/portfile.cmake
+++ b/ports/vanillapdf/portfile.cmake
@@ -1,0 +1,42 @@
+# Vanilla.PDF vcpkg portfile
+# https://github.com/vanillapdf/vanillapdf
+#
+# Maintainer: Juraj Zikmund <jzikmund@vanillapdf.com>
+# License: Apache-2.0
+#
+# This portfile builds Vanilla.PDF, a cross-platform SDK for creating and modifying PDF documents.
+# It supports both static and shared builds via the standard CMake `BUILD_SHARED_LIBS` option.
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO vanillapdf/vanillapdf
+    REF "v${VERSION}"
+    SHA512 f15d9a290de0eebac9073503ac555cbf389484aa3ff6385697ba879c336ed9cd4277af180f9d842b5bd8cca69bf6ef4dcfbedba07a6a76014e3974fe09fc6190
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+      -DVANILLAPDF_STANDALONE=OFF
+      -DVANILLAPDF_ENABLE_TESTS=OFF
+      -DVANILLAPDF_ENABLE_BENCHMARK=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "vanillapdf"
+    CONFIG_PATH "lib/cmake/vanillapdf"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE.txt"
+        "${SOURCE_PATH}/NOTICE.md"
+)

--- a/ports/vanillapdf/usage
+++ b/ports/vanillapdf/usage
@@ -1,0 +1,29 @@
+The package vanillapdf provides the following CMake targets:
+
+    find_package(vanillapdf CONFIG REQUIRED)
+    target_link_libraries(myapp PRIVATE vanillapdf::vanillapdf)
+
+Headers are located under the include directory:
+
+    #include <vanillapdf/document.h>
+    #include <vanillapdf/syntax/file.h>
+    #include <vanillapdf/semantics/document.h>
+    #include <vanillapdf/contents/content_stream.h>
+
+Features:
+
+- PDF parsing and manipulation
+- Digital signature support (via OpenSSL)
+- JPEG/JPEG2000 decompression
+- zlib stream decoding
+
+Optional features (must be enabled manually):
+
+- Skia rendering: `--feature=skia-support`
+- Benchmarks: `--feature=benchmarks`
+- Tests: `--feature=tests`
+
+Supports both static and shared builds depending on the selected triplet.
+
+License: Apache-2.0
+Homepage: https://github.com/vanillapdf/vanillapdf

--- a/ports/vanillapdf/usage
+++ b/ports/vanillapdf/usage
@@ -2,28 +2,3 @@ The package vanillapdf provides the following CMake targets:
 
     find_package(vanillapdf CONFIG REQUIRED)
     target_link_libraries(myapp PRIVATE vanillapdf::vanillapdf)
-
-Headers are located under the include directory:
-
-    #include <vanillapdf/document.h>
-    #include <vanillapdf/syntax/file.h>
-    #include <vanillapdf/semantics/document.h>
-    #include <vanillapdf/contents/content_stream.h>
-
-Features:
-
-- PDF parsing and manipulation
-- Digital signature support (via OpenSSL)
-- JPEG/JPEG2000 decompression
-- zlib stream decoding
-
-Optional features (must be enabled manually):
-
-- Skia rendering: `--feature=skia-support`
-- Benchmarks: `--feature=benchmarks`
-- Tests: `--feature=tests`
-
-Supports both static and shared builds depending on the selected triplet.
-
-License: Apache-2.0
-Homepage: https://github.com/vanillapdf/vanillapdf

--- a/ports/vanillapdf/vcpkg.json
+++ b/ports/vanillapdf/vcpkg.json
@@ -28,12 +28,6 @@
         "benchmark"
       ]
     },
-    "skia-support": {
-      "description": "Enable Skia graphics engine integration for rendering",
-      "dependencies": [
-        "skia"
-      ]
-    },
     "tests": {
       "description": "Enable unit and integration tests",
       "dependencies": [

--- a/ports/vanillapdf/vcpkg.json
+++ b/ports/vanillapdf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vanillapdf",
-  "version-string": "2.1.0",
+  "version": "2.1.0",
   "description": "Vanilla.PDF is a cross-platform SDK for creating and modifying PDF documents.",
   "homepage": "https://github.com/vanillapdf/vanillapdf",
   "documentation": "https://vanillapdf.github.io/vanillapdf",

--- a/ports/vanillapdf/vcpkg.json
+++ b/ports/vanillapdf/vcpkg.json
@@ -1,0 +1,45 @@
+{
+    "name": "vanillapdf",
+    "version-string": "2.1.0",
+    "description": "Vanilla.PDF is a cross-platform SDK for creating and modifying PDF documents.",
+    "homepage": "https://github.com/vanillapdf/vanillapdf",
+    "documentation": "https://vanillapdf.github.io/vanillapdf",
+    "license": "Apache-2.0",
+    "dependencies": [
+        {
+            "name": "vcpkg-cmake",
+            "host": true
+        },
+        {
+            "name": "vcpkg-cmake-config",
+            "host": true
+        },
+        "openssl",
+        "libjpeg-turbo",
+        "openjpeg",
+        "zlib",
+        "spdlog",
+        "nlohmann-json"
+    ],
+    "default-features": [],
+    "features": {
+        "skia-support": {
+            "description": "Enable Skia graphics engine integration for rendering",
+            "dependencies": [
+                "skia"
+            ]
+        },
+        "tests": {
+            "description": "Enable unit and integration tests",
+            "dependencies": [
+                "gtest"
+            ]
+        },
+        "benchmarks": {
+            "description": "Enable performance benchmarking tools",
+            "dependencies": [
+                "benchmark"
+            ]
+        }
+    }
+}

--- a/ports/vanillapdf/vcpkg.json
+++ b/ports/vanillapdf/vcpkg.json
@@ -20,19 +20,5 @@
       "host": true
     },
     "zlib"
-  ],
-  "features": {
-    "benchmarks": {
-      "description": "Enable performance benchmarking tools",
-      "dependencies": [
-        "benchmark"
-      ]
-    },
-    "tests": {
-      "description": "Enable unit and integration tests",
-      "dependencies": [
-        "gtest"
-      ]
-    }
-  }
+  ]
 }

--- a/ports/vanillapdf/vcpkg.json
+++ b/ports/vanillapdf/vcpkg.json
@@ -1,45 +1,44 @@
 {
-    "name": "vanillapdf",
-    "version-string": "2.1.0",
-    "description": "Vanilla.PDF is a cross-platform SDK for creating and modifying PDF documents.",
-    "homepage": "https://github.com/vanillapdf/vanillapdf",
-    "documentation": "https://vanillapdf.github.io/vanillapdf",
-    "license": "Apache-2.0",
-    "dependencies": [
-        {
-            "name": "vcpkg-cmake",
-            "host": true
-        },
-        {
-            "name": "vcpkg-cmake-config",
-            "host": true
-        },
-        "openssl",
-        "libjpeg-turbo",
-        "openjpeg",
-        "zlib",
-        "spdlog",
-        "nlohmann-json"
-    ],
-    "default-features": [],
-    "features": {
-        "skia-support": {
-            "description": "Enable Skia graphics engine integration for rendering",
-            "dependencies": [
-                "skia"
-            ]
-        },
-        "tests": {
-            "description": "Enable unit and integration tests",
-            "dependencies": [
-                "gtest"
-            ]
-        },
-        "benchmarks": {
-            "description": "Enable performance benchmarking tools",
-            "dependencies": [
-                "benchmark"
-            ]
-        }
+  "name": "vanillapdf",
+  "version-string": "2.1.0",
+  "description": "Vanilla.PDF is a cross-platform SDK for creating and modifying PDF documents.",
+  "homepage": "https://github.com/vanillapdf/vanillapdf",
+  "documentation": "https://vanillapdf.github.io/vanillapdf",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "libjpeg-turbo",
+    "nlohmann-json",
+    "openjpeg",
+    "openssl",
+    "spdlog",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ],
+  "features": {
+    "benchmarks": {
+      "description": "Enable performance benchmarking tools",
+      "dependencies": [
+        "benchmark"
+      ]
+    },
+    "skia-support": {
+      "description": "Enable Skia graphics engine integration for rendering",
+      "dependencies": [
+        "skia"
+      ]
+    },
+    "tests": {
+      "description": "Enable unit and integration tests",
+      "dependencies": [
+        "gtest"
+      ]
     }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9812,6 +9812,10 @@
       "baseline": "2.10",
       "port-version": 5
     },
+    "vanillapdf": {
+      "baseline": "2.1.0",
+      "port-version": 0
+    },
     "variant-lite": {
       "baseline": "2.0.0",
       "port-version": 0

--- a/versions/v-/vanillapdf.json
+++ b/versions/v-/vanillapdf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "334ec00d710e8a2677a8ba4c52e0928892f76a2a",
+      "git-tree": "30817fe584c4ce53a1ba8ed638f7178a7410cdf1",
       "version": "2.1.0",
       "port-version": 0
     }

--- a/versions/v-/vanillapdf.json
+++ b/versions/v-/vanillapdf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "30817fe584c4ce53a1ba8ed638f7178a7410cdf1",
+      "git-tree": "5a69c8d9fa47869f4e43bd454e25a620b54188da",
       "version": "2.1.0",
       "port-version": 0
     }

--- a/versions/v-/vanillapdf.json
+++ b/versions/v-/vanillapdf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "334ec00d710e8a2677a8ba4c52e0928892f76a2a",
+      "version": "2.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

