### PR TITLE
[vcpkg-make] Fix the make binary path on BSDs

### DIFF
--- a/ports/vcpkg-make/vcpkg.json
+++ b/ports/vcpkg-make/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-make",
-  "version-date": "2025-07-09",
+  "version-date": "2025-08-21",
   "documentation": "https://learn.microsoft.com/vcpkg/maintainers/functions/vcpkg_make_configure",
   "license": null,
   "supports": "native",

--- a/ports/vcpkg-make/vcpkg_make_configure.cmake
+++ b/ports/vcpkg-make/vcpkg_make_configure.cmake
@@ -133,5 +133,9 @@ function(vcpkg_make_configure)
         EMMAKEN_JUST_CONFIGURE
     )
 
-    find_program(Z_VCPKG_MAKE NAMES make gmake NAMES_PER_DIR REQUIRED)
+    if(VCPKG_HOST_IS_FREEBSD OR VCPKG_HOST_IS_OPENBSD)
+        find_program(Z_VCPKG_MAKE gmake REQUIRED)
+    else()
+        find_program(Z_VCPKG_MAKE NAMES make gmake NAMES_PER_DIR REQUIRED)
+    endif()
 endfunction()

--- a/ports/vcpkg-make/vcpkg_make_install.cmake
+++ b/ports/vcpkg-make/vcpkg_make_install.cmake
@@ -41,7 +41,11 @@ function(vcpkg_make_install)
     vcpkg_make_get_shell(shell_var)
     set(shell_cmd "${shell_var}")
 
-    find_program(Z_VCPKG_MAKE NAMES make gmake NAMES_PER_DIR REQUIRED)
+    if(VCPKG_HOST_IS_FREEBSD OR VCPKG_HOST_IS_OPENBSD)
+        find_program(Z_VCPKG_MAKE gmake REQUIRED)
+    else()
+        find_program(Z_VCPKG_MAKE NAMES make gmake NAMES_PER_DIR REQUIRED)
+    endif()
     set(make_command "${Z_VCPKG_MAKE}")
 
     set(destdir "${CURRENT_PACKAGES_DIR}")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10001,7 +10001,7 @@
       "port-version": 0
     },
     "vcpkg-make": {
-      "baseline": "2025-07-09",
+      "baseline": "2025-08-21",
       "port-version": 0
     },
     "vcpkg-msbuild": {

--- a/versions/v-/vcpkg-make.json
+++ b/versions/v-/vcpkg-make.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "25cbb472c3760bcb8ab3d34271f1c1c674ebcac7",
+      "version-date": "2025-08-21",
+      "port-version": 0
+    },
+    {
       "git-tree": "a61503261b3d9410e844b52cab080cdf91b17685",
       "version-date": "2025-07-09",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.