### PR TITLE
[openxlsx] new port

### DIFF
--- a/ports/openxlsx/fix-dependencies.patch
+++ b/ports/openxlsx/fix-dependencies.patch
@@ -1,0 +1,86 @@
+--- a/OpenXLSX/CMakeLists.txt.old	2025-07-14 15:07:03.000000000 +0200
++++ a/OpenXLSX/CMakeLists.txt	2025-07-29 10:04:55.753385000 +0200
+@@ -41,8 +41,7 @@ set(OPENXLSX_LIBRARY_TYPE "STATIC" CACHE
+ #=======================================================================================================================
+ 
+ if (OPENXLSX_ENABLE_NOWIDE)
+-    add_library(NoWide INTERFACE IMPORTED)
+-    target_include_directories(NoWide SYSTEM INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/external/nowide/>)
++    find_package(nowide CONFIG REQUIRED)
+ endif()
+ 
+ add_library(Zippy INTERFACE IMPORTED)
+@@ -51,8 +50,7 @@ if (OPENXLSX_ENABLE_NOWIDE)
+     target_compile_definitions(Zippy INTERFACE ENABLE_NOWIDE)
+ endif ()
+ 
+-add_library(PugiXML INTERFACE IMPORTED)
+-target_include_directories(PugiXML SYSTEM INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/external/pugixml/>)
++find_package(PugiXML CONFIG REQUIRED)
+ 
+ if (${OPENXLSX_COMPACT_MODE})
+     target_compile_definitions(PugiXML INTERFACE PUGIXML_COMPACT)
+@@ -143,12 +141,13 @@ if ("${OPENXLSX_LIBRARY_TYPE}" STREQUAL
+     target_link_libraries(OpenXLSX
+             PRIVATE
+             $<BUILD_INTERFACE:Zippy>
+-            $<BUILD_INTERFACE:PugiXML>)
++            PUBLIC
++            pugixml::pugixml)
+ 
+     if (OPENXLSX_ENABLE_NOWIDE)
+         target_link_libraries(OpenXLSX
+-                PRIVATE
+-                $<BUILD_INTERFACE:NoWide>)
++                PUBLIC
++                nowide::nowide)
+     endif ()
+ 
+     target_compile_definitions(OpenXLSX PUBLIC OPENXLSX_STATIC_DEFINE)
+@@ -171,12 +170,13 @@ if ("${OPENXLSX_LIBRARY_TYPE}" STREQUAL
+     target_link_libraries(OpenXLSX
+             PRIVATE
+             $<BUILD_INTERFACE:Zippy>
+-            $<BUILD_INTERFACE:PugiXML>)
++            PUBLIC
++            pugixml::pugixml)
+ 
+     if (OPENXLSX_ENABLE_NOWIDE)
+         target_link_libraries(OpenXLSX
+-                PRIVATE
+-                $<BUILD_INTERFACE:NoWide>)
++                PUBLIC
++                nowide::nowide)
+     endif ()
+ 
+     # Enable Link-Time Optimization (LTO)
+@@ -334,9 +334,16 @@ install(
+ # Package configuration
+ configure_file(OpenXLSXConfig.cmake
+         "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfig.cmake"
+-        COPYONLY
++        @ONLY
+         )
+ 
++install(
++        FILES
++        "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfig.cmake"
++        "${CMAKE_CURRENT_BINARY_DIR}/OpenXLSX/OpenXLSXConfigVersion.cmake"
++        DESTINATION ${ConfigPackageLocation}
++)
++
+ # Package export targets
+ export(
+         EXPORT OpenXLSXTargets
+--- a/OpenXLSX/OpenXLSXConfig.cmake.old	2025-07-29 10:01:35.707328300 +0200
++++ a/OpenXLSX/OpenXLSXConfig.cmake	2025-07-29 10:01:39.321206200 +0200
+@@ -1 +1,7 @@
+-include("${CMAKE_CURRENT_LIST_DIR}/OpenXLSXTargets.cmake")
+\ No newline at end of file
++include(CMakeFindDependencyMacro)
++find_dependency(pugixml CONFIG)
++if(@OPENXLSX_ENABLE_NOWIDE@)
++    find_dependency(nowide CONFIG)
++endif()
++
++include("${CMAKE_CURRENT_LIST_DIR}/OpenXLSXTargets.cmake")

--- a/ports/openxlsx/missing-header.patch
+++ b/ports/openxlsx/missing-header.patch
@@ -1,0 +1,10 @@
+--- a8cd841f13-8d82ae298d.clean/OpenXLSX/sources/XLSheet.cpp.old	2025-07-29 11:44:11.357978300 +0200
++++ a8cd841f13-8d82ae298d.clean/OpenXLSX/sources/XLSheet.cpp	2025-07-29 11:44:20.384836500 +0200
+@@ -46,6 +46,7 @@ YM      M9  MM    MM MM       MM    MM
+ // ===== External Includes ===== //
+ #include <algorithm> // std::max
+ #include <cctype>    // std::isdigit (issue #330)
++#include <cstring>
+ #include <limits>    // std::numeric_limits
+ #include <map>       // std::multimap
+ #include <pugixml.hpp>

--- a/ports/openxlsx/portfile.cmake
+++ b/ports/openxlsx/portfile.cmake
@@ -1,0 +1,42 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO troldal/OpenXLSX
+    REF 5723411d47643ce3b5b9994064c26ca8cd841f13
+    SHA512 edc7abe4da26699ea91c2ef84279a4f224af11c8ed298bea514c5992cd2c9a046ecdcd37c306f2b65cfb5ae398aaa98d027ad5b53a71c5119c3fafd7c7d60337
+    HEAD_REF master
+    PATCHES
+        pugixml.patch
+        fix-dependencies.patch
+        use-public-pugixml.patch
+        missing-header.patch)
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/external/nowide")
+file(REMOVE_RECURSE "${SOURCE_PATH}/external/pugixml")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(OPENXLSX_LIBRARY_TYPE "STATIC")
+else()
+    set(OPENXLSX_LIBRARY_TYPE "SHARED")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DOPENXLSX_CREATE_DOCS=OFF
+        -DOPENXLSX_BUILD_BENCHMARKS:BOOL=OFF
+        -DOPENXLSX_BUILD_SAMPLES:BOOL=OFF
+        -DOPENXLSX_BUILD_TESTS:BOOL=OFF
+        -DOPENXLSX_COMPACT_MODE:BOOL=OFF
+        -DOPENXLSX_CREATE_DOCS:BOOL=OFF
+        -DOPENXLSX_LIBRARY_TYPE:STRING=${OPENXLSX_LIBRARY_TYPE})
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/OpenXLSX")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/license")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/license")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/openxlsx/pugixml.patch
+++ b/ports/openxlsx/pugixml.patch
@@ -1,0 +1,13 @@
+diff --git a/OpenXLSX/headers/XLXmlParser.hpp b/OpenXLSX/headers/XLXmlParser.hpp
+index 6c81b2c..6fa1bda 100644
+--- a/OpenXLSX/headers/XLXmlParser.hpp
++++ b/OpenXLSX/headers/XLXmlParser.hpp
+@@ -49,7 +49,7 @@ YM      M9  MM    MM MM       MM    MM   d'  `MM.    MM            MM   d'  `MM.
+ #include <memory> // shared_ptr
+ 
+ // ===== pugixml.hpp needed for pugi::impl::xml_memory_page_type_mask, pugi::xml_node_type, pugi::char_t, pugi::node_element, pugi::xml_node, pugi::xml_attribute, pugi::xml_document
+-#include <external/pugixml/pugixml.hpp> // not sure why the full include path is needed within the header file
++#include <pugixml.hpp>
+ #include "XLException.hpp"
+ 
+ namespace { // anonymous namespace to define constants / functions that shall not be exported from this module

--- a/ports/openxlsx/use-public-pugixml.patch
+++ b/ports/openxlsx/use-public-pugixml.patch
@@ -1,0 +1,55 @@
+diff -u a/OpenXLSX/sources/XLXmlParser.cpp a/OpenXLSX/sources/XLXmlParser.cpp
+--- a/OpenXLSX/sources/XLXmlParser.cpp	2025-07-29 11:15:46.597045900 +0200
++++ a/OpenXLSX/sources/XLXmlParser.cpp	2025-07-29 11:22:20.936601800 +0200
+@@ -188,9 +188,9 @@
+     XMLNode XMLNode::next_sibling_of_type(pugi::xml_node_type type_) const
+     {
+         if (_root) {
+-            pugi::xml_node_struct* next = _root->next_sibling;
+-            while (next && (PUGI_IMPL_NODETYPE(next) != type_)) next = next->next_sibling;
+-            if (next)
++            pugi::xml_node next = next_sibling();
++            while (!next.empty() && (next.type() != type_)) next = next.next_sibling();
++            if (!next.empty())
+                 return XMLNode(next);
+         }
+         return XMLNode();    // if no node matching type_ was found: return an empty node
+@@ -203,9 +203,9 @@
+     XMLNode XMLNode::previous_sibling_of_type(pugi::xml_node_type type_) const
+     {
+         if (_root) {
+-            pugi::xml_node_struct* prev = _root->prev_sibling_c;
+-            while (prev->next_sibling && (PUGI_IMPL_NODETYPE(prev) != type_)) prev = prev->prev_sibling_c;
+-            if (prev->next_sibling)
++            pugi::xml_node prev = previous_sibling();
++            while (!prev.next_sibling().empty() && (prev.type() != type_)) prev = prev.previous_sibling();
++            if (!prev.next_sibling().empty())
+                 return XMLNode(prev);
+         }
+         return XMLNode();    // if no node matching type_ was found: return an empty node
+@@ -218,10 +218,9 @@
+     XMLNode XMLNode::next_sibling_of_type(const pugi::char_t* name_, pugi::xml_node_type type_) const
+     {
+         if (_root) {
+-            for (pugi::xml_node_struct* i = _root->next_sibling; i; i = i->next_sibling)
++            for (pugi::xml_node i = next_sibling(name_); !i.empty(); i = i.next_sibling(name_))
+             {
+-                const pugi::char_t* iname = i->name;
+-                if (iname && pugi::impl::strequal(name_, iname) && (PUGI_IMPL_NODETYPE(i) == type_))
++                if (i.type() == type_)
+                     return XMLNode(i);
+             }
+         }
+@@ -235,10 +234,9 @@
+     XMLNode XMLNode::previous_sibling_of_type(const pugi::char_t* name_, pugi::xml_node_type type_) const
+     {
+         if (_root) {
+-            for (pugi::xml_node_struct* i = _root->prev_sibling_c; i->next_sibling; i = i->prev_sibling_c)
++            for (pugi::xml_node i = previous_sibling(name_); !i.next_sibling().empty(); i = i.previous_sibling(name_))
+             {
+-                const pugi::char_t* iname = i->name;
+-                if (iname && pugi::impl::strequal(name_, iname) && (PUGI_IMPL_NODETYPE(i) == type_))
++                if (i.type() == type_)
+                     return XMLNode(i);
+             }
+         }

--- a/ports/openxlsx/vcpkg.json
+++ b/ports/openxlsx/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "openxlsx",
+  "version-date": "2025-07-14",
+  "description": "OpenXLSX is a C++ library for reading, writing, creating and modifying Microsoft Excel® files, with the .xlsx format.",
+  "homepage": "https://github.com/troldal/OpenXLSX",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "nowide",
+      "platform": "windows"
+    },
+    "pugixml",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7228,6 +7228,10 @@
       "baseline": "2.5.1",
       "port-version": 1
     },
+    "openxlsx": {
+      "baseline": "2025-07-14",
+      "port-version": 0
+    },
     "openxr-loader": {
       "baseline": "1.1.45",
       "port-version": 1

--- a/versions/o-/openxlsx.json
+++ b/versions/o-/openxlsx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2c4ea09a2e6164c852eb8c7217d68aab505a8d2d",
+      "version-date": "2025-07-14",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/46602.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
