### PR TITLE
[nvtx3] Create a new port with 3.2.2

### DIFF
--- a/ports/nvtx3/portfile.cmake
+++ b/ports/nvtx3/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIA/NVTX
+    REF v${VERSION}
+    SHA512 46c5c11db52d8ce372d7372c02518916e9e946d4976f61d72b430035458e8c48a1c8ea06b1b6825057233cd8e453362f40f22cfd77cc19947c87f06e0420bc9f
+    HEAD_REF release-v3
+)
+
+# header-only library. we don't need other configurations
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/c"
+    OPTIONS
+        -DNVTX3_TARGETS_NOT_USING_IMPORTED=ON
+        -DNVTX3_INSTALL=ON
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/nvtx3")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+file(INSTALL "${SOURCE_PATH}/c/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/nvtx3/vcpkg.json
+++ b/ports/nvtx3/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "nvtx3",
+  "version": "3.2.2",
+  "description": "The NVIDIA® Tools Extension SDK (NVTX)",
+  "homepage": "https://nvidia.github.io/NVTX/",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/nvtx3/vcpkg.json
+++ b/ports/nvtx3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nvtx3",
   "version": "3.2.2",
-  "description": "The NVIDIA® Tools Extension SDK (NVTX)",
+  "description": "The NVIDIA Tools Extension SDK (NVTX) is a C-based Application Programming Interface (API) for annotating events, code ranges, and resources in your applications.",
   "homepage": "https://nvidia.github.io/NVTX/",
   "license": "Apache-2.0",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6808,6 +6808,10 @@
       "baseline": "2.1.2",
       "port-version": 9
     },
+    "nvtx3": {
+      "baseline": "3.2.2",
+      "port-version": 0
+    },
     "nyan-lang": {
       "baseline": "0.3.1",
       "port-version": 0

--- a/versions/n-/nvtx3.json
+++ b/versions/n-/nvtx3.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a007df90ad9c2f1b0d1e3e7811e721ec71ac5d4a",
+      "version": "3.2.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/n-/nvtx3.json
+++ b/versions/n-/nvtx3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a007df90ad9c2f1b0d1e3e7811e721ec71ac5d4a",
+      "git-tree": "f3dca47907ff6eecc5e64cae940a3fbe0720f063",
       "version": "3.2.2",
       "port-version": 0
     }


### PR DESCRIPTION

Create a new port from https://github.com/NVIDIA/NVTX/releases/tag/v3.2.2. 

- Help #46700
- https://github.com/NVIDIA/NVTX/blob/release-v3/c/CMakeLists.txt

It's a header-only library, and the recent version supports `find_package(nvtx3)`

```log
The following packages are already installed:
    nvtx3:arm64-osx@3.2.2
Total install time: 546 us
nvtx3 provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(nvtx3 CONFIG REQUIRED)
  target_link_libraries(main PRIVATE nvtx3::nvtx3-c nvtx3::nvtx3-cpp)

```

### Target `CUDA::nvToolsExt` and `CUDA::nvtx3`

- https://cmake.org/cmake/help/v4.1/module/FindCUDAToolkit.html#nvtoolsext
- https://cmake.org/cmake/help/v4.1/module/FindCUDAToolkit.html#nvtx3

Some times, CUDA configuration may fail with creating `nvToolsExt` target.
Using the port will prevent the header search failures.

- https://github.com/pytorch/pytorch/pull/147418
-  https://github.com/pytorch/pytorch/blob/e2d141dbde55c2a4370fac5165b0561b6af4798b/cmake/public/cuda.cmake#L172-L187

```log
CMake Error at cmake/public/cuda.cmake:186 (set_property):
  The link interface of target "torch::nvtoolsext" contains:

    CUDA::nvToolsExt
```

## References

- https://nvidia.github.io/NVTX/
- https://cmake.org/cmake/help/v4.1/module/FindCUDAToolkit.html
- https://github.com/luncliff/vcpkg-registry/pull/421
- https://github.com/luncliff/vcpkg-registry/pull/419

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
