### PR TITLE
[stringzilla] Bump to 3.12.5

### DIFF
--- a/ports/stringzilla/portfile.cmake
+++ b/ports/stringzilla/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/StringZilla
     REF "v${VERSION}"
-    SHA512 65bb238b07521e6efeff15caa4abf6a8d15f66a5635e0b68e7ba255149f30cf56e76d91f183789093e45593639cb9f397d2cbb8bb02033179fbd150018e2c234
+    SHA512 1ec86fddf8fdc118bc0aaec5cf3d6a34b2e20572f2f8f7dcf33b50637faa7b8be6c04ae5be9df28fce6b0859fd75f4a6c76d39e8663fea965b8b40389433e2d4
     HEAD_REF master
 )
 

--- a/ports/stringzilla/vcpkg.json
+++ b/ports/stringzilla/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stringzilla",
-  "version": "3.12.4",
+  "version": "3.12.5",
   "description": "StringZilla is the GodZilla of string libraries, using SIMD and SWAR to accelerate string operations on modern CPUs.",
   "homepage": "https://github.com/ashvardanian/StringZilla",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9173,7 +9173,7 @@
       "port-version": 1
     },
     "stringzilla": {
-      "baseline": "3.12.4",
+      "baseline": "3.12.5",
       "port-version": 0
     },
     "strong-type": {

--- a/versions/s-/stringzilla.json
+++ b/versions/s-/stringzilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "781a6e2b9611185fdbde12458660b604cc7e3d22",
+      "version": "3.12.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "6770292f19937d808f6c492797491131fbf5bd95",
       "version": "3.12.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
