### PR TITLE
[dacap-clip] New port

### DIFF
--- a/ports/dacap-clip/fix-install-header-and-force-static-compilation.patch
+++ b/ports/dacap-clip/fix-install-header-and-force-static-compilation.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 79f7074..775b565 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,7 +25,7 @@ if(UNIX AND NOT APPLE)
+   option(CLIP_X11_WITH_PNG "Compile with libpng to support copy/paste image in png format" on)
+ endif()
+ 
+-add_library(clip clip.cpp)
++add_library(clip STATIC clip.cpp)
+ 
+ if(CLIP_ENABLE_IMAGE)
+   target_sources(clip PRIVATE image.cpp)
+@@ -109,6 +109,8 @@ endif()
+ if(CLIP_INSTALL)
+   include(GNUInstallDirs)
+ 
++  target_include_directories(clip PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++
+   install(
+     FILES clip.h
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/ports/dacap-clip/portfile.cmake
+++ b/ports/dacap-clip/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO dacap/clip
+  REF v1.10
+  SHA512 a29531ef276650807233b635ecceaf408147e4e263268eaf8237d74c9a7641d28cda5c6d1eaad4dbe634e720a5969dd6cc82aaeffbc36e0c9598ded31e419ea6
+  PATCHES
+    "fix-install-header-and-force-static-compilation.patch")
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    -DCLIP_ENABLE_LIST_FORMATS=ON
+    -DCLIP_EXAMPLES=OFF
+    -DCLIP_TESTS=OFF
+    -DCLIP_X11_WITH_PNG=ON
+  MAYBE_UNUSED_VARIABLES
+    CLIP_X11_WITH_PNG # only an option when UNIX AND NOT APPLE
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_cmake_config_fixup(PACKAGE_NAME clip CONFIG_PATH "lib/cmake/clip")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/dacap-clip/vcpkg.json
+++ b/ports/dacap-clip/vcpkg.json
@@ -6,10 +6,7 @@
   "license": "MIT",
   "supports": "!android & !uwp",
   "dependencies": [
-    {
-      "name": "libpng",
-      "host": true
-    },
+    "libpng",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/dacap-clip/vcpkg.json
+++ b/ports/dacap-clip/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "dacap-clip",
+  "version": "1.10.0",
+  "description": "Cross-platform C++ library to copy/paste clipboard content.",
+  "homepage": "https://github.com/dacap/clip",
+  "license": "MIT",
+  "supports": "!android & !uwp",
+  "dependencies": [
+    {
+      "name": "libpng",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2288,6 +2288,10 @@
       "baseline": "may2021",
       "port-version": 1
     },
+    "dacap-clip": {
+      "baseline": "1.10.0",
+      "port-version": 0
+    },
     "darknet": {
       "baseline": "2024-10-10",
       "port-version": 0

--- a/versions/d-/dacap-clip.json
+++ b/versions/d-/dacap-clip.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0ad4f98980c12760d101423af06ebd2ad213fd67",
+      "version": "1.10.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/d-/dacap-clip.json
+++ b/versions/d-/dacap-clip.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0ad4f98980c12760d101423af06ebd2ad213fd67",
+      "git-tree": "6f7bfb92450f247a05aabd780ab123e48a19cc99",
       "version": "1.10.0",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
