### PR TITLE
[stringzilla] update to 4.0.11

### DIFF
--- a/ports/stringzilla/portfile.cmake
+++ b/ports/stringzilla/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/StringZilla
     REF "v${VERSION}"
-    SHA512 0846227e430fefbdef50f42798a61616e29919b23bdb355f20ce19ab3dafd894d28187b7a55f2b7abc660deefabcd87b6dd99ab387fceaf8008d92cc628701bf
+    SHA512 32ebd01005596984ec3a73ca437fd089aefce77c4af2723fa475c61d88591d425e89457f7869cbe38c5a133a2f08ea4fbb994f6478fa71a0e77d8d2439bd5cc8
     HEAD_REF master
 )
 

--- a/ports/stringzilla/vcpkg.json
+++ b/ports/stringzilla/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stringzilla",
-  "version": "4.0.7",
+  "version": "4.0.11",
   "description": "StringZilla is the GodZilla of string libraries, using SIMD and SWAR to accelerate string operations on modern CPUs.",
   "homepage": "https://github.com/ashvardanian/StringZilla",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9289,7 +9289,7 @@
       "port-version": 1
     },
     "stringzilla": {
-      "baseline": "4.0.7",
+      "baseline": "4.0.11",
       "port-version": 0
     },
     "strong-type": {

--- a/versions/s-/stringzilla.json
+++ b/versions/s-/stringzilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb193ef57ddb629e6ceba0e9e8a01f44be266267",
+      "version": "4.0.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "66a43ad40ebcb2d408cbe55ad6f38d4175a3f307",
       "version": "4.0.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ashvardanian/StringZilla/releases/tag/v4.0.11
https://github.com/ashvardanian/StringZilla/releases/tag/v4.0.10
https://github.com/ashvardanian/StringZilla/releases/tag/v4.0.9
https://github.com/ashvardanian/StringZilla/releases/tag/v4.0.8
