### PR TITLE
[libheif] update to 1.20.2

### DIFF
--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  strukturag/libheif
     REF "v${VERSION}"
-    SHA512 74bc51caf30997e1d327ab8253e9d3556906cd14828794a72c4ba42f2c154b79c1d717e0833a6afc3f6ebff909b630326c11a052d7eb832008769157fad3760b
+    SHA512 4497d1afbccc15806cc11c22653e83d7900a009ad584a8d6b1ada6fac1ace9a70d834eb32653da567f0ddabc23ec641c5d69503282e303bf1bf2def72544b1b5
     HEAD_REF master
     PATCHES
         cxx-linkage-pkgconfig.diff

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libheif",
-  "version": "1.20.1",
-  "port-version": 1,
+  "version": "1.20.2",
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/ports/openimageio/libheif-1_20_2.patch
+++ b/ports/openimageio/libheif-1_20_2.patch
@@ -1,0 +1,26 @@
+diff --git a/src/heif.imageio/heifinput.cpp b/src/heif.imageio/heifinput.cpp
+index b87cb16..13b964d 100644
+--- a/src/heif.imageio/heifinput.cpp
++++ b/src/heif.imageio/heifinput.cpp
+@@ -390,7 +390,7 @@ HeifInput::read_native_scanline(int subimage, int miplevel, int y, int /*z*/,
+ #else
+     int ystride = 0;
+ #endif
+-    const uint8_t* hdata = m_himage.get_plane(heif_channel_interleaved,
++    const uint8_t* hdata = m_himage.get_plane2(heif_channel_interleaved,
+                                               &ystride);
+     if (!hdata) {
+         errorfmt("Unknown read error");
+diff --git a/src/heif.imageio/heifoutput.cpp b/src/heif.imageio/heifoutput.cpp
+index 32e46ea..b7be1da 100644
+--- a/src/heif.imageio/heifoutput.cpp
++++ b/src/heif.imageio/heifoutput.cpp
+@@ -155,7 +155,7 @@ HeifOutput::write_scanline(int y, int /*z*/, TypeDesc format, const void* data,
+ #else
+     int hystride = 0;
+ #endif
+-    uint8_t* hdata = m_himage.get_plane(heif_channel_interleaved, &hystride);
++    uint8_t* hdata = m_himage.get_plane2(heif_channel_interleaved, &hystride);
+     hdata += hystride * (y - m_spec.y);
+     memcpy(hdata, data, hystride);
+     return true;

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         fix-openimageio_include_dir.patch
         fix-openexr-target-missing.patch
         ${FIX_LIBHEIF_BUILD_PATCH}
+        libheif-1_20_2.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/ext")

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openimageio",
   "version": "3.0.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7042,7 +7042,7 @@
     },
     "openimageio": {
       "baseline": "3.0.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "openjpeg": {
       "baseline": "2.5.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4877,8 +4877,8 @@
       "port-version": 6
     },
     "libheif": {
-      "baseline": "1.20.1",
-      "port-version": 1
+      "baseline": "1.20.2",
+      "port-version": 0
     },
     "libhsplasma": {
       "baseline": "2024-03-07",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "71519f65f5aa00ded247297c0c899ff679d869b9",
+      "version": "1.20.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "0e3ed4a35299acdbb186b6ac6ad9a3d622e7d09d",
       "version": "1.20.1",
       "port-version": 1

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d243ed3402e75314bdda39e76ef5ed018fa0ba0",
+      "version": "3.0.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "cc83d2febddebf7f5eadf47a624bc36dc3726fce",
       "version": "3.0.8.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/strukturag/libheif/releases/tag/v1.20.2
