### PR TITLE
[libxmlb] Add new port

### DIFF
--- a/ports/libxmlb/portfile.cmake
+++ b/ports/libxmlb/portfile.cmake
@@ -1,0 +1,28 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO hughsie/libxmlb
+    REF "${VERSION}"
+    SHA512 ab80012fc8c0c9b70c8d77f931cd3ff0f0f62086d9b26c490b1b942f7be8dc72d9797d5995c7edcfc36652e3562650e47b2cead87103e06077c7b7e19ec8230f
+    HEAD_REF main
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dgtkdoc=false
+        -Dintrospection=false
+        -Dtests=false
+        -Dstemmer=false
+        -Dcli=false
+        -Dlzma=disabled
+        -Dzstd=disabled
+)
+
+vcpkg_install_meson()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libxmlb/vcpkg.json
+++ b/ports/libxmlb/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "libxmlb",
+  "version": "0.3.22",
+  "description": "The libxmlb library takes XML source, and converts it to a structured binary representation with a deduplicated string table where the strings have the NULs included",
+  "homepage": "https://github.com/hughsie/libxmlb/",
+  "license": "LGPL-2.1-only",
+  "supports": "!windows | mingw",
+  "dependencies": [
+    "glib",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5664,6 +5664,10 @@
       "baseline": "2.13.8",
       "port-version": 1
     },
+    "libxmlb": {
+      "baseline": "0.3.22",
+      "port-version": 0
+    },
     "libxmlmm": {
       "baseline": "0.6.0",
       "port-version": 4

--- a/versions/l-/libxmlb.json
+++ b/versions/l-/libxmlb.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7245a7fbb379b585f611d2538fa6582a455a5212",
+      "version": "0.3.22",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

