### PR TITLE
[behaviortree-cpp] De-vendor lexy

### DIFF
--- a/ports/behaviortree-cpp/fix-dependencies.patch
+++ b/ports/behaviortree-cpp/fix-dependencies.patch
@@ -1,0 +1,15 @@
+diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
+index 77a7c18..7eeaceb 100644
+--- a/cmake/Config.cmake.in
++++ b/cmake/Config.cmake.in
+@@ -1,5 +1,10 @@
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++
++find_dependency(Threads)
++find_dependency(lexy CONFIG)
++
+ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+ 
+ set(@PROJECT_NAME@_TARGETS "BT::@PROJECT_NAME@")

--- a/ports/behaviortree-cpp/portfile.cmake
+++ b/ports/behaviortree-cpp/portfile.cmake
@@ -10,6 +10,13 @@ vcpkg_from_github(
         use-external-lexy.patch
 )
 
+# Set BTCPP_SHARED_LIBS based on VCPKG_LIBRARY_LINKAGE
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(BTCPP_SHARED_LIBS ON)
+else()
+    set(BTCPP_SHARED_LIBS OFF)
+endif()
+
 # Remove vendored lexy directory to prevent conflicts with foonathan-lexy port
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/lexy")
 
@@ -23,6 +30,7 @@ vcpkg_cmake_configure(
         -DBTCPP_BUILD_TOOLS=OFF
         -DBTCPP_GROOT_INTERFACE=OFF
         -DBTCPP_SQLITE_LOGGING=OFF
+        -DBTCPP_SHARED_LIBS=${BTCPP_SHARED_LIBS}
     MAYBE_UNUSED_VARIABLES
         CMAKE_DISABLE_FIND_PACKAGE_Curses
 )
@@ -34,7 +42,3 @@ vcpkg_copy_pdbs()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()

--- a/ports/behaviortree-cpp/portfile.cmake
+++ b/ports/behaviortree-cpp/portfile.cmake
@@ -7,7 +7,11 @@ vcpkg_from_github(
     PATCHES
         fix-x86_build.patch
         remove-source-charset.diff
+        use-external-lexy.patch
 )
+
+# Remove vendored lexy directory to prevent conflicts with foonathan-lexy port
+file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/lexy")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/behaviortree-cpp/portfile.cmake
+++ b/ports/behaviortree-cpp/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         fix-x86_build.patch
         remove-source-charset.diff
         use-external-lexy.patch
+        fix-dependencies.patch
 )
 
 # Set BTCPP_SHARED_LIBS based on VCPKG_LIBRARY_LINKAGE

--- a/ports/behaviortree-cpp/use-external-lexy.patch
+++ b/ports/behaviortree-cpp/use-external-lexy.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index aa19bdb..5b12345 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -96,7 +96,8 @@ endif()
+ #############################################################
+ # LIBRARY
+ 
+-add_subdirectory(3rdparty/lexy)
++find_package(lexy CONFIG REQUIRED)
++message(STATUS "Found foonathan-lexy: ${lexy_VERSION}")
+ 
+ add_library(minitrace STATIC 3rdparty/minitrace/minitrace.cpp)
+ target_compile_definitions(minitrace PRIVATE MTR_ENABLED=True)

--- a/ports/behaviortree-cpp/vcpkg.json
+++ b/ports/behaviortree-cpp/vcpkg.json
@@ -1,12 +1,14 @@
 {
   "name": "behaviortree-cpp",
   "version": "4.7.0",
+  "port-version": 1,
   "description": "Behavior Trees Library in C++.",
   "homepage": "https://www.behaviortree.dev",
   "supports": "!uwp",
   "dependencies": [
     "boost-coroutine2",
     "cppzmq",
+    "foonathan-lexy",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8da6953e7473d2f6a499abd186c2ef151144d309",
+      "version": "4.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9e4342eb2c4df9d10a5c47b947bdb121c706a073",
       "version": "4.7.0",
       "port-version": 0

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8da6953e7473d2f6a499abd186c2ef151144d309",
+      "git-tree": "9a896b78a14b07cb6392dd8d1a431b95fec83a49",
       "version": "4.7.0",
       "port-version": 1
     },

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9a896b78a14b07cb6392dd8d1a431b95fec83a49",
+      "git-tree": "698d27b36d7e3b53430558a6e92d51cc8bd22d79",
       "version": "4.7.0",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -642,7 +642,7 @@
     },
     "behaviortree-cpp": {
       "baseline": "4.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "benchmark": {
       "baseline": "1.9.4",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


Note: still needs a find_dependency call?