### PR TITLE
[libwebp] SIMD is optional on emscripten

### DIFF
--- a/ports/libwebp/vcpkg.json
+++ b/ports/libwebp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libwebp",
   "version": "1.6.0",
+  "port-version": 1,
   "description": "WebP codec: library to encode and decode images in WebP format",
   "homepage": "https://github.com/webmproject/libwebp",
   "license": "BSD-3-Clause",
@@ -33,7 +34,10 @@
   "default-features": [
     "libwebpmux",
     "nearlossless",
-    "simd"
+    {
+      "name": "simd",
+      "platform": "!emscripten"
+    }
   ],
   "features": {
     "all": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5630,7 +5630,7 @@
     },
     "libwebp": {
       "baseline": "1.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libwebsockets": {
       "baseline": "4.3.5",

--- a/versions/l-/libwebp.json
+++ b/versions/l-/libwebp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c0a4a598eacd380393ff3a92be045f4474643649",
+      "version": "1.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d9dee7fa77c6779e018d20afd7f216813dc33f7c",
       "version": "1.6.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #47026.

Reflects upstream default:
https://github.com/webmproject/libwebp/blob/1.6.0/CMakeLists.txt#L26-L32