### PR TITLE
[libjpeg-turbo] Add tools feature

### DIFF
--- a/ports/libjpeg-turbo/portfile.cmake
+++ b/ports/libjpeg-turbo/portfile.cmake
@@ -39,6 +39,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         jpeg7 WITH_JPEG7
         jpeg8 WITH_JPEG8
+        tools ENABLE_EXECUTABLES
 )
 
 vcpkg_cmake_configure(
@@ -46,12 +47,12 @@ vcpkg_cmake_configure(
     OPTIONS
         -DENABLE_STATIC=${ENABLE_STATIC}
         -DENABLE_SHARED=${ENABLE_SHARED}
-        -DENABLE_EXECUTABLES=OFF
         -DINSTALL_DOCS=OFF
         -DWITH_CRT_DLL=${WITH_CRT_DLL}
         ${FEATURE_OPTIONS}
         ${LIBJPEGTURBO_SIMD}
     OPTIONS_DEBUG
+        -DENABLE_EXECUTABLES=OFF
         -DINSTALL_HEADERS=OFF
     MAYBE_UNUSED_VARIABLES
         WITH_CRT_DLL
@@ -59,6 +60,16 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+
+if(ENABLE_EXECUTABLES)
+    vcpkg_copy_tools(
+        TOOL_NAMES cjpeg djpeg jpegtran rdjpgcom wrjpgcom
+        AUTO_CLEAN
+    )
+    vcpkg_clean_executables_in_bin(
+        FILE_NAMES tjbench
+    )
+endif()
 
 vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libjpeg-turbo)

--- a/ports/libjpeg-turbo/vcpkg.json
+++ b/ports/libjpeg-turbo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libjpeg-turbo",
   "version": "3.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libjpeg-turbo is a JPEG image codec that uses SIMD instructions (MMX, SSE2, NEON, AltiVec) to accelerate baseline JPEG compression and decompression on x86, x86-64, ARM, and PowerPC systems.",
   "homepage": "https://github.com/libjpeg-turbo/libjpeg-turbo",
   "license": "BSD-3-Clause",
@@ -21,6 +21,9 @@
     },
     "jpeg8": {
       "description": "Emulate libjpeg v8 API/ABI (this makes libjpeg-turbo backward-incompatible with libjpeg v6b!)"
+    },
+    "tools": {
+      "description": "Build executables"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4906,7 +4906,7 @@
     },
     "libjpeg-turbo": {
       "baseline": "3.1.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libjuice": {
       "baseline": "1.6.1",

--- a/versions/l-/libjpeg-turbo.json
+++ b/versions/l-/libjpeg-turbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c415206250825da0b848c8fac1334f5547d929e9",
+      "version": "3.1.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "6180688844449e5724d6dc8eb49ab90124438ce2",
       "version": "3.1.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.