### PR TITLE
[quickjs-ng] New port

### DIFF
--- a/ports/quickjs-ng/portfile.cmake
+++ b/ports/quickjs-ng/portfile.cmake
@@ -1,3 +1,7 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO quickjs-ng/quickjs
@@ -6,15 +10,8 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-set(_OPTIONS)
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic" AND VCPKG_TARGET_IS_WINDOWS)
-    # Without following option the .lib file will not be generated which prevents the tools from being built. 
-    list(APPEND _OPTIONS -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON)
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${_OPTIONS}
 )
 
 vcpkg_cmake_install()
@@ -28,9 +25,6 @@ vcpkg_copy_tools(
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
-endif()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/quickjs-ng/portfile.cmake
+++ b/ports/quickjs-ng/portfile.cmake
@@ -1,0 +1,36 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO quickjs-ng/quickjs
+    REF v${VERSION}
+    SHA512 e099502b50b2483b29fcad16c21e03164cba86181a90b2957774117138a0c7af32a0649f1468d18c20b33725fb30418314b49be54d3a7ad2b838e5578018c61d
+    HEAD_REF master
+)
+
+set(_OPTIONS)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic" AND VCPKG_TARGET_IS_WINDOWS)
+    # Without following option the .lib file will not be generated which prevents the tools from being built. 
+    list(APPEND _OPTIONS -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/quickjs PACKAGE_NAME qjs)
+
+vcpkg_copy_tools(
+    TOOL_NAMES qjs qjsc
+    AUTO_CLEAN
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
+endif()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/quickjs-ng/usage
+++ b/ports/quickjs-ng/usage
@@ -1,0 +1,4 @@
+quickjs-ng provides CMake targets:
+
+find_package(qjs CONFIG REQUIRED)
+target_link_libraries(main PRIVATE qjs)

--- a/ports/quickjs-ng/usage
+++ b/ports/quickjs-ng/usage
@@ -1,4 +1,4 @@
 quickjs-ng provides CMake targets:
 
-find_package(qjs CONFIG REQUIRED)
-target_link_libraries(main PRIVATE qjs)
+  find_package(qjs CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE qjs)

--- a/ports/quickjs-ng/vcpkg.json
+++ b/ports/quickjs-ng/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "quickjs-ng",
+  "version": "0.10.1",
+  "description": "QuickJS, the Next Generation: a mighty JavaScript engine. A small and embeddable JavaScript engine supporting the latest ECMAScript specification.",
+  "homepage": "https://github.com/quickjs-ng/quickjs",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8148,6 +8148,10 @@
       "baseline": "1.15.1",
       "port-version": 9
     },
+    "quickjs-ng": {
+      "baseline": "0.10.1",
+      "port-version": 0
+    },
     "quill": {
       "baseline": "10.0.1",
       "port-version": 0

--- a/versions/q-/quickjs-ng.json
+++ b/versions/q-/quickjs-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d4e690dd2c6a3512a383262ac9ae70e2d96971ca",
+      "git-tree": "e7b0e61f6029cc44b81a9b7ee40e8195e963a999",
       "version": "0.10.1",
       "port-version": 0
     }

--- a/versions/q-/quickjs-ng.json
+++ b/versions/q-/quickjs-ng.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d4e690dd2c6a3512a383262ac9ae70e2d96971ca",
+      "version": "0.10.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
