### PR TITLE
[wolfssl] update to 5.8.2, GPLv3, and remove default blinding config

### DIFF
--- a/ports/wolfssl/portfile.cmake
+++ b/ports/wolfssl/portfile.cmake
@@ -33,9 +33,6 @@ foreach(config RELEASE DEBUG)
   if ("secret-callback" IN_LIST FEATURES)
       string(APPEND VCPKG_COMBINED_C_FLAGS_${config} " -DHAVE_SECRET_CALLBACK")
   endif()
-  if ("curve25519-blinding" IN_LIST FEATURES)
-      string(APPEND VCPKG_COMBINED_C_FLAGS_${config} " -DWOLFSSL_CURVE25519_BLINDING")
-  endif()
 endforeach()
 
 vcpkg_cmake_configure(

--- a/ports/wolfssl/portfile.cmake
+++ b/ports/wolfssl/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfssl/wolfssl
     REF "v${VERSION}-stable"
-    SHA512 b3953692a87aada84d77a26aac3ee1791344af3cf6e3d0b4fa9913095bc0892dd4cfe1491a893b469469bdfba511fe067ee80d3c0beab8df5ac5e174fa5f5577
+    SHA512 29f52644966f21908e0d3f795c62b0f5af9cd2d766db20c6ed5c588611f19f048119827fe6e787ccc3ce676d8c97cf7ab409d996df0e3acb812d6cd01364de61
     HEAD_REF master
     PATCHES
     )

--- a/ports/wolfssl/vcpkg.json
+++ b/ports/wolfssl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wolfssl",
-  "version": "5.8.0",
+  "version": "5.8.2",
   "port-version": 1,
   "description": "TLS and Cryptographic library for many platforms",
   "homepage": "https://wolfssl.com",

--- a/ports/wolfssl/vcpkg.json
+++ b/ports/wolfssl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "wolfssl",
   "version": "5.8.2",
-  "port-version": 1,
   "description": "TLS and Cryptographic library for many platforms",
   "homepage": "https://wolfssl.com",
   "license": "GPL-3.0-or-later",

--- a/ports/wolfssl/vcpkg.json
+++ b/ports/wolfssl/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 1,
   "description": "TLS and Cryptographic library for many platforms",
   "homepage": "https://wolfssl.com",
-  "license": "GPL-2.0-or-later",
+  "license": "GPL-3.0-or-later",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10285,7 +10285,7 @@
       "port-version": 0
     },
     "wolfssl": {
-      "baseline": "5.8.0",
+      "baseline": "5.8.2",
       "port-version": 1
     },
     "wolftpm": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10286,7 +10286,7 @@
     },
     "wolfssl": {
       "baseline": "5.8.2",
-      "port-version": 1
+      "port-version": 0
     },
     "wolftpm": {
       "baseline": "3.9.1",

--- a/versions/w-/wolfssl.json
+++ b/versions/w-/wolfssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02fafcdf7995b0f52f9b8a7b1d8e9434ac125799",
+      "version": "5.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d8784628ded587685d828236e7831207a68c28b4",
       "version": "5.8.2",
       "port-version": 1

--- a/versions/w-/wolfssl.json
+++ b/versions/w-/wolfssl.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "d8784628ded587685d828236e7831207a68c28b4",
-      "version": "5.8.2",
-      "port-version": 1
-    },
-    {
       "git-tree": "d498ee8ee4fe96b46333efb1633f314c07e80874",
       "version": "5.8.0",
       "port-version": 1

--- a/versions/w-/wolfssl.json
+++ b/versions/w-/wolfssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8784628ded587685d828236e7831207a68c28b4",
+      "version": "5.8.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "d498ee8ee4fe96b46333efb1633f314c07e80874",
       "version": "5.8.0",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
