### PR TITLE
[whisper-cpp] add optional backends as feature

### DIFF
--- a/ports/whisper-cpp/vcpkg.json
+++ b/ports/whisper-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "whisper-cpp",
   "version": "1.7.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Port of OpenAI's Whisper model in C/C++",
   "homepage": "https://github.com/ggml-org/whisper.cpp",
   "license": "MIT",
@@ -15,5 +15,44 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA support for GPU acceleration",
+      "dependencies": [
+        "cuda",
+        {
+          "name": "ggml",
+          "features": [
+            "cuda"
+          ]
+        }
+      ]
+    },
+    "metal": {
+      "description": "Enable Metal support for GPU acceleration on macOS",
+      "supports": "osx",
+      "dependencies": [
+        {
+          "name": "ggml",
+          "features": [
+            "metal"
+          ]
+        }
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan support for GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml",
+          "features": [
+            "vulkan"
+          ]
+        },
+        "vulkan",
+        "vulkan-headers"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10306,7 +10306,7 @@
     },
     "whisper-cpp": {
       "baseline": "1.7.6",
-      "port-version": 1
+      "port-version": 2
     },
     "wiiuse": {
       "baseline": "0.15.6",

--- a/versions/w-/whisper-cpp.json
+++ b/versions/w-/whisper-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf8841b8b8c125a25648f10f46ad37070775eba9",
+      "version": "1.7.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "4c0a04c25cdbeac34d8f47761d39c2a529234148",
       "version": "1.7.6",
       "port-version": 1


### PR DESCRIPTION
[x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
**not a version change** - SHA512s are updated for each updated download. 
**not a version change** - The "supports" clause reflects platforms that may be fixed by this new version. 
**nothing poped up on my end** - Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. 
[x] Any patches that are no longer applied are deleted from the port's directory.
[x] -  The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
[x] Only one version is added to each modified port's versions file.
