### PR TITLE
[yalantinglibs] update to 0.5.4

### DIFF
--- a/ports/yalantinglibs/portfile.cmake
+++ b/ports/yalantinglibs/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_BUILD_TYPE release)  # header-only
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alibaba/yalantinglibs
-    REF d4337e3297fa9bb8ef67473d7f40e766da39f4e3 # Use commit id to avoid target to multiple commits(the author will fix it in the next release), see https://github.com/alibaba/yalantinglibs/issues/1027
-    SHA512 a4572dd0e9ca4052091be0f40cc93616bb982432ada4640f9f92df4ec2173731d53a7758af6ee7835ae8841f3ad81dd4e615dfea8af5b88298823c6724774b00
+    REF "${VERSION}"
+    SHA512 16d4a9dfffeca3010dd473e6c26df652b57ba6ed2c35624600fb984db8071a0c7181f2b08da2600b8fddd9ffba631f1a641e9c4a6dc9f2aa3e48e6cacca537aa
     HEAD_REF main
 )
 

--- a/ports/yalantinglibs/vcpkg.json
+++ b/ports/yalantinglibs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yalantinglibs",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A Collection of C++20 libraries, include struct_pack, struct_json, struct_xml, struct_yaml, struct_pb, easylog, coro_rpc, coro_http and async_simple",
   "homepage": "https://github.com/alibaba/yalantinglibs",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10513,7 +10513,7 @@
       "port-version": 4
     },
     "yalantinglibs": {
-      "baseline": "0.5.3",
+      "baseline": "0.5.4",
       "port-version": 0
     },
     "yaml-cpp": {

--- a/versions/y-/yalantinglibs.json
+++ b/versions/y-/yalantinglibs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3adb9d05dcb115e44d6bcc84dd0ded33b97476f",
+      "version": "0.5.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "015a60b072b0edd31883bfce1adad2d0a0cf3d29",
       "version": "0.5.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
