### PR TITLE
[qt5-location] Add patch for missing include

### DIFF
--- a/ports/qt5-location/mapboxgl-gcc13.patch
+++ b/ports/qt5-location/mapboxgl-gcc13.patch
@@ -1,0 +1,34 @@
+diff --git a/src/3rdparty/mapbox-gl-native/include/mbgl/util/geometry.hpp b/src/3rdparty/mapbox-gl-native/include/mbgl/util/geometry.hpp
+index a28c59a..92d928a 100644
+--- a/src/3rdparty/mapbox-gl-native/include/mbgl/util/geometry.hpp
++++ b/src/3rdparty/mapbox-gl-native/include/mbgl/util/geometry.hpp
+@@ -1,5 +1,6 @@
+ #pragma once
+
++#include <cstdint>
+ #include <mapbox/geometry/geometry.hpp>
+ #include <mapbox/geometry/point_arithmetic.hpp>
+ #include <mapbox/geometry/for_each_point.hpp>
+diff --git a/src/3rdparty/mapbox-gl-native/include/mbgl/util/string.hpp b/src/3rdparty/mapbox-gl-native/include/mbgl/util/string.hpp
+index 13498cc..4dc82a8 100644
+--- a/src/3rdparty/mapbox-gl-native/include/mbgl/util/string.hpp
++++ b/src/3rdparty/mapbox-gl-native/include/mbgl/util/string.hpp
+@@ -4,6 +4,7 @@
+ #include <string>
+ #include <cassert>
+ #include <cstdlib>
++#include <cstdint>
+ #include <exception>
+
+ // Polyfill needed by Qt when building for Android with GCC
+diff --git a/src/3rdparty/mapbox-gl-native/src/mbgl/gl/stencil_mode.hpp b/src/3rdparty/mapbox-gl-native/src/mbgl/gl/stencil_mode.hpp
+index bc959c9..2fc62bb 100644
+--- a/src/3rdparty/mapbox-gl-native/src/mbgl/gl/stencil_mode.hpp
++++ b/src/3rdparty/mapbox-gl-native/src/mbgl/gl/stencil_mode.hpp
+@@ -1,5 +1,6 @@
+ #pragma once
+
++#include <cstdint>
+ #include <mbgl/util/variant.hpp>
+
+ namespace mbgl {

--- a/ports/qt5-location/portfile.cmake
+++ b/ports/qt5-location/portfile.cmake
@@ -1,3 +1,3 @@
 message(STATUS "${PORT} has a spurious failure in which it is unable to create a parent directory! Just retry.")
 include(${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake)
-qt_submodule_installation(PATCHES missing-include.patch disable-enum-warning.patch)
+qt_submodule_installation(PATCHES missing-include.patch disable-enum-warning.patch mapboxgl-gcc13.patch)

--- a/ports/qt5-location/vcpkg.json
+++ b/ports/qt5-location/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-location",
   "version": "5.15.17",
+  "port-version": 1,
   "description": "The Qt Location API helps you create viable mapping solutions using the data available from some of the popular location services.",
   "license": null,
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7846,7 +7846,7 @@
     },
     "qt5-location": {
       "baseline": "5.15.17",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-macextras": {
       "baseline": "5.15.17",

--- a/versions/q-/qt5-location.json
+++ b/versions/q-/qt5-location.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fc6c21285624e33ac46156dc3fda37e0ad36cccb",
+      "version": "5.15.17",
+      "port-version": 1
+    },
+    {
       "git-tree": "daca43cb0f4a73337690ca6e8852cb302d66130d",
       "version": "5.15.17",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #47481
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

See https://bugs.gentoo.org/885431 and https://codereview.qt-project.org/c/qt/qtlocation-mapboxgl/+/446790/3..5//COMMIT_MSG#b11

