### PR TITLE
[libunistring] fix iconv dependency on windows (solution copied from gettext port)

### DIFF
--- a/ports/libunistring/portfile.cmake
+++ b/ports/libunistring/portfile.cmake
@@ -8,6 +8,20 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 5fbb5a0a864db73a6d18cdea7b31237da907fff0ef288f3a8db6ebdba8ef61ad8855e5fc780c2bbf632218d8fa59dd119734e5937ca64dc77f53f30f13b80b17
 )
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND OPTIONS
+        # On windows during configure tests iconv is properly linked,
+        # but iconv-2.dll missing from the directory where check program is built
+        # causes one of the tests to fail and in result builds libunistring
+        # without iconv support, this flag allows to bypass the test.
+        #
+        # The failing test is "checking for working iconv", while in previous
+        # test "checking for iconv", configure only checks linking, in
+        # "checking for working iconv" it also runs resulting test application.
+        am_cv_func_iconv_works=yes
+    )
+endif()
+
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     SOURCE_BASE "v${VERSION}"
@@ -22,6 +36,8 @@ vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
     USE_WRAPPERS
+    OPTIONS
+        ${OPTIONS}
     OPTIONS
         "--with-libiconv-prefix=${CURRENT_INSTALLED_DIR}"
 )

--- a/ports/libunistring/vcpkg.json
+++ b/ports/libunistring/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libunistring",
   "version": "1.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "GNU libunistring provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.",
   "homepage": "https://www.gnu.org/software/libunistring/",
   "license": "LGPL-3.0-or-later OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5614,7 +5614,7 @@
     },
     "libunistring": {
       "baseline": "1.2",
-      "port-version": 2
+      "port-version": 3
     },
     "libunwind": {
       "baseline": "1.8.3",

--- a/versions/l-/libunistring.json
+++ b/versions/l-/libunistring.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a756642d40f9220f07dff556e4deffda7e777499",
+      "git-tree": "6b9c1ea458081c9560f174576432f07feba1f50e",
       "version": "1.2",
       "port-version": 3
     },

--- a/versions/l-/libunistring.json
+++ b/versions/l-/libunistring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a756642d40f9220f07dff556e4deffda7e777499",
+      "version": "1.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "2d4c1b3ca54d175219e941aa7c10fa90a7703d57",
       "version": "1.2",
       "port-version": 2


### PR DESCRIPTION
Libunistring package on windows is built without iconv support - which renders it _a bit_ useless.

Unfortunatelly, iconv is not a required for the libunistring build to succeed.

Fragment of build log without the patch:
```
checking for the common suffixes of directories in the library search path... lib,lib,lib
checking for iconv... yes
checking for working iconv... no              // <-----
checking whether iconv is compatible with its POSIX signature... yes
checking absolute name of <iconv.h>... "C:/vcpkg/installed/x64-windows/include\\iconv.h"
checking for inline... inline
```

With patch:
```
checking for the common suffixes of directories in the library search path... lib,lib,lib
checking for iconv... yes
checking for working iconv... (cached) yes              // <-----
checking how to link with libiconv... -liconv
checking whether iconv is compatible with its POSIX signature... yes
checking absolute name of <iconv.h>... "c:/vcpkg/installed/x64-windows/include\\iconv.h"
checking for inline... inline
```

Imported libs (without patch):
```
>dumpbin /imports unistring-5.dll | rg \.dll
Dump of file unistring-5.dll
    KERNEL32.dll
    VCRUNTIME140.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-locale-l1-1-0.dll
    api-ms-win-crt-convert-l1-1-0.dll
    api-ms-win-crt-environment-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll
```

Imported libs (with patch):
```
> dumpbin /imports unistring-5.dll | rg \.dll
Dump of file unistring-5.dll
    iconv-2.dll
    KERNEL32.dll
    VCRUNTIME140.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-locale-l1-1-0.dll
    api-ms-win-crt-convert-l1-1-0.dll
    api-ms-win-crt-environment-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll
```

<details>
  <summary>Example affected function (without patch)</summary>

