### PR TITLE
[jsonata] New port

### DIFF
--- a/ports/jsonata/portfile.cmake
+++ b/ports/jsonata/portfile.cmake
@@ -1,4 +1,6 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/jsonata/portfile.cmake
+++ b/ports/jsonata/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO rayokota/jsonata-cpp
+    REF "v${VERSION}"
+    SHA512 d2e64e1cce5d6db93f15913b6b8ccdc199c1be2e02247715d048dd1ae3322629db88f2361e73e705491606437829c86ae1c0256b274631de52f8b5081bddc429
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "jsonata" CONFIG_PATH "lib/cmake/jsonata")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/jsonata/usage
+++ b/ports/jsonata/usage
@@ -1,4 +1,4 @@
-The package jsonata provides CMake targets:
+jsonata provides CMake targets:
 
-    find_package(jsonata CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE jsonata::jsonata)
+  find_package(jsonata CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE jsonata::jsonata)

--- a/ports/jsonata/usage
+++ b/ports/jsonata/usage
@@ -1,0 +1,4 @@
+The package jsonata provides CMake targets:
+
+    find_package(jsonata CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE jsonata::jsonata)

--- a/ports/jsonata/vcpkg.json
+++ b/ports/jsonata/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "jsonata",
+  "version": "0.1.1",
+  "description": "JSONata for C++",
+  "homepage": "https://github.com/rayokota/jsonata-cpp",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "nlohmann-json",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4092,6 +4092,10 @@
       "baseline": "1.0.0",
       "port-version": 7
     },
+    "jsonata": {
+      "baseline": "0.1.1",
+      "port-version": 0
+    },
     "jsoncons": {
       "baseline": "1.3.2",
       "port-version": 0

--- a/versions/j-/jsonata.json
+++ b/versions/j-/jsonata.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7c8d55fbfeebe4754ded7cab5601e912e5e09c03",
+      "version": "0.1.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/j-/jsonata.json
+++ b/versions/j-/jsonata.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7c8d55fbfeebe4754ded7cab5601e912e5e09c03",
+      "git-tree": "aa7ba2994b21592d3ba361d8f9abb5b69f99fe4a",
       "version": "0.1.1",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

Add jsonata library to vcpkg ports

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


