### PR TITLE
[vcpkg-tool-nodejs] Do not break osx code signatures

### DIFF
--- a/ports/vcpkg-tool-nodejs/portfile.cmake
+++ b/ports/vcpkg-tool-nodejs/portfile.cmake
@@ -61,3 +61,8 @@ vcpkg_execute_in_download_mode(
 )
 
 file(RENAME "${CURRENT_PACKAGES_DIR}/tools/${ARCHIVE}" "${CURRENT_PACKAGES_DIR}/tools/node")
+
+# Do not break code signatures
+if(VCPKG_TARGET_IS_OSX)
+    set(VCPKG_FIXUP_MACHO_RPATH OFF)
+endif()

--- a/ports/vcpkg-tool-nodejs/vcpkg.json
+++ b/ports/vcpkg-tool-nodejs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-tool-nodejs",
   "version-semver": "16.18.0",
-  "port-version": 1,
+  "port-version": 2,
   "supports": "native"
 }

--- a/scripts/test_ports/vcpkg-ci-vcpkg-tool-nodejs/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-vcpkg-tool-nodejs/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 find_program(NODEJS
     NAMES node
     PATHS
-        "${CURRENT_HOST_INSTALLED_DIR}/tools/node"
-        "${CURRENT_HOST_INSTALLED_DIR}/tools/node/bin"
+        "${CURRENT_INSTALLED_DIR}/tools/node"
+        "${CURRENT_INSTALLED_DIR}/tools/node/bin"
     NO_DEFAULT_PATH
     REQUIRED
 )

--- a/scripts/test_ports/vcpkg-ci-vcpkg-tool-nodejs/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-vcpkg-tool-nodejs/portfile.cmake
@@ -1,0 +1,20 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+find_program(NODEJS
+    NAMES node
+    PATHS
+        "${CURRENT_HOST_INSTALLED_DIR}/tools/node"
+        "${CURRENT_HOST_INSTALLED_DIR}/tools/node/bin"
+    NO_DEFAULT_PATH
+    REQUIRED
+)
+execute_process(
+    COMMAND "${NODEJS}" --version
+    COMMAND_ECHO STDOUT
+    COMMAND_ERROR_IS_FATAL ANY
+)
+execute_process(
+    COMMAND "${NODEJS}" -p "process.arch"
+    COMMAND_ECHO STDOUT
+    COMMAND_ERROR_IS_FATAL ANY
+)

--- a/scripts/test_ports/vcpkg-ci-vcpkg-tool-nodejs/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-vcpkg-tool-nodejs/vcpkg.json
@@ -2,5 +2,8 @@
   "name": "vcpkg-ci-vcpkg-tool-nodejs",
   "version-string": "ci",
   "description": "Test port to validate vcpkg-tool-nodejs",
-  "supports": "native"
+  "supports": "native",
+  "dependencies": [
+    "vcpkg-tool-nodejs"
+  ]
 }

--- a/scripts/test_ports/vcpkg-ci-vcpkg-tool-nodejs/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-vcpkg-tool-nodejs/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "vcpkg-ci-vcpkg-tool-nodejs",
+  "version-string": "ci",
+  "description": "Test port to validate vcpkg-tool-nodejs",
+  "supports": "native"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9950,7 +9950,7 @@
     },
     "vcpkg-tool-nodejs": {
       "baseline": "16.18.0",
-      "port-version": 1
+      "port-version": 2
     },
     "vcpkg-tool-python2": {
       "baseline": "2.7.18",

--- a/versions/v-/vcpkg-tool-nodejs.json
+++ b/versions/v-/vcpkg-tool-nodejs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d004b33aa9e92c31d1238728de1546712af44d0",
+      "version-semver": "16.18.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "2738f551c277a4ac6650e7d140fc36aa26210a63",
       "version-semver": "16.18.0",
       "port-version": 1


### PR DESCRIPTION
Cherry-picked from https://github.com/microsoft/vcpkg/pull/46162.
Fixes nodejs on arm64-osx:
~~~
CMake Error at ports/qtwebengine/portfile.cmake:138 (execute_process):
  execute_process failed command indexes:

    1: "Abnormal exit with child return code: Subprocess killed"

Call Stack (most recent call first):
  scripts/ports.cmake:206 (include)

'/Users/vcpkg/Data/installed/arm64-osx/tools/node/bin/node' '--version'

~~~