### PR TITLE
[eigen3] Version db fix

### DIFF
--- a/ports/eigen3/vcpkg.json
+++ b/ports/eigen3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "eigen3",
   "version": "3.4.1",
+  "port-version": 1,
   "description": "C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.",
   "homepage": "http://eigen.tuxfamily.org",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2678,7 +2678,7 @@
     },
     "eigen3": {
       "baseline": "3.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "eipscanner": {
       "baseline": "1.3.0",

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "e4983ed273755fd9e95b45abe264eb028db11724",
+      "git-tree": "ea6ed04401cca325eff95c17cc0d01326a3c6a85",
+      "version": "3.4.1",
+      "port-version": 1
+    },
+    {
+      "git-tree": "86e81b275f5e8d1643d5204b1f5edaf7bfcbde5b",
       "version": "3.4.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The change in #47569 updated the git-tree of an existing version rather than creating a new one, which prevents it from being picked up by `vcpkg update`. This restores the git tree of 3.4.1#0 and creates a new version 3.4.1#1

Main fix was done in #47569 but in case update is blocked:

Fixes #47612
Fixes #47599 
Fixes #47588
Fixes #47568