### PR TITLE
[cppgraphqlgen] update to 4.5.9

### DIFF
--- a/ports/cppgraphqlgen/portfile.cmake
+++ b/ports/cppgraphqlgen/portfile.cmake
@@ -1,17 +1,9 @@
-vcpkg_download_distfile(LINUX_PATCH
-    URLS https://github.com/microsoft/cppgraphqlgen/commit/aa02e66edcf248c61a198eec546c401c3ada3667.patch?full_index=1
-    FILENAME fix-linux.patch
-    SHA512 d3664dbcc1a8df0eb538e82a932d3df16697b2f457039faa8b6cf6b95d3381f92de23433936f7196502db6afa9c8f58197194a65a87437092c1eb1cad684d652
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/cppgraphqlgen
     REF "v${VERSION}"
-    SHA512 1de45784485c285890200d31ce228a55ba19ed0d1bf0a3c18ea3c73d1938269f25833da1c28e8e155d875bdcf2fdf9916872f30ef9946de6bf58c1dfde451f4b
+    SHA512 eb26e6b9b51eabeb84ab82035097579dcdc5f44cc1d50ae85303bbab8fcc2a3da0749cef4e15bf09adb62a4783446bb8b661666db52517b2e98543177f662eb5
     HEAD_REF main
-    PATCHES
-        ${LINUX_PATCH}
 )
 
 vcpkg_check_features(

--- a/ports/cppgraphqlgen/vcpkg.json
+++ b/ports/cppgraphqlgen/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cppgraphqlgen",
-  "version": "4.5.7",
-  "port-version": 2,
+  "version": "4.5.9",
   "description": "C++ GraphQL schema service generator",
   "homepage": "https://github.com/microsoft/cppgraphqlgen",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2057,8 +2057,8 @@
       "port-version": 4
     },
     "cppgraphqlgen": {
-      "baseline": "4.5.7",
-      "port-version": 2
+      "baseline": "4.5.9",
+      "port-version": 0
     },
     "cppitertools": {
       "baseline": "2.3",

--- a/versions/c-/cppgraphqlgen.json
+++ b/versions/c-/cppgraphqlgen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75a00a0ed6f9b23e5b7ca132e7d6017a01deaa6a",
+      "version": "4.5.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "3ad7f8b9f23c95604d6fe6cd0710af8a4ea99176",
       "version": "4.5.7",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/microsoft/cppgraphqlgen/releases/tag/v4.5.9
https://github.com/microsoft/cppgraphqlgen/releases/tag/v4.5.8
