### PR TITLE
libx11: fix crossbuild

### DIFF
--- a/ports/libx11/portfile.cmake
+++ b/ports/libx11/portfile.cmake
@@ -21,14 +21,14 @@ vcpkg_from_gitlab(
         ${PATCHES}
         vcxserver.patch
         add_dl_pc.patch
-) 
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 
 set(OPTIONS "")
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     set(ENV{CPP} "cl_cpp_wrapper")
-    list(APPEND OPTIONS 
+    list(APPEND OPTIONS
                 --enable-loadable-i18n=no #Pointer conversion errors
                 --enable-unix-transport=no
                 --disable-thread-safety-constructor
@@ -36,7 +36,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     )
 endif()
 if(VCPKG_TARGET_IS_WINDOWS)
-    list(APPEND OPTIONS 
+    list(APPEND OPTIONS
         --enable-malloc0returnsnull=yes      #Configure fails to run the test for some reason
         --enable-ipv6
         --enable-hyperv
@@ -44,6 +44,11 @@ if(VCPKG_TARGET_IS_WINDOWS)
         --with-launchd=no
         --with-lint=no
         --disable-selective-werror
+        )
+endif()
+if(VCPKG_CROSSCOMPILING)
+    list(APPEND OPTIONS
+        --enable-malloc0returnsnull=yes
         )
 endif()
 if(NOT XLSTPROC)
@@ -64,7 +69,7 @@ vcpkg_find_acquire_program(PERL)
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
-    OPTIONS 
+    OPTIONS
         ${OPTIONS}
 )
 
@@ -92,7 +97,7 @@ if(NOT VCPKG_CROSSCOMPILING)
     file(READ "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/config.log" config_contents)
     string(REGEX MATCH "ac_cv_objext=[^\n]+" objsuffix "${config_contents}")
     string(REPLACE "ac_cv_objext=" "." objsuffix "${objsuffix}")
-    file(INSTALL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/util/makekeys${VCPKG_TARGET_EXECUTABLE_SUFFIX}" DESTINATION "${CURRENT_PACKAGES_DIR}/manual-tools/${PORT}")
+    file(INSTALL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/util/makekeys${VCPKG_TARGET_EXECUTABLE_SUFFIX}" DESTINATION "${CURRENT_PACKAGES_DIR}/manual-tools/${PORT}" PERMISSIONS OWNER_EXECUTE)
     file(INSTALL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/util/makekeys${objsuffix}" DESTINATION "${CURRENT_PACKAGES_DIR}/manual-tools/${PORT}")
 endif()
 

--- a/ports/libx11/vcpkg.json
+++ b/ports/libx11/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libx11",
   "version": "1.8.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The X Window System is a network-transparent window system that was designed at MIT.",
   "homepage": "https://www.x.org/wiki/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5666,7 +5666,7 @@
     },
     "libx11": {
       "baseline": "1.8.1",
-      "port-version": 2
+      "port-version": 3
     },
     "libxau": {
       "baseline": "1.0.9",

--- a/versions/l-/libx11.json
+++ b/versions/l-/libx11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08535ebfb1b088293359a9ce56e4829a1d6f8479",
+      "version": "1.8.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "4fda1cb1b842b106895d2ab377ec91cc9c39e932",
       "version": "1.8.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] ~Only one version is added to each modified port's versions file.~
