### PR TITLE
[unixodbc] Update to 2.3.12, use new port [libltdl]

### DIFF
--- a/ports/libltdl/libtoolize-ltdl-no-la
+++ b/ports/libltdl/libtoolize-ltdl-no-la
@@ -1,0 +1,12 @@
+#!/bin/sh
+me=libtoolize-ltdl
+echo "$me: running: $*" 1>&2
+"${VCPKG_LIBLTDL_LIBTOOLIZE:-libtoolize}" "$@" &&
+if test -f m4/ltdl.m4 ; then
+    echo "$me: disabling libltdl.la check in m4/ltdl.m4" # most distros removes the la file
+    sed -e 's,test -f "\$with_ltdl_lib/libltdl.la",test -d "\$with_ltdl_lib",' m4/ltdl.m4 > m4/_ltdl.m4.tmp &&
+    cp m4/_ltdl.m4.tmp m4/ltdl.m4 &&
+    rm m4/_ltdl.m4.tmp
+else
+    echo "$me: Cannot find m4/libltdl.m4" 1>&2
+fi

--- a/ports/libltdl/libtoolize-ltdl-no-la
+++ b/ports/libltdl/libtoolize-ltdl-no-la
@@ -1,9 +1,9 @@
 #!/bin/sh
-me=libtoolize-ltdl
+me=libtoolize-ltdl-no-la
 echo "$me: running: $*" 1>&2
 "${VCPKG_LIBLTDL_LIBTOOLIZE:-libtoolize}" "$@" &&
+echo "$me: disabling libltdl.la check in m4/ltdl.m4" # most distros removes the la file
 if test -f m4/ltdl.m4 ; then
-    echo "$me: disabling libltdl.la check in m4/ltdl.m4" # most distros removes the la file
     sed -e 's,test -f "\$with_ltdl_lib/libltdl.la",test -d "\$with_ltdl_lib",' m4/ltdl.m4 > m4/_ltdl.m4.tmp &&
     cp m4/_ltdl.m4.tmp m4/ltdl.m4 &&
     rm m4/_ltdl.m4.tmp

--- a/ports/libltdl/libtoolize-ltdl-no-la
+++ b/ports/libltdl/libtoolize-ltdl-no-la
@@ -1,7 +1,14 @@
 #!/bin/sh
 me=libtoolize-ltdl-no-la
-echo "$me: running: $*" 1>&2
-"${VCPKG_LIBLTDL_LIBTOOLIZE:-libtoolize}" "$@" &&
+if test -n "$VCPKG_LIBLTDL_LIBTOOLIZE"; then
+    libtoolize="${VCPKG_LIBLTDL_LIBTOOLIZE}"
+elif hash glibtoolize 2>/dev/null; then
+    libtoolize=glibtoolize
+else
+    libtoolize=libtoolize
+fi
+echo "$me: running: ${libtoolize} $*" 1>&2
+"${libtoolize}" "$@" &&
 echo "$me: disabling libltdl.la check in m4/ltdl.m4" # most distros removes the la file
 if test -f m4/ltdl.m4 ; then
     sed -e 's,test -f "\$with_ltdl_lib/libltdl.la",test -d "\$with_ltdl_lib",' m4/ltdl.m4 > m4/_ltdl.m4.tmp &&

--- a/ports/libltdl/portfile.cmake
+++ b/ports/libltdl/portfile.cmake
@@ -20,6 +20,7 @@ endif()
 
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}/libltdl"
+    AUTORECONF
     OPTIONS
         --enable-ltdl-install
         ${OPTIONS}

--- a/ports/libltdl/portfile.cmake
+++ b/ports/libltdl/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://ftpmirror.gnu.org/libtool/libtool-${VERSION}.tar.xz"
+         "https://ftp.gnu.org/pub/gnu/libtool/libtool-${VERSION}.tar.xz"
+    FILENAME "gnu-libtool-${VERSION}.tar.xz"
+    SHA512 eed207094bcc444f4bfbb13710e395e062e3f1d312ca8b186ab0cbd22dc92ddef176a0b3ecd43e02676e37bd9e328791c59a38ef15846d4eae15da4f20315724
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+)
+
+vcpkg_list(SET OPTIONS "")
+if(VCPKG_TARGET_IS_WINDOWS)
+    string(APPEND VCPKG_C_FLAGS " -D_CRT_SECURE_NO_WARNINGS")
+    string(APPEND VCPKG_CXX_FLAGS " -D_CRT_SECURE_NO_WARNINGS")
+    if(NOT VCPKG_TARGET_IS_MINGW)
+        vcpkg_list(APPEND OPTIONS ac_cv_header_dirent_h=no) # Ignore vcpkg port dirent
+    endif()
+endif()
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}/libltdl"
+    OPTIONS
+        --enable-ltdl-install
+        ${OPTIONS}
+)
+vcpkg_make_install()
+
+file(COPY "${CURRENT_PORT_DIR}/libtoolize-ltdl-no-la" DESTINATION "${CURRENT_PACKAGES_DIR}/manual-tools/${PORT}")
+file(CHMOD "${CURRENT_PACKAGES_DIR}/manual-tools/${PORT}/libtoolize-ltdl-no-la" FILE_PERMISSIONS
+    OWNER_READ OWNER_WRITE OWNER_EXECUTE
+    GROUP_READ GROUP_EXECUTE
+    WORLD_READ WORLD_EXECUTE
+)
+file(COPY "${CURRENT_PORT_DIR}/vcpkg-port-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/libltdl/COPYING.LIB")

