### PR TITLE
[qhull] replace cmake minimum required version on cmakelists.txt for compatibility with cmake 4

### DIFF
--- a/ports/qhull/include-qhullcpp-shared.patch
+++ b/ports/qhull/include-qhullcpp-shared.patch
@@ -2,6 +2,11 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index f50b187..30109b3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -71,3 +71,3 @@ cmake_minimum_required(VERSION 3.0)
+ project(qhull)
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.5..4.0)
+ 
 @@ -344,7 +344,7 @@ set(qhull_SHAREDP qhull_p)  # libqhull and qhull_p are deprecated, use qhull_r i
  
  set(qhull_TARGETS_APPLICATIONS qhull rbox qconvex qdelaunay qvoronoi qhalf)

--- a/ports/qhull/vcpkg.json
+++ b/ports/qhull/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qhull",
   "version": "8.0.2",
-  "port-version": 5,
+  "port-version": 6,
   "description": "computes the convex hull, Delaunay triangulation, Voronoi diagram",
   "homepage": "https://github.com/qhull/qhull",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7734,7 +7734,7 @@
     },
     "qhull": {
       "baseline": "8.0.2",
-      "port-version": 5
+      "port-version": 6
     },
     "qlementine": {
       "baseline": "1.2.2",

--- a/versions/q-/qhull.json
+++ b/versions/q-/qhull.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17b050822d49bfd33d3b44755597317ac49201ed",
+      "version": "8.0.2",
+      "port-version": 6
+    },
+    {
       "git-tree": "0c30770c608574944db1c98437d356af3e64fe5b",
       "version": "8.0.2",
       "port-version": 5


### PR DESCRIPTION
By replacing the minimum required version with the same line that is available on the latest commit of qhull, cmake 4 will happily build again.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [-] SHA512s are updated for each updated download.
- [?] The "supports" clause reflects platforms that may be fixed by this new version.
- [-] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [-] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

