### PR TITLE
[magma] fixed cuda compile ci failure

### DIFF
--- a/ports/magma/portfile.cmake
+++ b/ports/magma/portfile.cmake
@@ -24,14 +24,21 @@ vcpkg_extract_source_archive(
       fix-min-max.patch
 )
 
+
+
+vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT cuda_toolkit_root) 
+
 vcpkg_cmake_configure(
   SOURCE_PATH "${src_path}"
   OPTIONS
     -DMAGMA_ENABLE_CUDA=ON
     -DMAGMA_ENABLE_HIP=OFF # HIP is backend and seems additive?!
     -DUSE_FORTRAN=OFF
+    "-DCMAKE_CUDA_COMPILER:FILEPATH=${NVCC}"
+    "-DCUDAToolkit_ROOT=${cuda_toolkit_root}"
     ${opts}
 )
+
 
 vcpkg_cmake_install()
 

--- a/ports/magma/vcpkg.json
+++ b/ports/magma/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "magma",
   "version": "2.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Matrix Algebra on GPU and Multi-core Architectures (MAGMA) is a collection of next-generation linear algebra libraries for heterogeneous computing",
   "homepage": "https://icl.utk.edu/magma/",
   "license": null,

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -621,7 +621,6 @@ llvm:x64-android=fail
 log4cplus:arm64-uwp=fail
 log4cplus:x64-uwp=fail
 log4cpp:x64-linux=fail # dynamic exception specifications
-magma:x64-linux=fail
 marzbanpp:x64-linux=fail # triplet supported but vcpkg toolchain is too old (requires GCC 12+/Clang 19+)
 mchehab-zbar:arm-neon-android=fail
 mchehab-zbar:arm64-android=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6018,7 +6018,7 @@
     },
     "magma": {
       "baseline": "2.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "magnum": {
       "baseline": "2020.06",

--- a/versions/m-/magma.json
+++ b/versions/m-/magma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a54067bca358c87d6517a37b8360264e58097dc5",
+      "version": "2.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "1f027fdb55e2bea18637a7cbe85c2ea544ee2f6d",
       "version": "2.8.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
