### PR TITLE
[arun11299-cpp-subprocess] add new port

### DIFF
--- a/ports/arun11299-cpp-subprocess/portfile.cmake
+++ b/ports/arun11299-cpp-subprocess/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO arun11299/cpp-subprocess
+    REF "v${VERSION}"
+    SHA512 5be80a4a181f8534b6e2b36a2b192b77edd70b527ef881195ef02e915a1f78c894a804029a82f2f927c5194baef71a4f3184c124d42a6dd3c53cdc694410a576
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSUBPROCESS_TESTS=OFF
+        -DSUBPROCESS_INSTALL=ON
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.MIT")

--- a/ports/arun11299-cpp-subprocess/vcpkg.json
+++ b/ports/arun11299-cpp-subprocess/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "arun11299-cpp-subprocess",
+  "version": "2.1",
+  "description": "Subprocessing with modern C++ ",
+  "homepage": "https://github.com/arun11299/cpp-subprocess",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/arun11299-cpp-subprocess.json
+++ b/versions/a-/arun11299-cpp-subprocess.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7d613f0bdb1d9ccf52f8aa1bcaf6e31770bb9f40",
+      "version": "2.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -268,6 +268,10 @@
       "baseline": "2.1.1",
       "port-version": 0
     },
+    "arun11299-cpp-subprocess": {
+      "baseline": "2.1",
+      "port-version": 0
+    },
     "ashes": {
       "baseline": "2023-03-12",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/arun11299/cpp-subprocess/
