### PR TITLE
[duckdb] update to 1.4.0

### DIFF
--- a/ports/duckdb/extensions.patch
+++ b/ports/duckdb/extensions.patch
@@ -1,48 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1300ab8..db2a32c 100644
+index 1300ab8..038c03b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1277,9 +1277,23 @@ endif()
+@@ -1277,7 +1277,10 @@ endif()
  # Load extensions passed through cmake config var
  foreach(EXT IN LISTS BUILD_EXTENSIONS)
    if(NOT "${EXT}" STREQUAL "")
 -    if (EXISTS "${EXTENSION_CONFIG_BASE_DIR}/${EXT}.cmake")
-+    if ("${EXT}" STREQUAL "httpfs")
-+      duckdb_extension_load(${EXT}
-+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}
-+        INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}/extension/${EXT}/include
-+      )
-+    elseif ("${EXT}" STREQUAL "excel")
-+      # out-of-tree extension: load cmake file
-+      duckdb_extension_load(${EXT}
-+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}
-+        INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}/src/${EXT}/include
-+      )
-+    elseif ("${EXT}" STREQUAL "iceberg")
++    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}/extension_config.cmake")  
++      # out-of-tree extension  
++      include("${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}/extension_config.cmake")  
++    elseif (EXISTS "${EXTENSION_CONFIG_BASE_DIR}/${EXT}.cmake")  
        # out-of-tree extension: load cmake file
--      include("${EXTENSION_CONFIG_BASE_DIR}/${EXT}.cmake")
-+      duckdb_extension_load(${EXT}
-+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}
-+        INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}/src/${EXT}/include
-+      )
+       include("${EXTENSION_CONFIG_BASE_DIR}/${EXT}.cmake")
      else()
-       # in-tree or non-existent extension: load it
-       duckdb_extension_load(${EXT})
-diff --git a/DuckDBConfig.cmake.in b/DuckDBConfig.cmake.in
-index 7c5ce31..4095e02 100644
---- a/DuckDBConfig.cmake.in
-+++ b/DuckDBConfig.cmake.in
-@@ -9,6 +9,13 @@ find_dependency(Threads)
- if(NOT @WITH_INTERNAL_ICU@)
-     find_dependency(ICU COMPONENTS i18n uc data)
- endif()
-+set(EXTENSION_LIST "@BUILD_EXTENSIONS@")
-+list(FIND EXTENSION_LIST "excel" EXCEL_INDEX)
-+
-+if(EXCEL_INDEX GREATER_EQUAL 0)
-+  find_dependency(expat CONFIG)
-+  find_dependency(minizip-ng CONFIG)
-+endif()
- 
- # Compute paths
- get_filename_component(DuckDB_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)

--- a/ports/duckdb/extensions.patch
+++ b/ports/duckdb/extensions.patch
@@ -1,36 +1,41 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index eecaf51..65dbfae 100644
+index 1300ab8..db2a32c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1280,7 +1280,19 @@ endforeach()
+@@ -1277,9 +1277,23 @@ endif()
  # Load extensions passed through cmake config var
  foreach(EXT IN LISTS BUILD_EXTENSIONS)
    if(NOT "${EXT}" STREQUAL "")
--    duckdb_extension_load(${EXT})
-+    if("${EXT}" STREQUAL "httpfs")
-+      duckdb_extension_load(${EXT} 
-+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/httpfs
-+        INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/httpfs/extension/httpfs/include
+-    if (EXISTS "${EXTENSION_CONFIG_BASE_DIR}/${EXT}.cmake")
++    if ("${EXT}" STREQUAL "httpfs")
++      duckdb_extension_load(${EXT}
++        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}
++        INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}/extension/${EXT}/include
 +      )
-+    elseif("${EXT}" STREQUAL "excel")
-+      duckdb_extension_load(${EXT} 
-+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/excel
-+        INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/excel/src/excel/include
++    elseif ("${EXT}" STREQUAL "excel")
++      # out-of-tree extension: load cmake file
++      duckdb_extension_load(${EXT}
++        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}
++        INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}/src/${EXT}/include
 +      )
-+    else()
-+      duckdb_extension_load(${EXT})
-+    endif()
-   endif()
- endforeach()
- 
++    elseif ("${EXT}" STREQUAL "iceberg")
+       # out-of-tree extension: load cmake file
+-      include("${EXTENSION_CONFIG_BASE_DIR}/${EXT}.cmake")
++      duckdb_extension_load(${EXT}
++        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}
++        INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extension/${EXT}/src/${EXT}/include
++      )
+     else()
+       # in-tree or non-existent extension: load it
+       duckdb_extension_load(${EXT})
 diff --git a/DuckDBConfig.cmake.in b/DuckDBConfig.cmake.in
-index 7c5ce31..efb9ec3 100644
+index 7c5ce31..4095e02 100644
 --- a/DuckDBConfig.cmake.in
 +++ b/DuckDBConfig.cmake.in
-@@ -10,6 +10,14 @@ if(NOT @WITH_INTERNAL_ICU@)
+@@ -9,6 +9,13 @@ find_dependency(Threads)
+ if(NOT @WITH_INTERNAL_ICU@)
      find_dependency(ICU COMPONENTS i18n uc data)
  endif()
- 
 +set(EXTENSION_LIST "@BUILD_EXTENSIONS@")
 +list(FIND EXTENSION_LIST "excel" EXCEL_INDEX)
 +
