### PR TITLE
[eigen3] use 3.4.1 tag

### DIFF
--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.com
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libeigen/eigen
-    REF cd7263e7f626e75c9210b74d2d6043a8c0519f1c # from 3.4 branch on Aug 18, 2025 (3.4.1-250818)
-    SHA512 dd3992bdc79bd9a04c71d2e6c767cfaf3f20a27b4a72abf0e9157b9712b83101bc4ffe188f4f48d045a33617ad2c7a882d1ea1579b4ce997e5f377be38b8906e
+    REF ${VERSION}
+    SHA512 8b82e6785eda1982fd8f2a8321b0fff144062eb78cac6b9d0c87cba374cfaa3f2bde33a34069b2871ae548ce681f5a7e1247918c5215d92ed4836614548a1936
     HEAD_REF master
 )
 

--- a/ports/eigen3/vcpkg.json
+++ b/ports/eigen3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "eigen3",
-  "version": "3.4.1-250818",
-  "port-version": 1,
+  "version": "3.4.1",
   "description": "C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.",
   "homepage": "http://eigen.tuxfamily.org",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2677,8 +2677,8 @@
       "port-version": 0
     },
     "eigen3": {
-      "baseline": "3.4.1-250818",
-      "port-version": 1
+      "baseline": "3.4.1",
+      "port-version": 0
     },
     "eipscanner": {
       "baseline": "1.3.0",

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86e81b275f5e8d1643d5204b1f5edaf7bfcbde5b",
+      "version": "3.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a57c5626217c9da254311b5856216d52bfa2acc",
       "version": "3.4.1-250818",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Currently, vcpkg lists a recent commit from the [`3.4`](https://gitlab.com/libeigen/eigen/-/tree/3.4?ref_type=heads) upstream branch as `3.4.1-250818`. Now there is a `3.4.1` tag upstream, which can be used instead. (For reference, the PR which introduced that commit here: https://github.com/microsoft/vcpkg/pull/34542)
There are no functional changes between the currently listed commit in vcpkg and the new tag, all 4 new commits are CI related, see [the full diff](https://gitlab.com/libeigen/eigen/-/compare/cd7263e7f626e75c9210b74d2d6043a8c0519f1c...3.4.1?from_project_id=15462818). But it is certainly good to list an official tag instead of some close-by commit.