--- a/ports/libltdl/vcpkg-port-config.cmake
+++ b/ports/libltdl/vcpkg-port-config.cmake
@@ -4,7 +4,8 @@
 #   A libtoolize (wrapper) which disables the check for  libltdl.la.
 #   la files are removed from packages in vcpkg (and in most distros).
 #   They add little value in modern environments, and they use absolute paths.
-# - <out_var_basename>_OPTIONS_RELEASE, <out_var_basename>_OPTIONS_DEBUG:
+# - <out_var_basename>_OPTIONS_RELEASE,
+#   <out_var_basename>_OPTIONS_DEBUG:
 #   Options to pass to vcpkg_make_configure.
 #
 # Usage:
@@ -14,8 +15,6 @@
 #   vcpkg_make_configure(
 #       SOURCE_PATH "${SOURCE_PATH}"
 #       AUTORECONF
-#       OPTIONS
-#           --with-included-ltdl=no
 #       OPTIONS_RELEASE
 #           ${LIBLTDL_OPTIONS_RELEASE}
 #       OPTIONS_DEBUG
@@ -35,10 +34,12 @@ function(vcpkg_libltdl_get_vars out_var_basename)
     endif()
 
     vcpkg_list(SET options_release
+        "--with-included-ltdl=no"
         "--with-ltdl-include=${CURRENT_INSTALLED_DIR}/include"
         "--with-ltdl-lib=${CURRENT_INSTALLED_DIR}/lib"
     )
     vcpkg_list(SET options_debug
+        "--with-included-ltdl=no"
         "--with-ltdl-include=${CURRENT_INSTALLED_DIR}/include"
         "--with-ltdl-lib=${CURRENT_INSTALLED_DIR}/debug/lib"
     )

--- a/ports/libltdl/vcpkg-port-config.cmake
+++ b/ports/libltdl/vcpkg-port-config.cmake
@@ -1,11 +1,11 @@
 # Provide variables to use lib ltldl with autoconf.
 #
-# - <out_var_basename>_LIBTOOLIZE
+# - <PREFIX>_LIBTOOLIZE
 #   A libtoolize (wrapper) which disables the check for  libltdl.la.
 #   la files are removed from packages in vcpkg (and in most distros).
 #   They add little value in modern environments, and they use absolute paths.
-# - <out_var_basename>_OPTIONS_RELEASE,
-#   <out_var_basename>_OPTIONS_DEBUG:
+# - <PREFIX>_OPTIONS_RELEASE,
+#   <PREFIX>_OPTIONS_DEBUG:
 #   Options to pass to vcpkg_make_configure.
 #
 # Usage:
@@ -21,7 +21,7 @@
 #           ${LIBLTDL_OPTIONS_RELEASE}
 #   )
 
-function(vcpkg_libltdl_get_vars out_var_basename)
+function(vcpkg_libltdl_get_vars prefix)
     # Select host libtoolize: triplet, environment, PATH, plain name.
     if(NOT VCPKG_LIBLTDL_LIBTOOLIZE)
         set(VCPKG_LIBLTDL_LIBTOOLIZE "$ENV{LIBTOOLIZE}")
@@ -43,7 +43,7 @@ function(vcpkg_libltdl_get_vars out_var_basename)
         "--with-ltdl-include=${CURRENT_INSTALLED_DIR}/include"
         "--with-ltdl-lib=${CURRENT_INSTALLED_DIR}/debug/lib"
     )
-    set("${out_var}_OPTIONS_RELEASE" "${options_release}" PARENT_SCOPE)
-    set("${out_var}_OPTIONS_DEBUG" "${options_debug}" PARENT_SCOPE)
-    set("${out_var}_LIBTOOLIZE" "${CURRENT_INSTALLED_DIR}/manual-tools/libltdl/libtoolize-ltdl-no-la" PARENT_SCOPE)
+    set("${prefix}_OPTIONS_RELEASE" "${options_release}" PARENT_SCOPE)
+    set("${prefix}_OPTIONS_DEBUG" "${options_debug}" PARENT_SCOPE)
+    set("${prefix}_LIBTOOLIZE" "${CURRENT_INSTALLED_DIR}/manual-tools/libltdl/libtoolize-ltdl-no-la" PARENT_SCOPE)
 endfunction()

