### PR TITLE
[xlsxio] update to 0.2.36

### DIFF
--- a/ports/xlsxio/portfile.cmake
+++ b/ports/xlsxio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO brechtsanders/xlsxio
     REF "${VERSION}"
-    SHA512 9608e208cd71669e2b38bd64b0f21c8642ff34dbbb1d03f1d3ea1a6c166ada4e945b781fbaeb0f7f43753a23c3a5e833dcb5c5d6fd39177c99a00f867cc040d6
+    SHA512 6d22aa23290da84fbbf9ed5fbfbc3203b0171b58de14e94283cdd240c65f7f2b0b5b9f7f044d0b0a5d925f645cac305718b338b806004d8f844a525292972d28
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/xlsxio/vcpkg.json
+++ b/ports/xlsxio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xlsxio",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "Cross-platform C library for reading values from and writing values to .xlsx files",
   "homepage": "https://github.com/brechtsanders/xlsxio",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10513,7 +10513,7 @@
       "port-version": 0
     },
     "xlsxio": {
-      "baseline": "0.2.35",
+      "baseline": "0.2.36",
       "port-version": 0
     },
     "xmlsec": {

--- a/versions/x-/xlsxio.json
+++ b/versions/x-/xlsxio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c92fa3dc93a3be86440a6eeb95dc2faf262b54c4",
+      "version": "0.2.36",
+      "port-version": 0
+    },
+    {
       "git-tree": "99e158bbe73bccd5edff7a1a6c36c40ec37a1fcd",
       "version": "0.2.35",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/brechtsanders/xlsxio/releases/tag/0.2.36