### PR TITLE
[argus] New port at version 0.1.0

### DIFF
--- a/ports/argus/portfile.cmake
+++ b/ports/argus/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
+  REPO lucocozz/Argus
+  REF "v${VERSION}"
+  SHA512 8464448d0aa664c8bf9f6992ee31db6827fd7b94c376446f4abe4ba8ff05ed85e86efc40fc9e9cbfb469a8fec5efaf2f8cb20cd28402a2091a614b157a63cf0b
+  HEAD_REF main
+)
+
+set(OPTIONS "")
+if(NOT "regex" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dregex=false)
+endif()
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${OPTIONS}
+        -Dbenchmarks=false
+        -Dexamples=false
+        -Dtests=false
+)
+
+vcpkg_install_meson()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/argus/vcpkg.json
+++ b/ports/argus/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "argus",
+  "version": "0.1.0",
+  "description": "Argus is a cross-platform modern feature-rich command-line argument parser for C",
+  "homepage": "https://github.com/lucocozz/argus",
+  "license": "MIT",
+  "supports": "!(windows & static) & !(windows & x86)",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ],
+  "features": {
+    "regex": {
+      "description": "Enable regex validation support using PCRE2",
+      "dependencies": [
+        "pcre2"
+      ]
+    }
+  }
+}

--- a/versions/a-/argus.json
+++ b/versions/a-/argus.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "abb6b37bc3ad957fae11e7dabb205928dcf14f2f",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -240,6 +240,10 @@
       "baseline": "0.3.2",
       "port-version": 0
     },
+    "argus": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "aricpp": {
       "baseline": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
