### PR TITLE
[ada-idna] update to 0.3.4

### DIFF
--- a/ports/ada-idna/install.patch
+++ b/ports/ada-idna/install.patch
@@ -1,8 +1,36 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a1eda0c..af4079e 100644
+index a3abd0f..c37c36b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -51,8 +51,6 @@ else()
+@@ -12,6 +12,10 @@ include(GNUInstallDirs)
+ include(CTest)
+ include(cmake/idna-flags.cmake)
+ 
++if(ADA_USE_SIMDUTF)
++  find_package(simdutf CONFIG REQUIRED)
++endif()
++
+ add_subdirectory(src)
+ 
+ option(ADA_USE_SIMDUTF "Whether to use SIMDUTF for unicode transcoding" OFF)
+@@ -20,16 +24,6 @@ if(ADA_IDNA_BENCHMARKS OR BUILD_TESTING)
+   include(cmake/CPM.cmake)
+ endif()
+ 
+-if(ADA_USE_SIMDUTF)
+-  include(cmake/CPM.cmake)
+-  CPMAddPackage(
+-    NAME simdutf
+-    GITHUB_REPOSITORY simdutf/simdutf
+-    VERSION 7.0.0
+-    OPTIONS "SIMDUTF_TESTS OFF"
+-  )
+-endif()
+-
+ if (ADA_IDNA_BENCHMARKS)
+   message(STATUS "Ada benchmarks enabled.")
+   CPMAddPackage(
+@@ -63,8 +57,6 @@ else()
    endif()
  endif(BUILD_TESTING)
  
@@ -11,7 +39,7 @@ index a1eda0c..af4079e 100644
  add_library(ada-idna::ada-idna ALIAS ada-idna)
  
  set_target_properties(
-@@ -83,3 +81,8 @@ install(
+@@ -95,3 +87,8 @@ install(
    ARCHIVE COMPONENT ada-idna_development
    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
  )
@@ -20,3 +48,16 @@ index a1eda0c..af4079e 100644
 +    FILE unofficial-ada-idna-config.cmake
 +    NAMESPACE unofficial::ada-idna::
 +    DESTINATION share/unofficial-ada-idna)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index e48bcda..3e7ba16 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -12,7 +12,7 @@ target_include_directories(ada-idna PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SO
+ target_include_directories(ada-idna PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+ 
+ if(ADA_USE_SIMDUTF)
+-  target_link_libraries(ada-idna PRIVATE simdutf)
++  target_link_libraries(ada-idna PRIVATE simdutf::simdutf)
+   target_compile_definitions(ada-idna PRIVATE ADA_USE_SIMDUTF)
+ endif()
+ 

--- a/ports/ada-idna/portfile.cmake
+++ b/ports/ada-idna/portfile.cmake
@@ -2,10 +2,16 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ada-url/idna
     REF "${VERSION}"
-    SHA512 cc113fc1ea4602ea262658d17f57ca0ef1a7ce2ee0d02de5379e9c58a5ac6a3afa59d3d43336505d13e75a764da431a3db809962d077a9dc27b9e0fa672ee82e
+    SHA512 e9887102e10b5963518ef4dc62b2538b941201e099eb80ee1c3a6742a370a7bbf600005363f665ffdc438b09ced9a30158b33c93032fc7d491ea54f158190db6
     HEAD_REF main
     PATCHES
         install.patch
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        simdutf         ADA_USE_SIMDUTF
 )
 
 vcpkg_cmake_configure(
@@ -13,6 +19,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DADA_IDNA_BENCHMARKS=OFF
         -DBUILD_TESTING=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/ada-idna/vcpkg.json
+++ b/ports/ada-idna/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ada-idna",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "C++ library implementing the to_ascii and to_unicode functions from the Unicode Technical Standard.",
   "homepage": "https://github.com/ada-url/idna",
   "license": "Apache-2.0 AND MIT",
@@ -13,5 +13,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "simdutf": {
+      "description": "Whether to use SIMDUTF for unicode transcoding",
+      "dependencies": [
+        "simdutf"
+      ]
+    }
+  }
 }

--- a/versions/a-/ada-idna.json
+++ b/versions/a-/ada-idna.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29c19b994e4c4c26d59474c2ac18c137f1ca4baf",
+      "version": "0.3.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "7c74dda0a2da1ded40b16efad9c84ab361eb6980",
       "version": "0.3.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -37,7 +37,7 @@
       "port-version": 17
     },
     "ada-idna": {
-      "baseline": "0.3.3",
+      "baseline": "0.3.4",
       "port-version": 0
     },
     "ada-url": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ada-url/idna/releases/tag/0.3.4
