### PR TITLE
[vbs-enclave-tooling-codegen] Use manual-link folder for enclave support static libs

### DIFF
--- a/ports/vbs-enclave-tooling-codegen/vcpkg.json
+++ b/ports/vbs-enclave-tooling-codegen/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vbs-enclave-tooling-codegen",
   "version": "0.0.2-prerelease",
+  "port-version": 1,
   "description": "Supports code generation for VBS enclaves.",
   "homepage": "https://github.com/microsoft/vbsEnclaveTooling",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9906,7 +9906,7 @@
     },
     "vbs-enclave-tooling-codegen": {
       "baseline": "0.0.2-prerelease",
-      "port-version": 0
+      "port-version": 1
     },
     "vc": {
       "baseline": "1.4.4",

--- a/versions/v-/vbs-enclave-tooling-codegen.json
+++ b/versions/v-/vbs-enclave-tooling-codegen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc6f436a61c65a8af9ff964be82f5fecabb2fe8f",
+      "version": "0.0.2-prerelease",
+      "port-version": 1
+    },
+    {
       "git-tree": "870aafddc5d596ba89e52748bebb069e0836e47b",
       "version": "0.0.2-prerelease",
       "port-version": 0


### PR DESCRIPTION
Fixes #46641 

Didn't realize vcpkg did autolinking by default. The static lib that gets built in this port stubs out some CRT functionality so it can be used within vbs enclaves. To prevent conflicting symbols for regular non-enclave projects I've moved the static libs to the `manual-link` folder. Confirmed both enclave and non-enclave projects can be built now after installing this port.