### PR TITLE
[lastools] Copy CSV files that are used as lookup tables

### DIFF
--- a/ports/lastools/portfile.cmake
+++ b/ports/lastools/portfile.cmake
@@ -29,6 +29,9 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/LASlib PACKAGE_NAME laslib)
 
 if(BUILD_TOOLS)
     vcpkg_copy_tools(TOOL_NAMES las2las64 las2txt64 lascopcindex64 lasdiff64 lasindex64 lasinfo64 lasmerge64 lasprecision64 laszip64 txt2las64  AUTO_CLEAN)
+
+    # Copy CSV files that are used as lookup tables by las2las.
+    file(COPY ${SOURCE_PATH}/bin/serf/geo DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}/serf)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/lastools/vcpkg.json
+++ b/ports/lastools/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "lastools",
   "version": "2.0.3",
+  "port-version": 1,
   "description": "LAStools: award-winning software for efficient LiDAR processing (with LASzip)",
   "homepage": "https://github.com/LAStools/LAStools",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4414,7 +4414,7 @@
     },
     "lastools": {
       "baseline": "2.0.3",
-      "port-version": 0
+      "port-version": 1
     },
     "laszip": {
       "baseline": "3.4.4",

--- a/versions/l-/lastools.json
+++ b/versions/l-/lastools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32bfb1c66d429ff857d870fb92724fd165013d75",
+      "version": "2.0.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "ef0c4018e358e6adb7835f43588e759537401811",
       "version": "2.0.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #46796 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.