### PR TITLE
[fkyaml] add new port

### DIFF
--- a/ports/fkyaml/fix-natvis-path.patch
+++ b/ports/fkyaml/fix-natvis-path.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b1a8b81..59c9464 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -190,7 +190,7 @@ if(FK_YAML_INSTALL)
+   if(FK_YAML_INSTALL_NATVIS)
+     install(
+       FILES ${FK_YAML_NATVIS_FILE}
+-      DESTINATION .
++      DESTINATION ./share/${PROJECT_NAME}
+     )
+   endif()
+ 

--- a/ports/fkyaml/fix-natvis-path.patch
+++ b/ports/fkyaml/fix-natvis-path.patch
@@ -7,7 +7,7 @@ index b1a8b81..59c9464 100644
      install(
        FILES ${FK_YAML_NATVIS_FILE}
 -      DESTINATION .
-+      DESTINATION ./share/${PROJECT_NAME}
++      DESTINATION share/fkyaml
      )
    endif()
  

--- a/ports/fkyaml/portfile.cmake
+++ b/ports/fkyaml/portfile.cmake
@@ -13,13 +13,10 @@ set(VCPKG_BUILD_TYPE release) # header-only port
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-    -DFK_YAML_INSTALL=ON
+        -DFK_YAML_INSTALL=ON
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME fkYAML CONFIG_PATH share/cmake/fkYAML)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/fkYAML)
 vcpkg_fixup_pkgconfig()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/fkyaml/portfile.cmake
+++ b/ports/fkyaml/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME fkYAML CONFIG_PATH share/cmake/fkYAML)
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 

--- a/ports/fkyaml/portfile.cmake
+++ b/ports/fkyaml/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 20a7e2a236f77e27a676348585cbf6c36d8c46f1ad0964b879eb61925e3d6545d6dda46379b897712890faa2b8d5e837b7f9cc312448a3d762f0017c618cbcd1
     HEAD_REF develop
+    PATCHES
+        fix-natvis-path.patch
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port

--- a/ports/fkyaml/portfile.cmake
+++ b/ports/fkyaml/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO fktn-k/fkYAML
+    REF "v${VERSION}"
+    SHA512 20a7e2a236f77e27a676348585cbf6c36d8c46f1ad0964b879eb61925e3d6545d6dda46379b897712890faa2b8d5e837b7f9cc312448a3d762f0017c618cbcd1
+    HEAD_REF develop
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+    -DFK_YAML_INSTALL=ON
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME fkYAML CONFIG_PATH share/cmake/fkYAML)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/fkyaml/vcpkg.json
+++ b/ports/fkyaml/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "fkyaml",
+  "version": "0.4.2",
+  "description": "A C++ header-only YAML library",
+  "homepage": "https://github.com/fktn-k/fkYAML",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2936,6 +2936,10 @@
       "baseline": "2025.05.19.00",
       "port-version": 0
     },
+    "fkyaml": {
+      "baseline": "0.4.2",
+      "port-version": 0
+    },
     "flagpp": {
       "baseline": "2.1",
       "port-version": 0

--- a/versions/f-/fkyaml.json
+++ b/versions/f-/fkyaml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d2a480c71768819bef7d97dabcd851e08de252f5",
+      "git-tree": "7b7ac9ff0b4be21d89479bd001a87a6bb906f4bd",
       "version": "0.4.2",
       "port-version": 0
     }

--- a/versions/f-/fkyaml.json
+++ b/versions/f-/fkyaml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8432480c76d951075ee15df41240123062b410fb",
+      "git-tree": "0e9e187d48bdf02c37dd468a07fab5718320f184",
       "version": "0.4.2",
       "port-version": 0
     }

--- a/versions/f-/fkyaml.json
+++ b/versions/f-/fkyaml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0e9e187d48bdf02c37dd468a07fab5718320f184",
+      "git-tree": "21138b93a764b6ba43549ceb71ff28b5aecd9ea6",
       "version": "0.4.2",
       "port-version": 0
     }

--- a/versions/f-/fkyaml.json
+++ b/versions/f-/fkyaml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7b7ac9ff0b4be21d89479bd001a87a6bb906f4bd",
+      "git-tree": "8432480c76d951075ee15df41240123062b410fb",
       "version": "0.4.2",
       "port-version": 0
     }

--- a/versions/f-/fkyaml.json
+++ b/versions/f-/fkyaml.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d2a480c71768819bef7d97dabcd851e08de252f5",
+      "version": "0.4.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/fktn-k/fkYAML/releases/tag/v0.4.2
