### PR TITLE
[coin] Revise, cleanup

### DIFF
--- a/ports/coin/expat.diff
+++ b/ports/coin/expat.diff
@@ -1,0 +1,13 @@
+diff --git a/src/xml/document.cpp b/src/xml/document.cpp
+index f31e2ed..576ceb5 100644
+--- a/src/xml/document.cpp
++++ b/src/xml/document.cpp
+@@ -52,7 +52,7 @@
+ #include <Inventor/lists/SbList.h>
+ #include <Inventor/SbString.h>
+ 
+-#include "expat/expat.h"
++#include <expat.h>
+ #include "utils.h"
+ #include "elementp.h"
+ 

--- a/ports/coin/openal.diff
+++ b/ports/coin/openal.diff
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b9891b1..be310f0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -324,9 +324,14 @@ if(HAVE_SOUND)
+     if(OpenAL_FOUND)
+       set(HAVE_OPENAL 1)
+       # Checks specific OpenAL configurations
+-      set(CMAKE_REQUIRED_INCLUDES ${OPENGL_INCLUDE_DIR})
++      set(CMAKE_REQUIRED_INCLUDES "")
++      set(CMAKE_REQUIRED_LIBRARIES OpenAL::OpenAL)
++      block(SCOPE_FOR POLICIES)
++      cmake_policy(SET CMP0075 NEW)
+       check_include_file(AL/al.h HAVE_AL_AL_H)
+       check_include_file(OpenAL/al.h HAVE_OPENAL_AL_H)
++      endblock()
++      set(CMAKE_REQUIRED_LIBRARIES)
+       set(CMAKE_REQUIRED_INCLUDES)
+       if(NOT TARGET OpenAL::OpenAL)
+         add_library(OpenAL::OpenAL UNKNOWN IMPORTED)
+diff --git a/src/glue/openal_wrapper.cpp b/src/glue/openal_wrapper.cpp
+index 7ffd12c..25e745b 100644
+--- a/src/glue/openal_wrapper.cpp
++++ b/src/glue/openal_wrapper.cpp
+@@ -62,6 +62,9 @@
+ #elif defined HAVE_OPENAL_AL_H
+ #include <OpenAL/al.h>
+ #include <OpenAL/alc.h>
++#else
++#include <al.h>
++#include <alc.h>
+ #endif
+ #endif /* OPENALWRAPPER_ASSUME_OPENAL */
+ 

--- a/ports/coin/openal.diff
+++ b/ports/coin/openal.diff
@@ -1,19 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b9891b1..be310f0 100644
+index b9891b1..0cf864f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -324,9 +324,14 @@ if(HAVE_SOUND)
+@@ -324,9 +324,11 @@ if(HAVE_SOUND)
      if(OpenAL_FOUND)
        set(HAVE_OPENAL 1)
        # Checks specific OpenAL configurations
 -      set(CMAKE_REQUIRED_INCLUDES ${OPENGL_INCLUDE_DIR})
 +      set(CMAKE_REQUIRED_INCLUDES "")
 +      set(CMAKE_REQUIRED_LIBRARIES OpenAL::OpenAL)
-+      block(SCOPE_FOR POLICIES)
-+      cmake_policy(SET CMP0075 NEW)
        check_include_file(AL/al.h HAVE_AL_AL_H)
        check_include_file(OpenAL/al.h HAVE_OPENAL_AL_H)
-+      endblock()
 +      set(CMAKE_REQUIRED_LIBRARIES)
        set(CMAKE_REQUIRED_INCLUDES)
        if(NOT TARGET OpenAL::OpenAL)

--- a/ports/coin/portfile.cmake
+++ b/ports/coin/portfile.cmake
@@ -38,6 +38,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         simage      VCPKG_LOCK_FIND_PACKAGE_simage
         superglu    USE_SUPERGLU
         superglu    VCPKG_LOCK_FIND_PACKAGE_superglu
