### PR TITLE
[opentelemetry-cpp-contrib-version] Update to 2025-09-25

### DIFF
--- a/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
@@ -4,9 +4,9 @@ function(clone_opentelemetry_cpp_contrib CONTRIB_SOURCE_PATH)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-telemetry/opentelemetry-cpp-contrib
-        REF 2297c4feed5a623e7b9cff84d4398495a20ee7d2
+        REF 9176445fccead4f356d56040372f090f218158c1
         HEAD_REF main
-        SHA512 88e42c215caa983d5eed78fd387fd8735f03fbc308e12fd2afcb61760ab399e31c17ea68ca2d69e4571f61bf1b965f67ff4058881c4ab3b0d86c33932bdf5663
+        SHA512 7e88efe814fa165f1391b02a5414f02ffd953ee817cd89521888a492c7ff0e7e0cdb099b93b94f95722f9247501c29319c254773f7c55635d325a1ad9a08e28e
     )
     set(${CONTRIB_SOURCE_PATH} ${SOURCE_PATH} CACHE INTERNAL "")
 endfunction()

--- a/ports/opentelemetry-cpp-contrib-version/vcpkg.json
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp-contrib-version",
-  "version-date": "2025-06-11",
+  "version-date": "2025-09-25",
   "description": "This port manages the opentelemetry-cpp-version that will be used for opentelemetry-cpp",
   "homepage": "https://github.com/open-telemetry/opentelemetry-cpp-contrib",
   "license": "Apache-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7145,7 +7145,7 @@
       "port-version": 1
     },
     "opentelemetry-cpp-contrib-version": {
-      "baseline": "2025-06-11",
+      "baseline": "2025-09-25",
       "port-version": 0
     },
     "opentracing": {

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4cbb4503c6329e518b2aa8e5815ecc9bf70fada6",
+      "version-date": "2025-09-25",
+      "port-version": 0
+    },
+    {
       "git-tree": "b37ecae3f6ecb13c8dfd6a89a833f92500a05e22",
       "version-date": "2025-06-11",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
