### PR TITLE
[yalantinglibs] update to 0.5.3

### DIFF
--- a/ports/yalantinglibs/portfile.cmake
+++ b/ports/yalantinglibs/portfile.cmake
@@ -3,7 +3,7 @@ set(VCPKG_BUILD_TYPE release)  # header-only
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alibaba/yalantinglibs
-    REF b569ab7cda5744a037def20b0d13e99b62f059f7 # Use commit id to avoid target to multiple commits(0.5.0 worked but 0.5.3 failed), see https://github.com/alibaba/yalantinglibs/issues/1027
+    REF d4337e3297fa9bb8ef67473d7f40e766da39f4e3 # Use commit id to avoid target to multiple commits(the author will fix it in the next release), see https://github.com/alibaba/yalantinglibs/issues/1027
     SHA512 06a61247102e0f90b76987b7a5e244dd5e727ee2c67aedac472bf8984b4e9a91c8634ec3c210ad3f70266207870df0f83b2bc6a1e23ad5febb16d095f322173b
     HEAD_REF main
 )

--- a/ports/yalantinglibs/portfile.cmake
+++ b/ports/yalantinglibs/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_BUILD_TYPE release)  # header-only
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alibaba/yalantinglibs
-    REF ${VERSION} 
-    SHA512 417e0817941d9446d5746771fcf4a4a20bd0bc58bea75926a177b702cd9b80e02a4851f8523bd086d7164955fc7306f4c084d601c3d65d3e8dede49414ea9283
+    REF b569ab7cda5744a037def20b0d13e99b62f059f7 # Use commit id to avoid target to multiple commits(0.5.0 worked but 0.5.3 failed), see https://github.com/alibaba/yalantinglibs/issues/1027
+    SHA512 06a61247102e0f90b76987b7a5e244dd5e727ee2c67aedac472bf8984b4e9a91c8634ec3c210ad3f70266207870df0f83b2bc6a1e23ad5febb16d095f322173b
     HEAD_REF main
 )
 

--- a/ports/yalantinglibs/portfile.cmake
+++ b/ports/yalantinglibs/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alibaba/yalantinglibs
     REF d4337e3297fa9bb8ef67473d7f40e766da39f4e3 # Use commit id to avoid target to multiple commits(the author will fix it in the next release), see https://github.com/alibaba/yalantinglibs/issues/1027
-    SHA512 06a61247102e0f90b76987b7a5e244dd5e727ee2c67aedac472bf8984b4e9a91c8634ec3c210ad3f70266207870df0f83b2bc6a1e23ad5febb16d095f322173b
+    SHA512 a4572dd0e9ca4052091be0f40cc93616bb982432ada4640f9f92df4ec2173731d53a7758af6ee7835ae8841f3ad81dd4e615dfea8af5b88298823c6724774b00
     HEAD_REF main
 )
 

--- a/ports/yalantinglibs/vcpkg.json
+++ b/ports/yalantinglibs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yalantinglibs",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "description": "A Collection of C++20 libraries, include struct_pack, struct_json, struct_xml, struct_yaml, struct_pb, easylog, coro_rpc, coro_http and async_simple",
   "homepage": "https://github.com/alibaba/yalantinglibs",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10441,7 +10441,7 @@
       "port-version": 4
     },
     "yalantinglibs": {
-      "baseline": "0.5.0",
+      "baseline": "0.5.3",
       "port-version": 0
     },
     "yaml-cpp": {

--- a/versions/y-/yalantinglibs.json
+++ b/versions/y-/yalantinglibs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2643a61de6329516137abe1fb8b988243d61b88a",
+      "version": "0.5.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "57d3a7e6c37fb17d9acefc9845c9d4141a6f8944",
       "version": "0.5.0",
       "port-version": 0

--- a/versions/y-/yalantinglibs.json
+++ b/versions/y-/yalantinglibs.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f98d63995aeb930773646c4b69ef5fcc981a02b6",
+      "git-tree": "015a60b072b0edd31883bfce1adad2d0a0cf3d29",
       "version": "0.5.3",
       "port-version": 0
     },

--- a/versions/y-/yalantinglibs.json
+++ b/versions/y-/yalantinglibs.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2643a61de6329516137abe1fb8b988243d61b88a",
+      "git-tree": "f98d63995aeb930773646c4b69ef5fcc981a02b6",
       "version": "0.5.3",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