@@ -38,7 +43,6 @@ index 7c5ce31..efb9ec3 100644
 +  find_dependency(expat CONFIG)
 +  find_dependency(minizip-ng CONFIG)
 +endif()
-+
+ 
  # Compute paths
  get_filename_component(DuckDB_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
- set(DuckDB_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -66,7 +66,7 @@ endif()
 vcpkg_cmake_configure(
         SOURCE_PATH ${SOURCE_PATH}
         OPTIONS
-            -DOVERRIDE_GIT_DESCRIBE=v${VERSION}
+            -DOVERRIDE_GIT_DESCRIBE=v${VERSION}-0-g0123456789
             -DDUCKDB_EXPLICIT_VERSION=v${VERSION}
             -DBUILD_UNITTESTS=OFF
             -DBUILD_SHELL=FALSE

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO duckdb/duckdb
         REF v${VERSION}
-        SHA512 8e725d94cfd81989d4f6d206728188e5b290ce3a7f71d89adc6beed91957f965180d34d69d9099d04e35fc402b389de56184875397b29286789bd9c5655595c5
+        SHA512 c6514268d136b7c1c768c4d5470b230345b68d5db0c78acd48329d8fa0b6faff146d1840ff5d207dacdc9930a60aed09495f3867bd0e11bc9c63bdbef7781478
         HEAD_REF main
     PATCHES
         extensions.patch
@@ -20,8 +20,8 @@ if("excel" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH DUCKDB_EXCCEL_SOURCE_PATH
         REPO duckdb/duckdb-excel
-        REF 6c7a0270608d18053d23359834b775d40804a052
-        SHA512 442b4dc9405f34a9b624e5c4e874ebf2cffd1f5c477257b090613f987d83fcc02bc2293b8d163fffe018aa250e90bcadc9ac345e84dc4c96f4092c19c769f924
+        REF 8504be9ec8183e4082141f9359b53a64d3a440b7
+        SHA512 295bfe67c2902c09b584bee623dee7db69aad272a00e6bd4038ec65e2d8a977d1ace7261af8f67863c2fae709acc414e290e40f0bad43bae679c0a8639a0d6b5
         HEAD_REF main
     )
     file(RENAME "${DUCKDB_EXCCEL_SOURCE_PATH}" "${SOURCE_PATH}/extension/excel")
@@ -31,11 +31,22 @@ if("httpfs" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH DUCKDB_HTTPFS_SOURCE_PATH
         REPO duckdb/duckdb_httpfs
-        REF a4a014d4fc232c3087ee44a804959b5d67a0f8c5
-        SHA512 7e774a0714b863ecd49ad6ff07b8ecf780614f8e81d097dc01def37b48efb140efba003a5caa2deec9c83c636906fbcb44f5d74813da31f162d9d8b06016afe8
+        REF 0989823e43554e8a00b31959a853e29ab9bd07f9
+        SHA512 71461d522aa5338df81931f937ed538b453b274d22e91ad7e0f1a92e4437a29cc869a0f5be3bd5a9abf0045dfd4681a787923ee32374be471483909c0a60a21f
         HEAD_REF main
     )
     file(RENAME "${DUCKDB_HTTPFS_SOURCE_PATH}" "${SOURCE_PATH}/extension/httpfs")
+endif()
+
+if("iceberg" IN_LIST FEATURES)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH DUCKDB_HTTPFS_SOURCE_PATH
+        REPO duckdb/duckdb-iceberg
+        REF 6b636bff44aeeccf6f6d5b54de6edf280274beea
+        SHA512 f8ce593117dd5423fd5445b6fa6c1f3b11ee7c8a2fdb988c3c0208a59d5ed980b941116866f7cb1d0597662e98c03687da071cbc5617c71086eb112621e31748
+        HEAD_REF main
+    )
+    file(RENAME "${DUCKDB_HTTPFS_SOURCE_PATH}" "${SOURCE_PATH}/extension/iceberg")
 endif()
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" DUCKDB_BUILD_STATIC)

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -29,6 +29,7 @@
     "httpfs": {
       "description": "Statically link the httpfs extension into DuckDB",
       "dependencies": [
+        "curl",
         "openssl"
       ]
     },

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "High-performance in-process analytical database system",
   "homepage": "https://duckdb.org",
   "license": "MIT",
@@ -30,6 +30,12 @@
       "description": "Statically link the httpfs extension into DuckDB",
       "dependencies": [
         "openssl"
+      ]
+    },
+    "iceberg": {
+      "description": "Statically link the iceberg extension into DuckDB",
+      "dependencies": [
+        "roaring"
       ]
     },
     "icu": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2537,7 +2537,7 @@
       "port-version": 0
     },
     "duckdb": {
-      "baseline": "1.3.2",
+      "baseline": "1.4.0",
       "port-version": 0
     },
     "duckx": {

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "27abdd46d05cbc46b822a9e14e8ebebfa6cce4ca",
+      "git-tree": "1eb43714bf6fdca640e07130e3d4f9aee975c59f",
       "version": "1.4.0",
       "port-version": 0
     },

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "42e2af68d6ed1c88b27463e41576a16ec9f676dd",
+      "git-tree": "27abdd46d05cbc46b822a9e14e8ebebfa6cce4ca",
       "version": "1.4.0",
       "port-version": 0
     },

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "42e2af68d6ed1c88b27463e41576a16ec9f676dd",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "949d406276949f7c04d50c0b990cfae8ea7a8979",
       "version": "1.3.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/duckdb/duckdb/releases/tag/v1.4.0
