### PR TITLE
[structopt] Add port

### DIFF
--- a/ports/structopt/0000-vendored-dependencies.patch
+++ b/ports/structopt/0000-vendored-dependencies.patch
@@ -1,0 +1,79 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8c6f3dd..a85803b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,6 +36,9 @@ option(STRUCTOPT_SAMPLES "Build structopt samples")
+ include(CMakePackageConfigHelpers)
+ include(GNUInstallDirs)
+ 
++find_package(magic_enum REQUIRED)
++find_package(unofficial-visit_struct REQUIRED)
++
+ add_library(structopt INTERFACE)
+ add_library(structopt::structopt ALIAS structopt)
+ 
+@@ -43,6 +46,9 @@ target_compile_features(structopt INTERFACE cxx_std_17)
+ target_include_directories(structopt INTERFACE
+   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
++target_link_libraries(structopt INTERFACE
++  magic_enum::magic_enum
++  unofficial::visit_struct::visit_struct)
+ 
+ if(STRUCTOPT_SAMPLES)
+   add_subdirectory(samples)
+diff --git a/include/structopt/app.hpp b/include/structopt/app.hpp
+index b60cc29..c89aa5d 100644
+--- a/include/structopt/app.hpp
++++ b/include/structopt/app.hpp
+@@ -6,7 +6,7 @@
+ #include <string>
+ #include <structopt/is_stl_container.hpp>
+ #include <structopt/parser.hpp>
+-#include <structopt/third_party/visit_struct/visit_struct.hpp>
++#include <visit_struct/visit_struct.hpp>
+ #include <type_traits>
+ #include <vector>
+ 
+diff --git a/include/structopt/parser.hpp b/include/structopt/parser.hpp
+index 5ef391c..1cbfc71 100644
+--- a/include/structopt/parser.hpp
++++ b/include/structopt/parser.hpp
+@@ -13,8 +13,8 @@
+ #include <structopt/is_number.hpp>
+ #include <structopt/is_specialization.hpp>
+ #include <structopt/sub_command.hpp>
+-#include <structopt/third_party/magic_enum/magic_enum.hpp>
+-#include <structopt/third_party/visit_struct/visit_struct.hpp>
++#include <magic_enum/magic_enum.hpp>
++#include <visit_struct/visit_struct.hpp>
+ #include <tuple>
+ #include <type_traits>
+ #include <utility>
+diff --git a/include/structopt/visitor.hpp b/include/structopt/visitor.hpp
+index f36c155..dbaa619 100644
+--- a/include/structopt/visitor.hpp
++++ b/include/structopt/visitor.hpp
+@@ -7,7 +7,7 @@
+ #include <string>
+ #include <structopt/is_specialization.hpp>
+ #include <structopt/string.hpp>
+-#include <structopt/third_party/visit_struct/visit_struct.hpp>
++#include <visit_struct/visit_struct.hpp>
+ #include <type_traits>
+ #include <vector>
+ 
+diff --git a/structoptConfig.cmake.in b/structoptConfig.cmake.in
+index 8f4580f..c272fe6 100644
+--- a/structoptConfig.cmake.in
++++ b/structoptConfig.cmake.in
+@@ -2,6 +2,9 @@
+ 
+ include(CMakeFindDependencyMacro)
+ 
++find_dependency(magic_enum)
++find_dependency(unofficial-visit_struct)
++
+ if (NOT TARGET structopt::structopt)
+   include(${CMAKE_CURRENT_LIST_DIR}/structoptTargets.cmake)
+ endif ()

--- a/ports/structopt/portfile.cmake
+++ b/ports/structopt/portfile.cmake
@@ -16,9 +16,22 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 # Header-only library
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/structopt)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/structopt")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/LICENSE.magic_enum"
+        "${SOURCE_PATH}/LICENSE.visit_struct"
+)
+
+# Remove redundant license files that are installed by the library
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/licenses)
+
+configure_file(
+    "${CMAKE_CURRENT_LIST_DIR}/usage"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage"
+    COPYONLY
+)

--- a/ports/structopt/portfile.cmake
+++ b/ports/structopt/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_cmake_install()
 
 # Header-only library
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/structopt")
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/structopt/portfile.cmake
+++ b/ports/structopt/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO p-ranav/structopt
+    REF "v${VERSION}"
+    SHA512 f284ec20379a1bfecfe1622e45d0570128455ecf0c24f2a1d26420c13a277112ca7ba350e2d40c0b0b37b38eba4ffa6ff164590b32262a5ba23186f7cd904511
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSTRUCTOPT_TESTS=OFF
+        -DSTRUCTOPT_SAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+# Header-only library
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/structopt)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/structopt/portfile.cmake
+++ b/ports/structopt/portfile.cmake
@@ -21,6 +21,10 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/structopt")
 vcpkg_fixup_pkgconfig()
 
