### PR TITLE
[matroska, ebml] Enable pkg-config install

### DIFF
--- a/ports/ebml/portfile.cmake
+++ b/ports/ebml/portfile.cmake
@@ -8,7 +8,6 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS -DDISABLE_PKGCONFIG=1
 )
 
 vcpkg_cmake_install()
@@ -21,3 +20,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL "${SOURCE_PATH}/LICENSE.LGPL" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()

--- a/ports/ebml/vcpkg.json
+++ b/ports/ebml/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ebml",
   "version": "1.4.5",
+  "port-version": 1,
   "description": "A C++ library to parse EBML files",
   "homepage": "https://github.com/Matroska-Org/libebml",
   "dependencies": [

--- a/ports/matroska/portfile.cmake
+++ b/ports/matroska/portfile.cmake
@@ -8,8 +8,6 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS 
-        -DDISABLE_PKGCONFIG=1
 )
 
 vcpkg_cmake_install()
@@ -22,3 +20,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL "${SOURCE_PATH}/LICENSE.LGPL" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()

--- a/ports/matroska/vcpkg.json
+++ b/ports/matroska/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "matroska",
   "version": "1.7.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "a C++ library to parse Matroska files (.mkv and .mka)",
   "homepage": "https://github.com/Matroska-Org/libmatroska",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2602,7 +2602,7 @@
     },
     "ebml": {
       "baseline": "1.4.5",
-      "port-version": 0
+      "port-version": 1
     },
     "ecal": {
       "baseline": "5.13.3",
@@ -6130,7 +6130,7 @@
     },
     "matroska": {
       "baseline": "1.7.1",
-      "port-version": 2
+      "port-version": 3
     },
     "mbedtls": {
       "baseline": "3.6.4",

--- a/versions/e-/ebml.json
+++ b/versions/e-/ebml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b67e2a399fe3de72e7873e968164abe0c238ad59",
+      "version": "1.4.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "211ad9219c349adeae527edf0bc1ae9c57028751",
       "version": "1.4.5",
       "port-version": 0

--- a/versions/m-/matroska.json
+++ b/versions/m-/matroska.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c137704f5db042cc03e9530be29aa46d4cfadf05",
+      "version": "1.7.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "3d414c27a074d4262517bf3fe72571e8f16ccab0",
       "version": "1.7.1",
       "port-version": 2


### PR DESCRIPTION
This PR enables pkg-config file generation for the matroska and ebml ports.
We're using Autoconf for our Linux builds, and we currently have to pass the flags manually to the configure script, while we could simply use the pkg-config support provided by those libraries if it were enabled in vcpkg.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
