### PR TITLE
[appstream] Add new port

### DIFF
--- a/ports/appstream/portfile.cmake
+++ b/ports/appstream/portfile.cmake
@@ -15,6 +15,8 @@ vcpkg_configure_meson(
       -Dstemming=false
       -Dsvg-support=false
       -Dgir=false
+    ADDITIONAL_BINARIES
+      "gperf = ['${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${HOST_EXECUTABLE_SUFFIX}']"
 )
 
 vcpkg_install_meson()
@@ -22,4 +24,3 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-

--- a/ports/appstream/portfile.cmake
+++ b/ports/appstream/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 80f3b7b9279152ce271bab61e97a41268d5dc5d977dc9488fc187df90077ac1a81169201d3d1a7a5578d36e962321035bfe34106486c2ac3d684621b40338de6
     HEAD_REF main
     PATCHES
-      remove-tests-and-data.patch
+      remove-uneeded-directories.patch
 )
 
 set(GLIB_TOOLS_DIR "${CURRENT_HOST_INSTALLED_DIR}/tools/glib")

--- a/ports/appstream/portfile.cmake
+++ b/ports/appstream/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ximion/appstream
+    REF "v${VERSION}"
+    SHA512 80f3b7b9279152ce271bab61e97a41268d5dc5d977dc9488fc187df90077ac1a81169201d3d1a7a5578d36e962321035bfe34106486c2ac3d684621b40338de6
+    HEAD_REF main
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+      -Dsystemd=false
+      -Dapidocs=false
+      -Dinstall-docs=false
+      -Dstemming=false
+      -Dsvg-support=false
+      -Dgir=false
+)
+
+vcpkg_install_meson()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+

--- a/ports/appstream/portfile.cmake
+++ b/ports/appstream/portfile.cmake
@@ -4,7 +4,11 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 80f3b7b9279152ce271bab61e97a41268d5dc5d977dc9488fc187df90077ac1a81169201d3d1a7a5578d36e962321035bfe34106486c2ac3d684621b40338de6
     HEAD_REF main
+    PATCHES
+      remove-tests-and-data.patch
 )
+
+set(GLIB_TOOLS_DIR "${CURRENT_HOST_INSTALLED_DIR}/tools/glib")
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -16,7 +20,9 @@ vcpkg_configure_meson(
       -Dsvg-support=false
       -Dgir=false
     ADDITIONAL_BINARIES
-      "gperf = ['${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${HOST_EXECUTABLE_SUFFIX}']"
+       gperf='${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${HOST_EXECUTABLE_SUFFIX}'
+       glib-mkenums='${GLIB_TOOLS_DIR}/glib-mkenums'
+       glib-compile-resources='${GLIB_TOOLS_DIR}/glib-compile-resources${VCPKG_HOST_EXECUTABLE_SUFFIX}'
 )
 
 vcpkg_install_meson()

--- a/ports/appstream/remove-tests-and-data.patch
+++ b/ports/appstream/remove-tests-and-data.patch
@@ -1,0 +1,17 @@
+diff --git a/meson.build b/meson.build
+index ee5b179a..ac89a905 100644
+--- a/meson.build
++++ b/meson.build
+@@ -224,10 +224,10 @@ if get_option('compose')
+ endif
+ subdir('tools/')
+ subdir('po/')
+-subdir('data/')
++#subdir('data/')
+ subdir('contrib/')
+ subdir('docs/')
+-subdir('tests/')
++#subdir('tests/')
+ if get_option('qt')
+     subdir('qt/')
+ endif

--- a/ports/appstream/remove-uneeded-directories.patch
+++ b/ports/appstream/remove-uneeded-directories.patch
@@ -1,5 +1,5 @@
 diff --git a/meson.build b/meson.build
-index ee5b179a..ac89a905 100644
+index ee5b179a..a1a0b2c3 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -224,10 +224,10 @@ if get_option('compose')
@@ -9,8 +9,9 @@ index ee5b179a..ac89a905 100644
 -subdir('data/')
 +#subdir('data/')
  subdir('contrib/')
- subdir('docs/')
+-subdir('docs/')
 -subdir('tests/')
++#subdir('docs/')
 +#subdir('tests/')
  if get_option('qt')
      subdir('qt/')

--- a/ports/appstream/vcpkg.json
+++ b/ports/appstream/vcpkg.json
@@ -11,6 +11,10 @@
       "host": true
     },
     "glib",
