### PR TITLE
[libphoneumber] update to 9.0.10

### DIFF
--- a/ports/libphonenumber/portfile.cmake
+++ b/ports/libphonenumber/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/libphonenumber
     REF "v${VERSION}"
-    SHA512 842a5a4fcc6533d8dfeeae2b791d8d531bb80ef9f5cb6a93a91043cd006ac14b84096f8ff3e23f030426a7e91b57f315100e5e990ef80d5bfdda83bff16d12a6
+    SHA512 d5e271a5cb7f78fef5f81c03b2c160ec2c368de2e2aec620a482ea89bea8d187ce7385b2582408942c3d793f7f93d8735f7349abf67196a6da2368f82c839743
     HEAD_REF master
     PATCHES 
         # fix compilation error due to deprecated warnings in protobuf generated files

--- a/ports/libphonenumber/vcpkg.json
+++ b/ports/libphonenumber/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libphonenumber",
-  "version": "9.0.9",
+  "version": "9.0.10",
   "description": "Google's common Java, C++ and JavaScript library for parsing, formatting, and validating international phone numbers.",
   "homepage": "https://github.com/google/libphonenumber",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5217,7 +5217,7 @@
       "port-version": 2
     },
     "libphonenumber": {
-      "baseline": "9.0.9",
+      "baseline": "9.0.10",
       "port-version": 0
     },
     "libplist": {

--- a/versions/l-/libphonenumber.json
+++ b/versions/l-/libphonenumber.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3eabab44947fa2d13612ddbfd0374e34553b597",
+      "version": "9.0.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "b5a83be2b2dda2dad971fcad0e0331c1a3bb6c2a",
       "version": "9.0.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/google/libphonenumber/releases/tag/v9.0.10
