### PR TITLE
[qt5-tools] Move non-mandatory dependencies into features (#45351)

### DIFF
--- a/ports/kf5config/vcpkg.json
+++ b/ports/kf5config/vcpkg.json
@@ -1,11 +1,13 @@
 {
   "name": "kf5config",
   "version": "5.98.0",
+  "port-version": 1,
   "description": "Configuration system",
   "homepage": "https://api.kde.org/frameworks/kconfig/html/index.html",
   "dependencies": [
     "ecm",
     "qt5-base",
+    "qt5-declarative",
     "qt5-tools",
     {
       "name": "vcpkg-cmake",

--- a/ports/qt5-tools/vcpkg.json
+++ b/ports/qt5-tools/vcpkg.json
@@ -1,24 +1,28 @@
 {
   "name": "qt5-tools",
   "version": "5.15.17",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A collection of tools and utilities that come with the Qt framework to assist developers in the creation, management, and deployment of Qt applications.",
   "license": null,
   "dependencies": [
-    {
-      "name": "qt5-activeqt",
-      "platform": "windows"
-    },
     {
       "name": "qt5-base",
       "default-features": false,
       "features": [
         "sqlite3plugin"
       ]
-    },
-    "qt5-declarative"
+    }
   ],
   "features": {
+    "qaxwidget": {
+      "description": "Use QAxWidget in Qt Designer.",
+      "dependencies": [
+        {
+          "name": "qt5-activeqt",
+          "platform": "windows"
+        }
+      ]
+    },
     "qdoc": {
       "description": "Build the qdoc tool.",
       "dependencies": [
@@ -29,6 +33,12 @@
             "clang"
           ]
         }
+      ]
+    },
+    "qquickwidget": {
+      "description": "Use QQuickWidget in Qt Designer.",
+      "dependencies": [
+        "qt5-declarative"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7946,7 +7946,7 @@
     },
     "qt5-tools": {
       "baseline": "5.15.17",
-      "port-version": 1
+      "port-version": 2
     },
     "qt5-translations": {
       "baseline": "5.15.17",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4218,7 +4218,7 @@
     },
     "kf5config": {
       "baseline": "5.98.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5configwidgets": {
       "baseline": "5.98.0",

--- a/versions/k-/kf5config.json
+++ b/versions/k-/kf5config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3b5587687dc3f332c8a3ea23b761ff3b001e22e",
+      "version": "5.98.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "387976b6e5d8785f9edac7b406c5d8baf2194810",
       "version": "5.98.0",
       "port-version": 0

--- a/versions/q-/qt5-tools.json
+++ b/versions/q-/qt5-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c55a6fe173490c6411f6c379f7b98ae3cbd7b485",
+      "version": "5.15.17",
+      "port-version": 2
+    },
+    {
       "git-tree": "a7d073db6022de57bf6c0e24e53514e1f0624abf",
       "version": "5.15.17",
       "port-version": 1


### PR DESCRIPTION
Package: `qt5-tools`

The 2 dependencies `qt5-declarative` and `qt5-activeqt` are for using QQuickWidget and QAxWidget in Qt Designer, which should be considered additional features.

Changes:

Dependencies `qt5-declarative` and `qt5-activeqt` are now moved to "features".

Fixes #45351