### PR TITLE
Disable Spotlight on macOS machines.

### DIFF
--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
     value: /Users/vcpkg/Data/downloads
   steps:
   - bash: |
+      sudo mdutil -ad || 0
       sudo mkdir ${{ variables.VCPKG_DOWNLOADS }} || 0
       sudo chmod 777 ${{ variables.VCPKG_DOWNLOADS }} || 0
       exit 0


### PR DESCRIPTION
We observed on cppmac-arm64-02:

```
macOS disk space report:
Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk3s5     495Gi   289Gi   186Gi    61%    8.2M  2.0G    0%   /System/Volumes/Data
 17G	/Users/vcpkg/Data
```

Some investigation led to:

```
sudo du -xhd 1 /System/Volumes/Data | sort -h

20G    /System/Volumes/Data/Users
260G    /System/Volumes/Data/.Spotlight-V100
291G    /System/Volumes/Data
```

showing Spotlight to be a significant contributor to the 'phantom missing space' we have been seeing.

We're going to see if this helps.
