### PR TITLE
[mumps-solver] Add port based on third-party cmake build

### DIFF
--- a/ports/coin-or-ipopt/mumps_pcfiles.patch
+++ b/ports/coin-or-ipopt/mumps_pcfiles.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -122,7 +122,7 @@
+ # MUMPS #
+ #########
+ 
+-AC_COIN_CHK_PKG(Mumps,[IpoptLib],[coinmumps])
++AC_COIN_CHK_PKG(Mumps,[IpoptLib],[mumps-solver])
+ 
+ # Check whether MPI_Initialized is available
+ #   we assume that MPI_Finalized is present if MPI_Initialized is present

--- a/ports/coin-or-ipopt/portfile.cmake
+++ b/ports/coin-or-ipopt/portfile.cmake
@@ -1,39 +1,68 @@
+set(VCPKG_BUILD_TYPE release)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO coin-or/Ipopt
-    REF ec43e37a06054246764fb116e50e3e30c9ada089
-    SHA512 f5b30e81b4a1a178e9a0e2b51b4832f07441b2c3e9a2aa61a6f07807f94185998e985fcf3c34d96fbfde78f07b69f2e0a0675e1e478a4e668da6da60521e0fd6
-    HEAD_REF master
+    REF "releases/${VERSION}"
+    SHA512 98b413b6beaf300175ef6f4e97ba4be6bdeee6aadcd0657eaf9da0142eba0f0b5ca3c84958e88757a13b42ccacb8137bb7bbae4f51f018ec7bbddc19eceedcc1
+    PATCHES
+      mumps_pcfiles.patch
+    #REF ec43e37a06054246764fb116e50e3e30c9ada089
+    #HEAD_REF master
+    #SHA512 f5b30e81b4a1a178e9a0e2b51b4832f07441b2c3e9a2aa61a6f07807f94185998e985fcf3c34d96fbfde78f07b69f2e0a0675e1e478a4e668da6da60521e0fd6
 )
-  # --with-precision        floating-point precision to use: single or double
-                          # (default)
-  # --with-intsize          integer type to use: specify 32 for int or 64 for
-                          # int64_t
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SOURCE_PATH}")
 
 set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
+
+set(CONFIGURE_ARGS
+      --without-spral
+      --without-hsl
+      --without-asl
+      --with-lapack
+      --enable-relocatable
+      --disable-f77
+      --disable-java
+      #--with-pardiso
+      #--without-wsmp
+      #--with-precision        floating-point precision to use: single or double(default)
+      #--with-intsize          integer type to use: specify 32 for int or 64(default) for int64_t
+)
+
+if("mumps" IN_LIST FEATURES)
+    list(APPEND CONFIGURE_ARGS "--with-mumps")
+    #list(APPEND CONFIGURE_ARGS "--mumps-pcfiles=mumps-solver")
+    #list(APPEND CONFIGURE_ARGS "--with-mumps-lflags=-L${CURRENT_INSTALLED_DIR}/lib/ -ldmumps -lsmumps")
+    #list(APPEND CONFIGURE_ARGS "--with-mumps-cflags=-I${CURRENT_INSTALLED_DIR}/include/")
+endif()
+
+if(VCPKG_HOST_IS_LINUX)
+    list(APPEND CONFIGURE_ARGS "LIBS=-lgfortran -lm")
+endif()
+
+# link against openblas, assumed static lib
+#set(OPENBLAS_LIB "${CMAKE_STATIC_LIBRARY_PREFIX}openblas${CMAKE_STATIC_LIBRARY_SUFFIX}")
+#set(LAPACK_LIB "${CMAKE_STATIC_LIBRARY_PREFIX}lapack${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+#if(VCPKG_HOST_IS_WINDOWS)
+#    list(APPEND CONFIGURE_ARGS "--with-lapack-lflags=${CURRENT_INSTALLED_DIR}/lib/${OPENBLAS_LIB}")
+#elseif(VCPKG_HOST_IS_LINUX)
+#    list(APPEND CONFIGURE_ARGS "--with-lapack-lflags=-L${CURRENT_INSTALLED_DIR}/lib -llapack -lgfortran -lm")
+#endif()
 
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
     OPTIONS
-      #--with-pardiso
-      --without-spral
-      #--without-wsmp
-      --without-hsl
-      --without-asl
-      --with-lapack
-      --without-mumps
-      --enable-relocatable
-      --disable-f77
-      --disable-java
+        ${CONFIGURE_ARGS}
 )
-
 vcpkg_install_make()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
+# Install usage file
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+# Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/coin-or-ipopt/usage
+++ b/ports/coin-or-ipopt/usage
@@ -1,0 +1,11 @@
+The package coin-or-ipopt provides pkg-config config:
+
+  pkg_check_modules(ipopt REQUIRED IMPORTED_TARGET ipopt)
+  target_link_libraries(main PRIVATE PkgConfig::ipopt)
+
+Ipopt (Interior Point OPTimizer, pronounced eye-pea-Opt) is a software package for large-scale nonlinear optimization
+
+The ipopt target provides access to the Coin-Or  IpOpt with with basic set of required dependencies, BLAS, LAPACK and mumps-solver.
+
+For more information, see:
+https://github.com/coin-or/Ipopt

