### PR TITLE
[poppler-data] Add new port

### DIFF
--- a/ports/poppler-data/portfile.cmake
+++ b/ports/poppler-data/portfile.cmake
@@ -1,0 +1,25 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+string(REPLACE "." "_" poppler_data_version "POPPLER_DATA_${VERSION}")
+
+vcpkg_from_gitlab(
+    GITLAB_URL gitlab.freedesktop.org/
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO poppler/poppler-data
+    REF "${poppler_data_version}"
+    SHA512 1d2cb04604a1a3d33edc45638d1a6ddacbcf99eeeed8bca7462cbd5d244edbebe94cd1f2487189060b0927287a8571fcc29ee3b3cd7fb4dc1c4d8f819d035a0a
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/")
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/poppler-data/vcpkg.json
+++ b/ports/poppler-data/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "poppler-data",
+  "version": "0.4.12",
+  "description": "This package consists of encoding files for use with poppler.",
+  "homepage": "https://poppler.freedesktop.org",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7456,6 +7456,10 @@
       "baseline": "24.3.0",
       "port-version": 1
     },
+    "poppler-data": {
+      "baseline": "0.4.12",
+      "port-version": 0
+    },
     "popsift": {
       "baseline": "0.9",
       "port-version": 5

--- a/versions/p-/poppler-data.json
+++ b/versions/p-/poppler-data.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "55f957c8edf789ff4da3d62b47f60b19632cb296",
+      "version": "0.4.12",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

