### PR TITLE
[libmtp] Add new port

### DIFF
--- a/ports/libmtp/disable-examples.patch
+++ b/ports/libmtp/disable-examples.patch
@@ -1,0 +1,10 @@
+diff --git a/Makefile.am b/Makefile.am
+index 5a0d464..b00bcea 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS=src examples util doc
++SUBDIRS=src util doc
+ ACLOCAL_AMFLAGS=-I m4
+ 
+ pkgconfigdir=$(libdir)/pkgconfig

--- a/ports/libmtp/dont-install-def-file.patch
+++ b/ports/libmtp/dont-install-def-file.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 088050e..c28ddbb 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -66,7 +66,7 @@ LT_CURRENT_MINUS_AGE=`expr $(CURRENT) - $(AGE)`
+ if COMPILE_MINGW32
+ W32_LIBS=-lws2_32
+ W32_LDFLAGS=-export-dynamic
+-if MS_LIB_EXE
++if FALSE
+ noinst_DATA=libmtp.lib
+ libmtp.def: $(srcdir)/libmtp.sym
+ 	echo "LIBRARY \"@PACKAGE@\"" > libmtp.def

--- a/ports/libmtp/portfile.cmake
+++ b/ports/libmtp/portfile.cmake
@@ -1,0 +1,39 @@
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libmtp/libmtp
+    REF ${VERSION}
+    FILENAME "libmtp-${VERSION}.tar.gz"
+    SHA512 97094b29073681da0c714b6c4aea2e5f35253a8d06229e60c0af46727413470e9da6be422d873449fc4dec6f9b8efce6d3edc657b9251182cc0a709859e99baa
+    PATCHES
+        disable-examples.patch
+        dont-install-def-file.patch
+)
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/m4/iconv.m4")
+file(REMOVE_RECURSE "${SOURCE_PATH}/src/gphoto2-endian.h")
+
+vcpkg_find_acquire_program(PKGCONFIG)
+set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_HOST_INSTALLED_DIR}/share/gettext/aclocal/\"")
+
+if(VCPKG_CROSSCOMPILING AND VCPKG_TARGET_IS_ANDROID)
+    set(cross_flags "--with-udev=${CURRENT_HOST_INSTALLED_DIR}/lib/udev/"
+                    "--enable-crossbuilddir=${CURRENT_INSTALLED_DIR}/lib/udev/"
+                    "HOST_MTP_HOTPLUG=${CURRENT_HOST_INSTALLED_DIR}/tools/libmtp/bin/mtp-hotplug${VCPKG_HOST_EXECUTABLE_SUFFIX}")
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS
+        ${cross_flags}
+        --disable-mtpz
+        --disable-doxygen
+)
+vcpkg_install_make()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libmtp/vcpkg.json
+++ b/ports/libmtp/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "libmtp",
+  "version-semver": "1.1.22",
+  "description": "A library to access MTP (Media Transfer Protocol) devices",
+  "homepage": "https://sourceforge.net/projects/libmtp/",
+  "license": "LGPL-2.1-or-later",
+  "supports": "(!windows | mingw) & !uwp & !android",
+  "dependencies": [
+    {
+      "name": "gettext",
+      "host": true
+    },
+    {
+      "name": "libmtp",
+      "host": true,
+      "platform": "android"
+    },
+    "libusb"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5112,6 +5112,10 @@
       "baseline": "2.7.1",
       "port-version": 0
     },
+    "libmtp": {
+      "baseline": "1.1.22",
+      "port-version": 0
+    },
     "libmultisense": {
       "baseline": "7.2.0",
       "port-version": 0

--- a/versions/l-/libmtp.json
+++ b/versions/l-/libmtp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b6c6e9ea77c5719ca7529b103b18e3ae4d94a11f",
+      "version-semver": "1.1.22",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #46412

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
