### PR TITLE
[sqlite3] Update to version 3.50.4

### DIFF
--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -4,7 +4,7 @@ string(REGEX REPLACE "^([0-9]+),0*([0-9][0-9]),0*([0-9][0-9]),0*([0-9][0-9])," "
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sqlite.org/2025/sqlite-autoconf-${SQLITE_VERSION}.tar.gz"
     FILENAME "sqlite-autoconf-${SQLITE_VERSION}.zip"
-    SHA512 6064ccce1a59dead2f36d93d5e65a09cc0dd54782fd5a7765af532cf5721ba9ddd15e9a62c4546e081b7560870dc85077ef421ff81db8717425ba1eb6f431782
+    SHA512 5862fc81fc087fd7280d9c7a701f972c35288d9f1fee4863443c35201e8db43a642a5f0d6eb81f8d0637859303a38301b459ffd1c39cd8283e18cbc4ae413aa1
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sqlite3/vcpkg.json
+++ b/ports/sqlite3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite3",
-  "version": "3.50.3",
+  "version": "3.50.4",
   "description": "SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.",
   "homepage": "https://sqlite.org/",
   "license": "blessing",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9109,7 +9109,7 @@
       "port-version": 0
     },
     "sqlite3": {
-      "baseline": "3.50.3",
+      "baseline": "3.50.4",
       "port-version": 0
     },
     "sqlitecpp": {

--- a/versions/s-/sqlite3.json
+++ b/versions/s-/sqlite3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66b97ff5a04f74e09b321708432721c5dca0c213",
+      "version": "3.50.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "31b40b0331963abeb58583e1616c9ac80b972486",
       "version": "3.50.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.