### PR TITLE
[tree-sitter] update to 0.25.9

### DIFF
--- a/ports/tree-sitter/portfile.cmake
+++ b/ports/tree-sitter/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tree-sitter/tree-sitter
     REF "v${VERSION}"
-    SHA512 0d26d0699f61fa27b5adbc298ff53f8e0f5b9f2f1b216744200f6f50cff777c9c5a5a5b92304a4d1889fccd9d8a6dd6b7d4947bac907a91850322281f754ea53
+    SHA512 c927274081bc61abde68399b0c7736cd2b0a5f96c79d1147fe85fc30cf48238afcff112cb61a5c89f3c3ccb3a5f154e4ac8935c1d423c63e93f814eb034ec50b
     HEAD_REF master
     PATCHES
         unofficial-cmake.diff

--- a/ports/tree-sitter/vcpkg.json
+++ b/ports/tree-sitter/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version-semver": "0.25.8",
+  "version-semver": "0.25.9",
   "description": "An incremental parsing system for programming tools.",
   "homepage": "https://github.com/tree-sitter/tree-sitter",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9733,7 +9733,7 @@
       "port-version": 1
     },
     "tree-sitter": {
-      "baseline": "0.25.8",
+      "baseline": "0.25.9",
       "port-version": 0
     },
     "tree-sitter-c": {

--- a/versions/t-/tree-sitter.json
+++ b/versions/t-/tree-sitter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00165334c5307c6cd04f7e006ffc0baec31bbe38",
+      "version-semver": "0.25.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "832ea9326a573cbcd22426e1f3dd479c9d3af640",
       "version-semver": "0.25.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/tree-sitter/tree-sitter/releases/tag/v0.25.9