```
> dumpbin /disasm unistring-5.dll | rg -A28 -i "str_iconveh:"
libunistring_str_iconveh:
  0000000180004A10: 40 53              push        rbx
  0000000180004A12: 48 83 EC 20        sub         rsp,20h
  0000000180004A16: 80 39 00           cmp         byte ptr [rcx],0
  0000000180004A19: 48 8B C2           mov         rax,rdx
  0000000180004A1C: 48 8B D9           mov         rbx,rcx
  0000000180004A1F: 74 23              je          0000000180004A44
  0000000180004A21: 49 8B D0           mov         rdx,r8
  0000000180004A24: 48 8B C8           mov         rcx,rax
  0000000180004A27: E8 74 C8 FF FF     call        libunistring_c_strcasecmp
  0000000180004A2C: 85 C0              test        eax,eax
  0000000180004A2E: 74 14              je          0000000180004A44
  0000000180004A30: FF 15 D2 27 04 00  call        qword ptr [__imp__errno]
  0000000180004A36: C7 00 28 00 00 00  mov         dword ptr [rax],28h
  0000000180004A3C: 33 C0              xor         eax,eax
  0000000180004A3E: 48 83 C4 20        add         rsp,20h
  0000000180004A42: 5B                 pop         rbx
  0000000180004A43: C3                 ret
  0000000180004A44: 48 8B CB           mov         rcx,rbx
  0000000180004A47: FF 15 3B 28 04 00  call        qword ptr [__imp__strdup]
  0000000180004A4D: 48 8B D8           mov         rbx,rax
  0000000180004A50: 48 85 C0           test        rax,rax
  0000000180004A53: 75 0C              jne         0000000180004A61
  0000000180004A55: FF 15 AD 27 04 00  call        qword ptr [__imp__errno]
  0000000180004A5B: C7 00 0C 00 00 00  mov         dword ptr [rax],0Ch
  0000000180004A61: 48 8B C3           mov         rax,rbx
  0000000180004A64: 48 83 C4 20        add         rsp,20h
  0000000180004A68: 5B                 pop         rbx
  0000000180004A69: C3                 ret
```

</details>

<details>
  <summary>Example affected function (with patch)</summary>

```
> dumpbin /disasm unistring-5.dll | rg -A28 "str_iconveh:"
libunistring_str_iconveh:
  0000000180004E00: 48 89 5C 24 10     mov         qword ptr [rsp+10h],rbx
  0000000180004E05: 48 89 6C 24 18     mov         qword ptr [rsp+18h],rbp
  0000000180004E0A: 48 89 74 24 20     mov         qword ptr [rsp+20h],rsi
  0000000180004E0F: 57                 push        rdi
  0000000180004E10: 48 83 EC 70        sub         rsp,70h
  0000000180004E14: 80 39 00           cmp         byte ptr [rcx],0
  0000000180004E17: 41 8B E9           mov         ebp,r9d
  0000000180004E1A: 49 8B F8           mov         rdi,r8
  0000000180004E1D: 48 8B F2           mov         rsi,rdx
  0000000180004E20: 48 8B D9           mov         rbx,rcx
  0000000180004E23: 0F 84 EC 00 00 00  je          0000000180004F15
  0000000180004E29: 49 8B D0           mov         rdx,r8
  0000000180004E2C: 48 8B CE           mov         rcx,rsi
  0000000180004E2F: E8 6C C4 FF FF     call        libunistring_c_strcasecmp
  0000000180004E34: 85 C0              test        eax,eax
  0000000180004E36: 0F 84 D9 00 00 00  je          0000000180004F15
  0000000180004E3C: 4C 8D 44 24 58     lea         r8,[rsp+58h]
  0000000180004E41: 48 8B D6           mov         rdx,rsi
  0000000180004E44: 48 8B CF           mov         rcx,rdi
  0000000180004E47: E8 94 FB FF FF     call        libunistring_iconveh_open
  0000000180004E4C: 85 C0              test        eax,eax
  0000000180004E4E: 0F 88 BD 00 00 00  js          0000000180004F11
  0000000180004E54: 33 FF              xor         edi,edi
  0000000180004E56: 48 8B CB           mov         rcx,rbx
  0000000180004E59: 48 89 BC 24 80 00  mov         qword ptr [rsp+80h],rdi
                    00 00
  0000000180004E61: 48 89 7C 24 50     mov         qword ptr [rsp+50h],rdi
  0000000180004E66: E8 0B 30 04 00     call        strlen
```

</details>

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


P.S. The other two packages that might have similar issue (I only did some grepping, haven't verified it), might be mpir and openmpi.
