### PR TITLE
[aws-c-event-stream] update to 0.5.6

### DIFF
--- a/ports/aws-c-event-stream/portfile.cmake
+++ b/ports/aws-c-event-stream/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-event-stream
     REF "v${VERSION}"
-    SHA512 5eb9d0aec42eeb637e16c6921a57d1de6a69da55842aed2230792632e62deb701be0049961e8b2daf6b01f048f2d9756cc71acebbcfc445ed0ebd8098a6b843a
+    SHA512 da7025520bc7e1ff931c629b94438e111b5b381c99cdb91c0e04d9b6c6ab51481f2f21942ee814c094ee551019187d14d0c67fef32667cb0712cd3e5f161d5fa
     HEAD_REF master
 )
 

--- a/ports/aws-c-event-stream/vcpkg.json
+++ b/ports/aws-c-event-stream/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-event-stream",
-  "version": "0.5.4",
+  "version": "0.5.6",
   "description": "C99 implementation of the vnd.amazon.event-stream content-type.",
   "homepage": "https://github.com/awslabs/aws-c-event-stream",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-event-stream.json
+++ b/versions/a-/aws-c-event-stream.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74d786e7bade018b655fd03645179d1a00e46be0",
+      "version": "0.5.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "f6a057233778790116b92ec301d0025614fa723a",
       "version": "0.5.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -445,7 +445,7 @@
       "port-version": 0
     },
     "aws-c-event-stream": {
-      "baseline": "0.5.4",
+      "baseline": "0.5.6",
       "port-version": 0
     },
     "aws-c-http": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/awslabs/aws-c-event-stream/releases/tag/v0.5.6
