### PR TITLE
[sqlgen] update to 0.2.0

### DIFF
--- a/ports/sqlgen/portfile.cmake
+++ b/ports/sqlgen/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO getml/sqlgen
     REF "v${VERSION}"
-    SHA512 7858e592c881f5ae41a5f3d250c3c79e00117993bba9abd51da9fc379ecc17af37e129c584de15be917019ea7f22ac32e52e1ffbd1ef87cc47c52b82cfd72bde 
+    SHA512 fa38b8e669d11fc21195911cf0669d1bcb192200006d0d784e0725a27d8c65668ec974097cd0470dd340dc05cc833734e8dc51773a87b8c61a7849761b6cf3af 
     HEAD_REF main
 )
 
@@ -13,6 +13,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SQLGEN_BUILD_SHARED)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        mysql               SQLGEN_MYSQL
         postgres            SQLGEN_POSTGRES
 )
 

--- a/ports/sqlgen/portfile.cmake
+++ b/ports/sqlgen/portfile.cmake
@@ -13,7 +13,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SQLGEN_BUILD_SHARED)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        mysql               SQLGEN_MYSQL
+        mariadb             SQLGEN_MYSQL
         postgres            SQLGEN_POSTGRES
 )
 

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -22,7 +22,7 @@
     }
   ],
   "features": {
-    "mysql": {
+    "mariadb": {
       "description": "Enable MySQL/MariaDB support",
       "dependencies": [
         "libmariadb"

--- a/ports/sqlgen/vcpkg.json
+++ b/ports/sqlgen/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlgen",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "sqlgen is an ORM and SQL query generator for C++-20, similar to Python's SQLAlchemy/SQLModel or Rust's Diesel.",
   "homepage": "https://github.com/getml/sqlgen/",
   "license": "MIT",
@@ -22,6 +22,12 @@
     }
   ],
   "features": {
+    "mysql": {
+      "description": "Enable MySQL/MariaDB support",
+      "dependencies": [
+        "libmariadb"
+      ]
+    },
     "postgres": {
       "description": "Enable PostgreSQL support",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9089,7 +9089,7 @@
       "port-version": 3
     },
     "sqlgen": {
-      "baseline": "0.1.0",
+      "baseline": "0.2.0",
       "port-version": 0
     },
     "sqlite-modern-cpp": {

--- a/versions/s-/sqlgen.json
+++ b/versions/s-/sqlgen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bca421a29e75ea254463fab7ef58e65e0b1b5782",
+      "version": "0.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0ca56df5bd7bd4b193c31802e67b9381b5a58ffa",
       "version": "0.1.0",
       "port-version": 0

--- a/versions/s-/sqlgen.json
+++ b/versions/s-/sqlgen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bca421a29e75ea254463fab7ef58e65e0b1b5782",
+      "git-tree": "23cd4ccef4a669f4fadc82d38f8f6014b9201d92",
       "version": "0.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

