### PR TITLE
[mpc] Add mirror

### DIFF
--- a/ports/mpc/portfile.cmake
+++ b/ports/mpc/portfile.cmake
@@ -1,12 +1,14 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnu.org/gnu/mpc/mpc-${VERSION}.tar.gz"
+    URLS
+        "https://ftpmirror.gnu.org/gnu/mpc/mpc-${VERSION}.tar.gz"
+        "https://ftp.gnu.org/gnu/mpc/mpc-${VERSION}.tar.gz"
     FILENAME "mpc-${VERSION}.tar.gz"
     SHA512 4bab4ef6076f8c5dfdc99d810b51108ced61ea2942ba0c1c932d624360a5473df20d32b300fc76f2ba4aa2a97e1f275c9fd494a1ba9f07c4cb2ad7ceaeb1ae97
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
 )
 
 vcpkg_configure_make(
@@ -18,7 +20,7 @@ vcpkg_install_make()
 
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING.LESSER" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.LESSER")

--- a/ports/mpc/vcpkg.json
+++ b/ports/mpc/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "mpc",
   "version": "1.3.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GNU MPC is a C library for the arithmetic of complex numbers with arbitrarily high precision and correct rounding of the result.",
   "homepage": "https://www.multiprecision.org/mpc/",
+  "license": "LGPL-3.0-or-later",
   "dependencies": [
     "gmp",
     "mpfr"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6422,7 +6422,7 @@
     },
     "mpc": {
       "baseline": "1.3.1",
-      "port-version": 1
+      "port-version": 2
     },
     "mpfr": {
       "baseline": "4.2.2",

--- a/versions/m-/mpc.json
+++ b/versions/m-/mpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13fee4f0fddd20945c718e7adf38ba0aaa2238ba",
+      "version": "1.3.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "9d1ac54ce56647856d76413a33a16b4fe39352bb",
       "version": "1.3.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
