### PR TITLE
[cpp-httplib] update to 0.24.0

### DIFF
--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yhirose/cpp-httplib
     REF "v${VERSION}"
-    SHA512 f8037a0d55019931beb4dfd12418c140e6b170ed7d0eb851f2eebefb8a5f48bb83fc3c9030b78a3524190d2d1647a16e14ac64209ce663bbaa717f03b167cb59
+    SHA512 9e6c50392fab0069ecde703117a88a694aea80b5ea8da6938d4918ec8084ebb7bfa72b6b9fd97da65f13d57f47b7774ecf42b78fbcfdfc015d9cffc208630572
     HEAD_REF master
     PATCHES
         fix-find-brotli.patch

--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-httplib",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1973,7 +1973,7 @@
       "port-version": 0
     },
     "cpp-httplib": {
-      "baseline": "0.23.1",
+      "baseline": "0.24.0",
       "port-version": 0
     },
     "cpp-ipc": {

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "575ea21139b6cb25f26bfdb1eecb8ca3942bcecd",
+      "version": "0.24.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "993d98ea0740c33e61811338b0fe57e8b7fe440c",
       "version": "0.23.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/yhirose/cpp-httplib/releases/tag/v0.24.0
