### PR TITLE
[reflectcpp] Update to 0.21.0

### DIFF
--- a/ports/reflectcpp/portfile.cmake
+++ b/ports/reflectcpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO getml/reflect-cpp
     REF "v${VERSION}"
-    SHA512 92feee43ac407013c15b7608637061fd5c22ccf9309a7f6ff7f60dbdf13e41aad0ad1200354da6f27a6d0824cabd7a0b0a067675b1625c2e1b7ec9017b3c3f4a
+    SHA512 3fb7235a72738dc21659a9b1cbdc5b783b1b5eb7eb4af8de35e0e6d5a886822c88cdd2a58b181c036ab36eac9892e65a9c9e260bf09d21f577bdd01e8d120410 
     HEAD_REF main
 )
 
@@ -16,8 +16,10 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         bson                REFLECTCPP_BSON
         capnproto           REFLECTCPP_CAPNPROTO
         cbor                REFLECTCPP_CBOR
+        csv                 REFLECTCPP_CSV
         flexbuffers         REFLECTCPP_FLEXBUFFERS
         msgpack             REFLECTCPP_MSGPACK
+        parquet             REFLECTCPP_PARQUET
         toml                REFLECTCPP_TOML
         ubjson              REFLECTCPP_UBJSON
         xml                 REFLECTCPP_XML

--- a/ports/reflectcpp/vcpkg.json
+++ b/ports/reflectcpp/vcpkg.json
@@ -1,13 +1,13 @@
 {
   "name": "reflectcpp",
-  "version": "0.20.0",
-  "description": "A C++ library for serialization and deserialization using reflection. Supports JSON, Avro, BSON, Cap'n Proto, CBOR, flexbuffers, msgpack, TOML, UBJSON, XML, YAML.",
+  "version": "0.21.0",
+  "description": "A C++ library for serialization and deserialization using reflection. Supports JSON, Avro, BSON, Cap'n Proto, CBOR, CSV, flexbuffers, msgpack, parquet, TOML, UBJSON, XML, YAML.",
   "homepage": "https://github.com/getml/reflect-cpp/",
   "license": "MIT",
   "dependencies": [
     {
       "name": "ctre",
-      "version>=": "3.9.0"
+      "version>=": "3.10.0"
     },
     {
       "name": "vcpkg-cmake",
@@ -46,7 +46,17 @@
       "dependencies": [
         {
           "name": "jsoncons",
-          "version>=": "0.176.0"
+          "version>=": "1.4.0"
+        }
+      ]
+    },
+    "csv": {
+      "description": "Enable CSV support",
+      "dependencies": [
+        {
+          "name": "arrow",
+          "version>=": "21.0.0",
+          "features": ["csv"]
         }
       ]
     },
@@ -68,6 +78,16 @@
         }
       ]
     },
+    "parquet": {
+      "description": "Enable parquet support",
+      "dependencies": [
+        {
+          "name": "arrow",
+          "version>=": "21.0.0",
+          "features": ["parquet"]
+        }
+      ]
+    },
     "toml": {
       "description": "Support for the TOML format",
       "dependencies": [
@@ -82,7 +102,7 @@
       "dependencies": [
         {
           "name": "jsoncons",
-          "version>=": "0.176.0"
+          "version>=": "1.4.0"
         }
       ]
     },

--- a/ports/reflectcpp/vcpkg.json
+++ b/ports/reflectcpp/vcpkg.json
@@ -55,8 +55,10 @@
       "dependencies": [
         {
           "name": "arrow",
-          "version>=": "21.0.0",
-          "features": ["csv"]
+          "features": [
+            "csv"
+          ],
+          "version>=": "21.0.0"
         }
       ]
     },
@@ -83,8 +85,10 @@
       "dependencies": [
         {
           "name": "arrow",
-          "version>=": "21.0.0",
-          "features": ["parquet"]
+          "features": [
+            "parquet"
+          ],
+          "version>=": "21.0.0"
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8349,7 +8349,7 @@
       "port-version": 0
     },
     "reflectcpp": {
-      "baseline": "0.20.0",
+      "baseline": "0.21.0",
       "port-version": 0
     },
     "refprop-headers": {

--- a/versions/r-/reflectcpp.json
+++ b/versions/r-/reflectcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "10079b349a09eabd7029392b2693db5256129c43",
+      "version": "0.21.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "552cd16c7931c4cd634459fca32d849e199add71",
       "version": "0.20.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.