+        zlib        VCPKG_LOCK_FIND_PACKAGE_ZLIB
 )
 
 vcpkg_cmake_configure(
@@ -58,7 +59,6 @@ vcpkg_cmake_configure(
         -DSPIDERMONKEY_RUNTIME_LINKING=OFF
         -DVCPKG_LOCK_FIND_PACKAGE_SpiderMonkey=OFF
         -DZLIB_RUNTIME_LINKING=OFF
-        -DVCPKG_LOCK_FIND_PACKAGE_ZLIB=ON
         ${FEATURE_OPTIONS}
     MAYBE_UNUSED_VARIABLES
         COIN_BUILD_MSVC_STATIC_RUNTIME

--- a/ports/coin/portfile.cmake
+++ b/ports/coin/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         expat.diff
+        openal.diff
         remove-default-config.patch
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/src/xml/expat")

--- a/ports/coin/portfile.cmake
+++ b/ports/coin/portfile.cmake
@@ -20,24 +20,24 @@ vcpkg_from_github(
     SHA512 5e9505efda536a6687fd1cfcc4589af9bfbdbd4a8d660335c060e1678f84c5db91415e0a40ee7b4b40e5894d7330172a24f822d38c0ea276badb92fc68efeec8
     HEAD_REF master
     PATCHES
+        expat.diff
         remove-default-config.patch
 )
+file(REMOVE_RECURSE "${SOURCE_PATH}/src/xml/expat")
+file(REMOVE_RECURSE "${SOURCE_PATH}/cmake/FindFontconfig.cmake")
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    set(COIN_BUILD_SHARED_LIBS OFF)
-else()
-    set(COIN_BUILD_SHARED_LIBS ON)
-endif()
-
-if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
-    set(COIN_BUILD_MSVC_STATIC_RUNTIME OFF)
-elseif(VCPKG_CRT_LINKAGE STREQUAL static)
-    set(COIN_BUILD_MSVC_STATIC_RUNTIME ON)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" COIN_BUILD_SHARED_LIBS)
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" COIN_BUILD_MSVC_STATIC_RUNTIME)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-FEATURES
-  superglu USE_SUPERGLU
+    FEATURES
+        bzip2       VCPKG_LOCK_FIND_PACKAGE_BZip2
+        fontconfig  VCPKG_LOCK_FIND_PACKAGE_Fontconfig
+        freetype    VCPKG_LOCK_FIND_PACKAGE_Freetype
+        openal      VCPKG_LOCK_FIND_PACKAGE_OpenAL
+        simage      VCPKG_LOCK_FIND_PACKAGE_simage
+        superglu    USE_SUPERGLU
+        superglu    VCPKG_LOCK_FIND_PACKAGE_superglu
 )
 
 vcpkg_cmake_configure(
@@ -48,21 +48,30 @@ vcpkg_cmake_configure(
         -DCOIN_BUILD_MSVC_STATIC_RUNTIME=${COIN_BUILD_MSVC_STATIC_RUNTIME}
         -DCOIN_BUILD_SHARED_LIBS=${COIN_BUILD_SHARED_LIBS}
         -DCOIN_BUILD_TESTS=OFF
+        -DUSE_EXTERNAL_EXPAT=ON
+        -DFONTCONFIG_RUNTIME_LINKING=OFF
+        -DFREETYPE_RUNTIME_LINKING=OFF
+        -DGLU_RUNTIME_LINKING=OFF
+        -DLIBBZIP2_RUNTIME_LINKING=OFF
+        -DOPENAL_RUNTIME_LINKING=OFF
+        -DSIMAGE_RUNTIME_LINKING=OFF
+        -DSPIDERMONKEY_RUNTIME_LINKING=OFF
+        -DVCPKG_LOCK_FIND_PACKAGE_SpiderMonkey=OFF
+        -DZLIB_RUNTIME_LINKING=OFF
+        -DVCPKG_LOCK_FIND_PACKAGE_ZLIB=ON
         ${FEATURE_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        COIN_BUILD_MSVC_STATIC_RUNTIME
+        VCPKG_LOCK_FIND_PACKAGE_superglu
 )
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Coin-${VERSION})
-
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/Coin/profiler")
 
-vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/coin/vcpkg.json
+++ b/ports/coin/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "coin",
   "version": "4.0.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A high-level 3D visualization library with Open Inventor 2.1 API",
   "homepage": "https://github.com/coin3d/coin",
   "license": "BSD-3-Clause",
@@ -13,6 +13,7 @@
     "boost-math",
     "boost-smart-ptr",
     "boost-static-assert",
+    "expat",
     "opengl-registry",
     {
       "name": "vcpkg-cmake",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -85,7 +85,6 @@ chromium-base:x64-osx=skip # broken on OSX for unknown reasons; it appears to be
 chromium-base(windows) =skip # chromium-base has several problems and is upgraded to "skip" because it hits a lot of servers that can slow CI broken on Windows because it does not yet support VS2022
 clamav:arm64-windows=fail
 clockutils:x64-linux=fail
-coin(uwp) = fail
 coroutine(uwp)=fail
 cpp-netlib(uwp)=fail
 cppcoro(uwp | linux | osx)=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1838,7 +1838,7 @@
     },
     "coin": {
       "baseline": "4.0.4",
-      "port-version": 1
+      "port-version": 2
     },
     "coin-or-buildtools": {
       "baseline": "2023-02-02",

--- a/versions/c-/coin.json
+++ b/versions/c-/coin.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "78e575788d22ffa4446406257ff73a81dd402ccd",
+      "git-tree": "f6e5130381ae9ea99e37d8828702f6f7d012d631",
       "version": "4.0.4",
       "port-version": 2
     },

--- a/versions/c-/coin.json
+++ b/versions/c-/coin.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f6e5130381ae9ea99e37d8828702f6f7d012d631",
+      "git-tree": "239f44987e69d92936626513da35ec981ea9e097",
       "version": "4.0.4",
       "port-version": 2
     },

--- a/versions/c-/coin.json
+++ b/versions/c-/coin.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "239f44987e69d92936626513da35ec981ea9e097",
+      "git-tree": "ba0c9da7750310f9bec11230e9d108ed265effd5",
       "version": "4.0.4",
       "port-version": 2
     },

--- a/versions/c-/coin.json
+++ b/versions/c-/coin.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78e575788d22ffa4446406257ff73a81dd402ccd",
+      "version": "4.0.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "02210572ddecf670de5a1bbdf26cdd48668add8b",
       "version": "4.0.4",
       "port-version": 1


### PR DESCRIPTION
Fix installation order problem with expat et al.: `find_package(X11)` transitively causes `EXPAT_FOUND`, breaking the build.
Link the actual (feature) dependencies instead of loading at runtime, to ensure using the vcpkg artifacts it declares to depends on (in particular in static builds!)