### PR TITLE
[glib] Suppress dtrace autodetection

### DIFF
--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -49,6 +49,7 @@ vcpkg_configure_meson(
     OPTIONS
         ${OPTIONS}
         -Ddocumentation=false
+        -Ddtrace=disabled
         -Dinstalled_tests=false
         -Dintrospection=disabled
         -Dlibelf=disabled

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glib",
   "version": "2.84.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3290,7 +3290,7 @@
     },
     "glib": {
       "baseline": "2.84.2",
-      "port-version": 1
+      "port-version": 2
     },
     "glib-networking": {
       "baseline": "2.78.0",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3aabce5c1a06d3dde0a6fce2f795eeb37fc4d15",
+      "version": "2.84.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "81c84377dd889cfe7d4c5dec61cfccc0787a2913",
       "version": "2.84.2",
       "port-version": 1


### PR DESCRIPTION
Fixes: #46450

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
