### PR TITLE
[vcpkg baseline][unixodbc] Skip ltdl subdir

### DIFF
--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         pkgconfig-libiconv.diff
+        subdirs.diff
 )
 
 vcpkg_libltdl_get_vars(LIBLTDL)

--- a/ports/unixodbc/subdirs.diff
+++ b/ports/unixodbc/subdirs.diff
@@ -1,0 +1,12 @@
+diff --git a/Makefile.am b/Makefile.am
+index 76d0b3a..19a88d5 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -11,7 +11,6 @@ SUBDIRS = \
+ 	log \
+ 	lst \
+ 	ini \
+-	libltdl \
+ 	odbcinst \
+ 	DriverManager \
+ 	exe \

--- a/ports/unixodbc/vcpkg.json
+++ b/ports/unixodbc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "unixodbc",
   "version": "2.3.12",
+  "port-version": 1,
   "description": "unixODBC is an Open Source ODBC sub-system and an ODBC SDK for Linux, Mac OSX, and UNIX",
   "homepage": "https://github.com/lurcher/unixODBC",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9894,7 +9894,7 @@
     },
     "unixodbc": {
       "baseline": "2.3.12",
-      "port-version": 0
+      "port-version": 1
     },
     "unleash-client-cpp": {
       "baseline": "1.3.0",

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ed30cea781c936049f0c33937aa67fa15452ab9",
+      "version": "2.3.12",
+      "port-version": 1
+    },
+    {
       "git-tree": "9e0f6a67aa215869cbbf29cb2dbb409c713764da",
       "version": "2.3.12",
       "port-version": 0


### PR DESCRIPTION
We have a ltdl port, we don't need the included one.