### PR TITLE
[arrow] Update to 21.0.0

### DIFF
--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     ARCHIVE_PATH
     URLS "https://archive.apache.org/dist/arrow/arrow-${VERSION}/apache-arrow-${VERSION}.tar.gz"
     FILENAME apache-arrow-${VERSION}.tar.gz
-    SHA512 067e62d7d311cebfca43473b0aacaacc534da47c3450b75328517df69281d8be1e79b0430cc7e975eb613e05c62a62d6ca92a4c4f7882ae7733f826d774d9081
+    SHA512 89da6de7eb2513c797d6671e1addf40b8b156215b481cf2511fa69faa16547c52d8220727626eeda499e4384d276e03880cd920aaab41c3d15106743d51a90a6
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH
@@ -91,6 +91,14 @@ if("acero" IN_LIST FEATURES)
     )
 endif()
 
+if("compute" IN_LIST FEATURES)
+    vcpkg_cmake_config_fixup(
+        PACKAGE_NAME arrowcompute
+        CONFIG_PATH lib/cmake/ArrowCompute
+        DO_NOT_DELETE_PARENT_CONFIG_PATH
+    )
+endif()
+
 if("flight" IN_LIST FEATURES)
     vcpkg_cmake_config_fixup(
         PACKAGE_NAME ArrowFlight
@@ -128,6 +136,11 @@ endif()
 if("acero" IN_LIST FEATURES)
     file(READ "${CMAKE_CURRENT_LIST_DIR}/usage-acero" usage-acero)
     file(APPEND "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" "${usage-acero}")
+endif()
+
+if("compute" IN_LIST FEATURES)
+    file(READ "${CMAKE_CURRENT_LIST_DIR}/usage-compute" usage-compute)
+    file(APPEND "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" "${usage-compute}")
 endif()
 
 if("flight" IN_LIST FEATURES)

--- a/ports/arrow/usage-compute
+++ b/ports/arrow/usage-compute
@@ -1,0 +1,3 @@
+
+    find_package(ArrowCompute CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE "$<IF:$<BOOL:${ARROW_BUILD_STATIC}>,ArrowCompute::arrow_compute_static,ArrowCompute::arrow_compute_shared>")

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "arrow",
-  "version": "20.0.0",
-  "port-version": 1,
+  "version": "21.0.0",
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",
@@ -106,7 +105,8 @@
       ]
     },
     "mimalloc": {
-      "description": "mimalloc allocator"
+      "description": "mimalloc allocator",
+      "supports": "!staticcrt"
     },
     "orc": {
       "description": "ORC support",
@@ -117,6 +117,13 @@
     "parquet": {
       "description": "Parquet support",
       "dependencies": [
+        {
+          "name": "arrow",
+          "default-features": false,
+          "features": [
+            "json"
+          ]
+        },
         "rapidjson"
       ]
     },

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -641,7 +641,6 @@ arrow[cuda]:x64-windows-release = feature-fails
 arrow[cuda]:x64-windows-static = feature-fails
 arrow[cuda]:x64-windows-static-md = feature-fails
 arrow[cuda](!(windows & x64 & !uwp & !xbox) & !(linux & x64) & !(linux & arm64)) = cascade
-arrow[mimalloc]:x64-windows-static-md = feature-fails
 arrow[orc]:arm64-android = cascade
 arrow[orc]:x64-android = cascade
 arrow[orc]:x64-windows = feature-fails

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44e37b3fb8df5a87f51550a11c1bd20af772a09a",
+      "version": "21.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ea170f76e42c4946d71e1473e51dc90cc1491d55",
       "version": "20.0.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -261,8 +261,8 @@
       "port-version": 8
     },
     "arrow": {
-      "baseline": "20.0.0",
-      "port-version": 1
+      "baseline": "21.0.0",
+      "port-version": 0
     },
     "arrow-adbc": {
       "baseline": "16",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
