### PR TITLE
[onnx] update to 1.19.0

### DIFF
--- a/ports/onnx-optimizer/dimension-explicit.patch
+++ b/ports/onnx-optimizer/dimension-explicit.patch
@@ -1,0 +1,13 @@
+diff --git a/onnxoptimizer/passes/fuse_add_bias_into_conv.h b/onnxoptimizer/passes/fuse_add_bias_into_conv.h
+index b4696b5..065bb68 100644
+--- a/onnxoptimizer/passes/fuse_add_bias_into_conv.h
++++ b/onnxoptimizer/passes/fuse_add_bias_into_conv.h
+@@ -134,7 +134,7 @@ struct FuseAddBiasIntoConv final : public PredicateBasedPass {
+         t.elem_type() = TensorProto_DataType_INT64;
+         Symbol sym = Symbol("value");
+         constant->t_(sym, t);
+-        std::vector<Dimension> s = {1};
++        std::vector<Dimension> s{Dimension{1}};
+         constant->output()->setSizes(s);
+         constant->output()->setElemType(TensorProto_DataType_INT64);
+         constant->insertBefore(orig_conv->node());

--- a/ports/onnx-optimizer/portfile.cmake
+++ b/ports/onnx-optimizer/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-cmakelists.patch
+        # from upstream commit https://github.com/onnx/optimizer/commit/31194ccb971bbbcc8218e103c7b0a8049ddddc3e
+        dimension-explicit.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" USE_STATIC_RUNTIME)

--- a/ports/onnx-optimizer/vcpkg.json
+++ b/ports/onnx-optimizer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "onnx-optimizer",
   "version-semver": "0.3.19",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Actively maintained ONNX Optimizer",
   "homepage": "https://github.com/onnx/optimizer",
   "license": "Apache-2.0",

--- a/ports/onnx/fix-cmakelists.patch
+++ b/ports/onnx/fix-cmakelists.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b666eec..66c234d 100644
+index 4799557..70feae9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -63,6 +63,16 @@ endif()
+@@ -91,6 +91,16 @@ endif()
  
  include(GNUInstallDirs)
  
@@ -16,16 +16,6 @@ index b666eec..66c234d 100644
 +        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnx
 +)
 +
- set(ONNX_ROOT ${PROJECT_SOURCE_DIR})
+ set(ONNX_ROOT ${onnx_SOURCE_DIR})
  
  # Read ONNX version
-@@ -104,7 +114,8 @@ endif()
- # find_package Python has replaced PythonInterp and PythonLibs since cmake 3.12
- # Use the following command in the future; now this is only compatible with the latest pybind11
- # find_package(Python ${PY_VERSION} COMPONENTS Interpreter Development REQUIRED)
--find_package(PythonInterp ${PY_VERSION} REQUIRED)
-+find_package(Python3 ${PY_VERSION} COMPONENTS Interpreter REQUIRED)
-+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
- if(BUILD_ONNX_PYTHON)
-   find_package(PythonLibs ${PY_VERSION})
- endif()

