### PR TITLE
[gz-msgs] Update to 11.1.0

### DIFF
--- a/ports/gz-msgs/move_bin_to_tools.patch
+++ b/ports/gz-msgs/move_bin_to_tools.patch
@@ -1,5 +1,5 @@
 diff --git a/gz-msgs-extras.cmake.in b/gz-msgs-extras.cmake.in
-index b70c04a..537a54e 100644
+index 7c322b1..78cf807 100644
 --- a/gz-msgs-extras.cmake.in
 +++ b/gz-msgs-extras.cmake.in
 @@ -33,7 +33,7 @@ set(FACTORY_SCRIPT_NAME "@PROJECT_NAME@_generate_factory.py")
@@ -21,4 +21,4 @@ index b70c04a..537a54e 100644
 +set(@PROJECT_NAME@_FACTORY_GENERATOR_SCRIPT ${VCPKG_IMPORT_PREFIX}/tools/@PROJECT_NAME@/${FACTORY_SCRIPT_NAME})
  
  ##################################################
- # A function to generate a target mesage library from a group of protobuf files .
+ # A function to generate a target message library from a group of protobuf files .

--- a/ports/gz-msgs/portfile.cmake
+++ b/ports/gz-msgs/portfile.cmake
@@ -15,7 +15,7 @@ ignition_modular_library(
    NAME ${PACKAGE_NAME}
    REF ${PORT}${VERSION_MAJOR}_${VERSION}
    VERSION ${VERSION}
-   SHA512 b96ec15d2ef46eebab6bebb6ffbd8f11b7bd9ed27156e753343603546d49db41afb3cf926b72de7eb9f702c40ad7e029dd3ddfe3e00d6d503cc45c1a0b8761d9
+   SHA512 43c75eb30f00708c54f3de54737a4f1bda4a77a1d1ca3ba1354270beb01db078e73b909fdebb33b938a45a9808d4d2f2c164efe01c98aaec7a88003c85fab6f9
    OPTIONS
       ${options}
       "-DCMAKE_PROJECT_INCLUDE=${CURRENT_PORT_DIR}/cmake-project-include.cmake"

--- a/ports/gz-msgs/vcpkg.json
+++ b/ports/gz-msgs/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gz-msgs",
-  "version": "11.0.2",
-  "port-version": 2,
+  "version": "11.1.0",
   "description": "Protobuf messages and functions for robot applications",
   "license": "Apache-2.0",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3549,8 +3549,8 @@
       "port-version": 1
     },
     "gz-msgs": {
-      "baseline": "11.0.2",
-      "port-version": 2
+      "baseline": "11.1.0",
+      "port-version": 0
     },
     "gz-msgs9": {
       "baseline": "9.5.0",

--- a/versions/g-/gz-msgs.json
+++ b/versions/g-/gz-msgs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e872aa215fc2daa52529e9477927abd0e1492b6a",
+      "version": "11.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "df537bd272706b69fb0a0379718eaaea03f7e8e3",
       "version": "11.0.2",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.