### PR TITLE
[angelscript] update to 2.38.0

### DIFF
--- a/ports/angelscript/fix-ndk-arm.patch
+++ b/ports/angelscript/fix-ndk-arm.patch
@@ -1,0 +1,49 @@
+diff --git a/angelscript/source/as_callfunc_arm_gcc.S b/angelscript/source/as_callfunc_arm_gcc.S
+index 994fcb0..62a9602 100644
+--- a/angelscript/source/as_callfunc_arm_gcc.S
++++ b/angelscript/source/as_callfunc_arm_gcc.S
+@@ -53,6 +53,12 @@
+ .global armFuncObjLast
+ .global armFuncR0ObjLast
+ 
++.type armFunc, %function
++.type armFuncR0, %function
++.type armFuncR0R1, %function
++.type armFuncObjLast, %function
++.type armFuncR0ObjLast, %function
++
+ /* --------------------------------------------------------------------------------------------*/
+ armFunc:
+     stmdb   sp!, {r4-r8, lr}
+@@ -315,6 +321,7 @@ nomoreargsarmFuncR0R1:
+     .arm            /* Use ARM instructions instead of Thumb.*/
+ #endif
+     .globl armFunc  /* Make the function globally accessible.*/
++    .type armFunc, %function
+ armFunc:
+     push    {r4-r8, r10, r11, lr}   /* sp must be 8-byte alignment for ABI compliance, so the pushed registers must be even */
+ 
+@@ -474,6 +482,7 @@ nomoreargsarmFuncObjLast:
+     .arm            /* Use ARM instructions instead of Thumb.*/
+ #endif
+     .globl armFuncR0ObjLast     /* Make the function globally accessible.*/
++    .type armFuncR0ObjLast, %function
+ armFuncR0ObjLast:
+     push    {r4-r8, r10, r11, lr}
+ 
+@@ -568,6 +577,7 @@ nomoreargsarmFuncR0ObjLast:
+     .arm            /* Use ARM instructions instead of Thumb.*/
+ #endif
+     .globl armFuncR0        /* Make the function globally accessible.*/
++    .type armFuncR0, %function
+ armFuncR0:
+     push {r4-r8, r10, r11, lr}
+ 
+@@ -644,6 +654,7 @@ nomoreargsarmFuncR0:
+     .arm            /* Use ARM instructions instead of Thumb.*/
+ #endif
+     .globl armFuncR0R1      /* Make the function globally accessible.*/
++    .type armFuncR0R1, %function
+ armFuncR0R1:
+     push {r4-r8, r10, r11, lr}
+ 

