### PR TITLE
[inspireface] Add new port

### DIFF
--- a/ports/inspireface/install.patch
+++ b/ports/inspireface/install.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3ff2f74e..d70fc66e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -322,7 +322,7 @@ endif ()
+ 
+ 
+ # Set the installation directory to the build directory
+-set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install")
++# set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install")
+ 
+ # Add a child project: InspireFace Source
+ add_subdirectory(cpp/inspireface)

--- a/ports/inspireface/portfile.cmake
+++ b/ports/inspireface/portfile.cmake
@@ -1,0 +1,49 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO HyperInspire/InspireFace
+    REF "v${VERSION}"
+    SHA512 7efc3a1ba10730d50e0e304b7313decc66a74dd4cff2e48f2fdb79780e5db04a895e348905bdc429d4b86fe0a5689c0c043d1fe6baaaaed328ebe16f5ff422c3
+    HEAD_REF master
+    PATCHES
+        install.patch
+)
+
+vcpkg_find_acquire_program(GIT)
+get_filename_component(GIT_EXE_PATH "${GIT}" DIRECTORY)
+vcpkg_add_to_path("${GIT_EXE_PATH}")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    vcpkg_list(APPEND IFS_OPTIONS "-DISF_BUILD_SHARED_LIBS=OFF")
+elseif(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    vcpkg_list(APPEND IFS_OPTIONS "-DISF_BUILD_SHARED_LIBS=ON")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DISF_BUILD_WITH_SAMPLE=OFF
+        -DISF_BUILD_WITH_TEST=OFF
+        ${IFS_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+if(NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/InspireFace/include" "${CURRENT_PACKAGES_DIR}/include")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/InspireFace/lib" "${CURRENT_PACKAGES_DIR}/lib")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/version.txt")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/InspireFace")
+endif()
+
+if(NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/InspireFace/lib" "${CURRENT_PACKAGES_DIR}/debug/lib")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/version.txt")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/InspireFace")
+endif()
+
+vcpkg_install_copyright(
+    COMMENT "The licensing of the open-source models employed by InspireFace adheres to the same requirements as InsightFace, specifying their use solely for academic purposes and explicitly prohibiting commercial applications."
+    FILE_LIST
+        "${SOURCE_PATH}/README.md"
+)

--- a/ports/inspireface/vcpkg.json
+++ b/ports/inspireface/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "inspireface",
+  "version": "1.2.3",
+  "description": "InspireFace is a cross-platform face recognition SDK developed in C/C++",
+  "homepage": "https://github.com/HyperInspire/InspireFace",
+  "license": null,
+  "supports": "!(windows | android)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3936,6 +3936,10 @@
       "baseline": "3.4.0",
       "port-version": 0
     },
+    "inspireface": {
+      "baseline": "1.2.3",
+      "port-version": 0
+    },
     "intel-ipsec": {
       "baseline": "1.1",
       "port-version": 0

--- a/versions/i-/inspireface.json
+++ b/versions/i-/inspireface.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c2646979a866e1e0b88a95a271ec124346ddff21",
+      "version": "1.2.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
