### PR TITLE
[pjproject] Add new port

### DIFF
--- a/ports/pjproject/add-required-windows-libs.patch
+++ b/ports/pjproject/add-required-windows-libs.patch
@@ -1,0 +1,20 @@
+diff --git a/pjlib/include/pj/config.h b/pjlib/include/pj/config.h
+index 7e1a173..cbff60d 100644
+--- a/pjlib/include/pj/config.h
++++ b/pjlib/include/pj/config.h
+@@ -115,6 +115,15 @@
+ #   undef PJ_WIN32
+ #   define PJ_WIN32 1
+ #   include <pj/compat/os_win32.h>
++#ifdef _MSC_VER
++    #pragma comment(lib, "ws2_32.lib")
++    #pragma comment(lib, "setupapi.lib")
++    #pragma comment(lib, "version.lib")
++    #pragma comment(lib, "imm32.lib")
++    #pragma comment(lib, "bcrypt.lib")
++    #pragma comment(lib, "mfuuid.lib")
++#endif
++
+ 
+ #elif defined(PJ_LINUX) || defined(linux) || defined(__linux)
+     /*

--- a/ports/pjproject/portfile.cmake
+++ b/ports/pjproject/portfile.cmake
@@ -1,0 +1,149 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO pjsip/pjproject
+    REF "${VERSION}"
+    SHA512 2f83ed32f16c27808d3b9cc8f3b364c68fe88caae9765012b385a0fea70ba8ef4dcfebe3b130156047546720351a527e17d6a1e967877d6a44a6ff3a1f695599
+    PATCHES
+        add-required-windows-libs.patch
+)
+
+file(MAKE_DIRECTORY "${SOURCE_PATH}/pjlib/include/pj")
+file(WRITE "${SOURCE_PATH}/pjlib/include/pj/config_site.h" [=[
+#ifndef PJ_CONFIG_SITE_H
+#define PJ_CONFIG_SITE_H
+
+#define PJ_HAS_SSL_SOCK                    1
+#define PJSUA_HAS_VIDEO                    1
+#define PJMEDIA_HAS_VIDEO                  1
+#define PJMEDIA_HAS_FFMPEG                 1
+#define PJMEDIA_HAS_OPUS_CODEC             1
+#define PJMEDIA_HAS_VPX_CODEC              1
+#define PJMEDIA_HAS_VPX_CODEC_VP9          1
+#define PJMEDIA_VIDEO_DEV_HAS_SDL          1
+
+#ifdef _MSC_VER
+    #define PJMEDIA_VIDEO_DEV_HAS_DSHOW    1
+#else
+    #define PJMEDIA_VIDEO_DEV_HAS_DSHOW    0    
+#endif
+
+#ifdef _WIN32
+    #define PJ_HAS_WINDOWS_H               1
+    #define PJ_WIN32_WINCE                 0
+#endif
+
+#endif /* PJ_CONFIG_SITE_H */
+]=])
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_replace_string(
+        "${SOURCE_PATH}/pjmedia/src/pjmedia-codec/opus.c"
+        "#    pragma comment(lib, \"libopus.a\")"
+        "#    pragma comment(lib, \"opus.lib\")"
+    )
+
+    vcpkg_replace_string(
+        "${SOURCE_PATH}/pjmedia/src/pjmedia-videodev/sdl_dev.c"
+        "#       pragma comment( lib, \"sdl2.lib\")"
+        "// #       pragma comment( lib, \"sdl2.lib\") // Disabled for vcpkg - SDL2 is linked via pkg-config"
+    )
+
+    file(COPY "${CURRENT_INSTALLED_DIR}/include/SDL2/" DESTINATION "${CURRENT_INSTALLED_DIR}/include/")
+
+    set(CONFIGURATION_RELEASE Release-Static)
+    set(CONFIGURATION_DEBUG Debug-Static)
+
+    if(VCPKG_CRT_LINKAGE STREQUAL "static")
+        set(RuntimeLibraryExt "")
+    else()
+        set(RuntimeLibraryExt "DLL")
+    endif()
+
+    vcpkg_msbuild_install(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PROJECT_SUBPATH "pjsip-apps/build/libpjproject.vcxproj"
+        PLATFORM ${VCPKG_TARGET_ARCHITECTURE}
+        RELEASE_CONFIGURATION ${CONFIGURATION_RELEASE}
+        DEBUG_CONFIGURATION ${CONFIGURATION_DEBUG}
+        OPTIONS_RELEASE "/p:RuntimeLibrary=MultiThreaded${RuntimeLibraryExt}"
+        OPTIONS_DEBUG "/p:RuntimeLibrary=MultiThreadedDebug${RuntimeLibraryExt}"
+    )
+
+    file(INSTALL "${SOURCE_PATH}/pjlib/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(INSTALL "${SOURCE_PATH}/pjlib-util/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(INSTALL "${SOURCE_PATH}/pjnath/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(INSTALL "${SOURCE_PATH}/pjmedia/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(INSTALL "${SOURCE_PATH}/pjsip/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+    set(PREFIX "\${pcfiledir}/../..")
+    set(LIBDIR "\${prefix}/lib")
+    set(INCLUDEDIR "\${prefix}/include") 
+    set(PJ_VERSION "${VERSION}")
+
+    set(PJ_INSTALL_LDFLAGS "-lpjproject-x86_64-x64-vc14-Release-Static")
+    set(PJ_INSTALL_LDFLAGS_PRIVATE "-lversion -lsetupapi -lmfuuid -lbcrypt -lcfgmgr32 -limm32 -lswresample -lswscale -lavformat -lavcodec -lavutil -lavdevice -lavfilter -lopus -lcrypto -lssl -lvpx -lSDL2 -lws2_32 -lole32 -loleaut32 -luuid -lodbc32 -lodbccp32 -lwinmm -ldsound -lstrmiids -ldxguid -lquartz")
+    set(PJ_INSTALL_CFLAGS "-I\${includedir}")
+    configure_file("${SOURCE_PATH}/libpjproject.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpjproject.pc" @ONLY)
+
+    if(NOT VCPKG_BUILD_TYPE)
+        set(LIBDIR "\${prefix}/debug/lib")
+        set(INCLUDEDIR "\${prefix}/include")
+        set(PJ_INSTALL_LDFLAGS "-lpjproject-x86_64-x64-vc14-Debug-Static")
+        configure_file("${SOURCE_PATH}/libpjproject.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpjproject.pc" @ONLY)
+    endif()
+
+    vcpkg_copy_pdbs()
+else()
+    set(ENV{PKG_CONFIG} "${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf/pkgconf")
+
+    set(_shimdir "${CURRENT_BUILDTREES_DIR}/sdl2-config-shim")
+    file(MAKE_DIRECTORY "${_shimdir}")
+    set(_shim "${_shimdir}/sdl2-config")
+    file(WRITE "${_shim}" [=[
+    #!/usr/bin/env sh
+    pc="${PKG_CONFIG:-pkg-config} sdl2"
+    case "$1" in
+    --cflags)      exec $pc --cflags ;;
+    --libs)        exec $pc --libs ;;
+    --static-libs) exec $pc --libs --static ;;
+    --version)     exec $pc --modversion ;;
+    --prefix)      exec $pc --variable=prefix ;;
+    *)             exec $pc "$@" ;;
+    esac
+    ]=])
+    file(CHMOD "${_shim}" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ WORLD_READ)
+
+    set(ENV{SDL_CONFIG} "${_shim}")
+    set(ENV{PATH} "${_shimdir}:$ENV{PATH}")
+
+    if (VCPKG_TARGET_IS_MINGW)
+        set(ENV{LIBS} "-lssl -lcrypto -lcrypt32 -lncrypt")
+    endif()
+
+    vcpkg_make_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        COPY_SOURCE
+        OPTIONS
+            "--with-ssl=${CURRENT_INSTALLED_DIR}"
+            "--with-opus=${CURRENT_INSTALLED_DIR}"
+            "--with-vpx=${CURRENT_INSTALLED_DIR}"
+            "--with-sdl=${CURRENT_INSTALLED_DIR}"
+            "--with-ffmpeg=${CURRENT_INSTALLED_DIR}"
+            "--enable-video"
+    )
+
+    vcpkg_make_install(
+        TARGETS "dep" "lib" "install"
+        OPTIONS
+            "LD=\\$\\(CXX\\)" "CXXLD=\\$\\(CXX\\)"
+    )
+endif()
+
+vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/pjproject/usage
+++ b/ports/pjproject/usage
@@ -1,0 +1,7 @@
+pjproject provides pkg-config support for integration:
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(PJ REQUIRED IMPORTED_TARGET libpjproject)
+    target_link_libraries(main PRIVATE PkgConfig::PJ)
+
+Note: Required Windows system libraries are automatically linked via pragma directives.

