### PR TITLE
fix(arrayfire): incorrect target import paths

### DIFF
--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -116,6 +116,20 @@ if(FEATURES STREQUAL "core")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 endif()
 
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_replace_string(
+      "${CURRENT_PACKAGES_DIR}/share/arrayfire/ArrayFireConfig.cmake"
+      "{PACKAGE_PREFIX_DIR}/share/ArrayFire/cmake"
+      "{PACKAGE_PREFIX_DIR}/share/arrayfire"
+    )
+else()
+    vcpkg_replace_string(
+      "${CURRENT_PACKAGES_DIR}/share/arrayfire/ArrayFireConfig.cmake"
+      "{PACKAGE_PREFIX_DIR}/cmake/"
+      "{PACKAGE_PREFIX_DIR}/share/arrayfire"
+    )
+endif()
+
 # Copyright and license
 file(INSTALL "${SOURCE_PATH}/COPYRIGHT.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -125,7 +125,7 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
 else()
     vcpkg_replace_string(
       "${CURRENT_PACKAGES_DIR}/share/arrayfire/ArrayFireConfig.cmake"
-      "{PACKAGE_PREFIX_DIR}/cmake/"
+      "{PACKAGE_PREFIX_DIR}/cmake"
       "{PACKAGE_PREFIX_DIR}/share/arrayfire"
     )
 endif()

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrayfire",
   "version-semver": "3.8.0",
-  "port-version": 8,
+  "port-version": 9,
   "description": "ArrayFire is a general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.",
   "homepage": "https://github.com/arrayfire/arrayfire",
   "license": "BSD-3-Clause",

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "835f6bb283f55c5fc34a795e034dc3b46760af5e",
+      "version-semver": "3.8.0",
+      "port-version": 9
+    },
+    {
       "git-tree": "3ed888c7fc2aa125e626ff0f097b00a4230bab1c",
       "version-semver": "3.8.0",
       "port-version": 8

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "835f6bb283f55c5fc34a795e034dc3b46760af5e",
+      "git-tree": "b96f3fac8bec3933c7ac5c6dbe7811194dc1bd4c",
       "version-semver": "3.8.0",
       "port-version": 9
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -266,7 +266,7 @@
     },
     "arrayfire": {
       "baseline": "3.8.0",
-      "port-version": 8
+      "port-version": 9
     },
     "arrow": {
       "baseline": "21.0.0",


### PR DESCRIPTION
The import paths for installed targets was still wrong even with `vcpkg_cmake_config_fixup()`

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
