### PR TITLE
[reactphysics3d] Add new port

### DIFF
--- a/ports/reactphysics3d/portfile.cmake
+++ b/ports/reactphysics3d/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(FIX_UPSTREAM_421
+    URLS https://github.com/DanielChappuis/reactphysics3d/pull/421.patch?full_index=1
+    SHA512 71ab7d5024fff100546d1cc934976f15e3ee3fe8df29ff62e1c743d3f0c5f6dad73def0b9d0a560fa423e610cb1388c88c3226d8e2b9f2b1afdf4535204541ff
+	FILENAME reactphysics3d-421.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DanielChappuis/reactphysics3d
@@ -5,7 +11,7 @@ vcpkg_from_github(
     SHA512 3ba9ec0e399d2dc46c126e4aa20718b9024f8097f36157e31b469f5135a726d3c0811e79335db970dfab7f258d1506dd4cefa46edca73f5940bf561dc9a5b11a
     HEAD_REF master
     PATCHES
-        https://github.com/DanielChappuis/reactphysics3d/pull/421.patch?full_index=1
+		"${FIX_UPSTREAM_421}"
 )
 
 vcpkg_cmake_configure(

--- a/ports/reactphysics3d/portfile.cmake
+++ b/ports/reactphysics3d/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    WINDOWS_USE_MSBUILD
 )
 
 vcpkg_cmake_install()

--- a/ports/reactphysics3d/portfile.cmake
+++ b/ports/reactphysics3d/portfile.cmake
@@ -16,7 +16,6 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    WINDOWS_USE_MSBUILD
 )
 
 vcpkg_cmake_install()

--- a/ports/reactphysics3d/portfile.cmake
+++ b/ports/reactphysics3d/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO DanielChappuis/reactphysics3d
+    REF "v${VERSION}"
+    SHA512 3ba9ec0e399d2dc46c126e4aa20718b9024f8097f36157e31b469f5135a726d3c0811e79335db970dfab7f258d1506dd4cefa46edca73f5940bf561dc9a5b11a
+    HEAD_REF master
+    PATCHES
+        https://github.com/DanielChappuis/reactphysics3d/pull/421.patch?full_index=1
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "ReactPhysics3D"
+    CONFIG_PATH "lib/cmake/ReactPhysics3D"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/reactphysics3d/portfile.cmake
+++ b/ports/reactphysics3d/portfile.cmake
@@ -21,10 +21,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(
-    PACKAGE_NAME "ReactPhysics3D"
-    CONFIG_PATH "lib/cmake/ReactPhysics3D"
-)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/ReactPhysics3D")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/reactphysics3d/portfile.cmake
+++ b/ports/reactphysics3d/portfile.cmake
@@ -1,3 +1,7 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_download_distfile(FIX_UPSTREAM_421
     URLS https://github.com/DanielChappuis/reactphysics3d/pull/421.patch?full_index=1
     SHA512 71ab7d5024fff100546d1cc934976f15e3ee3fe8df29ff62e1c743d3f0c5f6dad73def0b9d0a560fa423e610cb1388c88c3226d8e2b9f2b1afdf4535204541ff

--- a/ports/reactphysics3d/usage
+++ b/ports/reactphysics3d/usage
@@ -1,0 +1,7 @@
+ReactPhysics3D provides CMake targets:
+
+find_package(ReactPhysics3D REQUIRED)
+
+add_executable(helloworld main.cpp)
+
+target_link_libraries(helloworld ReactPhysics3D::ReactPhysics3D)

--- a/ports/reactphysics3d/usage
+++ b/ports/reactphysics3d/usage
@@ -1,7 +1,4 @@
 ReactPhysics3D provides CMake targets:
 
-find_package(ReactPhysics3D REQUIRED)
-
-add_executable(helloworld main.cpp)
-
-target_link_libraries(helloworld ReactPhysics3D::ReactPhysics3D)
+  find_package(ReactPhysics3D REQUIRED)
+  target_link_libraries(main PRIVATE ReactPhysics3D::ReactPhysics3D)

--- a/ports/reactphysics3d/vcpkg.json
+++ b/ports/reactphysics3d/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "reactphysics3d",
+  "version": "0.10.2",
+  "description": "Open source C++ physics engine library in 3D",
+  "homepage": "www.reactphysics3d.com",
+  "license": "Zlib",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8288,6 +8288,10 @@
       "baseline": "2.1.1",
       "port-version": 0
     },
+    "reactphysics3d": {
+      "baseline": "0.10.2",
+      "port-version": 0
+    },
     "readerwriterqueue": {
       "baseline": "1.0.7",
       "port-version": 0

--- a/versions/r-/reactphysics3d.json
+++ b/versions/r-/reactphysics3d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "81f3dc6bd13b2b700bd16342067431d3cabc11c9",
+      "git-tree": "a39f348da83bc8cfcc15c8af46760ed8e76e830f",
       "version": "0.10.2",
       "port-version": 0
     }

--- a/versions/r-/reactphysics3d.json
+++ b/versions/r-/reactphysics3d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5f98f1c25f121a25ba7261b623aa6b725ee1ae82",
+      "git-tree": "81f3dc6bd13b2b700bd16342067431d3cabc11c9",
       "version": "0.10.2",
       "port-version": 0
     }

--- a/versions/r-/reactphysics3d.json
+++ b/versions/r-/reactphysics3d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0235102e2de47e590882405040a071587f199234",
+      "git-tree": "81f3dc6bd13b2b700bd16342067431d3cabc11c9",
       "version": "0.10.2",
       "port-version": 0
     }

--- a/versions/r-/reactphysics3d.json
+++ b/versions/r-/reactphysics3d.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0235102e2de47e590882405040a071587f199234",
+      "version": "0.10.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/r-/reactphysics3d.json
+++ b/versions/r-/reactphysics3d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "81f3dc6bd13b2b700bd16342067431d3cabc11c9",
+      "git-tree": "5f98f1c25f121a25ba7261b623aa6b725ee1ae82",
       "version": "0.10.2",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #19309

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

