### PR TITLE
libnotify: add new port

### DIFF
--- a/ports/libnotify/0001-fix-parameter-name-omitted-error.patch
+++ b/ports/libnotify/0001-fix-parameter-name-omitted-error.patch
@@ -1,0 +1,15 @@
+diff --git a/libnotify/launch-context.c b/libnotify/launch-context.c
+index facb43c..9469042 100644
+--- a/libnotify/launch-context.c
++++ b/libnotify/launch-context.c
+@@ -49,8 +49,8 @@ notification_app_launch_context_finalize (GObject *object)
+ 
+ static char *
+ notification_app_launch_context_get_startup_notify_id (GAppLaunchContext *context,
+-                                                       GAppInfo *,
+-                                                       GList *)
++                                                       GAppInfo *gai,
++                                                       GList *gl)
+ {
+         NotificationAppLaunchContext *self = NOTIFICATION_APP_LAUNCH_CONTEXT (context);
+ 

--- a/ports/libnotify/portfile.cmake
+++ b/ports/libnotify/portfile.cmake
@@ -1,0 +1,48 @@
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.gnome.org"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "GNOME/libnotify"
+    REF "${VERSION}"
+    HEAD_REF "master"
+    SHA512 731f874676347e18b45eb63ae6a968bce8b34d57aadef444733b73a51b3b29297751699f3aeae9dfd2779afffc7e9c15d3a4141504cfe6cd46f51f79d3ee85d5
+    PATCHES
+        0001-fix-parameter-name-omitted-error.patch
+)
+
+vcpkg_list(SET RELEASE_OPTIONS)
+if("introspection" IN_LIST FEATURES)
+    vcpkg_list(APPEND RELEASE_OPTIONS -Dintrospection=enabled)
+    vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+else()
+    vcpkg_list(APPEND RELEASE_OPTIONS -Dintrospection=disabled)
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dtests=false
+        -Dman=false
+        -Dgtk_doc=false
+        -Ddocbook_docs=disabled
+    OPTIONS_RELEASE
+        ${RELEASE_OPTIONS}
+    OPTIONS_DEBUG
+        -Dintrospection=disabled
+    ADDITIONAL_BINARIES
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
+        "glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'"
+        "glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'"
+)
+
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libnotify/vcpkg.json
+++ b/ports/libnotify/vcpkg.json
@@ -1,0 +1,39 @@
+{
+  "name": "libnotify",
+  "version": "0.8.7",
+  "description": "A library for sending desktop notifications",
+  "homepage": "https://gitlab.gnome.org/GNOME/libnotify",
+  "license": "LGPL-2.1-or-later",
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "gdk-pixbuf",
+      "default-features": false
+    },
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ],
+  "features": {
+    "introspection": {
+      "description": "Enable GObject introspection",
+      "supports": "!static",
+      "dependencies": [
+        {
+          "name": "gdk-pixbuf",
+          "default-features": false,
+          "features": [
+            "introspection"
+          ]
+        },
+        "gobject-introspection"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5200,6 +5200,10 @@
       "baseline": "2021-11-03",
       "port-version": 0
     },
+    "libnotify": {
+      "baseline": "0.8.7",
+      "port-version": 0
+    },
     "libobfuscate": {
       "baseline": "2024-07-10",
       "port-version": 0

--- a/versions/l-/libnotify.json
+++ b/versions/l-/libnotify.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "069bf1b7252408efbbccc72304e4d9d4c1d9e6ef",
+      "version": "0.8.7",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
