### PR TITLE
[string-lite] Add a new port

### DIFF
--- a/ports/string-lite/portfile.cmake
+++ b/ports/string-lite/portfile.cmake
@@ -25,3 +25,8 @@ file(REMOVE_RECURSE
 )
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL
+    "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)

--- a/ports/string-lite/portfile.cmake
+++ b/ports/string-lite/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO martinmoene/string-lite
+    REF "v${VERSION}"
+    SHA512 36c359388b50775d1602dd7b4f6adb8acd0ce168
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSTRING_LITE_OPT_BUILD_TESTS=OFF
+        -DSTRING_LITE_OPT_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH lib/cmake/${PORT}
+)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/string-lite/portfile.cmake
+++ b/ports/string-lite/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martinmoene/string-lite
     REF "v${VERSION}"
-    SHA512 36c359388b50775d1602dd7b4f6adb8acd0ce168
+    SHA512 b61667660d32a96232737e0d38e02a0e6d934830e7dafdb9844eb87d855dbea43392797c291d9f39a0f352c43bcd6e5af9510b656887532be99f02982ff38dfa
     HEAD_REF master
 )
 

--- a/ports/string-lite/usage
+++ b/ports/string-lite/usage
@@ -1,0 +1,4 @@
+string-lite provides CMake targets:
+
+  find_package(string-lite CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE string-lite::string-lite)

--- a/ports/string-lite/vcpkg.json
+++ b/ports/string-lite/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "string-lite",
+  "version": "0.0.0",
+  "description": "String algorithms for C+11 and later in a single-file header-only library",
+  "homepage": "https://github.com/martinmoene/string-lite",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9280,6 +9280,10 @@
       "baseline": "0.5",
       "port-version": 2
     },
+    "string-lite": {
+      "baseline": "0.0.0",
+      "port-version": 0
+    },
     "string-theory": {
       "baseline": "3.9",
       "port-version": 0

--- a/versions/s-/string-lite.json
+++ b/versions/s-/string-lite.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "159e32f550255163c995005ef1053d511f375cc5",
+      "version": "0.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/string-lite.json
+++ b/versions/s-/string-lite.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "159e32f550255163c995005ef1053d511f375cc5",
+      "git-tree": "13265b38d3365914b570fd17d55c4ac56ccf5519",
       "version": "0.0.0",
       "port-version": 0
     }

--- a/versions/s-/string-lite.json
+++ b/versions/s-/string-lite.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "13265b38d3365914b570fd17d55c4ac56ccf5519",
+      "git-tree": "86f99967c2f0e89841f08e49633ff2803a339622",
       "version": "0.0.0",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
