### PR TITLE
[openimageio] Copy PDBs to installation

### DIFF
--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -83,6 +83,8 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+vcpkg_copy_pdbs()
+
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/OpenImageIO)
 
 if("tools" IN_LIST FEATURES)

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openimageio",
   "version": "3.0.9.1",
+  "port-version": 1,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7050,7 +7050,7 @@
     },
     "openimageio": {
       "baseline": "3.0.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "openjpeg": {
       "baseline": "2.5.3",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e54820d7e44c55eb9d15a76810a5d0905192e83e",
+      "version": "3.0.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "b67432cc74f9700d875b6f5a26cc92f33832f9d3",
       "version": "3.0.9.1",
       "port-version": 0


### PR DESCRIPTION
This became a problem for me recently so here's a patch. I like being able to step into ports when debugging, but for some reason OpenImageIO doesn't copy the PDBs when installing.

1785165 removed the `vcpkg_copy_pdbs()` line from `portfile.cmake`. It doesn't mention why. This patch simply adds it back in.

I've rebuilt it on my system and it solves the issue (I can step into the library), and I haven't encountered any new ones.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
