### PR TITLE
[sfl] update to 2.0.0

### DIFF
--- a/ports/sfl/portfile.cmake
+++ b/ports/sfl/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO slavenf/sfl-library
     REF "${VERSION}"
-    SHA512 e31ee88bdfbd345cfe3af8372e6fcb04ea9e4de62f8c0a0061780e2ad4edc89f3dfa0af8af2024a621481cc1ef3218f116012b33eadda84e3d688d8c354c74bb
+    SHA512 c73e604cec16224cd290be0dfbccb279c79706135185b864657e6a192129cfd30658d1d18defe44a34892f1b21caccabafdcc09d8b7b988dd3dabb73724c9031
     HEAD_REF master
 )
 

--- a/ports/sfl/vcpkg.json
+++ b/ports/sfl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sfl",
-  "version": "1.10.1",
+  "version": "2.0.0",
   "description": "header-only C++11 library that offers several new or less-known containers",
   "homepage": "https://github.com/slavenf/sfl-library",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8777,7 +8777,7 @@
       "port-version": 0
     },
     "sfl": {
-      "baseline": "1.10.1",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "sfml": {

--- a/versions/s-/sfl.json
+++ b/versions/s-/sfl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78535957c473c04e50ca65adf8689c5f2cdfbbad",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5dcddd2d67eb3f4be40b634a66482f4f42b51f71",
       "version": "1.10.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/slavenf/sfl-library/releases/tag/2.0.0
