### PR TITLE
[plutovg] update to 1.3.0

### DIFF
--- a/ports/plutovg/portfile.cmake
+++ b/ports/plutovg/portfile.cmake
@@ -2,14 +2,20 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sammycage/plutovg
     REF "v${VERSION}"
-    SHA512 e23830789401ad1dbf611451ce80e8a12391145dca28f26180cb2875a299ea38b5cb27311a17fd729a1341b96c1ff3c13248a8a6b9945ea981700bc51bba32c7
+    SHA512 d704286cb325d55c76852a08d573cae3f14b2a0f1fb8e43d922e64c685d4e71d69fe4ed7cc2368b3c0cde2992e8abfe9090781a80be251dcea50615266efc6ed
     HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+        font-face-cache        PLUTOVG_DISABLE_FONT_FACE_CACHE_LOAD
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DPLUTOVG_BUILD_EXAMPLES=OFF
+        ${FEATURE_OPTIONS}
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/plutovg/vcpkg.json
+++ b/ports/plutovg/vcpkg.json
@@ -14,9 +14,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "font-face-cache"
-  ],
   "features": {
     "font-face-cache": {
       "description": "Enable loading font face cache from files and directories"

--- a/ports/plutovg/vcpkg.json
+++ b/ports/plutovg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "plutovg",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Tiny 2D vector graphics library in C",
   "homepage": "https://github.com/sammycage/plutovg",
   "license": "MIT",
@@ -13,5 +13,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "font-face-cache"
+  ],
+  "features": {
+    "font-face-cache": {
+      "description": "Enable loading font face cache from files and directories"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7417,7 +7417,7 @@
       "port-version": 0
     },
     "plutovg": {
-      "baseline": "1.2.0",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "pmdk": {

--- a/versions/p-/plutovg.json
+++ b/versions/p-/plutovg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6748bb00df163ba51da0dc4f33c171e2f81e452e",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "eb627e356687aa76f34842e95f300cda490e0585",
       "version": "1.2.0",
       "port-version": 0

--- a/versions/p-/plutovg.json
+++ b/versions/p-/plutovg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6748bb00df163ba51da0dc4f33c171e2f81e452e",
+      "git-tree": "fe6f4197abcf5acc1d2ca80d5150539e509bf4e3",
       "version": "1.3.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/sammycage/plutovg/releases/tag/v1.3.0
