### PR TITLE
[hwloc] Update to 2.12.2

### DIFF
--- a/ports/hwloc/portfile.cmake
+++ b/ports/hwloc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-mpi/hwloc
     REF "hwloc-${VERSION}"
-    SHA512 1ed47955d4a3ecf66636f1c5a89648ef055aa4f26fac9b9bc64d6f7715d671dc823337ebf38df53d60b50d697eccadfbd48d28b4540a5153c59d7eecd347f91c
+    SHA512 e989b852a96bbe5d567e8a84b022ecd91a8b7577d211e2d4403938d1cc285f2ee4653bfbb952201481b904eb24d59a97cf71147acedb65d8f675f69798622b86
     PATCHES
         fix_shared_win_build.patch
         stdout_fileno.patch

--- a/ports/hwloc/vcpkg.json
+++ b/ports/hwloc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hwloc",
-  "version": "2.11.2",
+  "version": "2.12.2",
   "maintainers": "bgoglin<Brice.Goglin@inria.fr>",
   "description": [
     "Portable Hardware Locality (hwloc)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3813,7 +3813,7 @@
       "port-version": 1
     },
     "hwloc": {
-      "baseline": "2.11.2",
+      "baseline": "2.12.2",
       "port-version": 0
     },
     "hyperscan": {

--- a/versions/h-/hwloc.json
+++ b/versions/h-/hwloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f73360ab5454cd7af91a2732c1c2694b77b9430d",
+      "version": "2.12.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "4b14fa65f32abe3d816a08d5d37aaf183372338c",
       "version": "2.11.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/open-mpi/hwloc/releases/tag/hwloc-2.12.2
