### PR TITLE
[st-tree] update to 1.3.0

### DIFF
--- a/ports/st-tree/portfile.cmake
+++ b/ports/st-tree/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO erikerlandson/st_tree
     REF "version_${VERSION}"
-    SHA512 b2bd47509783c3efb366343aeb1713874225ba63348afcd1ddc770a4b0ae4d839455cee5e05d4cdc04a5aa798db21c8c9b414492c32d2b1458b2dfcbe87f2388
+    SHA512 354181bf397d92a863fcb46a6c07aec44599720456f61d639b3f0df4b95a6f908d0d44d3b2a430b3ef5a30c5df24ad29f638c4f8f80e51682d3eee800cfeea57
     HEAD_REF develop
 )
 

--- a/ports/st-tree/vcpkg.json
+++ b/ports/st-tree/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "st-tree",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "A fast and flexible c++ template class for tree data structures",
   "homepage": "https://github.com/erikerlandson/st_tree",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9197,7 +9197,7 @@
       "port-version": 0
     },
     "st-tree": {
-      "baseline": "1.2.2",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "stackwalker": {

--- a/versions/s-/st-tree.json
+++ b/versions/s-/st-tree.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "526ad9fc8ea20e519c365ff439bd8af976d9d8f6",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "af70973d62b638f747518a1e415ed7e1d3aca4fc",
       "version": "1.2.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/erikerlandson/st_tree/releases/tag/version_1.3.0
