### PR TITLE
[yalantinglibs] Use external iguana; remove vendored copy

### DIFF
--- a/ports/yalantinglibs/portfile.cmake
+++ b/ports/yalantinglibs/portfile.cmake
@@ -6,8 +6,12 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 16d4a9dfffeca3010dd473e6c26df652b57ba6ed2c35624600fb984db8071a0c7181f2b08da2600b8fddd9ffba631f1a641e9c4a6dc9f2aa3e48e6cacca537aa
     HEAD_REF main
+    PATCHES
+        use-external-iguana.patch
 )
 
+# Remove the vendored iguana sources
+file(REMOVE_RECURSE "${SOURCE_PATH}/include/ylt/standalone/iguana")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/yalantinglibs/use-external-iguana.patch
+++ b/ports/yalantinglibs/use-external-iguana.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c30d4db..9ef9bf3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,6 +6,9 @@ project(yaLanTingLibs
+         LANGUAGES CXX
+         )
+
++find_path(IGUANA_INCLUDE_DIRS "iguana/common.hpp")
++include_directories(${IGUANA_INCLUDE_DIRS})
++
+ # load pack finder
+ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Find/)
+ 

--- a/ports/yalantinglibs/vcpkg.json
+++ b/ports/yalantinglibs/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "yalantinglibs",
   "version": "0.5.4",
+  "port-version": 1,
   "description": "A Collection of C++20 libraries, include struct_pack, struct_json, struct_xml, struct_yaml, struct_pb, easylog, coro_rpc, coro_http and async_simple",
   "homepage": "https://github.com/alibaba/yalantinglibs",
   "license": "Apache-2.0",
@@ -17,6 +18,10 @@
     {
       "name": "frozen",
       "version>=": "1.2.0"
+    },
+    {
+      "name": "iguana",
+      "version>=": "1.0.9"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10538,7 +10538,7 @@
     },
     "yalantinglibs": {
       "baseline": "0.5.4",
-      "port-version": 0
+      "port-version": 1
     },
     "yaml-cpp": {
       "baseline": "0.8.0",

--- a/versions/y-/yalantinglibs.json
+++ b/versions/y-/yalantinglibs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76f2081c951e7e98504d7be27fa7644bda0be5b2",
+      "version": "0.5.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "a3adb9d05dcb115e44d6bcc84dd0ded33b97476f",
       "version": "0.5.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
