### PR TITLE
[tcl] Update to core-9-1-a0

### DIFF
--- a/ports/tcl/force-shell-install.patch
+++ b/ports/tcl/force-shell-install.patch
@@ -1,20 +1,11 @@
-From 85842ba83b70d99f90ee3fff8c956e82d17759f2 Mon Sep 17 00:00:00 2001
-From: Marek Roszko <mark.roszko@gmail.com>
-Date: Tue, 18 Aug 2020 23:11:27 -0400
-Subject: [PATCH] Remove broken exist check for shell install
-
----
- win/makefile.vc | 2 --
- 1 file changed, 2 deletions(-)
-
 diff --git a/win/makefile.vc b/win/makefile.vc
-index f5d2f4a..6bffe32 100644
+index 175c4b2..504cf19 100644
 --- a/win/makefile.vc
 +++ b/win/makefile.vc
-@@ -869,10 +869,8 @@ install-binaries:
- 	@$(CPY) "$(TCLLIB)" "$(BIN_INSTALL_DIR)\"
+@@ -1054,10 +1054,8 @@ install-binaries:
+ 	@$(CPY) "$(OUT_DIR)\zdll.lib" "$(LIB_INSTALL_DIR)\"
+ 	@$(CPY) "$(OUT_DIR)\tommath.lib" "$(LIB_INSTALL_DIR)\"
  !endif
- 	@$(CPY) "$(TCLIMPLIB)" "$(LIB_INSTALL_DIR)\"
 -!if exist($(TCLSH))
  	@echo Installing $(TCLSHNAME)
  	@$(CPY) "$(TCLSH)" "$(BIN_INSTALL_DIR)\"
@@ -22,6 +13,3 @@ index f5d2f4a..6bffe32 100644
  	@echo Installing $(TCLSTUBLIBNAME)
  	@$(CPY) "$(TCLSTUBLIB)" "$(LIB_INSTALL_DIR)\"
  
--- 
-2.28.0.windows.1
-

--- a/ports/tcl/force-shell-install.patch
+++ b/ports/tcl/force-shell-install.patch
@@ -1,8 +1,8 @@
 diff --git a/win/makefile.vc b/win/makefile.vc
-index 175c4b2..504cf19 100644
+index 547a00c..0528e9e 100644
 --- a/win/makefile.vc
 +++ b/win/makefile.vc
-@@ -1054,10 +1054,8 @@ install-binaries:
+@@ -1055,10 +1055,8 @@ install-binaries:
  	@$(CPY) "$(OUT_DIR)\zdll.lib" "$(LIB_INSTALL_DIR)\"
  	@$(CPY) "$(OUT_DIR)\tommath.lib" "$(LIB_INSTALL_DIR)\"
  !endif

--- a/ports/tcl/portfile.cmake
+++ b/ports/tcl/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tcltk/tcl
-    REF 0cb9c0b3f8c6426be5bf4b609aef819e379d123e
-    SHA512 5a4e293d8d741148674e67de3a10f94f8b812d2dd4a36ef9a3e2a64eb8b4e21c0a31649cf95bdb76290243f14c8b61982a1f28a71d5def771312543f595bba6f
+    REF e1b559b602eefccffdab183c9deef96241268116
+    SHA512 14efb9c0b0fea8f699eba4d814a588f4954cf8c41904f5782d711ed53a0d6f34647dd9c8dd05459fd72ec381f4fd8d665c42ad095181792b8736a855f81a5727
     PATCHES
         force-shell-install.patch
         remove-git-rev-parse.patch
@@ -76,26 +76,26 @@ if (VCPKG_TARGET_IS_WINDOWS)
         file(REMOVE ${TOOL_EXES})
 
         file(GLOB_RECURSE TOOLS
-                "${CURRENT_PACKAGES_DIR}/lib/dde1.4/*"
+                "${CURRENT_PACKAGES_DIR}/lib/dde1.5/*"
                 "${CURRENT_PACKAGES_DIR}/lib/nmake/*"
                 "${CURRENT_PACKAGES_DIR}/lib/reg1.3/*"
                 "${CURRENT_PACKAGES_DIR}/lib/tcl8/*"
                 "${CURRENT_PACKAGES_DIR}/lib/tcl8.6/*"
                 "${CURRENT_PACKAGES_DIR}/lib/tdbcsqlite31.1.0/*"
-                "${CURRENT_PACKAGES_DIR}/lib/registry1.3/*"
+                "${CURRENT_PACKAGES_DIR}/lib/registry1.4/*"
         )
         
         foreach(TOOL ${TOOLS})
             get_filename_component(DST_DIR ${TOOL} PATH)
             file(COPY "${TOOL}" DESTINATION ${DST_DIR})
         endforeach()
