### PR TITLE
[vbs-enclave-tooling-codegen] Add new port

### DIFF
--- a/ports/vbs-enclave-tooling-codegen/portfile.cmake
+++ b/ports/vbs-enclave-tooling-codegen/portfile.cmake
@@ -1,7 +1,3 @@
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-     message(FATAL_ERROR "ERROR: Vbs enclave tooling is not supported on x86 architecture.")
-endif()
-
 if (NOT EXISTS "$ENV{WindowsSDKDir}/Lib/$ENV{WindowsSDKVersion}.")
     message(FATAL_ERROR "ERROR: Cannot locate the Windows SDK. Please define %WindowsSDKDir% and %WindowsSDKVersion%.
 (Expected file to exist: $ENV{WindowsSDKDir}/Lib/$ENV{WindowsSDKVersion})")

--- a/ports/vbs-enclave-tooling-codegen/portfile.cmake
+++ b/ports/vbs-enclave-tooling-codegen/portfile.cmake
@@ -1,0 +1,75 @@
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+     message(FATAL_ERROR "ERROR: Vbs enclave tooling is not supported on x86 architecture.")
+endif()
+
+if (NOT EXISTS "$ENV{WindowsSDKDir}/Lib/$ENV{WindowsSDKVersion}.")
+    message(FATAL_ERROR "ERROR: Cannot locate the Windows SDK. Please define %WindowsSDKDir% and %WindowsSDKVersion%.
+(Expected file to exist: $ENV{WindowsSDKDir}/Lib/$ENV{WindowsSDKVersion})")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/VbsEnclaveTooling
+    REF "v${VERSION}"
+    SHA512 "510638e1b29125ed65423de03c5b8c57c27811832e0ebb60942c1d4b97a91be934c9a63b5550a52e9e2ac0a19fa5674f78f9d86e1393081c0042748934fdcd2b"
+    HEAD_REF main
+)
+
+# All the projects in the repo require some nuget packages to be installed so we need
+# to run nuget restore prior to running the msbuild function.
+vcpkg_find_acquire_program(NUGET)
+vcpkg_execute_required_process(
+    COMMAND ${NUGET} restore "${SOURCE_PATH}/VbsEnclaveTooling.sln"
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME nuget-restore
+)
+
+vcpkg_list(SET MSBUILD_OPTIONS
+    "/p:VbsEnclaveCodegenVersion=${VERSION}"
+)
+
+vcpkg_msbuild_install(
+  SOURCE_PATH "${SOURCE_PATH}"
+  PROJECT_SUBPATH VbsEnclaveTooling.sln
+  NO_INSTALL # Make sure libs, exes and dlls from consumed nuget packages don't get added
+  NO_TOOLCHAIN_PROPS 
+  OPTIONS 
+    ${MSBUILD_OPTIONS}
+)
+
+file(INSTALL
+    "${SOURCE_PATH}/src/ToolingSharedLibrary/Includes/VbsEnclaveABI"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
+    FILES_MATCHING PATTERN "*.h"
+)
+
+file(INSTALL
+    "${SOURCE_PATH}/Common/veil_enclave_wil_inc/wil"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
+    FILES_MATCHING PATTERN "*.h"
+)
+
+set(RELEASE_BUILD_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/_build/${VCPKG_TARGET_ARCHITECTURE}/Release")
+set(DEBUG_BUILD_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/_build/${VCPKG_TARGET_ARCHITECTURE}/Debug")
+
+# Note: the vcxproj project that creates edlcodegen.exe is always built using x64, regardless of what 
+# is passed to vcpkg_msbuild_install. This is by design.
+if (EXISTS "${RELEASE_BUILD_DIR}")
+    vcpkg_copy_tools(TOOL_NAMES edlcodegen SEARCH_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/_build/x64/Release"  AUTO_CLEAN)
+    file(GLOB CPP_SUPPORT_LIB_FILE "${RELEASE_BUILD_DIR}/veil_enclave_cpp_support_${VCPKG_TARGET_ARCHITECTURE}_Release_lib.lib")
+    file(INSTALL DESTINATION "${CURRENT_PACKAGES_DIR}/lib" TYPE FILE FILES "${CPP_SUPPORT_LIB_FILE}")
+endif()
+
+if(EXISTS "${DEBUG_BUILD_DIR}")
+    vcpkg_copy_tools(
+        TOOL_NAMES edlcodegen 
+        SEARCH_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/_build/x64/Debug" 
+        DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug"
+        AUTO_CLEAN
+    )
+
+    file(GLOB CPP_SUPPORT_LIB_FILE "${DEBUG_BUILD_DIR}/veil_enclave_cpp_support_${VCPKG_TARGET_ARCHITECTURE}_Debug_lib.lib")
+    file(INSTALL DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib" TYPE FILE FILES "${CPP_SUPPORT_LIB_FILE}")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/vbs-enclave-tooling-codegen/portfile.cmake
+++ b/ports/vbs-enclave-tooling-codegen/portfile.cmake
@@ -1,8 +1,3 @@
-if (NOT EXISTS "$ENV{WindowsSDKDir}/Lib/$ENV{WindowsSDKVersion}.")
-    message(FATAL_ERROR "ERROR: Cannot locate the Windows SDK. Please define %WindowsSDKDir% and %WindowsSDKVersion%.
-(Expected file to exist: $ENV{WindowsSDKDir}/Lib/$ENV{WindowsSDKVersion})")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/VbsEnclaveTooling

--- a/ports/vbs-enclave-tooling-codegen/vcpkg.json
+++ b/ports/vbs-enclave-tooling-codegen/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Supports code generation for VBS enclaves.",
   "homepage": "https://github.com/microsoft/vbsEnclaveTooling",
   "license": "MIT",
-  "supports": "windows",
+  "supports": "(windows & arm64) | (windows & x64)",
   "dependencies": [
     "flatbuffers",
     "ms-gsl",

--- a/ports/vbs-enclave-tooling-codegen/vcpkg.json
+++ b/ports/vbs-enclave-tooling-codegen/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "vbs-enclave-tooling-codegen",
+  "version": "0.0.2-prerelease",
+  "description": "Supports code generation for VBS enclaves.",
+  "homepage": "https://github.com/microsoft/vbsEnclaveTooling",
+  "license": "MIT",
+  "supports": "windows",
+  "dependencies": [
+    "flatbuffers",
+    "ms-gsl",
+    {
+      "name": "vcpkg-msbuild",
+      "host": true
+    },
+    "wil"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9892,6 +9892,10 @@
       "baseline": "2.0.0",
       "port-version": 0
     },
+    "vbs-enclave-tooling-codegen": {
+      "baseline": "0.0.2-prerelease",
+      "port-version": 0
+    },
     "vc": {
       "baseline": "1.4.4",
       "port-version": 0

--- a/versions/v-/vbs-enclave-tooling-codegen.json
+++ b/versions/v-/vbs-enclave-tooling-codegen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1f16c667d972611b0ec529d94bfd15c8987f4eff",
+      "git-tree": "3ed39c5f27ff5d73f53443424c99a15a2c241795",
       "version": "0.0.2-prerelease",
       "port-version": 0
     }

--- a/versions/v-/vbs-enclave-tooling-codegen.json
+++ b/versions/v-/vbs-enclave-tooling-codegen.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1f16c667d972611b0ec529d94bfd15c8987f4eff",
+      "version": "0.0.2-prerelease",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/v-/vbs-enclave-tooling-codegen.json
+++ b/versions/v-/vbs-enclave-tooling-codegen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "60d330db19da23918d76225f752e3759fe08324b",
+      "git-tree": "870aafddc5d596ba89e52748bebb069e0836e47b",
       "version": "0.0.2-prerelease",
       "port-version": 0
     }

--- a/versions/v-/vbs-enclave-tooling-codegen.json
+++ b/versions/v-/vbs-enclave-tooling-codegen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3ed39c5f27ff5d73f53443424c99a15a2c241795",
+      "git-tree": "60d330db19da23918d76225f752e3759fe08324b",
       "version": "0.0.2-prerelease",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Repository: https://github.com/microsoft/VbsEnclaveTooling 