### PR TITLE
 update async-mqtt port to 10.2.2

### DIFF
--- a/ports/async-mqtt/portfile.cmake
+++ b/ports/async-mqtt/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO redboltz/async_mqtt
     REF "${VERSION}"
-    SHA512 56ebe51512d4c7d552c70e971f0a08f1a6ab7abbe01c887a21287dd72970620294f3698a7aca1ca6c9ea6d408f19d863946dfd25aff5471c2d0be4e03d151feb
+    SHA512 d996582376dcf71ba841519d57343bca68f458662f40c9f33a5aa7c982e313de1bae8f11d7feb099ff13e9c4ec5957926d162bbf4eeb7fa0c61efd9e2b9bcb09
     HEAD_REF main
 )
 

--- a/ports/async-mqtt/vcpkg.json
+++ b/ports/async-mqtt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "async-mqtt",
-  "version": "10.2.1",
+  "version": "10.2.2",
   "description": "Header-only Asynchronous MQTT communication library for C++17 based on Boost.Asio.",
   "homepage": "https://github.com/redboltz/async_mqtt",
   "license": "BSL-1.0",

--- a/versions/a-/async-mqtt.json
+++ b/versions/a-/async-mqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6214788002a711cd5e7aa41c5bbf4f14f27e9f82",
+      "version": "10.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "634c9a510132ced26622c1a787b3b9ee5e080695",
       "version": "10.2.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -325,7 +325,7 @@
       "port-version": 0
     },
     "async-mqtt": {
-      "baseline": "10.2.1",
+      "baseline": "10.2.2",
       "port-version": 0
     },
     "async-simple": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
