### PR TITLE
[x86-simd-sort] update to 7.0, change homepage

### DIFF
--- a/ports/x86-simd-sort/portfile.cmake
+++ b/ports/x86-simd-sort/portfile.cmake
@@ -1,11 +1,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO intel/x86-simd-sort
+    REPO numpy/x86-simd-sort
     REF "v${VERSION}"
-    SHA512 8e7a1929b7234399d8ac30cd296b69efdfc0d9d03a91507f3b4e06f486b6b715199b35e0495f330c21b70165bcab48842cd7c0a887df4e6508b6151ad1dc9c2a
+    SHA512 de217d35a98da3b269454eaa8a2880b9aa36e4906670d0434799a45a8dcbe6d3fdf56cb16b683be510e34e0636b035e9de88a7b6e68b41e1eecceb5ecac4fe4a
     HEAD_REF master
 )
 
-file(COPY "${SOURCE_PATH}/src/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${SOURCE_PATH}/src/" DESTINATION "${CURRENT_PACKAGES_DIR}/include" PATTERN "README.md" EXCLUDE)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/x86-simd-sort/vcpkg.json
+++ b/ports/x86-simd-sort/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "x86-simd-sort",
-  "version": "5.0",
-  "description": "C++ header file library for high-performance SIMD-based sorting algorithms for primitive datatypes",
-  "homepage": "https://github.com/intel/x86-simd-sort",
+  "version": "7.0",
+  "description": "C++ template library for high performance SIMD based sorting algorithms",
+  "homepage": "https://github.com/numpy/x86-simd-sort",
   "license": "BSD-3-Clause"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10441,7 +10441,7 @@
       "port-version": 1
     },
     "x86-simd-sort": {
-      "baseline": "5.0",
+      "baseline": "7.0",
       "port-version": 0
     },
     "xapian": {

--- a/versions/x-/x86-simd-sort.json
+++ b/versions/x-/x86-simd-sort.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f866fd424e081b6bd0cc7a19a1dd92417e050d2",
+      "version": "7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c330680363901a75d292b1a8ab409285b851638e",
       "version": "5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/numpy/x86-simd-sort/releases/tag/v7.0
https://github.com/numpy/x86-simd-sort/releases/tag/v6.0

The homepage has been changed. Now numpy maintain x86-simd-sort.
ref: https://www.phoronix.com/news/Intel-NumPy-x86-simd-sort

