### PR TITLE
[ace] Upgrade to ACE 8.0.4

### DIFF
--- a/ports/ace/p2453.patch
+++ b/ports/ace/p2453.patch
@@ -1,0 +1,70 @@
+diff --git a/ACE_wrappers/TAO/TAO_IDL/be/be_codegen.cpp b/ACE_wrappers/TAO/TAO_IDL/be/be_codegen.cpp
+index a7ee5daa65e..a7a46d5fc10 100644
+--- a/ACE_wrappers/TAO/TAO_IDL/be/be_codegen.cpp
++++ b/ACE_wrappers/TAO/TAO_IDL/be/be_codegen.cpp
+@@ -3726,45 +3726,22 @@ TAO_CodeGen::make_rand_extension (char * const t)
+   // static_cast<> to an integral type.
+   unsigned int seed = static_cast<unsigned int> (msec);
+
+-  // We only care about UTF-8 / ASCII characters in generated
+-  // filenames.  A UTF-16 or UTF-32 character could potentially cause
+-  // a very large space to be searched in the below do/while() loop,
+-  // greatly slowing down this mkstemp() implementation.  It is more
+-  // practical to limit the search space to UTF-8 / ASCII characters
+-  // (i.e. 127 characters).
+-  //
+-  // Note that we can't make this constant static since the compiler
+-  // may not inline the return value of ACE_Numeric_Limits::max(),
+-  // meaning multiple threads could potentially initialize this value
+-  // in parallel.
+-  float const MAX_VAL =
+-    static_cast<float> (ACE_Numeric_Limits<char>::max ());
+-
+-  // Use high-order bits rather than low-order ones (e.g. rand() %
+-  // MAX_VAL).  See Numerical Recipes in C: The Art of Scientific
+-  // Computing (William  H. Press, Brian P. Flannery, Saul
+-  // A. Teukolsky, William T. Vetterling; New York: Cambridge
+-  // University Press, 1992 (2nd ed., p. 277).
+-  //
+-  // e.g.: MAX_VAL * rand() / (RAND_MAX + 1.0)
++  // Strict ASCII alphabet (uppercase letters and digits), independent of locale.
++  static constexpr char ALPHABET[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
++  static constexpr int ALEN = static_cast<int>(sizeof(ALPHABET) - 1); // no '\0'
+
+-  // Factor out the constant coefficient.
+-  float const coefficient =
+-    static_cast<float> (MAX_VAL / static_cast<float> (RAND_MAX) + 1.0f);
+-
+-  for (unsigned int n = 0; n < NUM_CHARS; ++n)
++  unsigned int const limit = (static_cast<unsigned int>(RAND_MAX) / ALEN) * ALEN;
++  for (size_t n = 0; n < NUM_CHARS; ++n)
+     {
+-      ACE_TCHAR r;
+-
+-      // This do/while() loop allows this alphanumeric character
+-      // selection to work for EBCDIC, as well.
++      unsigned int r32 = 0;
++      // Rejection sampling to avoid modulo bias.
+       do
+         {
+-          r = static_cast<ACE_TCHAR> (coefficient * ACE_OS::rand_r (&seed));
++          r32 = static_cast<unsigned int>(ACE_OS::rand_r(&seed));
+         }
+-      while (!ACE_OS::ace_isalnum (r));
++      while (r32 >= limit);
+
+-      t[n] = static_cast<char> (ACE_OS::ace_toupper (r));
++      t[n] = ALPHABET[r32 % ALEN];
+     }
+ }
+
+@@ -3784,8 +3761,7 @@ TAO_CodeGen::gen_conn_ts_includes (
+        i.advance ())
+     {
+       i.next (tmp);
+-      this->gen_standard_include (this->ciao_conn_header_,
+-                                  *tmp);
++      this->gen_standard_include (this->ciao_conn_header_, *tmp);
+     }
+ }
+

--- a/ports/ace/p2453.patch
+++ b/ports/ace/p2453.patch
@@ -1,7 +1,7 @@
-diff --git a/ACE_wrappers/TAO/TAO_IDL/be/be_codegen.cpp b/ACE_wrappers/TAO/TAO_IDL/be/be_codegen.cpp
+diff --git a/TAO/TAO_IDL/be/be_codegen.cpp b/TAO/TAO_IDL/be/be_codegen.cpp
 index a7ee5daa65e..a7a46d5fc10 100644
---- a/ACE_wrappers/TAO/TAO_IDL/be/be_codegen.cpp
-+++ b/ACE_wrappers/TAO/TAO_IDL/be/be_codegen.cpp
+--- a/TAO/TAO_IDL/be/be_codegen.cpp
++++ b/TAO/TAO_IDL/be/be_codegen.cpp
 @@ -3726,45 +3726,22 @@ TAO_CodeGen::make_rand_extension (char * const t)
    // static_cast<> to an integral type.
    unsigned int seed = static_cast<unsigned int> (msec);

