### PR TITLE
gtk3: fix crossbuild

### DIFF
--- a/ports/gtk3/vcpkg.json
+++ b/ports/gtk3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk3",
   "version": "3.24.43",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": null,
@@ -47,6 +47,8 @@
       "host": true
     },
     "libepoxy",
+    "libxi",
+    "libxrandr",
     "pango",
     {
       "name": "vcpkg-tool-meson",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3498,7 +3498,7 @@
     },
     "gtk3": {
       "baseline": "3.24.43",
-      "port-version": 1
+      "port-version": 2
     },
     "gtkmm": {
       "baseline": "4.14.0",

--- a/versions/g-/gtk3.json
+++ b/versions/g-/gtk3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "694065b241970f49ea673268b3a6dd4bf9f6d949",
+      "version": "3.24.43",
+      "port-version": 2
+    },
+    {
       "git-tree": "cfa24f84e35e0408a769693413b6539178a81bb5",
       "version": "3.24.43",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
