### PR TITLE
[igraph] update to 0.10.17

### DIFF
--- a/ports/igraph/portfile.cmake
+++ b/ports/igraph/portfile.cmake
@@ -4,9 +4,9 @@
 #  - The release tarball contains pre-generated parser sources, which eliminates the dependency on bison/flex.
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/igraph/igraph/releases/download/0.10.16/igraph-0.10.16.tar.gz"
-    FILENAME "igraph-0.10.16.tar.gz"
-    SHA512 f17b2777b8817618958f2b5505a8d066a45a25ac05ee646e3ae7e2e6d19c86d90aca3ad05866a03fb2545d21caa374d736f4f9b8c090c04da3bd88c632792fd8
+    URLS "https://github.com/igraph/igraph/releases/download/${VERSION}/igraph-${VERSION}.tar.gz"
+    FILENAME "igraph-${VERSION}.tar.gz"
+    SHA512 821a8ef3fa4d4049d0ca09fa54e0824b3b31ce2c3329cca902899a8fd2441ad4e106ea9c65e7ad8ef643c906e7b5f4d276b670f0fdbf80c8e6c473cf6536bc96
 )
 
 vcpkg_extract_source_archive(

--- a/ports/igraph/vcpkg.json
+++ b/ports/igraph/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "igraph",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "description": "igraph is a C library for network analysis and graph theory, with an emphasis on efficiency portability and ease of use.",
   "homepage": "https://igraph.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3845,7 +3845,7 @@
       "port-version": 0
     },
     "igraph": {
-      "baseline": "0.10.16",
+      "baseline": "0.10.17",
       "port-version": 0
     },
     "iguana": {

--- a/versions/i-/igraph.json
+++ b/versions/i-/igraph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "053dc17359a60076a8b062b951afed3961d3561c",
+      "version": "0.10.17",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d17d1792289749047af7ccab3672cc723d47373",
       "version": "0.10.16",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version. — **nothing fixed**
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. — **nothing fixed**
- [ ] Any patches that are no longer applied are deleted from the port's directory. — **no change to patches**
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


