### PR TITLE
[metis] Fix GKlib dependency target

### DIFF
--- a/ports/metis/build-fixes.patch
+++ b/ports/metis/build-fixes.patch
@@ -121,7 +121,7 @@ index fc6cec6..a56f6ca 100644
 +target_include_directories(metis INTERFACE $<INSTALL_INTERFACE:include>)
 +
 +find_package(GKlib CONFIG REQUIRED)
-+target_link_libraries(metis PRIVATE GKlib::GKlib)
++target_link_libraries(metis PRIVATE GKlib)
  
  if(METIS_INSTALL)
    install(TARGETS metis

--- a/ports/metis/vcpkg.json
+++ b/ports/metis/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "metis",
   "version-date": "2025-07-04",
+  "port-version": 1,
   "description": "Serial Graph Partitioning and Fill-reducing Matrix Ordering",
   "homepage": "https://github.com/KarypisLab/METIS",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6218,7 +6218,7 @@
     },
     "metis": {
       "baseline": "2025-07-04",
-      "port-version": 0
+      "port-version": 1
     },
     "metrohash": {
       "baseline": "1.1.3",

--- a/versions/m-/metis.json
+++ b/versions/m-/metis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d5284a7e97ef6c0461a693b6ab1fc5e525e916d",
+      "version-date": "2025-07-04",
+      "port-version": 1
+    },
+    {
       "git-tree": "83d3f4ee2d498f9bc5d8f63b562744442c6065f1",
       "version-date": "2025-07-04",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
