### PR TITLE
[libvpx] Don't expect GNU diff

### DIFF
--- a/ports/libvpx/0005-dont-expect-gnu-diff.patch
+++ b/ports/libvpx/0005-dont-expect-gnu-diff.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 356bbe26f..7f8c5559b 100755
+--- a/configure
++++ b/configure
+@@ -189,7 +189,7 @@ for t in ${all_targets}; do
+     [ -f "${source_path}/${t}.mk" ] && enable_feature ${t}
+ done
+ 
+-if ! diff --version >/dev/null; then
++if ! hash diff >/dev/null; then
+   die "diff missing: Try installing diffutils via your package manager."
+ fi
+

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         0003-add-uwp-v142-and-v143-support.patch
         0004-remove-library-suffixes.patch
+        0005-dont-expect-gnu-diff.patch
 )
 
 if(CMAKE_HOST_WIN32)

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libvpx",
   "version": "1.15.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5622,7 +5622,7 @@
     },
     "libvpx": {
       "baseline": "1.15.2",
-      "port-version": 1
+      "port-version": 2
     },
     "libwandio": {
       "baseline": "4.2.6-1",

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6677969951a14750a5ab721e7ee4e23a0ddaecf1",
+      "version": "1.15.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "09da74cfd77ee2d38d8849cc085875a306f8022a",
       "version": "1.15.2",
       "port-version": 1


### PR DESCRIPTION
This fixes the build on OpenBSD

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.