### PR TITLE
[double-conversion] Bump to 3.3.1

### DIFF
--- a/ports/double-conversion/portfile.cmake
+++ b/ports/double-conversion/portfile.cmake
@@ -1,17 +1,9 @@
-vcpkg_download_distfile(PATCH_501_FIX_CMAKE_3_5
-    URLS https://github.com/google/double-conversion/commit/101e1ba89dc41ceb75090831da97c43a76cd2906.patch?full_index=1
-    SHA512 a946a1909b10f3ac5262cbe5cd358a74cf018325223403749aaeb81570ef3e2f833ee806afdefcd388e56374629de8ccca0a1cef787afa481c79f9e8f8dcaa13
-    FILENAME google-double-conversion-101e1ba89dc41ceb75090831da97c43a76cd2906.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/double-conversion
     REF "v${VERSION}"
-    SHA512 51e84eb7a5c407f7bc8f8b8ca19932ece5c9d8ac18aedff7b7620fc67369d9b2aa8c5a6b133e7f8633d7cc5e3788bad6e60b0e48ac08d0a4bc5e4abe7cee1334
+    SHA512 60cab2fe623204cfa8737150e6ffcae091266180461dba377231e4fe8dccf712e74c643cd317b62266240ab82f1c0f820cf825038d627934d2dd0af1426f0cca
     HEAD_REF master
-    PATCHES
-        "${PATCH_501_FIX_CMAKE_3_5}"
 )
 
 vcpkg_cmake_configure(
@@ -19,13 +11,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-
-# Rename exported target files into something vcpkg_cmake_config_fixup expects
-if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT}")
-    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
-endif()
-
-vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/double-conversion/vcpkg.json
+++ b/ports/double-conversion/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "double-conversion",
-  "version": "3.3.0",
-  "port-version": 1,
+  "version": "3.3.1",
   "description": "Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles.",
   "homepage": "https://github.com/google/double-conversion",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2465,8 +2465,8 @@
       "port-version": 0
     },
     "double-conversion": {
-      "baseline": "3.3.0",
-      "port-version": 1
+      "baseline": "3.3.1",
+      "port-version": 0
     },
     "dp-thread-pool": {
       "baseline": "0.7.0",

--- a/versions/d-/double-conversion.json
+++ b/versions/d-/double-conversion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a28a9c42d582dc61662c0407cca8362e6dc346ae",
+      "version": "3.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "aab0be9dfa5d0fe2452be21cfd4c7997e437c05b",
       "version": "3.3.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
