### PR TITLE
[openslide] depend on gdk-pixbuf "others" feature

### DIFF
--- a/ports/openslide/vcpkg.json
+++ b/ports/openslide/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openslide",
   "version": "4.0.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "OpenSlide is a C library for reading whole slide image files (also known as virtual slides). It provides a consistent and simple API for reading files from multiple vendors.",
   "homepage": "https://openslide.org/",
   "license": "LGPL-2.1-only",
@@ -13,7 +13,10 @@
     },
     {
       "name": "gdk-pixbuf",
-      "default-features": false
+      "default-features": false,
+      "features": [
+        "others"
+      ]
     },
     "glib",
     "libdicom",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7066,7 +7066,7 @@
     },
     "openslide": {
       "baseline": "4.0.0",
-      "port-version": 2
+      "port-version": 3
     },
     "openssl": {
       "baseline": "3.5.1",

--- a/versions/o-/openslide.json
+++ b/versions/o-/openslide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "38b3b2656b0bff8bc0db907e97f1d6f6e90a740a",
+      "version": "4.0.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "504a6d42b6127c8d8f8c35b48861f8d84ae68c34",
       "version": "4.0.0",
       "port-version": 2


### PR DESCRIPTION
OpenSlide uses gdk-pixbuf only for its BMP loader.  Previously this was always available, but now it's gated behind the `others` feature due to an upstream default change.  Without it, MIRAX BMP slides won't load and OpenSlide's self-test won't pass.

Depend on the `others` feature so users don't need to debug an obscure runtime failure.  The next release of OpenSlide will replace the gdk-pixbuf dependency with a built-in BMP loader, so this is only needed temporarily.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.