### PR TITLE
Malware detector

### DIFF
--- a/ports/malware-detection/portfile.cmake
+++ b/ports/malware-detection/portfile.cmake
@@ -1,0 +1,17 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO galihru/malware-detector
+    REF v1.0.0  # Ganti dengan tag atau commit hash kamu
+    SHA512 0  # Sementara isi 0, akan diganti nanti setelah testing
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PREFER_NINJA
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/malware-detection/usage
+++ b/ports/malware-detection/usage
@@ -1,0 +1,6 @@
+# Usage file
+To use malware-detector, include the header and link the library:
+
+    #include <malware_detector/core.hpp>
+
+    target_link_libraries(main PRIVATE malware-detector)

--- a/ports/malware-detection/vcpkg.json
+++ b/ports/malware-detection/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "malware-detector",
+  "version": "1.0.0",
+  "description": "A C++ malware detection library.",
+  "homepage": "https://github.com/galihru/malware-detector",
+  "license": "MIT"
+}

--- a/ports/malware-detector/portfile.cmake
+++ b/ports/malware-detector/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO galihru/malware-detector
+    REF auto-release-104
+    SHA512 c7ba059206f06caebf4599062c54ccda916c999895000e943ec1bc0f1a8e18e43f4cb82e307bbe77306d998f41474c382f73983f5e2e88fd3881d6b30dd14b85
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DMALWARE_DETECTOR_BUILD_EXAMPLES=OFF
+        -DMALWARE_DETECTOR_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/malware_detector)
+
+# Fix pkgconfig
+vcpkg_fixup_pkgconfig()
+
+# Remove debug include directory
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# Install usage file
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/malware-detector RENAME copyright)

--- a/ports/malware-detector/portfile.cmake
+++ b/ports/malware-detector/portfile.cmake
@@ -1,8 +1,14 @@
-vcpkg_from_github(
+﻿vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO galihru/malware-detector
     REF auto-release-104
     SHA512 c7ba059206f06caebf4599062c54ccda916c999895000e943ec1bc0f1a8e18e43f4cb82e307bbe77306d998f41474c382f73983f5e2e88fd3881d6b30dd14b85
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tests MALWARE_DETECTOR_BUILD_TESTS
+        examples MALWARE_DETECTOR_BUILD_EXAMPLES
 )
 
 vcpkg_cmake_configure(
@@ -10,6 +16,8 @@ vcpkg_cmake_configure(
     OPTIONS
         -DMALWARE_DETECTOR_BUILD_EXAMPLES=OFF
         -DMALWARE_DETECTOR_BUILD_TESTS=OFF
+        -DMALWARE_DETECTOR_INSTALL=ON
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/malware-detector/usage
+++ b/ports/malware-detector/usage
@@ -1,0 +1,6 @@
+# Usage file
+To use malware-detector, include the header and link the library:
+
+    #include <malware_detector/core.hpp>
+
+    target_link_libraries(main PRIVATE malware-detector)

--- a/ports/malware-detector/vcpkg.json
+++ b/ports/malware-detector/vcpkg.json
@@ -1,0 +1,11 @@
+{
+    "name": "malware-detector",
+    "version": "1.0.104",
+    "homepage": "https://github.com/galihru/malware-detector",
+    "description": "A lightweight malware detector C++ library",
+    "license": "MIT",
+    "dependencies": [
+        "vcpkg-cmake",
+        "vcpkg-cmake-config"
+    ]
+}

--- a/ports/malware-detector/vcpkg.json
+++ b/ports/malware-detector/vcpkg.json
@@ -1,11 +1,16 @@
-{
+﻿{
     "name": "malware-detector",
     "version": "1.0.104",
     "homepage": "https://github.com/galihru/malware-detector",
     "description": "A lightweight malware detector C++ library",
     "license": "MIT",
+    "supports": "!(android | arm | uwp | xbox | wasm32)",
     "dependencies": [
         "vcpkg-cmake",
-        "vcpkg-cmake-config"
+        "vcpkg-cmake-config",
+        {
+            "name": "pthreads",
+            "platform": "!windows"
+        }
     ]
 }

--- a/ports/malware-detector/vcpkg.json
+++ b/ports/malware-detector/vcpkg.json
@@ -1,16 +1,16 @@
-﻿{
-    "name": "malware-detector",
-    "version": "1.0.104",
-    "homepage": "https://github.com/galihru/malware-detector",
-    "description": "A lightweight malware detector C++ library",
-    "license": "MIT",
-    "supports": "!(android | arm | uwp | xbox | wasm32)",
-    "dependencies": [
-        "vcpkg-cmake",
-        "vcpkg-cmake-config",
-        {
-            "name": "pthreads",
-            "platform": "!windows"
-        }
-    ]
+{
+  "name": "malware-detector",
+  "version": "1.0.104",
+  "description": "A lightweight malware detector C++ library",
+  "homepage": "https://github.com/galihru/malware-detector",
+  "license": "MIT",
+  "supports": "!(android | arm | uwp | xbox | wasm32)",
+  "dependencies": [
+    {
+      "name": "pthreads",
+      "platform": "!windows"
+    },
+    "vcpkg-cmake",
+    "vcpkg-cmake-config"
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6032,6 +6032,10 @@
       "baseline": "1.0.3",
       "port-version": 0
     },
+    "malware-detector": {
+      "baseline": "1.0.104",
+      "port-version": 0
+    },
     "manif": {
       "baseline": "0.0.5",
       "port-version": 0

--- a/versions/m-/malware-detector.json
+++ b/versions/m-/malware-detector.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "version": "1.0.0",
+      "port-version": 0,
+      "git-tree": "<isi-nanti>"
+    }
+  ]
+}

--- a/versions/m-/malware-detector.json
+++ b/versions/m-/malware-detector.json
@@ -1,9 +1,14 @@
 {
   "versions": [
     {
-      "version": "1.0.0",
-      "port-version": 0,
-      "git-tree": "<isi-nanti>"
+      "git-tree": "32d9e670abbcade3bad2b1efd77d14579a1099ee",
+      "version": "1.0.104",
+      "port-version": 0
+    },
+    {
+      "git-tree": "b9669961e8c64b62eeaccf4404d80db64de0ab07",
+      "version": "1.0.1",
+      "port-version": 0
     }
   ]
 }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
