### PR TITLE
[c4core] update to 0.2.7

### DIFF
--- a/ports/c4core/portfile.cmake
+++ b/ports/c4core/portfile.cmake
@@ -5,20 +5,20 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/c4core
     REF "v${VERSION}"
-    SHA512 027312776141bb93ba96a37190d2ed28a16985390d28dcdec69db1bca198d786633b30ffc66c11c7a05518a7c1d11cd310f650a112f436da4cfd099f03b74691
+    SHA512 c9264bc404a60c9eb926f53998bdf87338792a1c5c687cee9034620965abbe383ac413cfc9dc57bc571596d60c46df99df292229a26dbee232fb43fe40750092
     HEAD_REF master
     PATCHES
         disable-cpack.patch
 )
 
-set(CM_COMMIT_HASH b8e95acb1bdd564e47ac57d903a483604d90cbfa)
+set(CM_COMMIT_HASH 469017f6ddab72e860aa80221736c00d3dae0587)
 
 # Get cmake scripts for c4core
 vcpkg_download_distfile(
     CMAKE_ARCHIVE
     URLS "https://github.com/biojppm/cmake/archive/${CM_COMMIT_HASH}.zip"
     FILENAME "cmake-${CM_COMMIT_HASH}.zip"
-    SHA512 662c750279f4f1068bda60e999c54148e75f7a0daaf69e0540023770ef9008bab3d3acd41e06a193e5a095c614ccbdaa1c75fd4157cf03995dbbae6a6a24b445
+    SHA512 858200265b335297fefacf23780d2db596f09fe71dd04088ec34fa29d6d962dc04ece3429108ad3332289cbf41da2cae6991ac6211ff12f6c796ca4e25b7ceef
 )
 
 vcpkg_extract_source_archive(

--- a/ports/c4core/vcpkg.json
+++ b/ports/c4core/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c4core",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Library of low-level C++ utilities",
   "homepage": "https://github.com/biojppm/c4core",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1529,7 +1529,7 @@
       "port-version": 0
     },
     "c4core": {
-      "baseline": "0.2.6",
+      "baseline": "0.2.7",
       "port-version": 0
     },
     "c89stringutils": {

--- a/versions/c-/c4core.json
+++ b/versions/c-/c4core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f21a4b12cc5df173553ef817ae11245a3463773e",
+      "version": "0.2.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "4c6944f18c1c3263b0360dbab29544e752d2d7d1",
       "version": "0.2.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/biojppm/c4core/releases/tag/v0.2.7
