### PR TITLE
Add cconfig v1.0.0, header-only TOML/INI parser

### DIFF
--- a/ports/cconfig/portfile.cmake
+++ b/ports/cconfig/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Nouridin/cconfig
+    REF "v${VERSION}" # e.g., v1.0.0
+    SHA512 8CE0C0FCA4E55AF9CFD56BA7779F4775703752D328518FE72F242336A7D4DB08B53284CA6148FC65BDBFE7D5BE4F025F49DFC7B13A45E2B69F350E15966C1929
+    HEAD_REF main
+)
+
+# Copy the main header
+file(COPY "${SOURCE_PATH}/cconfig.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/cconfig")
+
+# Convenience header in root include folder
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/cconfig.h" "#include \"cconfig/cconfig.h\"\n")
+
+# Install license
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+# Remove auto-generated usage file if present
+file(REMOVE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage")
+
+# Add a minimal test to ensure the package is usable
+vcpkg_test_cmake(TEST_ROOT_DIR "${CURRENT_PORT_DIR}")

--- a/ports/cconfig/test_package/CMakeLists.txt
+++ b/ports/cconfig/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.10)
+project(cconfig-test C)
+
+find_package(cconfig CONFIG REQUIRED)
+
+add_executable(cconfig-test test.c)
+
+# For a header-only library, this primarily adds the include directories.
+target_link_libraries(cconfig-test PRIVATE cconfig::cconfig)
+
+message(STATUS "Successfully found and linked cconfig.")

--- a/ports/cconfig/test_package/test.c
+++ b/ports/cconfig/test_package/test.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include "cconfig.h"
+
+int main() {
+    // This is a minimal test to ensure the header can be included
+    // and the library can be linked.
+    printf("cconfig header included successfully.\n");
+    return 0;
+}

--- a/ports/cconfig/vcpkg.json
+++ b/ports/cconfig/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "cconfig",
+  "version-string": "1.0.0",
+  "description": "A small, dependency-free, single-header C library for parsing TOML and INI files.",
+  "homepage": "https://github.com/Nouridin/cconfig",
+  "license": "MIT",
+  "supports": "!(uwp)",
+  "maintainers": ["Nouridin"]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the maintainer guide.
- [x] The name of the port matches an existing name for this component on search engines.
- [x] Optional dependencies are resolved in exactly one way. (None for header-only)
- [x] The versioning scheme in vcpkg.json matches what upstream says.
- [x] The license declaration in vcpkg.json matches what upstream says.
- [x] The installed "copyright" file matches what upstream says.
- [x] The source code comes from an authoritative source.
- [x] The generated "usage text" is accurate.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