-        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/dde1.4"
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/dde1.5"
                             "${CURRENT_PACKAGES_DIR}/lib/nmake"
                             "${CURRENT_PACKAGES_DIR}/lib/reg1.3"
                             "${CURRENT_PACKAGES_DIR}/lib/tcl8"
                             "${CURRENT_PACKAGES_DIR}/lib/tcl8.6"
                             "${CURRENT_PACKAGES_DIR}/lib/tdbcsqlite31.1.0"
-                            "${CURRENT_PACKAGES_DIR}/lib/registry1.3"
+                            "${CURRENT_PACKAGES_DIR}/lib/registry1.4"
         )
     endif()
     if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL debug)
@@ -111,13 +111,13 @@ if (VCPKG_TARGET_IS_WINDOWS)
         )
         file(REMOVE ${EXES})
     
-        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/dde1.4"
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/dde1.5"
                             "${CURRENT_PACKAGES_DIR}/debug/lib/nmake"
                             "${CURRENT_PACKAGES_DIR}/debug/lib/reg1.3"
                             "${CURRENT_PACKAGES_DIR}/debug/lib/tcl8"
                             "${CURRENT_PACKAGES_DIR}/debug/lib/tcl8.6"
                             "${CURRENT_PACKAGES_DIR}/debug/lib/tdbcsqlite31.1.0"
-                            "${CURRENT_PACKAGES_DIR}/debug/lib/registry1.3"
+                            "${CURRENT_PACKAGES_DIR}/debug/lib/registry1.4"
         )
     endif()
     

--- a/ports/tcl/portfile.cmake
+++ b/ports/tcl/portfile.cmake
@@ -1,14 +1,18 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tcltk/tcl
-    REF 0fa6a4e5aad821a5c34fdfa070c37c3f1ffc8c8e
-    SHA512 9d7f35309fe8b1a7c116639aaea50cc01699787c7afb432389bee2b9ad56a67034c45d90c9585ef1ccf15bdabf0951cbef86257c0c6aedbd2591bbfae3e93b76
-    PATCHES force-shell-install.patch
+    REF 0cb9c0b3f8c6426be5bf4b609aef819e379d123e
+    SHA512 5a4e293d8d741148674e67de3a10f94f8b812d2dd4a36ef9a3e2a64eb8b4e21c0a31649cf95bdb76290243f14c8b61982a1f28a71d5def771312543f595bba6f
+    PATCHES
+        force-shell-install.patch
+        remove-git-rev-parse.patch
 )
 
 if (VCPKG_TARGET_IS_WINDOWS)
     if(VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
         set(TCL_BUILD_MACHINE_STR MACHINE=AMD64)
+    elseif(VCPKG_TARGET_ARCHITECTURE MATCHES "arm64")
+        set(TCL_BUILD_MACHINE_STR MACHINE=ARM64)
     else()
         set(TCL_BUILD_MACHINE_STR MACHINE=IX86)
     endif()
@@ -78,6 +82,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
                 "${CURRENT_PACKAGES_DIR}/lib/tcl8/*"
                 "${CURRENT_PACKAGES_DIR}/lib/tcl8.6/*"
                 "${CURRENT_PACKAGES_DIR}/lib/tdbcsqlite31.1.0/*"
+                "${CURRENT_PACKAGES_DIR}/lib/registry1.3/*"
         )
         
         foreach(TOOL ${TOOLS})
@@ -90,13 +95,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
                             "${CURRENT_PACKAGES_DIR}/lib/tcl8"
                             "${CURRENT_PACKAGES_DIR}/lib/tcl8.6"
                             "${CURRENT_PACKAGES_DIR}/lib/tdbcsqlite31.1.0"
