### PR TITLE
[libphonenumber] update to 9.0.11

### DIFF
--- a/ports/libphonenumber/enable-cpp17.patch
+++ b/ports/libphonenumber/enable-cpp17.patch
@@ -1,0 +1,34 @@
+diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
+index 27e4680..88df056 100644
+--- a/cpp/CMakeLists.txt
++++ b/cpp/CMakeLists.txt
+@@ -459,11 +459,13 @@ if (BUILD_STATIC_LIB)
+   add_library (phonenumber STATIC ${SOURCES})
+   target_link_libraries (phonenumber ${LIBRARY_DEPS})
+   target_include_directories(phonenumber PUBLIC $<INSTALL_INTERFACE:include>)
++  target_compile_features(phonenumber PUBLIC cxx_std_17)
+ 
+   if (BUILD_GEOCODER)
+     add_library (geocoding STATIC ${GEOCODING_SOURCES})
+     target_link_libraries (geocoding ${LIBRARY_DEPS})
+     target_include_directories(geocoding PUBLIC $<INSTALL_INTERFACE:include>)
++    target_compile_features(geocoding PUBLIC cxx_std_17)
+     add_dependencies (geocoding generate_geocoding_data)
+     add_dependencies (phonenumber generate_geocoding_data)
+   endif ()
+@@ -479,6 +481,7 @@ if (BUILD_SHARED_LIBS)
+   add_library (phonenumber-shared SHARED ${SOURCES})
+   target_link_libraries (phonenumber-shared ${LIBRARY_DEPS})
+   target_include_directories(phonenumber-shared PUBLIC $<INSTALL_INTERFACE:include>)
++  target_compile_features(phonenumber-shared PUBLIC cxx_std_17)
+ 
+   set_target_properties (phonenumber-shared
+     PROPERTIES
+@@ -495,6 +498,7 @@ if (BUILD_SHARED_LIBS)
+     add_library (geocoding-shared SHARED ${GEOCODING_SOURCES})
+     target_link_libraries (geocoding-shared ${LIBRARY_DEPS})
+     target_include_directories(geocoding-shared PUBLIC $<INSTALL_INTERFACE:include>)
++    target_compile_features(geocoding-shared PUBLIC cxx_std_17)
+     add_dependencies (geocoding-shared generate_geocoding_data)
+     add_dependencies (phonenumber-shared generate_geocoding_data)
+ 

--- a/ports/libphonenumber/portfile.cmake
+++ b/ports/libphonenumber/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/libphonenumber
     REF "v${VERSION}"
-    SHA512 d5e271a5cb7f78fef5f81c03b2c160ec2c368de2e2aec620a482ea89bea8d187ce7385b2582408942c3d793f7f93d8735f7349abf67196a6da2368f82c839743
+    SHA512 de00750caea6a4ce7f78f0b681c7ef687218af7f43e851615618cf36c3ebb47f25461a1a3a5bde4834a97064c3846d388fa07f9fbac7bbe762621c2325e57c8f
     HEAD_REF master
     PATCHES 
         # fix compilation error due to deprecated warnings in protobuf generated files

--- a/ports/libphonenumber/portfile.cmake
+++ b/ports/libphonenumber/portfile.cmake
@@ -13,6 +13,8 @@ vcpkg_from_github(
         fix-icui18n-lib-name.patch
         fix-find-protobuf.patch
         re2-2023-07-01-compat.patch
+        # enable C++17 for re2
+        enable-cpp17.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/libphonenumber/vcpkg.json
+++ b/ports/libphonenumber/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libphonenumber",
-  "version": "9.0.10",
+  "version": "9.0.11",
   "description": "Google's common Java, C++ and JavaScript library for parsing, formatting, and validating international phone numbers.",
   "homepage": "https://github.com/google/libphonenumber",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5225,7 +5225,7 @@
       "port-version": 2
     },
     "libphonenumber": {
-      "baseline": "9.0.10",
+      "baseline": "9.0.11",
       "port-version": 0
     },
     "libplist": {

--- a/versions/l-/libphonenumber.json
+++ b/versions/l-/libphonenumber.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9d4778be86bc1e13e9954aa837c298ec4bc9e4a3",
+      "git-tree": "dece0b91312ae358a7c860a6352b1abf5dd10de0",
       "version": "9.0.11",
       "port-version": 0
     },

--- a/versions/l-/libphonenumber.json
+++ b/versions/l-/libphonenumber.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d4778be86bc1e13e9954aa837c298ec4bc9e4a3",
+      "version": "9.0.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "f3eabab44947fa2d13612ddbfd0374e34553b597",
       "version": "9.0.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/google/libphonenumber/releases/tag/v9.0.11