--- a/ports/angelscript/fix-osx-x64.patch
+++ b/ports/angelscript/fix-osx-x64.patch
@@ -1,0 +1,16 @@
+diff --git a/angelscript/projects/cmake/CMakeLists.txt b/angelscript/projects/cmake/CMakeLists.txt
+index 6f9d540..1adea0b 100644
+--- a/angelscript/projects/cmake/CMakeLists.txt
++++ b/angelscript/projects/cmake/CMakeLists.txt
+@@ -74,11 +74,7 @@ set(ANGELSCRIPT_SOURCE
+     ../../source/as_builder.cpp
+     ../../source/as_bytecode.cpp
+     ../../source/as_callfunc.cpp
+-    ../../source/as_callfunc_mips.cpp
+-    ../../source/as_callfunc_x86.cpp
+     ../../source/as_callfunc_x64_gcc.cpp
+-    ../../source/as_callfunc_x64_msvc.cpp
+-    ../../source/as_callfunc_x64_mingw.cpp
+     ../../source/as_compiler.cpp
+     ../../source/as_configgroup.cpp
+     ../../source/as_context.cpp

--- a/ports/angelscript/fix-osx-x64.patch
+++ b/ports/angelscript/fix-osx-x64.patch
@@ -14,3 +14,16 @@ index 6f9d540..1adea0b 100644
      ../../source/as_compiler.cpp
      ../../source/as_configgroup.cpp
      ../../source/as_context.cpp
+diff --git a/angelscript/source/as_callfunc_x64_gcc.cpp b/angelscript/source/as_callfunc_x64_gcc.cpp
+index 1111148..d15c4e9 100644
+--- a/angelscript/source/as_callfunc_x64_gcc.cpp
++++ b/angelscript/source/as_callfunc_x64_gcc.cpp
+@@ -141,7 +141,7 @@ static asQWORD __attribute__((noinline))
+ 
+ 	// Restore stack pointer
+ 		"  mov %%r15, %%rsp \n"
+-#if defined(__clang__) && defined(__OPTIMIZE__)
++#if defined(__clang__) && defined(__OPTIMIZE__) && !(defined(__APPLE__) && defined(__x86_64__))
+ 	// Inform the stack unwind logic that the stack pointer has been restored
+ 	// This should only be done if any optimization is done. If no optimization (-O0) is used,
+ 	// then the compiler already backups the rsp before entering the inline assembler code

--- a/ports/angelscript/fix-win-arm64.patch
+++ b/ports/angelscript/fix-win-arm64.patch
@@ -1,16 +1,17 @@
 diff --git a/angelscript/projects/cmake/CMakeLists.txt b/angelscript/projects/cmake/CMakeLists.txt
-index 6f9d540..42a794c 100644
+index 6f9d540..6eae090 100644
 --- a/angelscript/projects/cmake/CMakeLists.txt
 +++ b/angelscript/projects/cmake/CMakeLists.txt
-@@ -79,6 +79,7 @@ set(ANGELSCRIPT_SOURCE
+@@ -77,7 +77,7 @@ set(ANGELSCRIPT_SOURCE
+     ../../source/as_callfunc_mips.cpp
+     ../../source/as_callfunc_x86.cpp
      ../../source/as_callfunc_x64_gcc.cpp
-     ../../source/as_callfunc_x64_msvc.cpp
-     ../../source/as_callfunc_x64_mingw.cpp
+-    ../../source/as_callfunc_x64_msvc.cpp
 +    ../../source/as_callfunc_arm64.cpp
+     ../../source/as_callfunc_x64_mingw.cpp
      ../../source/as_compiler.cpp
      ../../source/as_configgroup.cpp
-     ../../source/as_context.cpp
-@@ -106,9 +107,9 @@ set(ANGELSCRIPT_SOURCE
+@@ -106,9 +106,9 @@ set(ANGELSCRIPT_SOURCE
  )
  
  if(MSVC AND CMAKE_CL_64)
@@ -23,7 +24,7 @@ index 6f9d540..42a794c 100644
          message(FATAL ERROR "MSVC x86_64 target requires a working assembler")
      endif()
 diff --git a/angelscript/source/as_config.h b/angelscript/source/as_config.h
-index 9a99faf..4ee59ab 100644
+index 9a99faf..293cc2e 100644
 --- a/angelscript/source/as_config.h
 +++ b/angelscript/source/as_config.h
 @@ -532,7 +532,7 @@

--- a/ports/angelscript/fix-win-arm64.patch
+++ b/ports/angelscript/fix-win-arm64.patch
@@ -31,7 +31,7 @@ index 9a99faf..4ee59ab 100644
  	#endif
  
 -	#if defined(_M_ARM64)
-+	#if defined(_M_ARM )
++	#if defined(_M_ARM)
  		#define AS_ARM64
  
  		// TODO: MORE HERE

--- a/ports/angelscript/fix-win-arm64.patch
+++ b/ports/angelscript/fix-win-arm64.patch
@@ -1,10 +1,13 @@
 diff --git a/angelscript/projects/cmake/CMakeLists.txt b/angelscript/projects/cmake/CMakeLists.txt
-index 6f9d540..0d9c329 100644
+index 6f9d540..2a5e1a4 100644
 --- a/angelscript/projects/cmake/CMakeLists.txt
 +++ b/angelscript/projects/cmake/CMakeLists.txt
-@@ -108,7 +108,7 @@ set(ANGELSCRIPT_SOURCE
+@@ -106,9 +106,9 @@ set(ANGELSCRIPT_SOURCE
+ )
+ 
  if(MSVC AND CMAKE_CL_64)
-     enable_language(ASM_MASM)
+-    enable_language(ASM_MASM)
++    enable_language(ASM_MARMASM)
      if(CMAKE_ASM_MASM_COMPILER_WORKS)
 -        set(ANGELSCRIPT_SOURCE ${ANGELSCRIPT_SOURCE} ../../source/as_callfunc_x64_msvc_asm.asm)
 +        set(ANGELSCRIPT_SOURCE ${ANGELSCRIPT_SOURCE} ../../source/as_callfunc_arm64_msvc.asm)

--- a/ports/angelscript/fix-win-arm64.patch
+++ b/ports/angelscript/fix-win-arm64.patch
@@ -1,0 +1,13 @@
+diff --git a/angelscript/projects/cmake/CMakeLists.txt b/angelscript/projects/cmake/CMakeLists.txt
+index 6f9d540..0d9c329 100644
+--- a/angelscript/projects/cmake/CMakeLists.txt
++++ b/angelscript/projects/cmake/CMakeLists.txt
+@@ -108,7 +108,7 @@ set(ANGELSCRIPT_SOURCE
+ if(MSVC AND CMAKE_CL_64)
+     enable_language(ASM_MASM)
+     if(CMAKE_ASM_MASM_COMPILER_WORKS)
+-        set(ANGELSCRIPT_SOURCE ${ANGELSCRIPT_SOURCE} ../../source/as_callfunc_x64_msvc_asm.asm)
++        set(ANGELSCRIPT_SOURCE ${ANGELSCRIPT_SOURCE} ../../source/as_callfunc_arm64_msvc.asm)
+     else()
+         message(FATAL ERROR "MSVC x86_64 target requires a working assembler")
+     endif()

--- a/ports/angelscript/fix-win-arm64.patch
+++ b/ports/angelscript/fix-win-arm64.patch
@@ -1,8 +1,16 @@
 diff --git a/angelscript/projects/cmake/CMakeLists.txt b/angelscript/projects/cmake/CMakeLists.txt
-index 6f9d540..2a5e1a4 100644
+index 6f9d540..42a794c 100644
 --- a/angelscript/projects/cmake/CMakeLists.txt
 +++ b/angelscript/projects/cmake/CMakeLists.txt
-@@ -106,9 +106,9 @@ set(ANGELSCRIPT_SOURCE
+@@ -79,6 +79,7 @@ set(ANGELSCRIPT_SOURCE
+     ../../source/as_callfunc_x64_gcc.cpp
+     ../../source/as_callfunc_x64_msvc.cpp
+     ../../source/as_callfunc_x64_mingw.cpp
++    ../../source/as_callfunc_arm64.cpp
+     ../../source/as_compiler.cpp
+     ../../source/as_configgroup.cpp
+     ../../source/as_context.cpp
+@@ -106,9 +107,9 @@ set(ANGELSCRIPT_SOURCE
  )
  
  if(MSVC AND CMAKE_CL_64)
@@ -14,3 +22,16 @@ index 6f9d540..2a5e1a4 100644
      else()
          message(FATAL ERROR "MSVC x86_64 target requires a working assembler")
      endif()
+diff --git a/angelscript/source/as_config.h b/angelscript/source/as_config.h
+index 9a99faf..4ee59ab 100644
+--- a/angelscript/source/as_config.h
++++ b/angelscript/source/as_config.h
+@@ -532,7 +532,7 @@
+ 		#endif
+ 	#endif
+ 
+-	#if defined(_M_ARM64)
++	#if defined(_M_ARM )
+ 		#define AS_ARM64
+ 
+ 		// TODO: MORE HERE

--- a/ports/angelscript/mark-threads-private.patch
+++ b/ports/angelscript/mark-threads-private.patch
@@ -1,8 +1,8 @@
 diff --git a/angelscript/projects/cmake/CMakeLists.txt b/angelscript/projects/cmake/CMakeLists.txt
-index 7c800c5..982ad8b 100644
+index 6f9d540..5d39f9b 100644
 --- a/angelscript/projects/cmake/CMakeLists.txt
 +++ b/angelscript/projects/cmake/CMakeLists.txt
-@@ -145,7 +145,7 @@ endif()
+@@ -192,7 +192,7 @@ endif()
  
  # Don't override the default library output path to avoid conflicts when building for multiple target platforms
  #set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/../../lib)

--- a/ports/angelscript/portfile.cmake
+++ b/ports/angelscript/portfile.cmake
@@ -4,19 +4,20 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 87c94042932f15d07fe6ede4c3671b1f73ac757b68ab360187591497eeabc56a4ddb7901e4567108e44886a2011a29c2884d4b7389557826f36a6c384f4a9c69
 )
 
+set(PATCHES
+    mark-threads-private.patch
+    fix-dependency.patch
+)
+
 if (VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-    set(fix-osx64 "fix-osx-x64.patch")
-else()
-    set(fix-osx64 "")
+    list(APPEND PATCHES "fix-osx-x64.patch")
 endif()
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
-        mark-threads-private.patch
-        fix-dependency.patch
-        "${fix-osx64}"
+        ${PATCHES}
 )
 
 vcpkg_cmake_configure(

--- a/ports/angelscript/portfile.cmake
+++ b/ports/angelscript/portfile.cmake
@@ -4,12 +4,19 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 87c94042932f15d07fe6ede4c3671b1f73ac757b68ab360187591497eeabc56a4ddb7901e4567108e44886a2011a29c2884d4b7389557826f36a6c384f4a9c69
 )
 
+if (VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(fix-osx64 "fix-osx-x64.patch")
+else()
+    set(fix-osx64 "")
+endif()
+
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
         mark-threads-private.patch
         fix-dependency.patch
+        "${fix-osx64}"
 )
 
 vcpkg_cmake_configure(

--- a/ports/angelscript/portfile.cmake
+++ b/ports/angelscript/portfile.cmake
@@ -13,6 +13,10 @@ if (VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     list(APPEND PATCHES "fix-osx-x64.patch")
 endif()
 
+if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    list(APPEND PATCHES "fix-win-arm64.patch")
+endif()
+
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"

--- a/ports/angelscript/portfile.cmake
+++ b/ports/angelscript/portfile.cmake
@@ -17,12 +17,23 @@ if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
     list(APPEND PATCHES "fix-win-arm64.patch")
 endif()
 
+if (VCPKG_TARGET_IS_ANDROID AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+    list(APPEND PATCHES "fix-ndk-arm.patch")
+endif()
+
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
         ${PATCHES}
 )
+
+if (VCPKG_TARGET_IS_ANDROID AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+    vcpkg_replace_string("${SOURCE_PATH}/angelscript/source/as_callfunc_arm_gcc.S"
+[[.globl armFuncObjLast       /* Make the function globally accessible.*/]]
+[[.globl armFuncObjLast       /* Make the function globally accessible.*/
+.type armFuncObjLast, %function]])
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/angelscript/projects/cmake"

--- a/ports/angelscript/portfile.cmake
+++ b/ports/angelscript/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_download_distfile(ARCHIVE
 )
 
 set(PATCHES
-    mark-threads-private.patch
-    fix-dependency.patch
+    "mark-threads-private.patch"
+    "fix-dependency.patch"
 )
 
 if (VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")

--- a/ports/angelscript/portfile.cmake
+++ b/ports/angelscript/portfile.cmake
@@ -32,7 +32,7 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Angelscript)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/Angelscript")
 
 # Copy the addon files
 if("addons" IN_LIST FEATURES)

--- a/ports/angelscript/portfile.cmake
+++ b/ports/angelscript/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://angelcode.com/angelscript/sdk/files/angelscript_${VERSION}.zip"
     FILENAME "angelscript_${VERSION}.zip"
-    SHA512 ba7d88a42e1443fd12196da723538b24d999bc7ade92c0231237e4c5b8b0cb586931262c941898c62f454fd453d653724c74b6857e8a43eea6e34669795fc9cd
+    SHA512 87c94042932f15d07fe6ede4c3671b1f73ac757b68ab360187591497eeabc56a4ddb7901e4567108e44886a2011a29c2884d4b7389557826f36a6c384f4a9c69
 )
 
 vcpkg_extract_source_archive(

--- a/ports/angelscript/vcpkg.json
+++ b/ports/angelscript/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "The AngelCode Scripting Library, or AngelScript as it is also known, is an extremely flexible cross-platform scripting library designed to allow applications to extend their functionality through external scripts. It has been designed from the beginning to be an easy to use component, both for the application programmer and the script writer.",
   "homepage": "https://angelcode.com/angelscript",
   "license": "Zlib",
-  "supports": "!arm",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/angelscript/vcpkg.json
+++ b/ports/angelscript/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "angelscript",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "description": "The AngelCode Scripting Library, or AngelScript as it is also known, is an extremely flexible cross-platform scripting library designed to allow applications to extend their functionality through external scripts. It has been designed from the beginning to be an easy to use component, both for the application programmer and the script writer.",
   "homepage": "https://angelcode.com/angelscript",
   "license": "Zlib",

--- a/scripts/test_ports/vcpkg-ci-angelscript/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-angelscript/portfile.cmake
@@ -1,0 +1,3 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-angelscript/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-angelscript/project/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.29)
+project(capstone-test CXX)
+set(CMAKE_CXX_STANDARD 11)
+add_executable(main main.cpp)
+find_package(Angelscript CONFIG REQUIRED)
+target_link_libraries(main PRIVATE Angelscript::angelscript)

--- a/scripts/test_ports/vcpkg-ci-angelscript/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-angelscript/project/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.29)
-project(capstone-test CXX)
+project(angelscript-test CXX)
 set(CMAKE_CXX_STANDARD 11)
 add_executable(main main.cpp)
 find_package(Angelscript CONFIG REQUIRED)

--- a/scripts/test_ports/vcpkg-ci-angelscript/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-angelscript/project/main.cpp
@@ -1,0 +1,6 @@
+#include <angelscript.h>
+int main()
+{
+    auto LibraryVersion = asGetLibraryVersion();
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-angelscript/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-angelscript/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-angelscript",
+  "version-string": "ci",
+  "description": "Validates angelscript",
+  "dependencies": [
+    "angelscript",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ffa996617cfa1aab8b690614ee0b3512536db57d",
+      "git-tree": "60dedf7e42ab812fb5a13070a41574ff8771e82e",
       "version": "2.38.0",
       "port-version": 0
     },

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0376602a7ac91978ae301bd0b4f5a1ff06abf70d",
+      "git-tree": "0007ff530bf1ae9f581c7c8c4d9bc91a83a72fb1",
       "version": "2.38.0",
       "port-version": 0
     },

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0007ff530bf1ae9f581c7c8c4d9bc91a83a72fb1",
+      "git-tree": "bcb1966534c312e5ff71bd223d7c68f3630177c1",
       "version": "2.38.0",
       "port-version": 0
     },

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "60dedf7e42ab812fb5a13070a41574ff8771e82e",
+      "git-tree": "dfa3e0abfe1b7e0f09eb0930df41d258668cb61e",
       "version": "2.38.0",
       "port-version": 0
     },

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2164f9792d814c4226403d2f6e389b7ef4c4a3c4",
+      "git-tree": "0376602a7ac91978ae301bd0b4f5a1ff06abf70d",
       "version": "2.38.0",
       "port-version": 0
     },

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3bf3e87da42b4547c273f05d67e8b9d187245ee3",
+      "git-tree": "2164f9792d814c4226403d2f6e389b7ef4c4a3c4",
       "version": "2.38.0",
       "port-version": 0
     },

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bcb1966534c312e5ff71bd223d7c68f3630177c1",
+      "git-tree": "d7fb9957d99738d4c441dc7304c10fd55efbaeb3",
       "version": "2.38.0",
       "port-version": 0
     },

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "14b548b92ed5884a7918010c22d49dcf789a974e",
+      "git-tree": "4ccff9bdd3582da1012dd3e2fb5cf7d7c681bcb3",
       "version": "2.38.0",
       "port-version": 0
     },

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4ccff9bdd3582da1012dd3e2fb5cf7d7c681bcb3",
+      "git-tree": "ffa996617cfa1aab8b690614ee0b3512536db57d",
       "version": "2.38.0",
       "port-version": 0
     },

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "664d2414a5c862773a8ad867013699419b5d1f3d",
+      "git-tree": "3bf3e87da42b4547c273f05d67e8b9d187245ee3",
       "version": "2.38.0",
       "port-version": 0
     },

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d7fb9957d99738d4c441dc7304c10fd55efbaeb3",
+      "git-tree": "14b548b92ed5884a7918010c22d49dcf789a974e",
       "version": "2.38.0",
       "port-version": 0
     },

--- a/versions/a-/angelscript.json
+++ b/versions/a-/angelscript.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "664d2414a5c862773a8ad867013699419b5d1f3d",
+      "version": "2.38.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cb5cf64b9cd72cbcebfb4e68d3e82627541a39c6",
       "version": "2.37.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -133,7 +133,7 @@
       "port-version": 8
     },
     "angelscript": {
-      "baseline": "2.37.0",
+      "baseline": "2.38.0",
       "port-version": 0
     },
     "angle": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Resolves: https://github.com/microsoft/vcpkg/issues/47456

vcpkg_replace_string was used to avoid unreadable unicode symbols in ndk patch file.
Waiting for https://github.com/anjo76/angelscript/pull/18