### PR TITLE
[luau] update to 0.681

### DIFF
--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -10,12 +10,6 @@ vcpkg_from_github(
         cmake-config-export.patch
 )
 
-if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-    # In ARM64 it fails without /bigobj
-    set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} /bigobj")
-    set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} /bigobj")
-endif()
-
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
@@ -25,6 +19,7 @@ vcpkg_check_features(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DLUAU_BUILD_TESTS=OFF
         -DVERSION=${VERSION}
         ${FEATURE_OPTIONS}
     OPTIONS_DEBUG

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -10,6 +10,12 @@ vcpkg_from_github(
         cmake-config-export.patch
 )
 
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    # In ARM64 it fails without /bigobj
+    set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} /bigobj")
+    set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} /bigobj")
+endif()
+
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 8fbea170b2081188d24bfef4026813c6ea9959b08f1c6f574edf60fb1dfe986005a7742294b4b5fb7421814027d0e9e748d4cbfe8f9c0eba77c82647db9eae3c
+    SHA512 72f0c48ee5ccafbb1f7228d342b1d751b9cf9caa6745d606e9a9e5c301f7624bc6acc5138f14beb94e1e5f657c02f2b5e5a1ada6eebd62f87e11f791322a3b76
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.680",
+  "version": "0.681",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5921,7 +5921,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.680",
+      "baseline": "0.681",
       "port-version": 0
     },
     "luminoengine": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8db8e229178ce337b538c9f69fce4e31d63c1d39",
+      "git-tree": "01583a8dbda5db264210b59e959edb6ae1ca5930",
       "version": "0.681",
       "port-version": 0
     },

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cbeb0b714ed80544494a41ae32f45b4891ea967c",
+      "version": "0.681",
+      "port-version": 0
+    },
+    {
       "git-tree": "f4b5b50b9891472373d8e5e3eb5046e0624687e9",
       "version": "0.680",
       "port-version": 0

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cbeb0b714ed80544494a41ae32f45b4891ea967c",
+      "git-tree": "8db8e229178ce337b538c9f69fce4e31d63c1d39",
       "version": "0.681",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/luau-lang/luau/releases/tag/0.681
