### PR TITLE
[libudfread, libbluray] Add new ports

### DIFF
--- a/ports/libbluray/msvc.diff
+++ b/ports/libbluray/msvc.diff
@@ -1,0 +1,15 @@
+diff --git a/src/libbluray/bdnav/meta_parse.c b/src/libbluray/bdnav/meta_parse.c
+index d45be33c..20e1ec47 100644
+--- a/src/libbluray/bdnav/meta_parse.c
++++ b/src/libbluray/bdnav/meta_parse.c
+@@ -40,6 +40,10 @@
+ #include <strings.h>
+ #endif
+ 
++#ifdef _WIN32
++#define strncasecmp _strnicmp
++#endif
++
+ #ifdef HAVE_LIBXML2
+ #include <libxml/parser.h>
+ #include <libxml/xmlmemory.h>

--- a/ports/libbluray/portfile.cmake
+++ b/ports/libbluray/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_from_gitlab(
+    GITLAB_URL https://code.videolan.org
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO videolan/libbluray
+    REF ${VERSION}
+    SHA512 e728f8d93b311d540a3883ba869fdc2c10e91b4009bf1796947b510d3646088dfd7aeabaebb3a1dcbf49d5afee48743bfa620fd93aa54bf948238510e7e7719f
+    PATCHES
+        msvc.diff
+)
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND options -Dfontconfig=enabled)
+else()
+    list(APPEND options -Dfontconfig=disabled)
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Denable_tools=false
+        -Dbdj_jar=disabled
+        -Dfreetype=enabled
+        -Dlibxml2=enabled
+        ${options}
+)
+
+vcpkg_install_meson()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libbluray/vcpkg.json
+++ b/ports/libbluray/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "libbluray",
+  "version-semver": "1.4.0",
+  "description": "Library to access Blu-Ray disks",
+  "homepage": "https://www.videolan.org/developers/libbluray.html",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!uwp & !xbox",
+  "dependencies": [
+    {
+      "name": "fontconfig",
+      "platform": "!uwp & !windows"
+    },
+    "freetype",
+    "libudfread",
+    "libxml2",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/ports/libudfread/msvc.diff
+++ b/ports/libudfread/msvc.diff
@@ -1,0 +1,30 @@
+diff --git a/src/default_blockinput.c b/src/default_blockinput.c
+index 3926e65..1be4505 100644
+--- a/src/default_blockinput.c
++++ b/src/default_blockinput.c
+@@ -37,6 +37,9 @@
+ 
+ #ifdef _WIN32
+ #include <windows.h>
++#if !defined(ssize_t)
++#define ssize_t SSIZE_T
++#endif
+ #ifndef HAVE_UNISTD_H
+ #include <stdio.h>
+ #endif
+diff --git a/src/udfread.h b/src/udfread.h
+index d6fd9ef..94b6cbb 100644
+--- a/src/udfread.h
++++ b/src/udfread.h
+@@ -35,6 +35,11 @@ extern "C" {
+ #define UDF_PUBLIC
+ #endif
+ 
++#if defined(_WIN32) && !defined(ssize_t)
++#include <windows.h>
++#define ssize_t SSIZE_T
++#endif
++
+ /**
+  * @file udfread/udfread.h
+  * external API header

--- a/ports/libudfread/portfile.cmake
+++ b/ports/libudfread/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_gitlab(
+    OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://code.videolan.org
+    REPO videolan/libudfread
+    REF ${VERSION}
+    SHA512 63cdd8ce9b7525d17f8f685b87d1232334ebfe9ffcd48b3bb189231f4d3c88c11a19d3435be9252058d374b1cbd86eb38a045c969699730cb9729a541582f645
+    PATCHES
+        msvc.diff
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Denable_examples=false
+)
+
+vcpkg_install_meson()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libudfread/vcpkg.json
+++ b/ports/libudfread/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "libudfread",
+  "version-semver": "1.2.0",
+  "description": "UDF filesystem access library",
+  "homepage": "https://code.videolan.org/videolan/libudfread",
+  "license": "LGPL-2.1-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5532,6 +5532,10 @@
       "baseline": "1.1.0",
       "port-version": 5
     },
+    "libudfread": {
+      "baseline": "1.2.0",
+      "port-version": 0
+    },
     "libudis86": {
       "baseline": "2018-01-28",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4572,6 +4572,10 @@
       "baseline": "2024-11-30",
       "port-version": 0
     },
+    "libbluray": {
+      "baseline": "1.4.0",
+      "port-version": 0
+    },
     "libbson": {
       "baseline": "1.30.3",
       "port-version": 0

--- a/versions/l-/libbluray.json
+++ b/versions/l-/libbluray.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "78e9adbc51b025837d4d9ed078b29f39d94f8b9e",
+      "version-semver": "1.4.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libudfread.json
+++ b/versions/l-/libudfread.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "cc76c6694a4e2afa352b84e4b2fbd94102e766ef",
+      "version-semver": "1.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
libudfread is a dependency of libbluray, so I added them both

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

