### PR TITLE
[simage] update to 1.8.4

### DIFF
--- a/ports/simage/portfile.cmake
+++ b/ports/simage/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Coin3D/simage
     REF "v${VERSION}"
-    SHA512 42981f1dc67f17bc6bfc49ecbf035444b79ab467d5ece4310841856f5ec87d2b4352d5a7cb5713fb14ac5a25928f7d657fb74c93acdcd86b8b0dd89f26a5008a
+    SHA512 ef8ee5d4952e05861147fa59e7a29ed2020165917f45cc5de6760a52f7cd079135fc921f0e90b9ac9bfff7639204de4d44b0bf6a5f66e6cc35879f62638332b3
     HEAD_REF master
     PATCHES requies-all-dependencies.patch
 )

--- a/ports/simage/vcpkg.json
+++ b/ports/simage/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simage",
-  "version-semver": "1.8.3",
+  "version-semver": "1.8.4",
   "description": "Image file format library abstraction layer",
   "homepage": "https://github.com/coin3d/simage",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8769,7 +8769,7 @@
       "port-version": 5
     },
     "simage": {
-      "baseline": "1.8.3",
+      "baseline": "1.8.4",
       "port-version": 0
     },
     "simbody": {

--- a/versions/s-/simage.json
+++ b/versions/s-/simage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "24d49b172f523f7abd6f38c644e34da2016f6d9b",
+      "version-semver": "1.8.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "824535538b2f13b732f661d657380b480bebea82",
       "version-semver": "1.8.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
This version addresses the following CMake deprecation warning:
```cmake
...(cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
  ```

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

<!-- END OF NEW PORT CHECKLIST -->