### PR TITLE
[sbgecom] New port

### DIFF
--- a/ports/sbgecom/portfile.cmake
+++ b/ports/sbgecom/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO SBG-Systems/sbgECom
+    REF "${VERSION}-stable"
+    SHA512 d2d9aa2751f96fe87590aad71c276d2ab7a7a9e230887f8f83355b55fc25b57046dc84a8c5d2cfc8d4fd58e6c92210d3527937fe923cea660785d12db74997c3
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "sbgECom"
+    CONFIG_PATH lib/cmake/sbgECom
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/sbgecom/usage
+++ b/ports/sbgecom/usage
@@ -1,0 +1,4 @@
+sbgECom provides CMake targets:
+
+find_package(sbgECom CONFIG REQUIRED)
+target_link_libraries(main PRIVATE sbgECom::sbgECom)

--- a/ports/sbgecom/vcpkg.json
+++ b/ports/sbgecom/vcpkg.json
@@ -1,0 +1,16 @@
+{
+    "name": "sbgecom",
+    "version": "5.3.2276",
+    "homepage": "https://github.com/SBG-Systems/sbgECom",
+    "description": "C library used to communicate with SBG Systems IMU, AHRS and INS",
+    "license": "MIT",
+    "dependencies": [
+    {
+        "name" : "vcpkg-cmake",
+        "host" : true
+    },
+    {
+        "name" : "vcpkg-cmake-config",
+        "host" : true
+    }]
+}

--- a/ports/sbgecom/vcpkg.json
+++ b/ports/sbgecom/vcpkg.json
@@ -1,16 +1,17 @@
 {
-    "name": "sbgecom",
-    "version": "5.3.2276",
-    "homepage": "https://github.com/SBG-Systems/sbgECom",
-    "description": "C library used to communicate with SBG Systems IMU, AHRS and INS",
-    "license": "MIT",
-    "dependencies": [
+  "name": "sbgecom",
+  "version": "5.3.2276",
+  "description": "C library used to communicate with SBG Systems IMU, AHRS and INS",
+  "homepage": "https://github.com/SBG-Systems/sbgECom",
+  "license": "MIT",
+  "dependencies": [
     {
-        "name" : "vcpkg-cmake",
-        "host" : true
+      "name": "vcpkg-cmake",
+      "host": true
     },
     {
-        "name" : "vcpkg-cmake-config",
-        "host" : true
-    }]
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8580,6 +8580,10 @@
       "baseline": "6.0.1",
       "port-version": 1
     },
+    "sbgecom": {
+      "baseline": "5.3.2276",
+      "port-version": 0
+    },
     "sbp": {
       "baseline": "6.2.1",
       "port-version": 0

--- a/versions/s-/sbgecom.json
+++ b/versions/s-/sbgecom.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2bd2e0e8f37ab89e332588c9122da78e5db91756",
+      "version": "5.3.2276",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add sbgECom library to vcpkg ports

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x ] Only one version is added to each modified port's versions file.
