### PR TITLE
[LIEF] update to 0.17.0

### DIFF
--- a/ports/lief/fix-cmakelists.patch
+++ b/ports/lief/fix-cmakelists.patch
@@ -1,28 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fc2b679..4ec92b9 100644
+index 1b9d3701..dc7557fd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -113,19 +113,7 @@ message(STATUS "CMAKE_CXX_IMPLICIT_LINK_LIBRARIES: ${CMAKE_CXX_IMPLICIT_LINK_LIB
- message(STATUS "CMAKE_SYSTEM_PROCESSOR:            ${CMAKE_SYSTEM_PROCESSOR}")
- message(STATUS "CMAKE_MSVC_RUNTIME_LIBRARY:        ${CMAKE_MSVC_RUNTIME_LIBRARY}")
- 
--if(LIEF_INSTALL)
--  if(UNIX)
--    include(GNUInstallDirs)
--    set(CMAKE_INSTALL_LIBDIR "lib")
--  else()
--    set(CMAKE_INSTALL_LIBDIR      "lib")
--    set(CMAKE_INSTALL_DATADIR     "share")
-     set(CMAKE_INSTALL_INCLUDEDIR  "include")
--    set(CMAKE_INSTALL_BINDIR      "bin")
--    set(CMAKE_INSTALL_DATAROOTDIR "share")
--    message(STATUS "Setting installation destination to: ${CMAKE_INSTALL_PREFIX}")
--  endif()
--endif()
- 
- # LIEF Source definition
- # ======================
-@@ -318,7 +306,9 @@ else()
+@@ -313,7 +313,9 @@ else()
      ${CMAKE_CURRENT_BINARY_DIR}/include/LIEF/third-party/internal/span.hpp)
  endif()
  
@@ -33,7 +13,7 @@ index fc2b679..4ec92b9 100644
  
  if(ANDROID AND LIEF_LOGGING)
    target_link_libraries(LIB_LIEF PUBLIC log)
