### PR TITLE
[tiff] Update to 4.7.1

### DIFF
--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libtiff/libtiff
     REF "v${VERSION}"
-    SHA512 924bcd0fe19c03f65ffc068719371ab582057bf95c3847efd3bd03eaff1eb409ec3f22c9d373fafd9f993dd031a161850f0db082cb7068195c7c5c564fa222fc
+    SHA512 dcdabe2598db33a973d06f0009dd528aa1f38813bd6015e2595097b838a42240f9ccbe7524b5235ea2f4207a10d5d706339c7a6f4772b531e00a20281a00f67b
     HEAD_REF master
     PATCHES
         FindCMath.patch
@@ -12,7 +12,7 @@ vcpkg_from_gitlab(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        cxx     cxx
+        cxx     tiff-cxx
         jpeg    jpeg
         jpeg    CMAKE_REQUIRE_FIND_PACKAGE_JPEG
         libdeflate libdeflate

--- a/ports/tiff/prefer-config.diff
+++ b/ports/tiff/prefer-config.diff
@@ -1,11 +1,11 @@
 diff --git a/cmake/LERCCodec.cmake b/cmake/LERCCodec.cmake
-index 54504ca..3e04997 100644
+index c21dad3d..3d06367f 100644
 --- a/cmake/LERCCodec.cmake
 +++ b/cmake/LERCCodec.cmake
-@@ -25,7 +25,10 @@
- 
+@@ -26,7 +26,10 @@
  # libLerc
  set(LERC_SUPPORT FALSE)
+ set(LERC_STATIC FALSE)
 -find_package(LERC)
 +find_package(LERC NAMES unofficial-lerc)
 +if(TARGET unofficial::Lerc::Lerc)
@@ -15,7 +15,7 @@ index 54504ca..3e04997 100644
  if (lerc AND LERC_FOUND AND ZIP_SUPPORT)
      set(LERC_SUPPORT TRUE)
 diff --git a/cmake/WebPCodec.cmake b/cmake/WebPCodec.cmake
-index 1d676a7..7776917 100644
+index 1d676a78..77769171 100644
 --- a/cmake/WebPCodec.cmake
 +++ b/cmake/WebPCodec.cmake
 @@ -26,7 +26,7 @@
@@ -28,7 +28,7 @@ index 1d676a7..7776917 100644
  option(webp "use libwebp (required for WEBP compression)" ${WebP_FOUND})
  
 diff --git a/cmake/ZSTDCodec.cmake b/cmake/ZSTDCodec.cmake
-index 3fac861..2957aa3 100644
+index 3fac861a..2957aa3a 100644
 --- a/cmake/ZSTDCodec.cmake
 +++ b/cmake/ZSTDCodec.cmake
 @@ -28,7 +28,7 @@
@@ -41,15 +41,15 @@ index 3fac861..2957aa3 100644
  if(ZSTD_FOUND)
      if(TARGET zstd::libzstd_shared)
 diff --git a/libtiff/CMakeLists.txt b/libtiff/CMakeLists.txt
-index a8aa0c3..d5b9b25 100755
+index 2d76d1ee..68502a35 100755
 --- a/libtiff/CMakeLists.txt
 +++ b/libtiff/CMakeLists.txt
-@@ -163,7 +163,7 @@ if(JBIG_SUPPORT)
+@@ -161,7 +161,7 @@ if(JBIG_SUPPORT)
  endif()
  if(LERC_SUPPORT)
    target_link_libraries(tiff PRIVATE LERC::LERC)
 -  if(LERC_VERSION_STRING VERSION_GREATER_EQUAL "4.0")
 +  if(1)
-     if(NOT BUILD_SHARED_LIBS)
-       set_target_properties(tiff PROPERTIES COMPILE_DEFINITIONS LERC_STATIC)
-     endif()
+     string(APPEND tiff_requires_private " Lerc")
+   else()
+     list(APPEND tiff_libs_private_list "${LERC_LIBRARY}")

--- a/ports/tiff/vcpkg.json
+++ b/ports/tiff/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tiff",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "A library that supports the manipulation of TIFF image files",
   "homepage": "https://libtiff.gitlab.io/libtiff/",
   "license": "libtiff",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9569,7 +9569,7 @@
       "port-version": 2
     },
     "tiff": {
-      "baseline": "4.7.0",
+      "baseline": "4.7.1",
       "port-version": 0
     },
     "tinkerforge": {

--- a/versions/t-/tiff.json
+++ b/versions/t-/tiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9391305288677bb3959bf22a08218a61ffec0be0",
+      "version": "4.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "54c1c045d21157ce32df8a1c8b7b9d57b0d5d6ce",
       "version": "4.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.