### PR TITLE
[quarter] Add new port

### DIFF
--- a/ports/quarter/portfile.cmake
+++ b/ports/quarter/portfile.cmake
@@ -1,0 +1,49 @@
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO coin3d/quarter
+        REF "v${VERSION}"
+        SHA512 14c382d25e47b54d6ff747830131b0646dba398325ec1c748e543af2b2e1d8f690a34d2cdb18159dbc930dde0b9c8749bf437d8eb02d68b21bc597bb13796ea6
+        HEAD_REF master
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    set(QUARTER_BUILD_SHARED_LIBS OFF)
+else()
+    set(QUARTER_BUILD_SHARED_LIBS ON)
+endif()
+
+if ("qt5" IN_LIST FEATURES)
+    set(QUARTER_USE_QT5 ON)
+    set(QUARTER_USE_QT6 OFF)
+elseif ("qt6" IN_LIST FEATURES)
+    set(QUARTER_USE_QT6 ON)
+    set(QUARTER_USE_QT5 OFF)
+else()
+    message(FATAL_ERROR "Either qt5 or qt6 feature must be selected.")
+endif()
+
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+        -DQUARTER_BUILD_SHARED_LIBS=${QUARTER_BUILD_SHARED_LIBS}
+        -DQUARTER_USE_QT6=${QUARTER_USE_QT6}
+        -DQUARTER_USE_QT5=${QUARTER_USE_QT5}
+        -DQUARTER_BUILD_PLUGIN=OFF
+        -DQUARTER_BUILD_EXAMPLES=OFF
+        -DQUARTER_BUILD_DOCUMENTATION=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Quarter-${VERSION})
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/quarter/portfile.cmake
+++ b/ports/quarter/portfile.cmake
@@ -34,7 +34,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Quarter-${VERSION})
-vcpkg_fixup_pkgconfig()
+# Qt6 pkg-config files not installed https://github.com/microsoft/vcpkg/issues/25988
+# vcpkg_fixup_pkgconfig()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 

