### PR TITLE
[livepp] Update to 2.10.0

### DIFF
--- a/ports/livepp/portfile.cmake
+++ b/ports/livepp/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS https://liveplusplus.tech/downloads/${LIVEPP_FILE}
     FILENAME "${LIVEPP_FILE}"
-    SHA512 43c0395e958b2c71dbfb4c590657c15633d96d06dd9c5ca349c5e5c5040916693f7c2f8bc5237de31e40ea9010b7bde47858cc329ae7bfd464187b9af63fc5bb
+    SHA512 8f31fd51f189ad1b41639709fca76fd7152a0e9b7d5383a43ec13f4d60993c6069ba20f0bb7f9d449fa5f50b7400fe3faa14a3bf3406a2fc6d9e19619464189f
 )
 
 vcpkg_extract_source_archive(

--- a/ports/livepp/vcpkg.json
+++ b/ports/livepp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "livepp",
-  "version-semver": "2.9.3",
+  "version-semver": "2.10.0",
   "description": "Hot-reload for C & C++ transforms workflows and decreases iteration times.",
   "homepage": "https://liveplusplus.tech/",
   "documentation": "https://liveplusplus.tech/docs/documentation.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5853,7 +5853,7 @@
       "port-version": 0
     },
     "livepp": {
-      "baseline": "2.9.3",
+      "baseline": "2.10.0",
       "port-version": 0
     },
     "llama-cpp": {

--- a/versions/l-/livepp.json
+++ b/versions/l-/livepp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1ea6b001888a5b20bfc433ba755e1616ed32fb1",
+      "version-semver": "2.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "41c5429ffac43a63f1162df8aa948a74ff763207",
       "version-semver": "2.9.3",
       "port-version": 0


### PR DESCRIPTION
Update livepp port form 2.9.3 to 2.10.0: https://liveplusplus.tech/releases.html

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version.~~
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
- [ ] ~~Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
