### PR TITLE
[ffmpeg] add vaapi support in linux

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -580,6 +580,14 @@ else()
     set(WITH_MFX OFF)
 endif()
 
+if ("vaapi" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-vaapi")
+    set(WITH_VAAPI ON)
+else()
+    set(OPTIONS "${OPTIONS} --disable-vaapi")
+    set(WITH_VAAPI OFF)
+endif()
+
 set(OPTIONS_CROSS "--enable-cross-compile")
 
 # ffmpeg needs --cross-prefix option to use appropriate tools for cross-compiling.

--- a/ports/ffmpeg/vcpkg-cmake-wrapper.cmake
+++ b/ports/ffmpeg/vcpkg-cmake-wrapper.cmake
@@ -289,6 +289,16 @@ if(@WITH_OPENCL@)
   endif()
 endif()
 
+if(@WITH_VAAPI@)
+  find_package(PkgConfig )
+  pkg_check_modules(libva IMPORTED_TARGET libva)
+  pkg_check_modules(libva-drm IMPORTED_TARGET libva-drm)
+  list(APPEND FFMPEG_LIBRARIES PkgConfig::libva PkgConfig::libva-drm)
+  if(vcpkg_no_avcodec_target AND TARGET FFmpeg::avcodec)
+    target_link_libraries(FFmpeg::avcodec INTERFACE PkgConfig::libva PkgConfig::libva-drm)
+  endif()
+endif()
+
 endif(NOT z_vcpkg_using_vcpkg_find_ffmpeg)
 unset(z_vcpkg_using_vcpkg_find_ffmpeg)
 

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "7.1.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -711,6 +711,17 @@
       "description": "zlib support",
       "dependencies": [
         "zlib"
+      ]
+    },
+    "vaapi": {
+      "description": "VAAPI video decoding/encoding acceleration",
+      "supports": "linux",
+      "dependencies": [
+        {
+          "name": "libva",
+          "default-features": false,
+          "platform": "linux"
+        }
       ]
     }
   }

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -647,6 +647,17 @@
         "libtheora"
       ]
     },
+    "vaapi": {
+      "description": "VAAPI video decoding/encoding acceleration",
+      "supports": "linux",
+      "dependencies": [
+        {
+          "name": "libva",
+          "default-features": false,
+          "platform": "linux"
+        }
+      ]
+    },
     "version3": {
       "description": "Upgrade (L)GPL to version 3"
     },
@@ -711,17 +722,6 @@
       "description": "zlib support",
       "dependencies": [
         "zlib"
-      ]
-    },
-    "vaapi": {
-      "description": "VAAPI video decoding/encoding acceleration",
-      "supports": "linux",
-      "dependencies": [
-        {
-          "name": "libva",
-          "default-features": false,
-          "platform": "linux"
-        }
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2870,7 +2870,7 @@
     },
     "ffmpeg": {
       "baseline": "7.1.1",
-      "port-version": 3
+      "port-version": 4
     },
     "ffnvcodec": {
       "baseline": "12.2.72.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f61f5a41a01c6228401fc2ae93496fb8617be96e",
+      "version": "7.1.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "66b79b494da2724cb74dec6995e3f41fd2a8e85e",
       "version": "7.1.1",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



