### PR TITLE
[json11] Fix build for GCC 15

### DIFF
--- a/ports/json11/fix-gcc15-build.patch
+++ b/ports/json11/fix-gcc15-build.patch
@@ -1,0 +1,73 @@
+diff --git a/json11.cpp b/json11.cpp
+index 9647846..509dfdd 100644
+--- a/json11.cpp
++++ b/json11.cpp
+@@ -22,6 +22,7 @@
+ #include "json11.hpp"
+ #include <cassert>
+ #include <cmath>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstdio>
+ #include <limits>
+@@ -151,7 +152,7 @@ protected:
+
+     // Constructors
+     explicit Value(const T &value) : m_value(value) {}
+-    explicit Value(T &&value)      : m_value(move(value)) {}
++    explicit Value(T &&value)      : m_value(std::move(value)) {}
+
+     // Get type tag
+     Json::Type type() const override {
+@@ -198,7 +199,7 @@ class JsonString final : public Value<Json::STRING, string> {
+     const string &string_value() const override { return m_value; }
+ public:
+     explicit JsonString(const string &value) : Value(value) {}
+-    explicit JsonString(string &&value)      : Value(move(value)) {}
++    explicit JsonString(string &&value)      : Value(std::move(value)) {}
+ };
+
+ class JsonArray final : public Value<Json::ARRAY, Json::array> {
+@@ -206,7 +207,7 @@ class JsonArray final : public Value<Json::ARRAY, Json::array> {
+     const Json & operator[](size_t i) const override;
+ public:
+     explicit JsonArray(const Json::array &value) : Value(value) {}
+-    explicit JsonArray(Json::array &&value)      : Value(move(value)) {}
++    explicit JsonArray(Json::array &&value)      : Value(std::move(value)) {}
+ };
+
+ class JsonObject final : public Value<Json::OBJECT, Json::object> {
+@@ -214,7 +215,7 @@ class JsonObject final : public Value<Json::OBJECT, Json::object> {
+     const Json & operator[](const string &key) const override;
+ public:
+     explicit JsonObject(const Json::object &value) : Value(value) {}
+-    explicit JsonObject(Json::object &&value)      : Value(move(value)) {}
++    explicit JsonObject(Json::object &&value)      : Value(std::move(value)) {}
+ };
+
+ class JsonNull final : public Value<Json::NUL, NullStruct> {
+@@ -256,12 +257,12 @@ Json::Json(double value)               : m_ptr(make_shared<JsonDouble>(value)) {
+ Json::Json(int value)                  : m_ptr(make_shared<JsonInt>(value)) {}
+ Json::Json(bool value)                 : m_ptr(value ? statics().t : statics().f) {}
+ Json::Json(const string &value)        : m_ptr(make_shared<JsonString>(value)) {}
+-Json::Json(string &&value)             : m_ptr(make_shared<JsonString>(move(value))) {}
++Json::Json(string &&value)             : m_ptr(make_shared<JsonString>(std::move(value))) {}
+ Json::Json(const char * value)         : m_ptr(make_shared<JsonString>(value)) {}
+ Json::Json(const Json::array &values)  : m_ptr(make_shared<JsonArray>(values)) {}
+-Json::Json(Json::array &&values)       : m_ptr(make_shared<JsonArray>(move(values))) {}
++Json::Json(Json::array &&values)       : m_ptr(make_shared<JsonArray>(std::move(values))) {}
+ Json::Json(const Json::object &values) : m_ptr(make_shared<JsonObject>(values)) {}
+-Json::Json(Json::object &&values)      : m_ptr(make_shared<JsonObject>(move(values))) {}
++Json::Json(Json::object &&values)      : m_ptr(make_shared<JsonObject>(std::move(values))) {}
+
+ /* * * * * * * * * * * * * * * * * * * *
+  * Accessors
+@@ -359,7 +360,7 @@ struct JsonParser final {
+      * Mark this parse as failed.
+      */
+     Json fail(string &&msg) {
+-        return fail(move(msg), Json());
++        return fail(std::move(msg), Json());
+     }
+
+     template <typename T>

--- a/ports/json11/portfile.cmake
+++ b/ports/json11/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     SHA512 2129e048d8dee027dc1ba789d9901e017b7d698465e15236802ef68639161e1cc7c8665d5f50079333801717fd41ffbe2cb90fa2165b9a85629e8ced8f2b3cd8
     HEAD_REF master
     PATCHES destination.patch
+            fix-gcc15-build.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/json11/vcpkg.json
+++ b/ports/json11/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "json11",
   "version-date": "2017-06-20",
-  "port-version": 6,
+  "port-version": 7,
   "description": "json11 is a tiny JSON library for C++11, providing JSON parsing and serialization.",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4086,7 +4086,7 @@
     },
     "json11": {
       "baseline": "2017-06-20",
-      "port-version": 6
+      "port-version": 7
     },
     "json5-parser": {
       "baseline": "1.0.0",

--- a/versions/j-/json11.json
+++ b/versions/j-/json11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4bad80463986336f0e63a4442a6def1ed5c5c13a",
+      "version-date": "2017-06-20",
+      "port-version": 7
+    },
+    {
       "git-tree": "8b58dc7ee84c7424009066dd57f9b9f9a804f895",
       "version-date": "2017-06-20",
       "port-version": 6


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.