### PR TITLE
[xlsxio] update xlsxio to 0.2.35

### DIFF
--- a/ports/xlsxio/fix-dependencies.patch
+++ b/ports/xlsxio/fix-dependencies.patch
@@ -1,8 +1,20 @@
+From ac48075c5813f8ff2036aafddc0c391955ea36ae Mon Sep 17 00:00:00 2001
+From: Jackey Lea <1768478912@qq.com>
+Date: Wed, 23 Jul 2025 14:23:04 +0800
+Subject: [PATCH] =?UTF-8?q?vcpkg=E7=BC=96=E8=AF=91?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+---
+ CMakeLists.txt | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7e86706..f2bdc36 100644
+index 0ada641..2aa5744 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -57,7 +57,9 @@ ELSEIF(WITH_MINIZIP_NG)
+@@ -57,7 +57,10 @@ ELSEIF(WITH_MINIZIP_NG)
    SET(ANYZIP_LIBRARIES minizip${MINIZIP_NG_SUFFIX})
    SET(ANYZIP_DEF USE_MINIZIP;USE_MINIZIP_NG)
  ELSE()
@@ -10,10 +22,11 @@ index 7e86706..f2bdc36 100644
 +  FIND_PACKAGE(Minizip NAMES unofficial-minizip REQUIRED)
 +  SET(MINIZIP_INCLUDE_DIRS "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
 +  SET(MINIZIP_LIBRARIES unofficial::minizip::minizip)
++  SET(ANYZIP_DEF USE_MINIZIP)
    SET(ANYZIP_INCLUDE_DIRS ${MINIZIP_INCLUDE_DIRS})
    SET(ANYZIP_LIBRARIES ${MINIZIP_LIBRARIES})
    SET(ANYZIP_DEF USE_MINIZIP)
-@@ -68,7 +70,8 @@ IF(EXPAT_DIR)
+@@ -68,7 +71,8 @@ IF(EXPAT_DIR)
    FIND_PATH(EXPAT_INCLUDE_DIR NAMES expat.h NO_DEFAULT_PATH PATHS ${EXPAT_DIR}/include ${EXPAT_DIR})
    FIND_LIBRARY(EXPAT_LIBRARIES NAMES expat libexpat NO_DEFAULT_PATH PATHS ${EXPAT_DIR}/lib ${EXPAT_DIR})
  ELSE()
@@ -21,9 +34,9 @@ index 7e86706..f2bdc36 100644
 +  FIND_PACKAGE(EXPAT NAMES expat REQUIRED)
 +  SET(EXPAT_LIBRARIES expat::expat)
  ENDIF()
- #   dependancy: expatw (if wide library was requested)
+ #   dependency: expatw (if wide library was requested)
  IF(WITH_WIDE)
-@@ -225,13 +228,13 @@ FILE(WRITE "${CMAKE_CURRENT_BINARY_DIR}/xlsxio-config.cmake.in"
+@@ -225,13 +229,13 @@ FILE(WRITE "${CMAKE_CURRENT_BINARY_DIR}/xlsxio-config.cmake.in"
  IF (@WITH_LIBZIP@)
    FIND_DEPENDENCY(LibZip)
  ELSE()
@@ -39,3 +52,6 @@ index 7e86706..f2bdc36 100644
  ENDIF()
  
  IF(@WITH_WIDE@)
+-- 
+2.50.1.windows.1
+

--- a/ports/xlsxio/portfile.cmake
+++ b/ports/xlsxio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO brechtsanders/xlsxio
     REF "${VERSION}"
-    SHA512 67b9a4e275446f3ca08e91d31f05236855e761c06ed84ea3aea8c25a7cd6729191f6c95b9efe07392775a75e2713e7ec2c6d216b8d310e7b46bee531cccba8be
+    SHA512 9608e208cd71669e2b38bd64b0f21c8642ff34dbbb1d03f1d3ea1a6c166ada4e945b781fbaeb0f7f43753a23c3a5e833dcb5c5d6fd39177c99a00f867cc040d6
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/xlsxio/vcpkg.json
+++ b/ports/xlsxio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xlsxio",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "Cross-platform C library for reading values from and writing values to .xlsx files",
   "homepage": "https://github.com/brechtsanders/xlsxio",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10425,7 +10425,7 @@
       "port-version": 0
     },
     "xlsxio": {
-      "baseline": "0.2.34",
+      "baseline": "0.2.35",
       "port-version": 0
     },
     "xmlsec": {

--- a/versions/x-/xlsxio.json
+++ b/versions/x-/xlsxio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99e158bbe73bccd5edff7a1a6c36c40ec37a1fcd",
+      "version": "0.2.35",
+      "port-version": 0
+    },
+    {
       "git-tree": "fd38fc13e5e2b58d149261e8d692e1df7f93b88a",
       "version": "0.2.34",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
