### PR TITLE
[fontconfig] Update to 2.17.1

### DIFF
--- a/ports/fontconfig/emscripten.diff
+++ b/ports/fontconfig/emscripten.diff
@@ -1,13 +1,13 @@
 diff --git a/meson.build b/meson.build
-index 08d9532..37cc195 100644
+index d71643db..8d6c1cbc 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -289,7 +289,7 @@ if fc_cachedir in ['yes', 'no', 'default']
+@@ -392,7 +392,7 @@ if fc_cachedir in ['yes', 'no', 'default']
    endif
  endif
  
 -if host_machine.system() != 'windows'
 +if host_machine.system() != 'windows' and host_machine.system() != 'emscripten'
    thread_dep = dependency('threads')
-   conf.set('HAVE_PTHREAD', 1)
-   deps += [thread_dep]
+   if thread_dep.found() and cc.has_header('pthread.h')
+     conf.set('HAVE_PTHREAD', 1)

--- a/ports/fontconfig/libgetopt.patch
+++ b/ports/fontconfig/libgetopt.patch
@@ -1,119 +1,122 @@
+commit e380b079cab10df3142d6b4ed95f4f210bf56aef
+Author: Albert Lee <trisk@forkgnu.org>
+Date:   Thu Oct 9 02:55:27 2025 +0000
+
+    getopt patch
+
 diff --git a/fc-cache/meson.build b/fc-cache/meson.build
-index 5e40fac..3c3e46b 100644
+index 1d66ccf3..4745d947 100644
 --- a/fc-cache/meson.build
 +++ b/fc-cache/meson.build
-@@ -1,6 +1,7 @@
+@@ -1,6 +1,6 @@
  fccache = executable('fc-cache', ['fc-cache.c', fcstdint_h, alias_headers, ft_alias_headers],
    include_directories: [incbase, incsrc],
+-  dependencies: [libintl_dep],
++  dependencies: [libintl_dep, getopt_dep],
    link_with: [libfontconfig],
-+  dependencies: [getopt_dep],
    c_args: c_args,
    install: true,
- )
 diff --git a/fc-cat/meson.build b/fc-cat/meson.build
-index f26e4b8..476c0f9 100644
+index dd7ee29e..15da98c6 100644
 --- a/fc-cat/meson.build
 +++ b/fc-cat/meson.build
-@@ -1,6 +1,7 @@
+@@ -1,6 +1,6 @@
  fccat = executable('fc-cat', ['fc-cat.c', fcstdint_h, alias_headers, ft_alias_headers],
    include_directories: [incbase, incsrc],
+-  dependencies: [libintl_dep],
++  dependencies: [libintl_dep, getopt_dep],
    link_with: [libfontconfig],
-+  dependencies: [getopt_dep],
    c_args: c_args,
    install: true,
- )
 diff --git a/fc-conflist/meson.build b/fc-conflist/meson.build
-index f543cf9..f06640b 100644
+index 88208ff8..7fcf4f5a 100644
 --- a/fc-conflist/meson.build
 +++ b/fc-conflist/meson.build
-@@ -1,6 +1,7 @@
+@@ -1,6 +1,6 @@
  fcconflist = executable('fc-conflist', ['fc-conflist.c', fcstdint_h, alias_headers, ft_alias_headers],
    include_directories: [incbase, incsrc],
+-  dependencies: [libintl_dep],
++  dependencies: [libintl_dep, getopt_dep],
    link_with: [libfontconfig],
-+  dependencies: [getopt_dep],
    c_args: c_args,
    install: true,
- )
 diff --git a/fc-list/meson.build b/fc-list/meson.build
-index 2f679d5..4b0fb62 100644
+index 1be9df5d..cfff2ec1 100644
 --- a/fc-list/meson.build
 +++ b/fc-list/meson.build
