### PR TITLE
[uvw] update to 3.4.0

### DIFF
--- a/ports/uvw/fix-find-libuv.patch
+++ b/ports/uvw/fix-find-libuv.patch
@@ -1,12 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 289c006..180383f 100644
+index 2be8ae8..cda1957 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -193,6 +193,14 @@ if (BUILD_UVW_LIBS)
-         SOVERSION ${UVW_VERSION_MAJOR}
+@@ -194,6 +194,13 @@ if (BUILD_UVW_LIBS)
      )
  endif()
-+
+ 
 +find_package(libuv CONFIG REQUIRED)
 +if (TARGET libuv::uv)
 +    target_link_libraries(uvw PRIVATE libuv::uv)

--- a/ports/uvw/portfile.cmake
+++ b/ports/uvw/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO skypjack/uvw
-    REF "v${VERSION}_libuv_v1.46"
-    SHA512 a790f74a4d151319d3d692167b7d2229e6660dee34e7dc266815c3e5579dbe99e1da55e0466832ac8ec1881073317b744e384908de60bf62ef16420ee2fbc318
+    REF "v${VERSION}_libuv_v1.48"
+    SHA512 dbf03c63b0693263b77b405e8f6bf4c207795be9bd024bbc06484e523b55257add1eab632067a956d03399d91ee389c46312603e7754b152c4caf51b40f6bec4
     PATCHES
         fix-find-libuv.patch
 )

--- a/ports/uvw/vcpkg.json
+++ b/ports/uvw/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "uvw",
-  "version": "3.2.0",
-  "port-version": 1,
+  "version": "3.4.0",
   "description": "A compilable static library, event based, tiny and easy to use libuv wrapper in modern C++.",
   "homepage": "https://github.com/skypjack/uvw",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9917,8 +9917,8 @@
       "port-version": 0
     },
     "uvw": {
-      "baseline": "3.2.0",
-      "port-version": 1
+      "baseline": "3.4.0",
+      "port-version": 0
     },
     "uwebsockets": {
       "baseline": "20.74.0",

--- a/versions/u-/uvw.json
+++ b/versions/u-/uvw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7594d9cc52c2b21101036ef6d6f59613fe634cbc",
+      "version": "3.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7e8c728dc4f9b6a630f970effb1bbcbda809da6b",
       "version": "3.2.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/skypjack/uvw/releases/tag/v3.4.0_libuv_v1.48
