### PR TITLE
[dlib] Fix optional dependencies.

### DIFF
--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -44,9 +44,12 @@ vcpkg_cmake_configure(
         -DDLIB_WEBP_SUPPORT=OFF
         -DDLIB_USE_MKL_FFT=OFF
         -DDLIB_USE_FFMPEG=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_X11=ON
     OPTIONS_DEBUG
         ${dbg_opts}
         #-DDLIB_ENABLE_STACK_TRACE=ON
+    MAYBE_UNUSED_OPTIONS
+        CMAKE_DISABLE_FIND_PACKAGE_X11 # Not checked on Windows
 )
 
 vcpkg_cmake_install()

--- a/ports/dlib/vcpkg.json
+++ b/ports/dlib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dlib",
   "version": "20.0",
+  "port-version": 1,
   "description": "Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++",
   "homepage": "https://github.com/davisking/dlib",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2462,7 +2462,7 @@
     },
     "dlib": {
       "baseline": "20.0",
-      "port-version": 0
+      "port-version": 1
     },
     "dlpack": {
       "baseline": "1.1",

--- a/versions/d-/dlib.json
+++ b/versions/d-/dlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "84b2fce99d520f160ae6137f9321334029fc87d8",
+      "version": "20.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1b696e898c9b50f911e41e21ce14fe0cd9ecb8cc",
       "version": "20.0",
       "port-version": 0


### PR DESCRIPTION
As suggested by @Neumann-A, I hope this fixes the intermittent 'vtk build fails due to looking for x11 in /opt/homebrew/lib' problem.

dlib has the following find_package(... not-REQUIRED)s:

find_package(X11 QUIET) ... the broken fixed here

Guarded by DLIB_GIF_SUPPORT
find_package(GIF QUIET)

Directly controlled by
find_package(CUDA 7.5)
find_package(OpenMP)

Disabled by DDLIB_USE_FFMPEG=OFF
find_package(PkgConfig)

Are explicit dependencies so they will always be true: find_package(JPEG QUIET)
find_package(PNG QUIET)
find_package(BLAS QUIET)
find_package(LAPACK QUIET)

Only in an 'examples' directory we don't build:
find_package(OpenCV QUIET)

Only in the 'java' subdirectory:
find_package(SWIG QUIET)
find_package(Java QUIET)
find_package(JNI QUIET)
