### PR TITLE
[openturns] update to 1.25.1

### DIFF
--- a/ports/openturns/portfile.cmake
+++ b/ports/openturns/portfile.cmake
@@ -2,10 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openturns/openturns
     REF v${VERSION}
-    SHA512 960cdcceef3f6589edc6e278751045842c5903c28e51db65afc9b90be073821ac65d8445521008c045aa31fd8aae28a7b1f7b268a3ba057ecc1d7abdb18fe40f
+    SHA512 d73c294ce8fafb99da0769791cee09a6da76d3839489dd32227a7569c1fbbfc06c2a918d3951ea5b9d7a7efb1f30d11e04a52bb8d906e37411bc372235a9832b
     HEAD_REF master
     PATCHES
-        dependencies.diff
+      dependencies.diff
 )
 file(REMOVE "${SOURCE_PATH}/lib/src/Base/Algo/kissfft.hh")
 file(REMOVE "${SOURCE_PATH}/lib/src/Base/Func/openturns/exprtk.hpp")

--- a/ports/openturns/vcpkg.json
+++ b/ports/openturns/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openturns",
-  "version": "1.25",
+  "version": "1.25.1",
   "description": "OpenTURNS is a scientific C++ and Python library featuring an internal data model and algorithms dedicated to the treatment of uncertainties.",
   "homepage": "https://openturns.github.io/",
   "license": null,

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -746,8 +746,6 @@ openslide:x64-windows-static=fail
 openslide:x64-windows=fail
 openslide:x86-windows=fail
 opensubdiv:x64-android=fail
-openturns:arm64-windows-static-md=fail
-openturns:arm64-windows=fail
 # Incorrect use of arm64 intrinsics in <wchar.h> in VS 2022 17.13 broke these with -Zc:arm64-aliased-neon-types-
 openvino:arm64-windows-static-md=fail
 openvino:arm64-windows=fail
@@ -777,6 +775,8 @@ paho-mqtt:x64-uwp=fail
 paho-mqttpp3:arm-neon-android=fail
 paho-mqttpp3:arm64-android=fail
 paho-mqttpp3:x64-android=fail
+paraview:arm64-windows-static-md=fail
+paraview:arm64-windows=fail
 platform-folders:arm64-uwp=fail
 platform-folders:x64-uwp=fail
 plib:arm-neon-android=fail
@@ -1029,6 +1029,8 @@ v8:x86-windows=fail
 # vst3sdk CMake files work only with the GUI version of Xcode
 vst3sdk:arm64-osx=fail
 vst3sdk:x64-osx=fail
+vtk-dicom:arm64-windows-static-md=fail
+vtk-dicom:arm64-windows=fail
 wasmedge:arm-neon-android=fail
 # Collides with libpcap -> similar headers
 winpcap:x64-windows-release=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7125,7 +7125,7 @@
       "port-version": 4
     },
     "openturns": {
-      "baseline": "1.25",
+      "baseline": "1.25.1",
       "port-version": 0
     },
     "openvdb": {

--- a/versions/o-/openturns.json
+++ b/versions/o-/openturns.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "586cc564aaa3e0a42a9c2b3654e18bc9955bca21",
+      "version": "1.25.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "05d59bf0cea5c6e43afb583a00f47bae115bda9a",
       "version": "1.25",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