-@@ -507,11 +497,11 @@ if(LIEF_INSTALL)
+@@ -503,11 +505,11 @@ if(LIEF_INSTALL)
    endif()
  
    install(

--- a/ports/lief/fix-liefconfig-cmake-in.patch
+++ b/ports/lief/fix-liefconfig-cmake-in.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/LIEFConfig.cmake.in b/cmake/LIEFConfig.cmake.in
-index dba7363..7f88f98 100644
+index 562fda16..220208c7 100644
 --- a/cmake/LIEFConfig.cmake.in
 +++ b/cmake/LIEFConfig.cmake.in
-@@ -69,7 +69,7 @@ macro(LIEF_load_targets lib_type)
+@@ -76,7 +76,7 @@ macro(LIEF_load_targets lib_type)
      return()
    endif ()
  
@@ -11,12 +11,10 @@ index dba7363..7f88f98 100644
      # Need to find all dependencies even if they're private when LIEF is
      # compiled statically
      include(CMakeFindDependencyMacro)
-@@ -93,6 +93,10 @@ macro(LIEF_load_targets lib_type)
-     if(NOT @LIEF_DISABLE_FROZEN@ AND @LIEF_OPT_FROZEN_EXTERNAL@)
-       find_dependency(frozen)
+@@ -105,6 +105,8 @@ macro(LIEF_load_targets lib_type)
+       find_dependency(tl-expected)
      endif()
-+
-+    find_dependency(tl-expected)
+ 
 +    find_dependency(fmt)
 +    check_required_components(lief)
    endif()

--- a/ports/lief/fix-vcpkg-includes.patch
+++ b/ports/lief/fix-vcpkg-includes.patch
@@ -1,5 +1,5 @@
 diff --git a/src/BinaryStream/BinaryStream.cpp b/src/BinaryStream/BinaryStream.cpp
-index 83e618c..6447b7b 100644
+index 655948f6..cea9ffcd 100644
 --- a/src/BinaryStream/BinaryStream.cpp
 +++ b/src/BinaryStream/BinaryStream.cpp
 @@ -15,7 +15,7 @@
@@ -11,42 +11,16 @@ index 83e618c..6447b7b 100644
  
  #include <mbedtls/x509.h>
  #include <mbedtls/x509_crt.h>
-diff --git a/src/PE/Builder.cpp b/src/PE/Builder.cpp
-index 8cbe7b2..994e9bf 100644
---- a/src/PE/Builder.cpp
-+++ b/src/PE/Builder.cpp
-@@ -21,7 +21,7 @@
- 
- #include "logging.hpp"
- 
--#include "third-party/utfcpp.hpp"
-+#include <utf8cpp/utf8.h>
- 
- 
- #include "LIEF/PE/Builder.hpp"
-diff --git a/src/logging.cpp b/src/logging.cpp
-index 39936fe..f5e1345 100644
---- a/src/logging.cpp
-+++ b/src/logging.cpp
-@@ -20,7 +20,7 @@
- #include "logging.hpp"
- 
- #include "spdlog/spdlog.h"
--#include "spdlog/fmt/bundled/args.h"
-+#include <fmt/args.h>
- #include "spdlog/sinks/stdout_color_sinks.h"
- #include "spdlog/sinks/basic_file_sink.h"
- #include "spdlog/sinks/android_sink.h"
 diff --git a/src/utils.cpp b/src/utils.cpp
-index 0acbba1..b624a1d 100644
+index dc3dda28..356d4ad3 100644
 --- a/src/utils.cpp
 +++ b/src/utils.cpp
-@@ -22,7 +22,7 @@
- #include "LIEF/utils.hpp"
+@@ -23,7 +23,7 @@
  #include "LIEF/errors.hpp"
+ #include "LIEF/version.h"
  
 -#include "third-party/utfcpp.hpp"
 +#include <utf8cpp/utf8.h>
  
  #include "LIEF/config.h"
- #include "logging.hpp"
+ 

--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -22,10 +22,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
         "use-ccache"     LIEF_USE_CCACHE        # Use ccache to speed up compilation
 
-        "elf"            LIEF_ELF               # Build LIEF with ELF module
-        "pe"             LIEF_PE                # Build LIEF with PE  module
-        "macho"          LIEF_MACHO             # Build LIEF with MachO module
-
         "oat"            LIEF_OAT               # Build LIEF with OAT module
         "dex"            LIEF_DEX               # Build LIEF with DEX module
         "vdex"           LIEF_VDEX              # Build LIEF with VDEX module
@@ -48,6 +44,11 @@ vcpkg_cmake_configure(
         -DLIEF_OPT_EXTERNAL_EXPECTED=ON
         -DLIEF_DISABLE_FROZEN=OFF
         -DLIEF_DISABLE_EXCEPTIONS=OFF
+
+        # https://github.com/lief-project/LIEF/blob/0.16.6/src/paging.cpp requires ELF/PE/MACHO in any case
+        -DLIEF_ELF=ON
+        -DLIEF_PE=ON
+        -DLIEF_MACHO=ON
 
         "-DLIEF_EXTERNAL_SPAN_DIR=${_VCPKG_INSTALLED_DIR}/${TARGET_TRIPLET}/include/tcb"
 )

--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lief-project/LIEF
     REF ${VERSION}
-    SHA512 776d26bc5d8ec7bca823d1c0fc821b0efc2411976901e1fca0ffecbc64591798e9e21a483c1637e9877bdd921dc463ffaef4eeb6a76d9dd8463c97c5f50834d4
+    SHA512 deb81b887f328baa571b8c98d58be48ccc249b9145b241054743e47dae50bf301f62bfd6649647358769c10ca81c990cbd026ac5df45b4ebe5d1bce0f5b90e2d
     HEAD_REF master
     PATCHES
         fix-cmakelists.patch

--- a/ports/lief/vcpkg.json
+++ b/ports/lief/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lief",
-  "version-semver": "0.16.1",
+  "version-semver": "0.17.0",
   "description": "LIEF - Library to Instrument Executable Formats",
   "homepage": "https://lief.quarkslab.com",
   "license": "Apache-2.0",

--- a/ports/lief/vcpkg.json
+++ b/ports/lief/vcpkg.json
@@ -24,12 +24,9 @@
   "default-features": [
     "art",
     "dex",
-    "elf",
     "enable-json",
     "logging",
-    "macho",
     "oat",
-    "pe",
     "vdex"
   ],
   "features": {

--- a/ports/lief/vcpkg.json
+++ b/ports/lief/vcpkg.json
@@ -42,9 +42,6 @@
     "dex": {
       "description": "Build LIEF with DEX module"
     },
-    "elf": {
-      "description": "Build LIEF with ELF module"
-    },
     "enable-json": {
       "description": "Enable JSON-related APIs",
       "dependencies": [
@@ -60,14 +57,8 @@
     "logging-debug": {
       "description": "Enable debug logging"
     },
-    "macho": {
-      "description": "Build LIEF with MachO module"
-    },
     "oat": {
       "description": "Build LIEF with OAT module"
-    },
-    "pe": {
-      "description": "Build LIEF with PE module"
     },
     "use-ccache": {
       "description": "Use ccache to speed up compilation"

--- a/scripts/test_ports/vcpkg-ci-lief/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-lief/vcpkg.json
@@ -10,14 +10,11 @@
         "art",
         "c-api",
         "dex",
-        "elf",
         "enable-json",
         "extra-warnings",
         "logging",
         "logging-debug",
-        "macho",
         "oat",
-        "pe",
         "use-ccache",
         "vdex"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5813,7 +5813,7 @@
       "port-version": 0
     },
     "lief": {
-      "baseline": "0.16.1",
+      "baseline": "0.17.0",
       "port-version": 0
     },
     "lightgbm": {

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2b7ddf4dec374918e23da4782a0a3b578f42bb2",
+      "version-semver": "0.17.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c93d7992ef9c457a2e320a5f10df9e1dfae1407d",
       "version-semver": "0.16.1",
       "port-version": 0

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8ec08a28887c6f0031b95019e96ee5b35e8d83d4",
+      "git-tree": "6010290f828d52bd60856596ad56990f1685566e",
       "version-semver": "0.17.0",
       "port-version": 0
     },

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f2b7ddf4dec374918e23da4782a0a3b578f42bb2",
+      "git-tree": "e12a387a38be0d10379c133eeb7ea01cd8575f00",
       "version-semver": "0.17.0",
       "port-version": 0
     },

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e12a387a38be0d10379c133eeb7ea01cd8575f00",
+      "git-tree": "8ec08a28887c6f0031b95019e96ee5b35e8d83d4",
       "version-semver": "0.17.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

