### PR TITLE
[ceres] fix build with some CUDA versions

### DIFF
--- a/ports/ceres/0005_link_cuda_static.patch
+++ b/ports/ceres/0005_link_cuda_static.patch
@@ -1,0 +1,99 @@
+commit d0b87157ab0e27e9e4cf2ea27967b5d619e81a76
+Author: Markus Heß <hess@3dvisionlabs.com>
+Date:   Sat Mar 2 13:28:02 2024 +0000
+
+    Link static cuda libs when ceres is build static
+    
+    Change-Id: I8821a2df5302cf164b6f80d6787ae795691d6b32
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4ea82bcd..9729ccc2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -126,7 +126,7 @@ if (APPLE)
+ endif()
+ # We can't have an option called 'CUDA' since that is a reserved word -- a
+ # language definition.
+-option(USE_CUDA "Enable use of CUDA linear algebra solvers." ON)
++set(USE_CUDA "default" CACHE STRING "Enable use of CUDA linear algebra solvers.")
+ option(LAPACK "Enable use of LAPACK directly within Ceres." ON)
+ # Template specializations for the Schur complement based solvers. If
+ # compile time, binary size or compiler performance is an issue, you
+@@ -204,6 +204,12 @@ if (Eigen3_FOUND)
+   endif (EIGENSPARSE)
+ endif (Eigen3_FOUND)
+ 
++if (CMAKE_VERSION VERSION_LESS 3.17)
++  set_property(CACHE USE_CUDA PROPERTY STRINGS OFF default)
++else (CMAKE_VERSION VERSION_LESS 3.17)
++  set_property(CACHE USE_CUDA PROPERTY STRINGS OFF default static)
++endif (CMAKE_VERSION VERSION_LESS 3.17)
++
+ if (USE_CUDA)
+   if (CMAKE_VERSION VERSION_LESS 3.17)
+     # On older versions of CMake (20.04 default is 3.16) FindCUDAToolkit was
+@@ -233,6 +239,7 @@ if (USE_CUDA)
+       declare_imported_cuda_target(cusparse)
+       declare_imported_cuda_target(cudart ${CUDA_LIBRARIES})
+ 
++      set(CERES_CUDA_TARGET_SUFFIX "")
+       set(CUDAToolkit_BIN_DIR ${CUDA_TOOLKIT_ROOT_DIR}/bin)
+ 
+     else (CUDA_FOUND)
+@@ -252,22 +259,31 @@ if (USE_CUDA)
+         set(CMAKE_CUDA_ARCHITECTURES "50;60;70;80")
+         message("-- Setting CUDA Architecture to ${CMAKE_CUDA_ARCHITECTURES}")
+       endif()
+-      list(APPEND CERES_CUDA_LIBRARIES
+-        CUDA::cublas
+-        CUDA::cudart
+-        CUDA::cusolver
+-        CUDA::cusparse)
+-      set(CMAKE_CUDA_RUNTIME_LIBRARY NONE)
++
++      if (USE_CUDA STREQUAL "static")
++        set(CERES_CUDA_TARGET_SUFFIX "_static")
++      else (USE_CUDA STREQUAL "static")
++        set(CERES_CUDA_TARGET_SUFFIX "")
++      endif (USE_CUDA STREQUAL "static")
+     else (CUDAToolkit_FOUND)
+       message("-- Did not find CUDA, disabling CUDA support.")
+       update_cache_variable(USE_CUDA OFF)
+     endif (CUDAToolkit_FOUND)
+   endif (CMAKE_VERSION VERSION_LESS 3.17)
+ endif (USE_CUDA)
+-if (NOT USE_CUDA)
++
++if (USE_CUDA)
++  list(APPEND CERES_CUDA_LIBRARIES
++    CUDA::cublas${CERES_CUDA_TARGET_SUFFIX}
++    CUDA::cudart${CERES_CUDA_TARGET_SUFFIX}
++    CUDA::cusolver${CERES_CUDA_TARGET_SUFFIX}
++    CUDA::cusparse${CERES_CUDA_TARGET_SUFFIX})
++  unset (CERES_CUDA_TARGET_SUFFIX)
++  set(CMAKE_CUDA_RUNTIME_LIBRARY NONE)
++else (USE_CUDA)
+   message("-- Building without CUDA.")
+   list(APPEND CERES_COMPILE_OPTIONS CERES_NO_CUDA)
+-endif (NOT USE_CUDA)
++endif (USE_CUDA)
+ 
+ if (LAPACK)
+   find_package(LAPACK QUIET)
+diff --git a/internal/ceres/CMakeLists.txt b/internal/ceres/CMakeLists.txt
+index eecef260..b7e31ee6 100644
+--- a/internal/ceres/CMakeLists.txt
++++ b/internal/ceres/CMakeLists.txt
+@@ -118,11 +118,7 @@ if (ACCELERATESPARSE AND AccelerateSparse_FOUND)
+ endif()
+ 
+ if (USE_CUDA)
+-  list(APPEND CERES_LIBRARY_PRIVATE_DEPENDENCIES
+-    CUDA::cublas
+-    CUDA::cudart
+-    CUDA::cusolver
+-    CUDA::cusparse)
++  list(APPEND CERES_LIBRARY_PRIVATE_DEPENDENCIES ${CERES_CUDA_LIBRARIES})
+   set_source_files_properties(cuda_kernels_vector_ops.cu.cc PROPERTIES LANGUAGE CUDA)
+   set_source_files_properties(cuda_kernels_bsm_to_crs.cu.cc PROPERTIES LANGUAGE CUDA)
+   add_library(ceres_cuda_kernels STATIC cuda_kernels_vector_ops.cu.cc cuda_kernels_bsm_to_crs.cu.cc)

