### PR TITLE
add new port sourcemeta blaze

### DIFF
--- a/ports/sourcemeta-blaze/portfile.cmake
+++ b/ports/sourcemeta-blaze/portfile.cmake
@@ -6,21 +6,12 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-#vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-#    FEATURES
-#        lapack   USE_LAPACK
-#        openmp   BLAZE_SHARED_MEMORY_PARALLELIZATION
-#)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
 
-#vcpkg_cmake_config_fixup(CONFIG_PATH share/blaze/cmake)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/sourcemeta-blaze/portfile.cmake
+++ b/ports/sourcemeta-blaze/portfile.cmake
@@ -12,8 +12,5 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sourcemeta-blaze/portfile.cmake
+++ b/ports/sourcemeta-blaze/portfile.cmake
@@ -12,5 +12,12 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+vcpkg_cmake_config_fixup(PACKAGE_NAME blaze CONFIG_PATH "lib/cmake/blaze")
+
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sourcemeta-blaze/portfile.cmake
+++ b/ports/sourcemeta-blaze/portfile.cmake
@@ -11,6 +11,12 @@ vcpkg_from_github(
 file(REMOVE_RECURSE "${SOURCE_PATH}/vendor/core/vendor/boost-regex")
 file(REMOVE_RECURSE "${SOURCE_PATH}/vendor/core/vendor/uriparser")
 file(REMOVE_RECURSE "${SOURCE_PATH}/vendor/core/vendor/yaml")
+file(REMOVE_RECURSE "${SOURCE_PATH}/vendor/vendorpull")
+file(REMOVE_RECURSE "${SOURCE_PATH}/vendor/jsonschema-test-suite")
+file(REMOVE_RECURSE "${SOURCE_PATH}/vendor/core/vendor/googletest")
+file(REMOVE_RECURSE "${SOURCE_PATH}/vendor/core/vendor/googlebenchmark")
+
+
 
 
 vcpkg_cmake_configure(

--- a/ports/sourcemeta-blaze/portfile.cmake
+++ b/ports/sourcemeta-blaze/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO sourcemeta/blaze
+    REF 51a6158e5094c7881a68c0e9411023f1b1822a9f
+    SHA512 69d85f0eac77fdc73a0689df209c3241ea311a9599ee89bff62abbfc24c2a23848f8ea761e0b4efadd976024601f3b2a7c0ebb6ed696a16bfd976aabf6da2daf
+    HEAD_REF master
+)
+
+#vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+#    FEATURES
+#        lapack   USE_LAPACK
+#        openmp   BLAZE_SHARED_MEMORY_PARALLELIZATION
+#)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+#vcpkg_cmake_config_fixup(CONFIG_PATH share/blaze/cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sourcemeta-blaze/portfile.cmake
+++ b/ports/sourcemeta-blaze/portfile.cmake
@@ -8,6 +8,11 @@ vcpkg_from_github(
         use_vcpkg_libs.patch
 )
 
+file(REMOVE_RECURSE "${SOURCE_PATH}/vendor/core/vendor/boost-regex")
+file(REMOVE_RECURSE "${SOURCE_PATH}/vendor/core/vendor/uriparser")
+file(REMOVE_RECURSE "${SOURCE_PATH}/vendor/core/vendor/yaml")
+
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )

--- a/ports/sourcemeta-blaze/portfile.cmake
+++ b/ports/sourcemeta-blaze/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 51a6158e5094c7881a68c0e9411023f1b1822a9f
     SHA512 69d85f0eac77fdc73a0689df209c3241ea311a9599ee89bff62abbfc24c2a23848f8ea761e0b4efadd976024601f3b2a7c0ebb6ed696a16bfd976aabf6da2daf
     HEAD_REF master
+    PATCHES
+        use_vcpkg_libs.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/sourcemeta-blaze/use_vcpkg_libs.patch
+++ b/ports/sourcemeta-blaze/use_vcpkg_libs.patch
@@ -1,0 +1,19 @@
+diff --git a/vendor/core/CMakeLists.txt b/vendor/core/CMakeLists.txt
+index e30b6b3..9dfa331 100644
+--- a/vendor/core/CMakeLists.txt
++++ b/vendor/core/CMakeLists.txt
+@@ -41,12 +41,12 @@ if(SOURCEMETA_CORE_INSTALL)
+ endif()
+ 
+ if(SOURCEMETA_CORE_REGEX)
+-  find_package(BoostRegex REQUIRED)
++  find_package(Boost REQUIRED COMPONENTS regex) 
+   add_subdirectory(src/core/regex)
+ endif()
+ 
+ if(SOURCEMETA_CORE_URI)
+-  find_package(UriParser REQUIRED)
++  find_package(uriparser CONFIG REQUIRED char wchar_t)
+   add_subdirectory(src/core/uri)
+ endif()
+ 