-@@ -1,6 +1,7 @@
+@@ -1,6 +1,6 @@
  fclist = executable('fc-list', ['fc-list.c', fcstdint_h, alias_headers, ft_alias_headers],
    include_directories: [incbase, incsrc],
+-  dependencies: [libintl_dep],
++  dependencies: [libintl_dep, getopt_dep],
    link_with: [libfontconfig],
-+  dependencies: [getopt_dep],
    c_args: c_args,
    install: true,
- )
 diff --git a/fc-match/meson.build b/fc-match/meson.build
-index aca8bc8..cab4f09 100644
+index 1aa1b1b5..5b05c46b 100644
 --- a/fc-match/meson.build
 +++ b/fc-match/meson.build
-@@ -1,6 +1,7 @@
+@@ -1,6 +1,6 @@
  fcmatch = executable('fc-match', ['fc-match.c', fcstdint_h, alias_headers, ft_alias_headers],
    include_directories: [incbase, incsrc],
+-  dependencies: [libintl_dep],
++  dependencies: [libintl_dep, getopt_dep],
    link_with: [libfontconfig],
-+  dependencies: [getopt_dep],
    c_args: c_args,
    install: true,
- )
 diff --git a/fc-pattern/meson.build b/fc-pattern/meson.build
-index 07de245..b957c67 100644
+index d9b048cb..c2c6224a 100644
 --- a/fc-pattern/meson.build
 +++ b/fc-pattern/meson.build
-@@ -1,6 +1,7 @@
+@@ -1,6 +1,6 @@
  fcpattern = executable('fc-pattern', ['fc-pattern.c', fcstdint_h, alias_headers, ft_alias_headers],
    include_directories: [incbase, incsrc],
+-  dependencies: [libintl_dep],
++  dependencies: [libintl_dep, getopt_dep],
    link_with: [libfontconfig],
-+  dependencies: [getopt_dep],
    c_args: c_args,
    install: true,
- )
 diff --git a/fc-query/meson.build b/fc-query/meson.build
-index d0f2dd4..940b021 100644
+index 629bc71e..38c74c79 100644
 --- a/fc-query/meson.build
 +++ b/fc-query/meson.build
-@@ -1,7 +1,7 @@
+@@ -1,6 +1,6 @@
  fcquery = executable('fc-query', ['fc-query.c', fcstdint_h, alias_headers, ft_alias_headers],
    include_directories: [incbase, incsrc],
+-  dependencies: [freetype_dep, libintl_dep],
++  dependencies: [freetype_dep, libintl_dep, getopt_dep],
    link_with: [libfontconfig],
--  dependencies: [freetype_dep],
-+  dependencies: [freetype_dep, getopt_dep],
    c_args: c_args,
    install: true,
- )
 diff --git a/fc-scan/meson.build b/fc-scan/meson.build
-index 4de2134..c5b2b67 100644
+index 9049578f..70bb5fef 100644
 --- a/fc-scan/meson.build
 +++ b/fc-scan/meson.build
-@@ -1,7 +1,7 @@
+@@ -1,6 +1,6 @@
  fcscan = executable('fc-scan', ['fc-scan.c', fcstdint_h, alias_headers, ft_alias_headers],
    include_directories: [incbase, incsrc],
+-  dependencies: [freetype_dep, libintl_dep],
++  dependencies: [freetype_dep, libintl_dep, getopt_dep],
    link_with: [libfontconfig],
--  dependencies: [freetype_dep],
-+  dependencies: [freetype_dep, getopt_dep],
    c_args: c_args,
    install: true,
- )
 diff --git a/fc-validate/meson.build b/fc-validate/meson.build
-index e2b956e..8902d59 100644
+index fcabf294..0d80df86 100644
 --- a/fc-validate/meson.build
 +++ b/fc-validate/meson.build
-@@ -1,7 +1,7 @@
+@@ -1,6 +1,6 @@
  fcvalidate = executable('fc-validate', ['fc-validate.c', fcstdint_h, alias_headers, ft_alias_headers],
    include_directories: [incbase, incsrc],
+-  dependencies: [freetype_dep, libintl_dep],
++  dependencies: [freetype_dep, libintl_dep, getopt_dep],
    link_with: [libfontconfig],
--  dependencies: [freetype_dep],
-+  dependencies: [freetype_dep, getopt_dep],
    c_args: c_args,
    install: true,
- )
 diff --git a/meson.build b/meson.build
