### PR TITLE
[variant-lite] Update to v3.0.0

### DIFF
--- a/ports/variant-lite/portfile.cmake
+++ b/ports/variant-lite/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martinmoene/variant-lite
-    REF v2.0.0
-    SHA512 dd255d3664b42305e58c14a0bfc7d6ba54462656001e4e79c14fdb64a6f54b57a00ec3cf10d006614c849528529c6897031df4b52a49ecb91531e89d366d6a9c
+    REF v3.0.0
+    SHA512 e85f27179a997777e3f9ad1db5f424f0838c474904c9df6a6b9cce817ca57144b0e23d561b9514edd97f8fff88b2a372c5afccc46a15b35e4b7d287e6b197a9e
 )
 
 vcpkg_cmake_configure(

--- a/ports/variant-lite/vcpkg.json
+++ b/ports/variant-lite/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "variant-lite",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "A C++17-like variant, a type-safe union for C++98, C++11 and later in a single-file header-only library",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10029,7 +10029,7 @@
       "port-version": 1
     },
     "variant-lite": {
-      "baseline": "2.0.0",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "vbs-enclave-tooling-codegen": {

--- a/versions/v-/variant-lite.json
+++ b/versions/v-/variant-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e26d910cbb1e8c3da4c63aa3361770edaf523d6a",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "827279cee8fcc1e2cfc6fd195ebf523cba2917c5",
       "version": "2.0.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
