### PR TITLE
[openxr-loader,qtquick3d] Fix installation order quirks

### DIFF
--- a/ports/openxr-loader/portfile.cmake
+++ b/ports/openxr-loader/portfile.cmake
@@ -19,6 +19,11 @@ vcpkg_from_github(
         python3_8_compatibility.patch
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        vulkan  VCPKG_LOCK_FIND_PACKAGE_Vulkan
+)
+
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DYNAMIC_LOADER)
 
 vcpkg_find_acquire_program(PYTHON3)
@@ -26,12 +31,12 @@ vcpkg_find_acquire_program(PYTHON3)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBUILD_API_LAYERS=OFF
         -DBUILD_CONFORMANCE_TESTS=OFF
         -DBUILD_TESTS=OFF
         -DCMAKE_INSTALL_INCLUDEDIR=include
         -DDYNAMIC_LOADER=${DYNAMIC_LOADER}
-        "-DPYTHON_EXECUTABLE=${PYTHON3}"
         "-DPython3_EXECUTABLE=${PYTHON3}"
 )
 

--- a/ports/openxr-loader/vcpkg.json
+++ b/ports/openxr-loader/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openxr-loader",
   "version": "1.1.45",
+  "port-version": 1,
   "description": "A royalty-free, open standard that provides high-performance access to Augmented Reality (AR) and Virtual Reality (VR)—collectively known as XR—platforms and devices",
   "homepage": "https://github.com/KhronosGroup/OpenXR-SDK",
   "license": "Apache-2.0",

