### PR TITLE
[boinc] fix mingw build

### DIFF
--- a/ports/boinc/fix-mingw-build.patch
+++ b/ports/boinc/fix-mingw-build.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/hostinfo.cpp b/lib/hostinfo.cpp
+index c1fde8a348..7302f1b526 100644
+--- a/lib/hostinfo.cpp
++++ b/lib/hostinfo.cpp
+@@ -448,7 +448,7 @@ bool HOST_INFO::get_docker_compose_version_string(
+ bool HOST_INFO::have_docker() {
+ #ifdef _WIN32
+     for (WSL_DISTRO &wd: wsl_distros.distros) {
+-        if (!empty(wd.docker_version)) return true;
++        if (!wd.docker_version.empty()) return true;
+     }
+     return false;
+ #else

--- a/ports/boinc/portfile.cmake
+++ b/ports/boinc/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-android-build.patch
+        fix-mingw-build.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/boinc/vcpkg.json
+++ b/ports/boinc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "boinc",
   "version": "8.2.5",
+  "port-version": 1,
   "description": "Open-source software for volunteer computing and grid computing.",
   "homepage": "https://boinc.berkeley.edu/",
   "license": "LGPL-3.0-or-later",

--- a/versions/b-/boinc.json
+++ b/versions/b-/boinc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96b3027bbe3410692a2ff6b6236decaabd807492",
+      "version": "8.2.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "3aa6f828171b0446bdbae2e6172b6290f353ba60",
       "version": "8.2.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -778,7 +778,7 @@
     },
     "boinc": {
       "baseline": "8.2.5",
-      "port-version": 0
+      "port-version": 1
     },
     "bond": {
       "baseline": "13.0.1",


### PR DESCRIPTION
This fixes (hopefully) #47181 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Upstream patch has been submitted: https://github.com/BOINC/boinc/pull/6548
