### PR TITLE
[libremidi] Disable pipewire, add test port

### DIFF
--- a/ports/libremidi/portfile.cmake
+++ b/ports/libremidi/portfile.cmake
@@ -19,9 +19,11 @@ vcpkg_cmake_configure(
         ${options}
         -DLIBREMIDI_NO_BOOST=ON
         -DLIBREMIDI_NO_JACK=ON
+        -DLIBREMIDI_NO_PIPEWIRE=ON
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/libremidi/vcpkg.json
+++ b/ports/libremidi/vcpkg.json
@@ -1,17 +1,13 @@
 {
   "name": "libremidi",
   "version": "4.5.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A modern C++ MIDI real-time & file I/O library",
   "homepage": "https://github.com/jcelerier/libremidi",
   "license": "BSD-2-Clause",
   "dependencies": [
     {
       "name": "alsa",
-      "platform": "linux"
-    },
-    {
-      "name": "readerwriterqueue",
       "platform": "linux"
     },
     {

--- a/scripts/test_ports/vcpkg-ci-libremidi/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-libremidi/portfile.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-libremidi/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-libremidi/project/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.30)
+project(libremidi-test CXX)
+
+find_package(libremidi CONFIG REQUIRED)
+add_library(imported::libremidi ALIAS libremidi)
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE imported::libremidi)

--- a/scripts/test_ports/vcpkg-ci-libremidi/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-libremidi/project/main.cpp
@@ -1,0 +1,12 @@
+#include <libremidi/libremidi.hpp>
+#include <libremidi/backends.hpp>
+#include <iostream>
+
+int main()
+{
+    std::cout << "Default midi2 API: " << libremidi::get_api_display_name(libremidi::midi2::default_api()) << std::endl;
+    libremidi::midi_any::for_all_backends([](auto& backend) {
+        std::cout << "- " << backend.display_name << std::endl;
+    });
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-libremidi/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-libremidi/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-libremidi",
+  "version-string": "ci",
+  "description": "Validates libremidi",
+  "dependencies": [
+    "libremidi",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5286,7 +5286,7 @@
     },
     "libremidi": {
       "baseline": "4.5.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libressl": {
       "baseline": "4.1.0",

--- a/versions/l-/libremidi.json
+++ b/versions/l-/libremidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5a10d57f2032120b80d4645366bc7290a4f149e",
+      "version": "4.5.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "a9f7f74d1c8742a224f1bd79011ac5fee7a0247b",
       "version": "4.5.0",
       "port-version": 1


### PR DESCRIPTION
Resolves #46519.

If pipewire is desired, it must be added with proper dependencies.