### PR TITLE
[libyuv] update to 1916

### DIFF
--- a/ports/libyuv/cmake.diff
+++ b/ports/libyuv/cmake.diff
@@ -1,19 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9a20941d..d161326c 100644
+index c6cce8a6..799cabde 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -4,8 +4,9 @@
+@@ -4,6 +4,7 @@
  
- include(CheckCSourceCompiles)
- 
-+cmake_minimum_required(VERSION 3.12)
+ cmake_minimum_required( VERSION 3.16 )
  project ( YUV C CXX )	# "C" is required even for C++ projects
--cmake_minimum_required( VERSION 2.8.12 )
 +option( BUILD_TOOLS "Build tools" OFF )
  option( UNIT_TEST "Built unit tests" OFF )
  
- set ( ly_base_dir	${PROJECT_SOURCE_DIR} )
-@@ -149,6 +150,8 @@ if(WIN32)
+ include(CheckCSourceCompiles)
+@@ -184,6 +185,8 @@ if(WIN32)
    set_target_properties( ${ly_lib_shared} PROPERTIES IMPORT_PREFIX "lib" )
  endif()
  
@@ -22,7 +19,7 @@ index 9a20941d..d161326c 100644
  # this creates the cpuid tool
  add_executable      ( cpuid ${ly_base_dir}/util/cpuid.c )
  target_link_libraries  ( cpuid ${ly_lib_static} )
-@@ -161,10 +164,13 @@ target_link_libraries	( yuvconvert ${ly_lib_static} )
+@@ -196,10 +199,13 @@ target_link_libraries	( yuvconvert ${ly_lib_static} )
  add_executable      ( yuvconstants ${ly_base_dir}/util/yuvconstants.c )
  target_link_libraries  ( yuvconstants ${ly_lib_static} )
  
@@ -37,13 +34,13 @@ index 9a20941d..d161326c 100644
    add_definitions( -DHAVE_JPEG )
  endif()
  
-@@ -211,9 +217,20 @@ endif()
+@@ -246,9 +252,20 @@ endif()
  
  
  # install the conversion tool, .so, .a, and all the header files
--install ( TARGETS yuvconvert	DESTINATION bin )
+-install ( TARGETS yuvconvert DESTINATION bin )
 -install ( TARGETS ${ly_lib_static}						DESTINATION lib )
--install ( TARGETS ${ly_lib_shared} LIBRARY	DESTINATION lib RUNTIME DESTINATION bin ARCHIVE DESTINATION lib )
+-install ( TARGETS ${ly_lib_shared} LIBRARY DESTINATION lib RUNTIME DESTINATION bin ARCHIVE DESTINATION lib )
 +if (BUILD_TOOLS)
 +  install(TARGETS yuvconvert yuvconstants)
 +endif()

--- a/ports/libyuv/portfile.cmake
+++ b/ports/libyuv/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://chromium.googlesource.com/libyuv/libyuv
-    REF a37e6bc81b52d39cdcfd0f1428f5d6c2b2bc9861 # 1896 Fixes build error on macOS Homebrew LLVM 19
+    REF d98915a654d3564e4802a0004add46221c4e4348
     # Check https://chromium.googlesource.com/libyuv/libyuv/+/refs/heads/main/include/libyuv/version.h for a version!
     PATCHES
         cmake.diff

--- a/ports/libyuv/vcpkg.json
+++ b/ports/libyuv/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libyuv",
-  "version": "1896",
-  "port-version": 1,
+  "version": "1916",
   "description": "libyuv is an open source project that includes YUV scaling and conversion functionality",
   "homepage": "https://chromium.googlesource.com/libyuv/libyuv",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5785,8 +5785,8 @@
       "port-version": 5
     },
     "libyuv": {
-      "baseline": "1896",
-      "port-version": 1
+      "baseline": "1916",
+      "port-version": 0
     },
     "libzen": {
       "baseline": "0.4.41",

--- a/versions/l-/libyuv.json
+++ b/versions/l-/libyuv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "557f40e7241d91a80b55f849a18376613c45f13a",
+      "version": "1916",
+      "port-version": 0
+    },
+    {
       "git-tree": "cb6412fd44057b52849ebf8807a0c339cb525104",
       "version": "1896",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
