### PR TITLE
[livepp] Update to 2.9.3

### DIFF
--- a/ports/livepp/portfile.cmake
+++ b/ports/livepp/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS https://liveplusplus.tech/downloads/${LIVEPP_FILE}
     FILENAME "${LIVEPP_FILE}"
-    SHA512 a155f206f4e3cd73971820073db7d1449a3e02f45f2a05431f7536f703d948edf7e78dfdf06e7d0d7af728888c5fab638ef91aeb82f6ca46ec829de3beff95ec
+    SHA512 43c0395e958b2c71dbfb4c590657c15633d96d06dd9c5ca349c5e5c5040916693f7c2f8bc5237de31e40ea9010b7bde47858cc329ae7bfd464187b9af63fc5bb
 )
 
 vcpkg_extract_source_archive(

--- a/ports/livepp/vcpkg.json
+++ b/ports/livepp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "livepp",
-  "version-semver": "2.9.2",
-  "port-version": 1,
+  "version-semver": "2.9.3",
   "description": "Hot-reload for C & C++ transforms workflows and decreases iteration times.",
   "homepage": "https://liveplusplus.tech/",
   "documentation": "https://liveplusplus.tech/docs/documentation.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5793,8 +5793,8 @@
       "port-version": 0
     },
     "livepp": {
-      "baseline": "2.9.2",
-      "port-version": 1
+      "baseline": "2.9.3",
+      "port-version": 0
     },
     "llama-cpp": {
       "baseline": "4743",

--- a/versions/l-/livepp.json
+++ b/versions/l-/livepp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41c5429ffac43a63f1162df8aa948a74ff763207",
+      "version-semver": "2.9.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "04318b1e123339dcde888da24bed6e3620b974f2",
       "version-semver": "2.9.2",
       "port-version": 1


### PR DESCRIPTION
Update the livepp port from 2.9.2 to 2.9.3: https://liveplusplus.tech/releases.html

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
