### PR TITLE
[octave] add gui feature

### DIFF
--- a/ports/octave/portfile.cmake
+++ b/ports/octave/portfile.cmake
@@ -143,7 +143,14 @@ else()
     set(PORTAUDIO_OPTION "no")
 endif()
 
+if("gui" IN_LIST FEATURES)
+    set(GUI_OPTION "yes")
+else()
+    set(GUI_OPTION "no")
+endif()
+
 vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/fltk")
+vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/qt5/bin")
 
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -178,7 +185,7 @@ vcpkg_configure_make(
     --with-qhull_r=no
     --with-qrupdate=no
     --with-qscintilla=no
-    --with-qt=no
+    --with-qt=${GUI_OPTION}
     --with-sndfile # yes
     --with-spqr=${SPQR_OPTION}
     --with-suitesparseconfig=${SUITESPARSECONFIG_OPTION}

--- a/ports/octave/vcpkg.json
+++ b/ports/octave/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "octave",
   "version": "10.2.0",
+  "port-version": 1,
   "description": "High-level interpreted language, primarily intended for numerical computations.",
   "homepage": "https://octave.org/",
   "documentation": "https://docs.octave.org/latest/",
@@ -113,6 +114,31 @@
       "dependencies": [
         {
           "name": "freetype",
+          "default-features": false
+        }
+      ]
+    },
+    "gui": {
+      "description": "build with gui support",
+      "dependencies": [
+        {
+          "name": "freeglut",
+          "platform": "linux"
+        },
+        {
+          "name": "octave",
+          "default-features": false,
+          "features": [
+            "fontconfig",
+            "freetype"
+          ]
+        },
+        {
+          "name": "qt5-base",
+          "default-features": false
+        },
+        {
+          "name": "qt5-tools",
           "default-features": false
         }
       ]

--- a/scripts/test_ports/vcpkg-ci-octave/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-octave/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/scripts/test_ports/vcpkg-ci-octave/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-octave/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "vcpkg-ci-octave",
+  "version": "0.0.0",
+  "description": "Test the octave feature",
+  "dependencies": [
+    {
+      "name": "octave",
+      "features": [
+        "amd",
+        "arpack",
+        "bz2",
+        "camd",
+        "ccolamd",
+        "cholmod",
+        "colamd",
+        "cxsparse",
+        "fltk",
+        "fontconfig",
+        "freetype",
+        "gui",
+        "hdf5",
+        "klu",
+        "portaudio",
+        "spqr",
+        "umfpack"
+      ]
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6874,7 +6874,7 @@
     },
     "octave": {
       "baseline": "10.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "octomap": {
       "baseline": "1.10.0",

--- a/versions/o-/octave.json
+++ b/versions/o-/octave.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "db1baa59f8c1b8247854bbe33d2addbb51c2599b",
+      "version": "10.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "fd391d361e70146e35e1e866009cfb8d48d3a604",
       "version": "10.2.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

