### PR TITLE
[guile] Add mirror

### DIFF
--- a/ports/guile/portfile.cmake
+++ b/ports/guile/portfile.cmake
@@ -1,10 +1,12 @@
 vcpkg_download_distfile(GUILE_ARCHIVE 
-      URLS https://ftp.gnu.org/gnu/guile/guile-${VERSION}.tar.gz
-      FILENAME guile-${VERSION}.tar.gz
-      SHA512 8b0e6354fdfccd009fd92a5618828f8a8343faf20d1d3698be77a6ef7a8fe56ce633fd1239520e6a6be511ba4ca75eb90c8a81c45888b8b73d938cd2908d7a1f
-  )
+    URLS
+        "https://ftpmirror.gnu.org/guile/guile-${VERSION}.tar.gz"    
+        "https://ftp.gnu.org/gnu/guile/guile-${VERSION}.tar.gz"
+    FILENAME "guile-${VERSION}.tar.gz"
+    SHA512 8b0e6354fdfccd009fd92a5618828f8a8343faf20d1d3698be77a6ef7a8fe56ce633fd1239520e6a6be511ba4ca75eb90c8a81c45888b8b73d938cd2908d7a1f
+)
 
-vcpkg_extract_source_archive(GUILE_SOURCES ARCHIVE ${GUILE_ARCHIVE})
+vcpkg_extract_source_archive(GUILE_SOURCES ARCHIVE "${GUILE_ARCHIVE}")
 
 vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/gperf")
 
@@ -12,7 +14,7 @@ vcpkg_configure_make(
     SOURCE_PATH "${GUILE_SOURCES}"
     ADD_BIN_TO_PATH
     AUTOCONFIG
-  )
+)
 vcpkg_install_make()
 vcpkg_copy_pdbs()
 
@@ -21,18 +23,14 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_fixup_pkgconfig()
 
 if (NOT VCPKG_BUILD_TYPE)
-  foreach(file guile-tools guile-config guild)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/${file}" "${CURRENT_INSTALLED_DIR}/debug/../tools/guile/debug/bin" "`dirname $0`" IGNORE_UNCHANGED)
-  endforeach()
+    foreach(file guile-tools guile-config guild)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/${file}" "${CURRENT_INSTALLED_DIR}/debug/../tools/guile/debug/bin" "`dirname $0`" IGNORE_UNCHANGED)
+    endforeach()
   vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/guile-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../../..")
 endif()
 foreach(file guile-tools guile-config guild)
-  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/${file}" "${CURRENT_INSTALLED_DIR}/tools/guile/bin" "`dirname $0`" IGNORE_UNCHANGED)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/${file}" "${CURRENT_INSTALLED_DIR}/tools/guile/bin" "`dirname $0`" IGNORE_UNCHANGED)
 endforeach()
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/guile-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../..")
 
-file(
-    INSTALL "${GUILE_SOURCES}/COPYING.LESSER" 
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" 
-    RENAME copyright
-  )
+vcpkg_install_copyright(FILE_LIST "${GUILE_SOURCES}/COPYING.LESSER")

--- a/ports/guile/vcpkg.json
+++ b/ports/guile/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "guile",
   "version": "3.0.10",
+  "port-version": 1,
   "description": "GNU's programming and extension language",
   "homepage": "https://www.gnu.org/software/guile/",
   "documentation": "https://www.gnu.org/software/guile/manual/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3506,7 +3506,7 @@
     },
     "guile": {
       "baseline": "3.0.10",
-      "port-version": 0
+      "port-version": 1
     },
     "guilite": {
       "baseline": "2022-05-05",

--- a/versions/g-/guile.json
+++ b/versions/g-/guile.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "883037b0117f33c721a52c8f50d82f8ff2ff4a33",
+      "version": "3.0.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "4fe9e6fe1d7b38bb84a73f37e34d83e6abe526cb",
       "version": "3.0.10",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
