### PR TITLE
[magic-args] add new port

### DIFF
--- a/ports/magic-args/portfile.cmake
+++ b/ports/magic-args/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO fredemmott/magic_args
+    REF "v${VERSION}"
+    SHA512 ed89bf1d834ed5c053c436387604cbd27387cf014fc2de969bf557522fb47da8b6b599c9607694f9b99d5f829133683e524ae23ac909c9064e509e7b8b0056c2
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DBUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME magic_args CONFIG_PATH lib/cmake/magic_args)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/magic-args/vcpkg.json
+++ b/ports/magic-args/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "magic-args",
+  "version": "0.2.1",
+  "description": "Ease-of-use-first argument parsing for C++23",
+  "homepage": "https://github.com/fredemmott/magic_args",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6056,6 +6056,10 @@
       "baseline": "1.6.0",
       "port-version": 0
     },
+    "magic-args": {
+      "baseline": "0.2.1",
+      "port-version": 0
+    },
     "magic-enum": {
       "baseline": "0.9.7",
       "port-version": 1

--- a/versions/m-/magic-args.json
+++ b/versions/m-/magic-args.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "46424a15cb7b02332bda811812acb4fddb6668ac",
+      "version": "0.2.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/fredemmott/magic_args/

Retry https://github.com/microsoft/vcpkg/pull/46128.
Upstream has been updated.

Packaging is ready. [ref](https://github.com/fredemmott/magic_args/issues/17)
