### PR TITLE
[wolfTPM] Feature Update: Adding feature for No Active Thread Local Storage

### DIFF
--- a/ports/wolftpm/portfile.cmake
+++ b/ports/wolftpm/portfile.cmake
@@ -6,12 +6,38 @@ vcpkg_from_github(
     HEAD_REF master
     )
 
+if ("${VERSION}" VERSION_GREATER_EQUAL "3.9.2") #CMAKE logic added in versions newer than 3.9.1
+  if ("no-active-thread-ls" IN_LIST FEATURES)
+    set(ENABLE_NO_ACTIVE_THREAD_LS yes)
+  else()
+    set(ENABLE_NO_ACTIVE_THREAD_LS no)
+  endif()
+endif()
+
+
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+
+foreach(config RELEASE DEBUG)
+  if ("${VERSION}" VERSION_LESS "3.9.2") #CMAKE logic not present in versions older than 3.9.2
+    if ("no-active-thread-ls" IN_LIST FEATURES)
+      string(APPEND VCPKG_COMBINED_C_FLAGS_${config} " -DWOLFTPM_NO_ACTIVE_THREAD_LS")
+    endif()
+  endif()
+endforeach()
+
+# Add debug flag for debug builds
+string(APPEND VCPKG_COMBINED_C_FLAGS_DEBUG " -DDEBUG_WOLFTPM")
+
 vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
       -DWOLFTPM_EXAMPLES=no
       -DWOLFTPM_BUILD_OUT_OF_TREE=yes
+      -DWOLFTPM_NO_ACTIVE_THREAD_LS=${ENABLE_NO_ACTIVE_THREAD_LS}
+    OPTIONS_RELEASE
+      -DCMAKE_C_FLAGS=${VCPKG_COMBINED_C_FLAGS_RELEASE}
     OPTIONS_DEBUG
-      -DCMAKE_C_FLAGS='-DDEBUG_WOLFTPM'
+      -DCMAKE_C_FLAGS=${VCPKG_COMBINED_C_FLAGS_DEBUG}
     )
 
 vcpkg_cmake_install()

--- a/ports/wolftpm/vcpkg.json
+++ b/ports/wolftpm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "wolftpm",
   "version": "3.9.1",
+  "port-version": 1,
   "description": "TPM library used with wolfSSL library for many platforms",
   "homepage": "https://wolfssl.com",
   "license": "GPL-2.0-or-later",
@@ -14,6 +15,15 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
     "wolfssl"
-  ]
+  ],
+  "features": {
+    "no-active-thread-ls": {
+      "description": "Disable active thread local storage"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10222,7 +10222,7 @@
     },
     "wolftpm": {
       "baseline": "3.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "wordnet": {
       "baseline": "3.0",

--- a/versions/w-/wolftpm.json
+++ b/versions/w-/wolftpm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e34310bf5f336829a93a9ed4c9b6936b8008dea",
+      "version": "3.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "a992f959b43632e9ad2a7478aa54b330e4669e0f",
       "version": "3.9.1",
       "port-version": 0


### PR DESCRIPTION
This PR adds the ability to turn on the wolfTPM feature of `No Active Thread Local Storage`.

<s>The CMAKE logic changed in wolfTPM after version `3.9.1` see: [wolfTPM PR#420](https://github.com/wolfSSL/wolfTPM/pull/420)
This change was a inversion of of the logic parsing. So in version `3.9.1` you would need to set `-DWOLFTPM_NO_ACTIVE_THREAD_LS=no` while in newer/master versions of wolfTPM you now use `-DWOLFTPM_NO_ACTIVE_THREAD_LS=yes` to achieve this functionality.

Hence why in the PR you have the Logic change based on the version number. This is to hopefully abstract this issue from the package user so that future releases don`t break intended configuration.</s>


Initially was mistaken, a CMAKE option for this feature (`WOLFTPM_NO_ACTIVE_THREAD_LS`) was not present in the CMakeLists in 3.9.1 and older, it is available in the current master.

It should switch to using the CMAKE arguments for newer versions

`3.9.1` [CMakeLists ](https://github.com/wolfSSL/wolfTPM/blob/v3.9.1/CMakeLists.txt) (No `WOLFTPM_NO_ACTIVE_THREAD_LS` option, but feature is present in the code)

`Current/Master` [CMakeLists](https://github.com/wolfSSL/wolfTPM/blob/dcaf96b937704b7e87843111e403d8f63ccf9751/CMakeLists.txt#L103) Present in current master aka future releases


---- Check List ----
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
