### PR TITLE
[ada-url] update to 3.3.0

### DIFF
--- a/ports/ada-url/portfile.cmake
+++ b/ports/ada-url/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ada-url/ada
     REF "v${VERSION}"
-    SHA512 0363a75671ee98ad833211e0eb11a09048f0658cf55ec8f10a228224feb3519ac3fda4fe3cb6732137f0a0ec7e23329b12c50be32b0e68d7706a403f30620962
+    SHA512 728bf278fcac51a8ffdf5571cb486e789cd49511674c61e354c802bbfaeea64598fb22cd28ef4b02eacdd42c1c3437f40666ca8dba8097e0ecebbae1095de77f
     HEAD_REF main
     PATCHES
         no-cpm.patch

--- a/ports/ada-url/vcpkg.json
+++ b/ports/ada-url/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ada-url",
-  "version": "3.2.7",
+  "version": "3.3.0",
   "description": "WHATWG-compliant and fast URL parser written in modern C++",
   "homepage": "https://ada-url.com/",
   "license": "MIT OR Apache-2.0",

--- a/versions/a-/ada-url.json
+++ b/versions/a-/ada-url.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09166486a401aa7efa9efb4f221c6859d7caab2c",
+      "version": "3.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "166f7155664622c0d9d2bc80c53cb423e6da5ecf",
       "version": "3.2.7",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -41,7 +41,7 @@
       "port-version": 0
     },
     "ada-url": {
-      "baseline": "3.2.7",
+      "baseline": "3.3.0",
       "port-version": 0
     },
     "ade": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ada-url/ada/releases/tag/v3.3.0
