### PR TITLE
[cyrus-sasl] Apply patch to include missing headers in gcc14

### DIFF
--- a/ports/cyrus-sasl/fix-gcc14-time-includes.diff
+++ b/ports/cyrus-sasl/fix-gcc14-time-includes.diff
@@ -1,0 +1,26 @@
+diff --git a/lib/saslutil.c b/lib/saslutil.c
+index 46c628c7..5341cbb3 100644
+--- a/lib/saslutil.c
++++ b/lib/saslutil.c
+@@ -59,9 +59,7 @@
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+-#ifdef HAVE_TIME_H
+ #include <time.h>
+-#endif
+ #include "saslint.h"
+ #include <saslutil.h>
+ 
+diff --git a/plugins/cram.c b/plugins/cram.c
+index d02e9baa..89c9308d 100644
+--- a/plugins/cram.c
++++ b/plugins/cram.c
+@@ -52,6 +52,7 @@
+ #include <sys/stat.h>
+ #endif
+ #include <fcntl.h>
++#include <time.h>
+ 
+ #include <sasl.h>
+ #include <saslplug.h>

--- a/ports/cyrus-sasl/portfile.cmake
+++ b/ports/cyrus-sasl/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
         configure.diff
+        fix-gcc14-time-includes.diff
 )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/cyrus-sasl/vcpkg.json
+++ b/ports/cyrus-sasl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cyrus-sasl",
   "version": "2.1.28",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Cyrus SASL is an implementation of SASL that makes it easy for application developers to integrate authentication mechanisms into their application in a generic way.",
   "homepage": "https://github.com/cyrusimap/cyrus-sasl",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2282,7 +2282,7 @@
     },
     "cyrus-sasl": {
       "baseline": "2.1.28",
-      "port-version": 2
+      "port-version": 3
     },
     "czmq": {
       "baseline": "4.2.1",

--- a/versions/c-/cyrus-sasl.json
+++ b/versions/c-/cyrus-sasl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e7dd190cd5ce2cbd54af4607e57650f381fce708",
+      "version": "2.1.28",
+      "port-version": 3
+    },
+    {
       "git-tree": "089fb04a97b4b253724956fe9cf7cfd4aa14f935",
       "version": "2.1.28",
       "port-version": 2


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


Adds a patch for cyrus-sasl so that it can compile with gcc 14.


