### PR TITLE
[qcbor] add new port

### DIFF
--- a/ports/qcbor/install.patch
+++ b/ports/qcbor/install.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3537c27..bf569a5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -46,7 +46,8 @@ target_sources(qcbor
+ 
+ target_include_directories(qcbor
+     PUBLIC
+-        inc
++        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
++        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/qcbor>
+     PRIVATE
+         src
+ )
+@@ -90,8 +91,13 @@ set_target_properties(
+ include(GNUInstallDirs)
+ install(
+     TARGETS qcbor
++    EXPORT unofficial-qcbor-targets
+     PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/qcbor"
+ )
++install(EXPORT unofficial-qcbor-targets
++    FILE unofficial-qcbor-config.cmake
++    NAMESPACE unofficial::qcbor::
++    DESTINATION share/unofficial-qcbor)
+ 
+ if (NOT BUILD_QCBOR_TEST STREQUAL "OFF")
+     enable_testing()

--- a/ports/qcbor/portfile.cmake
+++ b/ports/qcbor/portfile.cmake
@@ -1,3 +1,8 @@
+# No DLL export(yet)
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO laurencelundblade/QCBOR

--- a/ports/qcbor/portfile.cmake
+++ b/ports/qcbor/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO laurencelundblade/QCBOR
+    REF v${VERSION}
+    SHA512 3961cbcde2dde3565b68f92b53e92db31b649b71bc683a8439bada3aa6c44f4727747ca7b4ad35c4ca6f5bd0594abc2bf36a6ce0c7452eb412e8dcd55e946585
+    HEAD_REF master
+    PATCHES
+        install.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_QCBOR_TEST=OFF
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/qcbor/vcpkg.json
+++ b/ports/qcbor/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "qcbor",
+  "version": "1.5.3",
+  "description": "Comprehensive, powerful, commercial-quality CBOR encoder/ decoder that is still suited for small devices.",
+  "homepage": "https://github.com/laurencelundblade/QCBOR",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/qcbor/vcpkg.json
+++ b/ports/qcbor/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "Comprehensive, powerful, commercial-quality CBOR encoder/ decoder that is still suited for small devices.",
   "homepage": "https://github.com/laurencelundblade/QCBOR",
   "license": "BSD-3-Clause",
-  "supports": "!windows | static",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/qcbor/vcpkg.json
+++ b/ports/qcbor/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Comprehensive, powerful, commercial-quality CBOR encoder/ decoder that is still suited for small devices.",
   "homepage": "https://github.com/laurencelundblade/QCBOR",
   "license": "BSD-3-Clause",
+  "supports": "!windows | static",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7664,6 +7664,10 @@
       "baseline": "2.3.7",
       "port-version": 3
     },
+    "qcbor": {
+      "baseline": "1.5.3",
+      "port-version": 0
+    },
     "qcoro": {
       "baseline": "0.12.0",
       "port-version": 0

--- a/versions/q-/qcbor.json
+++ b/versions/q-/qcbor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bac551b690e1f8aa5f8b98dc244352d9a2a14373",
+      "git-tree": "78d55821d9252e9e85bcfd345659d63ea4ba4efa",
       "version": "1.5.3",
       "port-version": 0
     }

--- a/versions/q-/qcbor.json
+++ b/versions/q-/qcbor.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "bac551b690e1f8aa5f8b98dc244352d9a2a14373",
+      "version": "1.5.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/laurencelundblade/QCBOR
