### PR TITLE
[hueplusplus] Add hueplusplus port

### DIFF
--- a/ports/hueplusplus/portfile.cmake
+++ b/ports/hueplusplus/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO enwi/hueplusplus
+    REF "v${VERSION}"
+    SHA512 13995056d3f0bda645bd2eb76426d044065057c4ffe8abbd36875459f1db8c2a04c0908ebb6ebeeb2730dabf126a17c6ac01c7cd2f2fdd0c7857ef02c550ca4f
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+if(VCPKG_HOST_IS_<WIN32> AND NOT CYGWIN)
+    vcpkg_cmake_config_fixup(CONFIG_PATH "cmake")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/cmake")
+else()
+    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/hueplusplus")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake/hueplusplus")
+endif()
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin/")
+file(RENAME "${CURRENT_PACKAGES_DIR}/lib/hueplusplusshared.dll" "${CURRENT_PACKAGES_DIR}/bin/hueplusplusshared.dll")
+file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/hueplusplusshared.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/hueplusplusshared.dll")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/hueplusplus/usage
+++ b/ports/hueplusplus/usage
@@ -1,0 +1,4 @@
+hueplusplus provides CMake targets:
+
+find_package(hueplusplus REQUIRED)
+target_link_libraries(<executable> PUBLIC hueplusplusstatic)

--- a/ports/hueplusplus/vcpkg.json
+++ b/ports/hueplusplus/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "hueplusplus",
+  "version": "1.2.0",
+  "homepage": "https://github.com/enwi/hueplusplus",
+  "description": "A simple and easy to use library for Philips Hue Lights",
+  "license": "LGPL-3.0+",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "nlohmann-json",
+    "mbedtls"
+  ]
+}

--- a/ports/hueplusplus/vcpkg.json
+++ b/ports/hueplusplus/vcpkg.json
@@ -1,10 +1,12 @@
 {
   "name": "hueplusplus",
   "version": "1.2.0",
-  "homepage": "https://github.com/enwi/hueplusplus",
   "description": "A simple and easy to use library for Philips Hue Lights",
+  "homepage": "https://github.com/enwi/hueplusplus",
   "license": "LGPL-3.0+",
   "dependencies": [
+    "mbedtls",
+    "nlohmann-json",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -12,8 +14,6 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    "nlohmann-json",
-    "mbedtls"
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3776,6 +3776,10 @@
       "baseline": "2.9.4",
       "port-version": 3
     },
+    "hueplusplus": {
+      "baseline": "1.2.0",
+      "port-version": 0
+    },
     "hungarian": {
       "baseline": "0.1.3",
       "port-version": 3

--- a/versions/h-/hueplusplus.json
+++ b/versions/h-/hueplusplus.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d916c50391e7294a2cdedee69430e5fdf67a8ff9",
+      "version": "1.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.