### PR TITLE
[imgui-sfml] Force static linking to prevent runtime issues

### DIFF
--- a/ports/imgui-sfml/portfile.cmake
+++ b/ports/imgui-sfml/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY) # this mirrors ImGui's portfile behavior
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sfml/imgui-sfml

--- a/ports/imgui-sfml/vcpkg.json
+++ b/ports/imgui-sfml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "imgui-sfml",
   "version": "3.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "ImGui binding for use with SFML",
   "homepage": "https://github.com/eliasdaler/imgui-sfml",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3886,7 +3886,7 @@
     },
     "imgui-sfml": {
       "baseline": "3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "imguizmo": {
       "baseline": "2024-05-29",

--- a/versions/i-/imgui-sfml.json
+++ b/versions/i-/imgui-sfml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae4b886823d6b123e94a3fbf120fcf571f81494b",
+      "version": "3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "061e5f2c8923c6ebe8c9b37ceeb36a8619022f24",
       "version": "3.0",
       "port-version": 1


### PR DESCRIPTION
This library links against `Dear ImGui`, which has an explicit warning against shared libraries:
[Using dear imgui via a shared library is not recommended](https://github.com/ocornut/imgui/blob/cee40f8af99eee390eb17adfe79a68a26d83c436/imgui.h#L83)
When running a simple application with `imgui-sfml` with shared libraries, this causes runtime issues.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
