### PR TITLE
Fix baseline not-green 20250716.1

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -734,10 +734,7 @@ omniorb:x64-android=fail
 # opencc/deps/rapidjson-1.1.0/rapidjson.h: Unknown machine endianess detected
 # opencc/deps/marisa-0.2.5/lib/marisa/grimoire/io/mapper.cc currently doesn't support UWP.
 opencc:x64-android=fail
-openimageio:arm-neon-android=fail
-openimageio:arm64-android=fail
 openimageio:arm64-windows-static-md=fail
-openimageio:x64-android=fail
 openmama:arm64-windows-static-md=fail
 openmama:x64-windows-static-md=fail
 openmesh:arm64-uwp=fail


### PR DESCRIPTION
CI run: https://dev.azure.com/vcpkg/public/_build/results?buildId=117892&view=results

## Remove the following entries from baseline

* `PASSING, REMOVE FROM FAIL LIST: openimageio:arm-neon-android`
* `PASSING, REMOVE FROM FAIL LIST: openimageio:arm64-android`
* `PASSING, REMOVE FROM FAIL LIST: openimageio:x64-android`