### PR TITLE
[expat] update to 2.7.2

### DIFF
--- a/ports/expat/portfile.cmake
+++ b/ports/expat/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libexpat/libexpat
     REF "${REF}"
-    SHA512 ea5452c511e18e0eb927eab46a47c7ced1b1be3b46232a38caef39aa86fd552a72f066db66ca824ade3ff2376b70ca72ca91bdf1d003770c91a38a47e8781b8f
+    SHA512 18d978a52f5ab9f5b0f8f0059a71c96d35708e437d763d356cde1babc6d4d08297f2b443d420b3906a51a7559fe4a84bc49bd51d4b9a6e1ee24c5d12b8c42707
     HEAD_REF master
 )
 

--- a/ports/expat/vcpkg.json
+++ b/ports/expat/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "expat",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "XML parser library written in C",
   "homepage": "https://github.com/libexpat/libexpat",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2757,7 +2757,7 @@
       "port-version": 0
     },
     "expat": {
-      "baseline": "2.7.1",
+      "baseline": "2.7.2",
       "port-version": 0
     },
     "expected-lite": {

--- a/versions/e-/expat.json
+++ b/versions/e-/expat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a1969f020361e85beab3071be085e6b13bf19786",
+      "version": "2.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "37702e8740157c39e52d0d254487c1811b7e1d7c",
       "version": "2.7.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/libexpat/libexpat/blob/R_2_7_2/expat/Changes#L44-L115
