### PR TITLE
[sqlgen] add new port

### DIFF
--- a/ports/sqlgen/portfile.cmake
+++ b/ports/sqlgen/portfile.cmake
@@ -1,0 +1,40 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO getml/sqlgen
+    REF "v${VERSION}"
+    SHA512 7858e592c881f5ae41a5f3d250c3c79e00117993bba9abd51da9fc379ecc17af37e129c584de15be917019ea7f22ac32e52e1ffbd1ef87cc47c52b82cfd72bde 
+    HEAD_REF main
+)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SQLGEN_BUILD_SHARED)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        postgres            SQLGEN_POSTGRES
+        sqlite3             SQLGEN_SQLITE3
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DSQLGEN_BUILD_TESTS=OFF
+        -DSQLGEN_BUILD_SHARED=${SQLGEN_BUILD_SHARED}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH "lib/cmake/${PORT}"
+)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/sqlgen/portfile.cmake
+++ b/ports/sqlgen/portfile.cmake
@@ -14,7 +14,6 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SQLGEN_BUILD_SHARED)
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         postgres            SQLGEN_POSTGRES
-        sqlite3             SQLGEN_SQLITE3
 )
 
 vcpkg_cmake_configure(
@@ -22,6 +21,7 @@ vcpkg_cmake_configure(
     OPTIONS
         ${FEATURE_OPTIONS}
         -DSQLGEN_BUILD_TESTS=OFF
+        -DSQLGEN_SQLITE3=ON
         -DSQLGEN_BUILD_SHARED=${SQLGEN_BUILD_SHARED}
 )
 

--- a/ports/sqlgen/usage
+++ b/ports/sqlgen/usage
@@ -1,0 +1,4 @@
+sqlgen provides CMake targets:
+
+    find_package(sqlgen CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE sqlgen::sqlgen)

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -10,7 +10,7 @@
       "version>=": "0.18.0"
     }
   ],
-  "features": {
+  "default-features": {
     "postgres": {
       "description": "Enable PostgreSQL support",
       "dependencies": [
@@ -31,7 +31,9 @@
           "version>=": "3.49.1"
         }
       ]
-    },
+    }
+  },
+  "features": {
     "tests": {
       "description": "Build the tests",
       "dependencies": [

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -8,6 +8,14 @@
     {
       "name": "reflectcpp",
       "version>=": "0.18.0"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ],
   "default-features": [

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -17,10 +17,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "postgres",
-    "sqlite3"
-  ],
   "features": {
     "postgres": {
       "description": "Enable PostgreSQL support",

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -45,8 +45,7 @@
       "description": "Build the tests",
       "dependencies": [
         {
-          "name": "gtest",
-          "version>=": "1.14.0"
+          "name": "gtest"
         }
       ]
     }

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -10,6 +10,10 @@
       "version>=": "0.18.0"
     }
   ],
+  "default-features": [
+    "postgres",
+    "sqlite3"
+  ],
   "features": {
     "postgres": {
       "description": "Enable PostgreSQL support",

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -26,8 +26,7 @@
       "description": "Enable PostgreSQL support",
       "dependencies": [
         {
-          "name": "libpq",
-          "version>=": "16.4"
+          "name": "libpq"
         }
       ]
     },

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -5,8 +5,12 @@
   "homepage": "https://github.com/getml/sqlgen/",
   "license": "MIT",
   "dependencies": [
+    "reflectcpp",
     {
-      "name": "reflectcpp"
+      "name": "sqlite3",
+      "features": [
+        "math"
+      ]
     },
     {
       "name": "vcpkg-cmake",
@@ -21,28 +25,13 @@
     "postgres": {
       "description": "Enable PostgreSQL support",
       "dependencies": [
-        {
-          "name": "libpq"
-        }
-      ]
-    },
-    "sqlite3": {
-      "description": "Enable SQLite3 support",
-      "dependencies": [
-        {
-          "name": "sqlite3",
-          "features": [
-            "math"
-          ]
-        }
+        "libpq"
       ]
     },
     "tests": {
       "description": "Build the tests",
       "dependencies": [
-        {
-          "name": "gtest"
-        }
+        "gtest"
       ]
     }
   }

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -37,8 +37,7 @@
           "name": "sqlite3",
           "features": [
             "math"
-          ],
-          "version>=": "3.49.1"
+          ]
         }
       ]
     },

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -6,8 +6,7 @@
   "license": "MIT",
   "dependencies": [
     {
-      "name": "reflectcpp",
-      "version>=": "0.18.0"
+      "name": "reflectcpp"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -10,7 +10,7 @@
       "version>=": "0.18.0"
     }
   ],
-  "default-features": {
+  "features": {
     "postgres": {
       "description": "Enable PostgreSQL support",
       "dependencies": [
@@ -31,9 +31,7 @@
           "version>=": "3.49.1"
         }
       ]
-    }
-  },
-  "features": {
+    },
     "tests": {
       "description": "Build the tests",
       "dependencies": [

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -25,8 +25,10 @@
       "dependencies": [
         {
           "name": "sqlite3",
-          "version>=": "3.49.1",
-          "features": ["math"]
+          "features": [
+            "math"
+          ],
+          "version>=": "3.49.1"
         }
       ]
     },

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -1,0 +1,43 @@
+{
+  "name": "sqlgen",
+  "version": "0.1.0",
+  "description": "sqlgen is an ORM and SQL query generator for C++-20, similar to Python's SQLAlchemy/SQLModel or Rust's Diesel.",
+  "homepage": "https://github.com/getml/sqlgen/",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "reflectcpp",
+      "version>=": "0.18.0"
+    }
+  ],
+  "features": {
+    "postgres": {
+      "description": "Enable PostgreSQL support",
+      "dependencies": [
+        {
+          "name": "libpq",
+          "version>=": "16.4"
+        }
+      ]
+    },
+    "sqlite3": {
+      "description": "Enable SQLite3 support",
+      "dependencies": [
+        {
+          "name": "sqlite3",
+          "version>=": "3.49.1",
+          "features": ["math"]
+        }
+      ]
+    },
+    "tests": {
+      "description": "Build the tests",
+      "dependencies": [
+        {
+          "name": "gtest",
+          "version>=": "1.14.0"
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9076,6 +9076,10 @@
       "baseline": "4.6.1",
       "port-version": 2
     },
+    "sqlgen": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "sqlite-modern-cpp": {
       "baseline": "2023-12-03",
       "port-version": 0

--- a/versions/s-/sqlgen.json
+++ b/versions/s-/sqlgen.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d8588dfa51658d7e39a8b189d75016dd8ebaad8d",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/sqlgen.json
+++ b/versions/s-/sqlgen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d8588dfa51658d7e39a8b189d75016dd8ebaad8d",
+      "git-tree": "10e096002fc94a36f7dd9e735e07dfe2b7c40331",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/s-/sqlgen.json
+++ b/versions/s-/sqlgen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "10e096002fc94a36f7dd9e735e07dfe2b7c40331",
+      "git-tree": "4a00a2dba37f2a284b45d57c5b100b312750beff",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/s-/sqlgen.json
+++ b/versions/s-/sqlgen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a00a2dba37f2a284b45d57c5b100b312750beff",
+      "git-tree": "0ca56df5bd7bd4b193c31802e67b9381b5a58ffa",
       "version": "0.1.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

