### PR TITLE
[qt5-*] Add general fix for all qt5-* builds in osx for forward to debug pc files

### DIFF
--- a/ports/qt5-base/cmake/qt_build_submodule.cmake
+++ b/ports/qt5-base/cmake/qt_build_submodule.cmake
@@ -20,6 +20,18 @@ function(qt_build_submodule SOURCE_PATH)
     qt_fix_cmake(${CURRENT_PACKAGES_DIR} ${PORT})
     vcpkg_fixup_pkgconfig() # Needs further investigation if this is enough!
 
+    # taken from qt5-base portfile.cmake
+    if(VCPKG_TARGET_IS_OSX)
+        file(GLOB _debug_files "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*_debug.pc")
+        foreach(_file ${_debug_files})
+            string(REGEX REPLACE "_debug\\.pc$" ".pc" _new_filename "${_file}")
+            string(REGEX MATCH "(Qt5[a-zA-Z]+)_debug\\.pc$" _not_used "${_file}")
+            set(_name ${CMAKE_MATCH_1})
+            file(STRINGS "${_file}" _version REGEX "^(Version):.+$")
+            file(WRITE "${_new_filename}" "Name: ${_name}\nDescription: Forwarding to the _debug version by vcpkg\n${_version}\nRequires: ${_name}_debug\n")
+        endforeach()
+    endif()
+
     #Replace with VCPKG variables if PR #7733 is merged
     unset(BUILDTYPES)
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version": "5.15.17",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Base provides the basic non-GUI functionality required by all Qt applications.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7770,7 +7770,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.17",
-      "port-version": 1
+      "port-version": 2
     },
     "qt5-canvas3d": {
       "baseline": "0",

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18f8915d90a0971f569cdc43e050b92c176d7eaf",
+      "version": "5.15.17",
+      "port-version": 2
+    },
+    {
       "git-tree": "3653c6ae33c947ecbc5c0ba7e8f8353e9634e1eb",
       "version": "5.15.17",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
