### PR TITLE
[imath] update to 3.2.2

### DIFF
--- a/ports/imath/portfile.cmake
+++ b/ports/imath/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/Imath
     REF "v${VERSION}"
-    SHA512 b5fbad894ff1a725d3b1488d4907106bbc21c4a0c2ac5aa912ef76219d033544a3d56c87f94c71af5ec01759a06a5db2385dcfed25ea5886540398df163c53cd
+    SHA512 492a624e4c0b59685d1ea58a3c2c63ddb4ba5ab9177c7d2a1b7e80be95d38ce02c74fafd2fe0982f7d21e5e75c938cc24a33a12d827dec32727cb8dcd5066450
     HEAD_REF master
 )
 

--- a/ports/imath/vcpkg.json
+++ b/ports/imath/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imath",
-  "version": "3.2.0",
+  "version": "3.2.2",
   "description": "Imath is a C++ and Python library of 2D and 3D vector, matrix, and math operations for computer graphics.",
   "homepage": "https://github.com/AcademySoftwareFoundation/Imath",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3893,7 +3893,7 @@
       "port-version": 0
     },
     "imath": {
-      "baseline": "3.2.0",
+      "baseline": "3.2.2",
       "port-version": 0
     },
     "imcce-openfa": {

--- a/versions/i-/imath.json
+++ b/versions/i-/imath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b167f9479ce8752a2839c39ee8f52c11af4c0266",
+      "version": "3.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "8e65a4e5cad0b5f8129f6f1a0dd7069984380259",
       "version": "3.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/AcademySoftwareFoundation/Imath/releases/tag/v3.2.2
