### PR TITLE
[mysvac-jsonlib] update to 3.0.0

### DIFF
--- a/ports/mysvac-jsonlib/portfile.cmake
+++ b/ports/mysvac-jsonlib/portfile.cmake
@@ -1,10 +1,8 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Mysvac/cpp-jsonlib
-    REF "${VERSION}"
-    SHA512 254223e64b1741dd71822cb815c53bc90a1d1f8343540c73a1ace0b61a5804a413b12ebb6f269aacac558961bb141d3a23d07eee9301c50ab79c8249af7b36e6
+    REF "v${VERSION}"
+    SHA512 8bc16ec0085a88922e24595fa2311f0b8acf95a1e9eb33fa09ab871acb457d6aa0b2073b0f7f73adb14b26eadd5112f3427fc34d691027dd0d2fee43d187d401
     HEAD_REF main
 )
 
@@ -16,7 +14,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 

--- a/ports/mysvac-jsonlib/usage
+++ b/ports/mysvac-jsonlib/usage
@@ -1,4 +1,4 @@
 mysvac-jsonlib provides CMake targets:
 
   find_package(mysvac-jsonlib CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE mysvac::jsonlib)
+  target_link_mysvac_jsonlib(main PRIVATE)

--- a/ports/mysvac-jsonlib/vcpkg.json
+++ b/ports/mysvac-jsonlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mysvac-jsonlib",
-  "version": "2.1.1",
-  "description": "A lightweight and efficient C++17 JSON library.",
+  "version": "3.0.0",
+  "description": "A lightweight and efficient C++20 JSON library.",
   "homepage": "https://github.com/Mysvac/cpp-jsonlib",
   "license": "MIT",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6537,7 +6537,7 @@
       "port-version": 4
     },
     "mysvac-jsonlib": {
-      "baseline": "2.1.1",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "mzying2001-sw": {

--- a/versions/m-/mysvac-jsonlib.json
+++ b/versions/m-/mysvac-jsonlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63de2dd55921559aab9f46671623720869fbb390",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c9a08c1854158e1debb812b75233fb9a90788873",
       "version": "2.1.1",
       "port-version": 0


### PR DESCRIPTION
<!-- PR Type: Update existing port -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version. *(or left unchanged if no change)*
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory. *(not applicable)*
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.*(not applicable)*
- [x] Only one version is added to each modified port's versions file.

