### PR TITLE
[boinc] update to 8.2.5

### DIFF
--- a/ports/boinc/fix-android-build.patch
+++ b/ports/boinc/fix-android-build.patch
@@ -1,0 +1,32 @@
+diff --git a/configure.ac b/configure.ac
+index fd30579c4b3..61382a61365 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -734,10 +734,10 @@ sse3_flags="-msse3"
+ avx_flags="-mavx"
+ CXXFLAGS="${save_cxxflags} ${sse3_flags}"
+ CPPFLAGS="${save_cppflags} ${sse3_flags}"
+-AC_LINK_IFELSE([AC_LANG_PROGRAM([],)], [], [sse_flags=""])
++AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],)], [], [sse_flags=""])
+ CXXFLAGS="${save_cxxflags} ${avx_flags}"
+ CPPFLAGS="${save_cppflags} ${avx_flags}"
+-AC_LINK_IFELSE([AC_LANG_PROGRAM([],)], [], [avx_flags=""])
++AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],)], [], [avx_flags=""])
+ CXXFLAGS="${save_cxxflags} ${sse3_flags}"
+ CXXFLAGS="${save_cxxflags} ${sse3_flags}"
+ AC_CHECK_HEADERS([intrin.h x86intrin.h pmmintrin.h xmmintrin.h emmintrin.h])
+diff --git a/lib/diagnostics.cpp b/lib/diagnostics.cpp
+index d92d0b6cf36..911b627b189 100644
+--- a/lib/diagnostics.cpp
++++ b/lib/diagnostics.cpp
+@@ -42,6 +42,10 @@
+ #include "mac_backtrace.h"
+ #endif
+ 
++#if defined(ANDROID) && __ANDROID_API__ < 33
++#undef HAVE_EXECINFO_H
++#endif
++
+ #ifdef HAVE_EXECINFO_H
+ #include <execinfo.h>
+ #endif

--- a/ports/boinc/portfile.cmake
+++ b/ports/boinc/portfile.cmake
@@ -4,8 +4,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BOINC/boinc
     REF "client_release/${MAJOR_MINOR}/${VERSION}"
-    SHA512 0e0c4f7647325f8f1e8a87da0d7ff43d1a3e5d3ef0dc3daf1fb974a47c0e4fb7318b3fdde77d0ae6ec4f3d30be113a5ceff33658facc8f3c2c325c8c61942698
+    SHA512 1cb7a4d5a411fe703137f5c8127e03ce70e01a9d1c9d23e19b9d4231c833fabad779cf52dc7b85500ff54121c4b5e900ea1634c312ee1d72cfdf4c2051703c38
     HEAD_REF master
+    PATCHES
+        fix-android-build.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/boinc/vcpkg.json
+++ b/ports/boinc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "boinc",
-  "version": "8.0.4",
+  "version": "8.2.5",
   "description": "Open-source software for volunteer computing and grid computing.",
   "homepage": "https://boinc.berkeley.edu/",
   "license": "LGPL-3.0-or-later",

--- a/versions/b-/boinc.json
+++ b/versions/b-/boinc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3aa6f828171b0446bdbae2e6172b6290f353ba60",
+      "version": "8.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "dceee841c00561abe3de8241f9399dd60db96193",
       "version": "8.0.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -769,7 +769,7 @@
       "port-version": 0
     },
     "boinc": {
-      "baseline": "8.0.4",
+      "baseline": "8.2.5",
       "port-version": 0
     },
     "bond": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
