### PR TITLE
[intel-mkl] update to 2025.2.0

### DIFF
--- a/ports/intel-mkl/portfile.cmake
+++ b/ports/intel-mkl/portfile.cmake
@@ -5,38 +5,27 @@
 
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 
-# https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2b9cdf66-5291-418e-a7e8-f90515cc9098/w_onemkl_p_2023.2.0.49500_offline.exe # windows
-# https://registrationcenter-download.intel.com/akdlm/IRC_NAS/dd6ae4b7-5d07-4307-8163-e1ccf7a770a0/m_onemkl_p_2023.2.2.9_offline.dmg # macos
-# https://registrationcenter-download.intel.com/akdlm/IRC_NAS/adb8a02c-4ee7-4882-97d6-a524150da358/l_onemkl_p_2023.2.0.49497_offline.sh # linux
+# https://registrationcenter-download.intel.com/akdlm/IRC_NAS/307bccae-8631-4712-8999-02a8abf51994/intel-onemkl-2025.2.0.630_offline.exe # windows
+# https://registrationcenter-download.intel.com/akdlm/IRC_NAS/47c7d946-fca1-441a-b0df-b094e3f045ea/intel-onemkl-2025.2.0.629_offline.sh # linux
 set(sha "")
+set(mkl_version 2025.2.0)
+set(mkl_short_version 2025.2)
 if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
   # nop
 elseif(VCPKG_TARGET_IS_WINDOWS)
-  set(mkl_version 2023.2.0) 
-  set(version_magic_number 49496)
-  set(filename w_onemkl_p_2023.2.0.49500_offline.exe)
-  set(magic_number 2b9cdf66-5291-418e-a7e8-f90515cc9098)
-  set(sha 00ef5e9e059290474fb0ed5eeec5b76fd2793d45e5707e90125adecfc526af8ca716bd0f33dbe9f077b56bf30c2cbdd27401978a087687600c6c7e5847767857)
+  set(filename intel-onemkl-2025.2.0.630_offline.exe)
+  set(magic_number 307bccae-8631-4712-8999-02a8abf51994)
+  set(sha 13d6c1ab943d2a3a16ee29be995215ef14eb469215c24633d9fdff1f0e1b3e78225ed92780b9a20d90812160da5a4969e16f0e9df36df45389c4fab4b5ecac3d)
   set(package_infix "win")
-elseif(VCPKG_TARGET_IS_OSX)
-  set(mkl_version 2023.2.2)
-  set(mkl_version_openmp 2023.2.0)
-  set(filename m_onemkl_p_2023.2.2.9_offline.dmg)
-  set(magic_number dd6ae4b7-5d07-4307-8163-e1ccf7a770a0)
-  set(sha 9de501e0c6553265a5226ff0b00bb36f5a1c89c39114c1a64a5ae816a58b50981faf341e98e00aec11103c565059567b96e61413aa09b22462c1c5ec975c5cb9)
-  set(package_infix "mac")
   set(package_libdir "lib")
-  set(compiler_libdir "mac/compiler/lib")
+  set(runtime_dir "bin")
 elseif(VCPKG_TARGET_IS_LINUX)
-  set(mkl_version 2023.2.0)
-  set(mkl_version_openmp 2023.2.0)
-  set(version_magic_number 49497)
-  set(filename l_onemkl_p_2023.2.0.49497_offline.sh)
-  set(magic_number adb8a02c-4ee7-4882-97d6-a524150da358)
-  set(sha 421d4c33014b9a77799273f78db9877c72401d7b2a9b697abb9e148def008c58259b11c0238ab658c8f8499b13ac7bb880b91d57338345e77d0475d5d65c39f3)
+  set(filename intel-onemkl-2025.2.0.629_offline.sh)
+  set(magic_number 47c7d946-fca1-441a-b0df-b094e3f045ea)
+  set(sha 60e0b86b2e63da1becb527db0d912d19e2a664671e1e6cf54ac6fad35ced3bb791e490d4b7d1a555231a0b553a32652d1c6c41869222c88f30e17fee5c436cd3)
   set(package_infix "lin")
-  set(package_libdir "lib/intel64")
-  set(compiler_libdir "linux/compiler/lib/intel64_lin")
+  set(package_libdir "lib")
+  set(runtime_dir "lib")
 endif()
 
 if(NOT sha)
