### PR TITLE
[luajit] Update to 2025-03-28

### DIFF
--- a/ports/luajit/003-do-not-set-macosx-deployment-target.patch
+++ b/ports/luajit/003-do-not-set-macosx-deployment-target.patch
@@ -1,8 +1,8 @@
 diff --git a/src/Makefile b/src/Makefile
-index 30d64be..b753ea1 100644
+index c83abfa0..12e79a5b 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -316,9 +316,6 @@ ifeq (,$(shell $(TARGET_CC) -o /dev/null -c -x c /dev/null -fno-stack-protector
+@@ -321,9 +321,6 @@ ifeq (,$(shell $(TARGET_CC) -o /dev/null -c -x c /dev/null -fno-stack-protector
    TARGET_XCFLAGS+= -fno-stack-protector
  endif
  ifeq (Darwin,$(TARGET_SYS))
@@ -11,4 +11,4 @@ index 30d64be..b753ea1 100644
 -  endif
    TARGET_STRIP+= -x
    TARGET_XCFLAGS+= -DLUAJIT_UNWIND_EXTERNAL
-   TARGET_XSHLDFLAGS= -dynamiclib -single_module -undefined dynamic_lookup -fPIC
+   TARGET_XSHLDFLAGS= -dynamiclib -undefined dynamic_lookup -fPIC

--- a/ports/luajit/msvcbuild.patch
+++ b/ports/luajit/msvcbuild.patch
@@ -1,31 +1,26 @@
 diff --git a/src/msvcbuild.bat b/src/msvcbuild.bat
-index aab4ef1..e92c486 100644
+index 69c0c61a..2abb7749 100644
 --- a/src/msvcbuild.bat
 +++ b/src/msvcbuild.bat
-@@ -79,10 +79,9 @@ buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
- @set LJCOMPILE=%LJCOMPILE% /Zi %DEBUGCFLAGS%
- @set LJLINK=%LJLINK% /opt:ref /opt:icf /incremental:no
+@@ -102,10 +102,10 @@ buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
+ @set LJLINKTYPE=%LJLINKTYPE_DEBUG%
  :NODEBUG
--@set LJLINK=%LJLINK% /%BUILDTYPE%
+ @set LJCOMPILE=%LJCOMPILE% %LJCOMPILETARGET%
+-@set LJLINK=%LJLINK% %LJLINKTYPE% %LJLINKTARGET%
++@set LJLINK=%LJLINK% %LJLINKTARGET%
  @if "%1"=="amalg" goto :AMALGDLL
  @if "%1"=="static" goto :STATIC
--%LJCOMPILE% /MD /DLUA_BUILD_AS_DLL lj_*.c lib_*.c
-+%LJCOMPILE%     /DLUA_BUILD_AS_DLL lj_*.c lib_*.c /Fdlua51.pdb
+-%LJCOMPILE% %LJDYNBUILD% lj_*.c lib_*.c
++%LJCOMPILE% %LJDYNBUILD% lj_*.c lib_*.c /Fdlua51.pdb
  @if errorlevel 1 goto :BAD
- %LJLINK% /DLL /out:%LJDLLNAME% lj_*.obj lib_*.obj
- @if errorlevel 1 goto :BAD
-@@ -102,7 +101,7 @@ buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
+ @if "%1"=="mixed" goto :STATICLIB
+ %LJLINK% /DLL /OUT:%LJDLLNAME% lj_*.obj lib_*.obj
+@@ -136,7 +136,7 @@ buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
  if exist %LJDLLNAME%.manifest^
    %LJMT% -manifest %LJDLLNAME%.manifest -outputresource:%LJDLLNAME%;2
  
 -%LJCOMPILE% luajit.c
 +%LJCOMPILE% luajit.c /Fdluajit.pdb
  @if errorlevel 1 goto :BAD
- %LJLINK% /out:luajit.exe luajit.obj %LJLIBNAME%
+ %LJLINK% /OUT:luajit.exe luajit.obj %LJLIBNAME%
  @if errorlevel 1 goto :BAD
-@@ -124,4 +123,5 @@ if exist luajit.exe.manifest^
- @goto :END
- :FAIL
- @echo You must open a "Visual Studio Command Prompt" to run this script
-+@exit 1
- :END

--- a/ports/luajit/portfile.cmake
+++ b/ports/luajit/portfile.cmake
@@ -6,9 +6,9 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO LuaJIT/LuaJIT
-    REF d0e88930ddde28ff662503f9f20facf34f7265aa  #2023-01-04
-    SHA512 e4111b2d7eeb05676c62d69da13a380a51d98f082c0be575a414c09ee27ff17d101b5b4a95e1b8a1bad14d55a4d2b305718a11878fbf36e0d3d48e62ba03407f
-    HEAD_REF master
+    REF f9140a622a0c44a99efb391cc1c2358bc8098ab7  #2025-03-28
+    SHA512 2b8a3f9b3c8d982864d0e264e2128390f0ea55ecb00d804b3bb19d8df4b8e2972be456a452b5372f0bbe035025b0e94f2214126f0dbd51021ca5c2ea4750378d
+    HEAD_REF v2.1
     PATCHES
         msvcbuild.patch
         003-do-not-set-macosx-deployment-target.patch

--- a/ports/luajit/vcpkg.json
+++ b/ports/luajit/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "luajit",
-  "version-date": "2023-01-04",
-  "port-version": 7,
+  "version-date": "2025-03-28",
   "description": "LuaJIT is a Just-In-Time (JIT) compiler for the Lua programming language.",
   "homepage": "https://github.com/LuaJIT/LuaJIT",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5909,8 +5909,8 @@
       "port-version": 7
     },
     "luajit": {
-      "baseline": "2023-01-04",
-      "port-version": 7
+      "baseline": "2025-03-28",
+      "port-version": 0
     },
     "luasec": {
       "baseline": "1.3.2",

--- a/versions/l-/luajit.json
+++ b/versions/l-/luajit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3dcccc6adcf1bfe4f541b3c6de2bbd707b0513e",
+      "version-date": "2025-03-28",
+      "port-version": 0
+    },
+    {
       "git-tree": "8d6aa0d4fd0ef4005685e468090f35e3a9a00802",
       "version-date": "2023-01-04",
       "port-version": 7


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This new version should be able to support Windows ARM64 (as requested in #45504) but I have no idea how to get the LuaJIT build system to do that in conjunction with the vcpkg machinery. I leave that to people with more vcpkg experience, for now I just do the version bump.