### PR TITLE
[babl, gegl] Update ports. Add introspection feature

### DIFF
--- a/ports/babl/portfile.cmake
+++ b/ports/babl/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.gimp.org/pub/babl/${VERSION_MAJOR_MINOR}/babl-${VERSION}.tar.xz"
     FILENAME "babl-${VERSION}.tar.xz"
-    SHA512 20e40baa6654785d69642e6e85542968db3c5d08da630adc590ff066a52c5938f4ce8a77c0097e00010a905c8c31d8f131eb0308a3f8b6439ab6be4133eae246
+    SHA512 ff410c9839f4fe4d6afd4dec7e4d02af34b1c8a4edbc05483784ed82f91045b1102414fc1c58357866044b7f1ab499eda24fe744f5dd692af5804020c76b2382
 )
 
 vcpkg_extract_source_archive(
@@ -18,12 +18,21 @@ else()
     list(APPEND feature_options "-Dwith-lcms=false")
 endif()
 
+if("introspection" IN_LIST FEATURES)
+    list(APPEND feature_options "-Denable-gir=true")
+    vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+else()
+    list(APPEND feature_options "-Denable-gir=false")
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${feature_options}
-        -Denable-gir=false
         -Dwith-docs=false
+    ADDITIONAL_BINARIES
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
 )
 vcpkg_install_meson()
 vcpkg_copy_pdbs()

--- a/ports/babl/vcpkg.json
+++ b/ports/babl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "babl",
-  "version": "0.1.110",
-  "port-version": 2,
+  "version": "0.1.114",
   "description": "A pixel encoding and color space conversion engine.",
   "homepage": "https://gegl.org/babl/",
   "license": "LGPL-3.0-or-later",
@@ -17,6 +16,12 @@
       "description": "Support CMYK ICC profiles.",
       "dependencies": [
         "lcms"
+      ]
+    },
+    "introspection": {
+      "description": "Enable introspection",
+      "dependencies": [
+        "gobject-introspection"
       ]
     }
   }

--- a/ports/gegl/portfile.cmake
+++ b/ports/gegl/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS https://download.gimp.org/pub/gegl/${VERSION_MAJOR_MINOR}/gegl-${VERSION}.tar.xz
     FILENAME "gegl-${VERSION}.tar.xz"
-    SHA512 95a6ef4866b90c9ce950af2e8e1e465044bc8f0e0065884b103c7d86d7a56f5b9142a90abc4676675add46e69b811f5b8225eb7676454d5c49d7cd19e4edab7e
+    SHA512 bf4801588abe8b568ae3d1daafa97af28516bbbdd44d2a0798c87412b49301f621db3cf1c7a3ec33f19d96ab4dbd37d80824f04460116a896dd7415aa0d5229d
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gegl/vcpkg.json
+++ b/ports/gegl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gegl",
-  "version": "0.4.54",
+  "version": "0.4.62",
   "description": "Generic Graphical Library.",
   "homepage": "https://gegl.org/",
   "license": "LGPL-3.0-or-later",

--- a/versions/b-/babl.json
+++ b/versions/b-/babl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cad9c6bb5734a52689427bed4145c2d0d9a80fca",
+      "version": "0.1.114",
+      "port-version": 0
+    },
+    {
       "git-tree": "feb19fafaacdb7dba45f5c2a42970ba81b2d87c5",
       "version": "0.1.110",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -585,8 +585,8 @@
       "port-version": 2
     },
     "babl": {
-      "baseline": "0.1.110",
-      "port-version": 2
+      "baseline": "0.1.114",
+      "port-version": 0
     },
     "backward-cpp": {
       "baseline": "2023-11-24",
@@ -3161,7 +3161,7 @@
       "port-version": 4
     },
     "gegl": {
-      "baseline": "0.4.54",
+      "baseline": "0.4.62",
       "port-version": 0
     },
     "gemmlowp": {

--- a/versions/g-/gegl.json
+++ b/versions/g-/gegl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9eddf53829c7d2dc14266b4002373790f09946de",
+      "version": "0.4.62",
+      "port-version": 0
+    },
+    {
       "git-tree": "d85039d4ae76e2fbb0721678333d4188049e26b3",
       "version": "0.4.54",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
