### PR TITLE
[libassert] Bump to 2.2.1

### DIFF
--- a/ports/libassert/portfile.cmake
+++ b/ports/libassert/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jeremy-rifkin/libassert
     REF "v${VERSION}"
-    SHA512 6d4c0eec7483e1b202c62c937e8be70d3d8d3c9630498af79172fcbf0f1523de753f864068280430408675cab02c5acd03412c1eb17bd7af65d092e3a754c1fd
+    SHA512 877f7ddac1b3ffa77d6c30b9aa4c6bf2a32bd3089b5348b75b4f52ef474cf6ee1f754bab5f0396e3ee3df83f9a438a5154c0fefce683c479b2f3a8adaef3c0a7
     HEAD_REF main
 )
 

--- a/ports/libassert/vcpkg.json
+++ b/ports/libassert/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libassert",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "The most over-engineered C++ assertion library",
   "homepage": "https://github.com/jeremy-rifkin/libassert",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4521,7 +4521,7 @@
       "port-version": 0
     },
     "libassert": {
-      "baseline": "2.2.0",
+      "baseline": "2.2.1",
       "port-version": 0
     },
     "libassuan": {

--- a/versions/l-/libassert.json
+++ b/versions/l-/libassert.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ab5a1843ee05a1535282abfb68f84edb62265d6",
+      "version": "2.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "05340b5b5622e0d14eea84b0810ac3010451475a",
       "version": "2.2.0",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
