### PR TITLE
[opentelemetry-cpp] update to 1.23.0

### DIFF
--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-telemetry/opentelemetry-cpp
     REF "v${VERSION}"
-    SHA512 a85869d2858f350e4a3b85e5d68e669a5fff42a2222ba7782bba92f5fe6856a110b3ddc9744a6c3e68c1ddfdc7bdb2b570bbeff78275a4e98cea889a8fda0120
+    SHA512 6dc0357d8b3410852d3f970f72b8bec59dba9d6c533ca600432102e65de161903bd9170d98cef7ff0af5191309577ffd2a69ccd004b840914a910a6a282204e4
     HEAD_REF main
     PATCHES
         fix-target_link.patch

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
-  "version-semver": "1.22.0",
-  "port-version": 1,
+  "version-semver": "1.23.0",
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7145,8 +7145,8 @@
       "port-version": 3
     },
     "opentelemetry-cpp": {
-      "baseline": "1.22.0",
-      "port-version": 1
+      "baseline": "1.23.0",
+      "port-version": 0
     },
     "opentelemetry-cpp-contrib-version": {
       "baseline": "2025-09-25",

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b81db5688f034b68139fa0e5dac22b434d35c54b",
+      "version-semver": "1.23.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "efa7bd528dbdffb93654882b1aacd3a99e9796a5",
       "version-semver": "1.22.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.23.0
