### PR TITLE
Add printing of disk usage on macOS to help debug where space is going.

### DIFF
--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -168,6 +168,13 @@ if ($lastLastExitCode -ne 0)
     exit $lastLastExitCode
 }
 
+if ($IsMacOS)
+{
+    Write-Host "macOS disk space report:"
+    & df -h | Where-Object { $_ -match "Avail|/System/Volumes/Data$" }
+    & du -sh $WorkingRoot
+}
+
 $parentHashesArgs = @()
 if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
 {


### PR DESCRIPTION
We are trying to diagnose a problem which slowly kills the macOS build machines; we see hundreds of GB of disk space which are unaccounted for.

This adds printing the filesystem consumption and the directory we use for test data; if those numbers start being very far apart that is an indication that we need to reset the physical machine.