### PR TITLE
 [vbs-enclave-tooling-codegen] Update to 0.1.2-prerelease.250820.1

### DIFF
--- a/ports/vbs-enclave-tooling-codegen/portfile.cmake
+++ b/ports/vbs-enclave-tooling-codegen/portfile.cmake
@@ -8,8 +8,7 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(
     PACKAGE_PATH
-    ARCHIVE ${ARCHIVE}
-    SOURCE_BASE ${LIB_VERSION}
+    ARCHIVE "${ARCHIVE}"
     NO_REMOVE_ONE_LEVEL
 )
 

--- a/ports/vbs-enclave-tooling-codegen/vcpkg.json
+++ b/ports/vbs-enclave-tooling-codegen/vcpkg.json
@@ -1,17 +1,12 @@
 {
   "name": "vbs-enclave-tooling-codegen",
-  "version": "0.1.1-prerelease",
+  "version": "0.1.2-prerelease.250820.1",
   "description": "Supports code generation for VBS enclaves.",
   "homepage": "https://github.com/microsoft/vbsEnclaveTooling",
   "license": "MIT",
   "supports": "(windows & arm64) | (windows & x64)",
   "dependencies": [
     "flatbuffers",
-    "ms-gsl",
-    {
-      "name": "vcpkg-msbuild",
-      "host": true
-    },
     "wil"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9969,7 +9969,7 @@
       "port-version": 0
     },
     "vbs-enclave-tooling-codegen": {
-      "baseline": "0.1.1-prerelease",
+      "baseline": "0.1.2-prerelease.250820.1",
       "port-version": 0
     },
     "vc": {

--- a/versions/v-/vbs-enclave-tooling-codegen.json
+++ b/versions/v-/vbs-enclave-tooling-codegen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6935269225e23833275501d265ac88ec6625af70",
+      "version": "0.1.2-prerelease.250820.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8eeada33483bca3671e5838633d19ae70297b475",
       "version": "0.1.1-prerelease",
       "port-version": 0

--- a/versions/v-/vbs-enclave-tooling-codegen.json
+++ b/versions/v-/vbs-enclave-tooling-codegen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6935269225e23833275501d265ac88ec6625af70",
+      "git-tree": "b833a1d9d789474f07b1f3cdf632931a036ed489",
       "version": "0.1.2-prerelease.250820.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


I updated the port to use the new NuGet package in our nuget feed instead of restoring the solution file via nuget restore. 