### PR TITLE
[libkml] patch to allow build on cmake 4

### DIFF
--- a/ports/libkml/fix-cmake-min-version.patch
+++ b/ports/libkml/fix-cmake-min-version.patch
@@ -1,0 +1,8 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 028f50a..bb63ffb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,2 +1,2 @@ cmake_minimum_required(VERSION 2.8)
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.5)
+ project(LibKML)

--- a/ports/libkml/portfile.cmake
+++ b/ports/libkml/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     SHA512 aa48158103d3af764bf98c1fb4cf3e1356b9cc6c8e79d80b96850916f0a8ccb1dac3a46427735dd0bf20647daa047d10e722ac3da2a214d4c1559bf6d5d7c853
     HEAD_REF master
     PATCHES
+        fix-cmake-min-version.patch
         patch_empty_literal_on_vc.patch
         fix-mingw.patch
         fix-minizip.patch

--- a/ports/libkml/vcpkg.json
+++ b/ports/libkml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libkml",
   "version": "1.3.0",
-  "port-version": 13,
+  "port-version": 14,
   "description": "Reference implementation of OGC KML 2.2",
   "homepage": "https://github.com/libkml/libkml",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4982,7 +4982,7 @@
     },
     "libkml": {
       "baseline": "1.3.0",
-      "port-version": 13
+      "port-version": 14
     },
     "liblas": {
       "baseline": "1.8.1",

--- a/versions/l-/libkml.json
+++ b/versions/l-/libkml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "db810242926524c54e87b931756965751329df66",
+      "version": "1.3.0",
+      "port-version": 14
+    },
+    {
       "git-tree": "010ce552eaee999aaf220936eb3e46b5bb88a9fc",
       "version": "1.3.0",
       "port-version": 13

--- a/versions/l-/libkml.json
+++ b/versions/l-/libkml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "db810242926524c54e87b931756965751329df66",
+      "git-tree": "36c36ef06ecd41819ab32ca2df9df39a577c256a",
       "version": "1.3.0",
       "port-version": 14
     },


### PR DESCRIPTION
Marked minimum required version as cmake 3.5 to allow build with cmake 4.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [-] SHA512s are updated for each updated download.
- [?] The "supports" clause reflects platforms that may be fixed by this new version.
- [-] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
