### PR TITLE
[appstream-glib] Add new port

### DIFF
--- a/ports/appstream-glib/portfile.cmake
+++ b/ports/appstream-glib/portfile.cmake
@@ -1,0 +1,32 @@
+string(REPLACE "." "_" appstream_glib_version "appstream_glib_${VERSION}")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO hughsie/appstream-glib
+    REF "${appstream_glib_version}"
+    SHA512 720182ef507777ca818b1e955e16b1b8691927882664c1cc42e094ad10949036991ffb9a666e2f3f104cb1ca29ed824c507e9b8e46089d54b41d30b7fed0d71c
+    HEAD_REF main
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Ddep11=false
+        -Dbuilder=true
+        -Drpm=false
+        -Dalpm=false
+        -Dfonts=true
+        -Dman=false
+        -Dgtk-doc=false
+        -Dintrospection=false
+    ADDITIONAL_BINARIES
+        "gperf = ['${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${VCPKG_HOST_EXECUTABLE_SUFFIX}']"
+)
+
+vcpkg_install_meson()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/appstream-glib/vcpkg.json
+++ b/ports/appstream-glib/vcpkg.json
@@ -1,0 +1,30 @@
+{
+  "name": "appstream-glib",
+  "version": "0.8.3",
+  "description": "Provides GObjects and helper methods to make it easy to read and write AppStream metadata.",
+  "homepage": "https://github.com/hughsie/appstream-glib/",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!windows | mingw",
+  "dependencies": [
+    "curl",
+    "fontconfig",
+    "freetype",
+    "gdk-pixbuf",
+    "glib",
+    {
+      "name": "gperf",
+      "host": true
+    },
+    "gtk3",
+    "json-glib",
+    "libarchive",
+    {
+      "name": "libuuid",
+      "platform": "linux"
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/appstream-glib.json
+++ b/versions/a-/appstream-glib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7044d05cd0cfcad82c0d8a6f4770b9fd3dd4166c",
+      "version": "0.8.3",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -172,6 +172,10 @@
       "baseline": "10.13.0",
       "port-version": 0
     },
+    "appstream-glib": {
+      "baseline": "0.8.3",
+      "port-version": 0
+    },
     "apr": {
       "baseline": "1.7.6",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
