### PR TITLE
[marisa-trie] update to 0.3.1

### DIFF
--- a/ports/marisa-trie/portfile.cmake
+++ b/ports/marisa-trie/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO s-yata/marisa-trie
     REF v${VERSION}
-    SHA512 6d72b13daec877c9c42e2c93e591e3a5e9c738bb130c5d90d6adfde81d5b500684ca176439b7502d9243b6417f34c7b39750ff3fb3a5c52d8d06cb9bc5f14c22
+    SHA512 60757e354e4f0ff47662930af5c32a762c5f348c60019abb2d502c6c21ec220731edd9be8ea36e3ec68df90a6584eb311fe1e3d4258b3392609a87b0ef427121
     HEAD_REF master
     PATCHES
         enable-debug.patch

--- a/ports/marisa-trie/vcpkg.json
+++ b/ports/marisa-trie/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "marisa-trie",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Matching Algorithm with Recursively Implemented StorAge (MARISA) is a space-efficient trie data structure. This is a C++ library for an implementation of MARISA.",
   "homepage": "https://github.com/s-yata/marisa-trie",
   "license": "BSD-2-Clause OR LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6081,7 +6081,7 @@
       "port-version": 0
     },
     "marisa-trie": {
-      "baseline": "0.3.0",
+      "baseline": "0.3.1",
       "port-version": 0
     },
     "marl": {

--- a/versions/m-/marisa-trie.json
+++ b/versions/m-/marisa-trie.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9ed96bfba38e536fc98accdf928837988de3ab32",
+      "version": "0.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c6087bdf3aa5e9e20deacb8964d4d4c2a698ea4a",
       "version": "0.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/s-yata/marisa-trie/releases/tag/v0.3.1
