### PR TITLE
[openvdb] update to 12.1.1

### DIFF
--- a/ports/openvdb/portfile.cmake
+++ b/ports/openvdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/openvdb
     REF "v${VERSION}"
-    SHA512 67b859bf77c53e68116faa7915bb6a5a50a8cff10435762890e13348625e8aebdb6661b722017632471648afe31e2f9d4cd2e18456c728192bfd0accd70a40ef
+    SHA512 3ca5f7656aa0bf753ae2bd4f8c40f2e0eec48a22a187fbd519e6a42c2f2b3c9a4b2f32d4a2daa692894af712e13172dfb4ca2e9af99b4d63196bf6b74c87ffb5
     PATCHES
         fix_cmake.patch
 )

--- a/ports/openvdb/vcpkg.json
+++ b/ports/openvdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openvdb",
-  "version": "12.0.1",
+  "version": "12.1.1",
   "description": "Sparse volume data structure and tools",
   "homepage": "https://www.openvdb.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7169,7 +7169,7 @@
       "port-version": 0
     },
     "openvdb": {
-      "baseline": "12.0.1",
+      "baseline": "12.1.1",
       "port-version": 0
     },
     "openvino": {

--- a/versions/o-/openvdb.json
+++ b/versions/o-/openvdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "434abea9f006d66d66f9238ee59105cc1067e7e2",
+      "version": "12.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "327ac401596e515e76f93287857211fbe0be9008",
       "version": "12.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/AcademySoftwareFoundation/openvdb/releases/tag/v12.1.1
