### PR TITLE
[catch2] update to 3.9.0

### DIFF
--- a/ports/catch2/fix-install-path.patch
+++ b/ports/catch2/fix-install-path.patch
@@ -1,45 +1,45 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1676ee7..34e8b95 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -164,7 +164,7 @@
+@@ -173,7 +173,7 @@ if(NOT_SUBPROJECT)
  
-     ## Provide some pkg-config integration
-     set(PKGCONFIG_INSTALL_DIR
--        "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig"
-+        "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-         CACHE PATH "Path where catch2.pc is installed"
-     )
-     configure_file(
+   ## Provide some pkg-config integration
+   set(PKGCONFIG_INSTALL_DIR
+-    "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig"
++    "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+     CACHE PATH "Path where catch2.pc is installed"
+   )
+ 
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 1e3af14..265626c 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -401,16 +401,28 @@
-     install(
-       TARGETS
-         Catch2
--        Catch2WithMain
-       EXPORT
-         Catch2Targets
-       LIBRARY DESTINATION
-         ${CMAKE_INSTALL_LIBDIR}
-       ARCHIVE DESTINATION
-         ${CMAKE_INSTALL_LIBDIR}
-       RUNTIME DESTINATION
-         ${CMAKE_INSTALL_BINDIR}
-     )
+@@ -402,7 +402,6 @@ if(NOT_SUBPROJECT)
+   install(
+     TARGETS
+       Catch2
+-      Catch2WithMain
+     EXPORT
+       Catch2Targets
+     LIBRARY DESTINATION
+@@ -413,6 +412,19 @@ if(NOT_SUBPROJECT)
+       ${CMAKE_INSTALL_BINDIR}
+   )
+ 
++  install(
++    TARGETS
++      Catch2WithMain
++    EXPORT
++      Catch2Targets
++     LIBRARY DESTINATION
++      ${CMAKE_INSTALL_LIBDIR}/manual-link
++    ARCHIVE DESTINATION
++      ${CMAKE_INSTALL_LIBDIR}/manual-link
++    RUNTIME DESTINATION
++      ${CMAKE_INSTALL_BINDIR}
++  )
 +
-+     install(
-+      TARGETS
-+        Catch2WithMain
-+      EXPORT
-+        Catch2Targets
-+      LIBRARY DESTINATION
-+        ${CMAKE_INSTALL_LIBDIR}/manual-link
-+      ARCHIVE DESTINATION
-+        ${CMAKE_INSTALL_LIBDIR}/manual-link
-+      RUNTIME DESTINATION
-+        ${CMAKE_INSTALL_BINDIR}
-+    )
- 
- 
-     install(
+   install(
+     EXPORT
+       Catch2Targets

--- a/ports/catch2/fix-install-path.patch
+++ b/ports/catch2/fix-install-path.patch
@@ -1,8 +1,15 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1676ee7..34e8b95 100644
+index 1676ee7..5231934 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -173,7 +173,7 @@ if(NOT_SUBPROJECT)
+@@ -167,13 +167,13 @@ if(NOT_SUBPROJECT)
+         "extras/gdbinit"
+         "extras/lldbinit"
+       DESTINATION
+-        ${CMAKE_INSTALL_DATAROOTDIR}/Catch2
++        ${CMAKE_INSTALL_DATAROOTDIR}/catch2
+     )
+   endif()
  
    ## Provide some pkg-config integration
    set(PKGCONFIG_INSTALL_DIR

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -12,9 +12,15 @@ vcpkg_from_github(
         fix-install-path.patch
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
+    FEATURES
+        thread-safe-assertions CATCH_CONFIG_EXPERIMENTAL_THREAD_SAFE_ASSERTIONS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${OPTIONS}
         -DCATCH_INSTALL_DOCS=OFF
         -DCMAKE_CXX_STANDARD=17
 )

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
     REF v${VERSION}
-    SHA512 071f407dfefa84c3f766e32de48525dcaa50f5c5b0a2e2e9e615fdfff8d36476c7a28c9c27f4030fcf2f5f612043124efe61582bc2c174ddb62b4f307f74ffc5
+    SHA512 b215216088dbebf0d590351767e71e7643158b26835e3d6dab8c826d8252c4ab09697dd9eaf37d34ad7fc7cc367846bf501ee9489ba3a407ace00ae5d18268ed
     HEAD_REF devel
     PATCHES
         fix-install-path.patch

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -13,5 +13,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "thread-safe-assertions": {
+      "description": "Enables thread safe assertions"
+    }
+  }
 }

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "catch2",
-  "version-semver": "3.8.1",
+  "version-semver": "3.9.0",
   "description": "A modern, C++-native, test framework for unit-tests, TDD and BDD.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1589,7 +1589,7 @@
       "port-version": 2
     },
     "catch2": {
-      "baseline": "3.8.1",
+      "baseline": "3.9.0",
       "port-version": 0
     },
     "cblas": {

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c200d65fddda4eb59d4e403725611e0862d2e878",
+      "version-semver": "3.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "663b04662ae30cc321b1b1a0c781c9f4a3d29b93",
       "version-semver": "3.8.1",
       "port-version": 0

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c200d65fddda4eb59d4e403725611e0862d2e878",
+      "git-tree": "590677ebecf3adb5538800ecf058a35390896fe0",
       "version-semver": "3.9.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/catchorg/Catch2/releases/tag/v3.9.0
