### PR TITLE
Resolve missing permissions block security alert

### DIFF
--- a/.github/workflows/check_tools_sha.yml
+++ b/.github/workflows/check_tools_sha.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "scripts/vcpkg-tools.json"
 
+permissions:
+  contents: read
+
 jobs:
   check-tools-sha:
     runs-on: ubuntu-latest


### PR DESCRIPTION
... and give the tools check task a better name than 'check_issues copy'

This resolves a security alert introduced in #46484 : https://github.com/microsoft/vcpkg/security/code-scanning/15