### PR TITLE
orange-math: update to 3.0.3

### DIFF
--- a/ports/orange-math/portfile.cmake
+++ b/ports/orange-math/portfile.cmake
@@ -1,26 +1,31 @@
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO orange-cpp/omath
     REF "v${VERSION}"
-    SHA512 467b1abbdf5b9a7f49ed50824eaa4641f05d6088e84f40320b5c82a1bdbf685cc8d0f0a4f4ab6be49e3a8ed13103ee3e808dde3b556a00742f7b53c519c183e3
+    SHA512 60be12375e95c09a2a3d42b464f14dbd46bcccb6d9e0e48f3ccc1ac97149aa33759f17dc012c8cb36bdba45a423261376f8dd910abbd7d519aa43ce47faea866
     HEAD_REF master
 )
 
-file(READ "${SOURCE_PATH}/cmake/omathConfig.cmake.in" cmake_config)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" OMATH_SHARED)
 
-file(WRITE "${SOURCE_PATH}/cmake/omathConfig.cmake.in"
-"${cmake_config}
-check_required_components(omath)
-")
-
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIBS)
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "avx2"      OMATH_USE_AVX2
+        "imgui"     OMATH_IMGUI_INTEGRATION
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
+        -DOMATH_USE_UNITY_BUILD=ON
         -DOMATH_BUILD_TESTS=OFF
         -DOMATH_THREAT_WARNING_AS_ERROR=OFF
-        -DOMATH_BUILD_AS_SHARED_LIBRARY=${BUILD_SHARED_LIBS}
+        -DOMATH_BUILD_AS_SHARED_LIBRARY=${OMATH_SHARED}
 )
 
 vcpkg_cmake_install()

--- a/ports/orange-math/portfile.cmake
+++ b/ports/orange-math/portfile.cmake
@@ -10,11 +10,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-# We just let it built further as compiler would emit error since it wont recognize -mavx2 -mfma
-if(VCPKG_TARGET_IS_ANDROID)
-    vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt" [[if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")]] [[if (0)]])
-endif()
-
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" OMATH_SHARED)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/orange-math/portfile.cmake
+++ b/ports/orange-math/portfile.cmake
@@ -10,6 +10,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# We just let it built further as compiler would emit error since it wont recognize -mavx2 -mfma
+if(VCPKG_TARGET_IS_ANDROID)
+    vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt" [[if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")]] [[if (0)]])
+endif()
+
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" OMATH_SHARED)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "General purpose math library",
   "homepage": "https://github.com/orange-cpp/omath",
   "license": "MIT",
+  "supports": "windows | linux",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -15,6 +16,7 @@
     }
   ],
   "default-features": [
+    "avx2",
     "imgui"
   ],
   "features": {

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -15,9 +15,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "imgui"
-  ],
   "features": {
     "avx2": {
       "description": "Omath will use AVX2 to boost performance"

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "General purpose math library",
   "homepage": "https://github.com/orange-cpp/omath",
   "license": "MIT",
-  "supports": "windows",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -16,13 +15,11 @@
     }
   ],
   "default-features": [
-    "avx2",
     "imgui"
   ],
   "features": {
     "avx2": {
-      "description": "Omath will use AVX2 to boost performance",
-      "supports": "!arm"
+      "description": "Omath will use AVX2 to boost performance"
     },
     "imgui": {
       "description": "Omath will define method to convert omath types to imgui types",

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -16,7 +16,6 @@
     }
   ],
   "default-features": [
-    "avx2",
     "imgui"
   ],
   "features": {

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "orange-math",
-  "version": "1.0.1",
+  "version": "3.0.3",
   "description": "General purpose math library",
   "homepage": "https://github.com/orange-cpp/omath",
   "license": "MIT",
@@ -14,5 +14,21 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "avx2",
+    "imgui"
+  ],
+  "features": {
+    "avx2": {
+      "description": "Omath will use AVX2 to boost performance",
+      "supports": "!arm"
+    },
+    "imgui": {
+      "description": "Omath will define method to convert omath types to imgui types",
+      "dependencies": [
+        "imgui"
+      ]
+    }
+  }
 }

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "3.0.3",
   "description": "General purpose math library",
   "homepage": "https://github.com/orange-cpp/omath",
