### PR TITLE
Enable [compact] feature for pugixml port, reducing memory consumption

### DIFF
--- a/ports/pugixml/portfile.cmake
+++ b/ports/pugixml/portfile.cmake
@@ -6,10 +6,17 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        compact PUGIXML_COMPACT
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DPUGIXML_BUILD_TESTS=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/pugixml/vcpkg.json
+++ b/ports/pugixml/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pugixml",
   "version": "1.15",
+  "port-version": 1,
   "description": "Light-weight, simple and fast XML parser for C++ with XPath support",
   "homepage": "https://github.com/zeux/pugixml",
   "license": "MIT",

--- a/ports/pugixml/vcpkg.json
+++ b/ports/pugixml/vcpkg.json
@@ -13,5 +13,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "compact": {
+      "description": "Enable compact memory mode (reduces memory consumption at the cost of performance)"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7718,7 +7718,7 @@
     },
     "pugixml": {
       "baseline": "1.15",
-      "port-version": 0
+      "port-version": 1
     },
     "pulsar-client-cpp": {
       "baseline": "3.7.0",

--- a/versions/p-/pugixml.json
+++ b/versions/p-/pugixml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e210d4650721b32c1e83bf0da6a0cf4c145bbbd9",
+      "version": "1.15",
+      "port-version": 1
+    },
+    {
       "git-tree": "a3181de4dee35567b45611a938eb0f44f5ee016d",
       "version": "1.15",
       "port-version": 0


### PR DESCRIPTION
Significantly (up to 80%) reduces memory use at the expense of performance. This feature sets PUGIXML_COMPACT CMake flag at the configure step. It allows this port to be used for projects that open very large (2GB+) XML files.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
