### PR TITLE
[libxml2] Cleanup

### DIFF
--- a/ports/azure-storage-cpp/cmake.diff
+++ b/ports/azure-storage-cpp/cmake.diff
@@ -1,0 +1,37 @@
+diff --git a/Microsoft.WindowsAzure.Storage/CMakeLists.txt b/Microsoft.WindowsAzure.Storage/CMakeLists.txt
+index ac9e65d..5827dec 100644
+--- a/Microsoft.WindowsAzure.Storage/CMakeLists.txt
++++ b/Microsoft.WindowsAzure.Storage/CMakeLists.txt
+@@ -21,7 +21,7 @@ option(BUILD_SAMPLES "Build sample codes" OFF)
+ if(UNIX)
+   find_package(Boost REQUIRED COMPONENTS log log_setup random system thread locale regex filesystem chrono date_time)
+   find_package(Threads REQUIRED)
+-  if(APPLE AND NOT OPENSSL_ROOT_DIR)
++  if(0)
+     # Prefer a homebrew version of OpenSSL over the one in /usr/lib
+     file(GLOB OPENSSL_ROOT_DIR /usr/local/Cellar/openssl/*)
+ 
+@@ -135,6 +135,9 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+ else()
+   message("-- Unknown compiler, success is doubtful.")
+ endif()
++if(NOT WIN32)
++  add_definitions(-D_NO_WASTORAGE_API) # no dllimport
++endif()
+ 
+ # Reconfigure final output directory
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/Binaries)
+@@ -142,11 +145,11 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/Binaries)
+ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/Binaries)
+ 
+ set(AZURESTORAGE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/includes)
+-set(AZURESTORAGE_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/includes ${CASABLANCA_INCLUDE_DIR} ${Boost_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIRS} ${UUID_INCLUDE_DIRS} ${LibXML2_INCLUDE_DIR})
++set(AZURESTORAGE_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/includes ${CASABLANCA_INCLUDE_DIR} ${Boost_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIRS} ${UUID_INCLUDE_DIRS} ${LIBXML2_INCLUDE_DIRS})
+ 
+ 
+ set(AZURESTORAGE_LIBRARY azurestorage)
+-set(AZURESTORAGE_LIBRARIES ${AZURESTORAGE_LIBRARY} ${CASABLANCA_LIBRARY} ${Boost_LIBRARIES} ${Boost_FRAMEWORK} ${OPENSSL_LIBRARIES} ${UUID_LIBRARIES} ${LibXML2_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
++set(AZURESTORAGE_LIBRARIES ${AZURESTORAGE_LIBRARY} ${CASABLANCA_LIBRARY} ${Boost_LIBRARIES} ${Boost_FRAMEWORK} ${OPENSSL_LIBRARIES} ${UUID_LIBRARIES} ${LIBXML2_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+ 
+ # Set version numbers centralized
+ set (AZURESTORAGE_VERSION_MAJOR 7)

--- a/ports/azure-storage-cpp/portfile.cmake
+++ b/ports/azure-storage-cpp/portfile.cmake
@@ -7,10 +7,10 @@ vcpkg_from_github(
     SHA512 83eabcaf2114c8af1cabbc96b6ef2b57c934a06f68e7a870adf336feaa19edd57aedaf8507d5c40500e46d4e77f5059f9286e319fe7cadeb9ffc8fa018fb030c
     HEAD_REF master
     PATCHES
+        cmake.diff
         fix-asio-error.patch
 )
-
-vcpkg_replace_string("${SOURCE_PATH}/Microsoft.WindowsAzure.Storage/CMakeLists.txt" [[file(GLOB OPENSSL_ROOT_DIR /usr/local/Cellar/openssl/*)]] "")
+file(REMOVE_RECURSE "${SOURCE_PATH}/Microsoft.WindowsAzure.Storage/cmake/Modules/FindLibXML2.cmake")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/Microsoft.WindowsAzure.Storage"
@@ -18,18 +18,10 @@ vcpkg_cmake_configure(
         -DCMAKE_FIND_FRAMEWORK=LAST
         -DBUILD_TESTS=OFF
         -DBUILD_SAMPLES=OFF
-    OPTIONS_RELEASE
-        "-DGETTEXT_LIB_DIR=${CURRENT_INSTALLED_DIR}/lib"
-    OPTIONS_DEBUG
-        "-DGETTEXT_LIB_DIR=${CURRENT_INSTALLED_DIR}/debug/lib"
 )
-
 vcpkg_cmake_install()
-
-file(INSTALL
-    "${SOURCE_PATH}/LICENSE.txt"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug/include")
-
 vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/azure-storage-cpp/vcpkg.json
+++ b/ports/azure-storage-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-storage-cpp",
   "version": "7.5.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": [
     "[legacy] Microsoft Azure Storage Client SDK for C++",
     "A client library for working with Microsoft Azure storage services including blobs, files, tables, and queues. This client library enables working with the Microsoft Azure storage services which include the blob service for storing binary and text data, the file service for storing binary and text data, the table service for storing structured non-relational data, and the queue service for storing messages that may be accessed by a client."
@@ -24,10 +24,6 @@
     {
       "name": "cpprestsdk",
       "default-features": false
-    },
-    {
-      "name": "gettext",
-      "platform": "osx"
     },
     {
       "name": "libuuid",

--- a/ports/libxml2/disable-xml2-config.diff
+++ b/ports/libxml2/disable-xml2-config.diff
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3850f6b..8beb11e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -669,7 +669,6 @@ if(1)
+     set(prefix "\$(cd \"\$(dirname \"\$0\")\"; pwd -P)/..")
+ endif()
+ configure_file(xml2-config.in xml2-config @ONLY)
+-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/xml2-config DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT development)
+ 
+ set(XML_INCLUDEDIR "-I${CMAKE_INSTALL_FULL_INCLUDEDIR}/libxml2")
+ set(XML_LIBDIR "-L${CMAKE_INSTALL_FULL_LIBDIR}")

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libxml2",
   "version": "2.14.5",
+  "port-version": 1,
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
   "license": "MIT",
@@ -19,10 +20,6 @@
     "zlib"
   ],
   "features": {
-    "ftp": {
-      "description": "Add the FTP support",
-      "supports": "!uwp"
-    },
     "http": {
       "description": "Add the HTTP support",
       "supports": "!uwp"

--- a/versions/a-/azure-storage-cpp.json
+++ b/versions/a-/azure-storage-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "295bce473cb862b963b9e212b3926e7295f7aa14",
+      "version": "7.5.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "8097d65acc403bcb0dc6cd5970ce78cc55f53498",
       "version": "7.5.0",
       "port-version": 7

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5714,7 +5714,7 @@
     },
     "libxml2": {
       "baseline": "2.14.5",
-      "port-version": 0
+      "port-version": 1
     },
     "libxmlb": {
       "baseline": "0.3.22",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -570,7 +570,7 @@
     },
     "azure-storage-cpp": {
       "baseline": "7.5.0",
-      "port-version": 7
+      "port-version": 8
     },
     "azure-storage-files-datalake-cpp": {
       "baseline": "12.12.0",

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80ab30fe4e56a98c8dd5045e191ef29780129394",
+      "version": "2.14.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "8e80e2104513a62275ab5ea5412acbf5a02d73fd",
       "version": "2.14.5",
       "port-version": 0


### PR DESCRIPTION
FTP support was removed in 2.14.0.
Tree became non-optional in 2.14.0.
ml2Conf.sh was removed.