### PR TITLE
[libogg] Switch to GitHub repo (due to gitlab repo availability, downtime)

### DIFF
--- a/ports/libogg/portfile.cmake
+++ b/ports/libogg/portfile.cmake
@@ -1,9 +1,8 @@
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.xiph.org
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiph/ogg
     REF v${VERSION}
-    SHA512 c41b71a0fcedd97251d01e1a61fd94f6185b2ab0fba96c38e878d354b488b0e9a9a9782674bc06f08c281681c3ddd775be704685d3f6a65131096caa46f261ba
+    SHA512 c247e1da8b12f8b33272fafb6d7c171a1a2687c3632977439fa60b96ccc2ad751d88a2931bb3e18e1ddf2eea2e82cdd0aab087b2ec5393a9228c703476fa0167
     HEAD_REF master
 )
 

--- a/ports/libogg/vcpkg.json
+++ b/ports/libogg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libogg",
   "version": "1.3.6",
+  "port-version": 1,
   "description": "Ogg is a multimedia container format, and the native file and stream format for the Xiph.org multimedia codecs.",
   "homepage": "https://www.xiph.org/ogg",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5178,7 +5178,7 @@
     },
     "libogg": {
       "baseline": "1.3.6",
-      "port-version": 0
+      "port-version": 1
     },
     "libopenmpt": {
       "baseline": "0.7.13",

--- a/versions/l-/libogg.json
+++ b/versions/l-/libogg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0631c72b35b0e169220b9c0fa9a6af4b229268cb",
+      "version": "1.3.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "c203f0f666f0a1641c5ff3d865bc0be87b808879",
       "version": "1.3.6",
       "port-version": 0


### PR DESCRIPTION
Xiph's Gitlab seems to be having repeated issues (constantly going up and down). This PR switches back to Xiph's GitHub repo, which has stable availability.

EDIT: Seems like the xiph gitlab repo may _currently_ be up-and-running again, but will leave this open for consideration.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.