### PR TITLE
[sfl] update to 1.10.0

### DIFF
--- a/ports/sfl/portfile.cmake
+++ b/ports/sfl/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO slavenf/sfl-library
     REF "${VERSION}"
-    SHA512 9e6f140c7a235c3f7dd5c76843d8b0d8d0e22491eaef1c9936dc55e28fed1e66c15c1d5d1e55ce40799ca691069745efcb234448ca202e4430668dba03a6c054
+    SHA512 eb480dfe89f5f3558b6470d6ded49cdccc6b2f68ca1a6b0b87d80ae6fb427e500d4cc95afdedc3c932b8051c5f1751f484996c8263e4ab3f5543c663a90daacb
     HEAD_REF master
 )
 

--- a/ports/sfl/vcpkg.json
+++ b/ports/sfl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sfl",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "header-only C++11 library that offers several new or less-known containers",
   "homepage": "https://github.com/slavenf/sfl-library",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8701,7 +8701,7 @@
       "port-version": 0
     },
     "sfl": {
-      "baseline": "1.9.2",
+      "baseline": "1.10.0",
       "port-version": 0
     },
     "sfml": {

--- a/versions/s-/sfl.json
+++ b/versions/s-/sfl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e40057c0d99b1ac2762cc9b78b3ed17dc06c2d1",
+      "version": "1.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b0571621408816c82df5cb412d06c549875ad9a4",
       "version": "1.9.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/slavenf/sfl-library/releases/tag/1.10.0
