### PR TITLE
[kaitai-struct-cpp-stl-runtime] update to 0.11

### DIFF
--- a/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
+++ b/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kaitai-io/kaitai_struct_cpp_stl_runtime
     REF ${VERSION}
-    SHA512 53b26627e281a12b6c1d217e8b439aba7dabf6fc55d3edc27e70f7757851f060f4039db3a16c48c5c60a715671b855b51e527f154df7d94547943f865c9d4b9a
+    SHA512 fd537c5d45d4c53de54c31b9286ff1100f74d62458fa2bbfd0d10d9cfedeb638e20c8d89a683b934310244de1de1093dbf79a06ac56a4918032ee31f0b49cbd7
     HEAD_REF master
 )
 

--- a/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
+++ b/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF ${VERSION}
     SHA512 fd537c5d45d4c53de54c31b9286ff1100f74d62458fa2bbfd0d10d9cfedeb638e20c8d89a683b934310244de1de1093dbf79a06ac56a4918032ee31f0b49cbd7
     HEAD_REF master
+    PATCHES
+        remove-werror.patch
 )
 
 set(STRING_ENCODING_TYPE "NONE")

--- a/ports/kaitai-struct-cpp-stl-runtime/remove-werror.patch
+++ b/ports/kaitai-struct-cpp-stl-runtime/remove-werror.patch
@@ -1,0 +1,16 @@
+diff --git a/Common.cmake b/Common.cmake
+index 31d8116..f46cbc3 100644
+--- a/Common.cmake
++++ b/Common.cmake
+@@ -12,9 +12,9 @@ endif()
+ #
+ # This method was taken from https://www.pragmaticlinux.com/2022/07/enable-compiler-warnings-with-cmake/
+ target_compile_options(${PROJECT_NAME} PRIVATE
+-    $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
++    $<$<CXX_COMPILER_ID:MSVC>:/W4>
+     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:
+-        -Wall -Wextra -Wpedantic -Werror
++        -Wall -Wextra -Wpedantic
+ 
+         # We're using the `long long` type intentionally. Although it's not part of C++98, in
+         # practice it is usually supported even by ancient compilers with very limited C++11

--- a/ports/kaitai-struct-cpp-stl-runtime/vcpkg.json
+++ b/ports/kaitai-struct-cpp-stl-runtime/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "kaitai-struct-cpp-stl-runtime",
-  "version": "0.10.1",
-  "port-version": 1,
+  "version": "0.11",
   "description": "Kaitai Struct is a declarative language used for describe various binary data structures, laid out in files or in memory. This library implements Kaitai Struct API for C++ using STL",
   "homepage": "http://kaitai.io/",
   "documentation": "https://doc.kaitai.io/lang_cpp_stl.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4117,8 +4117,8 @@
       "port-version": 7
     },
     "kaitai-struct-cpp-stl-runtime": {
-      "baseline": "0.10.1",
-      "port-version": 1
+      "baseline": "0.11",
+      "port-version": 0
     },
     "kangaru": {
       "baseline": "4.3.2",

--- a/versions/k-/kaitai-struct-cpp-stl-runtime.json
+++ b/versions/k-/kaitai-struct-cpp-stl-runtime.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a77e3c2ff8e794bf317b054b77599a17cce79001",
+      "git-tree": "c24e4f3de328fd608e8e828c063d66eeac2eb13b",
       "version": "0.11",
       "port-version": 0
     },

--- a/versions/k-/kaitai-struct-cpp-stl-runtime.json
+++ b/versions/k-/kaitai-struct-cpp-stl-runtime.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a77e3c2ff8e794bf317b054b77599a17cce79001",
+      "version": "0.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "6955b0e08a1013a8e3fc43984ddd4a9455bec5ed",
       "version": "0.10.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/releases/tag/0.11
