### PR TITLE
[python3] Test features, add ncurses and readline dependencies

### DIFF
--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.12.9",
-  "port-version": 4,
+  "port-version": 5,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",
@@ -75,6 +75,10 @@
           "default-features": false
         },
         {
+          "name": "ncurses",
+          "platform": "!windows | mingw"
+        },
+        {
           "name": "openssl",
           "default-features": false
         },
@@ -90,8 +94,11 @@
       ]
     },
     "readline": {
-      "description": "Build with readline. Requires system readline to be installed",
-      "supports": "!windows"
+      "description": "Build with readline.",
+      "supports": "!windows",
+      "dependencies": [
+        "readline"
+      ]
     }
   }
 }

--- a/scripts/test_ports/vcpkg-ci-python3/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-python3/vcpkg.json
@@ -10,5 +10,28 @@
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "ci"
+  ],
+  "features": {
+    "ci": {
+      "description": "Test features in CI",
+      "dependencies": [
+        {
+          "name": "python3",
+          "features": [
+            {
+              "name": "extensions",
+              "platform": "!(windows & staticcrt)"
+            },
+            {
+              "name": "readline",
+              "platform": "!windows"
+            }
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7734,7 +7734,7 @@
     },
     "python3": {
       "baseline": "3.12.9",
-      "port-version": 4
+      "port-version": 5
     },
     "qca": {
       "baseline": "2.3.7",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "33345c50e8be6c01a7ba52ef551d02f068bf7827",
+      "version": "3.12.9",
+      "port-version": 5
+    },
+    {
       "git-tree": "df599d27a7b29b37e98297ed124445bf40b25728",
       "version": "3.12.9",
       "port-version": 4


### PR DESCRIPTION
Should fix installation order trouble for python3[extensions] with regard to (n)curses.