### PR TITLE
Update cppslippi to 1.4.3.18

### DIFF
--- a/ports/cppslippi/portfile.cmake
+++ b/ports/cppslippi/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            cppslippi
     FILENAME        "CppSlippi-${VERSION}.zip"
-    SHA512          3857e96f693daa25a9b753884b4f4bd2511d5c3b47fd52045553f007483dfdaeebe1a4e17052694eb4d81bd6d0e580872d2c22d3ba3bbf483322d10bbc8944ca
+    SHA512          8bd20b485ce15fbd184d48dd8f58d20d448ea081efd97ae613cbb78a8c9fa0b8f9b643b16a6e25317e9582b86a968eac2ec1ee6b6b6749b8cc79a8b9a9f6de9b
     NO_REMOVE_ONE_LEVEL
 )
 

--- a/ports/cppslippi/vcpkg.json
+++ b/ports/cppslippi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppslippi",
-  "version": "1.4.3.16",
+  "version": "1.4.3.18",
   "description": "C++ Slippi replay file parser.",
   "homepage": "https://sourceforge.net/projects/cppslippi/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2089,7 +2089,7 @@
       "port-version": 3
     },
     "cppslippi": {
-      "baseline": "1.4.3.16",
+      "baseline": "1.4.3.18",
       "port-version": 0
     },
     "cpptoml": {

--- a/versions/c-/cppslippi.json
+++ b/versions/c-/cppslippi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23c843204961410d36f7c7948c4bd0bdc2829117",
+      "version": "1.4.3.18",
+      "port-version": 0
+    },
+    {
       "git-tree": "6e6b71494ea0da4bc14b4078698bec25a28630e0",
       "version": "1.4.3.16",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
