### PR TITLE
[g3log] Add dynamic-logging feature

### DIFF
--- a/ports/g3log/portfile.cmake
+++ b/ports/g3log/portfile.cmake
@@ -10,9 +10,14 @@ vcpkg_from_github(
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" G3_SHARED_LIB)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" G3_SHARED_RUNTIME)
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        dynamic-logging USE_DYNAMIC_LOGGING_LEVELS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
         -DG3_SHARED_LIB=${G3_SHARED_LIB} # Options.cmake
         -DG3_SHARED_RUNTIME=${G3_SHARED_RUNTIME} # Options.cmake
         -DADD_FATAL_EXAMPLE=OFF

--- a/ports/g3log/vcpkg.json
+++ b/ports/g3log/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "g3log",
   "version": "2.6",
+  "port-version": 1,
   "description": "Asynchronous logger with Dynamic Sinks",
   "homepage": "https://github.com/KjellKod/g3log",
   "license": "Unlicense",
@@ -14,5 +15,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "dynamic-logging": {
+      "description": "Enable dynamic logging levels"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3138,7 +3138,7 @@
     },
     "g3log": {
       "baseline": "2.6",
-      "port-version": 0
+      "port-version": 1
     },
     "gainput": {
       "baseline": "1.0.0",

--- a/versions/g-/g3log.json
+++ b/versions/g-/g3log.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e1548337703da81e267235ed5a4416888be4580",
+      "version": "2.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "f20671b45e773a71b84f8c8ae9bb0b8105b3cdce",
       "version": "2.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.