### PR TITLE
[cgicc] Fix mirrors & enable dynamic library

### DIFF
--- a/ports/cgicc/portfile.cmake
+++ b/ports/cgicc/portfile.cmake
@@ -1,8 +1,8 @@
-
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnu.org/gnu/cgicc/cgicc-${VERSION}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/cgicc/cgicc-${VERSION}.tar.gz"
+    URLS
+        "https://ftpmirror.gnu.org/cgicc/cgicc-${VERSION}.tar.gz"
+        "https://ftp.gnu.org/gnu/cgicc/cgicc-${VERSION}.tar.gz"
+        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/cgicc/cgicc-${VERSION}.tar.gz"
     FILENAME "cgicc-${VERSION}.tar.gz"
     SHA512 e57b8f30b26b29008bcf1ffc3b2d272bdbd77848fb02e24912b6182ae90923d5933b9d204c556ac922a389f73ced465065b6e2202fc0c3d008e0e6038e7c8052
 )
@@ -18,12 +18,12 @@ vcpkg_extract_source_archive(
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
-  SOURCE_PATH "${SOURCE_PATH}"
-  OPTIONS
-    -DCMAKE_CXX_STANDARD=11 # 17 removes std::unary_function
-  OPTIONS_DEBUG
-    -DDISABLE_INSTALL_HEADERS=ON
-    -DDISABLE_INSTALL_TOOLS=ON
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_CXX_STANDARD=11 # 17 removes std::unary_function
+    OPTIONS_DEBUG
+        -DDISABLE_INSTALL_HEADERS=ON
+        -DDISABLE_INSTALL_TOOLS=ON
 )
 
 vcpkg_cmake_install()
@@ -31,11 +31,10 @@ vcpkg_copy_pdbs()
 
 file(READ "${CURRENT_PACKAGES_DIR}/include/cgicc/CgiDefs.h" CGI_H)
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-  string(REPLACE "#  ifdef CGICC_STATIC" "#  if 0" CGI_H "${CGI_H}")
+    string(REPLACE "#  ifdef CGICC_STATIC" "#  if 0" CGI_H "${CGI_H}")
 else()
-  string(REPLACE "#  ifdef CGICC_STATIC" "#  if 1" CGI_H "${CGI_H}")
+    string(REPLACE "#  ifdef CGICC_STATIC" "#  if 1" CGI_H "${CGI_H}")
 endif()
 file(WRITE "${CURRENT_PACKAGES_DIR}/include/cgicc/CgiDefs.h" "${CGI_H}")
 
-
-file(INSTALL "${SOURCE_PATH}/COPYING.DOC" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.DOC")

--- a/ports/cgicc/portfile.cmake
+++ b/ports/cgicc/portfile.cmake
@@ -23,7 +23,6 @@ vcpkg_cmake_configure(
         -DCMAKE_CXX_STANDARD=11 # 17 removes std::unary_function
     OPTIONS_DEBUG
         -DDISABLE_INSTALL_HEADERS=ON
-        -DDISABLE_INSTALL_TOOLS=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/cgicc/vcpkg.json
+++ b/ports/cgicc/vcpkg.json
@@ -8,10 +8,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ]
 }

--- a/ports/cgicc/vcpkg.json
+++ b/ports/cgicc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cgicc",
   "version": "3.2.20",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GNU Cgicc is an ANSI C++ compliant class library that greatly simplifies the creation of CGI applications for the World Wide Web",
   "homepage": "https://www.gnu.org/software/cgicc/",
   "dependencies": [

--- a/ports/cgicc/vcpkg.json
+++ b/ports/cgicc/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 2,
   "description": "GNU Cgicc is an ANSI C++ compliant class library that greatly simplifies the creation of CGI applications for the World Wide Web",
   "homepage": "https://www.gnu.org/software/cgicc/",
+  "license": "LGPL-2.1-or-later",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1662,7 +1662,7 @@
     },
     "cgicc": {
       "baseline": "3.2.20",
-      "port-version": 1
+      "port-version": 2
     },
     "cglm": {
       "baseline": "0.9.4",

--- a/versions/c-/cgicc.json
+++ b/versions/c-/cgicc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03511d2570bd4f179d8d2f5042013dd52da009d3",
+      "version": "3.2.20",
+      "port-version": 2
+    },
+    {
       "git-tree": "d14a5cb5e4d6f0606e2071d1c94262916a45fd6b",
       "version": "3.2.20",
       "port-version": 1

--- a/versions/c-/cgicc.json
+++ b/versions/c-/cgicc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc5715d672c3c7a9697116e4bfb4d9cd7363ed91",
+      "git-tree": "4e02edf2aec0aef1be5eb6f6ca130d562278c2bf",
       "version": "3.2.20",
       "port-version": 2
     },

--- a/versions/c-/cgicc.json
+++ b/versions/c-/cgicc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "03511d2570bd4f179d8d2f5042013dd52da009d3",
+      "git-tree": "bc5715d672c3c7a9697116e4bfb4d9cd7363ed91",
       "version": "3.2.20",
       "port-version": 2
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
