### PR TITLE
[qt5-tools] enable qdoc feature also in debug

### DIFF
--- a/ports/qt5-tools/portfile.cmake
+++ b/ports/qt5-tools/portfile.cmake
@@ -1,21 +1,19 @@
 include(${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake)
 
-vcpkg_list(SET OPTIONS_RELEASE)
+vcpkg_list(SET OPTIONS)
 if("qdoc" IN_LIST FEATURES)
     set(ENV{LLVM_INSTALL_DIR} "${CURRENT_INSTALLED_DIR}")
-    vcpkg_list(APPEND OPTIONS_RELEASE -feature-qdoc)
+    vcpkg_list(APPEND OPTIONS -feature-qdoc)
 else()
-    vcpkg_list(APPEND OPTIONS_RELEASE -no-feature-qdoc)
+    vcpkg_list(APPEND OPTIONS -no-feature-qdoc)
 endif()
 
 qt_submodule_installation(
     PATCHES
         fix-pkgconfig-qt5uiplugin-not-found.patch
         libclang.patch
-    BUILD_OPTIONS_RELEASE
-        ${OPTIONS_RELEASE}
-    BUILD_OPTIONS_DEBUG
-        -no-feature-qdoc
+    BUILD_OPTIONS
+        ${OPTIONS}
 )
 
 if(EXISTS "${CURRENT_INSTALLED_DIR}/plugins/platforms/qminimal${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}")

--- a/ports/qt5-tools/vcpkg.json
+++ b/ports/qt5-tools/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-tools",
   "version": "5.15.17",
+  "port-version": 1,
   "description": "A collection of tools and utilities that come with the Qt framework to assist developers in the creation, management, and deployment of Qt applications.",
   "license": null,
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7886,7 +7886,7 @@
     },
     "qt5-tools": {
       "baseline": "5.15.17",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-translations": {
       "baseline": "5.15.17",

--- a/versions/q-/qt5-tools.json
+++ b/versions/q-/qt5-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7d073db6022de57bf6c0e24e53514e1f0624abf",
+      "version": "5.15.17",
+      "port-version": 1
+    },
+    {
       "git-tree": "718839eb66c9ec8b6fae3bc50cfc263e63f874c2",
       "version": "5.15.17",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
