### PR TITLE
Build dav1d with static linking if required by CRT

### DIFF
--- a/ports/dav1d/portfile.cmake
+++ b/ports/dav1d/portfile.cmake
@@ -18,10 +18,11 @@ elseif (VCPKG_TARGET_IS_WINDOWS)
     endforeach(GAS_PATH)
 endif()
 
-set(LIBRARY_TYPE ${VCPKG_LIBRARY_LINKAGE})
-if (LIBRARY_TYPE STREQUAL "dynamic")
+if ("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "static" OR "${VCPKG_CRT_LINKAGE}" STREQUAL "static")
+    set(LIBRARY_TYPE "static")
+else()
     set(LIBRARY_TYPE "shared")
-endif(LIBRARY_TYPE STREQUAL "dynamic")
+endif()
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/dav1d/vcpkg.json
+++ b/ports/dav1d/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dav1d",
   "version": "1.5.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "dav1d is a new open-source AV1 decoder developed by the VideoLAN and FFmpeg communities and sponsored by the Alliance for Open Media.",
   "homepage": "https://code.videolan.org/videolan/dav1d",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2334,7 +2334,7 @@
     },
     "dav1d": {
       "baseline": "1.5.1",
-      "port-version": 1
+      "port-version": 2
     },
     "daw-header-libraries": {
       "baseline": "2.123.2",

--- a/versions/d-/dav1d.json
+++ b/versions/d-/dav1d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ac8dac7199c5cfc284a86540b3d6b2883e363624",
+      "git-tree": "794cb64ab254bc16a407bd5eae26957e0bbe1e94",
       "version": "1.5.1",
       "port-version": 2
     },

--- a/versions/d-/dav1d.json
+++ b/versions/d-/dav1d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac8dac7199c5cfc284a86540b3d6b2883e363624",
+      "version": "1.5.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "2959b9e1c7cab8aa505b55950db3491998168c3c",
       "version": "1.5.1",
       "port-version": 1


### PR DESCRIPTION
Fixes #47670

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.