### PR TITLE
[nlohmann-json] Fix upstream #4864 - disabled std::optional support

### DIFF
--- a/ports/nlohmann-json/fix-4742_std_optional.patch
+++ b/ports/nlohmann-json/fix-4742_std_optional.patch
@@ -1,0 +1,108 @@
+diff --git a/include/nlohmann/detail/conversions/from_json.hpp b/include/nlohmann/detail/conversions/from_json.hpp
+index d647d742..797f714d 100644
+--- a/include/nlohmann/detail/conversions/from_json.hpp
++++ b/include/nlohmann/detail/conversions/from_json.hpp
+@@ -13,9 +13,6 @@
+ #include <forward_list> // forward_list
+ #include <iterator> // inserter, front_inserter, end
+ #include <map> // map
+-#ifdef JSON_HAS_CPP_17
+-    #include <optional> // optional
+-#endif
+ #include <string> // string
+ #include <tuple> // tuple, make_tuple
+ #include <type_traits> // is_arithmetic, is_same, is_enum, underlying_type, is_convertible
+@@ -32,6 +29,11 @@
+ #include <nlohmann/detail/string_concat.hpp>
+ #include <nlohmann/detail/value_t.hpp>
+ 
++// include after macro_scope.hpp
++#ifdef JSON_HAS_CPP_17
++    #include <optional> // optional
++#endif
++
+ NLOHMANN_JSON_NAMESPACE_BEGIN
+ namespace detail
+ {
+@@ -47,7 +49,6 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
+ }
+ 
+ #ifdef JSON_HAS_CPP_17
+-#ifndef JSON_USE_IMPLICIT_CONVERSIONS
+ template<typename BasicJsonType, typename T>
+ void from_json(const BasicJsonType& j, std::optional<T>& opt)
+ {
+@@ -60,8 +61,6 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
+         opt.emplace(j.template get<T>());
+     }
+ }
+-
+-#endif // JSON_USE_IMPLICIT_CONVERSIONS
+ #endif // JSON_HAS_CPP_17
+ 
+ // overloads for basic_json template parameters
+diff --git a/include/nlohmann/detail/conversions/to_json.hpp b/include/nlohmann/detail/conversions/to_json.hpp
+index ead45665..f8413850 100644
+--- a/include/nlohmann/detail/conversions/to_json.hpp
++++ b/include/nlohmann/detail/conversions/to_json.hpp
+@@ -267,7 +267,7 @@ struct external_constructor<value_t::object>
+ #ifdef JSON_HAS_CPP_17
+ template<typename BasicJsonType, typename T,
+          enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
+-void to_json(BasicJsonType& j, const std::optional<T>& opt)
++void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
+ {
+     if (opt.has_value())
+     {
+diff --git a/single_include/nlohmann/json.hpp b/single_include/nlohmann/json.hpp
+index 82d69f7c..53a9ea70 100644
+--- a/single_include/nlohmann/json.hpp
++++ b/single_include/nlohmann/json.hpp
+@@ -173,9 +173,6 @@
+ #include <forward_list> // forward_list
+ #include <iterator> // inserter, front_inserter, end
+ #include <map> // map
+-#ifdef JSON_HAS_CPP_17
+-    #include <optional> // optional
+-#endif
+ #include <string> // string
+ #include <tuple> // tuple, make_tuple
+ #include <type_traits> // is_arithmetic, is_same, is_enum, underlying_type, is_convertible
+@@ -4817,6 +4814,11 @@ NLOHMANN_JSON_NAMESPACE_END
+ // #include <nlohmann/detail/value_t.hpp>
+ 
+ 
++// include after macro_scope.hpp
++#ifdef JSON_HAS_CPP_17
++    #include <optional> // optional
++#endif
++
+ NLOHMANN_JSON_NAMESPACE_BEGIN
+ namespace detail
+ {
+@@ -4832,7 +4834,6 @@ inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
+ }
+ 
+ #ifdef JSON_HAS_CPP_17
+-#ifndef JSON_USE_IMPLICIT_CONVERSIONS
+ template<typename BasicJsonType, typename T>
+ void from_json(const BasicJsonType& j, std::optional<T>& opt)
+ {
+@@ -4845,8 +4846,6 @@ void from_json(const BasicJsonType& j, std::optional<T>& opt)
+         opt.emplace(j.template get<T>());
+     }
+ }
+-
+-#endif // JSON_USE_IMPLICIT_CONVERSIONS
+ #endif // JSON_HAS_CPP_17
+ 
+ // overloads for basic_json template parameters
+@@ -5914,7 +5913,7 @@ struct external_constructor<value_t::object>
+ #ifdef JSON_HAS_CPP_17
+ template<typename BasicJsonType, typename T,
+          enable_if_t<std::is_constructible<BasicJsonType, T>::value, int> = 0>
+-void to_json(BasicJsonType& j, const std::optional<T>& opt)
++void to_json(BasicJsonType& j, const std::optional<T>& opt) noexcept
+ {
+     if (opt.has_value())
+     {

--- a/ports/nlohmann-json/portfile.cmake
+++ b/ports/nlohmann-json/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 6cc1e86261f8fac21cc17a33da3b6b3c3cd5c116755651642af3c9e99bb3538fd42c1bd50397a77c8fb6821bc62d90e6b91bcdde77a78f58f2416c62fc53b97d
     HEAD_REF master
     PATCHES
-        fix-4864_std_optional.patch
+        fix-4742_std_optional.patch
 )
 
 if(NOT DEFINED nlohmann-json_IMPLICIT_CONVERSIONS)

--- a/ports/nlohmann-json/portfile.cmake
+++ b/ports/nlohmann-json/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 6cc1e86261f8fac21cc17a33da3b6b3c3cd5c116755651642af3c9e99bb3538fd42c1bd50397a77c8fb6821bc62d90e6b91bcdde77a78f58f2416c62fc53b97d
     HEAD_REF master
+    PATCHES
+        fix-4864_std_optional.patch
 )
 
 if(NOT DEFINED nlohmann-json_IMPLICIT_CONVERSIONS)

--- a/ports/nlohmann-json/vcpkg.json
+++ b/ports/nlohmann-json/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nlohmann-json",
   "version-semver": "3.12.0",
+  "port-version": 1,
   "description": "JSON for Modern C++",
   "homepage": "https://github.com/nlohmann/json",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6722,7 +6722,7 @@
     },
     "nlohmann-json": {
       "baseline": "3.12.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nlopt": {
       "baseline": "2.10.0",

--- a/versions/n-/nlohmann-json.json
+++ b/versions/n-/nlohmann-json.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ece1a5b49bc2983f6db85ae591cddfb614a24c1f",
+      "version-semver": "3.12.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "060c829772d52e920fee94cf84755031c61e3b67",
       "version-semver": "3.12.0",
       "port-version": 0

--- a/versions/n-/nlohmann-json.json
+++ b/versions/n-/nlohmann-json.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ece1a5b49bc2983f6db85ae591cddfb614a24c1f",
+      "git-tree": "f89a58e6478ca1e39120e93e7ed535c4aaf8198c",
       "version-semver": "3.12.0",
       "port-version": 1
     },


### PR DESCRIPTION
- Fixes upstream issue [4864](https://github.com/nlohmann/json/issues/4864) with merged upstream PR [4742](https://github.com/nlohmann/json/pull/4742). std::optional support was supposed to function in current stable release, but accidentally got disabled.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.