### PR TITLE
[usearch] update to 2.19.4

### DIFF
--- a/ports/usearch/portfile.cmake
+++ b/ports/usearch/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO unum-cloud/usearch
     REF "v${VERSION}"
-    SHA512 d023759cfb2c21811ce5e5df0ea7b344326cc45ab9a6b4e72e95a7db1cf157c282241920e3aeae4a8028bd1fa5c186b910a8fd4baa568209208aeed182615f81
+    SHA512 f69b9541d4713bdcb6d79f2870ffc89a9173fc4b4db7ae9ac5c25349b9f29e263036f8ba8fbbe3401b5b9a30e89ee2f25e2d338e7f6bc7cde339460de812c604
     HEAD_REF main
     PATCHES
         use-vcpkg-ports.patch

--- a/ports/usearch/vcpkg.json
+++ b/ports/usearch/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "usearch",
-  "version": "2.17.11",
+  "version": "2.19.9",
   "description": "Fastest Search & Clustering engine × for Vectors & Strings",
   "homepage": "https://github.com/unum-cloud/usearch",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9877,7 +9877,7 @@
       "port-version": 0
     },
     "usearch": {
-      "baseline": "2.17.11",
+      "baseline": "2.19.9",
       "port-version": 0
     },
     "usockets": {

--- a/versions/u-/usearch.json
+++ b/versions/u-/usearch.json
@@ -1,6 +1,16 @@
 {
   "versions": [
     {
+      "git-tree": "cf9e2113dc67f82c120f1b614f9f3102216b43b8",
+      "version": "2.19.9",
+      "port-version": 0
+    },
+    {
+      "git-tree": "f5d6b1ee8626ee1e13c636efa670638213a6b60a",
+      "version": "2.19.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "7e0ed4683a54d93826a849200292c5eab2e10ad1",
       "version": "2.17.11",
       "port-version": 0

--- a/versions/u-/usearch.json
+++ b/versions/u-/usearch.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "f5d6b1ee8626ee1e13c636efa670638213a6b60a",
-      "version": "2.19.4",
-      "port-version": 0
-    },
-    {
       "git-tree": "7e0ed4683a54d93826a849200292c5eab2e10ad1",
       "version": "2.17.11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/unum-cloud/usearch/releases/tag/v2.19.9