### PR TITLE
[fastgltf] update to 0.9.0

### DIFF
--- a/ports/fastgltf/portfile.cmake
+++ b/ports/fastgltf/portfile.cmake
@@ -1,31 +1,9 @@
-vcpkg_download_distfile(PATCH_FIX_ANDROID_ISSUE_74
-    URLS https://github.com/spnda/fastgltf/commit/e42df8b70d42f62fa9c678c23213e9cb649b9060.patch?full_index=1
-    SHA512 1f205aef9fa5658f7139304002528db612e5f6d74b8281a568c52a0bcd94830c113c9875ea887374785ad041139ee336a66de1881179b0317900249a1140f537
-    FILENAME spnda-fastgltf-v0.8.0-e42df8b70d42f62fa9c678c23213e9cb649b9060.patch
-)
-
-vcpkg_download_distfile(PATCH_UWP_DISABLE_MEMORYMAPPEDFILE
-    URLS https://github.com/spnda/fastgltf/commit/279d960eee4c85690c90df92ce0bdc121a6233f4.patch?full_index=1
-    SHA512 4f837e03c9b3ee3333a09b675e2395b300fff8e8231962a26da18e32d84cc9099bf231c174ca100c324e45beb0891fb5aeea40f35d71881350d845e6e2c95cd6
-    FILENAME spnda-fastgltf-v0.8.0-279d960eee4c85690c90df92ce0bdc121a6233f4.patch
-)
-
-vcpkg_download_distfile(PATCH_UWP_WINAPI_FAMILY
-    URLS https://github.com/spnda/fastgltf/commit/5278229d48e06d4770ecfea97402bbe1c8380038.patch?full_index=1
-    SHA512 2521859f6126d0602ac9d641553ab502ad21ccc6f9227cf23da16ae7ae6df77f53b9a2b883c52a9ae191476a57a07e0008aa42f00c61cef09cc5d7145586e729
-    FILENAME spnda-fastgltf-v0.8.0-5278229d48e06d4770ecfea97402bbe1c8380038.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO spnda/fastgltf
     REF "v${VERSION}"
-    SHA512 7fbc479e03b26ef246625abd86b005ed1dde84e607346e890b71abffc2b26cf7b59880ab286526da5b811dd1f74cff9a6d44d65e128154fcd0f1c540dc11f1f5
+    SHA512 b18162eb8a1631d9a28ed97961ac8f08d6aa2797f2bf035a470660cfd052f25c2bd47b77ce2c3f5367d5006c706cf6e00a710c14a25ad5e02b619430ea076882
     HEAD_REF main
-    PATCHES
-        "${PATCH_FIX_ANDROID_ISSUE_74}"
-        "${PATCH_UWP_DISABLE_MEMORYMAPPEDFILE}"
-        "${PATCH_UWP_WINAPI_FAMILY}"
 )
 
 vcpkg_cmake_configure(

--- a/ports/fastgltf/vcpkg.json
+++ b/ports/fastgltf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastgltf",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A modern C++17 glTF 2.0 library focused on speed, correctness, and usability",
   "homepage": "https://github.com/spnda/fastgltf",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2801,7 +2801,7 @@
       "port-version": 4
     },
     "fastgltf": {
-      "baseline": "0.8.0",
+      "baseline": "0.9.0",
       "port-version": 0
     },
     "fastio": {

--- a/versions/f-/fastgltf.json
+++ b/versions/f-/fastgltf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "711af0690ff761db0fd1e35c1645f2bd00bb90ad",
+      "version": "0.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "004b3a844521c72dd3699e70c91ff1e095b96b45",
       "version": "0.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/spnda/fastgltf/releases/tag/v0.9.0
