### PR TITLE
[aws-c-io] update to 0.21.5

### DIFF
--- a/ports/aws-c-io/portfile.cmake
+++ b/ports/aws-c-io/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-io
     REF "v${VERSION}"
-    SHA512 0a9ea40dbcae8b2885be4e0a8b5ddb5957a88e4448b1153a46b8a0a0698af5ced6eae738bbb4e4027f9983343222eef162a4b92f655a51746b914ac9bab92901
+    SHA512 49ad96dab0fa7b216525e70c54493a7d3921ccf2ecdafb281a6f0a8686d92f6fa8c3417e2ec0c0ce7f5f4cc2b7f87c8bbdadf19f7e5fbab9204627dfefb9faec
     HEAD_REF master
 )
 

--- a/ports/aws-c-io/vcpkg.json
+++ b/ports/aws-c-io/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-io",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "Handles all IO and TLS work for application protocols.",
   "homepage": "https://github.com/awslabs/aws-c-io",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-io.json
+++ b/versions/a-/aws-c-io.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96920278843d68ae95e2a2e61cae10c6b7cb79f9",
+      "version": "0.21.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "81a06df077824baaf93075e3f48238a3e97e1f3e",
       "version": "0.21.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -457,7 +457,7 @@
       "port-version": 0
     },
     "aws-c-io": {
-      "baseline": "0.21.4",
+      "baseline": "0.21.5",
       "port-version": 0
     },
     "aws-c-mqtt": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/awslabs/aws-c-io/releases/tag/v0.21.5
