### PR TITLE
[simpleble] update to 0.8.1

### DIFF
--- a/ports/simpleble/portfile.cmake
+++ b/ports/simpleble/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenBluetoothToolbox/SimpleBLE
     HEAD_REF main
-    REF a07397dbdd7f8149b7b235b5b21b88b60e8cfbed
-    SHA512 19b61093f529c37f6309c51b53499d86c45a7c3e2e6e8c619c191e40dac713ec1dafdf2a21f81bb9cb9ba6254ab226bd331ee7582facb84ef7756824ffa3eaa8
+    REF "v${VERSION}"
+    SHA512 059df611a8a529d6ad177e13f3a639a76b9dda8c72395bf660c63239c519096761e123459b814bbfac2e3e3407119477373453891c88daa4532e56f2c77da223
     PATCHES
         use-std-localtime.patch
 )

--- a/ports/simpleble/vcpkg.json
+++ b/ports/simpleble/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "simpleble",
-  "version-date": "2023-07-29",
-  "port-version": 2,
+  "version": "0.8.1",
   "description": "The ultimate fully-fledged cross-platform library and bindings for Bluetooth Low Energy (BLE).",
   "homepage": "https://github.com/OpenBluetoothToolbox/SimpleBLE",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8953,8 +8953,8 @@
       "port-version": 2
     },
     "simpleble": {
-      "baseline": "2023-07-29",
-      "port-version": 2
+      "baseline": "0.8.1",
+      "port-version": 0
     },
     "simpleini": {
       "baseline": "4.22",

--- a/versions/s-/simpleble.json
+++ b/versions/s-/simpleble.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e6c974ebad38438bfc00b4847b1d48878726de0f",
+      "version": "0.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "eace68173b736769b5ba2ca8be06a2926c4dcc4d",
       "version-date": "2023-07-29",
       "port-version": 2


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

0.8.1 is the last release with MIT license.
https://github.com/simpleble/simpleble/releases/tag/v0.9.0

