### PR TITLE
[geos] update to 3.14.0

### DIFF
--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.osgeo.org/geos/geos-${VERSION}.tar.bz2"
     FILENAME "geos-${VERSION}.tar.bz2"
-    SHA512 38a6d8bb05b374160c6e5eb82e5f601915ee44e75bdba0414bb7b1096a62f3cdfbb877389998bd3ff4c77c98927ce95a8d8298dd599a0fcb8ea0e83f174f1744
+    SHA512 c9f06396af4be8231930e48f249c550578c0ed9380a0d9da24e4d602fe9f14390846d02bd95531b3bf3ff8d554f5735da0e4b975dee24932d1f488d685e4aa72
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"

--- a/ports/geos/vcpkg.json
+++ b/ports/geos/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "geos",
-  "version": "3.13.1",
+  "version": "3.14.0",
   "description": "Geometry Engine Open Source",
   "homepage": "https://libgeos.org/",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3221,7 +3221,7 @@
       "port-version": 0
     },
     "geos": {
-      "baseline": "3.13.1",
+      "baseline": "3.14.0",
       "port-version": 0
     },
     "geotrans": {

--- a/versions/g-/geos.json
+++ b/versions/g-/geos.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ddacef5ca62039b7627dfa5fa5dd657be09a8b57",
+      "version": "3.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8785de3a774e793fb7eafb7aa7163d3442a3bcbc",
       "version": "3.13.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/libgeos/geos/blob/3.14.0/NEWS.md
