### PR TITLE
[gul14] Update to version 2.13.1

### DIFF
--- a/ports/gul14/portfile.cmake
+++ b/ports/gul14/portfile.cmake
@@ -1,13 +1,14 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gul-cpp/gul14
-    REF v2.11.2
-    SHA512 b18d0a26a5c53745b2a62d69ddb93f85bb4c9926c0a5f6c38374c150e8c3358e70d861c2870ab176689cef7d639466ce9277a3a3d25ea42fb359946489cc74ff
+    REF "v${VERSION}"
+    SHA512 50e20163ac0d29b80eb5b7fef3d57ccb8c649096414f432d613a900d8c420aa6847b1f2e47fb34571efc614d965ef265796b29ebf45bc99809ae8c505315c3bc
     HEAD_REF main
 )
 
 vcpkg_configure_meson(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS -Dtests=false
 )
 
 vcpkg_install_meson()

--- a/ports/gul14/vcpkg.json
+++ b/ports/gul14/vcpkg.json
@@ -1,13 +1,13 @@
 {
   "name": "gul14",
-  "version": "2.11.2",
+  "version": "2.13.1",
   "description": [
     "General Utility Library for C++14.",
     "GUL14 contains often-used utility functions and types that form the foundation for other libraries and programs.",
     "It provides basic functionality that is not available in the C++14 standard library, including some backports from later versions of the standard."
   ],
-  "homepage": "https://github.desy.de/gul-cpp/gul14.git",
-  "documentation": "https://gul14.info",
+  "homepage": "https://github.com/gul-cpp/gul14.git",
+  "documentation": "https://gul-cpp.github.io/gul14/",
   "license": "LGPL-2.1-or-later",
   "supports": "!uwp & !xbox",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3497,7 +3497,7 @@
       "port-version": 0
     },
     "gul14": {
-      "baseline": "2.11.2",
+      "baseline": "2.13.1",
       "port-version": 0
     },
     "gul17": {

--- a/versions/g-/gul14.json
+++ b/versions/g-/gul14.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11b7ffbc16255aaaae3a86f5f570f5818d3538d7",
+      "version": "2.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "814a293c1a792653842cbb7e97c3fdbb8564c517",
       "version": "2.11.2",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version. (DOES NOT APPLY)
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. (DOES NOT APPLY)
- [X] Any patches that are no longer applied are deleted from the port's directory. (DOES NOT APPLY)
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
