### PR TITLE
[uvw] Fix build errors by defining UVW_AS_LIB

### DIFF
--- a/ports/uvw/portfile.cmake
+++ b/ports/uvw/portfile.cmake
@@ -21,6 +21,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/uvw)
 
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/uvw/config.h" "#ifndef UVW_AS_LIB" "#define UVW_AS_LIB\n#ifndef UVW_AS_LIB")
+
 file(READ "${CURRENT_PACKAGES_DIR}/share/uvw/uvwConfig.cmake" cmake_config)
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/uvw/uvwConfig.cmake"
 "include(CMakeFindDependencyMacro)

--- a/ports/uvw/vcpkg.json
+++ b/ports/uvw/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "uvw",
   "version": "3.2.0",
+  "port-version": 1,
   "description": "A compilable static library, event based, tiny and easy to use libuv wrapper in modern C++.",
   "homepage": "https://github.com/skypjack/uvw",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9898,7 +9898,7 @@
     },
     "uvw": {
       "baseline": "3.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "uwebsockets": {
       "baseline": "20.74.0",

--- a/versions/u-/uvw.json
+++ b/versions/u-/uvw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e8c728dc4f9b6a630f970effb1bbcbda809da6b",
+      "version": "3.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "82ef2ed3a8ae1df65e8e922c5d7917d3271f457d",
       "version": "3.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Since we build uvw with `-DBUILD_UVW_LIBS=ON`, so we need hardcode `#define UVW_AS_LIB` in `config.h` to avoid build error on non-cmake downstream project.