### PR TITLE
[epoll-shim] Add new port

### DIFF
--- a/ports/epoll-shim/000-install-pkg-config-into-standard-location.patch
+++ b/ports/epoll-shim/000-install-pkg-config-into-standard-location.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 744c9e8..02ef4aa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -62,7 +62,7 @@ add_library(${_namespace}::epoll-shim-interpose ALIAS epoll-shim-interpose)\n")
+     configure_file("${PROJECT_SOURCE_DIR}/${_pc_filename}.pc.cmakein"
+                    "${PROJECT_BINARY_DIR}/${_pc_filename}.pc" @ONLY)
+     install(FILES "${PROJECT_BINARY_DIR}/${_pc_filename}.pc"
+-            DESTINATION "${CMAKE_INSTALL_PKGCONFIGDIR}")
++            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+   endforeach()
+ 
+   set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/libepoll-shim")

--- a/ports/epoll-shim/portfile.cmake
+++ b/ports/epoll-shim/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jiixyj/epoll-shim
+    REF v${VERSION}
+    SHA512 03f2cf64854dcb7c065284bbe765e6b52a9504969a733b450746226334fb9852e210b3db0d8ae40733abf62d75d35cc539140e9b5fb3507de9e47ebbc15f2ae3
+    HEAD_REF master
+    PATCHES
+        000-install-pkg-config-into-standard-location.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/epoll-shim)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/epoll-shim/vcpkg.json
+++ b/ports/epoll-shim/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "epoll-shim",
+  "version": "0.0.20240608",
+  "description": "Small epoll implementation using kqueue",
+  "homepage": "https://github.com/jiixyj/epoll-shim",
+  "license": "MIT",
+  "supports": "osx | freebsd | openbsd",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2728,6 +2728,10 @@
       "baseline": "3.15.0",
       "port-version": 0
     },
+    "epoll-shim": {
+      "baseline": "0.0.20240608",
+      "port-version": 0
+    },
     "eraser": {
       "baseline": "2.2.1",
       "port-version": 0

--- a/versions/e-/epoll-shim.json
+++ b/versions/e-/epoll-shim.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "07865cb81a0586ba5dbd0b09441a88ebce34e19d",
+      "version": "0.0.20240608",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.