### PR TITLE
[libffi] Support LLVM on Windows by adding quotes around the path to CCAS

### DIFF
--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -37,6 +37,8 @@ if(VCPKG_DETECTED_CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     if(ccas_options)
         vcpkg_list(APPEND options "CCASFLAGS=\${CCASFLAGS}${ccas_options}")
     endif()
+else()
+    vcpkg_list(APPEND options "CCAS='${VCPKG_DETECTED_CMAKE_C_COMPILER}'")
 endif()
 
 vcpkg_make_configure(

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libffi",
   "version": "3.5.1",
+  "port-version": 1,
   "description": "Portable, high level programming interface to various calling conventions",
   "homepage": "https://github.com/libffi/libffi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4734,7 +4734,7 @@
     },
     "libffi": {
       "baseline": "3.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libfido2": {
       "baseline": "1.15.0",

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc064220edfdea750a8a66ba94cc21ea1edf558e",
+      "version": "3.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "c1c83eb2fab1f1a0797415e7f5353bf1c4fd5f9d",
       "version": "3.5.1",
       "port-version": 0


### PR DESCRIPTION
This PR fixes compiling libffi on Windows, when using the LLVM toolchain.

The path to CCAS may include spaces.  On Windows, the build process runs within a MSYS2 shell, which doesn't deal withs paces in paths very well.  Add quotes around the path to fix this.

This fixes building libffi with the LLVM toolchain on Windows.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
