### PR TITLE
[mbedtls] update to 3.6.4

### DIFF
--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Mbed-TLS/mbedtls
     REF "v${VERSION}"
-    SHA512 ad5a8de072cd7bede21378a3301d8de7c4eec8e113ebe2a3ffe5bf8ebed1b236a52ae0425abe45eafdc534af65b51076ca458e342950174bf1bdbbc06d1bdad1
+    SHA512 67c0ec7824e1ffa3e4f8d02814201776f8c1b2dc0fb8f1f9246495e27a2c03b8c248eff00e8da3e206625b7d0aa82d38cf7ddfd9ed8b4623375b05dc1ecc0677
     HEAD_REF development
     PATCHES
         enable-pthread.patch

--- a/ports/mbedtls/vcpkg.json
+++ b/ports/mbedtls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mbedtls",
-  "version": "3.6.2",
+  "version": "3.6.4",
   "description": "An open source, portable, easy to use, readable and flexible SSL library",
   "homepage": "https://www.trustedfirmware.org/projects/mbed-tls/",
   "license": "Apache-2.0 OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6097,7 +6097,7 @@
       "port-version": 2
     },
     "mbedtls": {
-      "baseline": "3.6.2",
+      "baseline": "3.6.4",
       "port-version": 0
     },
     "mchehab-zbar": {

--- a/versions/m-/mbedtls.json
+++ b/versions/m-/mbedtls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70ebeccc1908660a6f2afabf001b9790b52482ef",
+      "version": "3.6.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "5312822288313d76c7e852e2577da58b0c169c21",
       "version": "3.6.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.4

