### PR TITLE
Patch for opencv4 to fix ARM64 build when ENABLE_BUILD_HARDENING is turned on

### DIFF
--- a/ports/opencv4/0022-remove-safeseh-arm64.patch
+++ b/ports/opencv4/0022-remove-safeseh-arm64.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/OpenCVCompilerDefenses.cmake b/cmake/OpenCVCompilerDefenses.cmake
+index 9fffdb4d72..ff612ea72d 100644
+--- a/cmake/OpenCVCompilerDefenses.cmake
++++ b/cmake/OpenCVCompilerDefenses.cmake
+@@ -41,7 +41,7 @@ if(MSVC)
+   ocv_add_defense_compiler_flag("/guard:cf")
+   ocv_add_defense_compiler_flag("/w34018 /w34146 /w34244 /w34267 /w34302 /w34308 /w34509 /w34532 /w34533 /w34700 /w34789 /w34995 /w34996")
+   set(OPENCV_LINKER_DEFENSES_FLAGS_COMMON "${OPENCV_LINKER_DEFENSES_FLAGS_COMMON} /guard:cf /dynamicbase" )
+-  if(NOT X86_64)
++  if(NOT X86_64 AND NOT AARCH64)
+     set(OPENCV_LINKER_DEFENSES_FLAGS_COMMON "${OPENCV_LINKER_DEFENSES_FLAGS_COMMON} /safeseh")
+   endif()
+ elseif(CV_CLANG)

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_from_github(
       0019-opencl-kernel.patch
       0020-fix-narrow-filesystem.diff
       0021-fix-qt-gen-def.patch
+      0022-remove-safeseh-arm64.patch
 )
 
 vcpkg_find_acquire_program(PKGCONFIG)

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.11.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7030,7 +7030,7 @@
     },
     "opencv4": {
       "baseline": "4.11.0",
-      "port-version": 4
+      "port-version": 5
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "febe477169fc2fa71930b3956aa524df42e846d9",
+      "version": "4.11.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "f96663c0d36e2aed2c1519d4138f712055014208",
       "version": "4.11.0",
       "port-version": 4


### PR DESCRIPTION
Fixes  #47396 


- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

The opencv Windows ARM64 build is disabled in ci.baseline.txt and this PR does not address any other issues that can occur.  I was able to build for ARM64 without the __fp16 errors, but there are other runtime errors.  This PR only addresses the one build error.