--- a/ports/pjproject/vcpkg.json
+++ b/ports/pjproject/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pjproject",
   "version": "2.15.1",
+  "port-version": 1,
   "description": "PJSIP (pjproject) with video (FFmpeg/libvpx/SDL2) + Opus/OpenSSL",
   "homepage": "https://github.com/pjsip/pjproject",
   "license": "GPL-2.0-or-later",

--- a/ports/pjproject/vcpkg.json
+++ b/ports/pjproject/vcpkg.json
@@ -1,0 +1,40 @@
+{
+  "name": "pjproject",
+  "version": "2.15.1",
+  "description": "PJSIP (pjproject) with video (FFmpeg/libvpx/SDL2) + Opus/OpenSSL",
+  "homepage": "https://github.com/pjsip/pjproject",
+  "license": "GPL-2.0-or-later",
+  "supports": "(windows & !uwp) | mingw | linux",
+  "dependencies": [
+    {
+      "name": "ffmpeg",
+      "default-features": false,
+      "features": [
+        "avcodec",
+        "avformat",
+        "swscale"
+      ]
+    },
+    "libvpx",
+    "openssl",
+    "opus",
+    {
+      "name": "pkgconf",
+      "host": true
+    },
+    "sdl2",
+    {
+      "name": "vcpkg-make",
+      "host": true
+    },
+    {
+      "name": "vcpkg-msbuild",
+      "host": true,
+      "platform": "windows"
+    },
+    {
+      "name": "vcpkg-pkgconfig-get-modules",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7406,7 +7406,7 @@
     },
     "pjproject": {
       "baseline": "2.15.1",
-      "port-version": 0
+      "port-version": 1
     },
     "pkgconf": {
       "baseline": "2.5.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7404,6 +7404,10 @@
       "baseline": "0.44.2",
       "port-version": 0
     },
+    "pjproject": {
+      "baseline": "2.15.1",
+      "port-version": 0
+    },
     "pkgconf": {
       "baseline": "2.5.1",
       "port-version": 1

--- a/versions/p-/pjproject.json
+++ b/versions/p-/pjproject.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "77670ee200279f968eb3df7e360e608aff502c7f",
+      "version": "2.15.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/p-/pjproject.json
+++ b/versions/p-/pjproject.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d16f4cec1e0af407357d6b707c2f9d46886fcdce",
+      "version": "2.15.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "77670ee200279f968eb3df7e360e608aff502c7f",
       "version": "2.15.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

---

Builds PJPROJECT (PJSIP) library with its dependencies (ffmpeg, openssl, libvpx, sdl2, opus)

Tested triplets: (only static linking for Windows/MinGW)
- x64-windows-static
- x64-mingw-static
- x64-linux
- x64-linux-dynamic