### PR TITLE
[c-ares] Add tools feature

### DIFF
--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -11,12 +11,17 @@ vcpkg_from_github(
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tool        CARES_BUILD_TOOLS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DCARES_STATIC=${BUILD_STATIC}
         -DCARES_SHARED=${BUILD_SHARED}
-        -DCARES_BUILD_TOOLS=OFF
         -DCARES_BUILD_TESTS=OFF
         -DCARES_BUILD_CONTAINER_TESTS=OFF
 )
@@ -37,3 +42,7 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")
+
+if ("tool" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES adig ahost AUTO_CLEAN)
+endif()

--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "c-ares",
   "version-semver": "1.34.5",
+  "port-version": 1,
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "license": "MIT-CMU",
@@ -13,5 +14,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tool": {
+      "description": "Builds c-ares executables"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1518,7 +1518,7 @@
     },
     "c-ares": {
       "baseline": "1.34.5",
-      "port-version": 0
+      "port-version": 1
     },
     "c-dbg-macro": {
       "baseline": "2020-02-29",

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d733716f373cf3ccd5da4f42ea1369064853d751",
+      "version-semver": "1.34.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "e39f819020d30d42ddfa5b351ed38bc78b0be157",
       "version-semver": "1.34.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
