### PR TITLE
[dlfcn-win32] Bump to 1.4.2

### DIFF
--- a/ports/dlfcn-win32/portfile.cmake
+++ b/ports/dlfcn-win32/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dlfcn-win32/dlfcn-win32
     REF "v${VERSION}"
-    SHA512 2ddcaad7fff09be654589642af14689ebbc15212caea5b5fb0238b34188c87cd9cb53d7aee45c7ae4dd6ddf6e637ee945567d7b858b97ceefff8f1ec46b786ae
+    SHA512 13b52c078c20f97b4293257904d64c4a018115a68af606a04699acbe3f7ff07887eecd2512363c062eb43a34cedd27c5989bded4b7d0530d697dbd65dbdbffac
     HEAD_REF master
 )
 
@@ -16,8 +16,6 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-vcpkg_copy_pdbs()
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 

--- a/ports/dlfcn-win32/vcpkg.json
+++ b/ports/dlfcn-win32/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dlfcn-win32",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "dlfcn-win32 is an implementation of dlfcn for Windows.",
   "homepage": "https://github.com/dlfcn-win32/dlfcn-win32",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2441,7 +2441,7 @@
       "port-version": 0
     },
     "dlfcn-win32": {
-      "baseline": "1.4.1",
+      "baseline": "1.4.2",
       "port-version": 0
     },
     "dlib": {

--- a/versions/d-/dlfcn-win32.json
+++ b/versions/d-/dlfcn-win32.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80f2c52f546e5ba65c29921cddcc2ce48ab93fe8",
+      "version": "1.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "9eb1d5778fcb3bfa4d46ade382ae6b6e924d301f",
       "version": "1.4.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
