### PR TITLE
[mosquitto] update to 2.0.22

### DIFF
--- a/ports/mosquitto/0004-support-static-build.patch
+++ b/ports/mosquitto/0004-support-static-build.patch
@@ -1,24 +1,24 @@
 diff --git a/apps/mosquitto_passwd/CMakeLists.txt b/apps/mosquitto_passwd/CMakeLists.txt
-index 13a7d826..5e96f49c 100644
+index 7ed1743..795bccb 100644
 --- a/apps/mosquitto_passwd/CMakeLists.txt
 +++ b/apps/mosquitto_passwd/CMakeLists.txt
 @@ -13,6 +13,10 @@ if (WITH_TLS)
  		)
  
  
--	target_link_libraries(mosquitto_passwd ${OPENSSL_LIBRARIES})
+-	target_link_libraries(mosquitto_passwd OpenSSL::SSL)
 +	if(WIN32)
-+		target_link_libraries(mosquitto_passwd ${OPENSSL_LIBRARIES} ws2_32 crypt32)
++		target_link_libraries(mosquitto_passwd OpenSSL::SSL)
 +	else()
-+		target_link_libraries(mosquitto_passwd ${OPENSSL_LIBRARIES})
++		target_link_libraries(mosquitto_passwd OpenSSL::SSL ws2_32 crypt32)
 +	endif()
  	install(TARGETS mosquitto_passwd RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
  endif (WITH_TLS)
 diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index 31cc35e3..a1a3e01a 100644
+index 21b6149..b218341 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
-@@ -69,7 +69,7 @@ if (UNIX AND NOT APPLE AND NOT ANDROID)
+@@ -70,7 +70,7 @@ if (UNIX AND NOT APPLE AND NOT ANDROID)
  endif (UNIX AND NOT APPLE AND NOT ANDROID)
  
  if (WIN32)
@@ -28,10 +28,10 @@ index 31cc35e3..a1a3e01a 100644
  
  if (WITH_SRV)
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 9380a046..62ce99e5 100644
+index d4bae7c..f529cbc 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -189,7 +189,7 @@ if (UNIX)
+@@ -195,7 +195,7 @@ if (UNIX)
  endif (UNIX)
  
  if (WIN32)

--- a/ports/mosquitto/portfile.cmake
+++ b/ports/mosquitto/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO eclipse/mosquitto
     HEAD_REF master
     REF "v${VERSION}"
-    SHA512 92994ec34cebc56dd9aba1a5c3e082117157b42dc5a4c418a9e57a741ad0f2d909226e432082d21b4c9836d2f13fc37d39a1a77f0122a349d1ba6d50974e5190
+    SHA512 ca8bdcb10fea751e655e2de393479b2f863287b396b13e441de46c32918229c1f80a386fdd6d0daf3b0161f640702b6d8a87f2278c9baf2150e2c533cb59e57a
     PATCHES
         0003-add-find_package-libwebsockets.patch
         0004-support-static-build.patch

--- a/ports/mosquitto/vcpkg.json
+++ b/ports/mosquitto/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mosquitto",
-  "version": "2.0.20",
+  "version": "2.0.22",
   "description": "Mosquitto is an open source message broker that implements the MQ Telemetry Transport protocol versions 3.1 and 3.1.1, MQTT provides a lightweight method of carrying out messaging using a publish/subscribe model, This makes it suitable for machine to machine messaging such as with low power sensors or mobile devices such as phones, embedded computers or microcontrollers like the Arduino",
   "homepage": "https://mosquitto.org/",
   "license": "EPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6329,7 +6329,7 @@
       "port-version": 3
     },
     "mosquitto": {
-      "baseline": "2.0.20",
+      "baseline": "2.0.22",
       "port-version": 0
     },
     "mozjpeg": {

--- a/versions/m-/mosquitto.json
+++ b/versions/m-/mosquitto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8fd367c63c64ada7084fd5f7009811a4dc84b901",
+      "version": "2.0.22",
+      "port-version": 0
+    },
+    {
       "git-tree": "ee450abba4fe411781a8bb412bd4b74a0e45892c",
       "version": "2.0.20",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/eclipse-mosquitto/mosquitto/releases/tag/v2.0.22
