### PR TITLE
[liburing] update to 2.12

### DIFF
--- a/ports/liburing/portfile.cmake
+++ b/ports/liburing/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO axboe/liburing
     REF "liburing-${VERSION}"
-    SHA512 151d01416eeca6b9d18cb7bbd96f4f8099f1aa377f0ff808b51fa7e2c990413fe8aa7b40712c806d6a800296a58e262fe551c358ee7d23153c3bfa10aeb67eb0
+    SHA512 ccd40be43d4ea046c63d949cfddd9adb0fda531e3ae4ee17d4639b82a11eda966d8a2afd280b4e6b45f907ea1d53bbd432bfd8ae7a015609e86555a766fc850f
     HEAD_REF master
     PATCHES
         fix-configure.patch     # ignore unsupported options, handle ENABLE_SHARED

--- a/ports/liburing/vcpkg.json
+++ b/ports/liburing/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liburing",
-  "version": "2.11",
+  "version": "2.12",
   "description": "Linux-native io_uring I/O access library",
   "homepage": "https://github.com/axboe/liburing",
   "license": "(MIT OR LGPL-2.1) AND (MIT OR GPL-2.0 WITH Linux-syscall-note)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5561,7 +5561,7 @@
       "port-version": 0
     },
     "liburing": {
-      "baseline": "2.11",
+      "baseline": "2.12",
       "port-version": 0
     },
     "libusb": {

--- a/versions/l-/liburing.json
+++ b/versions/l-/liburing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0626dc526958ca9bb4c486d3d40090f4ce7bcc42",
+      "version": "2.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "202c71ea897a3ba0608fafb9e341d36700e37c6c",
       "version": "2.11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/axboe/liburing/releases/tag/liburing-2.12
