### PR TITLE
[quill] Update to 10.1.0

### DIFF
--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
     REF "v${VERSION}"
-    SHA512 5456586e58d0374be428461ea1c0f3aa182db1be021bde39dd14cefb7f423add33c509a23e41c1a5dd7e485330bb2dae78b322c4a394908e1afb4e4d63f385c4
+    SHA512 b66edd24b2160e222db73b067c2252fba7be72cd0d26b7618da882184c54bc0e0bcaaa81c7da1f807a4c535f2cfd4c8b9484150edc4f8f78aee5a600688f09ce
     HEAD_REF master
 )
 

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "10.0.1",
+  "version": "10.1.0",
   "description": "Asynchronous Low Latency C++ Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8185,7 +8185,7 @@
       "port-version": 0
     },
     "quill": {
-      "baseline": "10.0.1",
+      "baseline": "10.1.0",
       "port-version": 0
     },
     "quirc": {

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa720d5f514381e018ecc03f1f59e76af486e8aa",
+      "version": "10.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "14633f42037950f2bfd627f04b0e2b41b59b0f64",
       "version": "10.0.1",
       "port-version": 0


### PR DESCRIPTION
Update quill port from 10.0.1 to 10.1.0: https://github.com/odygrd/quill/releases/tag/v10.1.0

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
