### PR TITLE
[gdbm] Try mirrors first

### DIFF
--- a/ports/gdbm/portfile.cmake
+++ b/ports/gdbm/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnu.org/gnu/gdbm/gdbm-${VERSION}.tar.gz"
-         "https://ftpmirror.gnu.org/gdbm/gdbm-${VERSION}.tar.gz"
+    URLS "https://ftpmirror.gnu.org/gdbm/gdbm-${VERSION}.tar.gz"
+         "https://ftp.gnu.org/gnu/gdbm/gdbm-${VERSION}.tar.gz"
          "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gdbm/gdbm-${VERSION}.tar.gz"
     FILENAME "gdbm-${VERSION}.tar.gz"
     SHA512 401ff8c707079f21da1ac1d6f4714a87f224b6f41943078487dc891be49f51fd1ac7a32fd599aae0fad185f2c6ba7432616d328fd6aaab068eb54db9562ff7fa

--- a/ports/gdbm/vcpkg.json
+++ b/ports/gdbm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdbm",
   "version": "1.24",
+  "port-version": 1,
   "description": "GDBM is a library of database functions that use extensible hashing and works similar to the standard UNIX dbm.",
   "homepage": "https://www.gnu.org.ua/software/gdbm/gdbm.html",
   "license": "GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3186,7 +3186,7 @@
     },
     "gdbm": {
       "baseline": "1.24",
-      "port-version": 0
+      "port-version": 1
     },
     "gdcm": {
       "baseline": "3.0.24",

--- a/versions/g-/gdbm.json
+++ b/versions/g-/gdbm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e0402af6ea114205282de7f19abbb88f45bc5bc0",
+      "version": "1.24",
+      "port-version": 1
+    },
+    {
       "git-tree": "6f1a4f9089dcb8097ecdf38fda0274e2f19c6294",
       "version": "1.24",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
