### PR TITLE
[pthreadpool] Updated pthreadpool to latest

### DIFF
--- a/ports/pthreadpool/fix-cmakelists.patch
+++ b/ports/pthreadpool/fix-cmakelists.patch
@@ -3,7 +3,7 @@ index 09d57b2..57d3a2c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -4,8 +4,6 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)
- PROJECT(pthreadpool C CXX)
+ PROJECT(pthreadpool C)
  
  # ---[ Options.
 -SET(PTHREADPOOL_LIBRARY_TYPE "default" CACHE STRING "Type of library (shared, static, or default) to build")

--- a/ports/pthreadpool/portfile.cmake
+++ b/ports/pthreadpool/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Maratyszcza/pthreadpool
-    REF 052e441b70091656199e2283fb1c16a7db6f0f85 # there is a too much gap from the last release...
-    SHA512 33be676e65719ae8510ec4e8254809033528802681870f8c91b083ce4006e5f630b80207a7e675464b406a785cb45bc74628996ea4817c02816b7b58ddf3a2bc
+    REF 560c60d342a76076f0557a3946924c6478470044 #2024-11-04
+    SHA512 d23e764e9a02f34210b3b9c5a66dae3b9e8211de6f78ec9b2672c19c48f364f4edb268ab77b1adf2802a3c35c6857deba81e48a658caa1a587fe8f3493a07f59
     PATCHES
         fix-cmakelists.patch
         fix-uwp.patch

--- a/ports/pthreadpool/vcpkg.json
+++ b/ports/pthreadpool/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pthreadpool",
-  "version-date": "2020-04-10",
-  "port-version": 3,
+  "version-date": "2024-11-04",
   "description": "Portable (POSIX/Windows/Emscripten) thread pool for C/C++",
   "homepage": "https://github.com/Maratyszcza/pthreadpool",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7625,8 +7625,8 @@
       "port-version": 1
     },
     "pthreadpool": {
-      "baseline": "2020-04-10",
-      "port-version": 3
+      "baseline": "2024-11-04",
+      "port-version": 0
     },
     "pthreads": {
       "baseline": "3.0.0",

--- a/versions/p-/pthreadpool.json
+++ b/versions/p-/pthreadpool.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00e018a68469e72cd73c387435107bf76b29967c",
+      "version-date": "2024-11-04",
+      "port-version": 0
+    },
+    {
       "git-tree": "e94ea81d9b3d3603132014397b58c039ae6b98f5",
       "version-date": "2020-04-10",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
