### PR TITLE
[libphonenumber] update to 9.0.8

### DIFF
--- a/ports/libphonenumber/portfile.cmake
+++ b/ports/libphonenumber/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/libphonenumber
     REF "v${VERSION}"
-    SHA512 67a868c478909111757651b9accb7977933dcd27e97294604110ca8dc3ffeabce025b19d535da6412e88411f2e01451309ca5fa2d4d440738c6efd4aa46de523
+    SHA512 a9eb5010d7aa595927ca2420608ef9016e383cd5bb51fed346213d3c4900cda9195dc1c5aff1b05842bf309ac0f8cc729d38cc54dcca0cf4bb99621982b1916c
     HEAD_REF master
     PATCHES 
         # fix compilation error due to deprecated warnings in protobuf generated files

--- a/ports/libphonenumber/vcpkg.json
+++ b/ports/libphonenumber/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libphonenumber",
-  "version": "9.0.6",
+  "version": "9.0.8",
   "description": "Google's common Java, C++ and JavaScript library for parsing, formatting, and validating international phone numbers.",
   "homepage": "https://github.com/google/libphonenumber",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5185,7 +5185,7 @@
       "port-version": 2
     },
     "libphonenumber": {
-      "baseline": "9.0.6",
+      "baseline": "9.0.8",
       "port-version": 0
     },
     "libplist": {

--- a/versions/l-/libphonenumber.json
+++ b/versions/l-/libphonenumber.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1cb98caacebae08443b2ca41cb72afc9d95ff320",
+      "version": "9.0.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "997021a041a854780a2c58035ac9369a17d6fcda",
       "version": "9.0.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/google/libphonenumber/releases/tag/v9.0.8
