### PR TITLE
[shapelib] update to 1.6.2

### DIFF
--- a/ports/shapelib/portfile.cmake
+++ b/ports/shapelib/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "http://download.osgeo.org/shapelib/shapelib-${VERSION}.zip"
     FILENAME "shapelib-${VERSION}.zip"
-    SHA512 50859bbd1ea8808aa06cd112cc16cc77c1bd29d93129180818a5ea3a753b63de4039f232d1d9f13ebd7d076e427d10036e5f00775e633eb637da511625fa29bb
+    SHA512 4f9c33cfce823ad019291eeb6103fdb9495f87a83667a99862544f65dec554975ab5663b37dc6c09eb329a5b73c46ee854b443f17cdc51e7d97ad35558511dc5
 )
 
 vcpkg_extract_source_archive(

--- a/ports/shapelib/vcpkg.json
+++ b/ports/shapelib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "shapelib",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Shapefile C Library is simple C API for reading and writing ESRI Shapefiles",
   "homepage": "https://download.osgeo.org/shapelib",
   "license": "MIT OR LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8845,7 +8845,7 @@
       "port-version": 0
     },
     "shapelib": {
-      "baseline": "1.6.1",
+      "baseline": "1.6.2",
       "port-version": 0
     },
     "shared-mime-info": {

--- a/versions/s-/shapelib.json
+++ b/versions/s-/shapelib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e42996cd35d052dc6f3bb6a6665b02adc459684",
+      "version": "1.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d314741ee9002b2f9a50d305ae759b1f2bb734b2",
       "version": "1.6.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