-index f616600..6d82a16 100644
+index 8d6c1cbc..1da460eb 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -202,6 +202,14 @@ if cc.links(files('meson-cc-tests/solaris-atomic-operations.c'), name: 'Solaris
+@@ -323,6 +323,13 @@ if cc.links(files('meson-cc-tests/solaris-atomic-operations.c'), name: 'Solaris
    conf.set('HAVE_SOLARIS_ATOMIC_OPS', 1)
  endif
  
@@ -124,7 +127,6 @@ index f616600..6d82a16 100644
 +else
 +  getopt_dep = dependency('', required: false)
 +endif
-+
  
- # Check iconv support
- iconv_dep = []
+ prefix = get_option('prefix')
+ 

--- a/ports/fontconfig/portfile.cmake
+++ b/ports/fontconfig/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fontconfig/fontconfig
     REF ${VERSION}
-    SHA512 daa6d1e6058e12c694d9e1512e09be957ff7f3fa375246b9d13eb0a8cf2f21e1512a5cabe93f270e96790e2c20420bf7422d213e43ab9749da3255286ea65a7c
+    SHA512 8e05cad63cd0c5ca15d1359e19a605912198fcc0ec6ecc11d5a0ef596d72e795cd8128e4d350716e63cbc01612c3807b1455b8153901333790316170c9ef8e75
     HEAD_REF master
     PATCHES
         emscripten.diff
@@ -43,11 +43,11 @@ set(replacement "")
 if(VCPKG_TARGET_IS_WINDOWS)
     set(replacement "**invalid-fontconfig-dir-do-not-use**")
 endif()
-set(configfile "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/config.h")
+set(configfile "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/meson-config.h")
 vcpkg_replace_string("${configfile}" "${CURRENT_PACKAGES_DIR}" "${replacement}")
 vcpkg_replace_string("${configfile}" "#define FC_TEMPLATEDIR \"/share/fontconfig/conf.avail\"" "#define FC_TEMPLATEDIR \"/usr/share/fontconfig/conf.avail\"" IGNORE_UNCHANGED)
 if(NOT VCPKG_BUILD_TYPE)
-    set(configfile "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/config.h")
+    set(configfile "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/meson-config.h")
     vcpkg_replace_string("${configfile}" "${CURRENT_PACKAGES_DIR}/debug" "${replacement}")
     vcpkg_replace_string("${configfile}" "#define FC_TEMPLATEDIR \"/share/fontconfig/conf.avail\"" "#define FC_TEMPLATEDIR \"/usr/share/fontconfig/conf.avail\"" IGNORE_UNCHANGED)
 endif()

--- a/ports/fontconfig/vcpkg.json
+++ b/ports/fontconfig/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fontconfig",
-  "version": "2.15.0",
-  "port-version": 4,
+  "version": "2.17.1",
   "description": "Library for configuring and customizing font access.",
   "homepage": "https://www.freedesktop.org/wiki/Software/fontconfig",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3033,8 +3033,8 @@
       "port-version": 0
     },
     "fontconfig": {
-      "baseline": "2.15.0",
-      "port-version": 4
+      "baseline": "2.17.1",
+      "port-version": 0
     },
     "foonathan-lexy": {
       "baseline": "2025.5.0",

--- a/versions/f-/fontconfig.json
+++ b/versions/f-/fontconfig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e8e1988161d1ce7176c0650e64471f70a177f81",
+      "version": "2.17.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "45600a1fe75fea35b062ebf982bcb7d2eb5451b5",
       "version": "2.15.0",
       "port-version": 4


### PR DESCRIPTION
Update fontconfig from 2.15.0 to 2.17.1. I addressed a compilation issue affecting Solaris/illumos upstream which was merged in 2.17.0 (https://gitlab.freedesktop.org/fontconfig/fontconfig/-/merge_requests/409 ). Updated the existing patches accordingly.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
