### PR TITLE
[tree-sitter] update to 2.5.10

### DIFF
--- a/ports/tree-sitter/portfile.cmake
+++ b/ports/tree-sitter/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tree-sitter/tree-sitter
     REF "v${VERSION}"
-    SHA512 c927274081bc61abde68399b0c7736cd2b0a5f96c79d1147fe85fc30cf48238afcff112cb61a5c89f3c3ccb3a5f154e4ac8935c1d423c63e93f814eb034ec50b
+    SHA512 f0465a2fabe303c1b62f1f55ed08aa57372ac11370d229adcccd99b5e8067be53e92da281cdfbcd034e2ecefb33ac90a119eeac9035670ac8fbaa4242cb87a11
     HEAD_REF master
     PATCHES
         unofficial-cmake.diff

--- a/ports/tree-sitter/vcpkg.json
+++ b/ports/tree-sitter/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version-semver": "0.25.9",
+  "version-semver": "0.25.10",
   "description": "An incremental parsing system for programming tools.",
   "homepage": "https://github.com/tree-sitter/tree-sitter",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9753,7 +9753,7 @@
       "port-version": 1
     },
     "tree-sitter": {
-      "baseline": "0.25.9",
+      "baseline": "0.25.10",
       "port-version": 0
     },
     "tree-sitter-c": {

--- a/versions/t-/tree-sitter.json
+++ b/versions/t-/tree-sitter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b86e93a72410148296d5e004b0cfe0a3bdb5843b",
+      "version-semver": "0.25.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "00165334c5307c6cd04f7e006ffc0baec31bbe38",
       "version-semver": "0.25.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/tree-sitter/tree-sitter/releases/tag/v0.25.10
