### PR TITLE
[libmediainfo] update to 25.07

### DIFF
--- a/ports/libmediainfo/portfile.cmake
+++ b/ports/libmediainfo/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MediaArea/MediaInfoLib
     REF "v${MEDIAINFO_VERSION}"
-    SHA512 b6a7482d7e7af7ceaf20dc1bdffeac2cf35ceea6f6a1311a8df4658940202cf190a599ba03a1e8d5dad2bd623263b55edd3b20ee0fce78ee1c4f938a014af3b4
+    SHA512 0e78fb000f7efc6f0b8942341dca5e5dc1e525533bb3763bd5e28be9e914041d4f7434a7190c1e6c0ca14ffc752516143c9b8a242d411ed380936320d564bf10
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/libmediainfo/vcpkg.json
+++ b/ports/libmediainfo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmediainfo",
-  "version": "25.4",
+  "version": "25.7",
   "description": "Get most relevant technical and tag data from video and audio files",
   "homepage": "https://github.com/MediaArea/MediaInfoLib",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5025,7 +5025,7 @@
       "port-version": 0
     },
     "libmediainfo": {
-      "baseline": "25.4",
+      "baseline": "25.7",
       "port-version": 0
     },
     "libmem": {

--- a/versions/l-/libmediainfo.json
+++ b/versions/l-/libmediainfo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ea3c934dd7833483ceecfa8d5c89bd6eea3d441",
+      "version": "25.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "8acb5ace1a3ab7c3e7c32bfe3ed1ff7ec9d0bc9b",
       "version": "25.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
