### PR TITLE
[aws-crt-cpp] update to 0.34.1

### DIFF
--- a/ports/aws-crt-cpp/portfile.cmake
+++ b/ports/aws-crt-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-crt-cpp
     REF "v${VERSION}"
-    SHA512 bdb6b43ceb61b03cb8ae581b55a5b95564e1380c236cf9e91cb49d917ef0c311e5e6093973a1a182bd6fce159ed59b1c82804c1f60240ac7212239035d959149
+    SHA512 e62c65cd751f30aea05e5234027c016b10aecf6a983fe6632af1828eb8538d6523ad02aaf4e6b9ca8b751232f9e49c4e55e7c12d6fee579a539b8d3cd26e083f
     PATCHES
         no-werror.patch
 )

--- a/ports/aws-crt-cpp/vcpkg.json
+++ b/ports/aws-crt-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-crt-cpp",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Protocols and SSL/TLS implementations for C++.",
   "homepage": "https://github.com/awslabs/aws-crt-cpp",
   "license": "Apache-2.0",

--- a/versions/a-/aws-crt-cpp.json
+++ b/versions/a-/aws-crt-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "300a1a29ea8b00ceae803defa7b0b344bb846178",
+      "version": "0.34.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "74b2312247169d30ad381039cbe06f82d01d426c",
       "version": "0.34.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -477,7 +477,7 @@
       "port-version": 0
     },
     "aws-crt-cpp": {
-      "baseline": "0.34.0",
+      "baseline": "0.34.1",
       "port-version": 0
     },
     "aws-lambda-cpp": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/awslabs/aws-crt-cpp/releases/tag/v0.34.1
