### PR TITLE
[octave] Add features

### DIFF
--- a/ports/octave/portfile.cmake
+++ b/ports/octave/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_extract_source_archive(
     ARCHIVE "${ARCHIVE}"
     PATCHES
         add_other_linkage_flags.patch
+        qhull.patch
 )
 
 include(vcpkg_find_fortran)
@@ -149,6 +150,25 @@ else()
     set(GUI_OPTION "no")
 endif()
 
+if("qhull" IN_LIST FEATURES)
+    set(QHULL_OPTION "yes")
+    set(QHULL_PKG_OPTION "qhullstatic_r")
+else()
+    set(QHULL_OPTION "no")
+endif()
+
+if("curl" IN_LIST FEATURES)
+    set(CURL_OPTION "yes")
+else()
+    set(CURL_OPTION "no")
+endif()
+
+if("graphicsmagick" IN_LIST FEATURES)
+    set(GRAPHICSMAGICK_OPTION "GraphicsMagick++")
+else()
+    set(GRAPHICSMAGICK_OPTION "no")
+endif()
+
 vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/fltk")
 vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/qt5/bin")
 
@@ -169,7 +189,7 @@ vcpkg_configure_make(
     --with-cholmod=${CHOLMOD_OPTION}
     --with-colamd=${COLAMD_OPTION}
     --with-cxsparse=${CXSPARSE_OPTION}
-    --with-curl=no
+    --with-curl=${CURL_OPTION}
     --with-fftw3 # yes
     --with-fftw3f # yes
     --with-fltk=${FLTK_OPTION}
@@ -178,11 +198,12 @@ vcpkg_configure_make(
     --with-glpk # yes
     --with-hdf5=${HDF5_OPTION}
     --with-klu=${KLU_OPTION}
-    --with-magick=no
+    --with-magick=${GRAPHICSMAGICK_OPTION}
     --with-opengl # yes
     --with-portaudio=${PORTAUDIO_OPTION}
     --with-pcre2 # yes
-    --with-qhull_r=no
+    --with-qhull_r=${QHULL_OPTION}
+    --with-qhull_r-pkg-config=${QHULL_PKG_OPTION}
     --with-qrupdate=no
     --with-qscintilla=no
     --with-qt=${GUI_OPTION}

--- a/ports/octave/qhull.patch
+++ b/ports/octave/qhull.patch
@@ -1,0 +1,41 @@
+diff --git a/configure.ac b/configure.ac
+--- configure.ac
++++ configure.ac
+@@ -1429,8 +1429,25 @@
+   AC_MSG_ERROR([to build Octave, you must have the PCRE or PCRE2 library and header files installed])
+ fi
+ 
+ ### Check for Qhull library.
++AC_ARG_WITH([qhull_r-pkg-config],
++  [AS_HELP_STRING([--with-qhull_r-pkg-config=LIB],
++    [search the qhull library with pkg-config (options: qhull_r (default) or qhullstatic_r)])
++dnl Second help string must not be indented for correct alignment
++AS_HELP_STRING([--without-qhull_r-pkg-config], [don't search qhull_r library with pkg-config])],
++  [case $withval in
++     yes | "")
++       qhull_pc_name="qhull_r"
++     ;;
++     no)
++       qhull_pc_name=""
++     ;;
++     *)
++       qhull_pc_name="$withval"
++     ;;
++   esac],
++  [qhull_pc_name="qhull_r"])
+ 
+ QHULL_CPPFLAGS=
+ QHULL_LDFLAGS=
+ QHULL_LIBS=
+@@ -1444,9 +1461,10 @@
+     [AC_DEFINE(HAVE_QHULL, 1, [Define to 1 if Qhull is available.])
+      QHULL_CPPFLAGS="$QHULL_R_CPPFLAGS"
+      QHULL_LDFLAGS="$QHULL_R_LDFLAGS"
+      QHULL_LIBS="$QHULL_R_LIBS"],
+-    [warn_qhull_r="Qhull library found, but does not seem to work properly.  This will result in loss of functionality for some geometry functions.  Please try recompiling the library with -fno-strict-aliasing."])])
++    [warn_qhull_r="Qhull library found, but does not seem to work properly.  This will result in loss of functionality for some geometry functions.  Please try recompiling the library with -fno-strict-aliasing."])],
++    [$qhull_pc_name])
+ AC_SUBST(QHULL_CPPFLAGS)
+ AC_SUBST(QHULL_LDFLAGS)
+ AC_SUBST(QHULL_LIBS)
+ 

--- a/ports/octave/vcpkg.json
+++ b/ports/octave/vcpkg.json
@@ -82,6 +82,15 @@
         }
       ]
     },
+    "curl": {
+      "description": "curl support",
+      "dependencies": [
+        {
+          "name": "curl",
+          "default-features": false
+        }
+      ]
+    },
     "cxsparse": {
       "description": "suitesparse-cxsparse support",
       "dependencies": [
@@ -114,6 +123,15 @@
       "dependencies": [
         {
           "name": "freetype",
+          "default-features": false
+        }
+      ]
+    },
+    "graphicsmagick": {
+      "description": "graphicsmagick support",
+      "dependencies": [
+        {
+          "name": "graphicsmagick",
           "default-features": false
         }
       ]
@@ -168,6 +186,12 @@
           "name": "portaudio",
           "default-features": false
         }
+      ]
+    },
+    "qhull": {
+      "description": "qhull support",
+      "dependencies": [
+        "qhull"
       ]
     },
     "spqr": {

--- a/scripts/test_ports/vcpkg-ci-octave/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-octave/vcpkg.json
@@ -13,14 +13,17 @@
         "ccolamd",
         "cholmod",
         "colamd",
+        "curl",
         "cxsparse",
         "fltk",
         "fontconfig",
         "freetype",
+        "graphicsmagick",
         "gui",
         "hdf5",
         "klu",
         "portaudio",
+        "qhull",
         "spqr",
         "umfpack"
       ]

--- a/versions/o-/octave.json
+++ b/versions/o-/octave.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "db1baa59f8c1b8247854bbe33d2addbb51c2599b",
+      "git-tree": "6c5b6328bfd441754e4d78c97a9d3d796e5119ee",
       "version": "10.2.0",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