--- a/ports/libltdl/vcpkg-port-config.cmake
+++ b/ports/libltdl/vcpkg-port-config.cmake
@@ -1,0 +1,48 @@
+# Provide variables to use lib ltldl with autoconf.
+#
+# - <out_var_basename>_LIBTOOLIZE
+#   A libtoolize (wrapper) which disables the check for  libltdl.la.
+#   la files are removed from packages in vcpkg (and in most distros).
+#   They add little value in modern environments, and they use absolute paths.
+# - <out_var_basename>_OPTIONS_RELEASE, <out_var_basename>_OPTIONS_DEBUG:
+#   Options to pass to vcpkg_make_configure.
+#
+# Usage:
+#   vcpkg_libltdl_get_vars(LIBLTDL)
+#   set(ENV{LIBTOOLIZE} "${LIBLTDL_LIBTOOLIZE}")
+#   
+#   vcpkg_make_configure(
+#       SOURCE_PATH "${SOURCE_PATH}"
+#       AUTORECONF
+#       OPTIONS
+#           --with-included-ltdl=no
+#       OPTIONS_RELEASE
+#           ${LIBLTDL_OPTIONS_RELEASE}
+#       OPTIONS_DEBUG
+#           ${LIBLTDL_OPTIONS_RELEASE}
+#   )
+
+function(vcpkg_libltdl_get_vars out_var_basename)
+    # Select host libtoolize: triplet, environment, PATH, plain name.
+    if(NOT VCPKG_LIBLTDL_LIBTOOLIZE)
+        set(VCPKG_LIBLTDL_LIBTOOLIZE "$ENV{LIBTOOLIZE}")
+    endif()
+    if(VCPKG_LIBLTDL_LIBTOOLIZE STREQUAL "")
+        find_program(VCPKG_LIBLTDL_LIBTOOLIZE NAMES libtoolize glibtoolize)
+    endif()
+    if(VCPKG_LIBLTDL_LIBTOOLIZE)
+        set(ENV{VCPKG_LIBLTDL_LIBTOOLIZE} "${VCPKG_LIBLTDL_LIBTOOLIZE}")
+    endif()
+
+    vcpkg_list(SET options_release
+        "--with-ltdl-include=${CURRENT_INSTALLED_DIR}/include"
+        "--with-ltdl-lib=${CURRENT_INSTALLED_DIR}/lib"
+    )
+    vcpkg_list(SET options_debug
+        "--with-ltdl-include=${CURRENT_INSTALLED_DIR}/include"
+        "--with-ltdl-lib=${CURRENT_INSTALLED_DIR}/debug/lib"
+    )
+    set("${out_var}_OPTIONS_RELEASE" "${options_release}" PARENT_SCOPE)
+    set("${out_var}_OPTIONS_DEBUG" "${options_debug}" PARENT_SCOPE)
+    set("${out_var}_LIBTOOLIZE" "${CURRENT_INSTALLED_DIR}/manual-tools/libltdl/libtoolize-ltdl-no-la" PARENT_SCOPE)
+endfunction()

--- a/ports/libltdl/vcpkg-port-config.cmake
+++ b/ports/libltdl/vcpkg-port-config.cmake
@@ -22,15 +22,9 @@
 #   )
 
 function(vcpkg_libltdl_get_vars prefix)
-    # Select host libtoolize: triplet, environment, PATH, plain name.
-    if(NOT VCPKG_LIBLTDL_LIBTOOLIZE)
-        set(VCPKG_LIBLTDL_LIBTOOLIZE "$ENV{LIBTOOLIZE}")
-    endif()
-    if(VCPKG_LIBLTDL_LIBTOOLIZE STREQUAL "")
-        find_program(VCPKG_LIBLTDL_LIBTOOLIZE NAMES libtoolize glibtoolize)
-    endif()
-    if(VCPKG_LIBLTDL_LIBTOOLIZE)
-        set(ENV{VCPKG_LIBLTDL_LIBTOOLIZE} "${VCPKG_LIBLTDL_LIBTOOLIZE}")
+    # Forward libtoolize from environment to libtoolize-ltdl-no-la.
+    if(NOT "$ENV{LIBTOOLIZE}" STREQUAL "")
+        set(ENV{VCPKG_LIBLTDL_LIBTOOLIZE} "$ENV{LIBTOOLIZE}")
     endif()
 
     vcpkg_list(SET options_release

--- a/ports/libltdl/vcpkg.json
+++ b/ports/libltdl/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "libltdl",
+  "version": "2.5.4",
+  "description": "A system independent dlopen wrapper for GNU libtool",
+  "homepage": "https://www.gnu.org/software/libtool/",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}

--- a/ports/unixodbc/pkgconfig-libiconv.diff
+++ b/ports/unixodbc/pkgconfig-libiconv.diff
@@ -1,0 +1,10 @@
+diff --git a/DriverManager/odbc.pc.in b/DriverManager/odbc.pc.in
+index defa7cd..db4dfe7 100644
+--- a/DriverManager/odbc.pc.in
++++ b/DriverManager/odbc.pc.in
+@@ -17,4 +17,4 @@ URL: http://unixodbc.org
+ Version: @PACKAGE_VERSION@
+ Cflags: -I${includedir}
+ Libs: -L${libdir} -lodbc
+-Libs.private: @LIBLTDL@ @LIBS@
++Libs.private: @LIBLTDL@ @LIBICONV@ @LIBS@

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -44,7 +44,8 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/unixodbc_conf.h" 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/unixodbc_conf.h" "#define SYSTEM_FILE_PATH \"${CURRENT_INSTALLED_DIR}/etc\"" "/* redacted */")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/unixodbc_conf.h" "#define SYSTEM_LIB_PATH \"${CURRENT_INSTALLED_DIR}/lib\"" "/* redacted */")
 
-configure_file("${CMAKE_CURRENT_LIST_DIR}/unixodbcConfig.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/unixodbcConfig.cmake" @ONLY)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/unofficial-unixodbc-config.cmake" "${CURRENT_PACKAGES_DIR}/share/unofficial-unixodbc/unofficial-unixodbc-config.cmake" @ONLY)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unixodbcConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}") # legacy
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_install_copyright(

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lurcher/unixODBC
-    REF 6c8071b1bef4e4991e7b3023a1c1c712168a818e # v2.3.11
-    SHA512 5c5b189e3b62935fdee5e25f5cf9b41fb2bc68fc9bd1652cab1b109032ab586978ba14d19e83328838b55e773f099046344bb4c84ec99edac309650ed863543e
+    REF ${VERSION}
+    SHA512 f0c0a995c90ff3abd00a031430e2f2034d45ca96c7fba34adc826a668c4eeb77ee2e1be27b7b1817c706f43df4fa434746362e746a39e779256e006deeb790c7
     HEAD_REF master
     PATCHES
         pkgconfig-libiconv.diff
@@ -35,16 +35,14 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share/${PORT}/man7"
 )
 
