### PR TITLE
add svt-av1 support in ffmpeg

### DIFF
--- a/ports/ffmpeg/0045-fix-svt-av1-integration_ffmpeg_n7_fix.patch
+++ b/ports/ffmpeg/0045-fix-svt-av1-integration_ffmpeg_n7_fix.patch
@@ -1,0 +1,14 @@
+# Source: https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/.gitlab/workflows/linux/ffmpeg_n7_fix.patch
+diff --git a/libavcodec/libsvtav1.c b/libavcodec/libsvtav1.c
+index 8fa42d590b..e99c656c5d 100644
+--- a/libavcodec/libsvtav1.c
++++ b/libavcodec/libsvtav1.c
+@@ -430,7 +430,7 @@ static av_cold int eb_enc_init(AVCodecContext *avctx)
+ 
+     svt_enc->eos_flag = EOS_NOT_REACHED;
+ 
+-    svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
++    svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, &svt_enc->enc_params);
+     if (svt_ret != EB_ErrorNone) {
+         return svt_print_error(avctx, svt_ret, "Error initializing encoder handle");
+     }

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_github(
         0041-add-const-for-opengl-definition.patch
         0043-fix-miss-head.patch
         0044-fix-vulkan-debug-callback-abi.patch
+        0045-fix-svt-av1-integration_ffmpeg_n7_fix.patch
 )
 
 if(SOURCE_PATH MATCHES " ")
@@ -593,6 +594,12 @@ if ("vaapi" IN_LIST FEATURES)
 else()
     set(OPTIONS "${OPTIONS} --disable-vaapi")
     set(WITH_VAAPI OFF)
+endif()
+
+if("svt-av1" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-libsvtav1")
+else()
+    set(OPTIONS "${OPTIONS} --disable-libsvtav1")
 endif()
 
 set(OPTIONS_CROSS "--enable-cross-compile")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -57,6 +57,7 @@
             "snappy",
             "soxr",
             "speex",
+            "svt-av1",
             "swresample",
             "swscale",
             "theora",
@@ -155,6 +156,14 @@
             "opencl"
           ],
           "platform": "!uwp & !osx"
+        },
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "svt-av1"
+          ],
+          "platform": "linux | (!osx & !uwp)"
         },
         {
           "name": "ffmpeg",
@@ -620,6 +629,13 @@
       "description": "SFTP protocol via libssh",
       "dependencies": [
         "libssh"
+      ]
+    },
+    "svt-av1": {
+      "description": "Scalable Video Technology AV1 encoding acceleration",
+      "supports": "linux | (!osx & !uwp)",
+      "dependencies": [
+        "svt-av1"
       ]
     },
     "swresample": {


### PR DESCRIPTION
Since the SVT-AV1 port was added recently, this PR adds support in ffmpeg to be built with SVT-AV1. 