### PR TITLE
[meojson] Add new port

### DIFF
--- a/ports/meojson/meojson-config.cmake
+++ b/ports/meojson/meojson-config.cmake
@@ -1,0 +1,8 @@
+include(CMakeFindDependencyMacro)
+
+if(NOT TARGET meojson::meojson)
+    add_library(meojson::meojson INTERFACE IMPORTED)
+    set_target_properties(meojson::meojson PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../../include"
+    )
+endif()

--- a/ports/meojson/portfile.cmake
+++ b/ports/meojson/portfile.cmake
@@ -1,0 +1,18 @@
+#header-only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO MistEO/meojson
+    REF v4.4.1
+    SHA512 c6f7ec05e754a68df75d1743c874e503098cac093f24403014e7759391d19733a281277fdd7b7789b21fa060892f3fc7bc107bb742754eb80add3969a12cf872
+    HEAD_REF master
+)
+
+file(INSTALL
+    "${SOURCE_PATH}/include/"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/meojson"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/meojson-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/meojson/usage
+++ b/ports/meojson/usage
@@ -1,0 +1,4 @@
+The package meojson provides CMake targets:
+
+    find_package(meojson CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE meojson::meojson)

--- a/ports/meojson/vcpkg.json
+++ b/ports/meojson/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "meojson",
+  "version": "4.4.1",
+  "description": "✨ Next-gen C++ JSON/JSON5 Serialization Engine | Zero Dependency | Header-Only | Unleash JSON Potential",
+  "homepage": "https://github.com/MistEO/meojson",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6148,6 +6148,10 @@
       "baseline": "2019-12-31",
       "port-version": 3
     },
+    "meojson": {
+      "baseline": "4.4.1",
+      "port-version": 0
+    },
     "mesa": {
       "baseline": "24.0.7",
       "port-version": 3

--- a/versions/m-/meojson.json
+++ b/versions/m-/meojson.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e9c0c4b78b045fed2ba003b2dcc8295d8d910f14",
+      "version": "4.4.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
