### PR TITLE
[graphicsmagick] update to 1.3.43, change to gitlab repo

### DIFF
--- a/ports/graphicsmagick/portfile.cmake
+++ b/ports/graphicsmagick/portfile.cmake
@@ -1,11 +1,11 @@
-set(GM_VERSION 1.3.41)
+string(REPLACE "." "_" graphicsmagick_version "GraphicsMagick-${VERSION}")
 
-vcpkg_from_sourceforge(
+vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://foss.heptapod.net/
     REPO graphicsmagick/graphicsmagick
-    REF ${GM_VERSION}
-    FILENAME "GraphicsMagick-${GM_VERSION}-windows.7z"
-    SHA512 4790081136af67bf406b94e3de88feff295cc98fd3b125776e014436b12dbb31331af4ee4f8497ccc39d4afda08145b5e4bfeb45b3210a50e17b14e4dc2a220d
+    REF ${graphicsmagick_version}
+    SHA512 c6ee4ded9df4816c5f9522b825d51d23b8c3bef3218b630891f16950452a98633c6a9076b87c07b47493af44b6b4c4cfddfed456a715c885ac3d1d4c6252a6a7
     PATCHES
         # GM always requires a dynamic BZIP2. This patch makes this dependent if _DLL is defined
         dynamic_bzip2.patch

--- a/ports/graphicsmagick/vcpkg.json
+++ b/ports/graphicsmagick/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "graphicsmagick",
-  "version": "1.3.41",
-  "port-version": 1,
+  "version": "1.3.43",
   "description": "Image processing library",
-  "homepage": "https://sourceforge.net/projects/graphicsmagick/",
+  "homepage": "http://www.graphicsmagick.org/",
+  "license": "MIT",
   "dependencies": [
     "bzip2",
     "freetype",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3409,8 +3409,8 @@
       "port-version": 5
     },
     "graphicsmagick": {
-      "baseline": "1.3.41",
-      "port-version": 1
+      "baseline": "1.3.43",
+      "port-version": 0
     },
     "graphite2": {
       "baseline": "1.3.14",

--- a/versions/g-/graphicsmagick.json
+++ b/versions/g-/graphicsmagick.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c3f253db45d2ff252ce9e6ee6420b498474dc7b",
+      "version": "1.3.43",
+      "port-version": 0
+    },
+    {
       "git-tree": "b8e50a2c6bc2a616e6ecfa78362025e0a6df0a04",
       "version": "1.3.41",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This is not the latest. This update is without much effort.
The big change here is to change to gitlab repo, that bring us easy access to all versions.
Maybe we can invest in future PRs to make this port more modern. Maybe compile it with the original autoconf, or maybe to add pc file like in the repo.
