### PR TITLE
[libva] add new port

### DIFF
--- a/ports/libva/portfile.cmake
+++ b/ports/libva/portfile.cmake
@@ -1,0 +1,56 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO intel/libva
+    REF "${VERSION}"
+    SHA512 cd633e5e09eac1ed10f1fc12b0f664f836e0eda9e47c17e1295b746cfd643a18fd0564a06a148ced3cf1e2321aa4d21275918bcf8c717d3981e98a598179f370
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    x11             WITH_X11
+    wayland         WITH_WAYLAND
+    glx            WITH_GLX
+)
+
+message(WARNING "You will need to install libdrm dependencies to use this port:\nsudo apt install libdrm-dev\n")
+
+if ("x11" IN_LIST FEATURES)
+    message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxext-dev libxfixes-dev libx11-xcb-dev libxcb-dri3-dev\n")
+endif()
+if ("wayland" IN_LIST FEATURES)
+    message(WARNING "You will need to install Wayland dependencies to use feature wayland:\nsudo apt install libwayland-dev\n")
+endif()
+if ("glx" IN_LIST FEATURES)
+    message(WARNING "You will need to install GLX dependencies to use feature glx:\nsudo apt install libglu1-mesa-dev\n")
+endif()
+if(WITH_X11)
+    list(APPEND options -Dwith_x11=yes)
+else()
+    list(APPEND options -Dwith_x11=no)
+endif()
+
+if(WITH_WAYLAND)
+    list(APPEND options -Dwith_wayland=yes)
+else()
+    list(APPEND options -Dwith_wayland=no)
+endif()
+
+if(WITH_GLX)
+    list(APPEND options -Dwith_glx=yes)
+else()
+    list(APPEND options -Dwith_glx=no)
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${options}
+)
+
+vcpkg_install_meson()
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libva/vcpkg.json
+++ b/ports/libva/vcpkg.json
@@ -11,14 +11,6 @@
     }
   ],
   "features": {
-    "wayland": {
-      "description": "Build with Wayland support",
-      "supports": "linux"
-    },
-    "x11": {
-      "description": "Build with X11 support",
-      "supports": "linux"
-    },
     "glx": {
       "description": "Build with GLX support",
       "supports": "linux",
@@ -30,6 +22,14 @@
           ]
         }
       ]
+    },
+    "wayland": {
+      "description": "Build with Wayland support",
+      "supports": "linux"
+    },
+    "x11": {
+      "description": "Build with X11 support",
+      "supports": "linux"
     }
   }
 }

--- a/ports/libva/vcpkg.json
+++ b/ports/libva/vcpkg.json
@@ -1,0 +1,35 @@
+{
+  "name": "libva",
+  "version": "2.22.0",
+  "description": "Libva is an implementation for VA-API (Video Acceleration API)",
+  "homepage": "https://github.com/intel/libva",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ],
+  "features": {
+    "wayland": {
+      "description": "Build with Wayland support",
+      "supports": "linux"
+    },
+    "x11": {
+      "description": "Build with X11 support",
+      "supports": "linux"
+    },
+    "glx": {
+      "description": "Build with GLX support",
+      "supports": "linux",
+      "dependencies": [
+        {
+          "name": "libva",
+          "features": [
+            "x11"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/ports/libva/vcpkg.json
+++ b/ports/libva/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Libva is an implementation for VA-API (Video Acceleration API)",
   "homepage": "https://github.com/intel/libva",
   "license": "MIT",
+  "supports": "linux",
   "dependencies": [
     {
       "name": "vcpkg-tool-meson",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5564,6 +5564,10 @@
       "baseline": "0.0.7",
       "port-version": 1
     },
+    "libva": {
+      "baseline": "2.22.0",
+      "port-version": 0
+    },
     "libvault": {
       "baseline": "0.63.0",
       "port-version": 0

--- a/versions/l-/libva.json
+++ b/versions/l-/libva.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "994e413f3169b97b92d78ab4399545fc9222487b",
+      "git-tree": "cfe6693c4b773959c98e2e77f4928f20563f9f39",
       "version": "2.22.0",
       "port-version": 0
     }

--- a/versions/l-/libva.json
+++ b/versions/l-/libva.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "994e413f3169b97b92d78ab4399545fc9222487b",
+      "version": "2.22.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

