### PR TITLE
[redis-plus-plus] update to 1.3.15

### DIFF
--- a/ports/redis-plus-plus/fix-absolute-path.patch
+++ b/ports/redis-plus-plus/fix-absolute-path.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c329f9b..785ca3c 100644
+index 4b99109..e45ca43 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -180,7 +180,7 @@ set(CMAKE_REQUIRED_LIBRARIES ${HIREDIS_FEATURE_TEST_LIB})
- CHECK_SYMBOL_EXISTS(redisEnableKeepAliveWithInterval ${HIREDIS_FEATURE_TEST_HEADER} REDIS_PLUS_PLUS_HAS_redisEnableKeepAliveWithInterval)
+@@ -158,7 +158,7 @@ if(${redisEnableKeepAliveWithInterval_POS} GREATER -1)
+ endif()
  
  set(REDIS_PLUS_PLUS_GENERATED_HEADER_DIR ${CMAKE_CURRENT_BINARY_DIR}/${REDIS_PLUS_PLUS_HEADER_DIR})
 -configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hiredis_features.h.in ${CMAKE_CURRENT_BINARY_DIR}/${REDIS_PLUS_PLUS_SOURCE_DIR}/hiredis_features.h)
 +configure_file("${CMAKE_CURRENT_SOURCE_DIR}/hiredis_features.h.in" "${CMAKE_CURRENT_BINARY_DIR}/${REDIS_PLUS_PLUS_SOURCE_DIR}/hiredis_features.h")
  
- # Restore CMAKE_REQUIRED_LIBRARIES
- set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_BACK})
+ # Build static library
+ option(REDIS_PLUS_PLUS_BUILD_STATIC "Build static library" ON)

--- a/ports/redis-plus-plus/portfile.cmake
+++ b/ports/redis-plus-plus/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sewenew/redis-plus-plus
     REF "${VERSION}"
-    SHA512 62dbba8e641fbac71ea322e2f7766360c601959c371bfde2ab9cb0613f65eb42b442e76ef4130d64ece4058b4f4d7872503d4774a505ab0616955e95706143c8
+    SHA512 3de216fc32894eb2d9f61a559bf69c8e154122209f2ba95aac202d769688d27cd1059424ad8a1173c7073ee34bfbd5ad981bb313d9298cd39ebe245e88d9e9fe
     HEAD_REF master
     PATCHES
         fix-conversion.patch

--- a/ports/redis-plus-plus/vcpkg.json
+++ b/ports/redis-plus-plus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-plus-plus",
-  "version-semver": "1.3.14",
+  "version-semver": "1.3.15",
   "description": "This is a C++ client for Redis. It's based on hiredis, and written in C++ 11",
   "homepage": "https://github.com/sewenew/redis-plus-plus",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8285,7 +8285,7 @@
       "port-version": 0
     },
     "redis-plus-plus": {
-      "baseline": "1.3.14",
+      "baseline": "1.3.15",
       "port-version": 0
     },
     "refl-cpp": {

--- a/versions/r-/redis-plus-plus.json
+++ b/versions/r-/redis-plus-plus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f6f33db854734d2ef41baca161efbe9c39dd8194",
+      "version-semver": "1.3.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "9102faa25c41f356a5041677c48a2bf7549e5a62",
       "version-semver": "1.3.14",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/sewenew/redis-plus-plus/releases/tag/1.3.15
