### PR TITLE
[jasper] update to 4.2.7

### DIFF
--- a/ports/jasper/portfile.cmake
+++ b/ports/jasper/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jasper-software/jasper
     REF "version-${VERSION}"
-    SHA512 4552e4823e08f7cb444d5835f30180ae1631b1784078769f0c1d51f40dd3bb6c8a1e960147d07312164dbb3b489561d06ee8f75112e76dbba8aacfd09c7d03e4
+    SHA512 10132a333c0dacc5bbe48049c4c3b6142088d2bb0fd975630d47739ab568e09f4ec7a361bee9d7e7f72b77d9b733a32ac3ea2a1ef1ef7022b5aae9d552681269
     HEAD_REF master
     PATCHES
         no_stdc_check.patch

--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "jasper",
-  "version": "4.2.4",
-  "port-version": 2,
+  "version": "4.2.7",
   "description": "Open source implementation of the JPEG-2000 Part-1 standard",
   "homepage": "https://github.com/jasper-software/jasper",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3997,8 +3997,8 @@
       "port-version": 1
     },
     "jasper": {
-      "baseline": "4.2.4",
-      "port-version": 2
+      "baseline": "4.2.7",
+      "port-version": 0
     },
     "jbcoe-value-types": {
       "baseline": "1.0.0",

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18ff4723524c542f2c6b5f900d492ef4032c3d87",
+      "version": "4.2.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "cf0e87a04297d4721c69efc07e8a1d5930bb8458",
       "version": "4.2.4",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/jasper-software/jasper/releases/tag/version-4.2.7
