### PR TITLE
[robotraconteur] Update to version 1.2.6

### DIFF
--- a/ports/robotraconteur/portfile.cmake
+++ b/ports/robotraconteur/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO robotraconteur/robotraconteur
     REF "v${VERSION}"
-    SHA512 4fe6111909e90554fd103085149989c15186f5d2769c2ec401c6e12d185a0db1160aed2b5cc8df2552fa14acaee83106f8ed161264a97bc8ebb1068d4b7d09c9
+    SHA512 ce66b853e8beab53f10b9df310446ac97d4ba61c616f9ced560eb1d26c3d1c44bbeadf33ab109fd64295d5f6521a39eddbd14c03d847a99cdcb2d0d0511d6a87
     HEAD_REF master
 )
 

--- a/ports/robotraconteur/vcpkg.json
+++ b/ports/robotraconteur/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "robotraconteur",
-  "version-semver": "1.2.5",
+  "version-semver": "1.2.6",
   "description": "The Robot Raconteur communication framework core library",
   "homepage": "https://www.robotraconteur.com",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8453,7 +8453,7 @@
       "port-version": 0
     },
     "robotraconteur": {
-      "baseline": "1.2.5",
+      "baseline": "1.2.6",
       "port-version": 0
     },
     "robotraconteur-companion": {

--- a/versions/r-/robotraconteur.json
+++ b/versions/r-/robotraconteur.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5439a1d90e214a5629dd2a33d8995f0a5a9d786f",
+      "version-semver": "1.2.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "d8cb39d1d73341aa5918bba2d4f17d5fe22a1215",
       "version-semver": "1.2.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
