### PR TITLE
[openimageio] Improve CI test port

### DIFF
--- a/scripts/test_ports/vcpkg-ci-openimageio/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-openimageio/vcpkg.json
@@ -28,6 +28,7 @@
             "ffmpeg",
             "freetype",
             "gif",
+            "libheif",
             "libraw",
             "opencolorio",
             "opencv",
@@ -37,6 +38,7 @@
               "platform": "!(windows & static) & !uwp & !mingw"
             },
             "tools",
+            "viewer",
             "webp"
           ]
         }


### PR DESCRIPTION
Add new features libheif and viewer.

Note sure how much of this checklist applies to CI test ports ...
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
