### PR TITLE
[pybind11] update to 3.0.1

### DIFF
--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pybind/pybind11
     REF "v${VERSION}"
-    SHA512 a68a5eb3253db771308ed0922852207e6dc9a3089ad055ba3ccd36690f68b93cad98cc1a3ab822eb653153af2eeef10e6f6272b93314b2da1119e17f6c63337b
+    SHA512 c17e6d6a78c38e760864b390ac2aa7df6a94ca53acb2e8be71f0d63d611b738fa20a16946c98a93fbfcad56cb0346ebf247bbe41c6f5171c6ce68397b1e5c4db
     HEAD_REF master
     PATCHES
         android.diff

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pybind11",
-  "version": "3.0.0",
-  "port-version": 1,
+  "version": "3.0.1",
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "documentation": "https://pybind11.readthedocs.io/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7693,8 +7693,8 @@
       "port-version": 0
     },
     "pybind11": {
-      "baseline": "3.0.0",
-      "port-version": 1
+      "baseline": "3.0.1",
+      "port-version": 0
     },
     "pystring": {
       "baseline": "1.1.4",

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c5d74751c919edb2c3c7a183ee633df69c45c15",
+      "version": "3.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3694d18de24e069c089c610eb2b7dfc8c252eec2",
       "version": "3.0.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/pybind/pybind11/releases/tag/v3.0.1
