### PR TITLE
[skia,dawn] Fix support for BSDs

### DIFF
--- a/ports/dawn/005-bsd-support.patch
+++ b/ports/dawn/005-bsd-support.patch
@@ -1,0 +1,42 @@
+diff --git a/include/dawn/native/VulkanBackend.h b/include/dawn/native/VulkanBackend.h
+index 201bc324..3221ad2e 100644
+--- a/include/dawn/native/VulkanBackend.h
++++ b/include/dawn/native/VulkanBackend.h
+@@ -83,7 +83,7 @@ struct ExternalImageExportInfoVk : ExternalImageExportInfo {
+ };
+ 
+ // Can't use DAWN_PLATFORM_IS(LINUX) since header included in both Dawn and Chrome
+-#if defined(__linux__) || defined(__Fuchsia__)
++#if defined(__linux__) || defined(__Fuchsia__) || defined(__OpenBSD__) || defined(__FreeBSD__)
+ 
+ // Common properties of external images represented by FDs. On successful import the file
+ // descriptor's ownership is transferred to the Dawn implementation and they shouldn't be
+diff --git a/src/dawn/common/Platform.h b/src/dawn/common/Platform.h
+index b4ac6100..cbc5c7b8 100644
+--- a/src/dawn/common/Platform.h
++++ b/src/dawn/common/Platform.h
+@@ -60,6 +60,11 @@
+ #error "Unsupported Windows platform."
+ #endif
+ 
++#elif defined(__OpenBSD__) || defined(__FreeBSD__)
++#define DAWN_PLATFORM_IS_LINUX 1
++#define DAWN_PLATFORM_IS_BSD 1
++#define DAWN_PLATFORM_IS_POSIX 1
++
+ #elif defined(__linux__)
+ #define DAWN_PLATFORM_IS_LINUX 1
+ #define DAWN_PLATFORM_IS_POSIX 1
+diff --git a/src/dawn/native/vulkan/BackendVk.cpp b/src/dawn/native/vulkan/BackendVk.cpp
+index 058cbecc..9bae2d27 100644
+--- a/src/dawn/native/vulkan/BackendVk.cpp
++++ b/src/dawn/native/vulkan/BackendVk.cpp
+@@ -56,7 +56,7 @@ constexpr char kSwiftshaderLibName[] = "libvk_swiftshader.dylib";
+ #endif
+ 
+ #if DAWN_PLATFORM_IS(LINUX)
+-#if DAWN_PLATFORM_IS(ANDROID)
++#if DAWN_PLATFORM_IS(ANDROID) || DAWN_PLATFORM_IS(BSD)
+ constexpr char kVulkanLibName[] = "libvulkan.so";
+ #else
+ constexpr char kVulkanLibName[] = "libvulkan.so.1";

--- a/ports/dawn/006-fix-x11-include-dirs.patch
+++ b/ports/dawn/006-fix-x11-include-dirs.patch
@@ -1,0 +1,23 @@
+diff --git a/src/dawn/native/CMakeLists.txt b/src/dawn/native/CMakeLists.txt
+index 72b92fc8..a1c6016c 100644
+--- a/src/dawn/native/CMakeLists.txt
++++ b/src/dawn/native/CMakeLists.txt
+@@ -926,6 +926,7 @@ if(BUILD_SHARED_LIBS)
+ endif()
+ 
+ if (DAWN_USE_X11)
++    target_include_directories(dawn_native_objects PRIVATE ${X11_INCLUDE_DIR})
+     target_include_directories(dawn_native PRIVATE ${X11_INCLUDE_DIR})
+ endif()
+ 
+@@ -999,6 +1000,10 @@ if (DAWN_BUILD_MONOLITHIC_LIBRARY)
+         )
+     endif()
+ 
++    if (DAWN_USE_X11)
++        target_include_directories(webgpu_dawn_objects PRIVATE ${X11_INCLUDE_DIR})
++    endif()
++
+     # Do the bundling of all the objects and dependencies together.
+     include(BundleLibraries)
+     bundle_libraries(webgpu_dawn ${DAWN_BUILD_MONOLITHIC_LIBRARY} webgpu_dawn_objects)