--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -10,6 +10,12 @@ if("tao" IN_LIST FEATURES)
         FILENAME "ACE-TAO-src-${VERSION}.tar.gz"
         SHA512 7ca16de48c669d113a25975be132eb358527de0b51b45dea665c609e3a37d39ac3aac07e816d3ded9cdcd6895d84417bf1d3db36c4e977fc36af53ec333f5d32
     )
+    vcpkg_extract_source_archive(
+        SOURCE_PATH
+        ARCHIVE "${ARCHIVE}"
+        PATCHES
+            p2453.patch
+    )
 else()
     # Don't change to vcpkg_from_github! This points to a release and not an archive
     vcpkg_download_distfile(ARCHIVE
@@ -17,16 +23,12 @@ else()
         FILENAME "ACE-src-${VERSION}.tar.gz"
         SHA512 0126b90b77c0b92f3a995bb4c9eb61ddc1c551c4ed078567f421dc3703f2427aff5445fcaa70d6cd690d61065fa4855dc865eda4297b64ce06b5c5cbb26968f8
     )
+    vcpkg_extract_source_archive(
+        SOURCE_PATH
+        ARCHIVE "${ARCHIVE}"
+    )
 endif()
 
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
-if("tao" IN_LIST FEATURES)
-    PATCHES
-        p2453.patch
-endif()
-)
 
 set(ACE_ROOT "${SOURCE_PATH}")
 set(ENV{ACE_ROOT} "${ACE_ROOT}")

--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -22,8 +22,10 @@ endif()
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+if("tao" IN_LIST FEATURES)
     PATCHES
         p2453.patch
+endif()
 )
 
 set(ACE_ROOT "${SOURCE_PATH}")

--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -8,20 +8,22 @@ if("tao" IN_LIST FEATURES)
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE%2BTAO-src-${VERSION}.tar.gz"
         FILENAME "ACE-TAO-src-${VERSION}.tar.gz"
-        SHA512 e7d0d8e1e1a8aa839278337dbba43ff70744bef8f4eece06b37c370e3b0e80f4bd7360d6f0fe3e31ea0c2355aae8e8de53114d9db10865a5aac789a026e2065c
+        SHA512 7ca16de48c669d113a25975be132eb358527de0b51b45dea665c609e3a37d39ac3aac07e816d3ded9cdcd6895d84417bf1d3db36c4e977fc36af53ec333f5d32
     )
 else()
     # Don't change to vcpkg_from_github! This points to a release and not an archive
     vcpkg_download_distfile(ARCHIVE
         URLS "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-${VERSION_DIRECTORY}/ACE-src-${VERSION}.tar.gz"
         FILENAME "ACE-src-${VERSION}.tar.gz"
-        SHA512 3adf34a72ee8b060c4edd41cb33053971473d077abe0aaa8448dc2b4c868ee1e9cc8c4934bcd41ae55e5decd7c540df114f415b383c37266b3bd044f290dc1f9
+        SHA512 0126b90b77c0b92f3a995bb4c9eb61ddc1c551c4ed078567f421dc3703f2427aff5445fcaa70d6cd690d61065fa4855dc865eda4297b64ce06b5c5cbb26968f8
     )
 endif()
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+    PATCHES
+        p2453.patch
 )
 
 set(ACE_ROOT "${SOURCE_PATH}")

--- a/ports/ace/vcpkg.json
+++ b/ports/ace/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ace",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "maintainers": "Johnny Willemsen <jwillemsen@remedy.nl>",
   "description": "The ADAPTIVE Communication Environment",
   "homepage": "https://github.com/DOCGroup/ACE_TAO",

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "27064ccfc9d652fd24011ed9f9e012807b129a8e",
+      "git-tree": "6c1355f190e96386e1544384c46ecedece80b8c9",
       "version": "8.0.4",
       "port-version": 0
     },

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6c1355f190e96386e1544384c46ecedece80b8c9",
+      "git-tree": "9fe314f67bf5e82e5016c48c35b1b6f013ff071b",
       "version": "8.0.4",
       "port-version": 0
     },

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27064ccfc9d652fd24011ed9f9e012807b129a8e",
+      "version": "8.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "2bff5561eeb495d056768eb8454e4b1cf9978166",
       "version": "8.0.3",
       "port-version": 0

--- a/versions/a-/ace.json
+++ b/versions/a-/ace.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9fe314f67bf5e82e5016c48c35b1b6f013ff071b",
+      "git-tree": "e9d0e71c123c3b21ae099f0d1b42c5d405529787",
       "version": "8.0.4",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -25,7 +25,7 @@
       "port-version": 3
     },
     "ace": {
-      "baseline": "8.0.3",
+      "baseline": "8.0.4",
       "port-version": 0
     },
     "acl": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fixes https://github.com/microsoft/vcpkg/issues/46237 

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
