### PR TITLE
Revert "[dav1d] Switch dav1d source to GitHub"

### DIFF
--- a/ports/dav1d/portfile.cmake
+++ b/ports/dav1d/portfile.cmake
@@ -1,9 +1,9 @@
-vcpkg_from_github(
+vcpkg_from_gitlab(
+    GITLAB_URL https://code.videolan.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO videolan/dav1d
     REF "${VERSION}"
     SHA512 96973b59b367bc98fbc8b6c4f871259d9635caf487da86d7f5a4c42715424faf937e7e3f142a3175a7b473c3e945decb03a23e7a854b7c0ff0d11eeb5b692fad
-    HEAD_REF master
 )
 
 if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")

--- a/ports/dav1d/vcpkg.json
+++ b/ports/dav1d/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dav1d",
   "version": "1.5.1",
-  "port-version": 1,
   "description": "dav1d is a new open-source AV1 decoder developed by the VideoLAN and FFmpeg communities and sponsored by the Alliance for Open Media.",
   "homepage": "https://code.videolan.org/videolan/dav1d",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2326,7 +2326,7 @@
     },
     "dav1d": {
       "baseline": "1.5.1",
-      "port-version": 1
+      "port-version": 0
     },
     "daw-header-libraries": {
       "baseline": "2.123.2",

--- a/versions/d-/dav1d.json
+++ b/versions/d-/dav1d.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "2959b9e1c7cab8aa505b55950db3491998168c3c",
-      "version": "1.5.1",
-      "port-version": 1
-    },
-    {
       "git-tree": "0ab099efbd7810199d63a8167c6c54fc6bedf8ba",
       "version": "1.5.1",
       "port-version": 0


### PR DESCRIPTION
Reverts microsoft/vcpkg#45824

The webpage for VideoLAN's GitLab is no longer showing a teapot error.