### PR TITLE
[sebsjames maths] add new port

### DIFF
--- a/ports/sebsjames-maths/portfile.cmake
+++ b/ports/sebsjames-maths/portfile.cmake
@@ -1,0 +1,24 @@
+set(VCPKG_BUILD_TYPE release)  # header-only
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO sebsjames/maths
+    REF "${VERSION}"
+    SHA512 bd1f44f2cb3cf14458a4c35052840cc19cd6a03058936853eedbd209fdb10012e74b2b51e7fc7a46e3e76861baf27e946a7e1e5feff545f81b255d9d4af4303e
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sebsjames-maths)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/sebsjames-maths/portfile.cmake
+++ b/ports/sebsjames-maths/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sebsjames-maths)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/maths)
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/sebsjames-maths/vcpkg.json
+++ b/ports/sebsjames-maths/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "sebsjames-maths",
+  "version": "1.0",
+  "description": "C++20 code for scalar, vector and complex maths.",
+  "homepage": "https://github.com/sebsjames/maths",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8644,6 +8644,10 @@
       "baseline": "1.4.6",
       "port-version": 0
     },
+    "sebsjames-maths": {
+      "baseline": "1.0",
+      "port-version": 0
+    },
     "secp256k1": {
       "baseline": "2022-07-11",
       "port-version": 1

--- a/versions/s-/sebsjames-maths.json
+++ b/versions/s-/sebsjames-maths.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "57d798164975ff7886d373a736f833be418d8e76",
+      "git-tree": "7203305bdf6d65da04a581117b017ac447322b11",
       "version": "1.0",
       "port-version": 0
     }

--- a/versions/s-/sebsjames-maths.json
+++ b/versions/s-/sebsjames-maths.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "57d798164975ff7886d373a736f833be418d8e76",
+      "version": "1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

fixes https://github.com/microsoft/vcpkg/issues/46321
