### PR TITLE
[libvpx] Fix dynamic linking

### DIFF
--- a/ports/libvpx/0006-Guard-installation-of-static-only-library.patch
+++ b/ports/libvpx/0006-Guard-installation-of-static-only-library.patch
@@ -1,0 +1,24 @@
+diff --git a/libs.mk b/libs.mk
+index c7db0c107..2c7b7c7ab 100644
+--- a/libs.mk
++++ b/libs.mk
+@@ -182,14 +182,18 @@ INSTALL-LIBS-$(CONFIG_ENCODERS) += include/vpx/vpx_tpl.h
+ ifeq ($(CONFIG_EXTERNAL_BUILD),yes)
+ ifeq ($(CONFIG_MSVS),yes)
+ INSTALL-LIBS-yes                  += $(foreach p,$(VS_PLATFORMS),$(LIBSUBDIR)/$(p)/$(CODEC_LIB).lib)
++ifeq ($(CONFIG_STATIC),yes)
+ INSTALL-LIBS-$(CONFIG_DEBUG_LIBS) += $(foreach p,$(VS_PLATFORMS),$(LIBSUBDIR)/$(p)/$(CODEC_LIB)d.lib)
++endif
+ INSTALL-LIBS-$(CONFIG_SHARED) += $(foreach p,$(VS_PLATFORMS),$(LIBSUBDIR)/$(p)/vpx.dll)
+ INSTALL-LIBS-$(CONFIG_SHARED) += $(foreach p,$(VS_PLATFORMS),$(LIBSUBDIR)/$(p)/vpx.exp)
+ endif
+ else
+ INSTALL-LIBS-$(CONFIG_STATIC) += $(LIBSUBDIR)/libvpx.a
++ifeq ($(CONFIG_STATIC),yes)
+ INSTALL-LIBS-$(CONFIG_DEBUG_LIBS) += $(LIBSUBDIR)/libvpx_g.a
+ endif
++endif
+ 
+ ifeq ($(CONFIG_VP9_ENCODER)$(CONFIG_RATE_CTRL),yesyes)
+   SIMPLE_ENCODE_SRCS := $(call enabled,CODEC_SRCS)
+

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/libvpx
@@ -10,6 +8,7 @@ vcpkg_from_github(
         0003-add-uwp-v142-and-v143-support.patch
         0004-remove-library-suffixes.patch
         0005-dont-expect-gnu-diff.patch
+        0006-Guard-installation-of-static-only-library.patch # https://chromium-review.googlesource.com/c/webm/libvpx/+/6973790
 )
 
 if(CMAKE_HOST_WIN32)

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libvpx",
   "version": "1.15.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5646,7 +5646,7 @@
     },
     "libvpx": {
       "baseline": "1.15.2",
-      "port-version": 2
+      "port-version": 3
     },
     "libwandio": {
       "baseline": "4.2.6-1",

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "762e5ae8de0629bb52e6460f8165a26ef63786e9",
+      "version": "1.15.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "6677969951a14750a5ab721e7ee4e23a0ddaecf1",
       "version": "1.15.2",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
