### PR TITLE
[libunistring] Use system-provided stdint.h under modern MSVC.

### DIFF
--- a/ports/libunistring/msvc-use-stdint.patch
+++ b/ports/libunistring/msvc-use-stdint.patch
@@ -1,0 +1,11 @@
+--- a/lib/Makefile.am	2025-09-18 14:31:56.883185700 +0100
++++ b/lib/Makefile.am	2025-09-18 14:32:34.860321900 +0100
+@@ -101,7 +101,7 @@
+ 	rm -f $@-t $@
+ 	{ echo '/* DO NOT EDIT! GENERATED AUTOMATICALLY! */'; \
+ 	  echo '#include <stddef.h>'; \
+-	  echo '#if __GLIBC__ >= 2'; \
++	  echo '#if __GLIBC__ >= 2 || (defined(_MSC_VER) && _MSC_VER >= 1600)'; \
+ 	  echo '#include <stdint.h>'; \
+ 	  echo '#else'; \
+ 	  if test -f /usr/include/stdint.h; then \

--- a/ports/libunistring/portfile.cmake
+++ b/ports/libunistring/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
         disable-gnulib-fetch.patch
         disable-subdirs.patch
         parallelize-symbol-collection.patch
+        msvc-use-stdint.patch
 )
 
 vcpkg_configure_make(

--- a/ports/libunistring/vcpkg.json
+++ b/ports/libunistring/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libunistring",
   "version": "1.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GNU libunistring provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.",
   "homepage": "https://www.gnu.org/software/libunistring/",
   "license": "LGPL-3.0-or-later OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5554,7 +5554,7 @@
     },
     "libunistring": {
       "baseline": "1.2",
-      "port-version": 1
+      "port-version": 2
     },
     "libunwind": {
       "baseline": "1.8.3",

--- a/versions/l-/libunistring.json
+++ b/versions/l-/libunistring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d4c1b3ca54d175219e941aa7c10fa90a7703d57",
+      "version": "1.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "3208f551857e54853db0434e6dd954f42c5cf699",
       "version": "1.2",
       "port-version": 1


### PR DESCRIPTION
We should be able to trust stdint.h to be fine by this point, and libunistring redefining stdint types via macros breaks compilation for any C++ code using types like std::int8_t after its headers are included.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
