### PR TITLE
[flatbuffers] Add patch to fix MSVC runtime flags

### DIFF
--- a/ports/flatbuffers/fix-runtime-flags-msvc.patch
+++ b/ports/flatbuffers/fix-runtime-flags-msvc.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f7f388f..4ab8149 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -456,12 +456,14 @@ if(FLATBUFFERS_BUILD_FLATC)
+   endif()
+ 
+   target_link_libraries(flatc PRIVATE $<BUILD_INTERFACE:ProjectConfig>)
++  if(FALSE) # DONT mess with runtime flags
+   target_compile_options(flatc
+     PRIVATE
+       $<$<AND:$<BOOL:${MSVC_LIKE}>,$<CONFIG:Release>>:
+         /MT
+       >
+   )
++  endif()
+ 
+   if(FLATBUFFERS_CODE_SANITIZE AND NOT WIN32)
+     add_fsanitize_to_target(flatc ${FLATBUFFERS_CODE_SANITIZE})

--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-uwp-build.patch
+        fix-runtime-flags-msvc.patch
 )
 
 set(options "")

--- a/ports/flatbuffers/vcpkg.json
+++ b/ports/flatbuffers/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "flatbuffers",
   "version": "25.9.23",
+  "port-version": 1,
   "description": "FlatBuffers is a cross platform serialization library architected for maximum memory efficiency. It allows you to directly access serialized data without parsing/unpacking it first, while still having great forwards/backwards compatibility.",
   "homepage": "https://google.github.io/flatbuffers/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2970,7 +2970,7 @@
     },
     "flatbuffers": {
       "baseline": "25.9.23",
-      "port-version": 0
+      "port-version": 1
     },
     "flatbush": {
       "baseline": "1.3.0",

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cf3ccaa4a8abd4a9dcc02a2006d3387e13e3a94c",
+      "version": "25.9.23",
+      "port-version": 1
+    },
+    {
       "git-tree": "34977bf5c6ebc9b593376b223f82a21e1c945d42",
       "version": "25.9.23",
       "port-version": 0


### PR DESCRIPTION
Fixing Error in CMakeLists.txt causing /MT to be added to compile after /MD, causing link failures when linking static lib in to dll later on.

cl : Command line warning D9025 : overriding '/MD' with '/MT'



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