--- a/ports/dawn/portfile.cmake
+++ b/ports/dawn/portfile.cmake
@@ -37,6 +37,8 @@ vcpkg_from_github(
         002-fix-uwp.patch
         003-fix-d3d11.patch
         004-deps.patch
+        005-bsd-support.patch
+        006-fix-x11-include-dirs.patch
 )
 
 # vcpkg_find_acquire_program(PYTHON3)

--- a/ports/dawn/vcpkg.json
+++ b/ports/dawn/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dawn",
   "version": "20250922.223923",
+  "port-version": 1,
   "description": "Dawn is an open-source and cross-platform implementation of the WebGPU standard.",
   "homepage": "https://dawn.googlesource.com/dawn",
   "license": "BSD-3-Clause",

--- a/ports/skia/allow-disabling-lib-dl.patch
+++ b/ports/skia/allow-disabling-lib-dl.patch
@@ -1,0 +1,28 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index 306bfffaf8..1632feccd4 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -1740,7 +1740,9 @@ skia_component("skia") {
+     if (is_ios) {
+       sources += [ "src/ports/SkOSFile_ios.h" ]
+     }
+-    libs += [ "dl" ]
++    if (skia_vcpkg_has_lib_dl) {
++      libs += [ "dl" ]
++    }
+   }
+ 
+   if (is_android) {
+diff --git a/gn/skia.gni b/gn/skia.gni
+index bea9cd832a..56a2125ea9 100644
+--- a/gn/skia.gni
++++ b/gn/skia.gni
+@@ -105,6 +105,8 @@ declare_args() {
+   }
+ 
+   skia_build_rust_targets = false
++
++  skia_vcpkg_has_lib_dl = true
+ }
+ 
+ declare_args() {

--- a/ports/skia/dont-use-response-file.patch
+++ b/ports/skia/dont-use-response-file.patch
@@ -1,0 +1,13 @@
+diff --git a/gn/toolchain/BUILD.gn b/gn/toolchain/BUILD.gn
+index 8eace39..67d7b00 100644
+--- a/gn/toolchain/BUILD.gn
++++ b/gn/toolchain/BUILD.gn
+@@ -305,7 +305,7 @@ template("gcc_like_toolchain") {
+         rspfile = "{{output}}.rsp"
+         rspfile_content = "{{inputs}}"
+         rm_py = rebase_path("../rm.py")
+-        command = "$shell python3 \"$rm_py\" \"{{output}}\" && $ar rcs {{output}} @$rspfile"
++        command = "$shell python3 \"$rm_py\" \"{{output}}\" && $ar rcs {{output}} `cat $rspfile`"
+       }
+ 
+       outputs =

--- a/ports/skia/fix-openbsd.patch
+++ b/ports/skia/fix-openbsd.patch
@@ -1,0 +1,35 @@
+diff --git a/src/ports/SkMemory_malloc.cpp b/src/ports/SkMemory_malloc.cpp
+index d784af53ef..df1eee3ff9 100644
+--- a/src/ports/SkMemory_malloc.cpp
++++ b/src/ports/SkMemory_malloc.cpp
+@@ -15,7 +15,7 @@
+ 
+ #if defined(SK_BUILD_FOR_MAC) || defined(SK_BUILD_FOR_IOS)
+ #include <malloc/malloc.h>
+-#elif defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_UNIX)
++#elif defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_UNIX) && !defined(__OpenBSD__)
+ #include <malloc.h>
+ #elif defined(SK_BUILD_FOR_WIN)
+ #include <malloc.h>
+@@ -126,7 +126,7 @@ size_t sk_malloc_size(void* addr, size_t size) {
+     #elif defined(SK_BUILD_FOR_ANDROID) && __ANDROID_API__ >= 17
+         completeSize = malloc_usable_size(addr);
+         SkASSERT(completeSize >= size);
+-    #elif defined(SK_BUILD_FOR_UNIX)
++    #elif defined(SK_BUILD_FOR_UNIX) && !defined(__OpenBSD__)
+         completeSize = malloc_usable_size(addr);
+         SkASSERT(completeSize >= size);
+     #elif defined(SK_BUILD_FOR_WIN)
+diff --git a/src/ports/SkOSFile_posix.cpp b/src/ports/SkOSFile_posix.cpp
+index 1be1330790..8af0a6d6a7 100644
+--- a/src/ports/SkOSFile_posix.cpp
++++ b/src/ports/SkOSFile_posix.cpp
+@@ -25,7 +25,7 @@
+ #endif
+ 
+ void sk_fsync(FILE* f) {
+-#if !defined(SK_BUILD_FOR_ANDROID) && !defined(__UCLIBC__) && !defined(_NEWLIB_VERSION)
++#if !defined(SK_BUILD_FOR_ANDROID) && !defined(__UCLIBC__) && !defined(_NEWLIB_VERSION) && !defined(__OpenBSD__)
+     int fd = fileno(f);
+     fsync(fd);
+ #endif

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_from_github(
         skparagraph-dllexport.patch
         dawn.patch
         use-pkgconfig-to-find-gl.patch
+        dont-use-response-file.patch
+        fix-openbsd.patch
+        allow-disabling-lib-dl.patch
 )
 
 # De-vendor
@@ -124,12 +127,20 @@ elseif(VCPKG_TARGET_IS_WINDOWS)
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
         string(APPEND OPTIONS " skia_enable_bentleyottmann=false")
     endif()
+elseif(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_FREEBSD OR VCPKG_TARGET_IS_OPENBSD)
+    string(APPEND OPTIONS " target_os=\"linux\"")
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     string(APPEND OPTIONS " is_component_build=true")
 else()
     string(APPEND OPTIONS " is_component_build=false")
+endif()
+
+if (VCPKG_TARGET_IS_OPENBSD)
+    string(APPEND OPTIONS " skia_vcpkg_has_lib_dl=false")
+else()
+    string(APPEND OPTIONS " skia_vcpkg_has_lib_dl=true")
 endif()
 
 set(required_externals

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -131,7 +131,6 @@ else()
 endif()
 
 set(required_externals
-    dng_sdk
     expat
     libjpeg
     libpng
@@ -140,6 +139,13 @@ set(required_externals
     zlib
     wuffs
 )
+
+if("dng" IN_LIST FEATURES)
+    list(APPEND required_externals dng_sdk)
+    string(APPEND OPTIONS " skia_use_dng_sdk=true")
+else()
+    string(APPEND OPTIONS " skia_use_dng_sdk=false")
+endif()
 
 if("fontconfig" IN_LIST FEATURES)
     list(APPEND required_externals fontconfig)

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
         pdfsubsetfont-uwp.diff
         skparagraph-dllexport.patch
         dawn.patch
+        use-pkgconfig-to-find-gl.patch
 )
 
 # De-vendor
@@ -80,6 +81,7 @@ declare_external_from_git(wuffs
 declare_external_from_pkgconfig(expat)
 declare_external_from_pkgconfig(fontconfig PATH "third_party")
 declare_external_from_pkgconfig(freetype2)
+declare_external_from_pkgconfig(gl)
 declare_external_from_pkgconfig(harfbuzz MODULES harfbuzz harfbuzz-subset)
 declare_external_from_pkgconfig(icu MODULES icu-uc)
 declare_external_from_pkgconfig(libjpeg PATH "third_party/libjpeg-turbo" MODULES libturbojpeg libjpeg)
@@ -179,6 +181,9 @@ else()
 endif()
 
 if("gl" IN_LIST FEATURES)
+    if (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_FREEBSD OR VCPKG_TARGET_IS_OPENBSD)
+        list(APPEND required_externals gl)
+    endif()
     string(APPEND OPTIONS " skia_use_gl=true")
 else()
     string(APPEND OPTIONS " skia_use_gl=false")

--- a/ports/skia/use-pkgconfig-to-find-gl.patch
+++ b/ports/skia/use-pkgconfig-to-find-gl.patch
@@ -1,0 +1,15 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index ce41442..9a90d00 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -1007,7 +1007,9 @@ optional("gpu") {
+         "src/gpu/ganesh/gl/glx/GrGLMakeGLXInterface.cpp",
+         "src/gpu/ganesh/gl/glx/GrGLMakeNativeInterface_glx.cpp",
+       ]
+-      libs += [ "GL" ]
++      deps += [
++        "//third_party/gl"
++      ]
+     } else if (is_mac) {
+       sources += [ "src/gpu/ganesh/gl/mac/GrGLMakeNativeInterface_mac.cpp" ]
+     } else if (is_ios) {

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -7,7 +7,7 @@
     "Skia is sponsored and managed by Google, but is available for use by anyone under the BSD Free Software License. While engineering of the core components is done by the Skia development team, we consider contributions from any source."
   ],
   "homepage": "https://skia.org",
-  "license": null,
+  "license": "BSD-3-Clause",
   "supports": "!(windows & arm32) & !mingw",
   "dependencies": [
     "expat",

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "skia",
   "version": "140",
+  "port-version": 1,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",
@@ -52,7 +53,7 @@
     },
     {
       "name": "fontconfig",
-      "platform": "linux"
+      "platform": "linux | freebsd | openbsd"
     },
     {
       "name": "freetype",
@@ -78,15 +79,15 @@
       "dependencies": [
         {
           "name": "dawn",
+          "platform": "osx | windows"
+        },
+        {
+          "name": "dawn",
           "default-features": false,
           "features": [
             "x11"
           ],
-          "platform": "linux"
-        },
-        {
-          "name": "dawn",
-          "platform": "osx | windows"
+          "platform": "linux | freebsd | openbsd"
         },
         {
           "name": "skia",

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -47,6 +47,10 @@
       "platform": "uwp"
     },
     {
+      "name": "dng",
+      "platform": "!(freebsd | openbsd)"
+    },
+    {
       "name": "fontconfig",
       "platform": "linux"
     },
@@ -96,6 +100,10 @@
     "direct3d": {
       "description": "Direct3D support for skia",
       "supports": "windows"
+    },
+    "dng": {
+      "description": "Support for DNG files",
+      "supports": "!(freebsd | openbsd)"
     },
     "fontconfig": {
       "description": "Fontconfig support",

--- a/scripts/test_ports/vcpkg-ci-dawn/project/webgpu_glfw3.cpp
+++ b/scripts/test_ports/vcpkg-ci-dawn/project/webgpu_glfw3.cpp
@@ -17,7 +17,7 @@
 #define GLFW_EXPOSE_NATIVE_COCOA
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #define DAWN_USE_X11
 #endif
 

--- a/scripts/test_ports/vcpkg-ci-dawn/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-dawn/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-ci-dawn",
-  "version-date": "2025-08-23",
+  "version-date": "2025-09-28",
   "description": "Validates dawn",
   "license": null,
   "supports": "!uwp & !android & !ios",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8958,7 +8958,7 @@
     },
     "skia": {
       "baseline": "140",
-      "port-version": 0
+      "port-version": 1
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2350,7 +2350,7 @@
     },
     "dawn": {
       "baseline": "20250922.223923",
-      "port-version": 0
+      "port-version": 1
     },
     "daxa": {
       "baseline": "3.0.3",

--- a/versions/d-/dawn.json
+++ b/versions/d-/dawn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "30d007ed4c6ff01de4e3e45d923d26673ac6916a",
+      "version": "20250922.223923",
+      "port-version": 1
+    },
+    {
       "git-tree": "ab06b79e17bffaf06a5373b6750ef33388793d65",
       "version": "20250922.223923",
       "port-version": 0

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a175473c2c239039081f87398bf806da330a693e",
+      "version": "140",
+      "port-version": 1
+    },
+    {
       "git-tree": "f51c683b289d76716471f84250e0a7831aa27797",
       "version": "140",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
