### PR TITLE
[pkgconf] Fix default lookup paths on riscv64 Linux

### DIFF
--- a/ports/pkgconf/portfile.cmake
+++ b/ports/pkgconf/portfile.cmake
@@ -34,6 +34,12 @@ elseif(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_CROSSCOMPILING AND VCPKG_TARGET
     set(SYSTEM_LIBDIR "/lib:/lib/i386-linux-gnu:/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnux32:/lib64:/lib32:/libx32:/usr/lib:/usr/lib/i386-linux-gnu:/usr/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnux32:/usr/lib64:/usr/lib32:/usr/libx32")
     set(PKG_DEFAULT_PATH "/usr/local/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig")
     set(PERSONALITY_PATH "/usr/share/pkgconfig/personality.d:/etc/pkgconfig/personality.d")
+elseif(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_CROSSCOMPILING AND VCPKG_TARGET_ARCHITECTURE MATCHES "riscv64")
+    # These defaults are obtained from pkgconf/pkg-config on Ubuntu
+    set(SYSTEM_INCLUDEDIR "/usr/include")
+    set(SYSTEM_LIBDIR "/lib:/lib/riscv64-linux-gnu:/usr/lib:/usr/lib/riscv64-linux-gnu")
+    set(PKG_DEFAULT_PATH "/usr/local/lib/riscv64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/lib/riscv64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig")
+    set(PERSONALITY_PATH "/usr/share/pkgconfig/personality.d:/etc/pkgconfig/personality.d")
 endif()
 
 if(DEFINED VCPKG_pkgconf_SYSTEM_LIBDIR)

--- a/ports/pkgconf/vcpkg.json
+++ b/ports/pkgconf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pkgconf",
   "version": "2.5.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "pkgconf is a program which helps to configure compiler and linker flags for development libraries. It is similar to pkg-config from freedesktop.org.",
   "homepage": "https://github.com/pkgconf/pkgconf",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7406,7 +7406,7 @@
     },
     "pkgconf": {
       "baseline": "2.5.1",
-      "port-version": 1
+      "port-version": 2
     },
     "plasma-wayland-protocols": {
       "baseline": "1.14.0",

--- a/versions/p-/pkgconf.json
+++ b/versions/p-/pkgconf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "12ad1f6607cde3d779367e4d9d728edc9fbb6cdd",
+      "version": "2.5.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "5ccb7c0a5bbbf338f36d8854f1cb8b0f2f3317da",
       "version": "2.5.1",
       "port-version": 1


### PR DESCRIPTION
On a RISC-V host vcpkg builds pkgconf with empty default lookup paths and the resulting pkgconf binary can't find system libraries like e.g. pulseaudio.

Example CMakeLists.txt and output:
```
cmake_minimum_required(VERSION 3.16)
project(pulse_test)
find_package(PkgConfig REQUIRED)
message(STATUS " PKG_CONFIG_EXECUTABLE = ${PKG_CONFIG_EXECUTABLE}")
message(STATUS " PKG_CONFIG_PATH = ${PKG_CONFIG_PATH}")
message(STATUS " CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
message(STATUS " CMAKE_PKG_CONFIG_PC_PATH = ${CMAKE_PKG_CONFIG_PC_PATH}")
pkg_check_modules(PULSEAUDIO IMPORTED_TARGET libpulse)
message(STATUS "PULSEAUDIO_FOUND = ${PULSEAUDIO_FOUND}")
```
```
[...]
-- Detecting CXX compile features - done
-- Found PkgConfig: /home/orangepi/vcpkgexp/build/vcpkg_installed/riscv64-linux/tools/pkgconf/pkgconf (found version "2.5.1")
--  PKG_CONFIG_EXECUTABLE = /home/orangepi/vcpkgexp/build/vcpkg_installed/riscv64-linux/tools/pkgconf/pkgconf
--  PKG_CONFIG_PATH = 
--  CMAKE_CURRENT_SOURCE_DIR = /home/orangepi/vcpkgexp
--  CMAKE_PKG_CONFIG_PC_PATH = 
-- Checking for module 'libpulse'
--   Package 'libpulse' not found
-- PULSEAUDIO_FOUND = 
-- Configuring done (51.4s)
-- Generating done (0.0s))
-- Build files have been written to: /home/orangepi/vcpkgexp/build
```

This patch sets the default lookup paths to the same as the system pkgconf on Ubuntu 24.04 on RISC-V and vcpkg's pkgconf can now find system libraries.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
