### PR TITLE
[opencolorio] Reduce minizip-ng feature deps

### DIFF
--- a/ports/opencolorio/vcpkg.json
+++ b/ports/opencolorio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencolorio",
   "version-semver": "2.2.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation. OCIO provides a straightforward and consistent user experience across all supporting applications while allowing for sophisticated back-end configuration options suitable for high-end production usage. OCIO is compatible with the Academy Color Encoding Specification (ACES) and is LUT-format agnostic, supporting many popular formats.",
   "homepage": "https://opencolorio.org/",
   "license": "BSD-3-Clause",
@@ -9,7 +9,13 @@
   "dependencies": [
     "expat",
     "imath",
-    "minizip-ng",
+    {
+      "name": "minizip-ng",
+      "default-features": false,
+      "features": [
+        "zlib"
+      ]
+    },
     "pystring",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6978,7 +6978,7 @@
     },
     "opencolorio": {
       "baseline": "2.2.1",
-      "port-version": 3
+      "port-version": 4
     },
     "opencsg": {
       "baseline": "1.8.1",

--- a/versions/o-/opencolorio.json
+++ b/versions/o-/opencolorio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a846323c9e6d289380ab049705ac80fefb92d0c",
+      "version-semver": "2.2.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "a0aa2a7240cc442c0e7b7144a8c253bac21330e5",
       "version-semver": "2.2.1",
       "port-version": 3


### PR DESCRIPTION
Fixes #46738.

zlib actually required to build opencolorio.