### PR TITLE
[quazip] update to 1.5

### DIFF
--- a/ports/quazip/portfile.cmake
+++ b/ports/quazip/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stachenov/quazip
-    REF v1.4
-    SHA512 38ce3aa77df1fd92229454e56b7290c066d1e319afa36a9f8ec8477004ae94df682e8f454f13cdaf586a1d0b0e033fe698081033a19536ecd53dd1e4b0204af9
+    REF v1.5
+    SHA512 c88850f1672d20c375798c58d1cb77744ca63e93b379cf3035a528b57e83a52c1908023870152ce5fc49ad0ccf93d723dbc730b8c1d2abe18cf0b13fba3be1e1
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -19,7 +19,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/QuaZip-Qt6-1.4 PACKAGE_NAME quazip-qt6)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/QuaZip-Qt6-1.5 PACKAGE_NAME quazip-qt6)
 vcpkg_copy_pdbs()
 # Qt6 pkg-config files not installed https://github.com/microsoft/vcpkg/issues/25988
 # vcpkg_fixup_pkgconfig()

--- a/ports/quazip/vcpkg.json
+++ b/ports/quazip/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "quazip",
-  "version": "1.4",
-  "port-version": 1,
+  "version": "1.5",
   "description": "Qt/C++ wrapper over minizip",
   "homepage": "https://stachenov.github.io/quazip/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8165,8 +8165,8 @@
       "port-version": 2
     },
     "quazip": {
-      "baseline": "1.4",
-      "port-version": 1
+      "baseline": "1.5",
+      "port-version": 0
     },
     "quickfast": {
       "baseline": "1.5",

--- a/versions/q-/quazip.json
+++ b/versions/q-/quazip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6c7887586f49b43528a0095deb5ae5605922bf79",
+      "version": "1.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "0e981c8d145807aac756fc5e289f7190cf106c91",
       "version": "1.4",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.