--- a/ports/quarter/portfile.cmake
+++ b/ports/quarter/portfile.cmake
@@ -1,31 +1,19 @@
 vcpkg_from_github(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO coin3d/quarter
-        REF "v${VERSION}"
-        SHA512 14c382d25e47b54d6ff747830131b0646dba398325ec1c748e543af2b2e1d8f690a34d2cdb18159dbc930dde0b9c8749bf437d8eb02d68b21bc597bb13796ea6
-        HEAD_REF master
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO coin3d/quarter
+    REF "v${VERSION}"
+    SHA512 14c382d25e47b54d6ff747830131b0646dba398325ec1c748e543af2b2e1d8f690a34d2cdb18159dbc930dde0b9c8749bf437d8eb02d68b21bc597bb13796ea6
+    HEAD_REF master
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    set(QUARTER_BUILD_SHARED_LIBS OFF)
-else()
-    set(QUARTER_BUILD_SHARED_LIBS ON)
-endif()
-
-if ("qt5" IN_LIST FEATURES)
-    set(QUARTER_USE_QT5 ON)
-    set(QUARTER_USE_QT6 OFF)
-else()
-    set(QUARTER_USE_QT6 ON)
-    set(QUARTER_USE_QT5 OFF)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" QUARTER_BUILD_SHARED_LIBS)
 
 vcpkg_cmake_configure(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
         -DQUARTER_BUILD_SHARED_LIBS=${QUARTER_BUILD_SHARED_LIBS}
-        -DQUARTER_USE_QT6=${QUARTER_USE_QT6}
-        -DQUARTER_USE_QT5=${QUARTER_USE_QT5}
+        -DQUARTER_USE_QT6=ON
+        -DQUARTER_USE_QT5=OFF
         -DQUARTER_BUILD_PLUGIN=OFF
         -DQUARTER_BUILD_EXAMPLES=OFF
         -DQUARTER_BUILD_DOCUMENTATION=OFF
@@ -36,12 +24,9 @@ vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Quarter-${VERSION})
 # Qt6 pkg-config files not installed https://github.com/microsoft/vcpkg/issues/25988
 # vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/quarter/portfile.cmake
+++ b/ports/quarter/portfile.cmake
@@ -15,11 +15,9 @@ endif()
 if ("qt5" IN_LIST FEATURES)
     set(QUARTER_USE_QT5 ON)
     set(QUARTER_USE_QT6 OFF)
-elseif ("qt6" IN_LIST FEATURES)
+else()
     set(QUARTER_USE_QT6 ON)
     set(QUARTER_USE_QT5 OFF)
-else()
-    message(FATAL_ERROR "Either qt5 or qt6 feature must be selected.")
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/quarter/usage
+++ b/ports/quarter/usage
@@ -1,4 +1,4 @@
 The package quarter provides CMake targets:
 
-    find_package(quarter CONFIG REQUIRED)
+    find_package(Quarter CONFIG REQUIRED)
     target_link_libraries(main PRIVATE Quarter::Quarter)

--- a/ports/quarter/usage
+++ b/ports/quarter/usage
@@ -1,0 +1,4 @@
+The package quarter provides CMake targets:
+
+    find_package(quarter CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Quarter::Quarter)

--- a/ports/quarter/vcpkg.json
+++ b/ports/quarter/vcpkg.json
@@ -1,0 +1,38 @@
+{
+  "name": "quarter",
+  "version": "1.2.3",
+  "description": "Coin3D GUI binding for Qt",
+  "homepage": "https://coin3d.github.io/quarter/",
+  "license": "BSD-3-Clause",
+  "supports": "!arm & !android & !uwp",
+  "dependencies": [
+    "coin",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "qt6"
+  ],
+  "features": {
+    "qt5": {
+      "description": "Build with Qt5",
+      "dependencies": [
+        "qt5-base",
+        "qt5-tools"
+      ]
+    },
+    "qt6": {
+      "description": "Build with Qt6",
+      "dependencies": [
+        "qtbase",
+        "qttools"
+      ]
+    }
+  }
+}

--- a/ports/quarter/vcpkg.json
+++ b/ports/quarter/vcpkg.json
@@ -8,6 +8,14 @@
   "dependencies": [
     "coin",
     {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "qttools",
+      "default-features": false
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
@@ -16,22 +24,18 @@
       "host": true
     }
   ],
-  "default-features": [
-    "qt6"
-  ],
   "features": {
     "qt5": {
       "description": "Build with Qt5",
       "dependencies": [
-        "qt5-base",
-        "qt5-tools"
-      ]
-    },
-    "qt6": {
-      "description": "Build with Qt6",
-      "dependencies": [
-        "qtbase",
-        "qttools"
+        {
+          "name": "qt5-base",
+          "default-features": false
+        },
+        {
+          "name": "qt5-tools",
+          "default-features": false
+        }
       ]
     }
   }

--- a/ports/quarter/vcpkg.json
+++ b/ports/quarter/vcpkg.json
@@ -23,20 +23,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "qt5": {
-      "description": "Build with Qt5",
-      "dependencies": [
-        {
-          "name": "qt5-base",
-          "default-features": false
-        },
-        {
-          "name": "qt5-tools",
-          "default-features": false
-        }
-      ]
-    }
-  }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8064,6 +8064,10 @@
       "baseline": "1.38",
       "port-version": 0
     },
+    "quarter": {
+      "baseline": "1.2.3",
+      "port-version": 0
+    },
     "quaternions": {
       "baseline": "1.0.0",
       "port-version": 2

--- a/versions/q-/quarter.json
+++ b/versions/q-/quarter.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2728f2e9ff56ea7de2afdd95b38af2715b6847bd",
+      "git-tree": "a276007615295568a553a82f024770c36fb7bafa",
       "version": "1.2.3",
       "port-version": 0
     }

--- a/versions/q-/quarter.json
+++ b/versions/q-/quarter.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "479f94739e2ce93fc5491a127efd4f62dc0b1efd",
+      "git-tree": "7547ff90aa81ebc7635aca8184e339dbdda485ec",
       "version": "1.2.3",
       "port-version": 0
     }

--- a/versions/q-/quarter.json
+++ b/versions/q-/quarter.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7547ff90aa81ebc7635aca8184e339dbdda485ec",
+      "git-tree": "2728f2e9ff56ea7de2afdd95b38af2715b6847bd",
       "version": "1.2.3",
       "port-version": 0
     }

--- a/versions/q-/quarter.json
+++ b/versions/q-/quarter.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "479f94739e2ce93fc5491a127efd4f62dc0b1efd",
+      "version": "1.2.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #45597

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

<!-- END OF NEW PORT CHECKLIST -->