@@ -77,156 +66,94 @@ file(MAKE_DIRECTORY "${extract_1_dir}")
 
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_find_acquire_program(7Z)
-    message(STATUS "Extracting offline installer")
-    vcpkg_execute_required_process(
-        COMMAND "${7Z}" x "${installer_path}" "-o${extract_0_dir}" "-y" "-bso0" "-bsp0"
-        WORKING_DIRECTORY "${extract_0_dir}"
-        LOGNAME "extract-${TARGET_TRIPLET}-0"
-    )
-
-    set(packages 
-        "intel.oneapi.win.mkl.devel,v=${mkl_version}-${version_magic_number}/oneapi-mkl-devel-for-installer_p_${mkl_version}.${version_magic_number}.msi" # has the required libs. 
-        "intel.oneapi.win.mkl.runtime,v=${mkl_version}-${version_magic_number}/oneapi-mkl-for-installer_p_${mkl_version}.${version_magic_number}.msi" # has the required DLLs
-        #"intel.oneapi.win.compilers-common-runtime,v=${mkl_version}-25922" # SVML
-        "intel.oneapi.win.openmp,v=${mkl_version}-${version_magic_number}/oneapi-comp-openmp-for-installer_p_${mkl_version}.${version_magic_number}.msi" # OpenMP
-        #"intel.oneapi.win.tbb.runtime,v=${mkl_version}-25874" #TBB
-        )
-
-    foreach(pack IN LISTS packages)
-        set(package_path "${extract_0_dir}/packages/${pack}")
-        cmake_path(GET pack STEM LAST_ONLY packstem)
-        cmake_path(NATIVE_PATH package_path package_path_native)
-        vcpkg_execute_required_process(
-            COMMAND "${LESSMSI}" x "${package_path_native}"
-            WORKING_DIRECTORY "${extract_1_dir}" 
-            LOGNAME "extract-${TARGET_TRIPLET}-${packstem}"
-        )
-        file(COPY "${extract_1_dir}/${packstem}/SourceDir/" DESTINATION "${extract_1_dir}")
-        file(REMOVE_RECURSE "${extract_1_dir}/${packstem}")
-    endforeach()
-
-    set(mkl_dir "${extract_1_dir}/Intel/Compiler/12.0/mkl/${mkl_version}")
-    file(COPY "${mkl_dir}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-    # see https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl-link-line-advisor.html for linking
-    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-      set(files "mkl_core_dll.lib" "mkl_${threading}_dll.lib" "mkl_intel_${interface}_dll.lib" "mkl_blas95_${interface}.lib" "mkl_lapack95_${interface}.lib") # "mkl_rt.lib" single dynamic lib with dynamic dispatch
-      file(COPY "${mkl_dir}/redist/intel64/" DESTINATION "${CURRENT_PACKAGES_DIR}/bin") # Could probably be reduced instead of copying all
-      if(NOT VCPKG_BUILD_TYPE)
-        file(COPY "${mkl_dir}/redist/intel64/" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-      endif()
-    else()
-      set(files "mkl_core.lib" "mkl_${threading}.lib" "mkl_intel_${interface}.lib" "mkl_blas95_${interface}.lib" "mkl_lapack95_${interface}.lib")
-    endif()
-    foreach(file IN LISTS files)
-      file(COPY "${mkl_dir}/lib/intel64/${file}" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/intel64") # instead of manual-link keep normal structure
-      if(NOT VCPKG_BUILD_TYPE)
-        file(COPY "${mkl_dir}/lib/intel64/${file}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/intel64")
-      endif()
-    endforeach()
-    file(COPY_FILE "${mkl_dir}/lib/pkgconfig/${main_pc_file}" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}")
-
-    set(compiler_dir "${extract_1_dir}/Intel/Compiler/12.0/compiler/${mkl_version}")
-    if(threading STREQUAL "intel_thread")
-      file(COPY "${compiler_dir}/windows/redist/intel64_win/compiler/" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-      file(COPY "${compiler_dir}/windows/compiler/lib/intel64_win/" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/intel64")
-      file(COPY_FILE "${compiler_dir}/lib/pkgconfig/openmp.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libiomp5.pc")
-      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libiomp5.pc" "/windows/compiler/lib/intel64_win/" "/lib/intel64/")
-      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libiomp5.pc" "-I \${includedir}" "-I\"\${includedir}\"")
-      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}" "openmp" "libiomp5")
-      if(NOT VCPKG_BUILD_TYPE)
-        file(COPY "${compiler_dir}/windows/redist/intel64_win/compiler/" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
-        file(COPY "${compiler_dir}/windows/compiler/lib/intel64_win/" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/intel64")
-      endif()
-    endif()
-else()
-    message(STATUS "Warning: This port is still a work on progress. 
-   E.g. it is not correctly filtering the libraries in accordance with
-   VCPKG_LIBRARY_LINKAGE. It is using the default threading (Intel OpenMP)
-   which is known to segfault when used together with GNU OpenMP.
+message(STATUS "Warning: This port is still a work on progress. 
+  E.g. it is not correctly filtering the libraries in accordance with
+  VCPKG_LIBRARY_LINKAGE. It is using the default threading (Intel OpenMP)
+  which is known to segfault when used together with GNU OpenMP.
 ")
-
-    message(STATUS "Extracting offline installer")
-    if(VCPKG_TARGET_IS_LINUX)
-      vcpkg_execute_required_process(
-          COMMAND "bash" "--verbose" "--noprofile" "${installer_path}" "--extract-only" "--extract-folder" "${extract_0_dir}"
-          WORKING_DIRECTORY "${extract_0_dir}"
-          LOGNAME "extract-${TARGET_TRIPLET}-0"
-      )
-      file(RENAME "${extract_0_dir}/l_onemkl_p_${mkl_version}.${version_magic_number}_offline/packages" "${extract_0_dir}/packages")
-    elseif(VCPKG_TARGET_IS_OSX)
-      find_program(HDIUTIL NAMES hdiutil REQUIRED)
-      file(MAKE_DIRECTORY "${extract_0_dir}/packages")
-      message(STATUS "... Don't interrupt.")
-      vcpkg_execute_required_process(
-          COMMAND "${CMAKE_COMMAND}" "-Ddmg_path=${installer_path}"
-                                     "-Doutput_dir=${extract_0_dir}/packages"
-                                     "-DHDIUTIL=${HDIUTIL}"
-                                     -P "${CMAKE_CURRENT_LIST_DIR}/copy-from-dmg.cmake"
-          WORKING_DIRECTORY "${extract_0_dir}"
-          LOGNAME "extract-${TARGET_TRIPLET}-0"
-      )
-      message(STATUS "... Done.")
-    endif()
-
-    file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.mkl.runtime,v=${mkl_version}-*")
-    cmake_path(GET package_path STEM LAST_ONLY packstem)
-    message(STATUS "Extracting ${packstem}")
-    vcpkg_execute_required_process(
-        COMMAND "${CMAKE_COMMAND}" "-E" "tar" "-xf" "${package_path}/cupPayload.cup"
-            "_installdir/mkl/${mkl_version}/lib"
-            "_installdir/mkl/${mkl_version}/licensing"
-        WORKING_DIRECTORY "${extract_1_dir}"
-        LOGNAME "extract-${TARGET_TRIPLET}-${packstem}"
-    )
-    file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.mkl.devel,v=${mkl_version}-*")
-    cmake_path(GET package_path STEM LAST_ONLY packstem)
-    message(STATUS "Extracting ${packstem}")
-    vcpkg_execute_required_process(
-        COMMAND "${CMAKE_COMMAND}" "-E" "tar" "-xf" "${package_path}/cupPayload.cup"
-            "_installdir/mkl/${mkl_version}/bin"
-            "_installdir/mkl/${mkl_version}/include"
-            "_installdir/mkl/${mkl_version}/lib"
-        WORKING_DIRECTORY "${extract_1_dir}"
-        LOGNAME "extract-${TARGET_TRIPLET}-${packstem}"
-    )
-    file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.openmp,v=${mkl_version_openmp}-*")
-    cmake_path(GET package_path STEM LAST_ONLY packstem)
-    message(STATUS "Extracting ${packstem}")
-    vcpkg_execute_required_process(
-        COMMAND "${CMAKE_COMMAND}" "-E" "tar" "-xf" "${package_path}/cupPayload.cup"
-            "_installdir/compiler/${mkl_version_openmp}"
-        WORKING_DIRECTORY "${extract_1_dir}"
-        LOGNAME "extract-${TARGET_TRIPLET}-${packstem}"
-    )
-
-    set(mkl_dir "${extract_1_dir}/_installdir/mkl/${mkl_version}")
-    file(COPY "${mkl_dir}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-    file(COPY "${mkl_dir}/${package_libdir}/" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/intel64")
-    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-      set(to_remove_suffix .a)
-    elseif(VCPKG_TARGET_IS_OSX)
-      set(to_remove_suffix .dylib)
-    else()
-      set(to_remove_suffix .so)
-    endif()
-    file(GLOB_RECURSE files_to_remove
-        "${CURRENT_PACKAGES_DIR}/lib/intel64/*${to_remove_suffix}"
-        "${CURRENT_PACKAGES_DIR}/lib/intel64/*${to_remove_suffix}.?"
-    )
-    file(REMOVE ${files_to_remove})
-    file(COPY_FILE "${mkl_dir}/lib/pkgconfig/${main_pc_file}" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}" "\${exec_prefix}/${package_libdir}" "\${exec_prefix}/lib/intel64" IGNORE_UNCHANGED)
   
-    set(compiler_dir "${extract_1_dir}/_installdir/compiler/${mkl_version_openmp}")
-    if(threading STREQUAL "intel_thread")
-      file(COPY "${compiler_dir}/${compiler_libdir}/" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/intel64")
-      file(COPY_FILE "${compiler_dir}/lib/pkgconfig/openmp.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libiomp5.pc")
-      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libiomp5.pc" "/${compiler_libdir}/" "/lib/intel64/" IGNORE_UNCHANGED)
-      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}" "openmp" "libiomp5")
-    endif()
+message(STATUS "Extracting offline installer")
+
+if(VCPKG_TARGET_IS_WINDOWS)
+  vcpkg_find_acquire_program(7Z)
+  vcpkg_execute_required_process(
+      COMMAND "${7Z}" x "${installer_path}" "-o${extract_0_dir}" "-y" "-bso0" "-bsp0"
+      WORKING_DIRECTORY "${extract_0_dir}"
+      LOGNAME "extract-${TARGET_TRIPLET}-0"
+  )
 endif()
+
+if(VCPKG_TARGET_IS_LINUX)
+  vcpkg_execute_required_process(
+      COMMAND "bash" "--verbose" "--noprofile" "${installer_path}" "--extract-only" "--extract-folder" "${extract_0_dir}"
+      WORKING_DIRECTORY "${extract_0_dir}"
+      LOGNAME "extract-${TARGET_TRIPLET}-0"
+  )
+  cmake_path(GET filename STEM LAST_ONLY filename_no_ext)
+  file(RENAME "${extract_0_dir}/${filename_no_ext}/packages" "${extract_0_dir}/packages")
+endif()
+
+file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.mkl.runtime,v=${mkl_version}+*")
+cmake_path(GET package_path STEM LAST_ONLY packstem)
+message(STATUS "Extracting ${packstem}")
+vcpkg_execute_required_process(
+    COMMAND "${CMAKE_COMMAND}" "-E" "tar" "-xf" "${package_path}/cupPayload.cup"
+        "_installdir/mkl/${mkl_short_version}/${runtime_dir}"
+        "_installdir/mkl/${mkl_short_version}/share/doc/mkl/licensing/"
+    WORKING_DIRECTORY "${extract_1_dir}"
+    LOGNAME "extract-${TARGET_TRIPLET}-${packstem}"
+)
+file(RENAME "${extract_1_dir}/_installdir/mkl/${mkl_short_version}/share/doc/mkl/licensing/" "${extract_1_dir}/_installdir/mkl/${mkl_short_version}/licensing/")
+file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.mkl.devel,v=${mkl_version}+*")
+cmake_path(GET package_path STEM LAST_ONLY packstem)
+message(STATUS "Extracting ${packstem}")
+vcpkg_execute_required_process(
+    COMMAND "${CMAKE_COMMAND}" "-E" "tar" "-xf" "${package_path}/cupPayload.cup"
+        "_installdir/mkl/${mkl_short_version}/bin"
+        "_installdir/mkl/${mkl_short_version}/include"
+        "_installdir/mkl/${mkl_short_version}/lib"
+    WORKING_DIRECTORY "${extract_1_dir}"
+    LOGNAME "extract-${TARGET_TRIPLET}-${packstem}"
+)
+file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.openmp,v=${mkl_version}+*")
+cmake_path(GET package_path STEM LAST_ONLY packstem)
+message(STATUS "Extracting ${packstem}")
+vcpkg_execute_required_process(
+    COMMAND "${CMAKE_COMMAND}" "-E" "tar" "-xf" "${package_path}/cupPayload.cup"
+        "_installdir/compiler/${mkl_short_version}"
+    WORKING_DIRECTORY "${extract_1_dir}"
+    LOGNAME "extract-${TARGET_TRIPLET}-${packstem}"
+)
+
+set(mkl_dir "${extract_1_dir}/_installdir/mkl/${mkl_short_version}")
+file(COPY "${mkl_dir}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${mkl_dir}/${package_libdir}/" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/")
+
+file(COPY_FILE "${mkl_dir}/lib/pkgconfig/${main_pc_file}" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}" "\${exec_prefix}/${package_libdir}" "\${exec_prefix}/lib/" IGNORE_UNCHANGED)
+
+set(compiler_dir "${extract_1_dir}/_installdir/compiler/${mkl_short_version}")
+if(threading STREQUAL "intel_thread")
+  file(COPY "${compiler_dir}/lib/" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/")
+  file(COPY_FILE "${compiler_dir}/lib/pkgconfig/openmp.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libiomp5.pc")
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}" "openmp" "libiomp5")
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(to_remove_suffix .a)
+else()
+  if(VCPKG_TARGET_IS_WINDOWS)
+    set(to_remove_suffix .dll)
+  else()
+    set(to_remove_suffix .so)
+  endif()
+endif()
+file(GLOB_RECURSE files_to_remove
+    "${CURRENT_PACKAGES_DIR}/bin/*${to_remove_suffix}"
+    "${CURRENT_PACKAGES_DIR}/lib/*${to_remove_suffix}"
+    "${CURRENT_PACKAGES_DIR}/lib/*${to_remove_suffix}.?"
+)
+file(REMOVE ${files_to_remove})
 
 file(COPY_FILE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/mkl.pc")
 if(NOT VCPKG_BUILD_TYPE)
@@ -236,7 +163,7 @@ if(NOT VCPKG_BUILD_TYPE)
       file(COPY_FILE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${file}" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${file}")
       vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${file}" "/include" "/../include")
       if(NOT VCPKG_TARGET_IS_WINDOWS)
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${file}" "/lib/intel64" "/../lib/intel64")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${file}" "/lib/" "/../lib/" IGNORE_UNCHANGED)
       endif()
     endforeach()
 endif()
@@ -254,14 +181,12 @@ endif()
 #TODO: Give lapack/blas information about the correct BLA_VENDOR depending on settings. 
 
 file(INSTALL "${mkl_dir}/licensing" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.mkl.product,v=${mkl_version}-*")
+file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.mkl.product,v=${mkl_version}+*")
 vcpkg_install_copyright(FILE_LIST "${package_path}/licenses/license.htm")
 
 file(REMOVE_RECURSE
     "${extract_0_dir}"
     "${extract_1_dir}"
-    "${CURRENT_PACKAGES_DIR}/lib/intel64/cmake"
-    "${CURRENT_PACKAGES_DIR}/lib/intel64/pkgconfig"
 )
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/intel-mkl/vcpkg.json
+++ b/ports/intel-mkl/vcpkg.json
@@ -1,15 +1,8 @@
 {
   "name": "intel-mkl",
-  "version": "2023.2.0",
+  "version": "2025.2.0",
   "description": "Intel® Math Kernel Library (Intel® MKL) accelerates math processing routines, increases application performance, and reduces development time on Intel® processors.",
   "homepage": "https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html",
   "license": null,
-  "supports": "(windows | linux | osx) & x64",
-  "dependencies": [
-    {
-      "name": "vcpkg-tool-lessmsi",
-      "host": true,
-      "platform": "windows"
-    }
-  ]
+  "supports": "(windows | linux) & x64"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3949,7 +3949,7 @@
       "port-version": 0
     },
     "intel-mkl": {
-      "baseline": "2023.2.0",
+      "baseline": "2025.2.0",
       "port-version": 0
     },
     "intelrdfpmathlib": {

--- a/versions/i-/intel-mkl.json
+++ b/versions/i-/intel-mkl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "68757c04f7759c50a2cd81b097e862da93673334",
+      "version": "2025.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ca67002cdb300b22fd2321c2af9d3dec3a59dc2",
       "version": "2023.2.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->


fix https://github.com/microsoft/vcpkg/issues/47232
