### PR TITLE
[gtest] Remove `cxx17` feature since C++17 is now the minimum requirement

### DIFF
--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -16,17 +16,11 @@ vcpkg_from_github(
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" GTEST_FORCE_SHARED_CRT)
 
-set(GTEST_USE_CXX17_OPTION "")
-if("cxx17" IN_LIST FEATURES)
-    set(GTEST_USE_CXX17_OPTION "-DCMAKE_CXX_STANDARD=17")
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DBUILD_GMOCK=ON
         -Dgtest_force_shared_crt=${GTEST_FORCE_SHARED_CRT}
-        ${GTEST_USE_CXX17_OPTION}
 )
 
 vcpkg_cmake_install()

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gtest",
   "version-semver": "1.17.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Google Testing and Mocking Framework",
   "homepage": "https://github.com/google/googletest",
   "license": "BSD-3-Clause",

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -14,10 +14,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "cxx17": {
-      "description": "Enable compiler C++17."
-    }
-  }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3490,7 +3490,7 @@
     },
     "gtest": {
       "baseline": "1.17.0",
-      "port-version": 1
+      "port-version": 2
     },
     "gtk": {
       "baseline": "4.16.3",

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8a81820356e90917e5eb5dfe0092bfac57dbb12",
+      "version-semver": "1.17.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "9ef57e3c1c7484e79ef8dd77e9cb7770f5331248",
       "version-semver": "1.17.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #47592

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

