### PR TITLE
[crashpad] Fix memset on non-trivial types for C++20

### DIFF
--- a/ports/crashpad/fix-linux-std-20.patch
+++ b/ports/crashpad/fix-linux-std-20.patch
@@ -1,0 +1,20 @@
+diff --git a/util/linux/thread_info.cc b/util/linux/thread_info.cc
+index 77ffb062..4cff830c 100644
+--- a/util/linux/thread_info.cc
++++ b/util/linux/thread_info.cc
+@@ -19,13 +19,13 @@
+ namespace crashpad {
+ 
+ ThreadContext::ThreadContext() {
+-  memset(this, 0, sizeof(*this));
++  memset(static_cast<void*>(this), 0, sizeof(*this));
+ }
+ 
+ ThreadContext::~ThreadContext() {}
+ 
+ FloatContext::FloatContext() {
+-  memset(this, 0, sizeof(*this));
++  memset(static_cast<void*>(this), 0, sizeof(*this));
+ }
+ 
+ FloatContext::~FloatContext() {}

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_git(
     URL https://chromium.googlesource.com/crashpad/crashpad
     REF 7e0af1d4d45b526f01677e74a56f4a951b70517d
     PATCHES
+        fix-linux-std-20.patch
         fix-linux.patch
         fix-lib-name-conflict.patch
 )

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2024-04-11",
-  "port-version": 8,
+  "port-version": 9,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2130,7 +2130,7 @@
     },
     "crashpad": {
       "baseline": "2024-04-11",
-      "port-version": 8
+      "port-version": 9
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2301a3307b932f29fcc21baccd75b67c9bc36c0",
+      "version-date": "2024-04-11",
+      "port-version": 9
+    },
+    {
       "git-tree": "a996b10d98428c6f61d1a8d75dd4b4d5509c37dd",
       "version-date": "2024-04-11",
       "port-version": 8


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

Fixes #45299.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.