--- a/ports/ceres/0006_fix_cuda_architectures.patch
+++ b/ports/ceres/0006_fix_cuda_architectures.patch
@@ -1,0 +1,49 @@
+commit 4939da2d6bbd8652020dc970ea0405d634e3550f
+Author: Markus Hess <hess@3dvisionlabs.com>
+Date:   Thu Jun 6 12:44:55 2024 +0000
+
+    Set CMAKE_CUDA_ARCHITECTURES depending on CUDAToolkit_VERSION
+    
+    Compilation fails if the CUDA architecture is not supported by the
+    installed version of the CUDA toolkit. This commit sets the
+    CMAKE_CUDA_ARCHITECTURES depending on the the installed CUDA toolkit
+    version.
+    
+    Change-Id: I4765512279ee56897388e6ea22b961aebeb0fbca
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9729ccc2..bfa2d8ff 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -255,8 +255,29 @@ if (USE_CUDA)
+         "find_dependency(CUDAToolkit ${CUDAToolkit_VERSION})")
+       enable_language(CUDA)
+       if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.18")
+-        # Support Maxwell, Pascal, Volta, Turing, and Ampere GPUs.
+-        set(CMAKE_CUDA_ARCHITECTURES "50;60;70;80")
++        # Support Maxwell GPUs (Default).
++        set(CMAKE_CUDA_ARCHITECTURES "50")
++        # Support other architectures depending on CUDA toolkit version.
++        if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "8.0")
++          # Support Pascal GPUs.
++          list(APPEND CMAKE_CUDA_ARCHITECTURES "60")
++        endif(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "8.0")
++        if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "9.0")
++          # Support Volta GPUs.
++          list(APPEND CMAKE_CUDA_ARCHITECTURES "70")
++        endif(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "9.0")
++        if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "10.0")
++          # Support Turing  GPUs.
++          list(APPEND CMAKE_CUDA_ARCHITECTURES "75")
++        endif(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "10.0")
++        if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.0")
++          # Support Ampere GPUs.
++          list(APPEND CMAKE_CUDA_ARCHITECTURES "80")
++        endif(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.0")
++        if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.8")
++          # Support Hopper GPUs.
++          list(APPEND CMAKE_CUDA_ARCHITECTURES "90")
++        endif(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.8")
+         message("-- Setting CUDA Architecture to ${CMAKE_CUDA_ARCHITECTURES}")
+       endif()
+ 

--- a/ports/ceres/0007_support_cuda_13.patch
+++ b/ports/ceres/0007_support_cuda_13.patch
@@ -1,0 +1,43 @@
+commit d9d0c4d0e0cc560b7a3556284201537859b16fc6
+Author: Mackay <1.732mackay@gmail.com>
+Date:   Wed Aug 6 21:36:12 2025 -0400
+
+    Update CMakeLists.txt to support CUDA 13
+    
+    Change-Id: I4a0a0b29a45c1108d27b6f85670c926f5dda0f5e
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bfa2d8ff..7e7e413d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -255,17 +255,19 @@ if (USE_CUDA)
+         "find_dependency(CUDAToolkit ${CUDAToolkit_VERSION})")
+       enable_language(CUDA)
+       if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.18")
+-        # Support Maxwell GPUs (Default).
+-        set(CMAKE_CUDA_ARCHITECTURES "50")
+-        # Support other architectures depending on CUDA toolkit version.
+-        if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "8.0")
+-          # Support Pascal GPUs.
+-          list(APPEND CMAKE_CUDA_ARCHITECTURES "60")
+-        endif(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "8.0")
+-        if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "9.0")
+-          # Support Volta GPUs.
+-          list(APPEND CMAKE_CUDA_ARCHITECTURES "70")
+-        endif(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "9.0")
++        set(CMAKE_CUDA_ARCHITECTURES "")
++        if (CUDAToolkit_VERSION VERSION_LESS "13.0")
++          # Support Maxwell GPUs.
++	  list(APPEND CMAKE_CUDA_ARCHITECTURES "50")
++          if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "8.0")
++            # Support Pascal GPUs.
++            list(APPEND CMAKE_CUDA_ARCHITECTURES "60")
++          endif(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "8.0")
++          if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "9.0")
++            # Support Volta GPUs.
++            list(APPEND CMAKE_CUDA_ARCHITECTURES "70")
++          endif(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "9.0")
++        endif(CUDAToolkit_VERSION VERSION_LESS "13.0")
+         if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL "10.0")
+           # Support Turing  GPUs.
+           list(APPEND CMAKE_CUDA_ARCHITECTURES "75")

