### PR TITLE
[libuv] Fix Android arm64 build by removing pthread/rt linkage

### DIFF
--- a/ports/libuv/fix-build-type.patch
+++ b/ports/libuv/fix-build-type.patch
@@ -1,8 +1,20 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5e8e016..b3c3f18 100644
+﻿diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 73d5aff8..e149b46e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -465,7 +465,7 @@ if(LIBUV_BUILD_SHARED)
+@@ -437,6 +437,11 @@ if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|Linux|NetBSD|OpenBSD")
+   list(APPEND uv_libraries m)
+ endif()
+ 
++## -lpthread -lrt is not found on android, and it is not necessary.
++if(ANDROID)
++  list(REMOVE_ITEM uv_libraries pthread rt)
++endif()
++
+ if(CYGWIN OR MSYS)
+   list(APPEND uv_defines _GNU_SOURCE)
+   list(APPEND uv_sources
+@@ -472,7 +477,7 @@ if(LIBUV_BUILD_SHARED)
    endif()
    target_link_libraries(uv ${uv_libraries})
    set_target_properties(uv PROPERTIES OUTPUT_NAME "uv")
@@ -11,7 +23,7 @@ index 5e8e016..b3c3f18 100644
  
  add_library(uv_a STATIC ${uv_sources})
  target_compile_definitions(uv_a PRIVATE ${uv_defines})
-@@ -485,6 +485,7 @@ set_target_properties(uv_a PROPERTIES OUTPUT_NAME "uv")
+@@ -492,6 +497,7 @@ set_target_properties(uv_a PROPERTIES OUTPUT_NAME "uv")
  if(WIN32)
    set_target_properties(uv_a PROPERTIES PREFIX "lib")
  endif()
@@ -19,7 +31,7 @@ index 5e8e016..b3c3f18 100644
  
  if(LIBUV_BUILD_TESTS)
    # Small hack: use ${uv_test_sources} now to get the runner skeleton,
-@@ -755,10 +756,6 @@ configure_file(libuv-static.pc.in libuv-static.pc @ONLY)
+@@ -767,10 +773,6 @@ configure_file(libuv-static.pc.in libuv-static.pc @ONLY)
  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
  install(FILES LICENSE-extra DESTINATION ${CMAKE_INSTALL_DOCDIR})
@@ -30,7 +42,7 @@ index 5e8e016..b3c3f18 100644
  install(EXPORT libuvConfig
  	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libuv
  	NAMESPACE libuv::)
-@@ -775,6 +772,11 @@ if(LIBUV_BUILD_SHARED)
+@@ -787,6 +789,11 @@ if(LIBUV_BUILD_SHARED)
            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/versions/l-/libuv.json
+++ b/versions/l-/libuv.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eaf94ede185f34dff0625254f6e64261d1c819fc",
+      "git-tree": "bfa5ac491f98f56f4e964d380e8591369a2e66db",
       "version-semver": "1.51.0",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #47474

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fix Android arm64 build by removing unnecessary pthread and rt libraries from libuv.

On Android NDK, -lpthread and -lrt are not required and cause build errors:
  error: call to undeclared function 'pthread_barrier_init'

This patch ensures libuv can be compiled on Android arm64. Tested locally with:
  Windows + Android NDK 28
  libuv 1.51.0
  Triplet: arm64-android

This patch is based on the official fix-build-type.patch, with an additional modification to support Android arm64 (remove pthread/rt linkage).

The native build success screenshot:

<img width="2022" height="672" alt="Snipaste_2025-09-24_12-54-20" src="https://github.com/user-attachments/assets/d2c33f60-bf29-46c6-ace5-d0ef950f29ee" />
