### PR TITLE
[ggml] update to 0.9.4

### DIFF
--- a/ports/ggml/pkgconfig.diff
+++ b/ports/ggml/pkgconfig.diff
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 90e274cc..b20534f9 100644
+index 5642058..98422c5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -294,7 +294,7 @@ if (GGML_STANDALONE)
+@@ -328,7 +328,7 @@ if (GGML_STANDALONE)
          @ONLY)
  
      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ggml.pc
@@ -11,7 +11,7 @@ index 90e274cc..b20534f9 100644
  endif()
  
  #
-@@ -335,6 +335,7 @@ set(variable_set_statements
+@@ -349,6 +349,7 @@ set(variable_set_statements
  set(GGML_SHARED_LIB ${BUILD_SHARED_LIBS})
  
  get_cmake_property(all_variables VARIABLES)
@@ -20,25 +20,24 @@ index 90e274cc..b20534f9 100644
      if(variable_name MATCHES "^GGML_")
          string(REPLACE ";" "\\;"
 diff --git a/ggml.pc.in b/ggml.pc.in
-index 9be62dc3..a37b0478 100644
+index 3e0291e..a762733 100644
 --- a/ggml.pc.in
 +++ b/ggml.pc.in
 @@ -6,5 +6,7 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
  Name: ggml
  Description: The GGML Tensor Library for Machine Learning
- Version: 0.0.0
+ Version: @GGML_VERSION@
 -Cflags: -I${includedir}
 -Libs: -L${libdir} -lggml
 +Cflags: -I${includedir} @GGML_PKGCONFIG_CFLAGS@
 +Libs: -L${libdir} -lggml @GGML_PKGCONFIG_LIBS_BACKEND@ -lggml-base
 +Libs.private: @GGML_PKGCONFIG_LIBS_PRIVATE@
 +Requires.private: @GGML_PKGCONFIG_REQUIRES_PRIVATE@
-\ No newline at end of file
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 2b5b8169..1a4475b5 100644
+index c8f3d85..d7c1599 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -183,6 +183,10 @@ endif()
+@@ -186,6 +186,10 @@ endif()
  
  # ggml
  
@@ -49,7 +48,7 @@ index 2b5b8169..1a4475b5 100644
  if (GGML_BACKEND_DL AND NOT BUILD_SHARED_LIBS)
      message(FATAL_ERROR "GGML_BACKEND_DL requires BUILD_SHARED_LIBS")
  endif()
-@@ -225,6 +229,7 @@ target_link_libraries(ggml PUBLIC ggml-base)
+@@ -228,6 +232,7 @@ target_link_libraries(ggml PUBLIC ggml-base)
  
  if (CMAKE_SYSTEM_NAME MATCHES "Linux")
      target_link_libraries(ggml PRIVATE dl)
@@ -57,7 +56,7 @@ index 2b5b8169..1a4475b5 100644
  endif()
  
  function(ggml_add_backend_library backend)
-@@ -269,12 +274,20 @@ function(ggml_add_backend backend)
+@@ -272,12 +277,20 @@ function(ggml_add_backend backend)
      string(TOUPPER "GGML_${backend}" backend_id)
      if (${backend_id})
          string(TOLOWER "ggml-${backend}" backend_target)
@@ -78,7 +77,7 @@ index 2b5b8169..1a4475b5 100644
      endif()
  endfunction()
  
-@@ -396,11 +409,15 @@ find_library(MATH_LIBRARY m)
+@@ -399,11 +412,15 @@ find_library(MATH_LIBRARY m)
  if (MATH_LIBRARY)
      if (NOT WIN32 OR NOT DEFINED ENV{ONEAPI_ROOT})
          target_link_libraries(ggml-base PRIVATE m)
@@ -94,7 +93,7 @@ index 2b5b8169..1a4475b5 100644
  endif()
  
  if(CMAKE_SYSTEM_NAME MATCHES "visionOS")
-@@ -413,4 +430,10 @@ if (BUILD_SHARED_LIBS)
+@@ -416,4 +433,10 @@ if (BUILD_SHARED_LIBS)
          target_compile_definitions(${target} PRIVATE GGML_BUILD)
          target_compile_definitions(${target} PUBLIC  GGML_SHARED)
      endforeach()
@@ -105,20 +104,8 @@ index 2b5b8169..1a4475b5 100644
 +set(GGML_PKGCONFIG_LIBS_BACKEND "${GGML_PKGCONFIG_LIBS_BACKEND}" PARENT_SCOPE)
 +set(GGML_PKGCONFIG_LIBS_PRIVATE "${GGML_PKGCONFIG_LIBS_PRIVATE}" PARENT_SCOPE)
 +set(GGML_PKGCONFIG_REQUIRES_PRIVATE "${GGML_PKGCONFIG_REQUIRES_PRIVATE}" PARENT_SCOPE)
-diff --git a/src/ggml-blas/CMakeLists.txt b/src/ggml-blas/CMakeLists.txt
-index 76064c3f..69415049 100644
---- a/src/ggml-blas/CMakeLists.txt
-+++ b/src/ggml-blas/CMakeLists.txt
-@@ -79,6 +79,7 @@ if (BLAS_FOUND)
-     endif()
- 
-     target_link_libraries     (ggml-blas PRIVATE ${BLAS_LIBRARIES})
-+    set(GGML_PKGCONFIG_REQUIRES_PRIVATE "${GGML_PKGCONFIG_REQUIRES_PRIVATE} cblas" PARENT_SCOPE)
-     target_include_directories(ggml-blas PRIVATE ${BLAS_INCLUDE_DIRS})
- else()
-     message(FATAL_ERROR "BLAS not found, please refer to "
 diff --git a/src/ggml-cpu/CMakeLists.txt b/src/ggml-cpu/CMakeLists.txt
-index ce0a3e12..0eea5432 100644
+index 42041b7..b17aca1 100644
 --- a/src/ggml-cpu/CMakeLists.txt
 +++ b/src/ggml-cpu/CMakeLists.txt
 @@ -52,6 +52,9 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
@@ -172,10 +159,10 @@ index ce0a3e12..0eea5432 100644
          message(STATUS "ARM detected")
          list(APPEND GGML_CPU_SOURCES
 diff --git a/src/ggml-metal/CMakeLists.txt b/src/ggml-metal/CMakeLists.txt
-index 0ca8a3c5..9606a9ed 100644
+index 63418fe..138996a 100644
 --- a/src/ggml-metal/CMakeLists.txt
 +++ b/src/ggml-metal/CMakeLists.txt
-@@ -14,6 +14,11 @@ target_link_libraries(ggml-metal PRIVATE
+@@ -19,6 +19,11 @@ target_link_libraries(ggml-metal PRIVATE
                        ${METALKIT_FRAMEWORK}
                        )
  
@@ -188,7 +175,7 @@ index 0ca8a3c5..9606a9ed 100644
      add_compile_definitions(GGML_METAL_NDEBUG)
  endif()
 diff --git a/src/ggml-opencl/CMakeLists.txt b/src/ggml-opencl/CMakeLists.txt
-index 9a7ccbcf..e4c110e6 100644
+index 7e6c843..de676a7 100644
 --- a/src/ggml-opencl/CMakeLists.txt
 +++ b/src/ggml-opencl/CMakeLists.txt
 @@ -7,6 +7,7 @@ ggml_add_backend_library(${TARGET_NAME}
@@ -200,7 +187,7 @@ index 9a7ccbcf..e4c110e6 100644
  
  if (GGML_OPENCL_PROFILING)
 diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
-index b97e7bf9..ec194126 100644
+index b97e7bf..ec19412 100644
 --- a/src/ggml-vulkan/CMakeLists.txt
 +++ b/src/ggml-vulkan/CMakeLists.txt
 @@ -77,6 +77,11 @@ if (Vulkan_FOUND)

--- a/ports/ggml/portfile.cmake
+++ b/ports/ggml/portfile.cmake
@@ -2,14 +2,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ggml-org/ggml
     REF v${VERSION}
-    SHA512 d2820f9d1a5f80a4ec154cd89fc944b9c8b172f547fdeeb630f43fa06186bf37cad2e02aafad781b4bda9d964a8daa02b90685c7e29a4beebf296d2e1e8a7b8f
+    SHA512 e2c47e5bcdf3eda66757e63b93f4adf56e7894edeed0d39f182c850cae4dddb49f3cf82ac9e8546dfcd48abf02b7bf0a64d22bacba4360b2f7ef2cb09855eadb
     HEAD_REF master
     PATCHES
         cmake-config.diff
         pkgconfig.diff
         relax-link-options.diff
         vulkan-shaders-gen.diff
-        vulkan-loader-storage.diff # backport of https://github.com/ggml-org/llama.cpp/pull/16224
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/ggml/vcpkg.json
+++ b/ports/ggml/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ggml",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Tensor library for machine learning",
   "homepage": "https://github.com/ggml-org/ggml",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3269,7 +3269,7 @@
       "port-version": 9
     },
     "ggml": {
-      "baseline": "0.9.3",
+      "baseline": "0.9.4",
       "port-version": 0
     },
     "ghc-filesystem": {

--- a/versions/g-/ggml.json
+++ b/versions/g-/ggml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aad364e21976fd07a7f6c06fd2b078fc079fc30f",
+      "version": "0.9.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "787d68f699c93cb7398e8be275c4649d2213f8b8",
       "version": "0.9.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ggml-org/ggml/releases/tag/v0.9.4
