### PR TITLE
[cudnn] simplify port and add compatibility with v x.10

### DIFF
--- a/ports/cudnn/FindCUDNN.cmake
+++ b/ports/cudnn/FindCUDNN.cmake
@@ -25,14 +25,14 @@
 include(FindPackageHandleStandardArgs)
 file(GLOB CUDNN_VERSION_DIRS
   LIST_DIRECTORIES true
-  "$ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v[1-9]*.[1-9]*"
+  "$ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v[1-9]*.[0-9]*"
 )
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
   HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
-  PATH_SUFFIXES cuda/include include include/11.8 include/12.0 include/12.1 include/12.2 include/12.3 include/12.4 include/12.5 include/12.6)
+  PATH_SUFFIXES cuda/include include include/11.8 include/12.0 include/12.1 include/12.2 include/12.3 include/12.4 include/12.5 include/12.6 include/12.7 include/12.8 include/12.9)
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
   HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/lib/x86_64-linux-gnu/ /usr/lib/aarch64-linux-gnu/ /usr/
-  PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/11.8/x64 lib/12.0/x64 lib/12.1/x64 lib/12.2/x64 lib/12.3/x64 lib/12.4/x64 lib/12.5/x64 lib/12.6/x64)
+  PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/11.8/x64 lib/12.0/x64 lib/12.1/x64 lib/12.2/x64 lib/12.3/x64 lib/12.4/x64 lib/12.5/x64 lib/12.6/x64 lib/12.7/x64 lib/12.8/x64 lib/12.9/x64)
 
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")
   file(READ ${CUDNN_INCLUDE_DIR}/cudnn.h CUDNN_HEADER_CONTENTS)
@@ -83,25 +83,23 @@ find_package_handle_standard_args(CUDNN
       VERSION_VAR    CUDNN_VERSION
 )
 
-if(WIN32)
-  set(CUDNN_DLL_DIR ${CUDNN_INCLUDE_DIR})
-  list(TRANSFORM CUDNN_DLL_DIR APPEND "/../bin")
-  find_file(CUDNN_LIBRARY_DLL NAMES cudnn64_${CUDNN_VERSION_MAJOR}.dll PATHS ${CUDNN_DLL_DIR})
-endif()
+set(CUDNN_DLL_DIR ${CUDNN_INCLUDE_DIR})
+list(TRANSFORM CUDNN_DLL_DIR APPEND "/../bin")
+find_file(CUDNN_LIBRARY_DLL NAMES cudnn64_${CUDNN_VERSION_MAJOR}.dll PATHS ${CUDNN_DLL_DIR})
 