--- a/ports/ceres/portfile.cmake
+++ b/ports/ceres/portfile.cmake
@@ -7,6 +7,9 @@ vcpkg_from_github(
     PATCHES
         0001_cmakelists_fixes.patch
         0004_remove_broken_fake_ba_jac.patch
+        0005_link_cuda_static.patch
+        0006_fix_cuda_architectures.patch
+        0007_support_cuda_13.patch
 )
 file(REMOVE "${SOURCE_PATH}/cmake/FindGflags.cmake")
 file(REMOVE "${SOURCE_PATH}/cmake/FindGlog.cmake")

--- a/ports/ceres/vcpkg.json
+++ b/ports/ceres/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ceres",
   "version": "2.2.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "non-linear optimization package",
   "homepage": "https://github.com/ceres-solver/ceres-solver",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1650,7 +1650,7 @@
     },
     "ceres": {
       "baseline": "2.2.0",
-      "port-version": 4
+      "port-version": 5
     },
     "cfitsio": {
       "baseline": "3.49",

--- a/versions/c-/ceres.json
+++ b/versions/c-/ceres.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da138ec4e0e7cccd3a1b448af30fd13abb6235b7",
+      "version": "2.2.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "990a68bdbd8678fc0c74294470228bf70a33cc75",
       "version": "2.2.0",
       "port-version": 4


### PR DESCRIPTION
This fixes issues with various CUDA versions. Patches are from upstream's master branch.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