+# Delete all third-party header files vendored by the structopt library.  The library has been patched to instead use
+# the external versions of these libraries.
+file(REMOVE RECURSE "${CURRENT_PACKAGES_DIR}/include/structopt/third_party")
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 vcpkg_install_copyright(

--- a/ports/structopt/portfile.cmake
+++ b/ports/structopt/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-# Header-only library
+# Header-only library.
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/structopt")
 vcpkg_fixup_pkgconfig()
 
@@ -28,7 +28,7 @@ vcpkg_install_copyright(
         "${SOURCE_PATH}/LICENSE.visit_struct"
 )
 
-# Remove redundant license files that are installed by the library
+# Remove redundant license files that are installed by the library.
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/licenses)
 
 configure_file(

--- a/ports/structopt/portfile.cmake
+++ b/ports/structopt/portfile.cmake
@@ -23,7 +23,7 @@ vcpkg_fixup_pkgconfig()
 
 # Delete all third-party header files vendored by the structopt library.  The library has been patched to instead use
 # the external versions of these libraries.
-file(REMOVE RECURSE "${CURRENT_PACKAGES_DIR}/include/structopt/third_party")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/structopt/third_party")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/structopt/portfile.cmake
+++ b/ports/structopt/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 f284ec20379a1bfecfe1622e45d0570128455ecf0c24f2a1d26420c13a277112ca7ba350e2d40c0b0b37b38eba4ffa6ff164590b32262a5ba23186f7cd904511
     HEAD_REF master
+    PATCHES
+        0000-vendored-dependencies.patch
 )
 
 vcpkg_cmake_configure(
@@ -24,8 +26,6 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_install_copyright(
     FILE_LIST
         "${SOURCE_PATH}/LICENSE"
-        "${SOURCE_PATH}/LICENSE.magic_enum"
-        "${SOURCE_PATH}/LICENSE.visit_struct"
 )
 
 # Remove redundant license files that are installed by the library.

--- a/ports/structopt/usage
+++ b/ports/structopt/usage
@@ -1,0 +1,4 @@
+structopt provides CMake targets:
+
+    find_package(structopt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE structopt::structopt)

--- a/ports/structopt/vcpkg.json
+++ b/ports/structopt/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "structopt",
+  "version": "0.1.3",
+  "description": "Parse command line arguments by defining a struct.",
+  "homepage": "https://github.com/p-ranav/structopt",
+  "documentation": "https://github.com/p-ranav/structopt",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/structopt/vcpkg.json
+++ b/ports/structopt/vcpkg.json
@@ -6,6 +6,7 @@
   "documentation": "https://github.com/p-ranav/structopt",
   "license": "MIT",
   "dependencies": [
+    "magic-enum",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -13,6 +14,7 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
+    "visit-struct"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9284,6 +9284,10 @@
       "baseline": "2020-09-14",
       "port-version": 4
     },
+    "structopt": {
+      "baseline": "0.1.3",
+      "port-version": 0
+    },
     "stx": {
       "baseline": "1.0.5",
       "port-version": 0

--- a/versions/s-/structopt.json
+++ b/versions/s-/structopt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "79199f9442cd4f9561dde259c4c24af796aae6a5",
+      "git-tree": "460841fbc7fc71c579036efc3ae6bc96caef746f",
       "version": "0.1.3",
       "port-version": 0
     }

--- a/versions/s-/structopt.json
+++ b/versions/s-/structopt.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "46b20a10c606bc100f03427bb66a038cb54bbfb1",
+      "version": "0.1.3",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/structopt.json
+++ b/versions/s-/structopt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "460841fbc7fc71c579036efc3ae6bc96caef746f",
+      "git-tree": "6fe8231fe54a51bd1bcc1dd5ca8aff4cb5a3d10b",
       "version": "0.1.3",
       "port-version": 0
     }

--- a/versions/s-/structopt.json
+++ b/versions/s-/structopt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0bcd061b12bb5fe2639fc59feebd0ad67f8bda42",
+      "git-tree": "23873d40fd0a580e4e02c3705fded0762e72e167",
       "version": "0.1.3",
       "port-version": 0
     }

--- a/versions/s-/structopt.json
+++ b/versions/s-/structopt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6fe8231fe54a51bd1bcc1dd5ca8aff4cb5a3d10b",
+      "git-tree": "8e4e317c3ba0dead53ae587f45d27022387eba29",
       "version": "0.1.3",
       "port-version": 0
     }

--- a/versions/s-/structopt.json
+++ b/versions/s-/structopt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "23873d40fd0a580e4e02c3705fded0762e72e167",
+      "git-tree": "79199f9442cd4f9561dde259c4c24af796aae6a5",
       "version": "0.1.3",
       "port-version": 0
     }

--- a/versions/s-/structopt.json
+++ b/versions/s-/structopt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "46b20a10c606bc100f03427bb66a038cb54bbfb1",
+      "git-tree": "0bcd061b12bb5fe2639fc59feebd0ad67f8bda42",
       "version": "0.1.3",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
