### PR TITLE
crashpad: export headers for MSBuild

### DIFF
--- a/ports/crashpad/crashpadConfig.cmake.in
+++ b/ports/crashpad/crashpadConfig.cmake.in
@@ -11,7 +11,7 @@ find_dependency(ZLIB)
 
 if(NOT TARGET crashpad::crashpad)
   add_library(crashpad::crashpad INTERFACE IMPORTED)
-  target_include_directories(crashpad::crashpad INTERFACE "${_IMPORT_PREFIX}/include/crashpad")
+  target_include_directories(crashpad::crashpad INTERFACE "${_IMPORT_PREFIX}/include/crashpad" "${_IMPORT_PREFIX}/include")
 
   set(_libs vcpkg_crashpad_client vcpkg_crashpad_client_common vcpkg_crashpad_util vcpkg_crashpad_base)
   if(APPLE)

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -145,6 +145,19 @@ install_headers("${SOURCE_PATH}/third_party/mini_chromium/mini_chromium/build")
 file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/gen/build/chromeos_buildflags.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/build")
 file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/gen/build/chromeos_buildflags.h.flags" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/build")
 
+# On Windows/MSVC, mirror headers into the root include directory so MSBuild integration
+# (which adds only <installed>/include) can resolve un-namespaced includes like
+# "client/..." and "base/...".
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    message(STATUS "Mirroring headers into include root for MSBuild consumption...")
+    file(COPY "${SOURCE_PATH}/client" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
+    file(COPY "${SOURCE_PATH}/util" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
+    file(COPY "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium/base" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
+    file(COPY "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium/build" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
+    file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/gen/build/chromeos_buildflags.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/build")
+    file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/gen/build/chromeos_buildflags.h.flags" DESTINATION "${CURRENT_PACKAGES_DIR}/include/build")
+endif()
+
 if(VCPKG_TARGET_IS_OSX)
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/obj/util/libmig_output.a" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
@@ -168,6 +181,12 @@ endif()
 file(REMOVE_RECURSE
     "${PACKAGES_INCLUDE_DIR}/util/net/testdata"
     "${PACKAGES_INCLUDE_DIR}/build/ios")
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/include/util/net/testdata"
+        "${CURRENT_PACKAGES_DIR}/include/build/ios")
+endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/crashpadConfig.cmake.in"
         "${CURRENT_PACKAGES_DIR}/share/${PORT}/crashpadConfig.cmake" @ONLY)

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -194,5 +194,10 @@ configure_file("${CMAKE_CURRENT_LIST_DIR}/crashpadConfig.cmake.in"
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/${PORT}/build/config")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/${PORT}/util/mach/__pycache__")
 
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    # Remove empty directory created under the mirrored root include
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/build/config")
+endif()
+
 vcpkg_copy_pdbs()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2024-04-11",
-  "port-version": 9,
+  "port-version": 10,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2024-04-11",
-  "port-version": 8,
+  "port-version": 9,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2024-04-11",
-  "port-version": 10,
+  "port-version": 9,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2134,7 +2134,7 @@
     },
     "crashpad": {
       "baseline": "2024-04-11",
-      "port-version": 9
+      "port-version": 10
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2134,7 +2134,7 @@
     },
     "crashpad": {
       "baseline": "2024-04-11",
-      "port-version": 8
+      "port-version": 9
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2134,7 +2134,7 @@
     },
     "crashpad": {
       "baseline": "2024-04-11",
-      "port-version": 10
+      "port-version": 9
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "850e25dd8c06342ed4c9222abba9d143b6b6569f",
+      "version-date": "2024-04-11",
+      "port-version": 10
+    },
+    {
       "git-tree": "e09362709483d289189ca39e58b74df140137d57",
       "version-date": "2024-04-11",
       "port-version": 9

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,12 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "850e25dd8c06342ed4c9222abba9d143b6b6569f",
-      "version-date": "2024-04-11",
-      "port-version": 10
-    },
-    {
-      "git-tree": "e09362709483d289189ca39e58b74df140137d57",
+      "git-tree": "3db57798ca8f3d8309c3564cc7a8a1ed8955bf63",
       "version-date": "2024-04-11",
       "port-version": 9
     },

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e09362709483d289189ca39e58b74df140137d57",
+      "version-date": "2024-04-11",
+      "port-version": 9
+    },
+    {
       "git-tree": "a996b10d98428c6f61d1a8d75dd4b4d5509c37dd",
       "version-date": "2024-04-11",
       "port-version": 8


### PR DESCRIPTION
Fixes #39749.
Changes
This PR addresses header resolution issues in the crashpad port for Windows/MSVC builds by implementing a dual header layout strategy:
Problem
The crashpad library uses unnamespaced includes like #include "client/..." and #include "base/..." in its headers. However, the current port only installs headers under include/crashpad/, causing MSBuild integration to fail since it only adds <installed>/include to the include path, not the namespaced subdirectory.
Solution

Dual header layout for Windows/MSVC: Mirror all necessary headers into the root include directory (include/) in addition to the existing namespaced location (include/crashpad/)
Updated CMake config: Modified crashpadConfig.cmake.in to include both header paths for proper resolution
Maintained backward compatibility: Existing CMake projects using the namespaced path continue to work

Files Modified

ports/crashpad/portfile.cmake: Added logic to copy headers to root include directory for Windows/MSVC builds
ports/crashpad/crashpadConfig.cmake.in: Updated to include both header paths
ports/crashpad/vcpkg.json: Bumped port-version to 9
Version database files updated accordingly

Testing

 Tested with vcpkg install crashpad:x86-windows-static
 Tested with vcpkg install crashpad:x64-windows-static
 Verified MSBuild integration with vcpkg integrate install