+    {
+      "name": "gperf",
+      "host": true
+    },
     "libxml2",
     "libxmlb",
     "libyaml",

--- a/ports/appstream/vcpkg.json
+++ b/ports/appstream/vcpkg.json
@@ -6,11 +6,11 @@
   "license": "LGPL-2.1-or-later",
   "dependencies": [
     "curl",
-    "glib",
     {
       "name": "gettext",
-      "host": "true"
+      "host": true
     },
+    "glib",
     "libxml2",
     "libxmlb",
     "libyaml",

--- a/ports/appstream/vcpkg.json
+++ b/ports/appstream/vcpkg.json
@@ -7,6 +7,10 @@
   "dependencies": [
     "curl",
     "glib",
+    {
+      "name": "gettext",
+      "host": "true"
+    },
     "libxml2",
     "libxmlb",
     "libyaml",

--- a/ports/appstream/vcpkg.json
+++ b/ports/appstream/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "appstream",
+  "version": "1.0.6",
+  "description": "Tools and libraries to work with AppStream metadata",
+  "homepage": "https://www.freedesktop.org/software/appstream/docs",
+  "license": "LGPL-2.1-or-later",
+  "dependencies": [
+    "curl",
+    "glib",
+    "libxml2",
+    "libxmlb",
+    "libyaml",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    },
+    "zstd"
+  ]
+}

--- a/ports/appstream/vcpkg.json
+++ b/ports/appstream/vcpkg.json
@@ -12,6 +12,10 @@
     },
     "glib",
     {
+      "name": "glib",
+      "host": true
+    },
+    {
       "name": "gperf",
       "host": true
     },

--- a/versions/a-/appstream.json
+++ b/versions/a-/appstream.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f83f195e41dd6a66dd794cdd64f76f785096dee4",
+      "git-tree": "02adb7f4345d8e614592ff33b26eab8e978d0359",
       "version": "1.0.6",
       "port-version": 0
     }

--- a/versions/a-/appstream.json
+++ b/versions/a-/appstream.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "061b5a5b641470b4a72a963684b5565a76b4571d",
+      "git-tree": "76e6caf65cc47e13648dfada5e681e595bcbef25",
       "version": "1.0.6",
       "port-version": 0
     }

--- a/versions/a-/appstream.json
+++ b/versions/a-/appstream.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3e02a8cff513c018ac314bf6ce3a418ce170e5b9",
+      "git-tree": "17b89d7d4be429c1cc3a044869413f2e9fe029f2",
       "version": "1.0.6",
       "port-version": 0
     }

--- a/versions/a-/appstream.json
+++ b/versions/a-/appstream.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "17b89d7d4be429c1cc3a044869413f2e9fe029f2",
+      "git-tree": "061b5a5b641470b4a72a963684b5565a76b4571d",
       "version": "1.0.6",
       "port-version": 0
     }

--- a/versions/a-/appstream.json
+++ b/versions/a-/appstream.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "76e6caf65cc47e13648dfada5e681e595bcbef25",
+      "git-tree": "f83f195e41dd6a66dd794cdd64f76f785096dee4",
       "version": "1.0.6",
       "port-version": 0
     }

--- a/versions/a-/appstream.json
+++ b/versions/a-/appstream.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "cb578b599ebbfa7b60f2c2ef0cba9febd489496b",
+      "version": "1.0.6",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/a-/appstream.json
+++ b/versions/a-/appstream.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cb578b599ebbfa7b60f2c2ef0cba9febd489496b",
+      "git-tree": "3e02a8cff513c018ac314bf6ce3a418ce170e5b9",
       "version": "1.0.6",
       "port-version": 0
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -172,6 +172,10 @@
       "baseline": "10.13.0",
       "port-version": 0
     },
+    "appstream": {
+      "baseline": "1.0.6",
+      "port-version": 0
+    },
     "appstream-glib": {
       "baseline": "0.8.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

This port is needed to update libadwaita after https://gitlab.gnome.org/GNOME/libadwaita/-/commit/876672aac1191e4ac26d835cb75761ce07ef69ec, which first appeared in libadwaita version 1.4.

ref: https://github.com/microsoft/vcpkg/issues/36328
unblocks: https://github.com/microsoft/vcpkg/pull/36376