### PR TITLE
[libunwind] update to 1.8.3

### DIFF
--- a/ports/libunwind/portfile.cmake
+++ b/ports/libunwind/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO "libunwind/libunwind"
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 50bb802a821939d38e38ce9f906934eea6a4e815f9401c18d5de6205ae0b5c7594e94d37bbf8f9da4012c0adebac208077548771d21bb89a4dedeb27645ceb25
+    SHA512 0619716b2385375d618d84b1e9a75c42a7fa86d452c7c3168b4aa78c6bda629c8bb5e3a984a642277e9949c1b7dc39d5e21ae9d2670437182c7b797a14544cfa
     PATCHES
         liblzma.diff
 )

--- a/ports/libunwind/vcpkg.json
+++ b/ports/libunwind/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libunwind",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Unix libray for portable stack unwinding",
   "homepage": "https://www.nongnu.org/libunwind",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5557,7 +5557,7 @@
       "port-version": 0
     },
     "libunwind": {
-      "baseline": "1.8.2",
+      "baseline": "1.8.3",
       "port-version": 0
     },
     "liburcu": {

--- a/versions/l-/libunwind.json
+++ b/versions/l-/libunwind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "93f45b3bd5c6ac40d2a5f26f39666d421a526d4b",
+      "version": "1.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff02fab09a333c0389d4335a69f8ff48e8f53a92",
       "version": "1.8.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/libunwind/libunwind/releases/tag/v1.8.3
