### PR TITLE
[lief] Add a comment to explain the access flag index

### DIFF
--- a/scripts/test_ports/vcpkg-ci-lief/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-lief/project/main.cpp
@@ -4,6 +4,7 @@
 
 int main()
 {
+   // Outputs a string representation of the PUBLIC access flag (index 1)
    std::cout << "access flags public = " << LIEF::DEX::to_string(LIEF::DEX::access_flags_list[1]) << std::endl;
    std::cout << "Version = " << LIEF_VERSION << std::endl;
    return 0;

--- a/scripts/test_ports/vcpkg-ci-lief/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-lief/vcpkg.json
@@ -1,25 +1,25 @@
 {
-    "name": "vcpkg-ci-lief",
-    "version-string": "ci",
-    "description": "Testing packages which provide lief",
-    "license": null,
-    "dependencies": [
+  "name": "vcpkg-ci-lief",
+  "version-string": "ci",
+  "description": "Testing packages which provide lief",
+  "license": null,
+  "dependencies": [
     {
       "name": "lief",
       "features": [
+        "art",
         "c-api",
+        "dex",
+        "elf",
         "enable-json",
         "extra-warnings",
         "logging",
         "logging-debug",
-        "use-ccache",
-        "elf",
-        "pe",
         "macho",
         "oat",
-        "dex",
-        "vdex",
-        "art"
+        "pe",
+        "use-ccache",
+        "vdex"
       ]
     },
     {


### PR DESCRIPTION
Adds a comment above the line that accesses LIEF::DEX::access_flags_list[1] to clarify that index 1 corresponds to the PUBLIC access flag.