### PR TITLE
[faudio] add native feature for Windows

### DIFF
--- a/ports/faudio/portfile.cmake
+++ b/ports/faudio/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_from_github(
 )
 
 set(options "")
-if(VCPKG_TARGET_IS_WINDOWS)
+if(VCPKG_TARGET_IS_WINDOWS AND "native" IN_LIST FEATURES)
     list(APPEND options -DPLATFORM_WIN32=TRUE)
 endif()
 

--- a/ports/faudio/portfile.cmake
+++ b/ports/faudio/portfile.cmake
@@ -1,9 +1,17 @@
+vcpkg_download_distfile(FIND_DEPENDENCY_FIX
+    URLS https://github.com/FNA-XNA/FAudio/commit/29b82ac28b3c83b5044962e88ea080875f73aebd.diff?full_index=1
+    FILENAME faudio-find-dependency-fix-29b82ac28b3c83b5044962e88ea080875f73aebd.diff
+    SHA512 001ba2f61a388c634fd927497109f333e86dbdecef6908c64827b6b467bb707df0c17a01054ab0a5c0a74cd1a02d61f888b6938932c871a850a418de40fa9e78
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FNA-XNA/faudio
     REF "${VERSION}"
     SHA512 f5acd68969e918a70ca59e2f9ef9f1c0c528a07d10537525c440247ccda0d11af7e079a815a17352f35e28c11abb33b6a926db44e87eeaa1f6910c8f0dee9ad4
     HEAD_REF master
+    PATCHES
+        "${FIND_DEPENDENCY_FIX}"
 )
 
 set(options "")

--- a/ports/faudio/vcpkg.json
+++ b/ports/faudio/vcpkg.json
@@ -1,16 +1,13 @@
 {
   "name": "faudio",
   "version-string": "25.08",
+  "port-version": 1,
   "description": "FAudio - accuracy-focused XAudio reimplementation for open platforms",
   "homepage": "https://fna-xna.github.io/",
   "license": "Zlib",
   "supports": "!uwp",
   "dependencies": [
-    {
-      "name": "sdl3",
-      "default-features": false,
-      "platform": "!windows"
-    },
+    "sdl3",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -19,5 +16,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "native"
+  ],
+  "features": {
+    "native": {
+      "description": "use the native audio backend when available"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2854,7 +2854,7 @@
     },
     "faudio": {
       "baseline": "25.08",
-      "port-version": 0
+      "port-version": 1
     },
     "fawdlstty-libfv": {
       "baseline": "0.0.8",

--- a/versions/f-/faudio.json
+++ b/versions/f-/faudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc54797a7be2a26ea2ee457663cc0a14b5009dd3",
+      "version-string": "25.08",
+      "port-version": 1
+    },
+    {
       "git-tree": "41a0af3a592b7b6416bf4ca695880977e9379f93",
       "version-string": "25.08",
       "port-version": 0

--- a/versions/f-/faudio.json
+++ b/versions/f-/faudio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cc54797a7be2a26ea2ee457663cc0a14b5009dd3",
+      "git-tree": "303b1ac9eaf522ace80268878b826600b422b798",
       "version-string": "25.08",
       "port-version": 1
     },


### PR DESCRIPTION
Add `sdl3` feature for Windows to use the SDL3 backend instead of the Windows platform backend. Useful for Windows XP which does not support the Windows platform backend.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
