### PR TITLE
[pkgconf] Add paths for FreeBSD

### DIFF
--- a/ports/pkgconf/portfile.cmake
+++ b/ports/pkgconf/portfile.cmake
@@ -21,8 +21,12 @@ set(PKG_DEFAULT_PATH "")
 set(SYSTEM_INCLUDEDIR "")
 set(PERSONALITY_PATH "personality.d")
 
-
-if(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_CROSSCOMPILING AND VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
+if(VCPKG_TARGET_IS_FREEBSD)
+    # These are taken from the FreeBSD port of pkgconf
+    set(SYSTEM_INCLUDEDIR "/usr/include")
+    set(SYSTEM_LIBDIR "/usr/lib")
+    set(PKG_DEFAULT_PATH "/usr/libdata/pkgconfig:/usr/local/libdata/pkgconfig:/usr/local/share/pkgconfig")
+elseif(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_CROSSCOMPILING AND VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
     # These defaults are obtained from pkgconf/pkg-config on Ubuntu and OpenSuse
     # vcpkg cannot do system introspection to obtain/set these values since it would break binary caching.
     set(SYSTEM_INCLUDEDIR "/usr/include")

--- a/ports/pkgconf/vcpkg.json
+++ b/ports/pkgconf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pkgconf",
   "version": "2.5.1",
+  "port-version": 1,
   "description": "pkgconf is a program which helps to configure compiler and linker flags for development libraries. It is similar to pkg-config from freedesktop.org.",
   "homepage": "https://github.com/pkgconf/pkgconf",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7402,7 +7402,7 @@
     },
     "pkgconf": {
       "baseline": "2.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "plasma-wayland-protocols": {
       "baseline": "1.14.0",

--- a/versions/p-/pkgconf.json
+++ b/versions/p-/pkgconf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ccb7c0a5bbbf338f36d8854f1cb8b0f2f3317da",
+      "version": "2.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "39d1d31a02b57fa9e187f182ec32639984cc59cb",
       "version": "2.5.1",
       "port-version": 0


### PR DESCRIPTION
This changes the paths on FreeBSD, which the ports system sets to values that are quite different to what is expected on Linux.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.