### PR TITLE
[vcpkg-tool-meson] Use isainfo -k instead of uname -m on Solaris/illumos

### DIFF
--- a/ports/vcpkg-tool-meson/vcpkg.json
+++ b/ports/vcpkg-tool-meson/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vcpkg-tool-meson",
   "version": "1.9.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Meson build system",
   "homepage": "https://github.com/mesonbuild/meson",
   "license": "Apache-2.0",

--- a/ports/vcpkg-tool-meson/vcpkg_configure_meson.cmake
+++ b/ports/vcpkg-tool-meson/vcpkg_configure_meson.cmake
@@ -156,6 +156,14 @@ function(z_vcpkg_get_build_and_host_system build_system host_system is_cross) #h
             OUTPUT_STRIP_TRAILING_WHITESPACE
             COMMAND_ERROR_IS_FATAL ANY)
 
+        if(CMAKE_HOST_SOLARIS)
+            execute_process(
+                COMMAND isainfo -k
+                OUTPUT_VARIABLE MACHINE
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                COMMAND_ERROR_IS_FATAL ANY)
+        endif()
+
         # Show real machine architecture to visually understand whether we are in a native Apple Silicon terminal or running under Rosetta emulation
         debug_message("Machine: ${MACHINE}")
 

--- a/scripts/cmake/vcpkg_configure_meson.cmake
+++ b/scripts/cmake/vcpkg_configure_meson.cmake
@@ -152,6 +152,14 @@ function(z_vcpkg_get_build_and_host_system build_system host_system is_cross) #h
             OUTPUT_STRIP_TRAILING_WHITESPACE
             COMMAND_ERROR_IS_FATAL ANY)
 
+        if(CMAKE_HOST_SOLARIS)
+            execute_process(
+                COMMAND isainfo -k
+                OUTPUT_VARIABLE MACHINE
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                COMMAND_ERROR_IS_FATAL ANY)
+        endif()
+
         # Show real machine architecture to visually understand whether we are in a native Apple Silicon terminal or running under Rosetta emulation
         debug_message("Machine: ${MACHINE}")
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10114,7 +10114,7 @@
     },
     "vcpkg-tool-meson": {
       "baseline": "1.9.0",
-      "port-version": 1
+      "port-version": 2
     },
     "vcpkg-tool-mozbuild": {
       "baseline": "4.0.2",

--- a/versions/v-/vcpkg-tool-meson.json
+++ b/versions/v-/vcpkg-tool-meson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e367b6c164136bca2cb53f0b8308932f0ccd33b9",
+      "version": "1.9.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "e54a5dd69eac88f0bf24ea348f192b971b2f81c5",
       "version": "1.9.0",
       "port-version": 1


### PR DESCRIPTION
`uname -m` always outputs `i86pc` on x86, but `isainfo -k` produces `amd64` or `i386` depending on kernel arch.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.