### PR TITLE
[ggml] Update, backport vulkan loader patch, restore test integrity

### DIFF
--- a/ports/ggml/portfile.cmake
+++ b/ports/ggml/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ggml-org/ggml
     REF v${VERSION}
-    SHA512 c31aeaaba328cd217f34191f1ce87720bb34dc39dc036f2ba8c92710636706f5be2cfcf86dc8c38ec737b020908da0e136447de10e7d9e6db698c812e7d21ae3
+    SHA512 d2820f9d1a5f80a4ec154cd89fc944b9c8b172f547fdeeb630f43fa06186bf37cad2e02aafad781b4bda9d964a8daa02b90685c7e29a4beebf296d2e1e8a7b8f
     HEAD_REF master
     PATCHES
         cmake-config.diff

--- a/ports/ggml/portfile.cmake
+++ b/ports/ggml/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         pkgconfig.diff
         relax-link-options.diff
         vulkan-shaders-gen.diff
+        vulkan-loader-storage.diff # backport of https://github.com/ggml-org/llama.cpp/pull/16224
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/ggml/vcpkg.json
+++ b/ports/ggml/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ggml",
-  "version": "0.9.1",
-  "port-version": 1,
+  "version": "0.9.3",
   "description": "Tensor library for machine learning",
   "homepage": "https://github.com/ggml-org/ggml",
   "license": "MIT",

--- a/ports/ggml/vcpkg.json
+++ b/ports/ggml/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ggml",
   "version": "0.9.1",
+  "port-version": 1,
   "description": "Tensor library for machine learning",
   "homepage": "https://github.com/ggml-org/ggml",
   "license": "MIT",

