### PR TITLE
[protobuf] Update to 6.30.2

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512 32a9ae3de113b8c94e2aed21ad8f58e5ed4419a6d4078e51f614f0fabbf3bfe6c4affc62c2c1326e030a54df0fdcc47bb715b45022191a363f17680ec651b68e
+    SHA512 f2ee857a36b49f87257a306b3f3c361770d74aaf24c4650b9d00994e1e1a0b09079fb0ce5ffb4d5a4a32d8ca46e3247d6db454918fa0b104fc8d58e8a0546a96
     HEAD_REF master
     PATCHES
         fix-static-build.patch
@@ -49,6 +49,7 @@ file(REMOVE_RECURSE
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DCMAKE_CXX_STANDARD=17
         -Dprotobuf_BUILD_SHARED_LIBS=${protobuf_BUILD_SHARED_LIBS}
         -Dprotobuf_MSVC_STATIC_RUNTIME=${protobuf_MSVC_STATIC_RUNTIME}
         -Dprotobuf_BUILD_TESTS=OFF
@@ -58,6 +59,8 @@ vcpkg_cmake_configure(
         -Dprotobuf_ABSL_PROVIDER=package
         -Dprotobuf_BUILD_LIBUPB=OFF
         ${FEATURE_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        protobuf_ABSL_PROVIDER
 )
 
 vcpkg_cmake_install()

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "protobuf",
-  "version": "5.29.3",
-  "port-version": 1,
+  "version": "5.30.2",
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protobuf",
-  "version": "5.30.2",
+  "version": "6.30.2",
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/ports/utf8-range/portfile.cmake
+++ b/ports/utf8-range/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512 32a9ae3de113b8c94e2aed21ad8f58e5ed4419a6d4078e51f614f0fabbf3bfe6c4affc62c2c1326e030a54df0fdcc47bb715b45022191a363f17680ec651b68e
+    SHA512 f2ee857a36b49f87257a306b3f3c361770d74aaf24c4650b9d00994e1e1a0b09079fb0ce5ffb4d5a4a32d8ca46e3247d6db454918fa0b104fc8d58e8a0546a96
     HEAD_REF main
     PATCHES
         fix-cmake.patch
@@ -14,6 +14,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/third_party/utf8_range"
     OPTIONS
         "-Dutf8_range_ENABLE_TESTS=off"
+        "-Dprotobuf_VERSION=${VERSION}"
 )
 
 vcpkg_cmake_install()

--- a/ports/utf8-range/vcpkg.json
+++ b/ports/utf8-range/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "utf8-range",
-  "version": "5.29.3",
+  "version": "5.30.2",
   "description": "Fast UTF-8 validation with Range algorithm (NEON+SSE4+AVX2)",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "MIT",

--- a/ports/utf8-range/vcpkg.json
+++ b/ports/utf8-range/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "utf8-range",
-  "version": "5.30.2",
+  "version": "6.30.2",
   "description": "Fast UTF-8 validation with Range algorithm (NEON+SSE4+AVX2)",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7589,8 +7589,8 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "5.29.3",
-      "port-version": 1
+      "baseline": "5.30.2",
+      "port-version": 0
     },
     "protobuf-c": {
       "baseline": "1.5.2",
@@ -9853,7 +9853,7 @@
       "port-version": 4
     },
     "utf8-range": {
-      "baseline": "5.29.3",
+      "baseline": "5.30.2",
       "port-version": 0
     },
     "utf8h": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7589,7 +7589,7 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "5.30.2",
+      "baseline": "6.30.2",
       "port-version": 0
     },
     "protobuf-c": {
@@ -9853,7 +9853,7 @@
       "port-version": 4
     },
     "utf8-range": {
-      "baseline": "5.30.2",
+      "baseline": "6.30.2",
       "port-version": 0
     },
     "utf8h": {

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb09218840704f3aab1246c10fee8751390ae114",
+      "version": "5.30.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1020e6e87d6a63311c6ebf7f7ec5124b9bf7be74",
       "version": "5.29.3",
       "port-version": 1

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "bb09218840704f3aab1246c10fee8751390ae114",
-      "version": "5.30.2",
+      "git-tree": "f75b2b4dfc4e94d25a150c641a733e147c1caa9f",
+      "version": "6.30.2",
       "port-version": 0
     },
     {

--- a/versions/u-/utf8-range.json
+++ b/versions/u-/utf8-range.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "ae42ffd523af3c25981d5603e853d57a082375d7",
-      "version": "5.30.2",
+      "git-tree": "ce9b756be2a10d7974e27ee1eb4f8e285a782948",
+      "version": "6.30.2",
       "port-version": 0
     },
     {

--- a/versions/u-/utf8-range.json
+++ b/versions/u-/utf8-range.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae42ffd523af3c25981d5603e853d57a082375d7",
+      "version": "5.30.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "67a0b0ded179b27dc30195bab68549fab519e1e2",
       "version": "5.29.3",
       "port-version": 0


### PR DESCRIPTION
Updates protobuf and its dependency to version 6.30.2

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
