### PR TITLE
[sdl2] Add subsystems as VCPKG features

### DIFF
--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -16,6 +16,27 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        # Subsystems
+        atomic   SDL_ATOMIC
+        audio    SDL_AUDIO
+        cpuinfo  SDL_CPUINFO
+        events   SDL_EVENTS
+        file     SDL_FILE
+        filesystem SDL_FILESYSTEM
+        haptic   SDL_HAPTIC
+        hidapi   SDL_HIDAPI
+        joystick SDL_JOYSTICK
+        loadso   SDL_LOADSO
+        locale   SDL_LOCALE
+        misc     SDL_MISC
+        power    SDL_POWER
+        render   SDL_RENDER
+        sensor   SDL_SENSOR
+        threads  SDL_THREADS
+        timers   SDL_TIMERS
+        video    SDL_VIDEO
+
+        # Dependencies
         alsa     SDL_ALSA
         dbus     SDL_DBUS
         ibus     SDL_IBUS

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -32,8 +32,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         power    SDL_POWER
         render   SDL_RENDER
         sensor   SDL_SENSOR
-        threads  SDL_THREADS
-        timers   SDL_TIMERS
         video    SDL_VIDEO
 
         # Dependencies

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -169,6 +169,14 @@
             "loadso"
           ],
           "platform": "windows"
