### PR TITLE
[qtbase] Fix windeployqt path handling in Debug mode with whitespaces in path.

### DIFF
--- a/ports/qtbase/qtpaths.debug.bat
+++ b/ports/qtbase/qtpaths.debug.bat
@@ -1,2 +1,2 @@
 @echo off
-"%0\..\qtpaths.exe" --qtconf "%0\..\qt.debug.conf" %*
+"%~dp0qtpaths.exe" --qtconf "%~dp0qt.debug.conf" %*

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.9.1",
+  "port-version": 1,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8062,7 +8062,7 @@
     },
     "qtbase": {
       "baseline": "6.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "qtcharts": {
       "baseline": "6.9.1",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74da42868a308a07489d21df058628ede5af1834",
+      "version": "6.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "be98b37ac43fb19787d8eb594a22343810259f17",
       "version": "6.9.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #47674

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.