### PR TITLE
[dylib] update to 3.0.1

### DIFF
--- a/ports/dylib/portfile.cmake
+++ b/ports/dylib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martin-olivier/dylib
     REF "v${VERSION}"
-    SHA512 8e691c1bc73f381ce8ec50d85165c122ba55167b050e696c8b26ccf1ba14999ca8129fb6c5b6c3320166f606acb2c21867d0786347c341d1267815580beb5c0a
+    SHA512 9975c202aacc698b0b30cec1d839e31eb4fc60d7ee54fc56a114d5e8905a2ac4757aa97fc580b3b1a3c98bdba1420a49707339a09a646e4e8663ef17fe3cded3
     HEAD_REF main
 )
 
@@ -12,9 +12,10 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/dylib)
-
-vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME dylib
+    CONFIG_PATH lib/cmake/dylib
+)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/dylib/vcpkg.json
+++ b/ports/dylib/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "dylib",
-  "version-semver": "2.2.1",
+  "version-semver": "3.0.1",
   "description": "C++ cross-platform wrapper around dynamic loading of shared libraries",
   "homepage": "https://github.com/martin-olivier/dylib",
   "license": "MIT",
+  "supports": "!android & !uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2577,7 +2577,7 @@
       "port-version": 0
     },
     "dylib": {
-      "baseline": "2.2.1",
+      "baseline": "3.0.1",
       "port-version": 0
     },
     "dyno": {

--- a/versions/d-/dylib.json
+++ b/versions/d-/dylib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3eb9f98bcb56f71389d23941acfb7f893745680",
+      "version-semver": "3.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "5fcb0f058217dc6352d308f18015ef37b3f5f23c",
       "version-semver": "2.2.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
