### PR TITLE
[xtensor] update to 0.27.0

### DIFF
--- a/ports/xtensor/portfile.cmake
+++ b/ports/xtensor/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xtensor
     REF "${VERSION}"
-    SHA512 9fe07376ef05d9822ffedba2804ef8af402e6560ca1424624bbfb220ef954b4f721d09c22dc045a76134a5856eccf97bfbe08450e5e70c58128583c9352afb5e
+    SHA512 52616a61f9c74c9a37daea5615edb210ff9ef636620266c04ef3e145a067ed685c36febdee4d225ff7c4865e45384e92034a0e7bf9d255727aca7100bc45143c
     HEAD_REF master
     PATCHES
         fix-find-tbb-and-install-destination.patch

--- a/ports/xtensor/vcpkg.json
+++ b/ports/xtensor/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xtensor",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "C++ tensors with broadcasting and lazy computing",
   "homepage": "https://github.com/xtensor-stack/xtensor",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10421,7 +10421,7 @@
       "port-version": 0
     },
     "xtensor": {
-      "baseline": "0.26.0",
+      "baseline": "0.27.0",
       "port-version": 0
     },
     "xtensor-blas": {

--- a/versions/x-/xtensor.json
+++ b/versions/x-/xtensor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43291e36aaad6a1ec14605cbb7eb6059f3c4ccec",
+      "version": "0.27.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "852e8a91b35bb4af715a8ba19a2b30b3bf74abc2",
       "version": "0.26.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/xtensor-stack/xtensor/releases/tag/0.27.0