-  "license": "MIT",
+  "license": "Zlib",
   "supports": "windows | linux",
   "dependencies": [
     {

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -776,6 +776,7 @@ optional-bare:x64-windows-static-md=skip
 optional-bare:x64-windows-static=skip
 optional-bare:x64-windows=skip
 optional-bare:x86-windows=skip
+orange-math:x64-linux=fail
 orc:arm-neon-android=fail
 orc:arm64-android=fail
 orc:x64-android=fail

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -2172,6 +2172,7 @@ openmvg(windows & arm) = fail # nmmintrin.h(17): fatal error C1189: #error:  Thi
 openscap[python](!windows) = feature-fails # CI image lacks swig
 opentelemetry-cpp[otlp](uwp) = feature-fails # --grpc_out: protoc-gen-grpc: The system cannot find the file specified. See https://github.com/microsoft/vcpkg/issues/34847
 openvdb[ax] = feature-fails # ax requires llvm version <= 14. Work when using a baseline + overwrite
+orange-math(linux) = fail # requires gcc15 or later
 osgearth[tools](osx) = feature-fails # Undefined _NSSearchPathForDirectoriesInDomains
 pangolin[core,eigen,examples,ffmpeg,gui,jpeg,lz4,module,openexr,png,pybind11,realsense,test,tiff,tools,vars,video,zstd](!(arm & windows)) = combination-fails # see https://github.com/microsoft/vcpkg/issues/31304
 poco[core,mariadb,mysql] = options # You can not install mariadb and mysql at the same time

--- a/scripts/test_ports/vcpkg-ci-orange-math/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-orange-math/project/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.26)
 
 project(vcpkg-ci-orange-math)
 
-set(CMAKE_CXX_STANDARD 26)
+set(CMAKE_CXX_STANDARD 23)
 
 add_executable(main main.cpp)
 

--- a/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
@@ -1,18 +1,7 @@
-#include <iostream>
 #include <omath/Vector2.hpp>
-#include <omath/pathfinding/Astar.hpp>
 
 int main()
 {
-	omath::pathfinding::NavigationMesh mesh;
-
-	mesh.m_verTextMap[{0.f, 0.f, 0.f}] = { {0.f, 1.f, 0.f} };
-	mesh.m_verTextMap[{0.f, 1.f, 0.f}] = { {0.f, 2.f, 0.f} };
-	mesh.m_verTextMap[{0.f, 2.f, 0.f}] = { {0.f, 3.f, 0.f} };
-	mesh.m_verTextMap[{0.f, 3.f, 0.f}] = {};
-
 	omath::Vector2 w = omath::Vector2(20.0, 30.0);
-	std::cout << w.x << "\t" << w.y << std::endl;
-
 	return 0;
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7101,7 +7101,7 @@
       "port-version": 1
     },
     "orange-math": {
-      "baseline": "1.0.1",
+      "baseline": "3.0.3",
       "port-version": 0
     },
     "orc": {

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "55aa9346aef1fa4d935e59167bb371aa6091cfb7",
+      "git-tree": "237d96964ad087cd579f6d21bc04181da48d1f2f",
       "version": "3.0.3",
       "port-version": 0
     },

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "237d96964ad087cd579f6d21bc04181da48d1f2f",
+      "git-tree": "4a075427ed6e5edf423bb464acdb1cb2a21ffc51",
       "version": "3.0.3",
       "port-version": 0
     },

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5be058afc332e9ed9ac5f58dac49729fd4c1a596",
+      "git-tree": "ae4b7b00db370ec2712fa46cc58a2147bc2f6cdc",
       "version": "3.0.3",
       "port-version": 0
     },

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a075427ed6e5edf423bb464acdb1cb2a21ffc51",
+      "git-tree": "e4d267c3d4b33acf267047cb64cf7cf9857ec4d8",
       "version": "3.0.3",
       "port-version": 0
     },

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5be058afc332e9ed9ac5f58dac49729fd4c1a596",
+      "version": "3.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "a0015767dd3fca5dcd70397302311194c88af7e4",
       "version": "1.0.1",
       "port-version": 0

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ae4b7b00db370ec2712fa46cc58a2147bc2f6cdc",
+      "git-tree": "55aa9346aef1fa4d935e59167bb371aa6091cfb7",
       "version": "3.0.3",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

I found it is tough to keep dll export surface working together with library code as I do not know much how to make it working properly besides it should compile without warnings, so dllexport/dllimport was deleted very long time ago, source code no longer support OMATH_EXPORT.
I decided to simplify vcpkg-ci-test little bit.