### PR TITLE
[fxdiv][pthreadpool] made cmake bindings unofficial

### DIFF
--- a/ports/fxdiv/add-cmake-config.patch
+++ b/ports/fxdiv/add-cmake-config.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index bcae6b5..b056d09 100644
+index bcae6b5..a20ea87 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -43,7 +43,7 @@ ENDIF()
@@ -16,13 +16,13 @@ index bcae6b5..b056d09 100644
  
  INSTALL(FILES include/fxdiv.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 +INSTALL(TARGETS fxdiv 
-+      EXPORT fxdiv-config
++      EXPORT unofficial-fxdiv-config
 +      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 +      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +      PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-+INSTALL(EXPORT fxdiv-config NAMESPACE fxdiv::
-+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}) # share/fxdiv
++INSTALL(EXPORT unofficial-fxdiv-config NAMESPACE unofficial::fxdiv::
++    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/unofficial-fxdiv) # share/fxdiv
  
  IF(FXDIV_BUILD_TESTS)
    # ---[ Build google test

--- a/ports/fxdiv/portfile.cmake
+++ b/ports/fxdiv/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT})
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/fxdiv/vcpkg.json
+++ b/ports/fxdiv/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "fxdiv",
   "version-date": "2021-02-21",
-  "port-version": 3,
+  "port-version": 4,
   "description": "C99/C++ header-only library for division via fixed-point multiplication by inverse",
   "homepage": "https://github.com/Maratyszcza/FXdiv",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/ports/pthreadpool/fix-cmakelists.patch
+++ b/ports/pthreadpool/fix-cmakelists.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1361e94..bf098c4 100644
+index 1361e94..5798f2e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -4,8 +4,6 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)
@@ -53,31 +53,25 @@ index 1361e94..bf098c4 100644
  
  IF(PTHREADPOOL_SYNC_PRIMITIVE STREQUAL "condvar")
    TARGET_COMPILE_DEFINITIONS(pthreadpool PRIVATE PTHREADPOOL_USE_FUTEX=0)
-@@ -136,7 +126,7 @@ ENDIF()
- SET_TARGET_PROPERTIES(pthreadpool PROPERTIES
-   C_STANDARD 11
-   C_EXTENSIONS NO)
--TARGET_LINK_LIBRARIES(pthreadpool PUBLIC pthreadpool_interface)
-+TARGET_LINK_LIBRARIES(pthreadpool PUBLIC pthreadpool_interface fxdiv::fxdiv)
- TARGET_INCLUDE_DIRECTORIES(pthreadpool PRIVATE src)
- IF(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-   SET(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 @@ -155,6 +145,9 @@ IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
  ENDIF()
  
  # ---[ Configure FXdiv
 +
-+find_package(fxdiv CONFIG REQUIRED)
-+add_library(fxdiv ALIAS fxdiv::fxdiv)
++find_package(unofficial-fxdiv CONFIG REQUIRED)
++add_library(fxdiv ALIAS unofficial::fxdiv::fxdiv)
  IF(NOT TARGET fxdiv)
    SET(FXDIV_BUILD_TESTS OFF CACHE BOOL "")
    SET(FXDIV_BUILD_BENCHMARKS OFF CACHE BOOL "")
-@@ -164,10 +157,22 @@ IF(NOT TARGET fxdiv)
+@@ -162,12 +155,24 @@ IF(NOT TARGET fxdiv)
+     "${FXDIV_SOURCE_DIR}"
+     "${CMAKE_BINARY_DIR}/FXdiv")
  ENDIF()
- TARGET_LINK_LIBRARIES(pthreadpool PRIVATE fxdiv)
+-TARGET_LINK_LIBRARIES(pthreadpool PRIVATE fxdiv)
++TARGET_LINK_LIBRARIES(pthreadpool PUBLIC fxdiv)
++
  
 -INSTALL(TARGETS pthreadpool
-+
 +INSTALL(TARGETS pthreadpool pthreadpool_interface
 +  EXPORT unofficial-pthreadpool-config-targets
 +  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -98,13 +92,13 @@ index 1361e94..bf098c4 100644
    IF(NOT TARGET gtest)
 diff --git a/Config.cmake.in b/Config.cmake.in
 new file mode 100644
-index 0000000..3ed0212
+index 0000000..575b8b1
 --- /dev/null
 +++ b/Config.cmake.in
 @@ -0,0 +1,6 @@
 +@PACKAGE_INIT@
 +
 +include(CMakeFindDependencyMacro)
-+find_dependency(fxdiv)
++find_dependency(unofficial-fxdiv)
 +
 +include ( "${CMAKE_CURRENT_LIST_DIR}/unofficial-pthreadpool-config-targets.cmake" )

--- a/ports/pthreadpool/vcpkg.json
+++ b/ports/pthreadpool/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pthreadpool",
   "version-date": "2024-11-04",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Portable (POSIX/Windows/Emscripten) thread pool for C/C++",
   "homepage": "https://github.com/Maratyszcza/pthreadpool",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3110,7 +3110,7 @@
     },
     "fxdiv": {
       "baseline": "2021-02-21",
-      "port-version": 3
+      "port-version": 4
     },
     "g2o": {
       "baseline": "2024-12-14",
@@ -7642,7 +7642,7 @@
     },
     "pthreadpool": {
       "baseline": "2024-11-04",
-      "port-version": 1
+      "port-version": 2
     },
     "pthreads": {
       "baseline": "3.0.0",

--- a/versions/f-/fxdiv.json
+++ b/versions/f-/fxdiv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3e0e748c872c7110b767f3241922f993e346845",
+      "version-date": "2021-02-21",
+      "port-version": 4
+    },
+    {
       "git-tree": "d00206d4978e82ddccd6d9f61090a76a3093abb4",
       "version-date": "2021-02-21",
       "port-version": 3

--- a/versions/p-/pthreadpool.json
+++ b/versions/p-/pthreadpool.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b7eac55af2b2e67efc867ca5d32ac194ba80b37f",
+      "version-date": "2024-11-04",
+      "port-version": 2
+    },
+    {
       "git-tree": "892c975ca8504f17839bb91fed6b937a734af46f",
       "version-date": "2024-11-04",
       "port-version": 1


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
