### PR TITLE
[libwebp] Update to 1.6.0

### DIFF
--- a/ports/libwebp/0003-simd.patch
+++ b/ports/libwebp/0003-simd.patch
@@ -1,13 +1,13 @@
 diff --git a/cmake/cpu.cmake b/cmake/cpu.cmake
-index 040c524..f345b89 100644
+index 3b0b2d37..a376b87b 100644
 --- a/cmake/cpu.cmake
 +++ b/cmake/cpu.cmake
 @@ -50,7 +50,7 @@ if(MSVC AND CMAKE_C_COMPILER_ID STREQUAL "MSVC")
    if(MSVC_VERSION GREATER_EQUAL 1800 AND NOT CMAKE_C_FLAGS MATCHES "/arch:")
      set(SIMD_ENABLE_FLAGS)
    else()
--    set(SIMD_ENABLE_FLAGS "/arch:AVX;/arch:SSE2;;;;")
-+    set(SIMD_ENABLE_FLAGS          ";/arch:SSE2;;;;") # /arch:AVX is too much for SSE4
+-    set(SIMD_ENABLE_FLAGS "/arch:AVX2;/arch:AVX;/arch:SSE2;;;;")
++    set(SIMD_ENABLE_FLAGS                    ";;/arch:SSE2;;;;") # /arch:AVX2;/arch:AVX is too much for SSE4
    endif()
    set(SIMD_DISABLE_FLAGS)
  else()

--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/libwebp
     REF "v${VERSION}"
-    SHA512 a922cb84e147f1aeaaac9ff4c6000ebad067a9a4b74d94c25d6c9181f487dfd6d8c7966ac1d239f4fad65cc07ad3d5c82ee9ab4adfa4b125d231056781632548
+    SHA512 298e0ad4c09392213baf5abb69d330c6203b618800073fe2df91d01d35034197c5d3e29a74573b06971473c52c74514f0e6e0f6c8162f923e2dd15cb1a692aef
     HEAD_REF master
     PATCHES
         0002-cmake-config.patch

--- a/ports/libwebp/vcpkg.json
+++ b/ports/libwebp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libwebp",
-  "version": "1.5.0",
-  "port-version": 1,
+  "version": "1.6.0",
   "description": "WebP codec: library to encode and decode images in WebP format",
   "homepage": "https://github.com/webmproject/libwebp",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5609,8 +5609,8 @@
       "port-version": 0
     },
     "libwebp": {
-      "baseline": "1.5.0",
-      "port-version": 1
+      "baseline": "1.6.0",
+      "port-version": 0
     },
     "libwebsockets": {
       "baseline": "4.3.5",

--- a/versions/l-/libwebp.json
+++ b/versions/l-/libwebp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9dee7fa77c6779e018d20afd7f216813dc33f7c",
+      "version": "1.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4da57885ea948ff63857226aaf586d6c44b4c96d",
       "version": "1.5.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.