### PR TITLE
 update async-mqtt port to 10.2.5

### DIFF
--- a/ports/async-mqtt/portfile.cmake
+++ b/ports/async-mqtt/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO redboltz/async_mqtt
     REF "${VERSION}"
-    SHA512 a387657938f30de323cad472c0299100bf341aec65a1d47ebaa407853bceddc448e811c6a91ad8534d22ce609a050d104098b035ad1cde64c35ee1d60b95adde
+    SHA512 618bcd8357fd560e6b92a1bce08da0259f59d53bcfa9aed9890f182cb6f20415cff2595f31a3ca68b6e9c7b1caed3499a2e1915cd84a43dabf2e1e324c029ac1
     HEAD_REF main
 )
 

--- a/ports/async-mqtt/vcpkg.json
+++ b/ports/async-mqtt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "async-mqtt",
-  "version": "10.2.4",
+  "version": "10.2.5",
   "description": "Header-only Asynchronous MQTT communication library for C++17 based on Boost.Asio.",
   "homepage": "https://github.com/redboltz/async_mqtt",
   "license": "BSL-1.0",

--- a/versions/a-/async-mqtt.json
+++ b/versions/a-/async-mqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "496c50a5fc2764aea0609870623c442fc1069607",
+      "version": "10.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "552ec916b5c22cf87bc5a601682cd2c780f45b42",
       "version": "10.2.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -325,7 +325,7 @@
       "port-version": 0
     },
     "async-mqtt": {
-      "baseline": "10.2.4",
+      "baseline": "10.2.5",
       "port-version": 0
     },
     "async-simple": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
