### PR TITLE
[sail] Bump to 0.9.9

### DIFF
--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO HappySeaFox/sail
     REF "v${VERSION}"
-    SHA512 1d390272d12e1b39939e9b7e0ccf046cc5401dad238945b6f9b1d94d6bb7ecebb9bb6bbe0cdd2f59d8df677ee1d413b3ef648c7ec64336179fcf0068f6e73fb2
+    SHA512 755e028b0cb0a2bb3ec97bfbc888a8afbf73923a36da2a0d32c535bd268c8e087404f44f233a6ef186234df108232d9315d71b7efd9abd2f088d988d4360320d
     HEAD_REF master
     PATCHES
         fix-include-directory.patch

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sail",
-  "version-semver": "0.9.8",
+  "version-semver": "0.9.9",
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8573,7 +8573,7 @@
       "port-version": 0
     },
     "sail": {
-      "baseline": "0.9.8",
+      "baseline": "0.9.9",
       "port-version": 0
     },
     "sajson": {

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fceb2ea21ecd1fed3e5482b6691305fb2c0e9a8a",
+      "version-semver": "0.9.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "bcc6d6a75983a75ade5ca06e6f46365747ee7dfd",
       "version-semver": "0.9.8",
       "port-version": 0


### PR DESCRIPTION
- Fixed several vulnerabilities found by Cisco TALOS

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
