### PR TITLE
[tracy] Add remaining build options from tracy v0.11.1 as features

### DIFF
--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -17,9 +17,29 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        on-demand TRACY_ON_DEMAND
-        fibers	  TRACY_FIBERS
-        verbose   TRACY_VERBOSE
+        on-demand                        TRACY_ON_DEMAND
+        fibers                           TRACY_FIBERS
+        verbose                          TRACY_VERBOSE
+        delayed-init                     TRACY_DELAYED_INIT
+        manual-lifetime                  TRACY_MANUAL_LIFETIME
+        manual-lifetime                  TRACY_DELAYED_INIT # TRACY_DELAYED_INIT augments TRACY_MANUAL_LIFETIME
+        no-callstack                     TRACY_NO_CALLSTACK
+        no-callstack-inlines             TRACY_NO_CALLSTACK_INLINES
+        only-localhost                   TRACY_ONLY_LOCALHOST
+        no-broadcast                     TRACY_NO_BROADCAST
+        only-ipv4                        TRACY_ONLY_IPV4
+        no-code-transfer                 TRACY_NO_CODE_TRANSFER
+        no-context-switch                TRACY_NO_CONTEXT_SWITCH
+        no-exit                          TRACY_NO_EXIT
+        no-sampling                      TRACY_NO_SAMPLING
+        no-verify                        TRACY_NO_VERIFY
+        no-vsync-capture                 TRACY_NO_VSYNC_CAPTURE
+        no-frame-image                   TRACY_NO_FRAME_IMAGE
+        no-system-tracing                TRACY_NO_SYSTEM_TRACING
+        patchable-nopsleds               TRACY_PATCHABLE_NOPSLEDS
+        timer-fallback                   TRACY_TIMER_FALLBACK
+        symbol-offline-resolve           TRACY_SYMBOL_OFFLINE_RESOLVE
+
     INVERTED_FEATURES
         crash-handler TRACY_NO_CRASH_HANDLER
 )

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tracy",
   "version": "0.11.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",
@@ -52,6 +52,9 @@
     "crash-handler": {
       "description": "Enable crash handler"
     },
+    "delayed-init": {
+      "description": "Enable delayed initialization of the library (init on first call)"
+    },
     "fibers": {
       "description": "Enable fibers support"
     },
@@ -80,8 +83,59 @@
         }
       ]
     },
+    "manual-lifetime": {
+      "description": "Enable the manual lifetime management of the profile"
+    },
+    "no-broadcast": {
+      "description": "Disable client discovery by broadcast to local network"
+    },
+    "no-callstack": {
+      "description": "Disable all callstack related functionality"
+    },
+    "no-callstack-inlines": {
+      "description": "Disables the inline functions in callstacks"
+    },
+    "no-code-transfer": {
+      "description": "Disable collection of source code"
+    },
+    "no-context-switch": {
+      "description": "Disable capture of context switches"
+    },
+    "no-exit": {
+      "description": "Client executable does not exit until all profile data is sent to server"
+    },
+    "no-frame-image": {
+      "description": "Disable the frame image support and its thread"
+    },
+    "no-sampling": {
+      "description": "Disable call stack sampling"
+    },
+    "no-system-tracing": {
+      "description": "Disable systrace sampling"
+    },
+    "no-verify": {
+      "description": "Disable zone validation for C API"
+    },
+    "no-vsync-capture": {
+      "description": "Disable capture of hardware Vsync events"
+    },
     "on-demand": {
       "description": "Enable on-demand profiling"
+    },
+    "only-ipv4": {
+      "description": "Tracy will only accept connections on IPv4 addresses (disable IPv6)"
+    },
+    "only-localhost": {
+      "description": "Only listen on the localhost interface"
+    },
+    "patchable-nopsleds": {
+      "description": "Enable nopsleds for efficient patching by system-level tools (e.g. rr)"
+    },
+    "symbol-offline-resolve": {
+      "description": "Instead of full runtime symbol resolution, only resolve the image path and offset to enable offline symbol resolution"
+    },
+    "timer-fallback": {
+      "description": "Use lower resolution timers"
     },
     "verbose": {
       "description": "Enables verbose logging"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9774,7 +9774,7 @@
     },
     "tracy": {
       "baseline": "0.11.1",
-      "port-version": 2
+      "port-version": 3
     },
     "transwarp": {
       "baseline": "2.2.3",

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c923660cb20168111f63250c415414ca7321e5e6",
+      "version": "0.11.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "ff802e1b85c20b5f276c4b82aaa60fc933444ab2",
       "version": "0.11.1",
       "port-version": 2


### PR DESCRIPTION
Fixes #47573 

Ensure that build options below are represented as features
https://github.com/wolfpld/tracy/blob/5d542dc09f3d9378d005092a4ad446bd405f819a/CMakeLists.txt#L70-L93

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. (**NA**)
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. (**NA**)
- [x] Any patches that are no longer applied are deleted from the port's directory. (**NA**)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
