### PR TITLE
[mgclient] add new port

### DIFF
--- a/ports/mgclient/export-cmake.patch
+++ b/ports/mgclient/export-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 92426e9..9af1543 100644
+index 92426e9..f96152a 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -16,6 +16,8 @@ add_library(project_options INTERFACE)
@@ -84,15 +84,16 @@ index 92426e9..9af1543 100644
 +    if(BUILD_SHARED_LIBS)
 +    install(TARGETS mgclient-shared
 +            EXPORT unofficial-mgclient-export
-             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-             RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 +    else()
 +    install(TARGETS mgclient-static
 +            EXPORT unofficial-mgclient-export
-+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+            RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
+             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-            RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
++            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 +    endif()
      install(DIRECTORY
              "${PROJECT_SOURCE_DIR}/include/"

--- a/ports/mgclient/export-cmake.patch
+++ b/ports/mgclient/export-cmake.patch
@@ -1,0 +1,92 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 92426e9..e43fd54 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -16,6 +16,8 @@ add_library(project_options INTERFACE)
+ include(../cmake/Sanitizers.cmake)
+ enable_sanitizers(project_options)
+ 
++include(GNUInstallDirs)
++
+ set(mgclient_src_files
+         mgallocator.c
+         mgclient.c
+@@ -62,14 +64,18 @@ else()
+     target_include_directories(mgclient-static
+             PRIVATE
+             "${PROJECT_SOURCE_DIR}/src"
+-            PUBLIC
+-            "${PROJECT_SOURCE_DIR}/include"
+             "${CMAKE_CURRENT_BINARY_DIR}"
+-            "${OPENSSL_INCLUDE_DIR}")
++            "${OPENSSL_INCLUDE_DIR}"
++            PUBLIC
++            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
++            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++            )
+     target_link_libraries(mgclient-static
+             PRIVATE
+-            ${OPENSSL_LIBRARIES} project_options project_c_warnings)
+-
++            ${OPENSSL_LIBRARIES})
++    target_compile_options(mgclient-static PRIVATE
++            $<TARGET_PROPERTY:project_options,INTERFACE_COMPILE_OPTIONS>
++            $<TARGET_PROPERTY:project_c_warnings,INTERFACE_COMPILE_OPTIONS>)
+     if(MGCLIENT_ON_WINDOWS)
+         target_link_libraries(mgclient-static PUBLIC ws2_32 crypt32 gdi32)
+     endif()
+@@ -87,14 +93,18 @@ else()
+     target_include_directories(mgclient-shared
+             PRIVATE
+             "${PROJECT_SOURCE_DIR}/src"
+-            PUBLIC
+-            "${PROJECT_SOURCE_DIR}/include"
+             "${CMAKE_CURRENT_BINARY_DIR}"
+-            "${OPENSSL_INCLUDE_DIR}")
++            "${OPENSSL_INCLUDE_DIR}"
++            PUBLIC
++            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
++            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++            )
+     target_link_libraries(mgclient-shared
+             PRIVATE
+-            ${OPENSSL_LIBRARIES} project_options project_c_warnings)
+-
++            ${OPENSSL_LIBRARIES})
++    target_compile_options(mgclient-shared PRIVATE
++            $<TARGET_PROPERTY:project_options,INTERFACE_COMPILE_OPTIONS>
++            $<TARGET_PROPERTY:project_c_warnings,INTERFACE_COMPILE_OPTIONS>)
+     if(MGCLIENT_ON_WINDOWS)
+         target_link_libraries(mgclient-shared PUBLIC ws2_32 crypt32 gdi32)
+     endif()
+@@ -103,16 +113,27 @@ else()
+             BASE_NAME "mgclient"
+             EXPORT_FILE_NAME "mgclient-export.h")
+ 
+-    include(GNUInstallDirs)
+-
+-    install(TARGETS mgclient-static mgclient-shared
++    if(BUILD_SHARED_LIBS)
++    install(TARGETS mgclient-shared
++            EXPORT unofficial-mgclient-export
+             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+             RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    else()
++    install(TARGETS mgclient-static
++            EXPORT unofficial-mgclient-export
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    endif()
+     install(DIRECTORY
+             "${PROJECT_SOURCE_DIR}/include/"
+             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+     install(FILES
+             "${CMAKE_CURRENT_BINARY_DIR}/mgclient-export.h"
+             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    install(EXPORT unofficial-mgclient-export
++            FILE unofficial-mgclient-config.cmake
++            NAMESPACE unofficial::mgclient::
++            DESTINATION share/unofficial-mgclient)
+ endif()

--- a/ports/mgclient/export-cmake.patch
+++ b/ports/mgclient/export-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 92426e9..e43fd54 100644
+index 92426e9..9af1543 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -16,6 +16,8 @@ add_library(project_options INTERFACE)
@@ -11,7 +11,15 @@ index 92426e9..e43fd54 100644
  set(mgclient_src_files
          mgallocator.c
          mgclient.c
-@@ -62,14 +64,18 @@ else()
+@@ -50,6 +52,7 @@ else()
+     find_package(OpenSSL REQUIRED)
+     include(GenerateExportHeader)
+ 
++    if(NOT BUILD_SHARED_LIBS)
+     add_library(mgclient-static STATIC ${mgclient_src_files})
+ 
+     generate_export_header(mgclient-static
+@@ -62,18 +65,22 @@ else()
      target_include_directories(mgclient-static
              PRIVATE
              "${PROJECT_SOURCE_DIR}/src"
@@ -35,7 +43,12 @@ index 92426e9..e43fd54 100644
      if(MGCLIENT_ON_WINDOWS)
          target_link_libraries(mgclient-static PUBLIC ws2_32 crypt32 gdi32)
      endif()
-@@ -87,14 +93,18 @@ else()
+-
++    else()
+     add_library(mgclient-shared SHARED ${mgclient_src_files})
+ 
+     generate_export_header(mgclient-shared
+@@ -87,32 +94,44 @@ else()
      target_include_directories(mgclient-shared
              PRIVATE
              "${PROJECT_SOURCE_DIR}/src"
@@ -59,10 +72,12 @@ index 92426e9..e43fd54 100644
      if(MGCLIENT_ON_WINDOWS)
          target_link_libraries(mgclient-shared PUBLIC ws2_32 crypt32 gdi32)
      endif()
-@@ -103,16 +113,27 @@ else()
-             BASE_NAME "mgclient"
-             EXPORT_FILE_NAME "mgclient-export.h")
++    endif()
  
+-    generate_export_header(mgclient-shared
+-            BASE_NAME "mgclient"
+-            EXPORT_FILE_NAME "mgclient-export.h")
+-
 -    include(GNUInstallDirs)
 -
 -    install(TARGETS mgclient-static mgclient-shared

--- a/ports/mgclient/portfile.cmake
+++ b/ports/mgclient/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO memgraph/mgclient
+    REF "v${VERSION}"
+    SHA512 67321e51255c4552a8e9a4ad55a5ed9159b92ecea87f8a667bc817b87289940558f1f1cd0dc5f99bb698739bd5e1b58d9ff3f13c4d61190f27bd009b0055a445
+    HEAD_REF master
+    PATCHES
+        export-cmake.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS options
+    FEATURES
+        cpp    BUILD_CPP_BINDINGS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${options}
+        -DBUILD_TESTING=OFF
+        -DBUILD_TESTING_INTEGRATION=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-mgclient)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/mgclient/vcpkg.json
+++ b/ports/mgclient/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "C/C++ Memgraph Client ",
   "homepage": "https://github.com/memgraph/mgclient",
   "license": "Apache-2.0",
+  "supports": "!android",
   "dependencies": [
     "openssl",
     {

--- a/ports/mgclient/vcpkg.json
+++ b/ports/mgclient/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "mgclient",
+  "version": "1.4.5",
+  "description": "C/C++ Memgraph Client ",
+  "homepage": "https://github.com/memgraph/mgclient",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cpp": {
+      "description": "build header only cpp bindings"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6312,6 +6312,10 @@
       "baseline": "1.35.1",
       "port-version": 5
     },
+    "mgclient": {
+      "baseline": "1.4.5",
+      "port-version": 0
+    },
     "mgnlibs": {
       "baseline": "2019-09-29",
       "port-version": 2

--- a/versions/m-/mgclient.json
+++ b/versions/m-/mgclient.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ed62026352435b77b2b91e292776f76cbdbd5704",
+      "git-tree": "330e70cc5a8d26aa962c53ffb33716158bc269e3",
       "version": "1.4.5",
       "port-version": 0
     }

--- a/versions/m-/mgclient.json
+++ b/versions/m-/mgclient.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "93e72df8f835d8ef0d6744489d6dde62d346667d",
+      "git-tree": "ed62026352435b77b2b91e292776f76cbdbd5704",
       "version": "1.4.5",
       "port-version": 0
     }

--- a/versions/m-/mgclient.json
+++ b/versions/m-/mgclient.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "93e72df8f835d8ef0d6744489d6dde62d346667d",
+      "version": "1.4.5",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/memgraph/mgclient

