### PR TITLE
[aws-crt-cpp] update to 0.33.5

### DIFF
--- a/ports/aws-crt-cpp/portfile.cmake
+++ b/ports/aws-crt-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-crt-cpp
     REF "v${VERSION}"
-    SHA512 3443c6b971db740b6d86333e1d438d043eeb21c4cc6d9df459312354d71207be458f9470f24a7bfbe9e7159687cb3f17060663e676535ad310feaff704aa2397
+    SHA512 9f4a57aca1cbc8cc7ea9ebd30565ba4bab790d47f5e965e3d1c2620b180e5a9559cacc473434d548d4c05805d1e5c84ac3faab6b7bcdb269b8415e66dcfe66c4
     PATCHES
         no-werror.patch
 )

--- a/ports/aws-crt-cpp/vcpkg.json
+++ b/ports/aws-crt-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-crt-cpp",
-  "version": "0.32.9",
+  "version": "0.33.5",
   "description": "C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Protocols and SSL/TLS implementations for C++.",
   "homepage": "https://github.com/awslabs/aws-crt-cpp",
   "license": "Apache-2.0",

--- a/versions/a-/aws-crt-cpp.json
+++ b/versions/a-/aws-crt-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "938e83a74f2aaf62be696a34e4da40c0a746be1d",
+      "version": "0.33.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "af63058b3d4b68dfe70775e7d91465b6bbaa48a5",
       "version": "0.32.9",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -473,7 +473,7 @@
       "port-version": 0
     },
     "aws-crt-cpp": {
-      "baseline": "0.32.9",
+      "baseline": "0.33.5",
       "port-version": 0
     },
     "aws-lambda-cpp": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/awslabs/aws-crt-cpp/releases/tag/v0.33.5