### PR TITLE
[simdjson] update to 4.0.5

### DIFF
--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO simdjson/simdjson
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 77dfb04e7806e6be755cc74f155077691e86c5575ea7fc8bedec9cf7cc38aa2fc75f51b948cd80f2c9a07f7faf03a2265d5178192309613a75b4c98ae0c37932
+    SHA512 d994339b5e87d3bca6e1f35ee798dbf469bdfc5f9889702b242088f5bd51d6fd395087ac67a17284224041ece3f29ec73d827326e7a2845de03cc4c0521bff5d
 )
 
 vcpkg_check_features(

--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO simdjson/simdjson
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 d994339b5e87d3bca6e1f35ee798dbf469bdfc5f9889702b242088f5bd51d6fd395087ac67a17284224041ece3f29ec73d827326e7a2845de03cc4c0521bff5d
+    SHA512 658ce8b6716cc5da4a6c75a0c9015098c3603c634aa6f336eaf07055a80b2a62cd0dfbc517b247edd5a64bb8b1e87affac1bacf0de4dea6da31ec50e536c05e5
 )
 
 vcpkg_check_features(

--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     REPO simdjson/simdjson
     REF "v${VERSION}"
     HEAD_REF master
-    SHA512 9cb542f8fe934064849e819aa4c059677fc60b83544de376ccd700f1867367bafb0b7ed1d16179deaae360f4036e60adc58af0034f68904cfcd32233a3d099c2
+    SHA512 77dfb04e7806e6be755cc74f155077691e86c5575ea7fc8bedec9cf7cc38aa2fc75f51b948cd80f2c9a07f7faf03a2265d5178192309613a75b4c98ae0c37932
 )
 
 vcpkg_check_features(

--- a/ports/simdjson/vcpkg.json
+++ b/ports/simdjson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdjson",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "An extremely fast JSON library that can parse gigabytes of JSON per second",
   "homepage": "https://simdjson.org/",
   "license": "Apache-2.0 OR MIT",

--- a/ports/simdjson/vcpkg.json
+++ b/ports/simdjson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdjson",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "An extremely fast JSON library that can parse gigabytes of JSON per second",
   "homepage": "https://simdjson.org/",
   "license": "Apache-2.0 OR MIT",

--- a/ports/simdjson/vcpkg.json
+++ b/ports/simdjson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdjson",
-  "version": "4.0.1",
+  "version": "4.0.3",
   "description": "An extremely fast JSON library that can parse gigabytes of JSON per second",
   "homepage": "https://simdjson.org/",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8893,7 +8893,7 @@
       "port-version": 0
     },
     "simdjson": {
-      "baseline": "4.0.1",
+      "baseline": "4.0.3",
       "port-version": 0
     },
     "simdutf": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8893,7 +8893,7 @@
       "port-version": 0
     },
     "simdjson": {
-      "baseline": "4.0.3",
+      "baseline": "4.0.4",
       "port-version": 0
     },
     "simdutf": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8893,7 +8893,7 @@
       "port-version": 0
     },
     "simdjson": {
-      "baseline": "4.0.4",
+      "baseline": "4.0.5",
       "port-version": 0
     },
     "simdutf": {

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "20366f6eb58ceb06a26ec42dccef84c1114ad791",
-      "version": "4.0.3",
+      "git-tree": "bb6686203e6176034df52fea356af7038f29848b",
+      "version": "4.0.4",
       "port-version": 0
     },
     {

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "bb6686203e6176034df52fea356af7038f29848b",
-      "version": "4.0.4",
+      "git-tree": "9ccfccd1bcff33665698a1f987764d4b932a5910",
+      "version": "4.0.5",
       "port-version": 0
     },
     {

--- a/versions/s-/simdjson.json
+++ b/versions/s-/simdjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20366f6eb58ceb06a26ec42dccef84c1114ad791",
+      "version": "4.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "43f2c60584ae400a8a9d59f26e7df9a9ca0d34ac",
       "version": "4.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/simdjson/simdjson/releases/tag/v4.0.5
https://github.com/simdjson/simdjson/releases/tag/v4.0.4
https://github.com/simdjson/simdjson/releases/tag/v4.0.3
https://github.com/simdjson/simdjson/releases/tag/v4.0.2