+        },
+        {
+          "name": "sdl2",
+          "default-features": false,
+          "features": [
+            "render"
+          ],
+          "platform": "uwp"
         }
       ]
     },

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl2",
   "version": "2.32.8",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "license": "Zlib",

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -15,68 +15,32 @@
     }
   ],
   "default-features": [
-    {
-      "name": "atomic"
-    },
-    {
-      "name": "audio"
-    },
-    {
-      "name": "cpuinfo"
-    },
-    {
-      "name": "events"
-    },
-    {
-      "name": "file"
-    },
-    {
-      "name": "filesystem"
-    },
-    {
-      "name": "haptic"
-    },
-    {
-      "name": "hidapi"
-    },
-    {
-      "name": "joystick"
-    },
-    {
-      "name": "loadso"
-    },
-    {
-      "name": "locale"
-    },
-    {
-      "name": "misc"
-    },
-    {
-      "name": "power"
-    },
-    {
-      "name": "render"
-    },
-    {
-      "name": "sensor"
-    },
-    {
-      "name": "threads"
-    },
-    {
-      "name": "timers"
-    },
-    {
-      "name": "video"
-    },
+    "atomic",
+    "audio",
+    "cpuinfo",
     {
       "name": "dbus",
       "platform": "linux"
     },
+    "events",
+    "file",
+    "filesystem",
+    "haptic",
+    "hidapi",
     {
       "name": "ibus",
       "platform": "linux"
     },
+    "joystick",
+    "loadso",
+    "locale",
+    "misc",
+    "power",
+    "render",
+    "sensor",
+    "threads",
+    "timers",
+    "video",
     {
       "name": "wayland",
       "platform": "linux"
@@ -87,6 +51,12 @@
     }
   ],
   "features": {
+    "alsa": {
+      "description": "Support for alsa audio",
+      "dependencies": [
+        "alsa"
+      ]
+    },
     "atomic": {
       "description": "Build with the Atomic subsystem enabled"
     },
@@ -95,6 +65,16 @@
     },
     "cpuinfo": {
       "description": "Build with the CPUinfo subsystem enabled"
+    },
+    "dbus": {
+      "description": "Build with D-Bus support",
+      "dependencies": [
+        {
+          "name": "dbus",
+          "default-features": false,
+          "platform": "linux"
+        }
+      ]
     },
     "events": {
       "description": "Build with the Events subsystem enabled"
@@ -110,6 +90,10 @@
     },
     "hidapi": {
       "description": "Build with the Hidapi subsystem enabled"
+    },
+    "ibus": {
+      "description": "Build with ibus IME support",
+      "supports": "linux"
     },
     "joystick": {
       "description": "Build with the Joystick subsystem enabled"
@@ -129,6 +113,12 @@
     "render": {
       "description": "Build with the Render subsystem enabled"
     },
+    "samplerate": {
+      "description": "Use libsamplerate for audio rate conversion",
+      "dependencies": [
+        "libsamplerate"
+      ]
+    },
     "sensor": {
       "description": "Build with the Sensor subsystem enabled"
     },
@@ -140,32 +130,6 @@
     },
     "video": {
       "description": "Build with the Video subsystem enabled"
-    },
-    "alsa": {
-      "description": "Support for alsa audio",
-      "dependencies": [
-        "alsa"
-      ]
-    },
-    "dbus": {
-      "description": "Build with D-Bus support",
-      "dependencies": [
-        {
-          "name": "dbus",
-          "default-features": false,
-          "platform": "linux"
-        }
-      ]
-    },
-    "ibus": {
-      "description": "Build with ibus IME support",
-      "supports": "linux"
-    },
-    "samplerate": {
-      "description": "Use libsamplerate for audio rate conversion",
-      "dependencies": [
-        "libsamplerate"
-      ]
     },
     "vulkan": {
       "description": "Vulkan functionality for SDL"

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -16,6 +16,60 @@
   ],
   "default-features": [
     {
+      "name": "atomic"
+    },
+    {
+      "name": "audio"
+    },
+    {
+      "name": "cpuinfo"
+    },
+    {
+      "name": "events"
+    },
+    {
+      "name": "file"
+    },
+    {
+      "name": "filesystem"
+    },
+    {
+      "name": "haptic"
+    },
+    {
+      "name": "hidapi"
+    },
+    {
+      "name": "joystick"
+    },
+    {
+      "name": "loadso"
+    },
+    {
+      "name": "locale"
+    },
+    {
+      "name": "misc"
+    },
+    {
+      "name": "power"
+    },
+    {
+      "name": "render"
+    },
+    {
+      "name": "sensor"
+    },
+    {
+      "name": "threads"
+    },
+    {
+      "name": "timers"
+    },
+    {
+      "name": "video"
+    },
+    {
       "name": "dbus",
       "platform": "linux"
     },
@@ -33,6 +87,60 @@
     }
   ],
   "features": {
+    "atomic": {
+      "description": "Build with the Atomic subsystem enabled"
+    },
+    "audio": {
+      "description": "Build with the Audio subsystem enabled"
+    },
+    "cpuinfo": {
+      "description": "Build with the CPUinfo subsystem enabled"
+    },
+    "events": {
+      "description": "Build with the Events subsystem enabled"
+    },
+    "file": {
+      "description": "Build with the File subsystem enabled"
+    },
+    "filesystem": {
+      "description": "Build with the Filesystem subsystem enabled"
+    },
+    "haptic": {
+      "description": "Build with the Haptic subsystem enabled"
+    },
+    "hidapi": {
+      "description": "Build with the Hidapi subsystem enabled"
+    },
+    "joystick": {
+      "description": "Build with the Joystick subsystem enabled"
+    },
+    "loadso": {
+      "description": "Build with the Loadso subsystem enabled"
+    },
+    "locale": {
+      "description": "Build with the Locale subsystem enabled"
+    },
+    "misc": {
+      "description": "Build with the Misc subsystem enabled"
+    },
+    "power": {
+      "description": "Build with the Power subsystem enabled"
+    },
+    "render": {
+      "description": "Build with the Render subsystem enabled"
+    },
+    "sensor": {
+      "description": "Build with the Sensor subsystem enabled"
+    },
+    "threads": {
+      "description": "Build with the Threads subsystem enabled"
+    },
+    "timers": {
+      "description": "Build with the Timers subsystem enabled"
+    },
+    "video": {
+      "description": "Build with the Video subsystem enabled"
+    },
     "alsa": {
       "description": "Support for alsa audio",
       "dependencies": [

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -39,8 +39,6 @@
     "power",
     "render",
     "sensor",
-    "threads",
-    "timers",
     "video",
     {
       "name": "wayland",
@@ -122,12 +120,6 @@
     },
     "sensor": {
       "description": "Build with the Sensor subsystem enabled"
-    },
-    "threads": {
-      "description": "Build with the Threads subsystem enabled"
-    },
-    "timers": {
-      "description": "Build with the Timers subsystem enabled"
     },
     "video": {
       "description": "Build with the Video subsystem enabled"

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -16,9 +16,15 @@
     }
   ],
   "default-features": [
-    "atomic",
+    {
+      "name": "atomic",
+      "platform": "!emscripten"
+    },
     "audio",
-    "cpuinfo",
+    {
+      "name": "cpuinfo",
+      "platform": "!emscripten"
+    },
     {
       "name": "dbus",
       "platform": "linux"
@@ -33,7 +39,10 @@
       "platform": "linux"
     },
     "joystick",
-    "loadso",
+    {
+      "name": "loadso",
+      "platform": "!emscripten"
+    },
     "locale",
     "misc",
     "power",
@@ -57,13 +66,15 @@
       ]
     },
     "atomic": {
-      "description": "Build with the Atomic subsystem enabled"
+      "description": "Build with the Atomic subsystem enabled",
+      "supports": "!emscripten"
     },
     "audio": {
       "description": "Build with the Audio subsystem enabled"
     },
     "cpuinfo": {
-      "description": "Build with the CPUinfo subsystem enabled"
+      "description": "Build with the CPUinfo subsystem enabled",
+      "supports": "!emscripten"
     },
     "dbus": {
       "description": "Build with D-Bus support",
@@ -85,7 +96,16 @@
       "description": "Build with the Filesystem subsystem enabled"
     },
     "haptic": {
-      "description": "Build with the Haptic subsystem enabled"
+      "description": "Build with the Haptic subsystem enabled",
+      "dependencies": [
+        {
+          "name": "sdl2",
+          "default-features": false,
+          "features": [
+            "joystick"
+          ]
+        }
+      ]
     },
     "hidapi": {
       "description": "Build with the Hidapi subsystem enabled"
@@ -98,7 +118,8 @@
       "description": "Build with the Joystick subsystem enabled"
     },
     "loadso": {
-      "description": "Build with the Loadso subsystem enabled"
+      "description": "Build with the Loadso subsystem enabled",
+      "supports": "!emscripten"
     },
     "locale": {
       "description": "Build with the Locale subsystem enabled"
@@ -122,7 +143,17 @@
       "description": "Build with the Sensor subsystem enabled"
     },
     "video": {
-      "description": "Build with the Video subsystem enabled"
+      "description": "Build with the Video subsystem enabled",
+      "dependencies": [
+        {
+          "name": "sdl2",
+          "default-features": false,
+          "features": [
+            "loadso"
+          ],
+          "platform": "windows"
+        }
+      ]
     },
     "vulkan": {
       "description": "Vulkan functionality for SDL"

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -7,6 +7,23 @@
   "license": "Zlib",
   "dependencies": [
     {
+      "name": "sdl2",
+      "default-features": false,
+      "features": [
+        "video"
+      ],
+      "platform": "uwp"
+    },
+    {
+      "name": "sdl2",
+      "default-features": false,
+      "features": [
+        "haptic",
+        "joystick"
+      ],
+      "platform": "android"
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8662,7 +8662,7 @@
     },
     "sdl2": {
       "baseline": "2.32.8",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f39dbbec077368e51efb27c83191bb20f0704b6",
+      "version": "2.32.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "18fee2d21bc61416833b7428caeb58ef09d763a1",
       "version": "2.32.8",
       "port-version": 0

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "67fd9a46cd05ca5ea9f16aae080b44aadc5d8ed9",
+      "git-tree": "75f471bd2e54f242b6e90f66b97972a7281f3ee2",
       "version": "2.32.8",
       "port-version": 1
     },

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "75f471bd2e54f242b6e90f66b97972a7281f3ee2",
+      "git-tree": "018bb98da41c3d38eeb80818587beb09089f6a61",
       "version": "2.32.8",
       "port-version": 1
     },

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "96fc0e0bc83a7b5a789ef23dce1accefd8f0e1e3",
+      "git-tree": "c6f037b4836e7ce23805afc8fd77bfc708cd0f5a",
       "version": "2.32.8",
       "port-version": 1
     },

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c6f037b4836e7ce23805afc8fd77bfc708cd0f5a",
+      "git-tree": "67fd9a46cd05ca5ea9f16aae080b44aadc5d8ed9",
       "version": "2.32.8",
       "port-version": 1
     },

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6f39dbbec077368e51efb27c83191bb20f0704b6",
+      "git-tree": "96fc0e0bc83a7b5a789ef23dce1accefd8f0e1e3",
       "version": "2.32.8",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

