### PR TITLE
[sdl2-image] Fix pc file on *-windows-static

### DIFF
--- a/ports/sdl2-image/portfile.cmake
+++ b/ports/sdl2-image/portfile.cmake
@@ -41,8 +41,14 @@ endif()
 
 vcpkg_fixup_pkgconfig()
 
+set(debug_libname "SDL2_imaged")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" AND VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/SDL2_image.pc" "-lSDL2_image" "-lSDL2_image-static")
+    set(debug_libname "SDL2_image-staticd")
+endif()
+
 if(NOT VCPKG_BUILD_TYPE)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/SDL2_image.pc" "-lSDL2_image" "-lSDL2_imaged")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/SDL2_image.pc" "-lSDL2_image" "-l${debug_libname}")
 endif()
 
 file(REMOVE_RECURSE 

--- a/ports/sdl2-image/vcpkg.json
+++ b/ports/sdl2-image/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2-image",
   "version": "2.8.8",
-  "port-version": 1,
+  "port-version": 2,
   "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
   "homepage": "https://github.com/libsdl-org/SDL_image",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8650,7 +8650,7 @@
     },
     "sdl2-image": {
       "baseline": "2.8.8",
-      "port-version": 1
+      "port-version": 2
     },
     "sdl2-mixer": {
       "baseline": "2.8.1",

--- a/versions/s-/sdl2-image.json
+++ b/versions/s-/sdl2-image.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e390ce4c736f698cd4e670d27fd9bca4185d047",
+      "version": "2.8.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "5cc9de78d44947f2029569202beba4b5af8ea2cc",
       "version": "2.8.8",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

---

Similar to the workaround for the `d` postfix, on `*-windows-static` triplets, the library has a `-static` suffix. I have submitted a patch upstream to work around this issue (libsdl-org/SDL_image#587), however the maintainers preferred to avoid the additional complexity.