### PR TITLE
[roaring] update to 4.3.10

### DIFF
--- a/ports/roaring/portfile.cmake
+++ b/ports/roaring/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RoaringBitmap/CRoaring
     REF "v${VERSION}"
-    SHA512 adb6c8ca9c00b695a47fcd07471cdbcb612efd4e5bb57a5e28940c1b023344df03adecc50b6708b9d2a345e2b65ddba07da9ff5c0d51bd73567bb90d106af2f7
+    SHA512 1b5528f2fda5d4e1e8d3387edb546f71977ea7f8cd4a89cfeec734725334aadded53683a9aa46f41aa9e32a373d44ef63269ef3557a9ccd8ed4a8cfb7f937b33
     HEAD_REF master
 )
 

--- a/ports/roaring/vcpkg.json
+++ b/ports/roaring/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "roaring",
-  "version": "4.3.9",
+  "version": "4.3.10",
   "description": "A better compressed bitset in C (and C++)",
   "homepage": "https://github.com/RoaringBitmap/CRoaring",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8441,7 +8441,7 @@
       "port-version": 0
     },
     "roaring": {
-      "baseline": "4.3.9",
+      "baseline": "4.3.10",
       "port-version": 0
     },
     "robin-hood-hashing": {

--- a/versions/r-/roaring.json
+++ b/versions/r-/roaring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aefa82e99d8684468ec3599a2c57cfc8066a6c97",
+      "version": "4.3.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "ece6f5c9de16dad1cc8fcae6b8189c25cf7ce4cb",
       "version": "4.3.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/RoaringBitmap/CRoaring/releases/tag/v4.3.10