-        )
-        file(CHMOD_RECURSE
-                "${CURRENT_PACKAGES_DIR}/tools/tcl/lib/tcl9.0/msgs" "${CURRENT_PACKAGES_DIR}/tools/tcl/lib/tcl9.0/tzdata"
-            PERMISSIONS
-                OWNER_READ OWNER_WRITE
-                GROUP_READ GROUP_WRITE
-                WORLD_READ WORLD_WRITE
+                            "${CURRENT_PACKAGES_DIR}/lib/registry1.3"
         )
     endif()
     if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL debug)
@@ -118,14 +117,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
                             "${CURRENT_PACKAGES_DIR}/debug/lib/tcl8"
                             "${CURRENT_PACKAGES_DIR}/debug/lib/tcl8.6"
                             "${CURRENT_PACKAGES_DIR}/debug/lib/tdbcsqlite31.1.0"
-        )
-
-        file(CHMOD_RECURSE
-                "${CURRENT_PACKAGES_DIR}/tools/tcl/debug/lib/tcl9.0/msgs" "${CURRENT_PACKAGES_DIR}/tools/tcl/debug/lib/tcl9.0/tzdata"
-            PERMISSIONS
-                OWNER_READ OWNER_WRITE
-                GROUP_READ GROUP_WRITE
-                WORLD_READ WORLD_WRITE
+                            "${CURRENT_PACKAGES_DIR}/debug/lib/registry1.3"
         )
     endif()
     

