### PR TITLE
[f3d] Add new port

### DIFF
--- a/ports/f3d/fix-install.patch
+++ b/ports/f3d/fix-install.patch
@@ -1,0 +1,354 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a2a29e18..06caee00 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -290,11 +290,11 @@ if (UNIX AND NOT APPLE AND NOT ANDROID)
+ endif()
+ 
+ install(FILES LICENSE.md
+-  DESTINATION ${F3D_LIC_DIR} COMPONENT licenses)
++  DESTINATION ${F3D_LIC_DIR} COMPONENT licenses EXCLUDE_FROM_ALL)
+ 
+ if (F3D_BUILD_APPLICATION)
+   install(FILES doc/THIRD_PARTY_LICENSES.md
+-    DESTINATION ${F3D_LIC_DIR} COMPONENT licenses)
++    DESTINATION ${F3D_LIC_DIR} COMPONENT licenses EXCLUDE_FROM_ALL)
+ endif ()
+ 
+ # Check that a LFS data file is big enough to be an actual file
+diff --git a/application/CMakeLists.txt b/application/CMakeLists.txt
+index 060b4fcd..3fd2c906 100644
+--- a/application/CMakeLists.txt
++++ b/application/CMakeLists.txt
+@@ -221,7 +221,7 @@ if(UNIX AND NOT APPLE)
+       add_custom_target(man ALL DEPENDS ${MAN_OUTPUT_FILE})
+ 
+       install(FILES "${CMAKE_BINARY_DIR}/f3d.1.gz"
+-        DESTINATION "share/man/man1/" COMPONENT documentation)
++        DESTINATION "share/man/man1/" COMPONENT documentation EXCLUDE_FROM_ALL)
+     else()
+       message(FATAL_ERROR "help2man or gzip not found, cannot create man entry, please disable F3D_LINUX_GENERATE_MAN or install them")
+     endif()
+@@ -250,16 +250,14 @@ endif()
+ install(EXPORT f3dTargets
+   NAMESPACE f3d::
+   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
+-  COMPONENT sdk
+-  EXCLUDE_FROM_ALL)
++  COMPONENT sdk)
+ 
+ install(
+   FILES
+     "${F3D_SOURCE_DIR}/cmake/application-config.cmake"
+   DESTINATION
+     "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
+-  COMPONENT sdk
+-  EXCLUDE_FROM_ALL)
++  COMPONENT sdk)
+ 
+ # Default config files
+ install(
+@@ -278,40 +276,40 @@ install(
+ # Other ressoure files
+ if(UNIX AND NOT APPLE AND NOT ANDROID)
+   install(FILES "${F3D_SOURCE_DIR}/resources/f3d.desktop"
+-    DESTINATION "share/applications" COMPONENT assets)
++    DESTINATION "share/applications" COMPONENT assets EXCLUDE_FROM_ALL)
+   install(FILES "${F3D_SOURCE_DIR}/resources/logo16.png"
+-    DESTINATION "share/icons/hicolor/16x16/apps" COMPONENT assets
++    DESTINATION "share/icons/hicolor/16x16/apps" COMPONENT assets EXCLUDE_FROM_ALL
+     RENAME "f3d.png")
+   install(FILES "${F3D_SOURCE_DIR}/resources/logo24.png"
+-    DESTINATION "share/icons/hicolor/24x24/apps" COMPONENT assets
++    DESTINATION "share/icons/hicolor/24x24/apps" COMPONENT assets EXCLUDE_FROM_ALL
+     RENAME "f3d.png")
+   install(FILES "${F3D_SOURCE_DIR}/resources/logo32.png"
+-    DESTINATION "share/icons/hicolor/32x32/apps" COMPONENT assets
++    DESTINATION "share/icons/hicolor/32x32/apps" COMPONENT assets EXCLUDE_FROM_ALL
+     RENAME "f3d.png")
+   install(FILES "${F3D_SOURCE_DIR}/resources/logo48.png"
+-    DESTINATION "share/icons/hicolor/48x48/apps" COMPONENT assets
++    DESTINATION "share/icons/hicolor/48x48/apps" COMPONENT assets EXCLUDE_FROM_ALL
+     RENAME "f3d.png")
+   install(FILES "${F3D_SOURCE_DIR}/resources/logo64.png"
+-    DESTINATION "share/icons/hicolor/64x64/apps" COMPONENT assets
++    DESTINATION "share/icons/hicolor/64x64/apps" COMPONENT assets EXCLUDE_FROM_ALL
+     RENAME "f3d.png")
+   install(FILES "${F3D_SOURCE_DIR}/resources/logo256.png"
+-    DESTINATION "share/icons/hicolor/256x256/apps" COMPONENT assets
++    DESTINATION "share/icons/hicolor/256x256/apps" COMPONENT assets EXCLUDE_FROM_ALL
+     RENAME "f3d.png")
+   install(FILES "${F3D_SOURCE_DIR}/resources/logo.svg"
+-    DESTINATION "share/icons/hicolor/scalable/apps" COMPONENT assets
++    DESTINATION "share/icons/hicolor/scalable/apps" COMPONENT assets EXCLUDE_FROM_ALL
+     RENAME "f3d.svg")
+   install(FILES "${F3D_SOURCE_DIR}/resources/logo-mono.svg"
+-    DESTINATION "share/icons/HighContrast/scalable/apps" COMPONENT assets
++    DESTINATION "share/icons/HighContrast/scalable/apps" COMPONENT assets EXCLUDE_FROM_ALL
+     RENAME "f3d.svg")
+   install(FILES "${F3D_SOURCE_DIR}/resources/completion.bash"
+-    DESTINATION "share/bash-completion/completions" COMPONENT shellext
++    DESTINATION "share/bash-completion/completions" COMPONENT shellext EXCLUDE_FROM_ALL
+     RENAME "f3d")
+   install(FILES "${F3D_SOURCE_DIR}/resources/completion.zsh"
+-    DESTINATION "share/zsh/site-functions" COMPONENT shellext
++    DESTINATION "share/zsh/site-functions" COMPONENT shellext EXCLUDE_FROM_ALL
+     RENAME "_f3d")
+   install(FILES "${F3D_SOURCE_DIR}/resources/completion.fish"
+-    DESTINATION "share/fish/vendor_completions.d" COMPONENT shellext
++    DESTINATION "share/fish/vendor_completions.d" COMPONENT shellext EXCLUDE_FROM_ALL
+     RENAME "f3d.fish")
+   install(FILES "${F3D_SOURCE_DIR}/resources/app.f3d.F3D.metainfo.xml"
+-    DESTINATION "share/metainfo" COMPONENT assets)
++    DESTINATION "share/metainfo" COMPONENT assets EXCLUDE_FROM_ALL)
+ endif()
+diff --git a/cmake/f3dPlugin.cmake b/cmake/f3dPlugin.cmake
+index 7307ef5e..7ffc9348 100644
+--- a/cmake/f3dPlugin.cmake
++++ b/cmake/f3dPlugin.cmake
+@@ -204,10 +204,6 @@ The `NAME` argument is required. The arguments are as follows:
+ macro(f3d_plugin_build)
+   cmake_parse_arguments(F3D_PLUGIN "FREEDESKTOP;FORCE_STATIC" "NAME;DESCRIPTION;VERSION" "VTK_MODULES;ADDITIONAL_RPATHS;MIMETYPE_XML_FILES;CONFIGURATION_DIRS" ${ARGN})
+ 
+-  find_package(VTK 9.2.6 REQUIRED COMPONENTS
+-               CommonCore CommonExecutionModel IOImport
+-               ${F3D_PLUGIN_VTK_MODULES})
+-
+   set(_force_static FALSE)
+   if(DEFINED BUILD_SHARED_LIBS AND NOT BUILD_SHARED_LIBS)
+     set(_force_static TRUE)
+@@ -254,7 +250,9 @@ macro(f3d_plugin_build)
+       ENABLE_TESTS            ${BUILD_TESTING})
+ 
+     vtk_module_build(
++      ENABLE_WRAPPING OFF
+       MODULES ${modules}
++      INSTALL_EXPORT "f3dLibraryTargets"
+       INSTALL_HEADERS OFF
+       PACKAGE "f3d_${F3D_PLUGIN_NAME}_vtkext_private")
+ 
+@@ -327,9 +325,9 @@ macro(f3d_plugin_build)
+     ${F3D_PLUGIN_VTK_MODULES}
+     ${modules})
+ 
+-  if(NOT F3D_PLUGIN_IS_STATIC)
++  if(NOT F3D_PLUGIN_IS_STATIC OR NOT BUILD_SHARED_LIBS)
+     install(TARGETS f3d-plugin-${F3D_PLUGIN_NAME}
+-      EXPORT f3dTargets
++      EXPORT "f3dLibraryTargets"
+       ARCHIVE DESTINATION ${_f3d_plugins_install_dir} COMPONENT plugin
+       LIBRARY DESTINATION ${_f3d_plugins_install_dir} COMPONENT plugin)
+   endif()
+@@ -361,10 +359,10 @@ macro(f3d_plugin_build)
+         "${CMAKE_BINARY_DIR}/share/thumbnailers/f3d-plugin-${F3D_PLUGIN_NAME}.thumbnailer")
+       install(FILES "${CMAKE_BINARY_DIR}/share/applications/f3d-plugin-${F3D_PLUGIN_NAME}.desktop"
+         DESTINATION "share/applications"
+-        COMPONENT plugin)
++        COMPONENT plugin EXCLUDE_FROM_ALL)
+       install(FILES "${CMAKE_BINARY_DIR}/share/thumbnailers/f3d-plugin-${F3D_PLUGIN_NAME}.thumbnailer"
+         DESTINATION "share/thumbnailers"
+-        COMPONENT plugin)
++        COMPONENT plugin EXCLUDE_FROM_ALL)
+     endif()
+   endif()
+ 
+diff --git a/library/CMakeLists.txt b/library/CMakeLists.txt
+index d00e9feb..53c8de85 100644
+--- a/library/CMakeLists.txt
++++ b/library/CMakeLists.txt
+@@ -112,8 +112,6 @@ set_target_properties(libf3d PROPERTIES
+   CXX_VISIBILITY_PRESET hidden
+   CXX_STANDARD 17
+   POSITION_INDEPENDENT_CODE ON
+-  OUTPUT_NAME "f3d"
+-  PDB_NAME "libf3d"
+   )
+ 
+ # It can be useful to disable soversion in case the links are duplicated
+@@ -237,17 +235,16 @@ install(
+     "${CMAKE_BINARY_DIR}/cmake/f3dConfigVersion.cmake"
+   DESTINATION
+     "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
+-  COMPONENT sdk
+-  EXCLUDE_FROM_ALL)
++  COMPONENT sdk)
+ 
+ ## Install the rest of the libraries and SDK parts
+-if(BUILD_SHARED_LIBS)
++if(ON)
+ 
+   # Install the libf3d
+   install(TARGETS libf3d
+     EXPORT f3dLibraryTargets
+     RUNTIME_DEPENDENCY_SET libf3dDeps
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT sdk EXCLUDE_FROM_ALL
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT sdk
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT library
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library)
+ 
+@@ -263,15 +260,13 @@ if(BUILD_SHARED_LIBS)
+   # Install the public headers
+   install(FILES ${F3D_PUBLIC_HEADERS}
+     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/f3d"
+-    COMPONENT sdk
+-    EXCLUDE_FROM_ALL)
++    COMPONENT sdk)
+ 
+   # Install the library exported targets
+   install(EXPORT f3dLibraryTargets
+     NAMESPACE f3d::
+     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
+-    COMPONENT sdk
+-    EXCLUDE_FROM_ALL)
++    COMPONENT sdk)
+ 
+   # Install library cmake files
+   install(
+@@ -280,14 +275,12 @@ if(BUILD_SHARED_LIBS)
+       "${F3D_SOURCE_DIR}/cmake/f3dEmbed.cmake"
+     DESTINATION
+       "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
+-    COMPONENT sdk
+-    EXCLUDE_FROM_ALL)
++    COMPONENT sdk)
+ 
+   # Install plugin headers
+   install(FILES ${F3D_PLUGIN_HEADERS}
+     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/f3d"
+-    COMPONENT plugin_sdk
+-    EXCLUDE_FROM_ALL)
++    COMPONENT plugin_sdk EXCLUDE_FROM_ALL)
+ 
+   # Install pluginsdk cmake and source files
+   install(
+@@ -300,7 +293,6 @@ if(BUILD_SHARED_LIBS)
+       "${F3D_SOURCE_DIR}/cmake/readerBoilerPlate.h.in"
+     DESTINATION
+       "${CMAKE_INSTALL_LIBDIR}/cmake/f3d"
+-    COMPONENT plugin_sdk
+-    EXCLUDE_FROM_ALL)
++    COMPONENT plugin_sdk EXCLUDE_FROM_ALL)
+ 
+ endif()
+diff --git a/plugins/alembic/module/CMakeLists.txt b/plugins/alembic/module/CMakeLists.txt
+index 271eaa88..3af83302 100644
+--- a/plugins/alembic/module/CMakeLists.txt
++++ b/plugins/alembic/module/CMakeLists.txt
+@@ -3,7 +3,7 @@ set(classes
+   )
+ 
+ set(_no_install "")
+-if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20220928)
++if(BUILD_SHARED_LIBS)
+   set(_no_install "NO_INSTALL")
+ endif()
+ 
+diff --git a/plugins/assimp/module/CMakeLists.txt b/plugins/assimp/module/CMakeLists.txt
+index 31e8840c..202b7444 100644
+--- a/plugins/assimp/module/CMakeLists.txt
++++ b/plugins/assimp/module/CMakeLists.txt
+@@ -3,7 +3,7 @@ set(classes
+   )
+ 
+ set(_no_install "")
+-if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20220928)
++if(BUILD_SHARED_LIBS)
+   set(_no_install "NO_INSTALL")
+ endif()
+ 
+diff --git a/plugins/draco/module/CMakeLists.txt b/plugins/draco/module/CMakeLists.txt
+index 6d690733..8cf42872 100644
+--- a/plugins/draco/module/CMakeLists.txt
++++ b/plugins/draco/module/CMakeLists.txt
+@@ -11,7 +11,7 @@ if(VTK_VERSION VERSION_GREATER_EQUAL 9.3.20240214)
+ endif()
+ 
+ set(_no_install "")
+-if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20220928)
++if(BUILD_SHARED_LIBS)
+   set(_no_install "NO_INSTALL")
+ endif()
+ 
+diff --git a/plugins/native/module/CMakeLists.txt b/plugins/native/module/CMakeLists.txt
+index 991cc9ac..1355eef0 100644
+--- a/plugins/native/module/CMakeLists.txt
++++ b/plugins/native/module/CMakeLists.txt
+@@ -8,7 +8,7 @@ if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20221216)
+ endif()
+ 
+ set(_no_install "")
+-if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20220928)
++if(BUILD_SHARED_LIBS)
+   set(_no_install "NO_INSTALL")
+ endif()
+ 
+diff --git a/plugins/occt/module/CMakeLists.txt b/plugins/occt/module/CMakeLists.txt
+index 493ea503..d89b49eb 100644
+--- a/plugins/occt/module/CMakeLists.txt
++++ b/plugins/occt/module/CMakeLists.txt
+@@ -3,7 +3,7 @@ set(classes
+   )
+ 
+ set(_no_install "")
+-if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20220928)
++if(BUILD_SHARED_LIBS)
+   set(_no_install "NO_INSTALL")
+ endif()
+ 
+diff --git a/vtkext/private/CMakeLists.txt b/vtkext/private/CMakeLists.txt
+index 0357f869..e55507c9 100644
+--- a/vtkext/private/CMakeLists.txt
++++ b/vtkext/private/CMakeLists.txt
+@@ -7,7 +7,9 @@ vtk_module_scan(
+   ENABLE_TESTS      ${BUILD_TESTING})
+ 
+ vtk_module_build(
++  ENABLE_WRAPPING OFF
+   MODULES ${modules}
++  INSTALL_EXPORT "f3dLibraryTargets"
+   INSTALL_HEADERS OFF
+   PACKAGE "f3d_vtkext_private")
+ 
+diff --git a/vtkext/private/module/CMakeLists.txt b/vtkext/private/module/CMakeLists.txt
+index fd5516c1..0f0527e8 100644
+--- a/vtkext/private/module/CMakeLists.txt
++++ b/vtkext/private/module/CMakeLists.txt
+@@ -112,7 +112,7 @@ if(F3D_MODULE_UI AND NOT F3D_USE_EXTERNAL_IMGUI)
+ endif()
+ 
+ set(_no_install "")
+-if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20220928)
++if(BUILD_SHARED_LIBS)
+   set(_no_install "NO_INSTALL")
+ endif()
+ 
+diff --git a/vtkext/public/CMakeLists.txt b/vtkext/public/CMakeLists.txt
+index d6bebf6c..d35b6a66 100644
+--- a/vtkext/public/CMakeLists.txt
++++ b/vtkext/public/CMakeLists.txt
+@@ -18,10 +18,10 @@ set(headers_component "")
+ set(f3d_vtk_no_install "")
+ set(f3d_vtk_force_static "")
+ get_target_property(f3d_vtk_target_type VTK::CommonCore TYPE)
+-if(BUILD_SHARED_LIBS AND NOT f3d_vtk_target_type STREQUAL STATIC_LIBRARY)
++if(ON)
+   # The headers and all "dev" part are installed as part of the plugin SDK
+   # The library itself is installed as part of the library
+-  set(export_name "f3d_vtkext")
++  set(export_name "f3dLibraryTargets")
+   set(headers_component "plugin_sdk")
+ else()
+   if(VTK_VERSION VERSION_GREATER_EQUAL 9.2.20220928)
+@@ -32,10 +32,10 @@ else()
+ endif()
+ 
+ vtk_module_build(
++  ENABLE_WRAPPING OFF
+   MODULES ${modules}
+   INSTALL_EXPORT ${export_name}
+-  INSTALL_HEADERS ON
+-  HEADERS_COMPONENT ${headers_component}
++  INSTALL_HEADERS OFF
+   ${f3d_vtkext_headers_exclude}
+   HEADERS_DESTINATION "include/f3d"
+   TARGETS_COMPONENT library

--- a/ports/f3d/portfile.cmake
+++ b/ports/f3d/portfile.cmake
@@ -1,0 +1,49 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO f3d-app/f3d
+    REF v${VERSION}
+    SHA512 ac3f9edca7c870f56603165a6035da36486f05dc8367ba9147f687f6de2f4c9dfb94077f6041f41dd689e03c0387f9fab62c69f995a4e18016d623844e83bb6b
+    HEAD_REF master
+    PATCHES
+        fix-install.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        application F3D_BUILD_APPLICATION
+        # optional modules
+        exr         F3D_MODULE_EXR
+        # optional plugins
+        alembic     F3D_PLUGIN_BUILD_ALEMBIC
+        assimp      F3D_PLUGIN_BUILD_ASSIMP
+        draco       F3D_PLUGIN_BUILD_DRACO
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DF3D_MACOS_BUNDLE=OFF
+        -DF3D_WINDOWS_BUILD_SHELL_THUMBNAILS_EXTENSION=OFF
+    MAYBE_UNUSED_VARIABLES
+        F3D_MACOS_BUNDLE
+        F3D_WINDOWS_BUILD_SHELL_THUMBNAILS_EXTENSION
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/f3d)
+
+# If the application feature is enabled, install it as a tool
+if("application" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES f3d AUTO_CLEAN)
+endif()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/f3d/usage
+++ b/ports/f3d/usage
@@ -1,0 +1,4 @@
+f3d provides CMake targets:
+
+    find_package(f3d CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE f3d::libf3d)

