### PR TITLE
[log4cxx] Add a feature to enable multiprocess logging support

### DIFF
--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         qt        LOG4CXX_QT_SUPPORT
         fmt       ENABLE_FMT_LAYOUT
+        mprfa     LOG4CXX_MULTIPROCESS_ROLLING_FILE_APPENDER
 )
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "log4cxx",
   "version": "1.4.0",
+  "port-version": 1,
   "description": "Apache log4cxx is a logging framework for C++ patterned after Apache log4j, which uses Apache Portable Runtime for most platform-specific code and should be usable on any platform supported by APR",
   "homepage": "https://logging.apache.org/log4cxx",
   "license": "Apache-2.0",
@@ -25,6 +26,9 @@
         "fmt"
       ]
     },
+    "mprfa": {
+      "description": "Synchronizes rollover when multiple process log to the same file"
+    },
     "qt": {
       "description": "Allow QString values in the LOG4CXX_WARN, LOG4CXX_INFO, LOG4CXX_DEBUG etc. macros",
       "dependencies": [
@@ -33,9 +37,6 @@
           "default-features": false
         }
       ]
-    },
-    "mprfa": {
-      "description": "Synchronizes rollover when multiple process log to the same file"
     }
   }
 }

--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -33,6 +33,9 @@
           "default-features": false
         }
       ]
+    },
+    "mprfa": {
+      "description": "Synchronizes rollover when multiple process log to the same file"
     }
   }
 }

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -1391,7 +1391,6 @@ libxxf86vm:x64-uwp = cascade
 libzim:arm64-uwp = cascade
 libzim:x64-uwp = cascade
 llgl[vulkan](osx) = cascade # no vulkan sdk installed
-log4cxx:arm64-windows = cascade
 luajit:arm-neon-android = cascade
 luasec:x64-linux = cascade
 luv:arm64-windows = cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5898,7 +5898,7 @@
     },
     "log4cxx": {
       "baseline": "1.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "loguru": {
       "baseline": "2.1.0",

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d18de9248f71f531db36562ac81fe70cec0d758",
+      "version": "1.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d70bc567a01c516fe772cfa41d5c3eefb353e64b",
       "version": "1.4.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #46359

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
