### PR TITLE
[dacap-clip] update to 1.11

### DIFF
--- a/ports/dacap-clip/portfile.cmake
+++ b/ports/dacap-clip/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO dacap/clip
-  REF v1.10
-  SHA512 a29531ef276650807233b635ecceaf408147e4e263268eaf8237d74c9a7641d28cda5c6d1eaad4dbe634e720a5969dd6cc82aaeffbc36e0c9598ded31e419ea6
+  REF v${VERSION}
+  SHA512 450653964c4c943daf47fca32f63d9de40aa6e2daf1cb96e3d71543d4919352adca3b6db529c4de985a72ec21166f97974484114d23e12ea73da31cc1d536481
   PATCHES
     "fix-install-header-and-force-static-compilation.patch")
 

--- a/ports/dacap-clip/vcpkg.json
+++ b/ports/dacap-clip/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dacap-clip",
-  "version": "1.10.0",
+  "version": "1.11",
   "description": "Cross-platform C++ library to copy/paste clipboard content.",
   "homepage": "https://github.com/dacap/clip",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2301,7 +2301,7 @@
       "port-version": 1
     },
     "dacap-clip": {
-      "baseline": "1.10.0",
+      "baseline": "1.11",
       "port-version": 0
     },
     "darknet": {

--- a/versions/d-/dacap-clip.json
+++ b/versions/d-/dacap-clip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "572ce455e5fa4df4f83a2f62a8bf5c617107c0c9",
+      "version": "1.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "6f7bfb92450f247a05aabd780ab123e48a19cc99",
       "version": "1.10.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/dacap/clip/releases/tag/v1.11
