### PR TITLE
[gperftools] update to 2.17.2

### DIFF
--- a/ports/gperftools/install.diff
+++ b/ports/gperftools/install.diff
@@ -82,7 +82,7 @@ index e9647d5..092f40d 100644
 +    src/gperftools/nallocx.h
 +    src/gperftools/profiler.h
 +    src/gperftools/stacktrace.h
-+    "${CMAKE_CURRENT_BINARY_DIR}/gperftools/tcmalloc.h"
++    src/gperftools/tcmalloc.h
 +  DESTINATION include/gperftools
 +)
 +

--- a/ports/gperftools/portfile.cmake
+++ b/ports/gperftools/portfile.cmake
@@ -19,7 +19,6 @@ vcpkg_check_features(
     FEATURES
         libunwind   gperftools_enable_libunwind
         override    GPERFTOOLS_WIN32_OVERRIDE
-        tools       GPERFTOOLS_BUILD_TOOLS
 )
 
 if(gperftools_enable_libunwind)
@@ -49,12 +48,6 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     foreach(gperf_header IN LISTS gperf_public_headers)
         vcpkg_replace_string("${gperf_header}" "__declspec(dllimport)" "")
     endforeach()
-endif()
-
-if("tools" IN_LIST FEATURES)
-    if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-        vcpkg_copy_tools(TOOL_NAMES addr2line-pdb nm-pdb AUTO_CLEAN)
-    endif()
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/gperftools/portfile.cmake
+++ b/ports/gperftools/portfile.cmake
@@ -2,14 +2,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gperftools/gperftools
     REF gperftools-${VERSION}
-    SHA512 a6eddee06cd6a9344c724522a5bb977082d6ee30eded1c6793d6bb508d4c8542a238dc0f62818c715f09312c858cc90cded0ee95ba2a3ea15fad8a0b78bcdaea
+    SHA512 0373053d1a67684a8a8c47818f3e4a5ad8f88993107868a1d90305a401c54e6ca94bde4dc5187bfce8cfc99e98e04ac72f3e2894806160a4dca006b6c86ba215
     HEAD_REF master
     PATCHES
         libunwind.diff
         install.diff
         win32-override.diff
 )
-file(REMOVE_RECURSE "${SOURCE_PATH}/vendor")
 
 if("override" IN_LIST FEATURES)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY ONLY_STATIC_CRT)

--- a/ports/gperftools/portfile.cmake
+++ b/ports/gperftools/portfile.cmake
@@ -55,8 +55,6 @@ if("tools" IN_LIST FEATURES)
     if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
         vcpkg_copy_tools(TOOL_NAMES addr2line-pdb nm-pdb AUTO_CLEAN)
     endif()
-    # Perl script
-    file(INSTALL "${SOURCE_PATH}/src/pprof" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/gperftools/portfile.cmake
+++ b/ports/gperftools/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gperftools/gperftools
     REF gperftools-${VERSION}
-    SHA512 abddaa4e5ff12a468add0db801f8473b8ce2316ca0b229ac9dbea3d528a30a47db4a825e7c4213dd8666b1a4555b3b31ba22ec43014ae5142b35c70010171df1
+    SHA512 c6f68c307f7ecc5a3ff49b616155cb6d5bcc8e7a14b52f480a4e7e6deed562e988af549cd6b3d6f9150d92561947460a2a97d3355c73b81a4d0414870c0b7d32
     HEAD_REF master
     PATCHES
         libunwind.diff

--- a/ports/gperftools/portfile.cmake
+++ b/ports/gperftools/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gperftools/gperftools
     REF gperftools-${VERSION}
-    SHA512 0373053d1a67684a8a8c47818f3e4a5ad8f88993107868a1d90305a401c54e6ca94bde4dc5187bfce8cfc99e98e04ac72f3e2894806160a4dca006b6c86ba215
+    SHA512 abddaa4e5ff12a468add0db801f8473b8ce2316ca0b229ac9dbea3d528a30a47db4a825e7c4213dd8666b1a4555b3b31ba22ec43014ae5142b35c70010171df1
     HEAD_REF master
     PATCHES
         libunwind.diff

--- a/ports/gperftools/vcpkg.json
+++ b/ports/gperftools/vcpkg.json
@@ -21,9 +21,6 @@
     "override": {
       "description": "Override Windows allocators",
       "supports": "windows & staticcrt"
-    },
-    "tools": {
-      "description": "Install tools"
     }
   }
 }

