### PR TITLE
[librdkafka] update to 2.11.1

### DIFF
--- a/ports/librdkafka/fix_oauthbearer_check.patch
+++ b/ports/librdkafka/fix_oauthbearer_check.patch
@@ -1,0 +1,13 @@
+diff --git a/src/rdkafka_conf.c b/src/rdkafka_conf.c
+index 92f3cb5..c11cda9 100644
+--- a/src/rdkafka_conf.c
++++ b/src/rdkafka_conf.c
+@@ -56,7 +56,7 @@
+ #include <windows.h>
+ #endif
+ 
+-#ifdef WITH_OAUTHBEARER_OIDC
++#if WITH_OAUTHBEARER_OIDC
+ #include <curl/curl.h>
+ #endif
+ 

--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO confluentinc/librdkafka
     REF "v${VERSION}"
-    SHA512 82d96cc77905e203a0178e378c78192b41afdc8e16fafd80cc16464fde2dc089b918d4664fd58857b5c888cdd8c40ffabe58993e9a7c2e2ff3e4ac9496927826
+    SHA512 e0eba567605578dd681d536a25f92251ccbdfab1630133c36f1d0e4c97b126cce2ccc64276a9dff88df17a847f72c8d04686db63579e1f57e76b5bd87aa2f411
     HEAD_REF master
     PATCHES
         lz4.patch

--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         lz4.patch
+        # remove it when https://github.com/confluentinc/librdkafka/pull/5136 is merged
+        fix_oauthbearer_check.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" RDKAFKA_BUILD_STATIC)

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "librdkafka",
-  "version": "2.10.1",
+  "version": "2.11.1",
   "description": "The Apache Kafka C/C++ library",
   "homepage": "https://github.com/confluentinc/librdkafka",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5313,7 +5313,7 @@
       "port-version": 0
     },
     "librdkafka": {
-      "baseline": "2.10.1",
+      "baseline": "2.11.1",
       "port-version": 0
     },
     "libredwg": {

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7cfcb9953022b64ab415647b66ccc5fe6ed26593",
+      "git-tree": "9bf07715e5c78c2906ceaa751a413853e2f055d1",
       "version": "2.11.1",
       "port-version": 0
     },

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7cfcb9953022b64ab415647b66ccc5fe6ed26593",
+      "version": "2.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4760dedb8cf40707f2a638cb488d13c5fbe28409",
       "version": "2.10.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/confluentinc/librdkafka/releases/tag/v2.11.1
