### PR TITLE
[harfbuzz] update to 11.3.2

### DIFF
--- a/ports/harfbuzz/add-parameter-name.patch
+++ b/ports/harfbuzz/add-parameter-name.patch
@@ -1,0 +1,13 @@
+diff --git a/util/test-hb-subset-parsing.c b/util/test-hb-subset-parsing.c
+index d619a51..ee83e95 100644
+--- a/util/test-hb-subset-parsing.c
++++ b/util/test-hb-subset-parsing.c
+@@ -101,7 +101,7 @@ test_parse_instancing_spec (void)
+ 
+ 
+ int
+-main (int, char **)
++main (int argc, char **argv)
+ {
+   test_parse_instancing_spec();
+ 

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
     REF ${VERSION}
-    SHA512 1dd91dea966e7da2d4077bb711f5936e30829a80b88ea77b987da57f15ae9566aa2eaf8bd1dcf099e73c2eb52b66654c6cb1f69c907c58f3d046e284e81d973c
+    SHA512 15b89d0d5a434d56474fde13b3fffa269dfbb4f2f24969ae5d3cbbd03aa9e782ab93a44bbb8517fd6396638e9fb5e1eca22e27d3a554a43be1f53817caab866b
     HEAD_REF master
     PATCHES
         fix-win32-build.patch

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
     REF ${VERSION}
-    SHA512 15b89d0d5a434d56474fde13b3fffa269dfbb4f2f24969ae5d3cbbd03aa9e782ab93a44bbb8517fd6396638e9fb5e1eca22e27d3a554a43be1f53817caab866b
+    SHA512 1d0f19e6aebc6aa273e749fb7968eff851dcfb15a0b5ef6cf268c74e77a81175d845c20c9285be7e9a7cb79871cb08bdac5c9d802a50fc5bd11a7225d510f48f
     HEAD_REF master
     PATCHES
         fix-win32-build.patch

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-win32-build.patch
+        add-parameter-name.patch
 )
 
 if("icu" IN_LIST FEATURES)

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "harfbuzz",
-  "version": "11.3.2",
+  "version": "11.3.3",
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "harfbuzz",
-  "version": "11.2.0",
+  "version": "11.3.2",
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3641,7 +3641,7 @@
       "port-version": 1
     },
     "harfbuzz": {
-      "baseline": "11.2.0",
+      "baseline": "11.3.2",
       "port-version": 0
     },
     "hash-library": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3641,7 +3641,7 @@
       "port-version": 1
     },
     "harfbuzz": {
-      "baseline": "11.3.2",
+      "baseline": "11.3.3",
       "port-version": 0
     },
     "hash-library": {

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "6b51cfe0b1c5d01ea16f004f1cff24523abb45ed",
-      "version": "11.3.2",
+      "git-tree": "14f2e7630c576d41e7ae856b844423cb4a14b87a",
+      "version": "11.3.3",
       "port-version": 0
     },
     {

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "19cc1216127d6961b81e288e5012a320cbc903ea",
+      "version": "11.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ef4fc292c6d2303971b50afc92fbd7bc38acc89d",
       "version": "11.2.0",
       "port-version": 0

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "19cc1216127d6961b81e288e5012a320cbc903ea",
+      "git-tree": "6b51cfe0b1c5d01ea16f004f1cff24523abb45ed",
       "version": "11.3.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/harfbuzz/harfbuzz/releases/tag/11.3.2
