### PR TITLE
libcroco: fix crossbuild

### DIFF
--- a/ports/libcroco/portfile.cmake
+++ b/ports/libcroco/portfile.cmake
@@ -18,6 +18,7 @@ endif()
 vcpkg_configure_make(
     USE_WRAPPERS
     SOURCE_PATH "${SOURCE_PATH}"
+    DETERMINE_BUILD_TRIPLET
     OPTIONS
         ${OPTIONS}
 )
@@ -26,7 +27,7 @@ vcpkg_install_make()
 
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
                     "${CURRENT_PACKAGES_DIR}/libcroco/bin/croco-0.6-config"
                     "${CURRENT_PACKAGES_DIR}/libcroco/debug/bin")
 

--- a/ports/libcroco/vcpkg.json
+++ b/ports/libcroco/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libcroco",
   "version": "0.6.13",
-  "port-version": 7,
+  "port-version": 8,
   "description": "A standalone css2 parsing and manipulation library",
   "license": "LGPL-2.0-only",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4654,7 +4654,7 @@
     },
     "libcroco": {
       "baseline": "0.6.13",
-      "port-version": 7
+      "port-version": 8
     },
     "libcsv": {
       "baseline": "3.0.3",

--- a/versions/l-/libcroco.json
+++ b/versions/l-/libcroco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d5c590cbf3bfb72e7796fa5060287b9d0361a90",
+      "version": "0.6.13",
+      "port-version": 8
+    },
+    {
       "git-tree": "8ac93f8d5df2dbb6ea9743ce9bdc2b5e7b317057",
       "version": "0.6.13",
       "port-version": 7


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
