### PR TITLE
[quarter] support arm64-osx

### DIFF
--- a/ports/quarter/vcpkg.json
+++ b/ports/quarter/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "quarter",
   "version": "1.2.3",
+  "port-version": 1,
   "description": "Coin3D GUI binding for Qt",
   "homepage": "https://coin3d.github.io/quarter/",
   "license": "BSD-3-Clause",
-  "supports": "!arm & !android & !uwp",
+  "supports": "!android & !uwp",
   "dependencies": [
     "coin",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8118,7 +8118,7 @@
     },
     "quarter": {
       "baseline": "1.2.3",
-      "port-version": 0
+      "port-version": 1
     },
     "quaternions": {
       "baseline": "1.0.0",

--- a/versions/q-/quarter.json
+++ b/versions/q-/quarter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "62e490a3c72e0f0c2a0957e1c5d6f30acce05bc3",
+      "version": "1.2.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "a276007615295568a553a82f024770c36fb7bafa",
       "version": "1.2.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

<!-- END OF NEW PORT CHECKLIST -->