### PR TITLE
[ffmpeg] Disable assembly on OpenBSD

### DIFF
--- a/ports/ffmpeg/build.sh.in
+++ b/ports/ffmpeg/build.sh.in
@@ -73,17 +73,21 @@ OSX_ARCH_COUNT=0@OSX_ARCH_COUNT@
 # arm64 Android build fails with 'relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol ff_cos_32; recompile with -fPIC'
 # x86 Android build fails with 'error: inline assembly requires more registers than available'.
 # x64 Android build fails with 'relocation R_X86_64_PC32 cannot be used against symbol ff_h264_cabac_tables; recompile with -fPIC'
-if [ "@VCPKG_CMAKE_SYSTEM_NAME@" = "Android" ]; then
-    OPTIONS_arm=" --disable-asm --disable-x86asm"
-    OPTIONS_arm64=" --disable-asm --disable-x86asm"
-    OPTIONS_x86=" --disable-asm --disable-x86asm"
-    OPTIONS_x86_64="${OPTIONS_x86}"
-else
-    OPTIONS_arm=" --disable-asm --disable-x86asm"
-    OPTIONS_arm64=" --enable-asm --disable-x86asm"
-    OPTIONS_x86=" --enable-asm --enable-x86asm"
-    OPTIONS_x86_64="${OPTIONS_x86}"
-fi
+# Also disable those on OpenBSD beacuse the cause similar failures
+case "@VCPKG_CMAKE_SYSTEM_NAME@" in
+    Android|OpenBSD)
+        OPTIONS_arm=" --disable-asm --disable-x86asm"
+        OPTIONS_arm64=" --disable-asm --disable-x86asm"
+        OPTIONS_x86=" --disable-asm --disable-x86asm"
+        OPTIONS_x86_64="${OPTIONS_x86}"
+        ;;
+    *)
+        OPTIONS_arm=" --disable-asm --disable-x86asm"
+        OPTIONS_arm64=" --enable-asm --disable-x86asm"
+        OPTIONS_x86=" --enable-asm --enable-x86asm"
+        OPTIONS_x86_64="${OPTIONS_x86}"
+        ;;
+esac
 
 case "@VCPKG_CMAKE_SYSTEM_NAME@" in
     FreeBSD|OpenBSD)

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "7.1.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2886,7 +2886,7 @@
     },
     "ffmpeg": {
       "baseline": "7.1.1",
-      "port-version": 5
+      "port-version": 6
     },
     "ffnvcodec": {
       "baseline": "12.2.72.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a69648323b8132a6d283cc81ffb9cb8316a9ee3",
+      "version": "7.1.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "0988005f333aa87d797fb08535d33995f6ec302f",
       "version": "7.1.1",
       "port-version": 5


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
