### PR TITLE
[coin] update to 4.0.4 and add feature superglu

### DIFF
--- a/ports/coin/portfile.cmake
+++ b/ports/coin/portfile.cmake
@@ -35,11 +35,10 @@ elseif(VCPKG_CRT_LINKAGE STREQUAL static)
     set(COIN_BUILD_MSVC_STATIC_RUNTIME ON)
 endif()
 
-if("superglu" IN_LIST FEATURES)
-    set(USE_SUPERGLU ON)
-else()
-    set(USE_SUPERGLU OFF)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+FEATURES
+  superglu USE_SUPERGLU
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -49,7 +48,7 @@ vcpkg_cmake_configure(
         -DCOIN_BUILD_MSVC_STATIC_RUNTIME=${COIN_BUILD_MSVC_STATIC_RUNTIME}
         -DCOIN_BUILD_SHARED_LIBS=${COIN_BUILD_SHARED_LIBS}
         -DCOIN_BUILD_TESTS=OFF
-        -DUSE_SUPERGLU=${USE_SUPERGLU}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/coin/portfile.cmake
+++ b/ports/coin/portfile.cmake
@@ -17,7 +17,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Coin3D/coin
     REF "v${VERSION}"
-    SHA512 c526c0545efa9852c647e163bbf69caae2e3a0eb4e99a8fc7a313172b8d1006e304a4d19bacbd8820443b0d4f90775ee31ca711da4ad2d432783ef5c8bc85074
+    SHA512 5e9505efda536a6687fd1cfcc4589af9bfbdbd4a8d660335c060e1678f84c5db91415e0a40ee7b4b40e5894d7330172a24f822d38c0ea276badb92fc68efeec8
     HEAD_REF master
     PATCHES
         remove-default-config.patch
@@ -35,6 +35,12 @@ elseif(VCPKG_CRT_LINKAGE STREQUAL static)
     set(COIN_BUILD_MSVC_STATIC_RUNTIME ON)
 endif()
 
+if("superglu" IN_LIST FEATURES)
+    set(USE_SUPERGLU ON)
+else()
+    set(USE_SUPERGLU OFF)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -43,6 +49,7 @@ vcpkg_cmake_configure(
         -DCOIN_BUILD_MSVC_STATIC_RUNTIME=${COIN_BUILD_MSVC_STATIC_RUNTIME}
         -DCOIN_BUILD_SHARED_LIBS=${COIN_BUILD_SHARED_LIBS}
         -DCOIN_BUILD_TESTS=OFF
+        -DUSE_SUPERGLU=${USE_SUPERGLU}
 )
 
 vcpkg_cmake_install()

--- a/ports/coin/remove-default-config.patch
+++ b/ports/coin/remove-default-config.patch
@@ -1,12 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -395,8 +395,8 @@
-     configure_file("${CMAKE_SOURCE_DIR}/${PROJECT_NAME}.pc.cmake.in" "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc" @ONLY)
+     configure_file("${PROJECT_SOURCE_DIR}/${PROJECT_NAME}.pc.cmake.in" "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc" @ONLY)
      install(FILES "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-     install(PROGRAMS "${CMAKE_SOURCE_DIR}/bin/coin-config" DESTINATION ${CMAKE_INSTALL_BINDIR})
--    configure_file("${CMAKE_SOURCE_DIR}/coin.cfg.cmake.in" "${CMAKE_BINARY_DIR}/${PROJECT_NAME_LOWER}-default.cfg" @ONLY)
+     install(PROGRAMS "${PROJECT_SOURCE_DIR}/bin/coin-config" DESTINATION ${CMAKE_INSTALL_BINDIR})
+-    configure_file("${PROJECT_SOURCE_DIR}/coin.cfg.cmake.in" "${CMAKE_BINARY_DIR}/${PROJECT_NAME_LOWER}-default.cfg" @ONLY)
 -    install(FILES "${CMAKE_BINARY_DIR}/${PROJECT_NAME_LOWER}-default.cfg" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/Coin/conf)
-+    #configure_file("${CMAKE_SOURCE_DIR}/coin.cfg.cmake.in" "${CMAKE_BINARY_DIR}/${PROJECT_NAME_LOWER}-default.cfg" @ONLY)
++    #configure_file("${PROJECT_SOURCE_DIR}/coin.cfg.cmake.in" "${CMAKE_BINARY_DIR}/${PROJECT_NAME_LOWER}-default.cfg" @ONLY)
 +    #install(FILES "${CMAKE_BINARY_DIR}/${PROJECT_NAME_LOWER}-default.cfg" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/Coin/conf)
    endif()
  endif()

--- a/ports/coin/vcpkg.json
+++ b/ports/coin/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "coin",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A high-level 3D visualization library with Open Inventor 2.1 API",
   "homepage": "https://github.com/coin3d/coin",
   "license": "BSD-3-Clause",
@@ -61,6 +61,13 @@
       "description": "Use simage for loading images (textures), audio, and animations",
       "dependencies": [
         "simage"
+      ]
+    },
+    "superglu": {
+      "description": "Use SuperGLU (SGI GLU fork with fixes) instead of system GLU",
+      "supports": "windows",
+      "dependencies": [
+        "superglu"
       ]
     },
     "zlib": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1825,7 +1825,7 @@
       "port-version": 0
     },
     "coin": {
-      "baseline": "4.0.3",
+      "baseline": "4.0.4",
       "port-version": 0
     },
     "coin-or-buildtools": {

--- a/versions/c-/coin.json
+++ b/versions/c-/coin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5bd70dc9bb2d7f6e6b4230708d403b753489af15",
+      "version": "4.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "e2e30210c211c4f2e33abcbb9962b8ee03c8711b",
       "version": "4.0.3",
       "port-version": 0

--- a/versions/c-/coin.json
+++ b/versions/c-/coin.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5bd70dc9bb2d7f6e6b4230708d403b753489af15",
+      "git-tree": "f496bc7243ce350967c8110f8845baa7ea2cca35",
       "version": "4.0.4",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
This version addresses the following CMake deprecation warning:
```cmake
...(cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
  ```
  
  Feature superglu will be used to optimize the display of B-spline curves in coin3d on windows.
see https://github.com/coin3d/coin/issues/375

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

<!-- END OF NEW PORT CHECKLIST -->