### PR TITLE
[robotraconteur-companion] Update to version 0.4.2

### DIFF
--- a/ports/robotraconteur-companion/portfile.cmake
+++ b/ports/robotraconteur-companion/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO robotraconteur/robotraconteur_companion
     REF "v${VERSION}"
-    SHA512 9df5fc4afe635b86cf150e59f06a809b856f17921507e75872f6afe723d2b9654cbb0ecc43533d3c7d673c11fb96545d627f4bbacdbd351a1a61d0ee65d71381
+    SHA512 8bee3f71f6f1cedc6af9b30d32ed16515c2c117a4d43c3b6304c799fe90447056c5e447f573c96018c57112d9c174de422c16eba3a27b5c1343e88377d7e4117
     HEAD_REF master
 )
 

--- a/ports/robotraconteur-companion/vcpkg.json
+++ b/ports/robotraconteur-companion/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "robotraconteur-companion",
-  "version-semver": "0.4.1",
+  "version-semver": "0.4.2",
   "homepage": "https://github.com/robotraconteur/robotraconteur_companion",
   "license": "Apache-2.0",
   "supports": "(windows & (x86 | x64)) | (linux & (x86 | x64 | arm64 | arm32)) | (osx & (x64 | arm64))",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8413,7 +8413,7 @@
       "port-version": 3
     },
     "robotraconteur-companion": {
-      "baseline": "0.4.1",
+      "baseline": "0.4.2",
       "port-version": 0
     },
     "rocksdb": {

--- a/versions/r-/robotraconteur-companion.json
+++ b/versions/r-/robotraconteur-companion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96ef1842bbd28e5d714e6f4b3c6aebc0a7705cbc",
+      "version-semver": "0.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c1df5476994d65c9237315095c5be35461769979",
       "version-semver": "0.4.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
