### PR TITLE
[pcapplusplus] Disable building unit test targets when installing.

### DIFF
--- a/ports/pcapplusplus/portfile.cmake
+++ b/ports/pcapplusplus/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DPCAPPP_BUILD_EXAMPLES=OFF
+        -DPCAPPP_BUILD_TESTS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/pcapplusplus/vcpkg.json
+++ b/ports/pcapplusplus/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pcapplusplus",
   "version": "25.5",
+  "port-version": 1,
   "description": "PcapPlusPlus is a multi-platform C++ library for capturing, parsing and crafting of network packets",
   "homepage": "https://github.com/seladb/PcapPlusPlus",
   "documentation": "https://pcapplusplus.github.io",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7270,7 +7270,7 @@
     },
     "pcapplusplus": {
       "baseline": "25.5",
-      "port-version": 0
+      "port-version": 1
     },
     "pcg": {
       "baseline": "2022-04-09",

--- a/versions/p-/pcapplusplus.json
+++ b/versions/p-/pcapplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7ae6087eafa63b40ae1f7f2505f896d75d3e2f2",
+      "version": "25.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "65dd04ad30adc8dd0a7b4173a04fcaec06e6ad30",
       "version": "25.5",
       "port-version": 0


### PR DESCRIPTION
The unit tests are not used or exported during the install process, so it is unnecessary for them to be built.

The test executables also end up being built in the `vcpkg_installed/vcpkg/blds/pcapplusplus/src/***.clean` folder where the source is, which is a bug due to pcapplusplus' CMake configuration.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
