### PR TITLE
[nvtx3] new package

### DIFF
--- a/ports/nvtx3/portfile.cmake
+++ b/ports/nvtx3/portfile.cmake
@@ -1,0 +1,14 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIA/NVTX
+    REF 2942f167cc30c5e3a44a2aecd5b0d9c07ff61a07 # 3.2.1
+    SHA512 73566c4aef45968bbaca7eb6fdfda1224b3c7912c2ef797af3462df40c182318585de93d3351d50ead35f3be5fb9444ba60673de757d5bc188f20c1756884f0a
+)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_cmake_config_fixup(CONFIG_PATH "/lib/cmake/nvtx3")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/nvtx3/vcpkg.json
+++ b/ports/nvtx3/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "3.2.1",
   "description": "NVTX (NVIDIA Tools Extension Library)",
   "homepage": "https://github.com/NVIDIA/NVTX",
+  "license": "Apache-2.0 WITH LLVM-exception",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/nvtx3/vcpkg.json
+++ b/ports/nvtx3/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "nvtx3",
+  "version": "3.2.1",
+  "description": "NVTX (NVIDIA Tools Extension Library)",
+  "homepage": "https://github.com/NVIDIA/NVTX",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6800,6 +6800,10 @@
       "baseline": "2.1.2",
       "port-version": 9
     },
+    "nvtx3": {
+      "baseline": "3.2.1",
+      "port-version": 0
+    },
     "nyan-lang": {
       "baseline": "0.3.1",
       "port-version": 0

--- a/versions/n-/nvtx3.json
+++ b/versions/n-/nvtx3.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "52f1b7a5cb31883e4dfe8c605a3f1cd25b4fbe0c",
+      "version": "3.2.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/n-/nvtx3.json
+++ b/versions/n-/nvtx3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "52f1b7a5cb31883e4dfe8c605a3f1cd25b4fbe0c",
+      "git-tree": "7499fdcb327a89b75a694dd49581e23ff75cb979",
       "version": "3.2.1",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

