### PR TITLE
[whisper-cpp] update to 1.8.0

### DIFF
--- a/ports/whisper-cpp/portfile.cmake
+++ b/ports/whisper-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ggml-org/whisper.cpp
     REF v${VERSION}
-    SHA512 7e0ec9d6afe234afaaa83d7d69051504252c27ecdacbedf3d70992429801bcd1078794a0bb76cf4dafb74131dd0f506bd24c3f3100815c35b8ac2b12336492ef
+    SHA512 98f47473d537143a2fcdda7d10adf55a3dd78318768de2625fde4bc84ce61150d60cfd2ae03145d90ac1954b4735ae4fcef71268239e9735c45714721dd31103
     HEAD_REF master
     PATCHES
         cmake-config.diff

--- a/ports/whisper-cpp/vcpkg.json
+++ b/ports/whisper-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "whisper-cpp",
-  "version": "1.7.6",
-  "port-version": 2,
+  "version": "1.8.0",
   "description": "Port of OpenAI's Whisper model in C/C++",
   "homepage": "https://github.com/ggml-org/whisper.cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10357,8 +10357,8 @@
       "port-version": 2
     },
     "whisper-cpp": {
-      "baseline": "1.7.6",
-      "port-version": 2
+      "baseline": "1.8.0",
+      "port-version": 0
     },
     "wiiuse": {
       "baseline": "0.15.6",

--- a/versions/w-/whisper-cpp.json
+++ b/versions/w-/whisper-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a90163123d8132ce3548f4e9f587cb54868e1a36",
+      "version": "1.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "bf8841b8b8c125a25648f10f46ad37070775eba9",
       "version": "1.7.6",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ggml-org/whisper.cpp/releases/tag/v1.8.0