-foreach(FILE IN ITEMS config.h unixodbc_conf.h)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define BIN_PREFIX \"${CURRENT_INSTALLED_DIR}/tools/unixodbc/bin\"" "")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define DEFLIB_PATH \"${CURRENT_INSTALLED_DIR}/lib\"" "")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define EXEC_PREFIX \"${CURRENT_INSTALLED_DIR}\"" "")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define INCLUDE_PREFIX \"${CURRENT_INSTALLED_DIR}/include\"" "")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define LIB_PREFIX \"${CURRENT_INSTALLED_DIR}/lib\"" "")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define PREFIX \"${CURRENT_INSTALLED_DIR}\"" "")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define SYSTEM_FILE_PATH \"${CURRENT_INSTALLED_DIR}/etc\"" "")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define SYSTEM_LIB_PATH \"${CURRENT_INSTALLED_DIR}/lib\"" "")
-endforeach()
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/unixodbc_conf.h" "#define BIN_PREFIX \"${CURRENT_INSTALLED_DIR}/tools/unixodbc/bin\"" "/* redacted */")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/unixodbc_conf.h" "#define DEFLIB_PATH \"${CURRENT_INSTALLED_DIR}/lib\"" "/* redacted */")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/unixodbc_conf.h" "#define EXEC_PREFIX \"${CURRENT_INSTALLED_DIR}\"" "/* redacted */")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/unixodbc_conf.h" "#define INCLUDE_PREFIX \"${CURRENT_INSTALLED_DIR}/include\"" "/* redacted */")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/unixodbc_conf.h" "#define LIB_PREFIX \"${CURRENT_INSTALLED_DIR}/lib\"" "/* redacted */")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/unixodbc_conf.h" "#define PREFIX \"${CURRENT_INSTALLED_DIR}\"" "/* redacted */")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/unixodbc_conf.h" "#define SYSTEM_FILE_PATH \"${CURRENT_INSTALLED_DIR}/etc\"" "/* redacted */")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/unixodbc_conf.h" "#define SYSTEM_LIB_PATH \"${CURRENT_INSTALLED_DIR}/lib\"" "/* redacted */")
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/unixodbcConfig.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/unixodbcConfig.cmake" @ONLY)
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -35,7 +35,7 @@ foreach(FILE IN ITEMS config.h unixodbc_conf.h)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define SYSTEM_LIB_PATH \"${CURRENT_INSTALLED_DIR}/lib\"" "")
 endforeach()
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unixodbcConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+configure_file("${CMAKE_CURRENT_LIST_DIR}/unixodbcConfig.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/unixodbcConfig.cmake" @ONLY)
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_install_copyright(

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -52,5 +52,6 @@ vcpkg_install_copyright(
     COMMENT
         "All libraries are LGPL Version 2.1. All programs are GPL Version 2.0."
     FILE_LIST
-        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/COPYING"
+        "${SOURCE_PATH}/exe/COPYING"
 )

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -6,11 +6,18 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_libltdl_get_vars(LIBLTDL)
+set(ENV{LIBTOOLIZE} "${LIBLTDL_LIBTOOLIZE}")
+
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTORECONF
     OPTIONS
         --with-included-ltdl=no
+    OPTIONS_RELEASE
+        ${LIBLTDL_OPTIONS_RELEASE}
+    OPTIONS_DEBUG
+        ${LIBLTDL_OPTIONS_RELEASE}
 )
 vcpkg_make_install()
 vcpkg_copy_pdbs()

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -14,8 +14,6 @@ set(ENV{LIBTOOLIZE} "${LIBLTDL_LIBTOOLIZE}")
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTORECONF
-    OPTIONS
-        --with-included-ltdl=no
     OPTIONS_RELEASE
         ${LIBLTDL_OPTIONS_RELEASE}
     OPTIONS_DEBUG

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
 vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTORECONF
+    OPTIONS
+        --with-included-ltdl=no
 )
 vcpkg_make_install()
 vcpkg_copy_pdbs()

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -6,40 +6,25 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-set(ENV{CFLAGS} "$ENV{CFLAGS} -Wno-error=implicit-function-declaration")
-
-if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_LINUX)
-    list(APPEND OPTIONS --with-included-ltdl)
-endif()
-
-vcpkg_configure_make(
+vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    AUTOCONFIG
-    COPY_SOURCE
-    OPTIONS ${OPTIONS}
+    AUTORECONF
 )
-
-vcpkg_install_make()
-
+vcpkg_make_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif ()
-
 file(REMOVE_RECURSE
-     "${CURRENT_PACKAGES_DIR}/debug/include"
-     "${CURRENT_PACKAGES_DIR}/debug/share"
-     "${CURRENT_PACKAGES_DIR}/debug/etc"
-     "${CURRENT_PACKAGES_DIR}/etc"
-     "${CURRENT_PACKAGES_DIR}/share/man"
-     "${CURRENT_PACKAGES_DIR}/share/${PORT}/man1"
-     "${CURRENT_PACKAGES_DIR}/share/${PORT}/man5"
-     "${CURRENT_PACKAGES_DIR}/share/${PORT}/man7"
+    "${CURRENT_PACKAGES_DIR}/debug/etc"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/etc"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/man1"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/man5"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/man7"
 )
 
