### PR TITLE
[stringzilla] update to 3.12.6

### DIFF
--- a/ports/stringzilla/portfile.cmake
+++ b/ports/stringzilla/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/StringZilla
     REF "v${VERSION}"
-    SHA512 1ec86fddf8fdc118bc0aaec5cf3d6a34b2e20572f2f8f7dcf33b50637faa7b8be6c04ae5be9df28fce6b0859fd75f4a6c76d39e8663fea965b8b40389433e2d4
+    SHA512 3fc405a352a7c040a04c1aa9932a45b74c4af79abc84d9ce50b73031ee637f9d21b37a85e4cc5076722d100d349a447b4987af5d1545b084bb4a70dd780366be
     HEAD_REF master
 )
 

--- a/ports/stringzilla/vcpkg.json
+++ b/ports/stringzilla/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stringzilla",
-  "version": "3.12.5",
+  "version": "3.12.6",
   "description": "StringZilla is the GodZilla of string libraries, using SIMD and SWAR to accelerate string operations on modern CPUs.",
   "homepage": "https://github.com/ashvardanian/StringZilla",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9233,7 +9233,7 @@
       "port-version": 1
     },
     "stringzilla": {
-      "baseline": "3.12.5",
+      "baseline": "3.12.6",
       "port-version": 0
     },
     "strong-type": {

--- a/versions/s-/stringzilla.json
+++ b/versions/s-/stringzilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3bc74c500addee9d0c6ccdb2b867736b6f545764",
+      "version": "3.12.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "781a6e2b9611185fdbde12458660b604cc7e3d22",
       "version": "3.12.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ashvardanian/StringZilla/releases/tag/v3.12.6
