### PR TITLE
[libidn2] update to 2.3.8

### DIFF
--- a/ports/libidn2/disable-subdirs.patch
+++ b/ports/libidn2/disable-subdirs.patch
@@ -1,21 +1,20 @@
 diff --git a/Makefile.am b/Makefile.am
-index 3c8179c..f37158c 100644
+index 6e42cf8..5861faf 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -15,7 +15,7 @@
- 
- DISTCHECK_CONFIGURE_FLAGS ?= --enable-gtk-doc --enable-gtk-doc-pdf --disable-gcc-warnings
+@@ -13,14 +13,12 @@
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <http://www.gnu.org/licenses/>.
  
 -SUBDIRS = gl unistring lib src examples fuzz po
-+SUBDIRS = gl unistring lib src               po
- ACLOCAL_AMFLAGS = -I m4 -I gl/m4 -I unistring/m4
- EXTRA_DIST = gl/m4/gnulib-cache.m4
++SUBDIRS = gl unistring lib src po
  
-@@ -23,7 +23,6 @@ if ENABLE_DOC
+ if ENABLE_DOC
  SUBDIRS += doc
  endif
  
 -SUBDIRS += tests
- 
- EXTRA_DIST += cfg.mk maint.mk CONTRIBUTING.md README.md
+-
+ EXTRA_DIST = cfg.mk maint.mk CONTRIBUTING.md DEPENDENCIES.md README.md
  EXTRA_DIST += COPYING COPYING.LESSERv3 COPYING.unicode COPYINGv2
+ 

--- a/ports/libidn2/portfile.cmake
+++ b/ports/libidn2/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnu.org/gnu/libidn/${IDN2_FILENAME}"
          "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libidn/${IDN2_FILENAME}"
     FILENAME "${IDN2_FILENAME}"
-    SHA512 eab5702bc0baed45492f8dde43a4d2ea3560ad80645e5f9e0cfa8d3b57bccd7fd782d04638e000ba07924a5d9f85e760095b55189188c4017b94705bef9b4a66
+    SHA512 4d8427c0f115268132f7544e80a808c883ab1406338f6c529b1a586b016d57aedb0857f66166eb8d9f37d70efc9dccf907b673b43b17bcf258c8797db1e829ce
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/libidn2/vcpkg.json
+++ b/ports/libidn2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libidn2",
-  "version": "2.3.7",
-  "port-version": 2,
+  "version": "2.3.8",
   "description": "GNU Libidn is an implementation of the Stringprep, Punycode and IDNA 2003 specifications. Libidn's purpose is to encode and decode internationalized domain names.",
   "homepage": "https://www.gnu.org/software/libidn/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4925,8 +4925,8 @@
       "port-version": 1
     },
     "libidn2": {
-      "baseline": "2.3.7",
-      "port-version": 2
+      "baseline": "2.3.8",
+      "port-version": 0
     },
     "libigl": {
       "baseline": "2.6.0",

--- a/versions/l-/libidn2.json
+++ b/versions/l-/libidn2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5afb16bce5310417ea06e99acd0101eb126d6e27",
+      "version": "2.3.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "328e0431111dc594862afb21b8a160f982794e9b",
       "version": "2.3.7",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://gitlab.com/libidn/libidn2/-/blob/v2.3.8/NEWS?ref_type=tags#L3
