### PR TITLE
[lockpp] update to 3.2.0

### DIFF
--- a/ports/lockpp/fix_package_projects.patch
+++ b/ports/lockpp/fix_package_projects.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d811dda..97ee8b8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,13 +39,7 @@ endif()
+ # Install Targets
+ # --------------------------------------------------------------------------------------------------------
+ 
+-include("cmake/cpm.cmake")
+-
+-CPMFindPackage(
+-  NAME           PackageProject
+-  VERSION        1.13.0
+-  GIT_REPOSITORY "https://github.com/TheLartians/PackageProject.cmake"
+-)
++include("cmake/PackageProject.cmake/CMakeLists.txt")
+ 
+ packageProject(
+   NAMESPACE cr

--- a/ports/lockpp/portfile.cmake
+++ b/ports/lockpp/portfile.cmake
@@ -2,9 +2,20 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Curve/lockpp
     REF "v${VERSION}"
-    SHA512 ce2572ff53096a53cda722e47bbd23e4c3a8b3856de9dfe775b7468cd5f7fcbc86412457af091b8977dd0b41d161c103b679c7a98016f6e9d3ab70aaa360648f
+    SHA512 0581718dc2451d3cc62f2d0443f52a1adc95fe7a8ee859bd9cca78d68aa029ce7bc9e5387eca24f1b5fe44fc4af3ec662426c471b16e5ad0f29aa83ae0d2c4c1
+    HEAD_REF master
+    PATCHES
+        fix_package_projects.patch
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH PACKAGE_PROJECT_SOURCE_PATH
+    REPO TheLartians/PackageProject.cmake
+    REF "v1.13.0"
+    SHA512 3cf0523bddc213f206ed0ca57803550cb7db9e293392d3741138be47f49d9027ef517e1656235a349a62b492d35c3fc677714dc00afe59e2d36144a9689cfa8f
     HEAD_REF master
 )
+file(RENAME "${PACKAGE_PROJECT_SOURCE_PATH}" "${SOURCE_PATH}/cmake/PackageProject.cmake")
 
 vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()

--- a/ports/lockpp/portfile.cmake
+++ b/ports/lockpp/portfile.cmake
@@ -20,5 +20,7 @@ file(RENAME "${PACKAGE_PROJECT_SOURCE_PATH}" "${SOURCE_PATH}/cmake/PackageProjec
 vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()
 
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/lockpp-${VERSION})
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/lockpp/vcpkg.json
+++ b/ports/lockpp/vcpkg.json
@@ -8,6 +8,10 @@
     {
       "name": "vcpkg-cmake",
       "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ]
 }

--- a/ports/lockpp/vcpkg.json
+++ b/ports/lockpp/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "name": "lockpp",
-  "version": "3.0",
-  "port-version": 1,
-  "description": "A C++17 Library that provides mutex protected objects",
+  "version": "3.2.0",
+  "description": "A C++23 Library that provides mutex protected objects",
   "homepage": "https://github.com/Curve/lockpp",
   "license": "MIT",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5885,8 +5885,8 @@
       "port-version": 0
     },
     "lockpp": {
-      "baseline": "3.0",
-      "port-version": 1
+      "baseline": "3.2.0",
+      "port-version": 0
     },
     "lodepng": {
       "baseline": "2021-12-04",

--- a/versions/l-/lockpp.json
+++ b/versions/l-/lockpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7440adf411d132295aa972b7f861f85d415c957",
+      "version": "3.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "17e2f663311b1a32f97d897cf7da3024e1b6c659",
       "version": "3.0",
       "port-version": 1

--- a/versions/l-/lockpp.json
+++ b/versions/l-/lockpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a7440adf411d132295aa972b7f861f85d415c957",
+      "git-tree": "9fda0b08583c4bd20972749e558016e3d8cf1d66",
       "version": "3.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Curve/lockpp/releases/tag/v3.2.0
https://github.com/Curve/lockpp/releases/tag/v3.1.0