--- a/ports/gperftools/vcpkg.json
+++ b/ports/gperftools/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gperftools",
-  "version": "2.16",
+  "version": "2.17",
   "description": "A high-performance multi-threaded malloc() implementation, plus some performance analysis tools.",
   "homepage": "https://github.com/gperftools/gperftools",
   "license": "BSD-3-Clause",

--- a/ports/gperftools/vcpkg.json
+++ b/ports/gperftools/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gperftools",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "A high-performance multi-threaded malloc() implementation, plus some performance analysis tools.",
   "homepage": "https://github.com/gperftools/gperftools",
   "license": "BSD-3-Clause",

--- a/ports/gperftools/vcpkg.json
+++ b/ports/gperftools/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gperftools",
-  "version": "2.17",
+  "version": "2.17.1",
   "description": "A high-performance multi-threaded malloc() implementation, plus some performance analysis tools.",
   "homepage": "https://github.com/gperftools/gperftools",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3381,7 +3381,7 @@
       "port-version": 0
     },
     "gperftools": {
-      "baseline": "2.17",
+      "baseline": "2.17.1",
       "port-version": 0
     },
     "gpgme": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3381,7 +3381,7 @@
       "port-version": 0
     },
     "gperftools": {
-      "baseline": "2.17.1",
+      "baseline": "2.17.2",
       "port-version": 0
     },
     "gpgme": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3381,7 +3381,7 @@
       "port-version": 0
     },
     "gperftools": {
-      "baseline": "2.16",
+      "baseline": "2.17",
       "port-version": 0
     },
     "gpgme": {

--- a/versions/g-/gperftools.json
+++ b/versions/g-/gperftools.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "30083288c1576e48259569ab9f46ba0ab881c11e",
-      "version": "2.17.1",
+      "git-tree": "99241585d369b3c1e0422741ab4b63fdce71d0df",
+      "version": "2.17.2",
       "port-version": 0
     },
     {

--- a/versions/g-/gperftools.json
+++ b/versions/g-/gperftools.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "dbf7d98a2b22b44057201050391bde85e15de8fe",
-      "version": "2.17",
+      "git-tree": "30083288c1576e48259569ab9f46ba0ab881c11e",
+      "version": "2.17.1",
       "port-version": 0
     },
     {

--- a/versions/g-/gperftools.json
+++ b/versions/g-/gperftools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5b5ef04017ca1b48a8a930cb577a3fad2edf7c7f",
+      "git-tree": "dbf7d98a2b22b44057201050391bde85e15de8fe",
       "version": "2.17",
       "port-version": 0
     },

--- a/versions/g-/gperftools.json
+++ b/versions/g-/gperftools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3cb19bb5ad91216b0bcba1b5a303602065d54b79",
+      "version": "2.17",
+      "port-version": 0
+    },
+    {
       "git-tree": "942debf1003954f938f11be718ad6582b3059c00",
       "version": "2.16",
       "port-version": 0

--- a/versions/g-/gperftools.json
+++ b/versions/g-/gperftools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3cb19bb5ad91216b0bcba1b5a303602065d54b79",
+      "git-tree": "5b5ef04017ca1b48a8a930cb577a3fad2edf7c7f",
       "version": "2.17",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/gperftools/gperftools/releases/tag/gperftools-2.17.2
https://github.com/gperftools/gperftools/releases/tag/gperftools-2.17.1
https://github.com/gperftools/gperftools/releases/tag/gperftools-2.17
