### PR TITLE
[tiny-optional] new port

### DIFF
--- a/ports/tiny-optional/portfile.cmake
+++ b/ports/tiny-optional/portfile.cmake
@@ -1,0 +1,16 @@
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Sedeniono/tiny-optional
+    REF "v${VERSION}"
+    SHA512 0143df1f9412f9273fcad012925a0e60a74fffa5f843831ee05fe287871c1122c82f6023b61c3e25a62c904014e4fa7cda2b60d1a8a146d7e57f9a3790c42cf3
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tiny-optional/portfile.cmake
+++ b/ports/tiny-optional/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Sedeniono/tiny-optional
     REF "v${VERSION}"
-    SHA512 0143df1f9412f9273fcad012925a0e60a74fffa5f843831ee05fe287871c1122c82f6023b61c3e25a62c904014e4fa7cda2b60d1a8a146d7e57f9a3790c42cf3
+    SHA512 d92394c20a12451c59b30a7bec446dce1be08a6aab2ed8527a6e23f04789be759b6f4eb83666d1985b2716df2031baeb84d5ec83d39ceaf43d7162921cb92d4a
 )
 
 vcpkg_cmake_configure(

--- a/ports/tiny-optional/vcpkg.json
+++ b/ports/tiny-optional/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "tiny-optional",
+  "version": "1.5.1",
+  "description": "Drop-in replacement for std::optional that does not waste memory unnecessarily",
+  "homepage": "https://github.com/Sedeniono/tiny-optional",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/tiny-optional/vcpkg.json
+++ b/ports/tiny-optional/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-optional",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Drop-in replacement for std::optional that does not waste memory unnecessarily",
   "homepage": "https://github.com/Sedeniono/tiny-optional",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9613,7 +9613,7 @@
       "port-version": 2
     },
     "tiny-optional": {
-      "baseline": "1.5.1",
+      "baseline": "1.5.2",
       "port-version": 0
     },
     "tiny-process-library": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9612,6 +9612,10 @@
       "baseline": "2018-10-25",
       "port-version": 2
     },
+    "tiny-optional": {
+      "baseline": "1.5.1",
+      "port-version": 0
+    },
     "tiny-process-library": {
       "baseline": "2.0.4",
       "port-version": 3

--- a/versions/t-/tiny-optional.json
+++ b/versions/t-/tiny-optional.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7c50ed2c75e191c08d92f82531378702c45d0435",
+      "version": "1.5.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/t-/tiny-optional.json
+++ b/versions/t-/tiny-optional.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "7c50ed2c75e191c08d92f82531378702c45d0435",
-      "version": "1.5.1",
+      "git-tree": "2b587acd9add11f69ade6e9be415d7066bd54c75",
+      "version": "1.5.2",
       "port-version": 0
     }
   ]


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #47571
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
