### PR TITLE
[opentelemetry-cpp] Update to 1.23.0

### DIFF
--- a/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg-port-config.cmake
@@ -4,9 +4,9 @@ function(clone_opentelemetry_cpp_contrib CONTRIB_SOURCE_PATH)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO open-telemetry/opentelemetry-cpp-contrib
-        REF 9176445fccead4f356d56040372f090f218158c1
+        REF ec0b6cf82ec204e13ff9b0b231ffda05c6191196
         HEAD_REF main
-        SHA512 7e88efe814fa165f1391b02a5414f02ffd953ee817cd89521888a492c7ff0e7e0cdb099b93b94f95722f9247501c29319c254773f7c55635d325a1ad9a08e28e
+        SHA512 3ea1780895e51a414713d3487dc82e071a4fd5b98dc055661b7d4267d5a099274d7cf2b043085f152174e870924086b9ef0c92a00efc7605ba53b5732ae55f33
     )
     set(${CONTRIB_SOURCE_PATH} ${SOURCE_PATH} CACHE INTERNAL "")
 endfunction()

--- a/ports/opentelemetry-cpp-contrib-version/vcpkg.json
+++ b/ports/opentelemetry-cpp-contrib-version/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp-contrib-version",
-  "version-date": "2025-09-25",
+  "version-date": "2025-09-26",
   "description": "This port manages the opentelemetry-cpp-version that will be used for opentelemetry-cpp",
   "homepage": "https://github.com/open-telemetry/opentelemetry-cpp-contrib",
   "license": "Apache-2.0"

--- a/ports/opentelemetry-cpp/portfile.cmake
+++ b/ports/opentelemetry-cpp/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-telemetry/opentelemetry-cpp
     REF "v${VERSION}"
-    SHA512 a85869d2858f350e4a3b85e5d68e669a5fff42a2222ba7782bba92f5fe6856a110b3ddc9744a6c3e68c1ddfdc7bdb2b570bbeff78275a4e98cea889a8fda0120
+    SHA512 6dc0357d8b3410852d3f970f72b8bec59dba9d6c533ca600432102e65de161903bd9170d98cef7ff0af5191309577ffd2a69ccd004b840914a910a6a282204e4
     HEAD_REF main
     PATCHES
         fix-target_link.patch

--- a/ports/opentelemetry-cpp/vcpkg.json
+++ b/ports/opentelemetry-cpp/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
-  "version-semver": "1.22.0",
-  "port-version": 1,
+  "version-semver": "1.23.0",
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7141,11 +7141,11 @@
       "port-version": 3
     },
     "opentelemetry-cpp": {
-      "baseline": "1.22.0",
-      "port-version": 1
+      "baseline": "1.23.0",
+      "port-version": 0
     },
     "opentelemetry-cpp-contrib-version": {
-      "baseline": "2025-09-25",
+      "baseline": "2025-09-26",
       "port-version": 0
     },
     "opentracing": {

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "526d6b9bd62462a132ded243de307059aadfda62",
+      "version-date": "2025-09-26",
+      "port-version": 0
+    },
+    {
       "git-tree": "4cbb4503c6329e518b2aa8e5815ecc9bf70fada6",
       "version-date": "2025-09-25",
       "port-version": 0

--- a/versions/o-/opentelemetry-cpp-contrib-version.json
+++ b/versions/o-/opentelemetry-cpp-contrib-version.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "526d6b9bd62462a132ded243de307059aadfda62",
+      "git-tree": "fa7042512bff195c698d6aa1febffe815373feb2",
       "version-date": "2025-09-26",
       "port-version": 0
     },

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6029594a4ac92c92239e5810d87bdb5260f0b855",
+      "version-semver": "1.23.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "efa7bd528dbdffb93654882b1aacd3a99e9796a5",
       "version-semver": "1.22.0",
       "port-version": 1

--- a/versions/o-/opentelemetry-cpp.json
+++ b/versions/o-/opentelemetry-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6029594a4ac92c92239e5810d87bdb5260f0b855",
+      "git-tree": "b81db5688f034b68139fa0e5dac22b434d35c54b",
       "version-semver": "1.23.0",
       "port-version": 0
     },


### PR DESCRIPTION
[opentelemetry-cpp-contrib-version] Update to 2025-09-26 that fixes breaking changes in opentelemetry-cpp 1.23.0.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.