### PR TITLE
[angle] Fixed osx build for packages that use angle

### DIFF
--- a/ports/angle/cmake-buildsystem/PlatformMac.cmake
+++ b/ports/angle/cmake-buildsystem/PlatformMac.cmake
@@ -38,9 +38,15 @@ if(USE_OPENGL)
     list(APPEND ANGLE_SOURCES
         ${angle_translator_glsl_base_sources}
         ${angle_translator_glsl_sources}
+        ${angle_translator_glsl_apple_sources}
     )
     # Enable GLSL compiler output.
     list(APPEND ANGLE_DEFINITIONS ANGLE_ENABLE_GLSL ANGLE_ENABLE_GL_DESKTOP_BACKEND ANGLE_ENABLE_APPLE_WORKAROUNDS ANGLE_ENABLE_CGL)
+
+    # Still need to link with Metal as we call MTLCreateSystemDefaultDevice even if USE_METAL is not defined
+    list(APPEND ANGLEGLESv2_LIBRARIES
+        "-framework Metal"
+    )
 endif()
 
 if(USE_OPENGL OR ENABLE_WEBGL)

--- a/ports/angle/portfile.cmake
+++ b/ports/angle/portfile.cmake
@@ -32,7 +32,7 @@ endif()
 
 set(USE_METAL OFF)
 if ("metal" IN_LIST FEATURES)
-    set(USE_METAL ON)
+  set(USE_METAL ON)
 endif()
 
 # chromium/7258

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_7258",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6eb27c13ec4328ed3d63f058a485a4e213087bda",
+      "version-string": "chromium_7258",
+      "port-version": 2
+    },
+    {
       "git-tree": "165d665818d070431c2889ac2b8f97f006948924",
       "version-string": "chromium_7258",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -138,7 +138,7 @@
     },
     "angle": {
       "baseline": "chromium_7258",
-      "port-version": 1
+      "port-version": 2
     },
     "ankurvdev-embedresource": {
       "baseline": "0.0.12",


### PR DESCRIPTION
Fixes #47088 

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