--- a/ports/sourcemeta-blaze/vcpkg.json
+++ b/ports/sourcemeta-blaze/vcpkg.json
@@ -7,6 +7,7 @@
   "supports": "!arm",
   "dependencies": [
     "boost-regex",
+    "libyaml",
     "uriparser",
     {
       "name": "vcpkg-cmake",

--- a/ports/sourcemeta-blaze/vcpkg.json
+++ b/ports/sourcemeta-blaze/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sourcemeta-blaze",
   "version": "1.0.0",
-  "port-version": 0,
   "description": "The ultra high-performance C++ JSON Schema validator, providing validation in the nano-second range along with perfect compliance scores. Supports Draft 4, Draft 6, Draft 7, 2019-09 and 2020-12. For both servers and embedded devices",
   "homepage": "https://blaze.sourcemeta.com",
   "license": "BSD-3-Clause",

--- a/ports/sourcemeta-blaze/vcpkg.json
+++ b/ports/sourcemeta-blaze/vcpkg.json
@@ -5,7 +5,6 @@
   "homepage": "https://blaze.sourcemeta.com",
   "license": "BSD-3-Clause",
   "dependencies": [
-    "boost-exception",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/sourcemeta-blaze/vcpkg.json
+++ b/ports/sourcemeta-blaze/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "sourcemeta-blaze",
+  "version": "1.0.0",
+  "port-version": 0,
+  "description": "The ultra high-performance C++ JSON Schema validator, providing validation in the nano-second range along with perfect compliance scores. Supports Draft 4, Draft 6, Draft 7, 2019-09 and 2020-12. For both servers and embedded devices",
+  "homepage": "https://blaze.sourcemeta.com",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "boost-exception",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/sourcemeta-blaze/vcpkg.json
+++ b/ports/sourcemeta-blaze/vcpkg.json
@@ -5,6 +5,8 @@
   "homepage": "https://blaze.sourcemeta.com",
   "license": "BSD-3-Clause",
   "dependencies": [
+    "boost-regex",
+    "uriparser",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/sourcemeta-blaze/vcpkg.json
+++ b/ports/sourcemeta-blaze/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "The ultra high-performance C++ JSON Schema validator, providing validation in the nano-second range along with perfect compliance scores. Supports Draft 4, Draft 6, Draft 7, 2019-09 and 2020-12. For both servers and embedded devices",
   "homepage": "https://blaze.sourcemeta.com",
   "license": "BSD-3-Clause",
+  "supports": "!arm",
   "dependencies": [
     "boost-regex",
     "uriparser",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9028,6 +9028,10 @@
       "baseline": "2.3.3",
       "port-version": 0
     },
+    "sourcemeta-blaze": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "soxr": {
       "baseline": "0.1.3",
       "port-version": 8

--- a/versions/s-/sourcemeta-blaze.json
+++ b/versions/s-/sourcemeta-blaze.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "115217a7e0608e9faa4cffd58de31573f16e66e8",
+      "git-tree": "1fe6c912b382589592f0691158cc1e07c4428976",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/s-/sourcemeta-blaze.json
+++ b/versions/s-/sourcemeta-blaze.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "95b08600c800de907b52e13c7b77b0df9af144ba",
+      "git-tree": "90dda9229e546d9c7b80a1dd91321b19e1ed9c1b",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/s-/sourcemeta-blaze.json
+++ b/versions/s-/sourcemeta-blaze.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6daad4c694dcf04cbc82d0fcb8802af217a06494",
+      "git-tree": "c74887dab57f282f7d44fe22bac99caa8ca24994",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/s-/sourcemeta-blaze.json
+++ b/versions/s-/sourcemeta-blaze.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c74887dab57f282f7d44fe22bac99caa8ca24994",
+      "git-tree": "95b08600c800de907b52e13c7b77b0df9af144ba",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/s-/sourcemeta-blaze.json
+++ b/versions/s-/sourcemeta-blaze.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0ee046dd16c80d7468275a956d92ff39ac7f4fb9",
+      "git-tree": "0ff3794b90954f5dbdad399cc40e311961733ad5",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/s-/sourcemeta-blaze.json
+++ b/versions/s-/sourcemeta-blaze.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "90dda9229e546d9c7b80a1dd91321b19e1ed9c1b",
+      "git-tree": "53ff2a96162c89bfbfd7a8db2f0a303220af48ca",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/s-/sourcemeta-blaze.json
+++ b/versions/s-/sourcemeta-blaze.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0ff3794b90954f5dbdad399cc40e311961733ad5",
+      "git-tree": "6daad4c694dcf04cbc82d0fcb8802af217a06494",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/s-/sourcemeta-blaze.json
+++ b/versions/s-/sourcemeta-blaze.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0ee046dd16c80d7468275a956d92ff39ac7f4fb9",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/sourcemeta-blaze.json
+++ b/versions/s-/sourcemeta-blaze.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "53ff2a96162c89bfbfd7a8db2f0a303220af48ca",
+      "git-tree": "115217a7e0608e9faa4cffd58de31573f16e66e8",
       "version": "1.0.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

- [x ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
