### PR TITLE
[orange-math] update to 3.5.1

### DIFF
--- a/ports/orange-math/portfile.cmake
+++ b/ports/orange-math/portfile.cmake
@@ -2,18 +2,11 @@ if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
-vcpkg_download_distfile(
-    FIX_VECTOR_INCLUDE
-    URLS https://github.com/orange-cpp/omath/commit/463532ba81030b3ed9ccfd6a277af0028c190bb3.patch?full_index=1
-    FILENAME fix-vector-include-463532ba81030b3ed9ccfd6a277af0028c190bb3.patch
-    SHA512 6ec747d3cd89fce54e26997ea3508cb9c6cbf9ee2d473a825ea0bf8d4ecfad6712217a348f4d43acc757e4ab2d865778163982b8c9e5c490946bb3e92679b8c6
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO orange-cpp/omath
     REF "v${VERSION}"
-    SHA512 42ecf51363be50e7382b9aebd03039f4e6ef855beaa227fbd354da6aad39e6cb328baf8ef8acf8eea551403fdd43a94980990c57cb70b408d065fa992bc68c72
+    SHA512 55ecfbc45f83d398cb40dcdcc1042b2d6d6c956448521830279c49ea689efc23787df1e43b1a28519ce97b38e765bbcd43dbda1bba36d05f8fade45555728656
     HEAD_REF master
 )
 

--- a/ports/orange-math/portfile.cmake
+++ b/ports/orange-math/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO orange-cpp/omath
     REF "v${VERSION}"
-    SHA512 f6ee4356df67bfd624444fbdbee27840d6124d03797e9d4e5ebc6524c4d54fffc8999ddbf1381132891ca7d1a45d61cd84fac515ef1a3c8005f15d70d1b93c5b
+    SHA512 42ecf51363be50e7382b9aebd03039f4e6ef855beaa227fbd354da6aad39e6cb328baf8ef8acf8eea551403fdd43a94980990c57cb70b408d065fa992bc68c72
     HEAD_REF master
 )
 

--- a/ports/orange-math/portfile.cmake
+++ b/ports/orange-math/portfile.cmake
@@ -2,6 +2,13 @@ if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
+vcpkg_download_distfile(
+    FIX_VECTOR_INCLUDE
+    URLS https://github.com/orange-cpp/omath/commit/463532ba81030b3ed9ccfd6a277af0028c190bb3.patch?full_index=1
+    FILENAME fix-vector-include-463532ba81030b3ed9ccfd6a277af0028c190bb3.patch
+    SHA512 6ec747d3cd89fce54e26997ea3508cb9c6cbf9ee2d473a825ea0bf8d4ecfad6712217a348f4d43acc757e4ab2d865778163982b8c9e5c490946bb3e92679b8c6
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO orange-cpp/omath

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "orange-math",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "General purpose math library",
   "homepage": "https://github.com/orange-cpp/omath",
   "license": "Zlib",

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "orange-math",
-  "version": "3.2.3",
+  "version": "3.5.0",
   "description": "General purpose math library",
   "homepage": "https://github.com/orange-cpp/omath",
   "license": "Zlib",

--- a/scripts/test_ports/vcpkg-ci-orange-math/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-orange-math/project/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.26)
 
-project(vcpkg-ci-orange-math)
+project(vcpkg-ci-orange-math LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(main main.cpp)
 

--- a/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
@@ -1,15 +1,8 @@
-#if defined(__has_include)
-    #if __has_include(<omath/omath.hpp>)
-		#include <omath/omath.hpp>
-	#else
-		#include <omath/Vector2.hpp>
-	#endif
-#else
-    #include <omath/Vector2.hpp>
-#endif
+#include <omath/Vector2.hpp>
 
 int main()
 {
 	omath::Vector2 w = omath::Vector2(20.0, 30.0);
 	return 0;
 }
+

--- a/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
@@ -1,7 +1,8 @@
-#include <omath/linear_algebra/vector2.hpp>
+#include <omath/omath.hpp>
 
 int main()
 {
 	omath::Vector2 w = omath::Vector2(20.0, 30.0);
 	return 0;
 }
+

--- a/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
@@ -1,4 +1,12 @@
-#include <omath/Vector2.hpp>
+#if defined(__has_include)
+    #if __has_include(<omath/omath.hpp>)
+		#include <omath/omath.hpp>
+	#else
+		#include <omath/Vector2.hpp>
+	#endif
+#else
+    #include <omath/Vector2.hpp>
+#endif
 
 int main()
 {

--- a/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
@@ -5,4 +5,3 @@ int main()
 	omath::Vector2 w = omath::Vector2(20.0, 30.0);
 	return 0;
 }
-

--- a/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-orange-math/project/main.cpp
@@ -1,4 +1,4 @@
-#include <omath/Vector2.hpp>
+#include <omath/linear_algebra/vector2.hpp>
 
 int main()
 {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7169,7 +7169,7 @@
       "port-version": 1
     },
     "orange-math": {
-      "baseline": "3.5.0",
+      "baseline": "3.5.1",
       "port-version": 0
     },
     "orc": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7169,7 +7169,7 @@
       "port-version": 1
     },
     "orange-math": {
-      "baseline": "3.2.3",
+      "baseline": "3.5.0",
       "port-version": 0
     },
     "orc": {

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a62c4bc23138ea5d24c156942f0edf232511eb7b",
+      "git-tree": "953a7b0192708fb4a322bb0e49b2965a6d5f47aa",
       "version": "3.5.0",
       "port-version": 0
     },

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "926e7c36e985875cc6e102bc7972121b725fdada",
+      "git-tree": "a62c4bc23138ea5d24c156942f0edf232511eb7b",
       "version": "3.5.0",
       "port-version": 0
     },

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "926e7c36e985875cc6e102bc7972121b725fdada",
+      "version": "3.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f910e956a141e8c6603ba9ebae5847279491bfe4",
       "version": "3.2.3",
       "port-version": 0

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "953a7b0192708fb4a322bb0e49b2965a6d5f47aa",
-      "version": "3.5.0",
+      "git-tree": "90016e1138d861753605b936c202097faac79408",
+      "version": "3.5.1",
       "port-version": 0
     },
     {

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "90016e1138d861753605b936c202097faac79408",
+      "git-tree": "0401d427a1dc821e7cf63f790571e2e7bd1ddf34",
       "version": "3.5.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

