### PR TITLE
[verdict] update to 1.4.2

### DIFF
--- a/ports/verdict/fix_osx.patch
+++ b/ports/verdict/fix_osx.patch
@@ -1,18 +1,5 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c41d98f70..83f7ca27a 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -53,7 +53,7 @@ configure_file(
- add_library(verdict ${verdict_SOURCES})
- target_include_directories(verdict PUBLIC
-   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
--
-+target_compile_features(verdict PUBLIC cxx_std_11)
- 
- # Setting the VERSION and SOVERSION of a library will include
- # version information either in the library, or in the library
 diff --git a/V_HexMetric.cpp b/V_HexMetric.cpp
-index 6ba32fa86..5fd976321 100644
+index fda4771..74eecb2 100644
 --- a/V_HexMetric.cpp
 +++ b/V_HexMetric.cpp
 @@ -2974,10 +2974,10 @@ double hex_distortion(int num_nodes, const double coordinates[][3])
@@ -40,10 +27,10 @@ index 6ba32fa86..5fd976321 100644
    for (node_id = 0; node_id < num_nodes; node_id++)
    {
 diff --git a/V_QuadMetric.cpp b/V_QuadMetric.cpp
-index 0c7c508e0..8e8a2537e 100644
+index 2486146..68af002 100644
 --- a/V_QuadMetric.cpp
 +++ b/V_QuadMetric.cpp
-@@ -1329,10 +1329,10 @@ double quad_distortion(int num_nodes, const double coordinates[][3])
+@@ -1409,10 +1409,10 @@ double quad_distortion(int num_nodes, const double coordinates[][3])
      double weight[maxTotalNumberGaussPoints];
  
      // create an object of GaussIntegration
@@ -58,7 +45,7 @@ index 0c7c508e0..8e8a2537e 100644
  
      // calculate element area
      int ife, ja;
-@@ -1355,7 +1355,7 @@ double quad_distortion(int num_nodes, const double coordinates[][3])
+@@ -1435,7 +1435,7 @@ double quad_distortion(int num_nodes, const double coordinates[][3])
      double dndy1_at_node[maxNumberNodes][maxNumberNodes];
      double dndy2_at_node[maxNumberNodes][maxNumberNodes];
  
@@ -68,10 +55,10 @@ index 0c7c508e0..8e8a2537e 100644
      VerdictVector normal_at_nodes[9];
  
 diff --git a/V_TetMetric.cpp b/V_TetMetric.cpp
-index feb026968..dc956edb0 100644
+index db3b7c3..b227006 100644
 --- a/V_TetMetric.cpp
 +++ b/V_TetMetric.cpp
-@@ -1354,10 +1354,10 @@ double tet_distortion(int num_nodes, const double coordinates[][3])
+@@ -1360,10 +1360,10 @@ double tet_distortion(int num_nodes, const double coordinates[][3])
    double weight[maxTotalNumberGaussPoints];
  
    // create an object of GaussIntegration for tet
@@ -86,7 +73,7 @@ index feb026968..dc956edb0 100644
  
    // vector xxi is the derivative vector of coordinates w.r.t local xi coordinate in the
    // computation space
-@@ -1402,7 +1402,7 @@ double tet_distortion(int num_nodes, const double coordinates[][3])
+@@ -1408,7 +1408,7 @@ double tet_distortion(int num_nodes, const double coordinates[][3])
    double dndy2_at_node[maxNumberNodes][maxNumberNodes];
    double dndy3_at_node[maxNumberNodes][maxNumberNodes];
  
@@ -96,10 +83,10 @@ index feb026968..dc956edb0 100644
    for (node_id = 0; node_id < num_nodes; node_id++)
    {
 diff --git a/V_TriMetric.cpp b/V_TriMetric.cpp
-index 2fb5c37e8..71c16bea7 100644
+index 3a2a16a..a2caba5 100644
 --- a/V_TriMetric.cpp
 +++ b/V_TriMetric.cpp
-@@ -664,10 +664,10 @@ double tri_distortion(int num_nodes, const double coordinates[][3])
+@@ -778,10 +778,10 @@ double tri_distortion(int num_nodes, const double coordinates[][3])
    // create an object of GaussIntegration
    int number_dims = 2;
    int is_tri = 1;
@@ -114,7 +101,7 @@ index 2fb5c37e8..71c16bea7 100644
  
    // calculate element area
    int ife, ja;
-@@ -691,7 +691,7 @@ double tri_distortion(int num_nodes, const double coordinates[][3])
+@@ -805,7 +805,7 @@ double tri_distortion(int num_nodes, const double coordinates[][3])
    double dndy1_at_node[maxNumberNodes][maxNumberNodes];
    double dndy2_at_node[maxNumberNodes][maxNumberNodes];
  

--- a/ports/verdict/include.patch
+++ b/ports/verdict/include.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7db55ee4f..c41d98f70 100644
+index 73c4de3..2cdd102 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -52,7 +52,7 @@ configure_file(
+@@ -54,7 +54,7 @@ configure_file(
  
- add_library(verdict ${verdict_SOURCES})
+ add_library(verdict ${verdict_SOURCES} ${verdict_HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/verdict_config.h)
  target_include_directories(verdict PUBLIC
 -  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 +  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
- 
- 
- # Setting the VERSION and SOVERSION of a library will include
+ if(UNIX)
+   target_link_libraries(verdict PRIVATE m)
+ endif()

--- a/ports/verdict/portfile.cmake
+++ b/ports/verdict/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  sandialabs/verdict
-    REF fb582cf4fc04ecbd2bf423554325bda01231227a
-    SHA512 137a386a6c11bf2738d752f995a8cf66661efedab72980a787893f8594066197dd8a966ed906d0d8b95cb05a2ec1b8e95906bb9214cf05604058719798ce7dbd
+    REF ${VERSION}
+    SHA512 e4a38fabcb7b56cbc50b59ee2d97c8a4cc3a2afea6ec22860005b77b79536a8dae16acef48197ae881f5b6dbd20495c16ba5b3eadd57d7d478482e5734a98b1d
     HEAD_REF master
     PATCHES include.patch
             fix_osx.patch

--- a/ports/verdict/vcpkg.json
+++ b/ports/verdict/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "verdict",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "description": "Compute quality functions of 2 and 3-dimensional regions.",
   "homepage": "https://github.com/sandialabs/verdict",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10101,7 +10101,7 @@
       "port-version": 1
     },
     "verdict": {
-      "baseline": "1.4.0",
+      "baseline": "1.4.2",
       "port-version": 0
     },
     "via-httplib": {

--- a/versions/v-/verdict.json
+++ b/versions/v-/verdict.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5bdd5e0da569597ce5fd1948a7adfbe595da9b75",
+      "version": "1.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "dc33a2fb229de296ae77638542f91d5bb1d63e69",
       "version": "1.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/sandialabs/verdict/releases/tag/1.4.2
