### PR TITLE
[libjxl] Specify types for arguments to disambiguate calls to pow()

### DIFF
--- a/ports/libjxl/disambiguate-pow-calls.patch
+++ b/ports/libjxl/disambiguate-pow-calls.patch
@@ -1,0 +1,20 @@
+--- a/lib/jxl/enc_ac_strategy.cc.orig	Tue Nov 26 13:02:35 2024
++++ b/lib/jxl/enc_ac_strategy.cc	Tue May 20 08:17:46 2025
+@@ -486,7 +486,7 @@
+   }
+   float loss_scalar =
+       pow(GetLane(SumOfLanes(df8, loss)) / (num_blocks * kDCTBlockSize),
+-          1.0 / 8.0) *
++          1.0f / 8.0f) *
+       (num_blocks * kDCTBlockSize) / quant_norm16;
+   entropy *= entropy_mul;
+   entropy += config.info_loss_multiplier * loss_scalar;
+@@ -569,7 +569,7 @@
+          tx.type == AcStrategyType::IDENTITY) &&
+         butteraugli_target < 5.0) {
+       static const float kFavor2X2AtHighQuality = 0.4;
+-      float weight = pow((5.0f - butteraugli_target) / 5.0f, 2.0);
++      float weight = pow((5.0f - butteraugli_target) / 5.0f, 2.0f);
+       entropy_mul -= kFavor2X2AtHighQuality * weight;
+     }
+     if ((tx.type != AcStrategyType::DCT && tx.type != AcStrategyType::DCT2X2 &&

--- a/ports/libjxl/portfile.cmake
+++ b/ports/libjxl/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         fix-dependencies.patch
         avoid-exe-linker-flags.patch # https://github.com/libjxl/libjxl/pull/4229
         msvc-remove-libm.patch
+        disambiguate-pow-calls.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libjxl/vcpkg.json
+++ b/ports/libjxl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libjxl",
   "version-semver": "0.11.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "JPEG XL image format reference implementation",
   "homepage": "https://github.com/libjxl/libjxl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4986,7 +4986,7 @@
     },
     "libjxl": {
       "baseline": "0.11.1",
-      "port-version": 3
+      "port-version": 4
     },
     "libkeyfinder": {
       "baseline": "2.2.8",

--- a/versions/l-/libjxl.json
+++ b/versions/l-/libjxl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac044181841dbaf63e6403aa3931b944574b2bdf",
+      "version-semver": "0.11.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "ec154d710200dced15443c1c292fbfa623a18439",
       "version-semver": "0.11.1",
       "port-version": 3


### PR DESCRIPTION
This patches a compilation problem that occurs with the illumos/Solaris `std::pow` declarations. Already fixed upstream but libjxl has not had a new release in a while: https://github.com/libjxl/libjxl/pull/4260

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
