### PR TITLE
[xproperty] update to 0.12.1

### DIFF
--- a/ports/xproperty/fix-target.patch
+++ b/ports/xproperty/fix-target.patch
@@ -1,44 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5dcddc2..9d99227 100644
+index accd038..2451bf0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -7,7 +7,7 @@
  ############################################################################
  
- cmake_minimum_required(VERSION 3.1)
+ cmake_minimum_required(VERSION 3.20)
 -project(xproperty)
 +project(xproperty CXX)
  
  set(XPROPERTY_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
  
-@@ -28,7 +28,8 @@ message(STATUS "xproperty v${${PROJECT_NAME}_VERSION}")
- # Dependencies
- # ============
- 
--find_package(xtl 0.5.3 REQUIRED)
-+set(xtl_REQUIRED_VERSION 0.5.3)
-+find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
- message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
- 
- # Build
-diff --git a/xpropertyConfig.cmake.in b/xpropertyConfig.cmake.in
-index 192c04f..38b305a 100644
---- a/xpropertyConfig.cmake.in
-+++ b/xpropertyConfig.cmake.in
-@@ -15,7 +15,12 @@
- 
- @PACKAGE_INIT@
- 
--set(PN xproperty)
--set_and_check(${PN}_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
--set(${PN}_LIBRARY "")
--check_required_components(${PN})
-+include(CMakeFindDependencyMacro)
-+find_dependency(xtl @xtl_REQUIRED_VERSION@)
-+
-+if(NOT TARGET @PROJECT_NAME@)
-+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
-+    get_target_property(@PROJECT_NAME@_INCLUDE_DIR @PROJECT_NAME@ INTERFACE_INCLUDE_DIRECTORIES)
-+endif()
-+
-+set(@PROJECT_NAME@_LIBRARY "")

--- a/ports/xproperty/portfile.cmake
+++ b/ports/xproperty/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO QuantStack/xproperty
-    REF 0.8.1
-    SHA512 70fcce3a3cc84be98d844aa59c14686945907db3c8fa1c9a916f0bab811ef96512464031e53f00d29cba7db750a0032f4b59d6ca524f52bc7cfe8de5cebad5e5
+    REF ${VERSION}
+    SHA512 e070427d75e5f1b7edab67599c9e61eb375b68e683db864ec1758d331bb0fcf8d20051831f69a36db5a2e9efc6eb2822f62f8cc1ed563d728a534c1cbec40d77
     HEAD_REF master
     PATCHES
         fix-target.patch
@@ -14,7 +14,6 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTS=OFF
-        -DDOWNLOAD_GTEST=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/xproperty/vcpkg.json
+++ b/ports/xproperty/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "xproperty",
-  "version": "0.8.1",
-  "port-version": 3,
+  "version": "0.12.1",
   "description": "Traitlets-like C++ properties and implementation of the observer pattern",
   "dependencies": [
+    "nlohmann-json",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -11,7 +11,6 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    "xtl"
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10545,8 +10545,8 @@
       "port-version": 0
     },
     "xproperty": {
-      "baseline": "0.8.1",
-      "port-version": 3
+      "baseline": "0.12.1",
+      "port-version": 0
     },
     "xproto": {
       "baseline": "2021.5",

--- a/versions/x-/xproperty.json
+++ b/versions/x-/xproperty.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53a98275aa99091112fee2461e80e908ff78b68f",
+      "version": "0.12.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "237cd26cda6bc5f75e9dd2d75e5a65725512065d",
       "version": "0.8.1",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/jupyter-xeus/xproperty/releases/tag/0.12.1
