### PR TITLE
[half] update to 2.2.1

### DIFF
--- a/ports/half/portfile.cmake
+++ b/ports/half/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_sourceforge(
     REF ${VERSION}
     FILENAME "half-${VERSION}.zip"
     NO_REMOVE_ONE_LEVEL
-    SHA512 299db9ab12d8135ae2eb1bb6229e11fec72c1ccc4d0db04d1c912c1e5cdadbddec738097b03c3bbf9b7993e589c32abcd509bfe0c20daf1996da65f633a94574
+    SHA512 946b1663a736eb486f670ba9dfcc56b43b9e7fb195988174b7dd004bdd2e23aba7a395b8867b4f58c97e73a50edf845b703b8cfc35708a562e6a9d7e1b4f4204
 )
 
 file(GLOB HEADER_FILES "${SOURCE_PATH}/include/*.hpp")

--- a/ports/half/vcpkg.json
+++ b/ports/half/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "half",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "C++ library for half precision floating point arithmetics.",
   "homepage": "https://sourceforge.net/projects/half/",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3641,7 +3641,7 @@
       "port-version": 0
     },
     "half": {
-      "baseline": "2.2.0",
+      "baseline": "2.2.1",
       "port-version": 0
     },
     "halide": {

--- a/versions/h-/half.json
+++ b/versions/h-/half.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb043c76e364be5e48acaf5ae8d158d632d9ec09",
+      "version": "2.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e3a5c15b1a3e75ee363b297822da89dcb6b3588b",
       "version": "2.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://half.sourceforge.net/changelog.html
