### PR TITLE
[vcpkg baseline][nspr] Unexport ldflags

### DIFF
--- a/ports/nspr/portfile.cmake
+++ b/ports/nspr/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_extract_source_archive(
         library-linkage.diff
         nsinstall-windows.diff
         parallel.diff
+        unexport-ldflags.diff
 )
 
 set(OPTIONS "")

--- a/ports/nspr/unexport-ldflags.diff
+++ b/ports/nspr/unexport-ldflags.diff
@@ -1,0 +1,13 @@
+diff --git a/nspr/config/nspr-config.in b/nspr/config/nspr-config.in
+index 2cb62a0..6db7aa3 100755
+--- a/nspr/config/nspr-config.in
++++ b/nspr/config/nspr-config.in
+@@ -136,7 +136,7 @@ if test "$echo_libs" = "yes"; then
+       if test -n "$lib_nspr"; then
+ 	libdirs="$libdirs -lnspr${major_version}"
+       fi
+-      os_ldflags="@LDFLAGS@"
++      os_ldflags=""
+       for i in $os_ldflags ; do
+ 	if echo $i | grep \^-L >/dev/null; then
+ 	  libdirs="$libdirs $i"

--- a/ports/nspr/vcpkg.json
+++ b/ports/nspr/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nspr",
   "version": "4.36",
+  "port-version": 1,
   "description": "Netscape portable runtime",
   "homepage": "https://releases.mozilla.org/pub/nspr/",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6714,7 +6714,7 @@
     },
     "nspr": {
       "baseline": "4.36",
-      "port-version": 0
+      "port-version": 1
     },
     "nss": {
       "baseline": "3.113.1",

--- a/versions/n-/nspr.json
+++ b/versions/n-/nspr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "acb02a481a11d66bd0dbc03a37b6ecdbacf49087",
+      "version": "4.36",
+      "port-version": 1
+    },
+    {
       "git-tree": "e8e42a8f8cc4970fecbe6d6e671031078c562c0e",
       "version": "4.36",
       "port-version": 0


### PR DESCRIPTION
This would just forward toolchain flags, creating installation order dependencies due to vcpkg-make. Cf. #46338. Fixes conditional postbuild-lint error due to the absolute paths for vcpkg libdirs, https://github.com/microsoft/vcpkg/pull/46323#issuecomment-3048337642.