### PR TITLE
[superglu] add new port

### DIFF
--- a/ports/superglu/change-output-name.patch
+++ b/ports/superglu/change-output-name.patch
@@ -1,0 +1,11 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -124,6 +124,7 @@
+ endif()
+ 
+ set_target_properties(GLU PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${SUPERGLU_SO_VERSION})
++set_target_properties(GLU PROPERTIES OUTPUT_NAME "superglu")
+ 
+ target_compile_definitions(GLU PRIVATE HAVE_CONFIG_H LIBRARYBUILD GLU_INTERNAL GLU_DEBUG=$<CONFIG:Debug>)
+ 

--- a/ports/superglu/portfile.cmake
+++ b/ports/superglu/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO coin3d/superglu
+    REF "v${VERSION}"
+    SHA512 ff1edb95192b4593e99106bf5d7fe30aabd8e42b21a6a02b2dcb2431b1388d87e7c1186a2291047f8a10897e872329e8dd993e89414e4d88f2e9e95c6a74fd52
+    HEAD_REF master
+    PATCHES
+        change-output-name.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSUPERGLU_BUILD_SHARED_LIBS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/superglu-${VERSION})
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/superglu/portfile.cmake
+++ b/ports/superglu/portfile.cmake
@@ -8,10 +8,13 @@ vcpkg_from_github(
         change-output-name.patch
 )
 
+vcpkg_find_acquire_program(PERL)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSUPERGLU_BUILD_SHARED_LIBS=OFF
+        "-DPERL_EXECUTABLE=${PERL}"
 )
 
 vcpkg_cmake_install()

--- a/ports/superglu/usage
+++ b/ports/superglu/usage
@@ -1,0 +1,4 @@
+The package superglu provides CMake targets:
+
+    find_package(superglu CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE superglu::GLU)

--- a/ports/superglu/vcpkg.json
+++ b/ports/superglu/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "SGI GLU with miscellaneous fixes",
   "homepage": "https://github.com/coin3d/superglu",
   "license": "SGI-B-1.1",
-  "supports": "windows",
+  "supports": "windows & !uwp",
   "dependencies": [
     "opengl-registry",
     {

--- a/ports/superglu/vcpkg.json
+++ b/ports/superglu/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "SGI GLU with miscellaneous fixes",
   "homepage": "https://github.com/coin3d/superglu",
   "license": "SGI-B-1.1",
-  "supports": "!arm & !android & !uwp",
+  "supports": "windows",
   "dependencies": [
     "opengl-registry",
     {

--- a/ports/superglu/vcpkg.json
+++ b/ports/superglu/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "superglu",
+  "version": "1.3.3",
+  "description": "SGI GLU with miscellaneous fixes",
+  "homepage": "https://github.com/coin3d/superglu",
+  "license": "SGI-B-1.1",
+  "supports": "!arm & !android & !uwp",
+  "dependencies": [
+    "opengl-registry",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9272,6 +9272,10 @@
       "baseline": "7.1.1",
       "port-version": 0
     },
+    "superglu": {
+      "baseline": "1.3.3",
+      "port-version": 0
+    },
     "superlu": {
       "baseline": "7.0.0",
       "port-version": 0

--- a/versions/s-/superglu.json
+++ b/versions/s-/superglu.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5c26cc5d3b9fdfdd0a2aab887b4593927635f7fd",
+      "version": "1.3.3",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/superglu.json
+++ b/versions/s-/superglu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5c26cc5d3b9fdfdd0a2aab887b4593927635f7fd",
+      "git-tree": "a3b16778c78783c44ce257e23f270b938eeeb047",
       "version": "1.3.3",
       "port-version": 0
     }

--- a/versions/s-/superglu.json
+++ b/versions/s-/superglu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a3b16778c78783c44ce257e23f270b938eeeb047",
+      "git-tree": "35720e4d973d60a716d7980ad44b8b7d777677a5",
       "version": "1.3.3",
       "port-version": 0
     }

--- a/versions/s-/superglu.json
+++ b/versions/s-/superglu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "35720e4d973d60a716d7980ad44b8b7d777677a5",
+      "git-tree": "b0cf2170a9c932e1c20c93d2556ef1d25fb3d991",
       "version": "1.3.3",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Superglu will be used to optimize the display of B-spline curves and surfaces in coin3d on windows.
see https://github.com/coin3d/coin/issues/375
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

<!-- END OF NEW PORT CHECKLIST -->