### PR TITLE
[sqlpp23] Add new port

### DIFF
--- a/ports/sqlpp23/fix-findpackage.patch
+++ b/ports/sqlpp23/fix-findpackage.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4cf2640d..98bf50de 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,11 +47,11 @@ set(SQLPP23_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/Sqlpp23 CACHE STRING
+ 
+ ### Dependencies
+ if(DEPENDENCY_CHECK AND BUILD_MYSQL_CONNECTOR)
+-    find_package(MySQL REQUIRED)
++    find_package(unofficial-libmysql REQUIRED)
+ endif()
+ 
+ if(DEPENDENCY_CHECK AND BUILD_MARIADB_CONNECTOR)
+-    find_package(MariaDB REQUIRED)
++    find_package(unofficial-libmariadb CONFIG REQUIRED)
+ endif()
+ 
+ if(DEPENDENCY_CHECK AND BUILD_POSTGRESQL_CONNECTOR)
+@@ -59,11 +59,11 @@ if(DEPENDENCY_CHECK AND BUILD_POSTGRESQL_CONNECTOR)
+ endif()
+ 
+ if(DEPENDENCY_CHECK AND BUILD_SQLITE3_CONNECTOR)
+-    find_package(SQLite3 REQUIRED)
++    find_package(unofficial-sqlite3 CONFIG REQUIRED)
+ endif()
+ 
+ if(DEPENDENCY_CHECK AND BUILD_SQLCIPHER_CONNECTOR)
+-    find_package(SQLCipher REQUIRED)
++    find_package(SQLCipher CONFIG REQUIRED)
+ endif()
+ 
+ ### Core targets

--- a/ports/sqlpp23/portfile.cmake
+++ b/ports/sqlpp23/portfile.cmake
@@ -34,5 +34,6 @@ vcpkg_cmake_config_fixup(
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE" "${SOURCE_PATH}/CREDITS")

--- a/ports/sqlpp23/portfile.cmake
+++ b/ports/sqlpp23/portfile.cmake
@@ -1,0 +1,38 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO rbock/sqlpp23
+    REF ${VERSION}
+    SHA512 6dd077289c8743d6aa1907642cbe255ebe93339cadf4aab6062b1c592f37c4ff1e7e62c5c3c5121f4550144411f514786858251680cf6fb3f2118e6d3f12ed7f
+    HEAD_REF main
+    PATCHES
+        fix-findpackage.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        mysql BUILD_MYSQL_CONNECTOR
+	mariadb BUILD_MARIADB_CONNECTOR
+	postgres BUILD_POSTGRESQL_CONNECTOR
+	sqlite3 BUILD_SQLITE3_CONNECTOR
+	sqlcipher BUILD_SQLCIPHER_CONNECTOR
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+	-DBUILD_WITH_MODULES=OFF
+	-DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+	CONFIG_PATH "lib/cmake/Sqlpp23/"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE" "${SOURCE_PATH}/CREDITS")

--- a/ports/sqlpp23/vcpkg.json
+++ b/ports/sqlpp23/vcpkg.json
@@ -1,0 +1,48 @@
+{
+  "name": "sqlpp23",
+  "version": "0.67",
+  "description": "A type safe SQL library for C++",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "mariadb": {
+      "description": "Build with MariaDB connection",
+      "dependencies": [
+        "libmariadb"
+      ]
+    },
+    "mysql": {
+      "description": "Build with MySQL connection",
+      "dependencies": [
+        "libmysql"
+      ]
+    },
+    "postgres": {
+      "description": "Build postgres connection",
+      "dependencies": [
+        "libpq"
+      ]
+    },
+    "sqlcipher": {
+      "description": "Build with sqlcipher connection",
+      "dependencies": [
+        "sqlcipher"
+      ]
+    },
+    "sqlite3": {
+      "description": "Build with sqlite3 connection",
+      "dependencies": [
+        "sqlite3"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9204,6 +9204,10 @@
       "baseline": "0.61",
       "port-version": 0
     },
+    "sqlpp23": {
+      "baseline": "0.67",
+      "port-version": 0
+    },
     "squirrel": {
       "baseline": "2021-09-17",
       "port-version": 0

--- a/versions/s-/sqlpp23.json
+++ b/versions/s-/sqlpp23.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "437caad2fb2f1329f65a0df4bc8855ecb9d6b5c6",
+      "git-tree": "38701fe64c0b2ea30005cd21730602d714156808",
       "version": "0.67",
       "port-version": 0
     }

--- a/versions/s-/sqlpp23.json
+++ b/versions/s-/sqlpp23.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "437caad2fb2f1329f65a0df4bc8855ecb9d6b5c6",
+      "version": "0.67",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Closes #46712 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
