### PR TITLE
[capstone] update to 5.0.6

### DIFF
--- a/ports/capstone/002-force-exportname-capstone.patch
+++ b/ports/capstone/002-force-exportname-capstone.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4797bc57..929eee49 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -658,7 +658,7 @@ target_include_directories(capstone PUBLIC
+ if(BUILD_STATIC_LIBS)
+     add_library(capstone_static STATIC $<TARGET_OBJECTS:capstone>)
+     # Use normal capstone name. Otherwise we get libcapstone_static.a
+-    set_target_properties(capstone_static PROPERTIES OUTPUT_NAME "capstone")
++    set_target_properties(capstone_static PROPERTIES OUTPUT_NAME "capstone" EXPORT_NAME "capstone")
+     target_include_directories(capstone_static PUBLIC
+         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+     )
+@@ -668,7 +668,7 @@ if(BUILD_SHARED_LIBS)
+     set_property(TARGET capstone PROPERTY POSITION_INDEPENDENT_CODE 1)
+     add_library(capstone_shared SHARED $<TARGET_OBJECTS:capstone>)
+     # Use normal capstone name. Otherwise we get libcapstone_shared.so
+-    set_target_properties(capstone_shared PROPERTIES OUTPUT_NAME "capstone")
++    set_target_properties(capstone_shared PROPERTIES OUTPUT_NAME "capstone" EXPORT_NAME "capstone")
+     set_target_properties(capstone_shared PROPERTIES
+         VERSION ${PROJECT_VERSION}
+         SOVERSION ${PROJECT_VERSION_MAJOR}

--- a/ports/capstone/portfile.cmake
+++ b/ports/capstone/portfile.cmake
@@ -2,13 +2,15 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "capstone-engine/capstone"
     REF "${VERSION}"
-    SHA512 2fd3194dd37065e6091d208c7670b12c0ca6872931eef794bd6b2dd624601c843e8ee6c5714eae0372e394e91a9bc1e4de7dfea6b1087542dd461226569101de
+    SHA512 d4ed08a2ab4ed8ede51a163e98542129d6441889cf6936ac9e3f8027fb2dfcbb04a7aacba14c2a007e788790bb3939c173b47db3d95f5dd9eafce2f30ff493e1
     HEAD_REF next
     PATCHES
         001-silence-windows-crt-secure-warnings.patch
+        002-force-exportname-capstone.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATIC_CRT)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CAPSTONE_STATIC)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
@@ -39,7 +41,13 @@ vcpkg_cmake_configure(
         -DCAPSTONE_BUILD_TESTS=OFF
         -DCAPSTONE_BUILD_CSTOOL=OFF
         -DCAPSTONE_BUILD_STATIC_RUNTIME=${STATIC_CRT}
+        -DBUILD_STATIC_RUNTIME=${STATIC_CRT}
+        -DBUILD_STATIC_LIBS=${CAPSTONE_STATIC}
         ${FEATURE_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        CAPSTONE_BUILD_STATIC_RUNTIME
+        BUILD_STATIC_RUNTIME
+        BUILD_STATIC_LIBS
 )
 
 vcpkg_cmake_install()
@@ -49,4 +57,6 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.TXT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(
+    FILE_LIST "${SOURCE_PATH}/LICENSE.TXT"
+)

--- a/ports/capstone/vcpkg.json
+++ b/ports/capstone/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "capstone",
-  "version": "5.0.3",
-  "port-version": 1,
+  "version": "5.0.6",
   "description": "Multi-architecture disassembly framework",
   "homepage": "https://github.com/capstone-engine/capstone",
   "license": "BSD-3-Clause",

--- a/scripts/test_ports/vcpkg-ci-capstone/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-capstone/portfile.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-capstone/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-capstone/project/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.29)
+project(capstone-test CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_executable(main main.cpp)
+
+find_package(capstone CONFIG REQUIRED)
+target_link_libraries(main PRIVATE capstone::capstone)

--- a/scripts/test_ports/vcpkg-ci-capstone/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-capstone/project/main.cpp
@@ -1,0 +1,8 @@
+#include <capstone/capstone.h>
+
+int main()
+{
+    csh handle;
+    cs_insn* insn = cs_malloc(handle);
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-capstone/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-capstone/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-capstone",
+  "version-string": "ci",
+  "description": "Validates capstone",
+  "dependencies": [
+    "capstone",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1553,8 +1553,8 @@
       "port-version": 0
     },
     "capstone": {
-      "baseline": "5.0.3",
-      "port-version": 1
+      "baseline": "5.0.6",
+      "port-version": 0
     },
     "cargs": {
       "baseline": "1.2.0",

--- a/versions/c-/capstone.json
+++ b/versions/c-/capstone.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bcd9fc1db64dc8b7dbf4a63968d25c320c398029",
+      "version": "5.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff71755fc4ef3ba463ff94cd92781858462f7a15",
       "version": "5.0.3",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

When I install capstone it creates targets like
```
capstone provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(capstone CONFIG REQUIRED)
  target_link_libraries(main PRIVATE capstone::capstone_static)
```
```
capstone provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(capstone CONFIG REQUIRED)
  target_link_libraries(main PRIVATE capstone::capstone_shared)
```
I tried to enforce it to stay capstone::capstone as it used to be in old versions. So I could pass
```
CMake Error at CMakeLists.txt:156 (target_link_libraries):
  Target "libmem" links to:

    capstone::capstone

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```