### PR TITLE
Feature/update smf port

### DIFF
--- a/ports/smf/portfile.cmake
+++ b/ports/smf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vpetrigo/smf
     REF "v${VERSION}"
-    SHA512 afe1b8e670c06f9ba50a8338957d2a23fc0ccda9a22a8091bc58b4ed3b6714907a85b8f6a823cde6eff1dfcbb5a834f31c5d14559ebbf92a73576f932c4e311d
+    SHA512 bed114b54142e6fbcbb5eec9dc202c61f73e7592559eaaeb0ed3c62231ed1e4bd5eedf4ac5b5bfa2b4cf64095f432d09a8644c37b47cdba8c367b14ad080bba0
     HEAD_REF main
 )
 

--- a/ports/smf/vcpkg.json
+++ b/ports/smf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "smf",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "State machine framework",
   "homepage": "https://github.com/vpetrigo/smf",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8949,7 +8949,7 @@
       "port-version": 0
     },
     "smf": {
-      "baseline": "0.2.2",
+      "baseline": "0.2.3",
       "port-version": 0
     },
     "smpeg2": {

--- a/versions/s-/smf.json
+++ b/versions/s-/smf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f316a24eb6a4101170931b3448fde657af7496b",
+      "version": "0.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "849e495dc04f74c36705009b02bc57e23fd1035b",
       "version": "0.2.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
