### PR TITLE
[sugar-proto] Add new port (depended protobuf, vcpkg-cmake, vcpkg-cmake-config)

### DIFF
--- a/ports/sugar-proto/portfile.cmake
+++ b/ports/sugar-proto/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO illegal-instruction-co/sugar-proto
+    REF v1.0.0
+    SHA512 eb36ed530bf7b78049489857785e310f8168a77506eb9f7cc53a3ca4b20f8b6c74dd4ddba2f25722489c7f8e008b6f2fe93f96aa7dc024b1f666a7ce7a0871a4
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sugar-proto)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+vcpkg_copy_pdbs()

--- a/ports/sugar-proto/vcpkg.json
+++ b/ports/sugar-proto/vcpkg.json
@@ -1,7 +1,18 @@
 {
   "name": "sugar-proto",
   "version": "1.0.0",
-  "description": "C++ sugar wrapper for protobuf",
+  "description": "C++ sugar wrapper for Google Protobuf",
   "homepage": "https://github.com/illegal-instruction-co/sugar-proto",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": [
+    "protobuf",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/sugar-proto/vcpkg.json
+++ b/ports/sugar-proto/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "sugar-proto",
+  "version": "1.0.0",
+  "description": "C++ sugar wrapper for protobuf",
+  "homepage": "https://github.com/illegal-instruction-co/sugar-proto",
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
**Describe the pull request**

This PR adds a new port: [sugar-proto](https://github.com/illegal-instruction-co/sugar-proto).

- Version: 1.0.0
- License: Apache-2.0
- Description: C++ sugar wrapper for Google Protobuf
- Depends on: protobuf, vcpkg-cmake, vcpkg-cmake-config

**Tested configurations**
- x64-linux
- CMake 3.16+
- GCC 13.3.0 (Ubuntu 24.04)

**Additional information**
- The port installs the `protoc-gen-sugar` binary (Protobuf compiler plugin).
- Headers are installed to `${CURRENT_PACKAGES_DIR}/include/sugar`.
- CMake package config files are installed to `${CURRENT_PACKAGES_DIR}/share/sugar-proto`.