### PR TITLE
[oatpp-swagger] Update to 1.3.1

### DIFF
--- a/ports/oatpp-swagger/portfile.cmake
+++ b/ports/oatpp-swagger/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oatpp/oatpp-swagger
-    REF ${OATPP_VERSION}
-    SHA512 5b4ced90690f484ebe15c3a0be47b1b851fb7b650e70c99fddc20430724aac8eff89d8c6187df750bd2ceff0e1144336f258d740fc10cdfa67a65a2f3b00d80b
+    REF "1.3.1"
+    SHA512 ba4668e3cc90163219a29d61ef5fba2f3565d9f35c2d050723b00706f2ac5bb721d020f1a49a7c9025694ff7c93c3ff7e4318ef4be5bd1438c02a54df72ba1e3
     HEAD_REF master
 )
 

--- a/ports/oatpp-swagger/portfile.cmake
+++ b/ports/oatpp-swagger/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oatpp/oatpp-swagger
-    REF "1.3.1"
+    REF "${VERSION}"
     SHA512 ba4668e3cc90163219a29d61ef5fba2f3565d9f35c2d050723b00706f2ac5bb721d020f1a49a7c9025694ff7c93c3ff7e4318ef4be5bd1438c02a54df72ba1e3
     HEAD_REF master
 )

--- a/ports/oatpp-swagger/vcpkg.json
+++ b/ports/oatpp-swagger/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "oatpp-swagger",
-  "version": "1.3.0",
-  "port-version": 1,
+  "version": "1.3.1",
   "description": "Oat++ OpenApi (Swagger) UI submodule.",
   "homepage": "https://github.com/oatpp/oatpp-swagger",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6833,8 +6833,8 @@
       "port-version": 1
     },
     "oatpp-swagger": {
-      "baseline": "1.3.0",
-      "port-version": 1
+      "baseline": "1.3.1",
+      "port-version": 0
     },
     "oatpp-websocket": {
       "baseline": "1.3.0",

--- a/versions/o-/oatpp-swagger.json
+++ b/versions/o-/oatpp-swagger.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7a264b9eadda8ad004adb569904b16e0bc6c8eb",
+      "version": "1.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b8935367b57b4203e0eba828a6b8f9cc5ebb659c",
       "version": "1.3.0",
       "port-version": 1

--- a/versions/o-/oatpp-swagger.json
+++ b/versions/o-/oatpp-swagger.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e7a264b9eadda8ad004adb569904b16e0bc6c8eb",
+      "git-tree": "7417bc330d88662aaf4e824223fc7709e7f954fd",
       "version": "1.3.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/oatpp/oatpp-swagger/releases/tag/1.3.1
This tag is an alias for `1.3.0-latest`, avoids issues with version ordering - see this old PR for `oatpp-swagger`: [42349](https://github.com/microsoft/vcpkg/pull/42349/)


