### PR TITLE
[cpp-sort] update to 2.0.0

### DIFF
--- a/ports/cpp-sort/portfile.cmake
+++ b/ports/cpp-sort/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Morwenn/cpp-sort
-    REF "${VERSION}"
-    SHA512 4ddb37e5724b0cf6f0889c889bc6a96f272f5eea1bf1ae151888d456b6a77fa64a2b887a8c8c7c42f2d0c77203c951e67a8358eed9694612e377e7233aef6c04
+    REF "v${VERSION}"
+    SHA512 4a81dc92f8b386a6c6303fa9f4787e9b214a79c342dad3dff1b876d0daf251e74b0ab94a068dcca0eeec838d19bc6b7ee1e777b9ee748cfd4a81aa7159e4fe14
     HEAD_REF 1.x.y-develop
 )
 

--- a/ports/cpp-sort/vcpkg.json
+++ b/ports/cpp-sort/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-sort",
-  "version": "1.17.0",
+  "version": "2.0.0",
   "description": "Sorting algorithms & related tools for C++14",
   "homepage": "https://github.com/Morwenn/cpp-sort/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2025,7 +2025,7 @@
       "port-version": 5
     },
     "cpp-sort": {
-      "baseline": "1.17.0",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "cpp-taskflow": {

--- a/versions/c-/cpp-sort.json
+++ b/versions/c-/cpp-sort.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa9145c386f60c60edf7c153fc19cc36d86792df",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "836bc1965fd04e43be570a140b0794e46bee76e5",
       "version": "1.17.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Morwenn/cpp-sort/releases/tag/v2.0.0
