### PR TITLE
[abseil] Fix mingw monolithic dll build

### DIFF
--- a/ports/abseil/001-mingw-dll.patch
+++ b/ports/abseil/001-mingw-dll.patch
@@ -1,0 +1,13 @@
+diff --git a/CMake/AbseilDll.cmake b/CMake/AbseilDll.cmake
+--- a/CMake/AbseilDll.cmake
++++ b/CMake/AbseilDll.cmake
+@@ -839,6 +839,9 @@ function(absl_make_dll)
+       ${_dll_libs}
+       ${ABSL_DEFAULT_LINKOPTS}
+       $<$<BOOL:${ANDROID}>:-llog>
++      $<$<BOOL:${MINGW}>:-ladvapi32>
++      $<$<BOOL:${MINGW}>:-ldbghelp>
++      $<$<BOOL:${MINGW}>:-lbcrypt>
+   )
+   set_target_properties(${_dll} PROPERTIES
+     LINKER_LANGUAGE "CXX"

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 8312acf0ed74fa28c6397f3e41ada656dbd5ca2bf8db484319d74b144ad19c0ebdc77f7f03436be6c6ca1cde706b9055079233cf0d6b5ada4ca48406f8a55dd8
     HEAD_REF master
+    PATCHES 
+        "001-mingw-dll.patch" # Upstreamed (not yet in a release): https://github.com/abseil/abseil-cpp/commit/f2dee57baf19ceeb6d12cf9af7cbb3c049396ba5
 )
 
 # With ABSL_PROPAGATE_CXX_STD=ON abseil automatically detect if it is being
@@ -37,6 +39,10 @@ if(VCPKG_TARGET_IS_MINGW)
     # definition issue.
     set(ABSL_MINGW_OPTIONS "-DLIBRT=LIBRT-NOTFOUND"
         "-DCMAKE_CXX_FLAGS=-D____FIReference_1_boolean_INTERFACE_DEFINED__")
+    # Specify ABSL_BUILD_MONOLITHIC_SHARED_LIBS=ON when VCPKG_LIBRARY_LINKAGE is dynamic to match Abseil's Windows (MSVC) defaults
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+        vcpkg_list(APPEND ABSL_MINGW_OPTIONS "-DABSL_BUILD_MONOLITHIC_SHARED_LIBS=ON")
+    endif()
 endif()
 
 vcpkg_cmake_configure(

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "abseil",
   "version": "20250127.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
     "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b26fa4d70b2ca2e9d19451356a1dfd89b336096",
+      "version": "20250127.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "77d9d95320ba6300dccfde18b9bee6c93795461e",
       "version": "20250127.1",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
     },
     "abseil": {
       "baseline": "20250127.1",
-      "port-version": 3
+      "port-version": 4
     },
     "absent": {
       "baseline": "0.3.1",


### PR DESCRIPTION
Fixes abseil monolithic .dll build (when using mingw), incorporates upstreamed patch (which isn't yet in a release)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
