### PR TITLE
[vcpkg baseline][ncurses][tvision] Fix ncurses include paths, add dependency

### DIFF
--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -74,13 +74,10 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
-file(GLOB pcfiles_release "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/*.pc")
-foreach(file IN LISTS pcfiles_release)
-    vcpkg_replace_string("${file}" [[ "-I${prefix}/include"]] "")
-endforeach()
-file(GLOB pcfiles_debug "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
-foreach(file IN LISTS pcfiles_debug)
-    vcpkg_replace_string("${file}" [[ "-I${prefix}/../include"]] "")
+# Prefer local files over search path
+file(GLOB headers "${CURRENT_PACKAGES_DIR}/include/ncursesw/*.h")
+foreach(file IN LISTS headers)
+    vcpkg_replace_string("${file}" [[#include <ncursesw/([^>]*)>]] [[#include "\1"]] REGEX IGNORE_UNCHANGED)
 endforeach()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ncurses",
   "version": "6.5",
+  "port-version": 1,
   "description": [
     "Free software emulation of curses in System V Release 4.0, and more.",
     "This port installs a wide character configuration (ncursesw)."

--- a/ports/tvision/find-curses.diff
+++ b/ports/tvision/find-curses.diff
@@ -1,5 +1,5 @@
 diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
-index d24f807..d652bee 100644
+index d24f807..e3ad262 100644
 --- a/source/CMakeLists.txt
 +++ b/source/CMakeLists.txt
 @@ -88,6 +88,7 @@ endif()
@@ -10,7 +10,7 @@ index d24f807..d652bee 100644
      # ncursesw
      find_library(NCURSESW ncursesw)
      if (NOT NCURSESW AND APPLE)
-@@ -125,6 +126,13 @@ if (NOT WIN32)
+@@ -125,6 +126,14 @@ if (NOT WIN32)
          tv_message(STATUS "Found 'tinfow': ${TINFOW}")
          target_link_libraries(${PROJECT_NAME} PUBLIC ${TINFOW})
      endif()
@@ -19,7 +19,8 @@ index d24f807..d652bee 100644
 +    set(CURSES_NEED_WIDE 1)
 +    find_package(Curses REQUIRED)
 +    target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_NCURSES)
-+    target_include_directories(${PROJECT_NAME} PRIVATE ${CURSES_INCLUDE_DIRS})
++    find_path(NCURSESW_INCLUDE NAMES "ncurses.h" PATHS ${CURSES_INCLUDE_DIRS} PATH_SUFFIXES "ncursesw")
++    target_include_directories(${PROJECT_NAME} PRIVATE ${NCURSESW_INCLUDE})
 +    target_link_libraries(${PROJECT_NAME} PUBLIC ${CURSES_LIBRARIES})
  
      # gpm

--- a/ports/tvision/find-curses.diff
+++ b/ports/tvision/find-curses.diff
@@ -1,0 +1,26 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index d24f807..d652bee 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -88,6 +88,7 @@ endif()
+ # Dependencies
+ 
+ if (NOT WIN32)
++#[[
+     # ncursesw
+     find_library(NCURSESW ncursesw)
+     if (NOT NCURSESW AND APPLE)
+@@ -125,6 +126,13 @@ if (NOT WIN32)
+         tv_message(STATUS "Found 'tinfow': ${TINFOW}")
+         target_link_libraries(${PROJECT_NAME} PUBLIC ${TINFOW})
+     endif()
++]]
++    set(CURSES_NEED_NCURSES 1)
++    set(CURSES_NEED_WIDE 1)
++    find_package(Curses REQUIRED)
++    target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_NCURSES)
++    target_include_directories(${PROJECT_NAME} PRIVATE ${CURSES_INCLUDE_DIRS})
++    target_link_libraries(${PROJECT_NAME} PUBLIC ${CURSES_LIBRARIES})
+ 
+     # gpm
+     if (TV_BUILD_USING_GPM)

--- a/ports/tvision/portfile.cmake
+++ b/ports/tvision/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 966226d643cd638fb516b621ac90a31f3ec8d1f6
     HEAD_REF master
     SHA512 b18a466cad2edebff62f6db6d5ab6b6b4d000fbc0fcc682f169efd9c0cc7efe5f0535ffa019f9dcb3d6e7931f77c476ec5d11aa7b39ed7ce0417ceec270f2d36
+    PATCHES
+        find-curses.diff
 )
 
 vcpkg_cmake_configure(

--- a/ports/tvision/vcpkg.json
+++ b/ports/tvision/vcpkg.json
@@ -1,11 +1,16 @@
 {
   "name": "tvision",
   "version-date": "2024-05-22",
+  "port-version": 1,
   "description": "A modern port of Turbo Vision 2.0, the classical framework for text-based user interfaces.",
   "homepage": "https://github.com/magiblot/tvision",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
+    {
+      "name": "ncurses",
+      "platform": "!windows"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6686,7 +6686,7 @@
     },
     "ncurses": {
       "baseline": "6.5",
-      "port-version": 0
+      "port-version": 1
     },
     "ndis-driver-library": {
       "baseline": "1.2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9838,7 +9838,7 @@
     },
     "tvision": {
       "baseline": "2024-05-22",
-      "port-version": 0
+      "port-version": 1
     },
     "tweeny": {
       "baseline": "3.2.0",

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a714211f4eb04f17c6f4f5e5b3ada6ea02484b4c",
+      "version": "6.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "ed26b2981b8cd1da1da7f35bee17631fa5da0131",
       "version": "6.5",
       "port-version": 0

--- a/versions/t-/tvision.json
+++ b/versions/t-/tvision.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "09ea5d719f5d52e985d0179968869a07860727b2",
+      "git-tree": "7f6b778d09ada8b8a745b671bad035a3c677e244",
       "version-date": "2024-05-22",
       "port-version": 1
     },

--- a/versions/t-/tvision.json
+++ b/versions/t-/tvision.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09ea5d719f5d52e985d0179968869a07860727b2",
+      "version-date": "2024-05-22",
+      "port-version": 1
+    },
+    {
       "git-tree": "8cee900fb22152eb04edacae88909ae9e75d8e9e",
       "version-date": "2024-05-22",
       "port-version": 0

--- a/versions/t-/tvision.json
+++ b/versions/t-/tvision.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7f6b778d09ada8b8a745b671bad035a3c677e244",
+      "git-tree": "2d4f68cdcac1b192a965530adc962a580be94bd1",
       "version-date": "2024-05-22",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes installation order problem since ncurses 6.5's switch to wide char.