### PR TITLE
[vbs-enclave-tooling-sdk] Add new port

### DIFF
--- a/ports/vbs-enclave-tooling-sdk/portfile.cmake
+++ b/ports/vbs-enclave-tooling-sdk/portfile.cmake
@@ -1,0 +1,75 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/VbsEnclaveTooling
+    REF "sdk-v${VERSION}"
+    SHA512 "c0ce7d15f5fd4e1a273d61cc1d254304a64a5f633eefc3d32effb5f5b99e2b9488c3cda7e080d02bf5cbfd8c47e7302132b6ed93184fd622fd303ee247c96411"
+    HEAD_REF main
+)
+
+set(VBS_ENCLAVE_SDK_SOURCE_PATH "${SOURCE_PATH}/src/VbsEnclaveSDK")
+
+# All the projects in the repo require some nuget packages to be installed so we need
+# to run nuget restore prior to running the msbuild function.
+vcpkg_find_acquire_program(NUGET)
+vcpkg_execute_required_process(
+    COMMAND ${NUGET} restore "${VBS_ENCLAVE_SDK_SOURCE_PATH}/vbs_enclave_implementation_library.sln"
+    WORKING_DIRECTORY "${VBS_ENCLAVE_SDK_SOURCE_PATH}"
+    LOGNAME nuget-restore
+)
+
+vcpkg_msbuild_install(
+  SOURCE_PATH "${SOURCE_PATH}"
+  PROJECT_SUBPATH "/src/VbsEnclaveSDK/vbs_enclave_implementation_library.sln"
+  NO_INSTALL # Make sure libs, exes and dlls from consumed nuget packages don't get added
+  NO_TOOLCHAIN_PROPS
+)
+
+function(install_headers SRC_DIR DST_SUBDIR)
+    file(GLOB_RECURSE HEADERS "${SRC_DIR}/*.h")
+    foreach(header IN LISTS HEADERS)
+        if(NOT header MATCHES ".*/Generated Files/.*")
+            file(INSTALL DESTINATION "${CURRENT_PACKAGES_DIR}/include/${DST_SUBDIR}" TYPE FILE FILES "${header}")
+        endif()
+    endforeach()
+endfunction()
+
+install_headers("${VBS_ENCLAVE_SDK_SOURCE_PATH}/src/veil_enclave_lib" "veil/enclave")
+install_headers("${VBS_ENCLAVE_SDK_SOURCE_PATH}/src/veil_host_lib" "veil/host")
+install_headers("${VBS_ENCLAVE_SDK_SOURCE_PATH}/src/veil_any_inc" "veil/veil_any_inc")
+install_headers("${SOURCE_PATH}/Common/veil_enclave_wil_inc/wil" "wil/enclave")
+
+foreach(CFG IN ITEMS Release Debug)
+    if(CFG STREQUAL "Release")
+        set(CFG_SUFFIX "rel")
+        set(PACKAGE_LIB_DIR "${CURRENT_PACKAGES_DIR}/lib")
+        set(CPP_SUPPORT_DIR "${CURRENT_PACKAGES_DIR}/lib/manual-link/vbs-enclave-tooling-sdk")
+    else()
+        set(CFG_SUFFIX "dbg")
+        set(PACKAGE_LIB_DIR "${CURRENT_PACKAGES_DIR}/debug/lib")
+        set(CPP_SUPPORT_DIR "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/vbs-enclave-tooling-sdk")
+    endif()
+
+    set(BASE_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${CFG_SUFFIX}/src/VbsEnclaveSDK")
+    set(BUILD_DIR "${BASE_DIR}/_build/${VCPKG_TARGET_ARCHITECTURE}/${CFG}")
+
+    if(EXISTS "${BUILD_DIR}")
+        set(LIB_SUFFIX "${CFG}_lib.lib")
+
+        file(INSTALL DESTINATION "${PACKAGE_LIB_DIR}" TYPE FILE FILES
+            "${BUILD_DIR}/veil_enclave_${VCPKG_TARGET_ARCHITECTURE}_${LIB_SUFFIX}"
+            "${BUILD_DIR}/veil_host_lib/veil_host_${VCPKG_TARGET_ARCHITECTURE}_${LIB_SUFFIX}"
+        )
+
+        file(INSTALL DESTINATION "${CURRENT_PACKAGES_DIR}/src/veil" TYPE FILE FILES
+            "${BASE_DIR}/src/veil_enclave_lib/Generated Files/VbsEnclave/Enclave/Abi/LinkerPragmas.veil_abi.cpp"
+        )
+
+        file(GLOB CPP_SUPPORT_LIB_FILE
+            "${BUILD_DIR}/veil_enclave_cpp_support_${VCPKG_TARGET_ARCHITECTURE}_${LIB_SUFFIX}"
+        )
+        file(MAKE_DIRECTORY "${CPP_SUPPORT_DIR}")
+        file(INSTALL DESTINATION "${CPP_SUPPORT_DIR}" TYPE FILE FILES "${CPP_SUPPORT_LIB_FILE}")
+    endif()
+endforeach()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/vbs-enclave-tooling-sdk/vcpkg.json
+++ b/ports/vbs-enclave-tooling-sdk/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "vbs-enclave-tooling-sdk",
+  "version": "0.1.2.1-prerelease",
+  "description": "The VBS enclave sdk.",
+  "homepage": "https://github.com/microsoft/vbsEnclaveTooling",
+  "license": "MIT",
+  "supports": "(windows & arm64) | (windows & x64)",
+  "dependencies": [
+    "ms-gsl",
+    {
+      "name": "vcpkg-msbuild",
+      "host": true
+    },
+    "wil"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9960,6 +9960,10 @@
       "baseline": "0.1.1-prerelease",
       "port-version": 0
     },
+    "vbs-enclave-tooling-sdk": {
+      "baseline": "0.1.2.1-prerelease",
+      "port-version": 0
+    },
     "vc": {
       "baseline": "1.4.4",
       "port-version": 0

--- a/versions/v-/vbs-enclave-tooling-sdk.json
+++ b/versions/v-/vbs-enclave-tooling-sdk.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e1b39bab5b636f599add6e9171bc7e274013de82",
+      "version": "0.1.2.1-prerelease",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.