--- a/ports/tcl/remove-git-rev-parse.patch
+++ b/ports/tcl/remove-git-rev-parse.patch
@@ -1,0 +1,39 @@
+diff --git a/unix/Makefile.in b/unix/Makefile.in
+index 2c0ddaa..ac24b32 100644
+--- a/unix/Makefile.in
++++ b/unix/Makefile.in
+@@ -2327,7 +2327,7 @@ tclUuid.h: $(TOP_DIR)/manifest.uuid
+ 
+ $(TOP_DIR)/manifest.uuid:
+ 	printf "git-" >$(TOP_DIR)/manifest.uuid
+-	(cd $(TOP_DIR); git rev-parse HEAD >>$(TOP_DIR)/manifest.uuid || \
++	(cd $(TOP_DIR); echo 0cb9c0b3f8c6426be5bf4b609aef819e379d123e >>$(TOP_DIR)/manifest.uuid || \
+ 	    (printf "svn-r" >$(TOP_DIR)/manifest.uuid ; \
+ 	    svn info --show-item last-changed-revision >>$(TOP_DIR)/manifest.uuid) || \
+ 	    printf "unknown" >$(TOP_DIR)/manifest.uuid)
+diff --git a/win/Makefile.in b/win/Makefile.in
+index 7a56163..d1dc64a 100644
+--- a/win/Makefile.in
++++ b/win/Makefile.in
+@@ -725,7 +725,7 @@ tclTest.${OBJEXT}: tclTest.c tclUuid.h
+ 
+ $(TOP_DIR)/manifest.uuid:
+ 	printf "git-" >$(TOP_DIR)/manifest.uuid
+-	(cd $(TOP_DIR); git rev-parse HEAD >>$(TOP_DIR)/manifest.uuid || \
++	(cd $(TOP_DIR); echo 0cb9c0b3f8c6426be5bf4b609aef819e379d123e >>$(TOP_DIR)/manifest.uuid || \
+ 	    (printf "svn-r" >$(TOP_DIR)/manifest.uuid ; \
+ 	    svn info --show-item last-changed-revision >>$(TOP_DIR)/manifest.uuid) || \
+ 	    printf "unknown" >$(TOP_DIR)/manifest.uuid)
+diff --git a/win/makefile.vc b/win/makefile.vc
+index 175c4b2..20996ca 100644
+--- a/win/makefile.vc
++++ b/win/makefile.vc
+@@ -879,7 +879,7 @@ $(TMP_DIR)\tclMainW.obj: $(GENERICDIR)\tclMain.c
+ 
+ $(ROOT)\manifest.uuid:
+ 	copy $(WIN_DIR)\gitmanifest.in $(ROOT)\manifest.uuid
+-	git rev-parse HEAD >>$(ROOT)\manifest.uuid
++	echo 0cb9c0b3f8c6426be5bf4b609aef819e379d123e >>$(ROOT)\manifest.uuid
+ 
+ $(TMP_DIR)\tclUuid.h:	$(ROOT)\manifest.uuid
+ 	copy $(WIN_DIR)\tclUuid.h.in+$(ROOT)\manifest.uuid $(TMP_DIR)\tclUuid.h

--- a/ports/tcl/remove-git-rev-parse.patch
+++ b/ports/tcl/remove-git-rev-parse.patch
@@ -1,39 +1,39 @@
 diff --git a/unix/Makefile.in b/unix/Makefile.in
-index 2c0ddaa..ac24b32 100644
+index e47b497..91ccf39 100644
 --- a/unix/Makefile.in
 +++ b/unix/Makefile.in
-@@ -2327,7 +2327,7 @@ tclUuid.h: $(TOP_DIR)/manifest.uuid
+@@ -2304,7 +2304,7 @@ tclUuid.h: $(TOP_DIR)/manifest.uuid
  
  $(TOP_DIR)/manifest.uuid:
  	printf "git-" >$(TOP_DIR)/manifest.uuid
 -	(cd $(TOP_DIR); git rev-parse HEAD >>$(TOP_DIR)/manifest.uuid || \
-+	(cd $(TOP_DIR); echo 0cb9c0b3f8c6426be5bf4b609aef819e379d123e >>$(TOP_DIR)/manifest.uuid || \
++	(cd $(TOP_DIR); echo e1b559b602eefccffdab183c9deef96241268116 >>$(TOP_DIR)/manifest.uuid || \
  	    (printf "svn-r" >$(TOP_DIR)/manifest.uuid ; \
  	    svn info --show-item last-changed-revision >>$(TOP_DIR)/manifest.uuid) || \
  	    printf "unknown" >$(TOP_DIR)/manifest.uuid)
 diff --git a/win/Makefile.in b/win/Makefile.in
-index 7a56163..d1dc64a 100644
+index 3f28d25..c21ff36 100644
 --- a/win/Makefile.in
 +++ b/win/Makefile.in
-@@ -725,7 +725,7 @@ tclTest.${OBJEXT}: tclTest.c tclUuid.h
+@@ -716,7 +716,7 @@ tclTest.${OBJEXT}: tclTest.c tclUuid.h
  
  $(TOP_DIR)/manifest.uuid:
  	printf "git-" >$(TOP_DIR)/manifest.uuid
 -	(cd $(TOP_DIR); git rev-parse HEAD >>$(TOP_DIR)/manifest.uuid || \
-+	(cd $(TOP_DIR); echo 0cb9c0b3f8c6426be5bf4b609aef819e379d123e >>$(TOP_DIR)/manifest.uuid || \
++	(cd $(TOP_DIR); echo e1b559b602eefccffdab183c9deef96241268116 >>$(TOP_DIR)/manifest.uuid || \
  	    (printf "svn-r" >$(TOP_DIR)/manifest.uuid ; \
  	    svn info --show-item last-changed-revision >>$(TOP_DIR)/manifest.uuid) || \
  	    printf "unknown" >$(TOP_DIR)/manifest.uuid)
 diff --git a/win/makefile.vc b/win/makefile.vc
-index 175c4b2..20996ca 100644
+index 547a00c..d0ac0d2 100644
 --- a/win/makefile.vc
 +++ b/win/makefile.vc
-@@ -879,7 +879,7 @@ $(TMP_DIR)\tclMainW.obj: $(GENERICDIR)\tclMain.c
+@@ -880,7 +880,7 @@ $(TMP_DIR)\tclMainW.obj: $(GENERICDIR)\tclMain.c
  
  $(ROOT)\manifest.uuid:
  	copy $(WIN_DIR)\gitmanifest.in $(ROOT)\manifest.uuid
 -	git rev-parse HEAD >>$(ROOT)\manifest.uuid
-+	echo 0cb9c0b3f8c6426be5bf4b609aef819e379d123e >>$(ROOT)\manifest.uuid
++	echo e1b559b602eefccffdab183c9deef96241268116 >>$(ROOT)\manifest.uuid
  
  $(TMP_DIR)\tclUuid.h:	$(ROOT)\manifest.uuid
  	copy $(WIN_DIR)\tclUuid.h.in+$(ROOT)\manifest.uuid $(TMP_DIR)\tclUuid.h

--- a/ports/tcl/vcpkg.json
+++ b/ports/tcl/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "tcl",
-  "version-string": "core-9-0-a1",
-  "port-version": 8,
+  "version-string": "core-9-0-2",
+  "port-version": 0,
   "description": "Tcl provides a powerful platform for creating integration applications that tie together diverse applications, protocols, devices, and frameworks. When paired with the Tk toolkit, Tcl provides the fastest and most powerful way to create GUI applications that run on PCs, Unix, and Mac OS X. Tcl can also be used for a variety of web-related tasks and for creating powerful command languages for applications.",
   "homepage": "https://github.com/tcltk/tcl",
-  "supports": "!android & !(windows & arm) & !uwp",
+  "supports": "!android & !uwp",
   "dependencies": [
     "zlib"
   ],

--- a/ports/tcl/vcpkg.json
+++ b/ports/tcl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tcl",
-  "version-string": "core-9-0-2",
+  "version-string": "core-9-1-a0",
   "description": "Tcl provides a powerful platform for creating integration applications that tie together diverse applications, protocols, devices, and frameworks. When paired with the Tk toolkit, Tcl provides the fastest and most powerful way to create GUI applications that run on PCs, Unix, and Mac OS X. Tcl can also be used for a variety of web-related tasks and for creating powerful command languages for applications.",
   "homepage": "https://github.com/tcltk/tcl",
   "supports": "!android & !uwp",

--- a/ports/tcl/vcpkg.json
+++ b/ports/tcl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tcl",
   "version-string": "core-9-0-2",
-  "port-version": 0,
   "description": "Tcl provides a powerful platform for creating integration applications that tie together diverse applications, protocols, devices, and frameworks. When paired with the Tk toolkit, Tcl provides the fastest and most powerful way to create GUI applications that run on PCs, Unix, and Mac OS X. Tcl can also be used for a variety of web-related tasks and for creating powerful command languages for applications.",
   "homepage": "https://github.com/tcltk/tcl",
   "supports": "!android & !uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9401,8 +9401,8 @@
       "port-version": 0
     },
     "tcl": {
-      "baseline": "core-9-0-2",
-      "port-version": 0
+      "baseline": "core-9-0-a1",
+      "port-version": 8
     },
     "tclap": {
       "baseline": "1.2.5",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9401,8 +9401,8 @@
       "port-version": 0
     },
     "tcl": {
-      "baseline": "core-9-0-a1",
-      "port-version": 8
+      "baseline": "core-9-0-2",
+      "port-version": 0
     },
     "tclap": {
       "baseline": "1.2.5",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9401,8 +9401,8 @@
       "port-version": 0
     },
     "tcl": {
-      "baseline": "core-9-0-a1",
-      "port-version": 8
+      "baseline": "core-9-1-a0",
+      "port-version": 0
     },
     "tclap": {
       "baseline": "1.2.5",

--- a/versions/t-/tcl.json
+++ b/versions/t-/tcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78009a47112c2198d0c3cc4dbe218635fc37cca5",
+      "version-string": "core-9-0-2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e17d8c12a1c924cfd28ae1ad9e5fad178b63eee5",
       "version-string": "core-9-0-a1",
       "port-version": 8

--- a/versions/t-/tcl.json
+++ b/versions/t-/tcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "21961bef09b69d5cbe3908bb32bd16abf9fc3cbd",
+      "version-string": "core-9-1-a0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e17d8c12a1c924cfd28ae1ad9e5fad178b63eee5",
       "version-string": "core-9-0-a1",
       "port-version": 8

--- a/versions/t-/tcl.json
+++ b/versions/t-/tcl.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "78009a47112c2198d0c3cc4dbe218635fc37cca5",
-      "version-string": "core-9-0-2",
-      "port-version": 0
-    },
-    {
       "git-tree": "e17d8c12a1c924cfd28ae1ad9e5fad178b63eee5",
       "version-string": "core-9-0-a1",
       "port-version": 8


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.