### PR TITLE
[proxy] update to 4.0.0

### DIFF
--- a/ports/proxy/portfile.cmake
+++ b/ports/proxy/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/proxy
     REF ${VERSION}
-    SHA512 9e9a0d46291d1bd92b205a5a27cfa0b08974f4e644b9ef66f2ba2ea1fed2df3e0adfc40b247a8f53a479a2dbbd2bad162f157e8cf73b72973a19f97193d4102b 
+    SHA512 b6484a9ebc71d0a76bf80b80dc6688c5c4f08ab02496e105f0b8392d8752d79216da315513755176aa98da95247dc785a20379e2e2b192eb463213c6f8c9cf6f
     HEAD_REF main
 )
 
@@ -13,7 +13,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "msft_proxy4")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/proxy/vcpkg.json
+++ b/ports/proxy/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "description": "A single-header C++20 library that facilitates runtime polymorphism.",
   "homepage": "https://github.com/microsoft/proxy",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7629,7 +7629,7 @@
       "port-version": 0
     },
     "proxy": {
-      "baseline": "3.4.0",
+      "baseline": "4.0.0",
       "port-version": 0
     },
     "proxygen": {

--- a/versions/p-/proxy.json
+++ b/versions/p-/proxy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb9194319ce85476c9d7025ed1b6d5537b950ddf",
+      "version": "4.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d5a981acb137fd036001a3e87153209ca33223ea",
       "version": "3.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/microsoft/proxy/releases/tag/4.0.0
