### PR TITLE
cairo[x11]: fix crossbuild.

### DIFF
--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cairo",
   "version": "1.18.4",
+  "port-version": 1,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "license": "LGPL-2.1-only OR MPL-1.1",
@@ -59,7 +60,10 @@
           "features": [
             "fontconfig"
           ]
-        }
+        },
+        "libx11",
+        "libxext",
+        "libxrender"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1554,7 +1554,7 @@
     },
     "cairo": {
       "baseline": "1.18.4",
-      "port-version": 0
+      "port-version": 1
     },
     "cairomm": {
       "baseline": "1.18.0",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d69b7a716a929457771c9045ba862f26cf5768c",
+      "version": "1.18.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "46db143e87befd1eea4d5225e886d2378d5d259f",
       "version": "1.18.4",
       "port-version": 0


### PR DESCRIPTION
IMPORTANT: both host (e.g. arm64-linux) and build (e.g. x64-linux) need to be modified with the next line included: set(X_VCPKG_FORCE_VCPKG_X_LIBRARIES ON)

This affects (actually tested on linux only) *nix builds only.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
