### PR TITLE
[simd] update to 6.2.153

### DIFF
--- a/ports/simd/portfile.cmake
+++ b/ports/simd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ermig1979/Simd
     REF "v${VERSION}"
-    SHA512 88c8c2a00b5768e2b9dfe753e770c5328982a68c21cc4de424842d4be3e606a8f8685f60be3a7cab26bc9ef35f7e52e489cece9ae989b4a86cc94be287b855ac
+    SHA512 91b0e4e4876330026154b1a5ad86fca164eed25ec478192999d7c0e55660fe18d7ecaecba6535fda55db53276734c0f81cd8398facfcd3e6a3f39d92330480cb
     HEAD_REF master
     PATCHES
         fix-platform-detection.patch

--- a/ports/simd/vcpkg.json
+++ b/ports/simd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simd",
-  "version": "6.2.152",
+  "version": "6.2.153",
   "description": "Simd image processing and machine learning library, designed for C and C++ programmers",
   "homepage": "https://github.com/ermig1979/Simd",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8869,7 +8869,7 @@
       "port-version": 1
     },
     "simd": {
-      "baseline": "6.2.152",
+      "baseline": "6.2.153",
       "port-version": 0
     },
     "simde": {

--- a/versions/s-/simd.json
+++ b/versions/s-/simd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f643241794d573c6f5a6e60989c2fd71db00aaae",
+      "version": "6.2.153",
+      "port-version": 0
+    },
+    {
       "git-tree": "2cea5d40f9c944a76e723a318aa3d761bf2e2a51",
       "version": "6.2.152",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ermig1979/Simd/releases/tag/v6.2.153
