### PR TITLE
[oatpp] Update to 1.3.1

### DIFF
--- a/ports/oatpp/portfile.cmake
+++ b/ports/oatpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oatpp/oatpp
-    REF ${OATPP_VERSION}
-    SHA512 4fe8587efe1b4ecae14554ec8edb209e5558a3e4a4e6ff49bbfaaf06d2cc12f2cc306c5edc43b8dafc465aff53098ad4bebb9971694761b91a553730d5acb59a
+    REF "1.3.1"
+    SHA512 2d6aec0a7f298fef19ce77517643388af4f127abe710b619aa17301b1c869b05f05758323370abdcc2eca9c675045f86b185af00b1689e469fc8aa4e02971f92
     HEAD_REF master
     PATCHES
         fix-target.patch

--- a/ports/oatpp/vcpkg.json
+++ b/ports/oatpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "oatpp",
-  "version": "1.3.0",
-  "port-version": 2,
+  "version": "1.3.1",
   "description": "Modern web framework.",
   "homepage": "https://github.com/oatpp/oatpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6789,8 +6789,8 @@
       "port-version": 0
     },
     "oatpp": {
-      "baseline": "1.3.0",
-      "port-version": 2
+      "baseline": "1.3.1",
+      "port-version": 0
     },
     "oatpp-consul": {
       "baseline": "1.3.0",

--- a/versions/o-/oatpp.json
+++ b/versions/o-/oatpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4bf8ba64010cb0a4bf81073e903f7f03cd0d5cea",
+      "version": "1.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "36f425ca9c764945b824bfe5ff506fe09a5361d8",
       "version": "1.3.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/oatpp/oatpp/releases/tag/1.3.1
This tag is an alias for `1.3.0-latest`, avoids issues with version ordering - see this old PR for `oatpp-swagger`: [42349](https://github.com/microsoft/vcpkg/pull/42349/files)