### PR TITLE
[geotrans] update to v3.10

### DIFF
--- a/ports/geotrans/portfile.cmake
+++ b/ports/geotrans/portfile.cmake
@@ -4,8 +4,8 @@ set(VCPKG_LIBRARY_LINKAGE "dynamic")
 # which we re-build anyway.  There is no source only package provided or it would be preferred (and smaller).
 vcpkg_download_distfile(ARCHIVE
     URLS "https://earth-info.nga.mil/php/download.php?file=wgs-mastertgz"
-    FILENAME "geotrans-3.9-master-adf1935.tgz"
-    SHA512 adf19357edc62681a2515e7210a752b0e09214b6ce69024e60150e0780059c08a9ab5a162a0562dbc37127438783a24bcde1adb88b559bc95ff9a5bea0eb8b39
+    FILENAME "geotrans-3.10-master-501325b.tgz"
+    SHA512 501e25b80bd92a9651a6879ee42768abff9871cec3c79d457b0e74940e6fd3a477d98568dea0c4a4da2aa251ada11e17ab76edf5bcbdbde68e0e5cfe1813491f
 )
 
 vcpkg_extract_source_archive(

--- a/ports/geotrans/vcpkg.json
+++ b/ports/geotrans/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "GEOTRANS is an application that allows you to convert geographic coordinates among a wide variety of coordinate systems, map projections, grids, and datums. GEOTRANS runs in Microsoft Windows and LINUX environments.",
   "homepage": "https://earth-info.nga.mil/GandG/update/index.php?action=home",
   "license": null,
-  "supports": "!uwp",
+  "supports": "!uwp & !osx",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/geotrans/vcpkg.json
+++ b/ports/geotrans/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "geotrans",
-  "version": "3.9",
-  "port-version": 1,
+  "version": "3.10",
   "description": "GEOTRANS is an application that allows you to convert geographic coordinates among a wide variety of coordinate systems, map projections, grids, and datums. GEOTRANS runs in Microsoft Windows and LINUX environments.",
   "homepage": "https://earth-info.nga.mil/GandG/update/index.php?action=home",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3225,8 +3225,8 @@
       "port-version": 0
     },
     "geotrans": {
-      "baseline": "3.9",
-      "port-version": 1
+      "baseline": "3.10",
+      "port-version": 0
     },
     "getdns": {
       "baseline": "1.7.3",

--- a/versions/g-/geotrans.json
+++ b/versions/g-/geotrans.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8fc876aee16f293e71d6cac9148a4418f88eba8c",
+      "git-tree": "9635e46c99f9a93ebce4632804c2720cb5063303",
       "version": "3.10",
       "port-version": 0
     },

--- a/versions/g-/geotrans.json
+++ b/versions/g-/geotrans.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8fc876aee16f293e71d6cac9148a4418f88eba8c",
+      "version": "3.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "b392617570c01a75595f982080630925b27ba3bf",
       "version": "3.9",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
