### PR TITLE
[protobuf] Update to 6.30.0

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512 46d60de626480f5bac256a09c57300fe5ec990664876edbe04c9385769b500ec88409da976acc28fcb2b2e987afc1bbbf5669f4fed4033c5464ab8bbd38723bc
+    SHA512 5359775e3edf6b3a67b5f38a086112cf7da2f94060d0e600375754beb3a68d557f9174f0ed21b8c51b030a40e74605e59d0785eeb54e67c8fb513fbf8dda43e0
     HEAD_REF master
     PATCHES
         fix-static-build.patch

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "protobuf",
-  "version": "5.29.5",
-  "port-version": 1,
+  "version": "5.30.0",
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",
   "dependencies": [
-    "abseil",
+    {
+      "name": "abseil",
+      "features": [
+        "cxx17"
+      ]
+    },
     {
       "name": "protobuf",
       "host": true

--- a/ports/utf8-range/portfile.cmake
+++ b/ports/utf8-range/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/third_party/utf8_range"
     OPTIONS
         "-Dutf8_range_ENABLE_TESTS=off"
+        "-Dprotobuf_VERSION=${VERSION}"
 )
 
 vcpkg_cmake_install()

--- a/ports/utf8-range/portfile.cmake
+++ b/ports/utf8-range/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
     REF "v${VERSION}"
-    SHA512 46d60de626480f5bac256a09c57300fe5ec990664876edbe04c9385769b500ec88409da976acc28fcb2b2e987afc1bbbf5669f4fed4033c5464ab8bbd38723bc
+    SHA512 5359775e3edf6b3a67b5f38a086112cf7da2f94060d0e600375754beb3a68d557f9174f0ed21b8c51b030a40e74605e59d0785eeb54e67c8fb513fbf8dda43e0
     HEAD_REF main
     PATCHES
         fix-cmake.patch

--- a/ports/utf8-range/vcpkg.json
+++ b/ports/utf8-range/vcpkg.json
@@ -1,11 +1,16 @@
 {
   "name": "utf8-range",
-  "version": "5.29.5",
+  "version": "5.30.0",
   "description": "Fast UTF-8 validation with Range algorithm (NEON+SSE4+AVX2)",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "MIT",
   "dependencies": [
-    "abseil",
+    {
+      "name": "abseil",
+      "features": [
+        "cxx17"
+      ]
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7597,8 +7597,8 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "5.29.5",
-      "port-version": 1
+      "baseline": "5.30.0",
+      "port-version": 0
     },
     "protobuf-c": {
       "baseline": "1.5.2",
@@ -9865,7 +9865,7 @@
       "port-version": 4
     },
     "utf8-range": {
-      "baseline": "5.29.5",
+      "baseline": "5.30.0",
       "port-version": 0
     },
     "utf8h": {

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aea0feb68bfba159cc4d985bac777ee6968e8cf2",
+      "version": "5.30.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7e946d4afefe3c33f74394d788f89c41e6881a77",
       "version": "5.29.5",
       "port-version": 1

--- a/versions/u-/utf8-range.json
+++ b/versions/u-/utf8-range.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb7f3ec01fba90c6d873995b7c6936f83535f390",
+      "version": "5.30.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5d28e170bfcc212d629bb070520e72492240ce65",
       "version": "5.29.5",
       "port-version": 0

--- a/versions/u-/utf8-range.json
+++ b/versions/u-/utf8-range.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bb7f3ec01fba90c6d873995b7c6936f83535f390",
+      "git-tree": "fb00b7aca4c73b50d35de978a230fbef79e8bb0c",
       "version": "5.30.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
