### PR TITLE
[cpp-httplib] update to 0.26.0

### DIFF
--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yhirose/cpp-httplib
     REF "v${VERSION}"
-    SHA512 702f68e8049362dfefc69002beb98d952f72ab72e8310c0bab878aaf9202e8421d9b738bf1a3a6278daecac30aff91e08e55c2a42f67535314e15992045612d8
+    SHA512 b364500f76e2ecb0fe21b032d831272e3f1dfeea71af74e325f8fc4ce9dcdb3c941b97a5b422bdeafb9facd058597b90f8bfc284fb9afe3c33fefa15dd5a010b
     HEAD_REF master
     PATCHES
         fix-find-brotli.patch

--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-httplib",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1985,7 +1985,7 @@
       "port-version": 0
     },
     "cpp-httplib": {
-      "baseline": "0.25.0",
+      "baseline": "0.26.0",
       "port-version": 0
     },
     "cpp-ipc": {

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6c10f2b887998ab2c4e150e3f35d6e29694f9d0",
+      "version": "0.26.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fbb576519a11d46494dc6f66306e42293479557b",
       "version": "0.25.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/yhirose/cpp-httplib/releases/tag/v0.26.0
