### PR TITLE
[sentry-native] update to 0.10.0

### DIFF
--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 bfc2210beb738ef1cc6ecaac046b46675ab5ef14616fe5afd041842063b26530b0e0f476b5b142c1fd8ed613272740268abd83f7dd754298733617552da47916
+    SHA512 d4074afed7f8dab59cab3cd65d74777d148d466dc1de46739db87f70af25c367c098f8c787775c20761cea2c411e5e9469784d4850572339893aa2463e64e4ea
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8717,7 +8717,7 @@
       "port-version": 2
     },
     "sentry-native": {
-      "baseline": "0.9.1",
+      "baseline": "0.10.0",
       "port-version": 0
     },
     "septag-dmon": {

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2993bfa28cbb97842e75b91889d5c174ef442e67",
+      "version": "0.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "717dd1e77b21f2b653abe0844117bda99c828102",
       "version": "0.9.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