-foreach(FILE config.h unixodbc_conf.h)
+foreach(FILE IN ITEMS config.h unixodbc_conf.h)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define BIN_PREFIX \"${CURRENT_INSTALLED_DIR}/tools/unixodbc/bin\"" "")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define DEFLIB_PATH \"${CURRENT_INSTALLED_DIR}/lib\"" "")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/unixODBC/${FILE}" "#define EXEC_PREFIX \"${CURRENT_INSTALLED_DIR}\"" "")
@@ -51,6 +36,11 @@ foreach(FILE config.h unixodbc_conf.h)
 endforeach()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unixodbcConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(
+    COMMENT
+        "All libraries are LGPL Version 2.1. All programs are GPL Version 2.0."
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+)

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -17,7 +17,7 @@ vcpkg_make_configure(
     OPTIONS_RELEASE
         ${LIBLTDL_OPTIONS_RELEASE}
     OPTIONS_DEBUG
-        ${LIBLTDL_OPTIONS_RELEASE}
+        ${LIBLTDL_OPTIONS_DEBUG}
 )
 vcpkg_make_install()
 vcpkg_copy_pdbs()

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 6c8071b1bef4e4991e7b3023a1c1c712168a818e # v2.3.11
     SHA512 5c5b189e3b62935fdee5e25f5cf9b41fb2bc68fc9bd1652cab1b109032ab586978ba14d19e83328838b55e773f099046344bb4c84ec99edac309650ed863543e
     HEAD_REF master
+    PATCHES
+        pkgconfig-libiconv.diff
 )
 
 vcpkg_libltdl_get_vars(LIBLTDL)

--- a/ports/unixodbc/unixodbcConfig.cmake
+++ b/ports/unixodbc/unixodbcConfig.cmake
@@ -23,11 +23,21 @@ if(NOT TARGET UNIX::odbc)
             IMPORTED_LOCATION_DEBUG "${UNIXODBC_LIBRARY_DEBUG}"
         )
     endif()
+    mark_as_advanced(UNIXODBC_LIBRARY_RELEASE UNIXODBC_LIBRARY_DEBUG)
 
     if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
+        find_library(UNIXODBC_LTDL_LIBRARY_RELEASE NAMES "ltdl" PATHS "${z_unixodbc_root}/lib" NO_DEFAULT_PATH REQUIRED)
+        find_library(UNIXODBC_LTDL_LIBRARY_DEBUG NAMES "ltdl" PATHS "${z_unixodbc_root}/debug/lib" NO_DEFAULT_PATH REQUIRED)
+        mark_as_advanced(UNIXODBC_LTDL_LIBRARY_RELEASE UNIXODBC_LTDL_LIBRARY_DEBUG)
+        if(UNIXODBC_LTDL_LIBRARY_DEBUG)
+            set(z_unixodbc_ltdl "$<$<CONFIG:DEBUG>:${UNIXODBC_LTDL_LIBRARY_DEBUG}>;$<$<NOT:$<CONFIG:DEBUG>>:${UNIXODBC_LTDL_LIBRARY_RELEASE}>")
+        else()
+            set(z_unixodbc_ltdl "${UNIXODBC_LTDL_LIBRARY_RELEASE}")
+        endif()
         set_target_properties(UNIX::odbc PROPERTIES
-            INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:Iconv::Iconv>;$<LINK_ONLY:ltdl>;${CMAKE_DL_LIBS}"
+            INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:Iconv::Iconv>;${z_unixodbc_ltdl};${CMAKE_DL_LIBS}"
         )
+        unset(z_unixodbc_ltdl)
     endif()
     unset(z_unixodbc_root)
 endif()

--- a/ports/unixodbc/unixodbcConfig.cmake
+++ b/ports/unixodbc/unixodbcConfig.cmake
@@ -1,44 +1,7 @@
+file(READ "${CMAKE_CURRENT_LIST_DIR}/usage" usage)
+message(WARNING "find_package(unixodbc) is deprecated.\n${usage}")
+include(CMakeFindDependencyMacro)
+find_dependency(unofficial-unixodbc CONFIG REQUIRED)
 if(NOT TARGET UNIX::odbc)
