### PR TITLE
[fastdds] update to 3.3.0

### DIFF
--- a/ports/fastdds/fix-deps.patch
+++ b/ports/fastdds/fix-deps.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b2ea15f4c..8996d18f1 100644
+index 7974e8b..8afdb5a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -255,8 +255,8 @@ if(NOT BUILD_SHARED_LIBS)
  endif()
  
  eprosima_find_package(fastcdr 2 REQUIRED)
--eprosima_find_thirdparty(Asio asio VERSION 1.10.8)
+-eprosima_find_thirdparty(Asio asio VERSION 1.13.0)
 -eprosima_find_thirdparty(TinyXML2 tinyxml2)
 +find_package(asio CONFIG REQUIRED)
 +find_package(tinyxml2 CONFIG REQUIRED)
@@ -23,10 +23,10 @@ index b2ea15f4c..8996d18f1 100644
  
  ###############################################################################
 diff --git a/src/cpp/CMakeLists.txt b/src/cpp/CMakeLists.txt
-index 44a74948c..09330717b 100644
+index 3f4a3aa..3394cc3 100644
 --- a/src/cpp/CMakeLists.txt
 +++ b/src/cpp/CMakeLists.txt
-@@ -505,8 +505,9 @@ target_link_libraries(${PROJECT_NAME}
+@@ -508,8 +508,9 @@ target_link_libraries(${PROJECT_NAME}
      ${PRIVACY}
      fastcdr
      foonathan_memory

--- a/ports/fastdds/include-cstdint.patch
+++ b/ports/fastdds/include-cstdint.patch
@@ -1,26 +1,12 @@
-diff --git a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterCompoundCondition.hpp b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterCompoundCondition.hpp
-index d4759de..66c2f7a 100644
---- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterCompoundCondition.hpp
-+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterCompoundCondition.hpp
-@@ -20,7 +20,7 @@
- #define _FASTDDS_TOPIC_DDSSQLFILTER_DDSFILTERCOMPOUNDCONDITION_HPP_
+diff --git a/src/cpp/rtps/security/common/SharedSecretHandle.h b/src/cpp/rtps/security/common/SharedSecretHandle.h
+index c53b153..b2b6507 100644
+--- a/src/cpp/rtps/security/common/SharedSecretHandle.h
++++ b/src/cpp/rtps/security/common/SharedSecretHandle.h
+@@ -21,6 +21,7 @@
+ #include <rtps/security/common/Handle.h>
  
- #include <memory>
--
+ #include <vector>
 +#include <cstdint>
- #include "DDSFilterCondition.hpp"
  
- namespace eprosima {
-diff --git a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterValue.hpp b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterValue.hpp
-index 4ae70cb..f66790e 100644
---- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterValue.hpp
-+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterValue.hpp
-@@ -23,7 +23,7 @@
- 
- #include <memory>
- #include <regex>
--
-+#include <cstdint>
  namespace eprosima {
  namespace fastdds {
- namespace dds {

--- a/ports/fastdds/portfile.cmake
+++ b/ports/fastdds/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eProsima/Fast-DDS
     REF "v${VERSION}"
-    SHA512 ddef07c182d5d0b6096c8714595775d13fbbf9bedcd7e296c38f5b8ce0488d89b7a0048741143dbffbb9c21c3707b1084d1cd80ae7d019c0cac90e0f5eba5519
+    SHA512 970b80dc87224183f730b32f21dba4cdd55cf9ac88ce662c0a0f710a2bca6233754d1274a71cca64a543407a4d5f09db3badf73201b6bb5f49ff68c81b368509
     HEAD_REF master
     PATCHES
         fix-deps.patch

--- a/ports/fastdds/vcpkg.json
+++ b/ports/fastdds/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fastdds",
-  "version": "3.2.2",
-  "port-version": 2,
+  "version": "3.3.0",
   "description": "eprosima Fast DDS (formerly Fast RTPS) is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.",
   "homepage": "https://www.eprosima.com/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2793,8 +2793,8 @@
       "port-version": 5
     },
     "fastdds": {
-      "baseline": "3.2.2",
-      "port-version": 2
+      "baseline": "3.3.0",
+      "port-version": 0
     },
     "fastfeat": {
       "baseline": "391d5e9",

--- a/versions/f-/fastdds.json
+++ b/versions/f-/fastdds.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06f094b701b48aaa0de221e69cc2dfead6d18801",
+      "version": "3.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c6aec23afb0337f6b4c9dedfe33337637ef258bd",
       "version": "3.2.2",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/eProsima/Fast-DDS/releases/tag/v3.3.0