--- a/ports/qtquick3d/android-openxr-vulkan.diff
+++ b/ports/qtquick3d/android-openxr-vulkan.diff
@@ -1,0 +1,14 @@
+diff --git a/src/xr/quick3dxr/openxr/CMakeLists.txt b/src/xr/quick3dxr/openxr/CMakeLists.txt
+index ad6ee98..efd3be7 100644
+--- a/src/xr/quick3dxr/openxr/CMakeLists.txt
++++ b/src/xr/quick3dxr/openxr/CMakeLists.txt
+@@ -52,6 +52,9 @@ qt_internal_extend_target(Quick3DXr CONDITION ANDROID AND QT_FEATURE_opengles2
+ qt_internal_extend_target(Quick3DXr CONDITION QT_FEATURE_vulkan
+     SOURCES
+         qopenxrgraphics_vulkan.cpp qopenxrgraphics_vulkan_p.h
++)
++
++qt_internal_extend_target(Quick3DXr CONDITION QT_FEATURE_vulkan OR ANDROID
+     DEFINES
+         XR_USE_GRAPHICS_API_VULKAN
+ )

--- a/ports/qtquick3d/android-openxr-vulkan.diff
+++ b/ports/qtquick3d/android-openxr-vulkan.diff
@@ -1,14 +1,15 @@
-diff --git a/src/xr/quick3dxr/openxr/CMakeLists.txt b/src/xr/quick3dxr/openxr/CMakeLists.txt
-index ad6ee98..efd3be7 100644
---- a/src/xr/quick3dxr/openxr/CMakeLists.txt
-+++ b/src/xr/quick3dxr/openxr/CMakeLists.txt
-@@ -52,6 +52,9 @@ qt_internal_extend_target(Quick3DXr CONDITION ANDROID AND QT_FEATURE_opengles2
- qt_internal_extend_target(Quick3DXr CONDITION QT_FEATURE_vulkan
-     SOURCES
-         qopenxrgraphics_vulkan.cpp qopenxrgraphics_vulkan_p.h
-+)
-+
-+qt_internal_extend_target(Quick3DXr CONDITION QT_FEATURE_vulkan OR ANDROID
-     DEFINES
-         XR_USE_GRAPHICS_API_VULKAN
- )
+diff --git a/src/xr/quick3dxr/openxr/qquick3dxrmanager_openxr.cpp b/src/xr/quick3dxr/openxr/qquick3dxrmanager_openxr.cpp
+index f0d2963..8db003b 100644
+--- a/src/xr/quick3dxr/openxr/qquick3dxrmanager_openxr.cpp
++++ b/src/xr/quick3dxr/openxr/qquick3dxrmanager_openxr.cpp
+@@ -2036,8 +2036,10 @@ XrResult QQuick3DXrManagerPrivate::createXrInstance()
+ 
+     auto graphicsAPI = QQuickWindow::graphicsApi();
+     if (graphicsAPI == QSGRendererInterface::Vulkan) {
++#ifdef XR_USE_GRAPHICS_API_VULKAN
+         if (isExtensionSupported(XR_FB_SWAPCHAIN_UPDATE_STATE_VULKAN_EXTENSION_NAME, extensionProperties))
+             enabledExtensions.append(XR_FB_SWAPCHAIN_UPDATE_STATE_VULKAN_EXTENSION_NAME);
++#endif
+     } else if (graphicsAPI == QSGRendererInterface::OpenGL) {
+         if (isExtensionSupported(XR_FB_SWAPCHAIN_UPDATE_STATE_OPENGL_ES_EXTENSION_NAME, extensionProperties))
+             enabledExtensions.append(XR_FB_SWAPCHAIN_UPDATE_STATE_OPENGL_ES_EXTENSION_NAME);

--- a/ports/qtquick3d/portfile.cmake
+++ b/ports/qtquick3d/portfile.cmake
@@ -1,5 +1,8 @@
 set(SCRIPT_PATH "${CURRENT_INSTALLED_DIR}/share/qtbase")
-set(${PORT}_PATCHES 0001-devendor-meshoptimizer.patch)
+set(${PORT}_PATCHES
+    0001-devendor-meshoptimizer.patch
+    android-openxr-vulkan.diff
+)
 
 include("${SCRIPT_PATH}/qt_install_submodule.cmake")
 

--- a/ports/qtquick3d/vcpkg.json
+++ b/ports/qtquick3d/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtquick3d",
   "version": "6.8.3",
+  "port-version": 1,
   "description": "Qt Quick 3D provides a high-level API for creating 3D content and 3D user interfaces based on Qt Quick.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -415,7 +415,6 @@ qt5-webengine = fail # Missing prerequisites for CI success
 qt5-x11extras(osx)=fail # Missing system libraries
 qt5-x11extras(windows)=fail # Missing libraries
 qtmultimedia(android)=fail
-qtquick3d(android)=fail
 qtvirtualkeyboard[t9write] = skip # depends on the port 't9write' that does not exists
 qtwayland(android | osx)=fail # Missing system libraries
 qwt-qt6:x64-osx=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8010,7 +8010,7 @@
     },
     "qtquick3d": {
       "baseline": "6.8.3",
-      "port-version": 0
+      "port-version": 1
     },
     "qtquick3dphysics": {
       "baseline": "6.8.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7098,7 +7098,7 @@
     },
     "openxr-loader": {
       "baseline": "1.1.45",
-      "port-version": 0
+      "port-version": 1
     },
     "optimus-cpp": {
       "baseline": "0.3.0",

--- a/versions/o-/openxr-loader.json
+++ b/versions/o-/openxr-loader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b47fb6babbac5b293d473f955337cc170e3e8a1",
+      "version": "1.1.45",
+      "port-version": 1
+    },
+    {
       "git-tree": "fc57b91bda0eb17a4f5902c2029bd9a9d7f28a05",
       "version": "1.1.45",
       "port-version": 0

--- a/versions/q-/qtquick3d.json
+++ b/versions/q-/qtquick3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ec9f37be62615a932d10fd6cf5fc512282f35b07",
+      "version": "6.8.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "fd5155e24d32095ef64e575516e488a1a56a3537",
       "version": "6.8.3",
       "port-version": 0


### PR DESCRIPTION
openxr-loader: Wire vulkan feature. Fixes baseline flakiness (unexpected pass in https://dev.azure.com/vcpkg/public/_build/results?buildId=117833&view=logs&j=18f767b8-9e55-53aa-9c57-42862973482f&t=3b7ff14d-7f23-576e-7151-bdf22f86f0a5).

qtquick3d: android doesn't imply qtbase[vulkan] doesn't imply openxr-loader[vulkan]. User must request the vulkan feature from both dependencies. Fixes expected fail in baseline.
(Alternative: Make qtquick3d\[openxr](android) depend on the vulkan feature of both dependencies.)