### PR TITLE
dbus: fix crossbuilding

### DIFF
--- a/ports/dbus/portfile.cmake
+++ b/ports/dbus/portfile.cmake
@@ -25,6 +25,19 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS options
 
 unset(ENV{DBUSDIR})
 
+if(VCPKG_TARGET_IS_LINUX AND VCPKG_CROSSCOMPILING)
+    if(NOT $ENV{TMPDIR} STREQUAL "")
+        set(DBUS_SESSION_SOCKET_DIR $ENV{TMPDIR})
+    elseif(NOT $ENV{TEMP} STREQUAL "")
+        set(DBUS_SESSION_SOCKET_DIR $ENV{TEMP})
+    elseif(NOT $ENV{TMP} STREQUAL "")
+        set(DBUS_SESSION_SOCKET_DIR $ENV{TMP})
+    else()
+        set(DBUS_SESSION_SOCKET_DIR /tmp)
+    endif()
+    LIST(APPEND options "-DDBUS_SESSION_SOCKET_DIR=${DBUS_SESSION_SOCKET_DIR}")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/dbus/vcpkg.json
+++ b/ports/dbus/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dbus",
   "version": "1.16.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "D-Bus specification and reference implementation, including libdbus and dbus-daemon",
   "homepage": "https://gitlab.freedesktop.org/dbus/dbus",
   "license": "AFL-2.1 OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2374,7 +2374,7 @@
     },
     "dbus": {
       "baseline": "1.16.2",
-      "port-version": 2
+      "port-version": 3
     },
     "dcmtk": {
       "baseline": "3.6.9",

--- a/versions/d-/dbus.json
+++ b/versions/d-/dbus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "67242b3a57663890d08150600c9121d6fcc381bd",
+      "version": "1.16.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "a29fd7f168a1d2a3de4267941c2e28965ea1125e",
       "version": "1.16.2",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
