### PR TITLE
[ci.feature.baseline] glib[selinux] should work now

### DIFF
--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -2089,7 +2089,6 @@ geogram[graphics] = feature-fails # imgui not found. See https://github.com/micr
 ggml[blas](windows & static) = feature-fails
 ginkgo[openmp](osx) = feature-fails # No openmp on osx
 ginkgo[openmp](windows) = feature-fails # needs openmp 3.0 support but msvc only supports openmp 2.0
-glib[selinux]:x64-linux = feature-fails # CI machines don't have libselinux1-dev installed
 glib-networking[openssl, gnutls] = options # You have to select exactly one ssl backend
 google-cloud-cpp[storagetransfer](osx) = feature-fails # See https://github.com/microsoft/vcpkg/issues/32149
 graphviz(osx) = fail # CMake configure error. See https://github.com/microsoft/vcpkg/issues/44414


### PR DESCRIPTION
When glib was upgraded to 2.84.2 in microsoft/vcpkg@c23913dea592755784ea1d448f908f5063fd1bcd , feature tests had recently been introduced to the CI pipeline. The more exhaustive test discovered that the CI failed to build the selinux feature enabled glib port, and accordingly it was marked as failing in [scripts/ci.feature.baseline.txt](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt).

A few days after microsoft/vcpkg@c23913dea592755784ea1d448f908f5063fd1bcd had landed in master, microsoft/vcpkg@f054aaf06874f107013807bffee10fbce4493180 patched the CI in order to allow for selinux consumers to be built, however, the failure record of glib[selinux] was not removed.

The unexpected success (or "failure to fail") of `glib[selinux]` on the x64-linux pipeline at microsoft/vcpkg#46450 indicates that microsoft/vcpkg@f054aaf06874f107013807bffee10fbce4493180 did indeed enable the CI to build selinux enabled glib.

This commit removes glib[selinux] from the known failures list.

Fixes: #46491 