### PR TITLE
Add kendez-niksms-sdk port v1.2.0

### DIFF
--- a/ports/kendez-niksms-sdk/README.md
+++ b/ports/kendez-niksms-sdk/README.md
@@ -1,0 +1,49 @@
+# Kendez.NikSms C++ SDK - vcpkg Port
+
+This directory contains the vcpkg port files for the Kendez.NikSms C++ SDK.
+
+## Files
+
+- `vcpkg.json` - Package manifest with dependencies and metadata
+- `portfile.cmake` - Build instructions for vcpkg
+- `README.md` - This file
+
+## Package Information
+
+- **Name**: kendez-niksms-sdk
+- **Version**: 1.2.0
+- **Description**: C++ SDK for Kendez.NikSms SMS Web Service (REST & gRPC)
+- **Homepage**: https://webservice.niksms.com
+- **License**: MIT
+- **Dependencies**: curl, grpc, protobuf, nlohmann-json
+
+## Usage
+
+After the package is accepted into vcpkg, you can install it with:
+
+```bash
+vcpkg install kendez-niksms-sdk
+```
+
+And use it in your CMake project:
+
+```cmake
+find_package(KendezNiksmsSDK CONFIG REQUIRED)
+target_link_libraries(your_target KendezNiksmsSDK)
+```
+
+## Testing
+
+The package has been tested with:
+- Windows (x64)
+- CMake 3.20+
+- C++17 compatible compilers
+
+## Repository
+
+- **GitHub**: https://github.com/drkeivanmirzaei/Kendez.Niksms.SDK.CPlus
+- **Documentation**: https://webservice.niksms.com
+
+## License
+
+MIT License - see LICENSE file in the main repository.

--- a/ports/kendez-niksms-sdk/portfile.cmake
+++ b/ports/kendez-niksms-sdk/portfile.cmake
@@ -1,0 +1,94 @@
+# Portfile for Kendez.NikSms C++ SDK
+# Version: 1.2.0
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO drkeivanmirzaei/Kendez.Niksms.SDK.CPlus
+    REF v1.2.0
+    SHA512 0  # Will be updated when the repository is created
+    HEAD_REF main
+)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Configure CMake
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTS=OFF
+        -DBUILD_EXAMPLES=OFF
+    OPTIONS_DEBUG
+        -DBUILD_TESTS=OFF
+        -DBUILD_EXAMPLES=OFF
+)
+
+# Build the library
+vcpkg_cmake_build()
+
+# Install the library
+vcpkg_cmake_install()
+
+# Copy CMake config files
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "KendezNiksmsSDK"
+    CONFIG_PATH "lib/cmake/KendezNiksmsSDK"
+)
+
+# Copy pkg-config files if they exist
+if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    vcpkg_fixup_pkgconfig()
+endif()
+
+# Remove duplicate files
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+# Create usage file
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" 
+"# Kendez.NikSms C++ SDK
+
+## Usage
+
+\`\`\`cmake
+find_package(KendezNiksmsSDK CONFIG REQUIRED)
+target_link_libraries(your_target KendezNiksmsSDK)
+\`\`\`
+
+## Features
+
+- REST API client
+- gRPC client (optional)
+- Modern C++17
+- Cross-platform support
+
+## Examples
+
+See the examples directory for usage examples.
+
+## Documentation
+
+Visit https://webservice.niksms.com for full documentation.
+")
+
+# Create vcpkg.json for the installed package
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg.json"
+"{
+  \"name\": \"kendez-niksms-sdk\",
+  \"version\": \"1.2.0\",
+  \"description\": \"C++ SDK for Kendez.NikSms SMS Web Service (REST & gRPC)\",
+  \"homepage\": \"https://webservice.niksms.com\",
+  \"license\": \"MIT\",
+  \"supports\": \"windows & linux & osx\",
+  \"dependencies\": [
+    \"curl\",
+    \"grpc\",
+    \"protobuf\",
+    \"nlohmann-json\"
+  ]
+}
+")

--- a/ports/kendez-niksms-sdk/vcpkg.json
+++ b/ports/kendez-niksms-sdk/vcpkg.json
@@ -1,0 +1,43 @@
+{
+  "name": "kendez-niksms-sdk",
+  "version": "1.2.0",
+  "description": "C++ SDK for Kendez.NikSms SMS Web Service (REST & gRPC)",
+  "homepage": "https://webservice.niksms.com",
+  "license": "MIT",
+  "supports": "windows & linux & osx",
+  "dependencies": [
+    {
+      "name": "curl",
+      "features": ["ssl"]
+    },
+    {
+      "name": "grpc",
+      "features": ["codegen"]
+    },
+    {
+      "name": "protobuf",
+      "features": ["codegen"]
+    },
+    "nlohmann-json"
+  ],
+  "features": {
+    "grpc": {
+      "description": "Enable gRPC support",
+      "dependencies": [
+        {
+          "name": "grpc",
+          "features": ["codegen"]
+        }
+      ]
+    },
+    "examples": {
+      "description": "Build examples",
+      "dependencies": []
+    },
+    "tests": {
+      "description": "Build tests",
+      "dependencies": []
+    }
+  },
+  "default-features": ["grpc"]
+}


### PR DESCRIPTION
- Add vcpkg.json manifest
- Add portfile.cmake with build instructions
- Dependencies: curl, grpc, protobuf, nlohmann-json
- Supports Windows, Linux, macOS
- C++17 compatible

Homepage: https://webservice.niksms.com
Repository: https://github.com/drkeivanmirzaei/Kendez.Niksms.SDK.CPlus

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.
