### PR TITLE
[yajl] Fix #44841: Replace deprecated LOCATION property in CMake

### DIFF
--- a/ports/yajl/cmake.patch
+++ b/ports/yajl/cmake.patch
@@ -34,3 +34,34 @@ index 99cf9e9..454482a 100644
          LIBRARY DESTINATION lib${LIB_SUFFIX}
          ARCHIVE DESTINATION lib${LIB_SUFFIX})
  INSTALL(TARGETS yajl_s ARCHIVE DESTINATION lib${LIB_SUFFIX})
+diff --git a/verify/CMakeLists.txt b/verify/CMakeLists.txt
+index 2f39008..967fca1 100644
+--- a/verify/CMakeLists.txt
++++ b/verify/CMakeLists.txt
+@@ -29,9 +29,7 @@ ADD_EXECUTABLE(json_verify ${SRCS})
+ TARGET_LINK_LIBRARIES(json_verify yajl_s)
+ 
+ # copy in the binary
+-GET_TARGET_PROPERTY(binPath json_verify LOCATION)
+-
+ ADD_CUSTOM_COMMAND(TARGET json_verify POST_BUILD
+-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${binPath} ${binDir})
++    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:json_verify> ${binDir})
+ 
+ INSTALL(TARGETS json_verify RUNTIME DESTINATION bin)
+diff --git a/reformatter/CMakeLists.txt b/reformatter/CMakeLists.txt
+index 52a9bee..267d02e 100644
+--- a/reformatter/CMakeLists.txt
++++ b/reformatter/CMakeLists.txt
+@@ -35,9 +35,7 @@ IF (NOT WIN32)
+ ENDIF (NOT WIN32)
+ 
+ # copy the binary into the output directory
+-GET_TARGET_PROPERTY(binPath json_reformat LOCATION)
+-
+ ADD_CUSTOM_COMMAND(TARGET json_reformat POST_BUILD
+-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${binPath} ${binDir})
++    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:json_reformat> ${binDir})
+ 
+ INSTALL(TARGETS json_reformat RUNTIME DESTINATION bin)
+ 

--- a/ports/yajl/portfile.cmake
+++ b/ports/yajl/portfile.cmake
@@ -4,7 +4,8 @@ vcpkg_from_github(
     REF a0ecdde0c042b9256170f2f8890dd9451a4240aa #2.1.0
     SHA512 cf0279fdbdc21d07bc0f2d409f1dddb39fd2ad62ab9872e620f46de4753958f8c59e44ef2ee734547f0f25f9490bada8c9e97dcc1a4b14b25d3e7a7254f8e1f3
     HEAD_REF master
-    PATCHES cmake.patch
+    PATCHES 
+        cmake.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/yajl/vcpkg.json
+++ b/ports/yajl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "yajl",
   "version": "2.1.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Yet Another JSON Library",
   "homepage": "https://github.com/lloyd/yajl",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10550,7 +10550,7 @@
     },
     "yajl": {
       "baseline": "2.1.0",
-      "port-version": 4
+      "port-version": 5
     },
     "yalantinglibs": {
       "baseline": "0.5.4",

--- a/versions/y-/yajl.json
+++ b/versions/y-/yajl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a607eaa50fbca51dea1b14b5718536d7fd5977e",
+      "version": "2.1.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "3f4f50d7448d28c577777c09895a93847124e1d3",
       "version": "2.1.0",
       "port-version": 4


### PR DESCRIPTION
<!-- [yajl] Fix #44841: Replace deprecated LOCATION property in CMake -->

Fixes #44841 by resolving the CMake build error in yajl port caused by deprecated `GET_TARGET_PROPERTY(... LOCATION)` usage.

```log
CMake Error at reformatter/CMakeLists.txt:38 (GET_TARGET_PROPERTY):
  The LOCATION property may not be read from target "json_reformat".  Use the
  target name directly with add_custom_command, or use the generator
  expression $<TARGET_FILE>, as appropriate.

CMake Error at verify/CMakeLists.txt:32 (GET_TARGET_PROPERTY):
  The LOCATION property may not be read from target "json_verify".  Use the
  target name directly with add_custom_command, or use the generator
  expression $<TARGET_FILE>, as appropriate.
```

Appended fixes to the existing `cmake.patch`, Replaced deprecated `GET_TARGET_PROPERTY(LOCATION)` with generator expression `$<TARGET_FILE>` in:
- `verify/CMakeLists.txt`
- `reformatter/CMakeLists.txt`

### Verification
1. Tested on Windows (x64):
   ```powershell
   ./vcpkg install yajl
   ```
2. Build succeeds with:
   - CMake 4.0+
   - Visual Studio 2022
   - Ninja 1.12.1

### Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