--- a/ports/f3d/vcpkg.json
+++ b/ports/f3d/vcpkg.json
@@ -1,0 +1,55 @@
+{
+  "name": "f3d",
+  "version": "3.2.0",
+  "description": "A fast and minimalist 3D viewer",
+  "homepage": "https://f3d.app",
+  "license": "BSD-3-Clause",
+  "supports": "!(windows & (arm | uwp))",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vtk",
+      "default-features": false,
+      "features": [
+        "opengl",
+        "seacas"
+      ]
+    }
+  ],
+  "features": {
+    "alembic": {
+      "description": "alembic plugin",
+      "dependencies": [
+        "alembic"
+      ]
+    },
+    "application": {
+      "description": "build the application"
+    },
+    "assimp": {
+      "description": "assimp plugin",
+      "dependencies": [
+        "assimp"
+      ]
+    },
+    "draco": {
+      "description": "draco plugin",
+      "dependencies": [
+        "draco"
+      ]
+    },
+    "exr": {
+      "description": "support for OpenEXR images",
+      "dependencies": [
+        "openexr"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2736,6 +2736,10 @@
       "baseline": "21.10",
       "port-version": 0
     },
+    "f3d": {
+      "baseline": "3.2.0",
+      "port-version": 0
+    },
     "faad2": {
       "baseline": "2.11.1",
       "port-version": 0

--- a/versions/f-/f3d.json
+++ b/versions/f-/f3d.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a3e0591c5f9db55c72e178ae36ddb2e30b2f206a",
+      "version": "3.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

