### PR TITLE
[opencv4] Turn off CV_TRACE

### DIFF
--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -114,6 +114,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
  "world"      BUILD_opencv_world
  INVERTED_FEATURES
  "fs"         OPENCV_DISABLE_FILESYSTEM_SUPPORT
+ "notrace"    CV_TRACE
 )
 
 if("dnn" IN_LIST FEATURES)

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -114,7 +114,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
  "world"      BUILD_opencv_world
  INVERTED_FEATURES
  "fs"         OPENCV_DISABLE_FILESYSTEM_SUPPORT
- "notrace"    CV_TRACE
 )
 
 if("dnn" IN_LIST FEATURES)
@@ -432,6 +431,7 @@ vcpkg_cmake_configure(
         -DWITH_VA=OFF
         -DWITH_VA_INTEL=OFF
         -DWITH_ZLIB_NG=OFF
+        -DCV_TRACE=OFF
         ###### Additional build flags
         ${ADDITIONAL_BUILD_FLAGS}
     OPTIONS_RELEASE

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.11.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",
@@ -280,6 +280,9 @@
     },
     "nonfree": {
       "description": "allow nonfree and unredistributable libraries"
+    },
+    "notrace": {
+      "description": "Disables OpenCv Tracing, CV_TRACE can cause memory leaks https://github.com/opencv/opencv/issues/19727) "
     },
     "opencl": {
       "description": "Enable opencl support",

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -281,9 +281,6 @@
     "nonfree": {
       "description": "allow nonfree and unredistributable libraries"
     },
-    "notrace": {
-      "description": "Disables OpenCv Tracing, CV_TRACE can cause memory leaks https://github.com/opencv/opencv/issues/19727) "
-    },
     "opencl": {
       "description": "Enable opencl support",
       "supports": "!osx",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6990,7 +6990,7 @@
     },
     "opencv4": {
       "baseline": "4.11.0",
-      "port-version": 2
+      "port-version": 3
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "613573385ab4db7d8487efebd684b77e1c7127a3",
+      "version": "4.11.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "5046c8873031518509958aa1b583deed99ac1355",
       "version": "4.11.0",
       "port-version": 2

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "613573385ab4db7d8487efebd684b77e1c7127a3",
+      "git-tree": "cf1bf47c5fe2de53cc195e861fd428e7afe08807",
       "version": "4.11.0",
       "port-version": 3
     },


### PR DESCRIPTION
Allows unsetting CV_TRACE in the opencv CMAKE options, allowing avoiding https://github.com/opencv/opencv/issues/19727

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


