### PR TITLE
[otl] update to 4.0.487

### DIFF
--- a/ports/otl/portfile.cmake
+++ b/ports/otl/portfile.cmake
@@ -1,9 +1,9 @@
-set(OTL_VERSION 40481)
+set(OTL_VERSION 40487)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "http://otl.sourceforge.net/otlv4_${OTL_VERSION}.zip"
     FILENAME "otlv4_${OTL_VERSION}.zip"
-    SHA512 5e7001dc9f003264db86228cffc0d44ebc6dffabd2e046a37cb58b6d4d59435db1103b95fb719819c6443e822a9263f5e2efc29dbbee463e91277789c955bd98
+    SHA512 1bb2ee26a271814b696c996da6837ab7f078942c22e48736ce4d8cd7d285e8ec82fdaf1341e2855230561342512abbe2e6668aee382bd3e5bc09256485e63597
 )
 
 vcpkg_extract_source_archive(

--- a/ports/otl/vcpkg.json
+++ b/ports/otl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "otl",
-  "version": "4.0.481",
-  "port-version": 1,
+  "version": "4.0.487",
   "description": "Oracle, Odbc and DB2-CLI Template Library",
   "homepage": "https://otl.sourceforge.net/",
   "license": "ISC"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7177,8 +7177,8 @@
       "port-version": 0
     },
     "otl": {
-      "baseline": "4.0.481",
-      "port-version": 1
+      "baseline": "4.0.487",
+      "port-version": 0
     },
     "outcome": {
       "baseline": "2.2.12",

--- a/versions/o-/otl.json
+++ b/versions/o-/otl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc2db7cee754a10d50e007183a8ccbdb5b3df582",
+      "version": "4.0.487",
+      "port-version": 0
+    },
+    {
       "git-tree": "4aef2b4e38f93e3c7e06ffe14eaa7064627fcefb",
       "version": "4.0.481",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.