--- a/ports/ggml/vulkan-loader-storage.diff
+++ b/ports/ggml/vulkan-loader-storage.diff
@@ -1,0 +1,44 @@
+diff --git a/src/ggml-vulkan/ggml-vulkan.cpp b/src/ggml-vulkan/ggml-vulkan.cpp
+index ebbb412e55f4b..977e38f79b66d 100644
+--- a/src/ggml-vulkan/ggml-vulkan.cpp
++++ b/src/ggml-vulkan/ggml-vulkan.cpp
+@@ -7,12 +7,14 @@
+ 
+ // See https://github.com/KhronosGroup/Vulkan-Hpp?tab=readme-ov-file#extensions--per-device-function-pointers-
+ #define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
++// We use VULKAN_HPP_DEFAULT_DISPATCHER, but not VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
++// to avoid conflicts with applications or other libraries who might use it.
++namespace vk::detail { class DispatchLoaderDynamic; }
++vk::detail::DispatchLoaderDynamic & ggml_vk_default_dispatcher();
++#define VULKAN_HPP_DEFAULT_DISPATCHER ggml_vk_default_dispatcher()
+ 
+ #include <vulkan/vulkan.hpp>
+ 
+-// See https://github.com/KhronosGroup/Vulkan-Hpp?tab=readme-ov-file#extensions--per-device-function-pointers-
+-VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
+-
+ #include <algorithm>
+ #include <cmath>
+ #include <iomanip>
+@@ -4498,6 +4500,12 @@ static bool ggml_vk_instance_portability_enumeration_ext_available(const std::ve
+ static bool ggml_vk_instance_debug_utils_ext_available(const std::vector<vk::ExtensionProperties> & instance_extensions);
+ static bool ggml_vk_device_is_supported(const vk::PhysicalDevice & vkdev);
+ 
++static vk::detail::DispatchLoaderDynamic ggml_vk_default_dispatcher_instance;
++
++vk::detail::DispatchLoaderDynamic & ggml_vk_default_dispatcher() {
++    return ggml_vk_default_dispatcher_instance;
++}
++
+ static void ggml_vk_instance_init() {
+     if (vk_instance_initialized) {
+         return;
+@@ -4505,7 +4513,7 @@ static void ggml_vk_instance_init() {
+     VK_LOG_DEBUG("ggml_vk_instance_init()");
+ 
+     // See https://github.com/KhronosGroup/Vulkan-Hpp?tab=readme-ov-file#extensions--per-device-function-pointers-
+-    VULKAN_HPP_DEFAULT_DISPATCHER.init(vkGetInstanceProcAddr);
++    ggml_vk_default_dispatcher_instance.init(vkGetInstanceProcAddr);
+ 
+     uint32_t api_version = vk::enumerateInstanceVersion();
+ 

--- a/scripts/test_ports/vcpkg-ci-ggml/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-ggml/portfile.cmake
@@ -6,7 +6,6 @@ vcpkg_from_github(
     REF v0.9.1
     SHA512 c31aeaaba328cd217f34191f1ce87720bb34dc39dc036f2ba8c92710636706f5be2cfcf86dc8c38ec737b020908da0e136447de10e7d9e6db698c812e7d21ae3
     HEAD_REF master
-    PATCHES
 )
 
 vcpkg_cmake_configure(

--- a/scripts/test_ports/vcpkg-ci-llama-cpp/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-llama-cpp/project/CMakeLists.txt
@@ -13,9 +13,9 @@ pkg_check_modules(llama-cpp llama REQUIRED IMPORTED_TARGET)
 add_executable(test-pkconfig main.cxx)
 target_link_libraries(test-pkconfig PRIVATE PkgConfig::llama-cpp)
 
-# Vulkan on Android isn't really useful, but the build can succeed.
+# Picking Android to verify that ggml::ggml-vulkan can be used with apps
+# which instantiate VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE.
 if(ANDROID AND TARGET ggml::ggml-vulkan)
-    # Instantiates VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
     find_package(Vulkan REQUIRED)
     target_link_libraries(test-cmake PRIVATE Vulkan::Vulkan)
     target_compile_definitions(test-cmake PRIVATE VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)

--- a/scripts/test_ports/vcpkg-ci-llama-cpp/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-llama-cpp/project/CMakeLists.txt
@@ -12,3 +12,13 @@ pkg_check_modules(llama-cpp llama REQUIRED IMPORTED_TARGET)
 
 add_executable(test-pkconfig main.cxx)
 target_link_libraries(test-pkconfig PRIVATE PkgConfig::llama-cpp)
+
+# Vulkan on Android isn't really useful, but the build can succeed.
+if(ANDROID AND TARGET ggml::ggml-vulkan)
+    # Instantiates VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
+    find_package(Vulkan REQUIRED)
+    target_link_libraries(test-cmake PRIVATE Vulkan::Vulkan)
+    target_compile_definitions(test-cmake PRIVATE VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
+    target_link_libraries(test-pkconfig PRIVATE Vulkan::Vulkan)
+    target_compile_definitions(test-pkconfig PRIVATE VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
+endif()

--- a/scripts/test_ports/vcpkg-ci-llama-cpp/project/main.cxx
+++ b/scripts/test_ports/vcpkg-ci-llama-cpp/project/main.cxx
@@ -1,5 +1,7 @@
 #include <llama.h>
 
+// Verify that ggml::ggml-vulkan can be used with apps which
+// instantiate VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE.
 #if defined(VULKAN_HPP_DISPATCH_LOADER_DYNAMIC) && VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
 #include <vulkan/vulkan.hpp>
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE

--- a/scripts/test_ports/vcpkg-ci-whisper-cpp/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-whisper-cpp/project/CMakeLists.txt
@@ -12,13 +12,3 @@ pkg_check_modules(whisper-cpp whisper REQUIRED IMPORTED_TARGET)
 
 add_executable(test-pkconfig main.cxx)
 target_link_libraries(test-pkconfig PRIVATE PkgConfig::whisper-cpp)
-
-# Vulkan on Android isn't really useful, but the build can succeed.
-if(ANDROID AND TARGET ggml::ggml-vulkan)
-    # Instantiates VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
-    find_package(Vulkan REQUIRED)
-    target_link_libraries(test-cmake PRIVATE Vulkan::Vulkan)
-    target_compile_definitions(test-cmake PRIVATE VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
-    target_link_libraries(test-pkconfig PRIVATE Vulkan::Vulkan)
-    target_compile_definitions(test-pkconfig PRIVATE VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
-endif()

--- a/scripts/test_ports/vcpkg-ci-whisper-cpp/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-whisper-cpp/project/CMakeLists.txt
@@ -12,3 +12,13 @@ pkg_check_modules(whisper-cpp whisper REQUIRED IMPORTED_TARGET)
 
 add_executable(test-pkconfig main.cxx)
 target_link_libraries(test-pkconfig PRIVATE PkgConfig::whisper-cpp)
+
+# Vulkan on Android isn't really useful, but the build can succeed.
+if(ANDROID AND TARGET ggml::ggml-vulkan)
+    # Instantiates VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
+    find_package(Vulkan REQUIRED)
+    target_link_libraries(test-cmake PRIVATE Vulkan::Vulkan)
+    target_compile_definitions(test-cmake PRIVATE VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
+    target_link_libraries(test-pkconfig PRIVATE Vulkan::Vulkan)
+    target_compile_definitions(test-pkconfig PRIVATE VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
+endif()

--- a/scripts/test_ports/vcpkg-ci-whisper-cpp/project/main.cxx
+++ b/scripts/test_ports/vcpkg-ci-whisper-cpp/project/main.cxx
@@ -1,10 +1,5 @@
 #include <whisper.h>
 
-#if defined(VULKAN_HPP_DISPATCH_LOADER_DYNAMIC) && VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
-#include <vulkan/vulkan.hpp>
-VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
-#endif
-
 int main()
 {
     auto context_params = whisper_context_default_params();

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3262,7 +3262,7 @@
     },
     "ggml": {
       "baseline": "0.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ghc-filesystem": {
       "baseline": "1.5.14",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3261,8 +3261,8 @@
       "port-version": 9
     },
     "ggml": {
-      "baseline": "0.9.1",
-      "port-version": 1
+      "baseline": "0.9.3",
+      "port-version": 0
     },
     "ghc-filesystem": {
       "baseline": "1.5.14",

--- a/versions/g-/ggml.json
+++ b/versions/g-/ggml.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "526c58e8c0046e4f4e68bbd8b4cfa3b62eb2d5ca",
-      "version": "0.9.1",
-      "port-version": 1
+      "git-tree": "787d68f699c93cb7398e8be275c4649d2213f8b8",
+      "version": "0.9.3",
+      "port-version": 0
     },
     {
       "git-tree": "950d27949cf784074165b74fc14a45164774c2cc",

--- a/versions/g-/ggml.json
+++ b/versions/g-/ggml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "526c58e8c0046e4f4e68bbd8b4cfa3b62eb2d5ca",
+      "version": "0.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "950d27949cf784074165b74fc14a45164774c2cc",
       "version": "0.9.1",
       "port-version": 0


### PR DESCRIPTION
Don't let ggml lib own `vk` symbols. (Backport of https://github.com/ggml-org/llama.cpp/pull/16224.) Restore/keep one test for this property.
Amends #47464 (merged), #47459 (discussion).

Update ggml to 0.9.3.