### PR TITLE
[units] update to 3.1.1

### DIFF
--- a/ports/units/portfile.cmake
+++ b/ports/units/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nholthaus/units
     REF v${VERSION}
-    SHA512 2280782fe020fb60fe16f304105de73b30fa51c36e075bfa9b4d0c9d585936084802dd8cca6b1967ad10c7ad949afce27937050184151c2a67f2113f14c38c1b
+    SHA512 75014265c1c327a95638ca4ae10021f6e5218db1c932bac222c50b8dfe14a3135eb360083491a3437fafd10b621d8b0ff82213602d905bc5244bbe24dd915a14
 )
 
 set(VCPKG_BUILD_TYPE "release")
@@ -10,7 +10,7 @@ set(VCPKG_BUILD_TYPE "release")
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBUILD_TESTS=OFF
+        -DUNITS_BUILD_TESTS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/units/vcpkg.json
+++ b/ports/units/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "units",
-  "version": "2.3.4",
+  "version": "3.1.1",
   "description": "A compile-time, header-only, dimensional analysis and unit conversion library built on c++14 with no dependencies.",
   "homepage": "https://github.com/nholthaus/units",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9881,7 +9881,7 @@
       "port-version": 0
     },
     "units": {
-      "baseline": "2.3.4",
+      "baseline": "3.1.1",
       "port-version": 0
     },
     "unittest-cpp": {

--- a/versions/u-/units.json
+++ b/versions/u-/units.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c2ec62f4e79abcf97bfb48f4833f965d167b3baa",
+      "version": "3.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c81b8837750b2d638f5c12ffa2d5fa8acbefa025",
       "version": "2.3.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/nholthaus/units/releases/tag/v3.1.1
