### PR TITLE
[simd] update to 6.2.154

### DIFF
--- a/ports/simd/portfile.cmake
+++ b/ports/simd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ermig1979/Simd
     REF "v${VERSION}"
-    SHA512 91b0e4e4876330026154b1a5ad86fca164eed25ec478192999d7c0e55660fe18d7ecaecba6535fda55db53276734c0f81cd8398facfcd3e6a3f39d92330480cb
+    SHA512 d68e5cedfdfd66f026377585741c4c5c95acd4d5012a207ece7de38d82d99f83024b07b1c9ea60db65acc6f9ede5a9e93fc16cad02c613dcc7d5de91736aa09c
     HEAD_REF master
     PATCHES
         fix-platform-detection.patch

--- a/ports/simd/vcpkg.json
+++ b/ports/simd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simd",
-  "version": "6.2.153",
+  "version": "6.2.154",
   "description": "Simd image processing and machine learning library, designed for C and C++ programmers",
   "homepage": "https://github.com/ermig1979/Simd",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8929,7 +8929,7 @@
       "port-version": 1
     },
     "simd": {
-      "baseline": "6.2.153",
+      "baseline": "6.2.154",
       "port-version": 0
     },
     "simde": {

--- a/versions/s-/simd.json
+++ b/versions/s-/simd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb2b245a8a3666d52091973effae367a96f5032f",
+      "version": "6.2.154",
+      "port-version": 0
+    },
+    {
       "git-tree": "f643241794d573c6f5a6e60989c2fd71db00aaae",
       "version": "6.2.153",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ermig1979/Simd/releases/tag/v6.2.154
