### PR TITLE
[arcticdb-sparrow] update 1.2.0

### DIFF
--- a/ports/arcticdb-sparrow/portfile.cmake
+++ b/ports/arcticdb-sparrow/portfile.cmake
@@ -17,7 +17,7 @@ else()
 endif()
 
 # Check for features
-if("json_reader" IN_LIST FEATURES)
+if("json-reader" IN_LIST FEATURES)
     set(BUILD_JSON_READER ON)
 else()
     set(BUILD_JSON_READER OFF)

--- a/ports/arcticdb-sparrow/portfile.cmake
+++ b/ports/arcticdb-sparrow/portfile.cmake
@@ -16,6 +16,13 @@ else()
     set(SPARROW_BUILD_SHARED OFF)
 endif()
 
+# Check for features
+if("json_reader" IN_LIST FEATURES)
+    set(BUILD_JSON_READER ON)
+else()
+    set(BUILD_JSON_READER OFF)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -23,6 +30,7 @@ vcpkg_cmake_configure(
         -DSPARROW_BUILD_SHARED=${SPARROW_BUILD_SHARED}
         -DBUILD_TESTS=OFF
         -DBUILD_EXAMPLES=OFF
+        -DCREATE_JSON_READER_TARGET=${BUILD_JSON_READER}
 )
 
 vcpkg_cmake_install()

--- a/ports/arcticdb-sparrow/vcpkg.json
+++ b/ports/arcticdb-sparrow/vcpkg.json
@@ -15,5 +15,16 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "json_reader": {
+      "description": "Generate json_reader target",
+      "dependencies": [
+        "nlohmann_json"
+      ]
+    },
+    "examples": {
+      "description": "Build examples"
+    }
+  }
 }

--- a/ports/arcticdb-sparrow/vcpkg.json
+++ b/ports/arcticdb-sparrow/vcpkg.json
@@ -17,14 +17,14 @@
     }
   ],
   "features": {
-    "json_reader": {
-      "description": "Generate json_reader target",
-      "dependencies": [
-        "nlohmann_json"
-      ]
-    },
     "examples": {
       "description": "Build examples"
+    },
+    "json-reader": {
+      "description": "Generate json_reader target",
+      "dependencies": [
+        "nlohmann-json"
+      ]
     }
   }
 }

--- a/ports/arcticdb-sparrow/vcpkg.json
+++ b/ports/arcticdb-sparrow/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "arcticdb-sparrow",
   "version": "1.2.0",
+  "port-version": 1,
   "description": "C++20 idiomatic APIs for the Apache Arrow Columnar Format",
   "homepage": "https://github.com/man-group/sparrow",
   "license": "Apache-2.0",

--- a/versions/a-/arcticdb-sparrow.json
+++ b/versions/a-/arcticdb-sparrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "021d76215516d3b462159d588bbaaa6785ad7d50",
+      "version": "1.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a3656ab2e65ade0c04b6cee33e63eb65548e04c6",
       "version": "1.2.0",
       "port-version": 0

--- a/versions/a-/arcticdb-sparrow.json
+++ b/versions/a-/arcticdb-sparrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "212ace8c15b6855b710a0426138a8bdb5c7cc35c",
+      "git-tree": "a3656ab2e65ade0c04b6cee33e63eb65548e04c6",
       "version": "1.2.0",
       "port-version": 0
     },

--- a/versions/a-/arcticdb-sparrow.json
+++ b/versions/a-/arcticdb-sparrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a3656ab2e65ade0c04b6cee33e63eb65548e04c6",
+      "git-tree": "212ace8c15b6855b710a0426138a8bdb5c7cc35c",
       "version": "1.2.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -206,7 +206,7 @@
     },
     "arcticdb-sparrow": {
       "baseline": "1.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "arcus": {
       "baseline": "4.10.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.