### PR TITLE
[openslide] produce expected DLL name

### DIFF
--- a/ports/openslide/portfile.cmake
+++ b/ports/openslide/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         cross-build.diff
         fix-win-build.patch
         slidetool-unicode.patch
+        windows-dll-name.patch
 )
 if(VCPKG_CROSSCOMPILING)
     file(COPY 

--- a/ports/openslide/vcpkg.json
+++ b/ports/openslide/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openslide",
   "version": "4.0.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "OpenSlide is a C library for reading whole slide image files (also known as virtual slides). It provides a consistent and simple API for reading files from multiple vendors.",
   "homepage": "https://openslide.org/",
   "license": "LGPL-2.1-only",

--- a/ports/openslide/windows-dll-name.patch
+++ b/ports/openslide/windows-dll-name.patch
@@ -1,0 +1,27 @@
+commit 6d80b9db41810eb316d81cd2149265b89f5dc35f
+Author: Benjamin Gilbert <bgilbert@cs.cmu.edu>
+Date:   Mon Aug 4 21:32:06 2025 -0600
+
+    meson: use `lib` library prefix when building on Windows
+    
+    Meson defaults to omitting the `lib` library prefix on Windows except when
+    building with MinGW, producing openslide-1.dll.  OpenSlide Java, OpenSlide
+    Python, and other bindings assume the library is libopenslide-1.dll, since
+    that's what openslide-bin ships.  Ensure we use that name.
+    
+    Signed-off-by: Benjamin Gilbert <bgilbert@cs.cmu.edu>
+
+diff --git a/src/meson.build b/src/meson.build
+index 676e5feb3f56..821fc3b938fc 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -81,6 +81,9 @@ libopenslide = library(
+   openslide_sources,
+   version : soversion,
+   c_args : ['-D_OPENSLIDE_BUILDING_DLL', '-DG_LOG_DOMAIN="OpenSlide"'],
++  # Meson omits 'lib' by default on Windows except on MinGW.  Maintain
++  # compatibility with the MinGW build, since it was here first.
++  name_prefix : host_machine.system() == 'windows' ? 'lib' : [],
+   gnu_symbol_visibility : visibility,
+   include_directories : config_h_include,
+   dependencies : [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7082,7 +7082,7 @@
     },
     "openslide": {
       "baseline": "4.0.0",
-      "port-version": 3
+      "port-version": 4
     },
     "openssl": {
       "baseline": "3.5.1",

--- a/versions/o-/openslide.json
+++ b/versions/o-/openslide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b567364c9a7a35be645762c75647b9a27509429d",
+      "version": "4.0.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "38b3b2656b0bff8bc0db907e97f1d6f6e90a740a",
       "version": "4.0.0",
       "port-version": 3


### PR DESCRIPTION
Meson defaults to `openslide-1.dll` with clang and `libopenslide-1.dll` with MinGW.  Bindings expect `libopenslide-1.dll`, so always use that name.

Upstream in https://github.com/openslide/openslide/pull/686.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.