### PR TITLE
[libheif] update to 1.20.1

### DIFF
--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         gdk-pixbuf.patch
+        support-uncompress.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  strukturag/libheif
     REF "v${VERSION}"
-    SHA512 9159f379119d1c0ac6bb7dbde916efd12a85275ef2f696ece2fc18e52593c78201090dcc1bf3b97d160f27d594a755c5987cb6c4cea811b9a5f2c999f72724e3
+    SHA512 74bc51caf30997e1d327ab8253e9d3556906cd14828794a72c4ba42f2c154b79c1d717e0833a6afc3f6ebff909b630326c11a052d7eb832008769157fad3760b
     HEAD_REF master
     PATCHES
         gdk-pixbuf.patch
@@ -42,11 +42,11 @@ endif()
 vcpkg_fixup_pkgconfig()
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libheif/heif.h" "!defined(LIBHEIF_STATIC_BUILD)" "1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libheif/heif_library.h" "!defined(LIBHEIF_STATIC_BUILD)" "1")
 else()
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libheif/heif.h" "!defined(LIBHEIF_STATIC_BUILD)" "0")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libheif/heif_library.h" "!defined(LIBHEIF_STATIC_BUILD)" "0")
 endif()
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libheif/heif.h" "#ifdef LIBHEIF_EXPORTS" "#if 0")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libheif/heif_library.h" "#ifdef LIBHEIF_EXPORTS" "#if 0")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libheif/support-uncompress.patch
+++ b/ports/libheif/support-uncompress.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7dfbe6f..8581aec 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -459,7 +459,7 @@ endif()
+ if (LIBSHARPYUV_FOUND)
+     list(APPEND REQUIRES_PRIVATE "libsharpyuv")
+ endif()
+-if (WITH_HEADER_COMPRESSION OR WITH_UNCOMPRESSED_CODEC)
++if (0)
+     find_package(ZLIB)
+     if (ZLIB_FOUND)
+         message("zlib found")

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -43,11 +43,7 @@
     },
     "iso23001-17": {
       "description": "Support for ISO23001-17 (uncompressed) codec",
-      "license": "LGPL-3.0-only",
-      "dependencies": [
-        "brotli",
-        "zlib"
-      ]
+      "license": "LGPL-3.0-only"
     },
     "jpeg": {
       "description": "JPEG decoding and encoding via libjpeg-turbo",

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -36,6 +36,7 @@
     },
     "hevc": {
       "description": "HEVC encoding via x265",
+      "supports": "!android",
       "license": "GPL-2.0-or-later",
       "dependencies": [
         "x265"

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -43,7 +43,11 @@
     },
     "iso23001-17": {
       "description": "Support for ISO23001-17 (uncompressed) codec",
-      "license": "LGPL-3.0-only"
+      "license": "LGPL-3.0-only",
+      "dependencies": [
+        "brotli",
+        "zlib"
+      ]
     },
     "jpeg": {
       "description": "JPEG decoding and encoding via libjpeg-turbo",

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libheif",
-  "version": "1.19.8",
-  "port-version": 1,
+  "version": "1.20.1",
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4837,8 +4837,8 @@
       "port-version": 6
     },
     "libheif": {
-      "baseline": "1.19.8",
-      "port-version": 1
+      "baseline": "1.20.1",
+      "port-version": 0
     },
     "libhsplasma": {
       "baseline": "2024-03-07",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "df357306958bc370307f9eccc1b5761ecafb44df",
+      "git-tree": "bc92f186fcc55b1ba4300124bcacdb62dfde09bc",
       "version": "1.20.1",
       "port-version": 0
     },

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc92f186fcc55b1ba4300124bcacdb62dfde09bc",
+      "git-tree": "527fefc69657673d129be1eeef8a93289857d246",
       "version": "1.20.1",
       "port-version": 0
     },

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3560fd6b853be9bf507b7b43ee981211af3e87f",
+      "version": "1.20.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3818c7a07a9299759d1de597f0091d9f127b3d95",
       "version": "1.19.8",
       "port-version": 1

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f3560fd6b853be9bf507b7b43ee981211af3e87f",
+      "git-tree": "df357306958bc370307f9eccc1b5761ecafb44df",
       "version": "1.20.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/strukturag/libheif/releases/tag/v1.20.1