-if( CUDNN_FOUND AND NOT TARGET CuDNN::CuDNN )
-  if( EXISTS "${CUDNN_LIBRARY_DLL}" )
-    add_library( CuDNN::CuDNN      SHARED IMPORTED )
-    set_target_properties( CuDNN::CuDNN PROPERTIES
+if(CUDNN_FOUND AND NOT TARGET CuDNN::CuDNN AND NOT CMAKE_SCRIPT_MODE_FILE)
+  if(EXISTS "${CUDNN_LIBRARY_DLL}")
+    add_library(CuDNN::CuDNN      SHARED IMPORTED)
+    set_target_properties(CuDNN::CuDNN PROPERTIES
       IMPORTED_LOCATION                 "${CUDNN_LIBRARY_DLL}"
       IMPORTED_IMPLIB                   "${CUDNN_LIBRARY}"
       INTERFACE_INCLUDE_DIRECTORIES     "${CUDNN_INCLUDE_DIR}"
-      IMPORTED_LINK_INTERFACE_LANGUAGES "C" )
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C")
   else()
-    add_library( CuDNN::CuDNN      UNKNOWN IMPORTED )
-    set_target_properties( CuDNN::CuDNN PROPERTIES
+    add_library(CuDNN::CuDNN      UNKNOWN IMPORTED)
+    set_target_properties(CuDNN::CuDNN PROPERTIES
       IMPORTED_LOCATION                 "${CUDNN_LIBRARY}"
       INTERFACE_INCLUDE_DIRECTORIES     "${CUDNN_INCLUDE_DIR}"
-      IMPORTED_LINK_INTERFACE_LANGUAGES "C" )
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C")
   endif()
 endif()

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -2,58 +2,7 @@ set(MINIMUM_CUDNN_VERSION "7.6.5")
 
 vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT OUT_CUDA_VERSION CUDA_VERSION)
 
-# Try to find CUDNN if it exists; only download if it doesn't exist
-file(GLOB CUDNN_VERSION_DIRS
-  LIST_DIRECTORIES true
-  "$ENV{CUDA_PATH}/../../../NVIDIA/CUDNN/v[1-9]*.[1-9]*"
-)
-find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/include /usr/include/x86_64-linux-gnu/ /usr/include/aarch64-linux-gnu/
-  PATH_SUFFIXES cuda/include include include/11.8 include/12.0 include/12.1 include/12.2 include/12.3 include/12.4 include/12.5 include/12.6)
-message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
-find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} ${CUDNN_VERSION_DIRS} /usr/lib/x86_64-linux-gnu/ /usr/lib/aarch64-linux-gnu/ /usr/
-  PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64 cuda/lib/x64 lib/11.8/x64 lib/12.0/x64 lib/12.1/x64 lib/12.2/x64 lib/12.3/x64 lib/12.4/x64 lib/12.5/x64 lib/12.6/x64)
-message(STATUS "CUDNN_LIBRARY: ${CUDNN_LIBRARY}")
-if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")
-  file(READ ${CUDNN_INCLUDE_DIR}/cudnn.h CUDNN_HEADER_CONTENTS)
-elseif(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn_v8.h")
-  file(READ ${CUDNN_INCLUDE_DIR}/cudnn_v8.h CUDNN_HEADER_CONTENTS)
-elseif(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn_v7.h")
-  file(READ ${CUDNN_INCLUDE_DIR}/cudnn_v7.h CUDNN_HEADER_CONTENTS)
-endif()
-if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn_version.h")
-  file(READ "${CUDNN_INCLUDE_DIR}/cudnn_version.h" CUDNN_VERSION_H_CONTENTS)
-  string(APPEND CUDNN_HEADER_CONTENTS "${CUDNN_VERSION_H_CONTENTS}")
-  unset(CUDNN_VERSION_H_CONTENTS)
-elseif(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn_version_v8.h")
-  file(READ "${CUDNN_INCLUDE_DIR}/cudnn_version_v8.h" CUDNN_VERSION_H_CONTENTS)
-  string(APPEND CUDNN_HEADER_CONTENTS "${CUDNN_VERSION_H_CONTENTS}")
-  unset(CUDNN_VERSION_H_CONTENTS)
-elseif(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn_version_v7.h")
-  file(READ "${CUDNN_INCLUDE_DIR}/cudnn_version_v7.h" CUDNN_VERSION_H_CONTENTS)
-  string(APPEND CUDNN_HEADER_CONTENTS "${CUDNN_VERSION_H_CONTENTS}")
-  unset(CUDNN_VERSION_H_CONTENTS)
-endif()
-if(CUDNN_HEADER_CONTENTS)
-  string(REGEX MATCH "define CUDNN_MAJOR * +([0-9]+)"
-               _CUDNN_VERSION_MAJOR "${CUDNN_HEADER_CONTENTS}")
-  string(REGEX REPLACE "define CUDNN_MAJOR * +([0-9]+)" "\\1"
-               _CUDNN_VERSION_MAJOR "${_CUDNN_VERSION_MAJOR}")
-  string(REGEX MATCH "define CUDNN_MINOR * +([0-9]+)"
-               _CUDNN_VERSION_MINOR "${CUDNN_HEADER_CONTENTS}")
-  string(REGEX REPLACE "define CUDNN_MINOR * +([0-9]+)" "\\1"
-               _CUDNN_VERSION_MINOR "${_CUDNN_VERSION_MINOR}")
-  string(REGEX MATCH "define CUDNN_PATCHLEVEL * +([0-9]+)"
-               _CUDNN_VERSION_PATCH "${CUDNN_HEADER_CONTENTS}")
-  string(REGEX REPLACE "define CUDNN_PATCHLEVEL * +([0-9]+)" "\\1"
-               _CUDNN_VERSION_PATCH "${_CUDNN_VERSION_PATCH}")
-  if(NOT _CUDNN_VERSION_MAJOR)
-    set(_CUDNN_VERSION "?")
-  else()
-    set(_CUDNN_VERSION "${_CUDNN_VERSION_MAJOR}.${_CUDNN_VERSION_MINOR}.${_CUDNN_VERSION_PATCH}")
-  endif()
-endif()
+include("${CURRENT_PORT_DIR}/FindCUDNN.cmake")
 
 if (CUDNN_INCLUDE_DIR AND CUDNN_LIBRARY AND _CUDNN_VERSION VERSION_GREATER_EQUAL MINIMUM_CUDNN_VERSION)
   message(STATUS "Found CUDNN ${_CUDNN_VERSION} located on system: (include ${CUDNN_INCLUDE_DIR} lib: ${CUDNN_LIBRARY})")

--- a/ports/cudnn/vcpkg.json
+++ b/ports/cudnn/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cudnn",
   "version": "7.6.5",
-  "port-version": 15,
+  "port-version": 16,
   "description": "NVIDIA's cuDNN deep neural network acceleration library.",
   "homepage": "https://developer.nvidia.com/cudnn",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2206,7 +2206,7 @@
     },
     "cudnn": {
       "baseline": "7.6.5",
-      "port-version": 15
+      "port-version": 16
     },
     "cunit": {
       "baseline": "2.1.3",

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48e410f08565c010facbe07075833c6ca863f781",
+      "version": "7.6.5",
+      "port-version": 16
+    },
+    {
       "git-tree": "1708ed3cc056c2d863c3e4e7901b057e083eeaa4",
       "version": "7.6.5",
       "port-version": 15


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.