### PR TITLE
Added port for deadlightreal/SwiftNet - my C networking library

### DIFF
--- a/ports/swiftnet/portfile.cmake
+++ b/ports/swiftnet/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO deadlightreal/SwiftNet
+    REF 1.0.0
+    SHA512 fcccf5509cd97bef076b2ce3bb95b1c1c029935d00597e5281415878b61e6c4c2da8471292e986bf6f324e21bd9b9efef5908cf96897ff8981293a71cb6cee5a
+)
+
+file(MAKE_DIRECTORY ${SOURCE_PATH}/build)
+
+vcpkg_execute_required_process(
+    COMMAND cmake ../src -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=${CURRENT_PACKAGES_DIR}
+    WORKING_DIRECTORY ${SOURCE_PATH}/build
+)
+
+vcpkg_execute_required_process(
+    COMMAND make install -j ${VCPKG_CONCURRENCY}
+    WORKING_DIRECTORY ${SOURCE_PATH}/build
+)
+
+vcpkg_execute_required_process(
+    COMMAND make -j ${VCPKG_CONCURRENCY}
+    WORKING_DIRECTORY ${SOURCE_PATH}/build
+)
+
+file(INSTALL
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+    TYPE FILE
+    FILES ${SOURCE_PATH}/build/output/libswift_net.a
+)
+
+file(INSTALL
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+    TYPE DIRECTORY
+    FILES ${SOURCE_PATH}/src/swift_net.h
+)
+
+vcpkg_copy_pdbs()

--- a/ports/swiftnet/portfile.cmake
+++ b/ports/swiftnet/portfile.cmake
@@ -34,4 +34,9 @@ file(INSTALL
     FILES ${SOURCE_PATH}/src/swift_net.h
 )
 
+file(INSTALL
+    FILES "${SOURCE_PATH}/LICENSE"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
 vcpkg_copy_pdbs()

--- a/ports/swiftnet/usage
+++ b/ports/swiftnet/usage
@@ -1,0 +1,5 @@
+To use SwiftNet, add this to your CMakeLists.txt:
+
+find_package(swiftnet REQUIRED)
+target_include_directories(main PRIVATE ${SWIFTNET_INCLUDE_DIRS})
+target_link_libraries(main PRIVATE ${SWIFTNET_LIBRARIES})

--- a/ports/swiftnet/vcpkg.json
+++ b/ports/swiftnet/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "swiftnet",
+  "version-string": "1.0.0",
+  "description": "SwiftNet is a C networking library made using raw sockets and no external libraries",
+  "homepage": "https://github.com/deadlightreal/SwiftNet",
+  "license": "Apache-2.0",
+  "dependencies": []
+}

--- a/ports/swiftnet/vcpkg.json
+++ b/ports/swiftnet/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "name": "swiftnet",
-  "version-string": "1.0.0",
+  "version": "1.0.0",
   "description": "SwiftNet is a C networking library made using raw sockets and no external libraries",
   "homepage": "https://github.com/deadlightreal/SwiftNet",
-  "license": "Apache-2.0",
-  "dependencies": []
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
