### PR TITLE
[usockets] Add android support

### DIFF
--- a/ports/usockets/CMakeLists.txt
+++ b/ports/usockets/CMakeLists.txt
@@ -27,14 +27,16 @@ else()
     target_compile_definitions(uSockets PRIVATE -DLIBUS_NO_SSL)
 endif()
 
-if(WIN32)
+if(WIN32 OR ANDROID)
     # https://github.com/uNetworking/uSockets/blob/8606de6414a102c55bef8e8ef3391932d7e8df6a/src/libusockets.h#L339-L348
     find_package(libuv CONFIG REQUIRED)
     target_link_libraries(uSockets PRIVATE $<IF:$<TARGET_EXISTS:libuv::uv_a>,libuv::uv_a,libuv::uv>)
     target_compile_definitions(uSockets PRIVATE -DLIBUS_USE_LIBUV)
 
-    # https://github.com/uNetworking/uSockets/blob/8606de6414a102c55bef8e8ef3391932d7e8df6a/src/libusockets.h#L35
-    target_link_libraries(uSockets PRIVATE ws2_32)
+    if(WIN32)
+        # https://github.com/uNetworking/uSockets/blob/8606de6414a102c55bef8e8ef3391932d7e8df6a/src/libusockets.h#L35
+        target_link_libraries(uSockets PRIVATE ws2_32)
+    endif()
 endif()
 
 

--- a/ports/usockets/unofficial-usockets-config.cmake
+++ b/ports/usockets/unofficial-usockets-config.cmake
@@ -1,5 +1,5 @@
 include(CMakeFindDependencyMacro)
-if(WIN32)
+if(WIN32 OR ANDROID)
     find_dependency(libuv CONFIG)
 endif()
 if("@WITH_OPENSSL@")

--- a/ports/usockets/vcpkg.json
+++ b/ports/usockets/vcpkg.json
@@ -1,14 +1,14 @@
 {
   "name": "usockets",
   "version": "0.8.8",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Miniscule cross-platform eventing, networking & crypto for async applications",
   "homepage": "https://github.com/uNetworking/uSockets",
   "license": "Apache-2.0",
   "dependencies": [
     {
       "name": "libuv",
-      "platform": "windows"
+      "platform": "windows | android"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9810,7 +9810,7 @@
     },
     "usockets": {
       "baseline": "0.8.8",
-      "port-version": 2
+      "port-version": 3
     },
     "usrsctp": {
       "baseline": "0.9.5.0",

--- a/versions/u-/usockets.json
+++ b/versions/u-/usockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "080448b6175d620e1b986327d0a10caee41946d4",
+      "version": "0.8.8",
+      "port-version": 3
+    },
+    {
       "git-tree": "28a78040653744fdea484a20a0cfee8b14f14312",
       "version": "0.8.8",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
