### PR TITLE
[sentry-native] update to 0.11.0

### DIFF
--- a/ports/sentry-native/fix-crashpad-wer.patch
+++ b/ports/sentry-native/fix-crashpad-wer.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 2873b3d..7ee1d78 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -488,7 +488,7 @@ if(SENTRY_BACKEND_CRASHPAD)
+@@ -616,7 +616,7 @@ if(SENTRY_BACKEND_CRASHPAD)
  	endif()
  	add_subdirectory(external/crashpad crashpad_build)
 
@@ -11,7 +11,7 @@ index 2873b3d..7ee1d78 100644
  		add_dependencies(sentry crashpad::wer)
  	endif()
 
-@@ -503,7 +503,9 @@ if(SENTRY_BACKEND_CRASHPAD)
+@@ -632,7 +632,9 @@ if(SENTRY_BACKEND_CRASHPAD)
  		set_property(TARGET crashpad_snapshot PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
  		set_property(TARGET crashpad_tools PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
  		set_property(TARGET crashpad_util PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
@@ -21,17 +21,17 @@ index 2873b3d..7ee1d78 100644
  		set_property(TARGET crashpad_zlib PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
  		set_property(TARGET mini_chromium PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
  	endif()
-@@ -520,7 +522,9 @@ if(SENTRY_BACKEND_CRASHPAD)
+@@ -648,7 +650,9 @@ if(SENTRY_BACKEND_CRASHPAD)
+ 		set_target_properties(crashpad_snapshot PROPERTIES FOLDER ${SENTRY_FOLDER})
+ 		set_target_properties(crashpad_tools PROPERTIES FOLDER ${SENTRY_FOLDER})
  		set_target_properties(crashpad_util PROPERTIES FOLDER ${SENTRY_FOLDER})
- 		set_target_properties(crashpad_zlib PROPERTIES FOLDER ${SENTRY_FOLDER})
- 		set_target_properties(mini_chromium PROPERTIES FOLDER ${SENTRY_FOLDER})
 +if(SENTRY_TRANSPORT_CRASHPAD_USE_WER)
  		set_target_properties(crashpad_wer PROPERTIES FOLDER ${SENTRY_FOLDER})
 +endif()
+ 		set_target_properties(crashpad_zlib PROPERTIES FOLDER ${SENTRY_FOLDER})
+ 		set_target_properties(mini_chromium PROPERTIES FOLDER ${SENTRY_FOLDER})
  	endif()
-
- 	target_link_libraries(sentry PRIVATE
-@@ -530,7 +534,7 @@ if(SENTRY_BACKEND_CRASHPAD)
+@@ -660,7 +664,7 @@ if(SENTRY_BACKEND_CRASHPAD)
  	install(EXPORT crashpad_export NAMESPACE sentry_crashpad:: FILE sentry_crashpad-targets.cmake
  		DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
  	)

--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 d4074afed7f8dab59cab3cd65d74777d148d466dc1de46739db87f70af25c367c098f8c787775c20761cea2c411e5e9469784d4850572339893aa2463e64e4ea
+    SHA512 f2bf1f5fb3548991b26d717d8922da212588c6c33fe0eeb847c4d4547fd8a7235c35a7075e2609adead76ee5384dd2e5e7929da85f62ea5f1a812a72bec1ac5a
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.10.0",
-  "port-version": 1,
+  "version": "0.11.0",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8765,8 +8765,8 @@
       "port-version": 2
     },
     "sentry-native": {
-      "baseline": "0.10.0",
-      "port-version": 1
+      "baseline": "0.11.0",
+      "port-version": 0
     },
     "septag-dmon": {
       "baseline": "2022-02-08",

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e499329287be58526d5b0b866de75a36d46aef1",
+      "version": "0.11.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ef09306a15893912e14e54eea8453c66ebf287b",
       "version": "0.10.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
