### PR TITLE
[faker-cxx] add new port

### DIFF
--- a/ports/faker-cxx/portfile.cmake
+++ b/ports/faker-cxx/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO cieslarmichal/faker-cxx
+    REF "v${VERSION}"
+    SHA512 5deffc3f820926719a8398d9ecb6e643d94667c6959b5f9e121d6300239d9537c8a8a39389ce74d5d174df215220d48fd599398063063e5ad778bc00e0d659b1
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+vcpkg_cmake_install()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME faker-cxx
+    CONFIG_PATH "lib/cmake"
+)   
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE" "${SOURCE_PATH}/LICENSES.md")

--- a/ports/faker-cxx/vcpkg.json
+++ b/ports/faker-cxx/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "faker-cxx",
+  "version": "4.0.1",
+  "description": "C++ Faker library for generating fake (but realistic) data.",
+  "homepage": "https://cieslarmichal.github.io/faker-cxx/",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -297,6 +297,7 @@ ecal:x64-android=fail
 elfio:arm-neon-android=fail
 elfio:arm64-android=fail
 elfio:x64-android=fail
+faker-cxx:x64-linux=fail # requires gcc13 or later
 # clang rejects variable length arrays
 fbgemm:x64-android=fail
 # variable length arrays in C++ are a Clang extension

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -2095,6 +2095,7 @@ dcmtk(uwp) = fail # Please set the C++ runtime location (required for running ap
 dmlc[openmp](osx) = feature-fails # No openmp on osx
 dv-processing[tools](osx) = feature-fails # Broke with compiler version. See https://github.com/microsoft/vcpkg/issues/39852
 embree3[core,avx,avx2,avx512,default-features,sse2,sse42](osx) = combination-fails # CMake Error at CMakeLists.txt:447 (MESSAGE):   Using Embree as static library is not supported with AppleClang >= 9.0 when multiple ISAs are selected.  Please either build a shared library or enable only one ISA.
+faker-cxx(linux) = fail # requires gcc13 or later
 ffmpeg[all,all-gpl](x64 & android) = feature-fails
 ffmpeg[nvcodec,ffplay,opengl](android) = feature-fails
 fftw3[openmp](osx) = feature-fails # waits for https://github.com/microsoft/vcpkg/pull/30833

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2752,6 +2752,10 @@
       "baseline": "2.4.1",
       "port-version": 0
     },
+    "faker-cxx": {
+      "baseline": "4.0.1",
+      "port-version": 0
+    },
     "fameta-counter": {
       "baseline": "2021-02-13",
       "port-version": 0

--- a/versions/f-/faker-cxx.json
+++ b/versions/f-/faker-cxx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "deecd5efe8a7aba81a2cbafe3d470a8b832861b8",
+      "version": "4.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/cieslarmichal/faker-cxx
