### PR TITLE
[psimd][fp16] make cmake bindings unofficial

### DIFF
--- a/ports/fp16/fix-cmake.patch
+++ b/ports/fp16/fix-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e0d87f8..10a09a9 100644
+index e0d87f8..ae08c37 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -3,7 +3,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
@@ -11,17 +11,19 @@ index e0d87f8..10a09a9 100644
  
  # ---[ Options.
  OPTION(FP16_BUILD_TESTS "Build FP16 unit tests" ON)
-@@ -33,7 +33,8 @@ SET(CONFU_DEPENDENCIES_SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps
+@@ -33,7 +33,10 @@ SET(CONFU_DEPENDENCIES_SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps
  SET(CONFU_DEPENDENCIES_BINARY_DIR ${CMAKE_BINARY_DIR}/deps
    CACHE PATH "Confu-style dependencies binary directory")
  
 -IF(NOT DEFINED PSIMD_SOURCE_DIR)
-+find_package(psimd CONFIG REQUIRED)
++find_package(unofficial-psimd CONFIG REQUIRED)
++add_library(psimd ALIAS unofficial::psimd::psimd)
++
 +IF(FALSE)
    MESSAGE(STATUS "Downloading PSimd to ${CONFU_DEPENDENCIES_SOURCE_DIR}/psimd (define PSIMD_SOURCE_DIR to avoid it)")
    CONFIGURE_FILE(cmake/DownloadPSimd.cmake "${CONFU_DEPENDENCIES_BINARY_DIR}/psimd-download/CMakeLists.txt")
    EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
-@@ -77,7 +78,7 @@ ENDIF()
+@@ -77,7 +80,7 @@ ENDIF()
  TARGET_INCLUDE_DIRECTORIES(fp16 INTERFACE
      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
      $<INSTALL_INTERFACE:include>)
@@ -30,36 +32,33 @@ index e0d87f8..10a09a9 100644
  INSTALL(FILES include/fp16.h
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  INSTALL(FILES
-@@ -89,8 +90,25 @@ INSTALL(FILES
+@@ -89,6 +92,23 @@ INSTALL(FILES
      include/fp16/avx2.py
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fp16)
  
 +
 +INSTALL(TARGETS fp16   
-+  EXPORT fp16-config-targets
++  EXPORT unofficial-fp16-config-targets
 +      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 +      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +      PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-+  INSTALL(EXPORT fp16-config-targets NAMESPACE fp16::
-+    FILE fp16-config-targets.cmake
-+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}) # share/fp16
++  INSTALL(EXPORT unofficial-fp16-config-targets NAMESPACE unofficial::fp16::
++    FILE unofficial-fp16-config-targets.cmake
++    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unofficial-fp16) # share/fp16
 +
 +include(CMakePackageConfigHelpers)
-+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/fp16-config.cmake" INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME})
-+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/fp16-config.cmake DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME})
++configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/unofficial-fp16-config.cmake" INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unofficial-fp16)
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-fp16-config.cmake DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unofficial-fp16)
 +
 +
 +
  # ---[ Configure psimd
--IF(NOT TARGET psimd)
-+IF(FALSE)
+ IF(NOT TARGET psimd)
    ADD_SUBDIRECTORY(
-     "${PSIMD_SOURCE_DIR}"
-     "${CONFU_DEPENDENCIES_BINARY_DIR}/psimd")
 diff --git a/Config.cmake.in b/Config.cmake.in
 new file mode 100644
-index 0000000..a1e87dc
+index 0000000..4523150
 --- /dev/null
 +++ b/Config.cmake.in
 @@ -0,0 +1,7 @@
@@ -69,4 +68,4 @@ index 0000000..a1e87dc
 +find_dependency(psimd)
 +
 +
-+include ( "${CMAKE_CURRENT_LIST_DIR}/fp16-config-targets.cmake" )
++include ( "${CMAKE_CURRENT_LIST_DIR}/unofficial-fp16-config-targets.cmake" )

--- a/ports/fp16/fix-cmake.patch
+++ b/ports/fp16/fix-cmake.patch
@@ -65,7 +65,7 @@ index 0000000..4523150
 +@PACKAGE_INIT@
 +
 +include(CMakeFindDependencyMacro)
-+find_dependency(psimd)
++find_dependency(unofficial-psimd)
 +
 +
 +include ( "${CMAKE_CURRENT_LIST_DIR}/unofficial-fp16-config-targets.cmake" )

--- a/ports/fp16/portfile.cmake
+++ b/ports/fp16/portfile.cmake
@@ -13,6 +13,6 @@ vcpkg_cmake_configure(
         -DFP16_BUILD_BENCHMARKS=OFF
 )
 vcpkg_cmake_install()
-
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/fp16/vcpkg.json
+++ b/ports/fp16/vcpkg.json
@@ -1,13 +1,17 @@
 {
   "name": "fp16",
   "version-date": "2021-02-21",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Header-only library for conversion to/from half-precision floating point formats",
   "homepage": "https://github.com/Maratyszcza/FP16",
   "dependencies": [
     "psimd",
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/ports/psimd/add-cmake-config.patch
+++ b/ports/psimd/add-cmake-config.patch
@@ -13,11 +13,10 @@ index bd69c62..f3c5f15 100644
 +
 +
 +INSTALL(TARGETS psimd 
-+      EXPORT psimd-config
++      EXPORT unofficial-psimd-config
 +      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 +      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +      PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-+INSTALL(EXPORT psimd-config NAMESPACE psimd::
-+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}) # share/psimd
-\ No newline at end of file
++INSTALL(EXPORT unofficial-psimd-config NAMESPACE unofficial::psimd::
++    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unofficial-${PROJECT_NAME}) # share/psimd

--- a/ports/psimd/vcpkg.json
+++ b/ports/psimd/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "psimd",
   "version-date": "2021-02-21",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Portable 128-bit SIMD intrinsics",
   "homepage": "https://github.com/Maratyszcza/psimd",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3022,7 +3022,7 @@
     },
     "fp16": {
       "baseline": "2021-02-21",
-      "port-version": 3
+      "port-version": 4
     },
     "freealut": {
       "baseline": "1.1.0",
@@ -7622,7 +7622,7 @@
     },
     "psimd": {
       "baseline": "2021-02-21",
-      "port-version": 3
+      "port-version": 4
     },
     "ptc-print": {
       "baseline": "1.4.1",

--- a/versions/f-/fp16.json
+++ b/versions/f-/fp16.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac1f4f6738ddb4851c462d1f1743dc1c212e30fd",
+      "version-date": "2021-02-21",
+      "port-version": 4
+    },
+    {
       "git-tree": "241ca8f44eba44a43f044e60a40e56c9670e181d",
       "version-date": "2021-02-21",
       "port-version": 3

--- a/versions/f-/fp16.json
+++ b/versions/f-/fp16.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ac1f4f6738ddb4851c462d1f1743dc1c212e30fd",
+      "git-tree": "b822a76b22a163c4318fbb6ad1efec24ee1ac862",
       "version-date": "2021-02-21",
       "port-version": 4
     },

--- a/versions/p-/psimd.json
+++ b/versions/p-/psimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d329a7455cd397077978bf60ba75b7e38bbd507",
+      "version-date": "2021-02-21",
+      "port-version": 4
+    },
+    {
       "git-tree": "5bc6a225b777b59bcbbe248b295ac01db1c7f533",
       "version-date": "2021-02-21",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