--- a/ports/coin-or-ipopt/vcpkg.json
+++ b/ports/coin-or-ipopt/vcpkg.json
@@ -1,11 +1,38 @@
 {
   "name": "coin-or-ipopt",
-  "version-date": "2023-02-01",
+  "version": "3.14.19",
+  "port-version":3,
   "description": "Ipopt (Interior Point OPTimizer, pronounced eye-pea-Opt) is a software package for large-scale nonlinear optimization",
   "homepage": "https://github.com/coin-or/Ipopt",
   "license": "EPL-2.0",
   "dependencies": [
     "coinutils",
-    "intel-mkl"
-  ]
+    "lapack",
+    "blas",
+    "pkgconf"
+
+  ],
+  "default-features": [
+    "mumps"
+  ],
+  "features": {
+    "openblas":{
+        "description": "use openblas backend",
+        "dependencies": [
+        {
+          "name":"openblas",
+          "features":["blas","lapack"]
+        }
+      ]
+    },
+    "mumps": {
+      "description": "Enable MUMPS linear solver",
+      "dependencies": [
+        "mumps-solver"
+      ]
+    },
+    "hsl": {
+      "description": "Enable HSL linear solvers (requires HSL sources)"
+    }
+  }
 }

--- a/ports/mumps-solver/mumps-solver.pc.in
+++ b/ports/mumps-solver/mumps-solver.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_FULL_EXEC_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: mumps-solver
+Description: MUltifrontal Massively Parallel sparse direct Solver
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -ldmumps -lsmumps -lmumps_common -lmpiseq -lmpiseq_c -lmpiseq_fortran -lpord -lgfortran -lm

--- a/ports/mumps-solver/mumps_pc.patch
+++ b/ports/mumps-solver/mumps_pc.patch
@@ -1,0 +1,26 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -189,6 +189,23 @@
+ # --- MUMPS itself
+ include(cmake/mumps.cmake)
+ 
++# --- MUMPS pkg-config
++# Configure the .pc file from the template
++configure_file(
++  mumps.pc.in
++  ${CMAKE_CURRENT_BINARY_DIR}/mumps.pc
++  @ONLY
++)
++
++# Install the generated .pc
++install(
++  FILES ${CMAKE_CURRENT_BINARY_DIR}/mumps.pc
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
++)
++
++
++
++
+ if(MUMPS_matlab)
+   include(cmake/matlab.cmake)
+ endif()

--- a/ports/mumps-solver/portfile.cmake
+++ b/ports/mumps-solver/portfile.cmake
@@ -1,0 +1,36 @@
+set(VCPKG_BUILD_TYPE release)
+
+set(CONFIGURE_VERSION "5.8.1")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO scivision/mumps
+    REF "v${VERSION}.0"
+    SHA512 bb28d9cbd3a355f0f2ec5a1f81f5ad78cbbd66b00832c65adcae2159a3def47227584dba7028fcc42c60b49a2e1cda223ec6b115bbc80959ccff824f0a337053
+    PATCHES
+      mumps_pc.patch
+)
+
+# Copy pkg-config template
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/mumps-solver.pc.in" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+      -DMUMPS_parallel=OFF
+)
+
+vcpkg_cmake_build()
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/mumps-solver)
+vcpkg_copy_pdbs()
+#vcpkg_fixup_pkgconfig()
+
+# Install usage file and custom FindModules
+#file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+#file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/FindMUMPS.cmake"  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+# Handle copyright
+#vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/mumps-solver/usage
+++ b/ports/mumps-solver/usage
@@ -1,0 +1,13 @@
+The package mumps provides CMake targets:
+
+	find_package(MUMPS CONFIG REQUIRED)
+
+mumps-solver uses a scivision cmake harness to build MUMPS (MUltifrontal
+Massively Parallel sparse direct Solver) for solving systems of linear
+equations of the form Ax = b where A is a square sparse matrix.
+
+The MUMPS target provides access to the Coin-Or build of mumps-solver
+with all required dependencies (BLAS, LAPACK, METIS).
+
+For more information, see:
+https://github.com/coin-or-tools/ThirdParty-Mumps

--- a/ports/mumps-solver/vcpkg.json
+++ b/ports/mumps-solver/vcpkg.json
@@ -1,0 +1,38 @@
+{
+  "name": "mumps-solver",
+  "version": "5.8.1",
+  "port-version": 1,
+  "description": "MUMPS (MUltifrontal Massively Parallel sparse direct Solver) build with scivision harness",
+  "homepage": "https://mumps-solver.org/index.php",
+  "supports": "x64 & (linux | windows)",
+  "license": "CeCILL-C",
+  "dependencies": [
+    {
+      "name": "pkgconf",
+      "platform": "windows"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "lapack",
+    "blas",
+    "metis"
+  ],
+  "features": {
+    "mpi": {
+      "description": "Enable MPI support",
+      "dependencies": [
+        "mpi",
+        "scalapack"
+      ]
+    },
+    "openmp": {
+      "description": "Enable OpenMP support"
+    }
+  }
+}


### PR DESCRIPTION
Reboot of #46813
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

