### PR TITLE
[libinterpolate] update to 2.7.2

### DIFF
--- a/ports/libinterpolate/portfile.cmake
+++ b/ports/libinterpolate/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CD3/libInterpolate
     REF ${VERSION}
-    SHA512 6d53e1fb3af3067ddd13e491563e8da5af9756efba5a2def486f014c23969633ca73cf43dd2f93047716ebb6565f5e9911b6ab85abef2db3b9faefc26ab3aa59  
+    SHA512 25abb4df8ea0648cd9cdd309f2491a9fc2cdbc5af3cc786fec39302680835bb1f29281628dd89323f353d377d9702d9b9f894c85c5cb0aa7cbae5590d05d3e27
     HEAD_REF master
 )
 

--- a/ports/libinterpolate/vcpkg.json
+++ b/ports/libinterpolate/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libinterpolate",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Header-only C++ interpolation library.",
   "homepage": "https://github.com/CD3/libInterpolate",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4969,7 +4969,7 @@
       "port-version": 0
     },
     "libinterpolate": {
-      "baseline": "2.7.1",
+      "baseline": "2.7.2",
       "port-version": 0
     },
     "libirecovery": {

--- a/versions/l-/libinterpolate.json
+++ b/versions/l-/libinterpolate.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "988f6b9d813ef9fee41ee11e9387409defaac22f",
+      "version": "2.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "19a1aae3d8ceed34a7e04604ee4fdf00faf0040e",
       "version": "2.7.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/CD3/libInterpolate/releases/tag/2.7.2
