### PR TITLE
[dstorage] Update for 1.3.0 release

### DIFF
--- a/ports/dstorage/portfile.cmake
+++ b/ports/dstorage/portfile.cmake
@@ -5,7 +5,7 @@ set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.DirectStorage/${VERSION}"
     FILENAME "directstorage.${VERSION}.zip"
-    SHA512 0bae992933ff6d3a04e1af287ac96bc4516aaaf7f36d21249b1ab8147ccd5aa913f7151b36c628def5a733c24b7d35900574e845243a4cb4ee65f710e06ae9da
+    SHA512 589a83194e9e05654523b9ca10401982d235dbaa991c8535807d5b9f851d877281417d79a0210f77b46c0f65114f805f4a12f04b7bdb3de8a00fe20c78def791
 )
 
 vcpkg_extract_source_archive(

--- a/ports/dstorage/vcpkg.json
+++ b/ports/dstorage/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dstorage",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "DirectStorage for Windows",
   "homepage": "https://aka.ms/directstorage/",
   "documentation": "https://github.com/microsoft/DirectStorage",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2493,7 +2493,7 @@
       "port-version": 0
     },
     "dstorage": {
-      "baseline": "1.2.4",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "dtl": {

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02f6bc9a797fd71bd6a4599e5602184309408c93",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0f5f47583c0add0aae4f515e7293c17fd9162e0a",
       "version": "1.2.4",
       "port-version": 0


### PR DESCRIPTION
New release of DirectStorage per [this blog post](https://devblogs.microsoft.com/directx/directstorage-1-3-is-now-available/).
