### PR TITLE
[eigen3] Restore fix for MSBuild system-wide integration users

### DIFF
--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -34,6 +34,10 @@ vcpkg_cmake_config_fixup()
 
 vcpkg_fixup_pkgconfig()
 
+# Copy the eigen header files to conventional location for user-wide MSBuild integration
+file(GLOB INCLUDES ${CURRENT_PACKAGES_DIR}/include/eigen3/*)
+file(COPY ${INCLUDES} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(

--- a/ports/eigen3/vcpkg.json
+++ b/ports/eigen3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "eigen3",
   "version": "3.4.1-250818",
+  "port-version": 1,
   "description": "C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.",
   "homepage": "http://eigen.tuxfamily.org",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2666,7 +2666,7 @@
     },
     "eigen3": {
       "baseline": "3.4.1-250818",
-      "port-version": 0
+      "port-version": 1
     },
     "eipscanner": {
       "baseline": "1.3.0",

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a57c5626217c9da254311b5856216d52bfa2acc",
+      "version": "3.4.1-250818",
+      "port-version": 1
+    },
+    {
       "git-tree": "66092cc1695138f81da71b0a9055c216dcaef019",
       "version": "3.4.1-250818",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Restores a fix in Eigen3 for users of the MSBuild integration. The conventionally expected header location is `#include <eigen/header.h>`, without this fix projects have to do `#include <eigen3/eigen/header.h>` instead, breaking many consumers of the library by going against upstream conventions.

The fix is to duplicate the eigen headers in the expected location.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist: -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

<!-- END OF PORT UPDATE CHECKLIST (delete this line) -->

