### PR TITLE
[gmp] Fix builds for x64-linux

### DIFF
--- a/ports/gmp/c23.patch
+++ b/ports/gmp/c23.patch
@@ -1,0 +1,37 @@
+diff --git a/acinclude.m4 b/acinclude.m4
+index e84c5c785..8e7bb4ae7 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -564,23 +564,6 @@
+ }
+ ])
+ 
+-# __builtin_alloca is not available everywhere, check it exists before
+-# seeing that it works
+-GMP_PROG_CC_WORKS_PART_TEST([$1],[__builtin_alloca availability],
+-[int k; int foo () { __builtin_alloca (k); }],
+-  [GMP_PROG_CC_WORKS_PART([$1], [alloca array],
+-[/* The following provokes an internal compiler error from Itanium HP-UX cc
+-    under +O2 or higher.  We use this sort of code in mpn/generic/mul_fft.c. */
+-int k;
+-int foo ()
+-{
+-  int i, **a;
+-  a = __builtin_alloca (k);
+-  for (i = 0; i <= k; i++)
+-    a[i] = __builtin_alloca (1 << i);
+-}
+-])])
+-
+ GMP_PROG_CC_WORKS_PART([$1], [abs int -> double conversion],
+ [/* The following provokes an internal error from the assembler on
+    power2-ibm-aix4.3.1.0.  gcc -mrios2 compiles to nabs+fcirz, and this
+@@ -609,7 +609,7 @@
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}

--- a/ports/gmp/portfile.cmake
+++ b/ports/gmp/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
         msvc_symbol.patch
         arm64-coff.patch
         remove_compiler_info.patch
+        c23.patch
 )
 
 vcpkg_list(SET OPTIONS)

--- a/ports/gmp/vcpkg.json
+++ b/ports/gmp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gmp",
   "version": "6.3.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The GNU Multiple Precision Arithmetic Library",
   "homepage": "https://gmplib.org",
   "license": "LGPL-3.0-only OR GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3374,7 +3374,7 @@
     },
     "gmp": {
       "baseline": "6.3.0",
-      "port-version": 2
+      "port-version": 3
     },
     "gmsh": {
       "baseline": "4.14.0",

--- a/versions/g-/gmp.json
+++ b/versions/g-/gmp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b979ff042700c317cb1ae4f2471e00bcfcf7d82",
+      "version": "6.3.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "d9ef9fbb509e23fcb49f567f3c383ca3fd37e2c0",
       "version": "6.3.0",
       "port-version": 2


### PR DESCRIPTION
Fixes #47536

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This pull request merges the following two commits from the GMP upstream repository:
- **Complete function prototype in acinclude.m4 for C23 compatibility**: https://gmplib.org/repo/gmp/rev/8e7bb4ae7a18
- **Remove broken __builtin_alloca configure test**: https://gmplib.org/repo/gmp/rev/1dc7d5dabc8d

These two revisions are necessary for producing a proper configure on x64-linux, but have yet to be part of a release tarball which vcpkg can download from. Therefore, this pull request includes a pre-install patch that applies them. 