--- a/ports/onnx/fix-cxx_standard.patch
+++ b/ports/onnx/fix-cxx_standard.patch
@@ -1,12 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 55869f4..e8b20cb 100644
+index 8bed591..ccbf050 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -524,6 +524,7 @@ else()
-   set_target_properties(onnx_proto PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
- endif()
- target_compile_definitions(onnx_proto PRIVATE ${ONNX_API_DEFINE})
+@@ -434,7 +434,7 @@ list(APPEND ONNX_SRCS ${__tmp_srcs})
+ # Hide all symbols we don't need
+ set_target_properties(onnx_proto PROPERTIES CXX_VISIBILITY_PRESET hidden)
+ set_target_properties(onnx_proto PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
+-
 +target_compile_features(onnx_proto PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
- 
+ set(LINKED_PROTOBUF_TARGET protobuf::libprotobuf)
  if(ONNX_USE_LITE_PROTO)
    if(TARGET protobuf::libprotobuf-lite)

--- a/ports/onnx/fix-dependency-protobuf.patch
+++ b/ports/onnx/fix-dependency-protobuf.patch
@@ -1,28 +1,26 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d81ac1d..9f97998 100644
+index 4799557..8bed591 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -149,6 +149,7 @@ if(ONNX_BUILD_TESTS)
-   set(googletest_STATIC_LIBRARIES GTest::gtest)
- endif()
+@@ -181,6 +181,7 @@ endif()
  
-+find_package(Protobuf CONFIG REQUIRED)
- if((ONNX_USE_LITE_PROTO AND TARGET protobuf::libprotobuf-lite) OR ((NOT ONNX_USE_LITE_PROTO) AND TARGET protobuf::libprotobuf))
-   # Sometimes we need to use protoc compiled for host architecture while linking
-   # libprotobuf against target architecture. See https://github.com/caffe2/caffe
+ list(APPEND CMAKE_MODULE_PATH ${ONNX_ROOT}/cmake/external)
+ if(NOT ONNX_BUILD_CUSTOM_PROTOBUF)
++  find_package(Protobuf CONFIG REQUIRED)
+   if((ONNX_USE_LITE_PROTO AND TARGET protobuf::libprotobuf-lite) OR ((NOT ONNX_USE_LITE_PROTO) AND TARGET protobuf::libprotobuf))
+     # Sometimes we need to use protoc compiled for host architecture while linking
+     # libprotobuf against target architecture. See https://github.com/caffe2/caffe
 diff --git a/cmake/ONNXConfig.cmake.in b/cmake/ONNXConfig.cmake.in
-index d588f8a..dbd4398 100644
+index a5129bf..19cee03 100644
 --- a/cmake/ONNXConfig.cmake.in
 +++ b/cmake/ONNXConfig.cmake.in
-@@ -6,9 +6,8 @@
- # library version information
+@@ -5,7 +5,8 @@
  set(ONNX_VERSION "@ONNX_VERSION@")
  
--list(APPEND CMAKE_PREFIX_PATH "@PROTOBUF_DIR@")
--set(Protobuf_INCLUDE_DIR "@PROTOBUF_INCLUDE_DIR@")
--find_package(Protobuf REQUIRED)
-+include(CMakeFindDependencyMacro)
-+find_dependency(Protobuf CONFIG)
+ if((NOT @@ONNX_USE_PROTOBUF_SHARED_LIBS@@) AND @@Build_Protobuf@@)
+-  find_package(Protobuf REQUIRED CONFIG)
++  include(CMakeFindDependencyMacro)
++  find_dependency(Protobuf CONFIG)
+ endif()
  
  # import targets
- include ("${CMAKE_CURRENT_LIST_DIR}/ONNXTargets.cmake")

--- a/ports/onnx/portfile.cmake
+++ b/ports/onnx/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO onnx/onnx
     REF "v${VERSION}"
-    SHA512 5a18e2b19ec9c18c8b115fb7e12ed98eddaa581c95f15c4dd420cd6c86e7caa04f9a393da589e76b89cf9b3544abd3749a8c77c2446782f37502eb74e9b1f661
+    SHA512 e6f7b5782a43a91783607549e4d0f0a9cbd46dfb67a602f81aaffc7bcdd8f450fe9c225f0bc314704f2923e396f0df5b03ea91af4a7887203c0b8372bc2749d0
     PATCHES
         fix-cmakelists.patch
         fix-dependency-protobuf.patch

--- a/ports/onnx/vcpkg.json
+++ b/ports/onnx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "onnx",
-  "version-semver": "1.17.0",
-  "port-version": 2,
+  "version-semver": "1.19.0",
   "description": "Open standard for machine learning interoperability",
   "homepage": "https://onnx.ai",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6949,8 +6949,8 @@
       "port-version": 0
     },
     "onnx": {
-      "baseline": "1.17.0",
-      "port-version": 2
+      "baseline": "1.19.0",
+      "port-version": 0
     },
     "onnx-optimizer": {
       "baseline": "0.3.19",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6954,7 +6954,7 @@
     },
     "onnx-optimizer": {
       "baseline": "0.3.19",
-      "port-version": 1
+      "port-version": 2
     },
     "onnxruntime-gpu": {
       "baseline": "1.19.2",

--- a/versions/o-/onnx-optimizer.json
+++ b/versions/o-/onnx-optimizer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c3a60f46286ff0104677e13fe1a49e2a1f8f6c3",
+      "version-semver": "0.3.19",
+      "port-version": 2
+    },
+    {
       "git-tree": "df755dc18bda1d4c02a54db6cef63e46021ce872",
       "version-semver": "0.3.19",
       "port-version": 1

--- a/versions/o-/onnx.json
+++ b/versions/o-/onnx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "81fc417d50710acbd0b8849956420f1385d43880",
+      "version-semver": "1.19.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5db9b37d64932bc2c245c5ce52daded31de03a9e",
       "version-semver": "1.17.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/onnx/onnx/releases/tag/v1.19.0
