### PR TITLE
[unicorn] update to 2.1.4

### DIFF
--- a/ports/unicorn/portfile.cmake
+++ b/ports/unicorn/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO unicorn-engine/unicorn
     REF "${VERSION}"
-    SHA512 49aa53cd981e88857cf579010e3e86a6808fbfc9723fbf73c3d5bcebf945c5d78ffcdf426a4bbcd06b13337a3a0ce76bce8815497e3521023ae432a053d3e4bb
+    SHA512 c9ae4230a20b77e0187cde33dbf4827b3504b6c24debd61fc79ec9c13fa2051335c834c101433cebbbc8e3baadae56212b79c5922bf37ea1f777d66d8e67b495
     HEAD_REF master
     PATCHES
         fix-build.patch

--- a/ports/unicorn/vcpkg.json
+++ b/ports/unicorn/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "unicorn",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Unicorn is a lightweight multi-platform, multi-architecture CPU emulator framework",
   "homepage": "https://github.com/unicorn-engine/unicorn",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9825,7 +9825,7 @@
       "port-version": 0
     },
     "unicorn": {
-      "baseline": "2.1.3",
+      "baseline": "2.1.4",
       "port-version": 0
     },
     "unicorn-lib": {

--- a/versions/u-/unicorn.json
+++ b/versions/u-/unicorn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "032ac11fc54c36682e1dc5c073e14782dc6bfe87",
+      "version": "2.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "798ab1504a56c7ac87dff423f3e87a666d0e6e16",
       "version": "2.1.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/unicorn-engine/unicorn/releases/tag/2.1.4
