### PR TITLE
[s2n] update to 1.5.25

### DIFF
--- a/ports/s2n/portfile.cmake
+++ b/ports/s2n/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aws/s2n-tls
     REF "v${VERSION}"
-    SHA512 faed1a4765874b91da53d3e2c6430ad14701bca45cb3e7fa9a5d1cde957ed2d7e3cc21a713d09a848e341d09f483e769a0651e15d118d2f9b8a8aa76e873b3f2 
+    SHA512 f9c8a8c472ae99939972e0f610411bf696119ec5fff0685093fb9ebd442479703e84e156989e5963e003087b0771a185975fce4398ead5b8ea997888bf766c75 
     PATCHES
         fix-cmake-target-path.patch
         openssl.patch

--- a/ports/s2n/vcpkg.json
+++ b/ports/s2n/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "s2n",
-  "version": "1.5.21",
+  "version": "1.5.25",
   "description": "C99 implementation of the TLS/SSL protocols.",
   "homepage": "https://github.com/aws/s2n-tls",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8561,7 +8561,7 @@
       "port-version": 0
     },
     "s2n": {
-      "baseline": "1.5.21",
+      "baseline": "1.5.25",
       "port-version": 0
     },
     "safeint": {

--- a/versions/s-/s2n.json
+++ b/versions/s-/s2n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fc87ea0c4015942263749892283207d21be1e0e8",
+      "version": "1.5.25",
+      "port-version": 0
+    },
+    {
       "git-tree": "24707dccee264b02321864dc189ca8579fab9297",
       "version": "1.5.21",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/aws/s2n-tls/releases/tag/v1.5.25