### PR TITLE
[pcre2] update to 10.46

### DIFF
--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PCRE2Project/pcre2
     REF "pcre2-${VERSION}"
-    SHA512 2c4fd0bcd6c4f606627c17336d583e14d7bd3f5cd5ab0219ded46e7d784a792a8bbd33332fd06772f451041c046e15d1feaa6b48d8f9aa00dcddbc6cdb89be92
+    SHA512 c945dfcf31795ab9ed2a19fec775087b3daaa64235a632260e7d8c7fc9fcb7f47321540670bd05cf691af52dd8df5679d148ef0829276163d5db3cecd0e7c2da
     HEAD_REF master
     PATCHES
         pcre2-10.35_fix-uwp.patch

--- a/ports/pcre2/vcpkg.json
+++ b/ports/pcre2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pcre2",
-  "version": "10.45",
+  "version": "10.46",
   "description": "Regular Expression pattern matching using the same syntax and semantics as Perl 5.",
   "homepage": "https://github.com/PCRE2Project/pcre2",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7305,7 +7305,7 @@
       "port-version": 7
     },
     "pcre2": {
-      "baseline": "10.45",
+      "baseline": "10.46",
       "port-version": 0
     },
     "pdal": {

--- a/versions/p-/pcre2.json
+++ b/versions/p-/pcre2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b9e8bfd3ac8c49f5399e82a016319f1c256a1cc4",
+      "version": "10.46",
+      "port-version": 0
+    },
+    {
       "git-tree": "c3bbfe8c53a8712c9a988361cfb476af65fc0bee",
       "version": "10.45",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/PCRE2Project/pcre2/releases/tag/pcre2-10.46
