### PR TITLE
Add imgui docking

### DIFF
--- a/ports/imgui-docking/portfile.cmake
+++ b/ports/imgui-docking/portfile.cmake
@@ -1,3 +1,4 @@
+# Download the docking branch source from GitHub at a fixed commit
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ocornut/imgui
@@ -5,6 +6,7 @@ vcpkg_from_github(
     SHA512 5bb29c5b0102c01d3408e0f1bf171049274faa6ab8e9e1413788abf306f7014e57ab6cd5644bfa7c8d028ba174b8e82662e26f9db7854a1c01c22ff95216c968
 )
 
+# Install core ImGui header and source files
 file(INSTALL
     ${SOURCE_PATH}/imgui.h
     ${SOURCE_PATH}/imconfig.h
@@ -16,8 +18,16 @@ file(INSTALL
     DESTINATION ${CURRENT_PACKAGES_DIR}/include
 )
 
+# Install docking backends
 file(INSTALL
     ${SOURCE_PATH}/backends/
     DESTINATION ${CURRENT_PACKAGES_DIR}/include/backends
     FILES_MATCHING PATTERN "*.h" PATTERN "*.cpp"
+)
+
+# Install LICENSE file to satisfy vcpkg audit
+file(INSTALL
+    ${SOURCE_PATH}/LICENSE.txt
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/imgui-docking
+    RENAME copyright
 )

--- a/ports/imgui-docking/portfile.cmake
+++ b/ports/imgui-docking/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ocornut/imgui
+    REF 8ccff821533bed25fb6e8b4bbc44445fdd3609a4
+    SHA512 5bb29c5b0102c01d3408e0f1bf171049274faa6ab8e9e1413788abf306f7014e57ab6cd5644bfa7c8d028ba174b8e82662e26f9db7854a1c01c22ff95216c968
+)
+
+file(INSTALL
+    ${SOURCE_PATH}/imgui.h
+    ${SOURCE_PATH}/imconfig.h
+    ${SOURCE_PATH}/imgui.cpp
+    ${SOURCE_PATH}/imgui_draw.cpp
+    ${SOURCE_PATH}/imgui_widgets.cpp
+    ${SOURCE_PATH}/imgui_tables.cpp
+    ${SOURCE_PATH}/imgui_demo.cpp
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+)
+
+file(INSTALL
+    ${SOURCE_PATH}/backends/
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include/backends
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.cpp"
+)

--- a/ports/imgui-docking/portfile.cmake
+++ b/ports/imgui-docking/portfile.cmake
@@ -19,10 +19,13 @@ file(INSTALL
 )
 
 # Install docking backends
+file(GLOB BACKENDS
+    "${SOURCE_PATH}/backends/*.h"
+    "${SOURCE_PATH}/backends/*.cpp"
+)
 file(INSTALL
-    ${SOURCE_PATH}/backends/
+    ${BACKENDS}
     DESTINATION ${CURRENT_PACKAGES_DIR}/include/backends
-    FILES_MATCHING PATTERN "*.h" PATTERN "*.cpp"
 )
 
 # Install LICENSE file to satisfy vcpkg audit

--- a/ports/imgui-docking/vcpkg.json
+++ b/ports/imgui-docking/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "imgui-docking",
+  "version-string": "1.92.3-docking",
+  "description": "Dear ImGui (docking branch): Immediate Mode GUI with docking support",
+  "homepage": "https://github.com/ocornut/imgui/tree/docking"
+}

--- a/ports/imgui-docking/vcpkg.json
+++ b/ports/imgui-docking/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui-docking",
   "version-string": "1.92.3-docking",
-  "description": "Dear ImGui (docking branch): Immediate Mode GUI with docking support",
-  "homepage": "https://github.com/ocornut/imgui/tree/docking"
+  "description": "Dear ImGui docking branch: header-only library with docking/backends support",
+  "homepage": "https://github.com/ocornut/imgui",
+  "supports": "!uwp"
 }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.