-    if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
-        include(CMakeFindDependencyMacro)
-        find_dependency(Iconv)
-    endif()
-
-    get_filename_component(z_unixodbc_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
-    get_filename_component(z_unixodbc_root "${z_unixodbc_root}" PATH)
-
-    find_library(UNIXODBC_LIBRARY_RELEASE NAMES "odbc" PATHS "${z_unixodbc_root}/lib" NO_DEFAULT_PATH REQUIRED)
-    add_library(UNIX::odbc UNKNOWN IMPORTED)
-    set_target_properties(UNIX::odbc PROPERTIES
-        IMPORTED_CONFIGURATIONS RELEASE
-        IMPORTED_LOCATION_RELEASE "${UNIXODBC_LIBRARY_RELEASE}"
-        INTERFACE_INCLUDE_DIRECTORIES "${z_unixodbc_root}/include"
-    )
-    find_library(UNIXODBC_LIBRARY_DEBUG NAMES "odbc" PATHS "${z_unixodbc_root}/debug/lib" NO_DEFAULT_PATH)
-    if(UNIXODBC_LIBRARY_DEBUG)
-        set_property(TARGET UNIX::odbc APPEND PROPERTY
-            IMPORTED_CONFIGURATIONS DEBUG
-        )
-        set_target_properties(UNIX::odbc PROPERTIES
-            IMPORTED_LOCATION_DEBUG "${UNIXODBC_LIBRARY_DEBUG}"
-        )
-    endif()
-    mark_as_advanced(UNIXODBC_LIBRARY_RELEASE UNIXODBC_LIBRARY_DEBUG)
-
-    if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
-        find_library(UNIXODBC_LTDL_LIBRARY_RELEASE NAMES "ltdl" PATHS "${z_unixodbc_root}/lib" NO_DEFAULT_PATH REQUIRED)
-        find_library(UNIXODBC_LTDL_LIBRARY_DEBUG NAMES "ltdl" PATHS "${z_unixodbc_root}/debug/lib" NO_DEFAULT_PATH REQUIRED)
-        mark_as_advanced(UNIXODBC_LTDL_LIBRARY_RELEASE UNIXODBC_LTDL_LIBRARY_DEBUG)
-        if(UNIXODBC_LTDL_LIBRARY_DEBUG)
-            set(z_unixodbc_ltdl "$<$<CONFIG:DEBUG>:${UNIXODBC_LTDL_LIBRARY_DEBUG}>;$<$<NOT:$<CONFIG:DEBUG>>:${UNIXODBC_LTDL_LIBRARY_RELEASE}>")
-        else()
-            set(z_unixodbc_ltdl "${UNIXODBC_LTDL_LIBRARY_RELEASE}")
-        endif()
-        set_target_properties(UNIX::odbc PROPERTIES
-            INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:Iconv::Iconv>;${z_unixodbc_ltdl};${CMAKE_DL_LIBS}"
-        )
-        unset(z_unixodbc_ltdl)
-    endif()
-    unset(z_unixodbc_root)
+    add_library(#[[skip-usage-heuristics]] UNIX::odbc ALIAS unofficial::unixodbc::unixodbc)
 endif()
-

--- a/ports/unixodbc/unofficial-unixodbc-config.cmake
+++ b/ports/unixodbc/unofficial-unixodbc-config.cmake
@@ -1,0 +1,44 @@
+if(NOT TARGET unofficial::unixodbc::unixodbc)
+    if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
+        include(CMakeFindDependencyMacro)
+        find_dependency(Iconv)
+    endif()
+
+    get_filename_component(z_unixodbc_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
+    get_filename_component(z_unixodbc_root "${z_unixodbc_root}" PATH)
+
+    find_library(UNIXODBC_LIBRARY_RELEASE NAMES "odbc" PATHS "${z_unixodbc_root}/lib" NO_DEFAULT_PATH REQUIRED)
+    add_library(unofficial::unixodbc::unixodbc UNKNOWN IMPORTED)
+    set_target_properties(unofficial::unixodbc::unixodbc PROPERTIES
+        IMPORTED_CONFIGURATIONS RELEASE
+        IMPORTED_LOCATION_RELEASE "${UNIXODBC_LIBRARY_RELEASE}"
+        INTERFACE_INCLUDE_DIRECTORIES "${z_unixodbc_root}/include"
+    )
+    find_library(UNIXODBC_LIBRARY_DEBUG NAMES "odbc" PATHS "${z_unixodbc_root}/debug/lib" NO_DEFAULT_PATH)
+    if(UNIXODBC_LIBRARY_DEBUG)
+        set_property(TARGET unofficial::unixodbc::unixodbc APPEND PROPERTY
+            IMPORTED_CONFIGURATIONS DEBUG
+        )
+        set_target_properties(unofficial::unixodbc::unixodbc PROPERTIES
+            IMPORTED_LOCATION_DEBUG "${UNIXODBC_LIBRARY_DEBUG}"
+        )
+    endif()
+    mark_as_advanced(UNIXODBC_LIBRARY_RELEASE UNIXODBC_LIBRARY_DEBUG)
+
+    if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
+        find_library(UNIXODBC_LTDL_LIBRARY_RELEASE NAMES "ltdl" PATHS "${z_unixodbc_root}/lib" NO_DEFAULT_PATH REQUIRED)
+        find_library(UNIXODBC_LTDL_LIBRARY_DEBUG NAMES "ltdl" PATHS "${z_unixodbc_root}/debug/lib" NO_DEFAULT_PATH REQUIRED)
+        mark_as_advanced(UNIXODBC_LTDL_LIBRARY_RELEASE UNIXODBC_LTDL_LIBRARY_DEBUG)
+        if(UNIXODBC_LTDL_LIBRARY_DEBUG)
+            set(z_unixodbc_ltdl "$<$<CONFIG:DEBUG>:${UNIXODBC_LTDL_LIBRARY_DEBUG}>;$<$<NOT:$<CONFIG:DEBUG>>:${UNIXODBC_LTDL_LIBRARY_RELEASE}>")
+        else()
+            set(z_unixodbc_ltdl "${UNIXODBC_LTDL_LIBRARY_RELEASE}")
+        endif()
+        set_target_properties(unofficial::unixodbc::unixodbc PROPERTIES
+            INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:Iconv::Iconv>;${z_unixodbc_ltdl};${CMAKE_DL_LIBS}"
+        )
+        unset(z_unixodbc_ltdl)
+    endif()
+    unset(z_unixodbc_root)
+endif()
+

--- a/ports/unixodbc/usage
+++ b/ports/unixodbc/usage
@@ -1,4 +1,16 @@
-The package unixodbc is compatible with built-in CMake targets:
+unixodbc provides CMake targets:
 
-    find_package(unixodbc REQUIRED)
-    target_link_libraries(main PRIVATE UNIX::odbc)
+  # unixODBC Driver Manager library
+  find_package(unofficial-unixodbc CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE (unofficial::unixodbc::odbc)
+
+unixodbc provides pkg-config modules:
+
+  # unixODBC Driver Manager library
+  odbc
+
+  # unixODBC Cursor Library
+  odbccr
+
+  # unixODBC Configuration Library
+  odbcinst

--- a/ports/unixodbc/vcpkg.json
+++ b/ports/unixodbc/vcpkg.json
@@ -1,9 +1,15 @@
 {
   "name": "unixodbc",
   "version": "2.3.11",
-  "port-version": 2,
+  "port-version": 3,
   "description": "unixODBC is an Open Source ODBC sub-system and an ODBC SDK for Linux, Mac OSX, and UNIX",
   "homepage": "https://github.com/lurcher/unixODBC",
-  "license": "LGPL-2.1-only",
-  "supports": "osx | linux"
+  "license": null,
+  "supports": "linux | osx",
+  "dependencies": [
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
 }

--- a/ports/unixodbc/vcpkg.json
+++ b/ports/unixodbc/vcpkg.json
@@ -7,6 +7,7 @@
   "license": null,
   "supports": "linux | osx",
   "dependencies": [
+    "libltdl",
     {
       "name": "vcpkg-make",
       "host": true

--- a/ports/unixodbc/vcpkg.json
+++ b/ports/unixodbc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "unixodbc",
-  "version": "2.3.11",
-  "port-version": 3,
+  "version": "2.3.12",
   "description": "unixODBC is an Open Source ODBC sub-system and an ODBC SDK for Linux, Mac OSX, and UNIX",
   "homepage": "https://github.com/lurcher/unixODBC",
   "license": null,

--- a/scripts/test_ports/vcpkg-ci-unixodbc/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-unixodbc/portfile.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-unixodbc/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-unixodbc/project/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.30)
+project(unixodbc-test C)
+
+find_package(unixodbc CONFIG REQUIRED)
+
+add_executable(main main.c)
+target_link_libraries(main PRIVATE UNIX::odbc)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(unixodbc_pc odbc REQUIRED IMPORTED_TARGET)
+
+add_executable(main-pkconfig main.c)
+target_link_libraries(main-pkconfig PRIVATE PkgConfig::unixodbc_pc)

--- a/scripts/test_ports/vcpkg-ci-unixodbc/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-unixodbc/project/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.30)
 project(unixodbc-test C)
 
+# legacy vcpkg-only name, now forwarding to "unofficial" names
 find_package(unixodbc CONFIG REQUIRED)
 
 add_executable(main main.c)

--- a/scripts/test_ports/vcpkg-ci-unixodbc/project/main.c
+++ b/scripts/test_ports/vcpkg-ci-unixodbc/project/main.c
@@ -13,8 +13,8 @@ int main()
 	if ((result != SQL_SUCCESS) && (result != SQL_SUCCESS_WITH_INFO))
 		return 1;
 
-    char l_dsn[100], l_desc[100];
-    short int l_len1, l_len2, l_next;
+    SQLCHAR l_dsn[100], l_desc[100];
+    SQLUSMALLINT l_len1, l_len2, l_next;
     for (short int l_next = SQL_FETCH_FIRST;
          SQLDataSources(odbc_handle, l_next, l_dsn, sizeof(l_dsn), &l_len1, l_desc, sizeof(l_desc), &l_len2) == SQL_SUCCESS;
          l_next = SQL_FETCH_NEXT)

--- a/scripts/test_ports/vcpkg-ci-unixodbc/project/main.c
+++ b/scripts/test_ports/vcpkg-ci-unixodbc/project/main.c
@@ -1,0 +1,17 @@
+/* https://www.unixodbc.org/doc/ProgrammerManual/Tutorial/ has
+ * #include <odbc/sql.h>
+ * but actual pkgconfig files and MS ODBC documentation suggest
+ * #include <sql.h>
+ */
+#include <sql.h>
+
+int main()
+{
+    SQLHENV odbc_handle;
+	long result = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &odbc_handle);
+	if ((result != SQL_SUCCESS) && (result != SQL_SUCCESS_WITH_INFO))
+		return 1;
+
+    SQLFreeHandle(SQL_HANDLE_ENV, odbc_handle);
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-unixodbc/project/main.c
+++ b/scripts/test_ports/vcpkg-ci-unixodbc/project/main.c
@@ -4,6 +4,7 @@
  * #include <sql.h>
  */
 #include <sql.h>
+#include <stdio.h>
 
 int main()
 {
@@ -11,6 +12,15 @@ int main()
 	long result = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &odbc_handle);
 	if ((result != SQL_SUCCESS) && (result != SQL_SUCCESS_WITH_INFO))
 		return 1;
+
+    char l_dsn[100], l_desc[100];
+    short int l_len1, l_len2, l_next;
+    for (short int l_next = SQL_FETCH_FIRST;
+         SQLDataSources(odbc_handle, l_next, l_dsn, sizeof(l_dsn), &l_len1, l_desc, sizeof(l_desc), &l_len2) == SQL_SUCCESS;
+         l_next = SQL_FETCH_NEXT)
+    {
+        printf("Server '%s' (%s)\n", l_dsn, l_desc);
+    }
 
     SQLFreeHandle(SQL_HANDLE_ENV, odbc_handle);
     return 0;

--- a/scripts/test_ports/vcpkg-ci-unixodbc/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-unixodbc/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "vcpkg-ci-unixodbc",
+  "version-string": "ci",
+  "description": "Test port for unixodbc usage",
+  "homepage": "https://github.com/microsoft/vcpkg",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    "unixodbc"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9866,7 +9866,7 @@
     },
     "unixodbc": {
       "baseline": "2.3.11",
-      "port-version": 2
+      "port-version": 3
     },
     "unleash-client-cpp": {
       "baseline": "1.3.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9865,8 +9865,8 @@
       "port-version": 6
     },
     "unixodbc": {
-      "baseline": "2.3.11",
-      "port-version": 3
+      "baseline": "2.3.12",
+      "port-version": 0
     },
     "unleash-client-cpp": {
       "baseline": "1.3.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5020,6 +5020,10 @@
       "baseline": "3.3.2",
       "port-version": 1
     },
+    "libltdl": {
+      "baseline": "2.5.4",
+      "port-version": 0
+    },
     "liblttng-ust": {
       "baseline": "2.14.0-rc1",
       "port-version": 0

--- a/versions/l-/libltdl.json
+++ b/versions/l-/libltdl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "436cf67bd0b79d581bf650da44d9c415765b628d",
+      "git-tree": "0c6e65df16966da08e14e0fb18ef8abad174ab99",
       "version": "2.5.4",
       "port-version": 0
     }

--- a/versions/l-/libltdl.json
+++ b/versions/l-/libltdl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0c6e65df16966da08e14e0fb18ef8abad174ab99",
+      "git-tree": "755aefa378d17a92a1116bbb32c7b58ef9518dae",
       "version": "2.5.4",
       "port-version": 0
     }

--- a/versions/l-/libltdl.json
+++ b/versions/l-/libltdl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "710dc06137bb977d27bfd91e535deafa75ec085a",
+      "version": "2.5.4",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libltdl.json
+++ b/versions/l-/libltdl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "755aefa378d17a92a1116bbb32c7b58ef9518dae",
+      "git-tree": "2c97575fd1ac927693c5f780cdb4b3da22c25c2d",
       "version": "2.5.4",
       "port-version": 0
     }

--- a/versions/l-/libltdl.json
+++ b/versions/l-/libltdl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "710dc06137bb977d27bfd91e535deafa75ec085a",
+      "git-tree": "436cf67bd0b79d581bf650da44d9c415765b628d",
       "version": "2.5.4",
       "port-version": 0
     }

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eba9acd477c866f4aecd390c41b91df77ade801e",
+      "git-tree": "7ca29b7787a83e667b0034d0cfb4fdaf53ab3847",
       "version": "2.3.12",
       "port-version": 0
     },

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5332438d6dedc8728728fc3f0813a54472472981",
+      "version": "2.3.11",
+      "port-version": 3
+    },
+    {
       "git-tree": "29dd7a9c7a6649ace85fd2e695dc4613ba6cb13a",
       "version": "2.3.11",
       "port-version": 2

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7ca29b7787a83e667b0034d0cfb4fdaf53ab3847",
+      "git-tree": "79ccb75e4eb283255df9716b84dbe16d6cb4655d",
       "version": "2.3.12",
       "port-version": 0
     },

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "96a86ec4730251e906efec476e12a1f4e584c487",
-      "version": "2.3.11",
-      "port-version": 3
+      "git-tree": "270b567124d21fac0fc7cd1dd01a90b4fea0cee2",
+      "version": "2.3.12",
+      "port-version": 0
     },
     {
       "git-tree": "29dd7a9c7a6649ace85fd2e695dc4613ba6cb13a",

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "79ccb75e4eb283255df9716b84dbe16d6cb4655d",
+      "git-tree": "9e0f6a67aa215869cbbf29cb2dbb409c713764da",
       "version": "2.3.12",
       "port-version": 0
     },

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9cb175a0e2a7dd7b502a7d365968437784760c80",
+      "git-tree": "96a86ec4730251e906efec476e12a1f4e584c487",
       "version": "2.3.11",
       "port-version": 3
     },

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5332438d6dedc8728728fc3f0813a54472472981",
+      "git-tree": "9cb175a0e2a7dd7b502a7d365968437784760c80",
       "version": "2.3.11",
       "port-version": 3
     },

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "270b567124d21fac0fc7cd1dd01a90b4fea0cee2",
+      "git-tree": "eba9acd477c866f4aecd390c41b91df77ade801e",
       "version": "2.3.12",
       "port-version": 0
     },


### PR DESCRIPTION
Test and fix the offered exports. CMake config is unofficial.

The system's installed libltdl cannot be relied on to be found and used, e.g. on osx.
autoreconf for unixodbc would create an "included" one, but that one is meant to be used without installation, breaking vcpkg's artifact caching.

This PR adds a port `libltdl` which provides an installed library and script code which helps hooking the lib into autoreconf. Autoreconf will still use the system's `libtoolize` infrastructure including `ltdl.m4`, to leverage the distributor's patches. (Look at msys2 to see what I mean, and at my previous attempts #21731, #27217.)
Name check: https://repology.org/project/libltdl/information