### PR TITLE
[openimageio] update to 3.0.9.0

### DIFF
--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -1,14 +1,8 @@
-vcpkg_download_distfile(FIX_LIBHEIF_BUILD_PATCH
-    URLS https://github.com/AcademySoftwareFoundation/OpenImageIO/commit/09250af27d11f6ea761872490403d074424b6e62.diff?full_index=1
-    FILENAME AcademySoftwareFoundation-OpenImageIO-libheif-build.patch
-    SHA512 3a0f9c735244ac40194b73b740c75ca4d0dc77623a12c017098502497bfdf98e4e76dfa48f4e632fbcaa50b3daa58234feb9279a4f1beba91d4c4bb38ff4889a
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/OpenImageIO
     REF "v${VERSION}"
-    SHA512 80efcdba979e1afda609ede4f743b44bc5d277b2ae4bfb96943aee23570d8652f5d0975f5f0bc8c3c9764c4da3ad6bd430c5dab149822648d4b0ba051ba18c11
+    SHA512 fdf411b7035367020b8f3056979c6f25800cdbfa545d844485ddb2ab41148c5b471b75a40bfa1f8ba52bafa8fe8459b221391ff3ddfdf891b4169444141cf75c
     HEAD_REF master
     PATCHES
         fix-dependencies.patch
@@ -16,7 +10,6 @@ vcpkg_from_github(
         imath-version-guard.patch
         fix-openimageio_include_dir.patch
         fix-openexr-target-missing.patch
-        ${FIX_LIBHEIF_BUILD_PATCH}
         libheif-1_20_2.patch
 )
 

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openimageio",
-  "version": "3.0.8.0",
-  "port-version": 2,
+  "version": "3.0.9.0",
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7041,8 +7041,8 @@
       "port-version": 4
     },
     "openimageio": {
-      "baseline": "3.0.8.0",
-      "port-version": 2
+      "baseline": "3.0.9.0",
+      "port-version": 0
     },
     "openjpeg": {
       "baseline": "2.5.3",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c0532ef7c81d287987a6e84b256c4b5b10f2033",
+      "version": "3.0.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6d243ed3402e75314bdda39e76ef5ed018fa0ba0",
       "version": "3.0.8.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/tag/v3.0.9.0
