### PR TITLE
anari: Update to version 0.14.1

### DIFF
--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KhronosGroup/ANARI-SDK
   REF "v${VERSION}"
-  SHA512 86514b51f943aabd779b4c4adcad2d0db69912f2ace8aabeffbee7c3eb24f75e9055bb3690dc19d51b35da8c5f7342dea9437fc04db2094616c672b1e2cb31e0
+  SHA512 02db5cdf5f84df213b4d14f93363b7949d6c1a51c9cda616ef3612cb072f6b30bc942c5a6b0b9e89ea8b76b048fabd6bafcabde3c55380c3d90837116fa8b237
   HEAD_REF next_release
   PATCHES anari-lib-maybe-static-lib.patch
 )

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "anari",
-  "version": "0.13.1",
+  "version": "0.14.1",
   "description": "Cross-Platform 3D Rendering Engine API.",
   "homepage": "https://www.khronos.org/anari",
   "license": "Apache-2.0",

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a988fe0e6db993e29d2628acf456fc8b99e5ea31",
+      "version": "0.14.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e0a023514ab5a50fb801731a3376cdf260327c01",
       "version": "0.13.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -125,7 +125,7 @@
       "port-version": 0
     },
     "anari": {
-      "baseline": "0.13.1",
+      "baseline": "0.14.1",
       "port-version": 0
     },
     "anax": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
