### PR TITLE
[fixed-math] add new port

### DIFF
--- a/ports/fixed-math/disable-cpm.patch
+++ b/ports/fixed-math/disable-cpm.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bfd3c01..d9f7abe 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.21 FATAL_ERROR )
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
+ 
+ include(get_fixed_math_version)
+-include(cmake/CPM.cmake)
+ 
+ project(fixed_math
+         LANGUAGES CXX

--- a/ports/fixed-math/portfile.cmake
+++ b/ports/fixed-math/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO arturbac/fixed_math
+    REF "v${VERSION}"
+    SHA512 fc1415e205cc5f2a63ad8019397c9aad082a7f256d050f894b3e2b6f3824396142333004a3a11a024594d7c95e5b302e8cab75faa9fc3563a5e04db1791efaf6
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+    -DFIXEDMATH_ENABLE_UNIT_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME fixed_math CONFIG_PATH lib/cmake/fixed_math)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENCE")

--- a/ports/fixed-math/portfile.cmake
+++ b/ports/fixed-math/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 fc1415e205cc5f2a63ad8019397c9aad082a7f256d050f894b3e2b6f3824396142333004a3a11a024594d7c95e5b302e8cab75faa9fc3563a5e04db1791efaf6
     HEAD_REF master
+    PATCHES
+        disable-cpm.patch
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port

--- a/ports/fixed-math/vcpkg.json
+++ b/ports/fixed-math/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "fixed-math",
+  "version": "2.2.0",
+  "description": "A High-Performance C++23, C++17 Library for Fixed-Point 48.16 Arithmetic",
+  "homepage": "https://github.com/arturbac/fixed_math",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2908,6 +2908,10 @@
       "baseline": "2024-09-19",
       "port-version": 0
     },
+    "fixed-math": {
+      "baseline": "2.2.0",
+      "port-version": 0
+    },
     "fixed-string": {
       "baseline": "0.1.1",
       "port-version": 0

--- a/versions/f-/fixed-math.json
+++ b/versions/f-/fixed-math.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2f27a8c4715c3df31446d18ef3cdcdb85080c82c",
+      "version": "2.2.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/f-/fixed-math.json
+++ b/versions/f-/fixed-math.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f27a8c4715c3df31446d18ef3cdcdb85080c82c",
+      "git-tree": "8df43d7b2e440a8b479272acad96e2796ad3f1ed",
       "version": "2.2.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/arturbac/fixed_math
