### PR TITLE
[aws-crt-cpp] update to 0.34.4

### DIFF
--- a/ports/aws-crt-cpp/portfile.cmake
+++ b/ports/aws-crt-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-crt-cpp
     REF "v${VERSION}"
-    SHA512 e62c65cd751f30aea05e5234027c016b10aecf6a983fe6632af1828eb8538d6523ad02aaf4e6b9ca8b751232f9e49c4e55e7c12d6fee579a539b8d3cd26e083f
+    SHA512 12e45aca6efeb6bfce4c0cf06ef4b5007647ad3049a7dd3639fff0f10f7dd3643a216e6850625874f563e561c24d9000bad12217246c65e33f5892319c5d717d
     PATCHES
         no-werror.patch
 )

--- a/ports/aws-crt-cpp/vcpkg.json
+++ b/ports/aws-crt-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-crt-cpp",
-  "version": "0.34.1",
+  "version": "0.34.4",
   "description": "C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Protocols and SSL/TLS implementations for C++.",
   "homepage": "https://github.com/awslabs/aws-crt-cpp",
   "license": "Apache-2.0",

--- a/versions/a-/aws-crt-cpp.json
+++ b/versions/a-/aws-crt-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a6d089e58e65bbce9e0c81c4a607b4807f2a68ac",
+      "version": "0.34.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "300a1a29ea8b00ceae803defa7b0b344bb846178",
       "version": "0.34.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -477,7 +477,7 @@
       "port-version": 0
     },
     "aws-crt-cpp": {
-      "baseline": "0.34.1",
+      "baseline": "0.34.4",
       "port-version": 0
     },
     "aws-lambda-cpp": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/awslabs/aws-crt-cpp/releases/tag/v0.34.4
