### PR TITLE
[kubernetes] update to 0.13.0

### DIFF
--- a/ports/kubernetes/002-disable-werror.patch
+++ b/ports/kubernetes/002-disable-werror.patch
@@ -1,0 +1,14 @@
+diff --git a/kubernetes/CMakeLists.txt b/kubernetes/CMakeLists.txt
+index 4615b63..104c4d6 100644
+--- a/kubernetes/CMakeLists.txt
++++ b/kubernetes/CMakeLists.txt
+@@ -6,9 +6,6 @@ cmake_policy(SET CMP0063 NEW)
+ set(CMAKE_C_VISIBILITY_PRESET default)
+ set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
+ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=implicit-function-declaration")
+-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=missing-declarations")
+-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=int-conversion")
+ 
+ option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+ 

--- a/ports/kubernetes/portfile.cmake
+++ b/ports/kubernetes/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kubernetes-client/c
     REF "v${VERSION}"
-    SHA512 42f74f87a8e534a936ae3e7148375ddb350de753ec9514d139d87febb5c3355e7722aec0a5b745abad3ee9691fd7a139b81e2e2688102e72a61ed488320fe3f5
+    SHA512 4cee597f81a0181ba9a3dee9c7f01b7e55cba939fc3367d1d314aeb6a39044701886fe4b7f8eb72e890aafed653afa0f2f36cbd3aaa91ee85cf581f1b1eaec85
     HEAD_REF master
     PATCHES
         001-fix-destination.patch

--- a/ports/kubernetes/portfile.cmake
+++ b/ports/kubernetes/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         001-fix-destination.patch
+        002-disable-werror.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/kubernetes/vcpkg.json
+++ b/ports/kubernetes/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Kubernetes C client",
   "homepage": "https://github.com/kubernetes-client/c/",
   "license": "Apache-2.0",
-  "supports": "!uwp",
+  "supports": "!windows | mingw",
   "dependencies": [
     "curl",
     "libwebsockets",

--- a/ports/kubernetes/vcpkg.json
+++ b/ports/kubernetes/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "kubernetes",
-  "version": "0.6.0",
-  "port-version": 1,
+  "version": "0.13.0",
   "description": "Kubernetes C client",
   "homepage": "https://github.com/kubernetes-client/c/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4389,8 +4389,8 @@
       "port-version": 0
     },
     "kubernetes": {
-      "baseline": "0.6.0",
-      "port-version": 1
+      "baseline": "0.13.0",
+      "port-version": 0
     },
     "kuku": {
       "baseline": "2.1.0",

--- a/versions/k-/kubernetes.json
+++ b/versions/k-/kubernetes.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1d8a23c0f502e91afd44c9ff57cfceda6180858a",
+      "git-tree": "513eaed2273386e4c397606e17d12a5e76225d1e",
       "version": "0.13.0",
       "port-version": 0
     },

--- a/versions/k-/kubernetes.json
+++ b/versions/k-/kubernetes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d8a23c0f502e91afd44c9ff57cfceda6180858a",
+      "version": "0.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9abf392af62dfcfb3020d675dfc6b37110127185",
       "version": "0.6.0",
       "port-version": 1

--- a/versions/k-/kubernetes.json
+++ b/versions/k-/kubernetes.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "513eaed2273386e4c397606e17d12a5e76225d1e",
+      "git-tree": "ff1313dbaf8188681431a2cf974307399520cc5a",
       "version": "0.13.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/kubernetes-client/c/releases/tag/v0.13.0

kubernetes uses `__attribute__((deprecated))` since 0.12.0.
I have to drop support for MSVC.
https://github.com/kubernetes-client/c/blob/release-0.13/kubernetes/model/events_v1_event_list.h#L32
