### PR TITLE
Add tracy features `manual-lifetime` and `no-callstack`

### DIFF
--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -17,11 +17,14 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        on-demand TRACY_ON_DEMAND
-        fibers	  TRACY_FIBERS
-        verbose   TRACY_VERBOSE
+        on-demand        TRACY_ON_DEMAND
+        fibers           TRACY_FIBERS
+        verbose          TRACY_VERBOSE
+        manual-lifetime  TRACY_MANUAL_LIFETIME
+        manual-lifetime  TRACY_DELAYED_INIT
     INVERTED_FEATURES
-        crash-handler TRACY_NO_CRASH_HANDLER
+        crash-handler     TRACY_NO_CRASH_HANDLER
+        capture-callstack TRACY_NO_CALLSTACK
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS TOOLS_OPTIONS

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tracy",
   "version": "0.11.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",
@@ -21,9 +21,13 @@
     }
   ],
   "default-features": [
+    "capture-callstack",
     "crash-handler"
   ],
   "features": {
+    "capture-callstack": {
+      "description": "Enable callstack related functionality"
+    },
     "cli-tools": {
       "description": "Build Tracy command-line tools: `capture`, `csvexport`, `import-chrome`, `import-fuchsia` and `update`",
       "supports": "!(windows & x86)",
@@ -80,11 +84,15 @@
         }
       ]
     },
+    "manual-lifetime": {
+      "description": "Enable the manual lifetime management of the profile"
+    },
     "on-demand": {
       "description": "Enable on-demand profiling"
     },
     "verbose": {
-      "description": "Enables verbose logging"
+      "description": "Enables verbose logging",
+      "supports": "!android"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9774,7 +9774,7 @@
     },
     "tracy": {
       "baseline": "0.11.1",
-      "port-version": 2
+      "port-version": 3
     },
     "transwarp": {
       "baseline": "2.2.3",

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05eaa7212b6f4d637e2c3eb5efbe1ad56a1c330e",
+      "version": "0.11.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "ff802e1b85c20b5f276c4b82aaa60fc933444ab2",
       "version": "0.11.1",
       "port-version": 2


### PR DESCRIPTION
Fixes #47573 

Notice that `TRACY_MANUAL_LIFETIME` requires the `TRACY_DELAYED_INIT` option.
See documentation for information on building with `TRACY_MANUAL_LIFETIME`

Restricted verbose feature mode to not support android, as this was failing for all android builds (I do not have access to historical build data, so I do not know if this was failing previously):

- https://dev.azure.com/vcpkg/public/_build/results?buildId=120665&view=logs&j=18f767b8-9e55-53aa-9c57-42862973482f&t=3b7ff14d-7f23-576e-7151-bdf22f86f0a5&l=258
- https://dev.azure.com/vcpkg/public/_build/results?buildId=120665&view=logs&j=f1a99d27-903c-5ce5-ab6b-a2a85be7b723&t=0cf19538-6d32-595e-016c-46a2053c87b9&l=258
- https://dev.azure.com/vcpkg/public/_build/results?buildId=120665&view=logs&j=185c373b-2f55-539e-a6cb-ef2677cc0d97&t=eb0c8c1c-c0fa-5b60-852f-5fac320dff10&l=258

https://github.com/wolfpld/tracy/releases/download/v0.11.1/tracy.pdf

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
