### PR TITLE
[unarr] add new package

### DIFF
--- a/ports/7zip/CMakeLists.txt
+++ b/ports/7zip/CMakeLists.txt
@@ -412,7 +412,7 @@ endif()
 # CPP/7zip/Bundles/Format7zF/makefile[_gcc].mak
 # CPP/7zip/7zip[_gcc].mak
 
-target_compile_definitions(7zip PRIVATE Z7_EXTERNAL_CODECS)
+target_compile_definitions(7zip PRIVATE Z7_EXTERNAL_CODECS Z7_PPMD_SUPPORT)
 target_sources(7zip PRIVATE
     CPP/7zip/Archive/ArchiveExports.cpp
     CPP/7zip/Archive/DllExports2.cpp

--- a/ports/7zip/vcpkg.json
+++ b/ports/7zip/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "7zip",
   "version": "25.1",
+  "port-version": 1,
   "description": "Library for archiving file with a high compression ratio.",
   "homepage": "https://www.7-zip.org",
   "license": "LGPL-2.1-or-later",

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f38b229..6029798 100644
+index f38b229..9d055f9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -52,19 +52,6 @@ add_library(
@@ -22,20 +22,23 @@ index f38b229..6029798 100644
    rar/lzss.h
    rar/rar.h
    rar/rarvm.h
-@@ -102,6 +89,12 @@ target_include_directories(
+@@ -102,6 +89,15 @@ target_include_directories(
  if(BUILD_SHARED_LIBS)
    target_compile_definitions(unarr PUBLIC UNARR_IS_SHARED_LIBRARY)
  endif()
 +# Debundle 7zip
 +find_package(7zip CONFIG REQUIRED)
 +target_link_libraries(unarr PRIVATE 7zip::7zip)
++# Ensure 7zip headers are accessible
++get_target_property(7ZIP_INCLUDE_DIRS 7zip::7zip INTERFACE_INCLUDE_DIRECTORIES)
++target_include_directories(unarr PRIVATE ${7ZIP_INCLUDE_DIRS})
 +# 7zip upstream does not supply a .pc file. Add it to Libs.private.
 +set(PROJECT_LIBS_PRIVATE "-I${7zip_INCLUDE_DIRS} -l${7zip_LIBRARIES}")
 +set(UNARR_DEPENDS_7zip "${UNARR_DEPENDS_7zip} find_dependency(7zip)")
  
  if(USE_SYSTEM_BZ2)
    find_package(BZip2)
-@@ -154,28 +147,6 @@ if(ZLIB_FOUND)
+@@ -154,29 +150,7 @@ if(ZLIB_FOUND)
  endif()
  
  if(ENABLE_7Z)
@@ -61,10 +64,12 @@ index f38b229..6029798 100644
 -  if(LIBLZMA_FOUND) # TODO: Replace 7z lzma with system lzma
 -    target_sources(unarr PRIVATE lzmasdk/LzmaDec.h lzmasdk/LzmaDec.c)
 -  endif()
-   target_compile_definitions(unarr PRIVATE -DHAVE_7Z -DZ7_PPMD_SUPPORT)
+-  target_compile_definitions(unarr PRIVATE -DHAVE_7Z -DZ7_PPMD_SUPPORT)
++  target_compile_definitions(unarr PRIVATE -DHAVE_7Z -DZ7_PPMD_SUPPORT -DZ7_EXTERNAL_CODECS)
  endif()
  
-@@ -194,8 +165,7 @@ if(UNIX
+ # Compiler specific settings
+@@ -194,8 +168,7 @@ if(UNIX
              -Werror-implicit-function-declaration
              $<$<CONFIG:Release>:-fomit-frame-pointer>
              $<$<C_COMPILER_ID:Clang,AppleClang>:
@@ -74,7 +79,7 @@ index f38b229..6029798 100644
    if(BUILD_FUZZER)
      target_compile_options(unarr PUBLIC "${sanitize_opts}")
      target_compile_definitions(
-@@ -218,7 +188,7 @@ if(UNIX
+@@ -218,7 +191,7 @@ if(UNIX
  
    # Clang linker needs -flto too when doing lto
    if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f38b229..f614f0d 100644
+index f38b229..40160a0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -52,19 +52,6 @@ add_library(
@@ -22,20 +22,21 @@ index f38b229..f614f0d 100644
    rar/lzss.h
    rar/rar.h
    rar/rarvm.h
-@@ -102,6 +89,12 @@ target_include_directories(
+@@ -102,6 +89,13 @@ target_include_directories(
  if(BUILD_SHARED_LIBS)
    target_compile_definitions(unarr PUBLIC UNARR_IS_SHARED_LIBRARY)
  endif()
-+#Debundle 7zip
++# Debundle 7zip
 +find_package(7zip CONFIG REQUIRED)
 +target_link_libraries(unarr PRIVATE 7zip::7zip)
++target_include_directories(unarr PRIVATE ${7zip_INCLUDE_DIRS})
 +# 7zip upstream does not supply a .pc file. Add it to Libs.private.
 +set(PROJECT_LIBS_PRIVATE "-I${7zip_INCLUDE_DIRS} -l${7zip_LIBRARIES}")
 +set(UNARR_DEPENDS_7zip "${UNARR_DEPENDS_7zip} find_dependency(7zip)")
  
  if(USE_SYSTEM_BZ2)
    find_package(BZip2)
-@@ -154,28 +147,6 @@ if(ZLIB_FOUND)
+@@ -154,28 +148,6 @@ if(ZLIB_FOUND)
  endif()
  
  if(ENABLE_7Z)

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f38b229..fc598b8 100644
+index f38b229..da527d4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -52,19 +52,6 @@ add_library(
@@ -35,8 +35,11 @@ index f38b229..fc598b8 100644
  
  if(USE_SYSTEM_BZ2)
    find_package(BZip2)
-@@ -154,28 +147,6 @@ if(ZLIB_FOUND)
+@@ -152,30 +145,9 @@ if(ZLIB_FOUND)
+   set(PROJECT_REQUIRES_PRIVATE "${PROJECT_REQUIRES_PRIVATE} zlib")
+   set(UNARR_DEPENDS_ZLIB "find_dependency(ZLIB)")
  endif()
++target_include_directories(unarr PRIVATE "${ZLIB_INCLUDE_DIR}")
  
  if(ENABLE_7Z)
 -  target_sources(

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,8 +1,41 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5e61516..6c16a64 100644
+index f38b229..f614f0d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -154,28 +154,11 @@ if(ZLIB_FOUND)
+@@ -52,19 +52,6 @@ add_library(
+   # common/custalloc.c
+   common/stream.c
+   common/unarr.c
+-  lzmasdk/7zTypes.h
+-  lzmasdk/Compiler.h
+-  lzmasdk/CpuArch.h
+-  lzmasdk/Ppmd.h
+-  lzmasdk/Ppmd7.h
+-  lzmasdk/Ppmd8.h
+-  lzmasdk/Precomp.h
+-  lzmasdk/CpuArch.c
+-  lzmasdk/Ppmd7.c
+-  lzmasdk/Ppmd8.c
+-  lzmasdk/Ppmd7Dec.c
+-  lzmasdk/Ppmd7aDec.c
+-  lzmasdk/Ppmd8Dec.c
+   rar/lzss.h
+   rar/rar.h
+   rar/rarvm.h
+@@ -102,6 +89,12 @@ target_include_directories(
+ if(BUILD_SHARED_LIBS)
+   target_compile_definitions(unarr PUBLIC UNARR_IS_SHARED_LIBRARY)
+ endif()
++#Debundle 7zip
++find_package(7zip CONFIG REQUIRED)
++target_link_libraries(unarr PRIVATE 7zip::7zip)
++# 7zip upstream does not supply a .pc file. Add it to Libs.private.
++set(PROJECT_LIBS_PRIVATE "-I${7zip_INCLUDE_DIRS} -l${7zip_LIBRARIES}")
++set(UNARR_DEPENDS_7zip "${UNARR_DEPENDS_7zip} find_dependency(7zip)")
+ 
+ if(USE_SYSTEM_BZ2)
+   find_package(BZip2)
+@@ -154,28 +147,6 @@ if(ZLIB_FOUND)
  endif()
  
  if(ENABLE_7Z)
@@ -28,14 +61,38 @@ index 5e61516..6c16a64 100644
 -  if(LIBLZMA_FOUND) # TODO: Replace 7z lzma with system lzma
 -    target_sources(unarr PRIVATE lzmasdk/LzmaDec.h lzmasdk/LzmaDec.c)
 -  endif()
-+  find_package(7zip CONFIG REQUIRED)
-+  target_link_libraries(unarr PRIVATE 7zip::7zip)
-+  # 7zip upstream does not supply a .pc file. Add it to Libs.private.
-+  set(PROJECT_LIBS_PRIVATE "-I${7zip_INCLUDE_DIRS} -l${7zip_LIBRARIES}")
-+  set(UNARR_DEPENDS_7zip "${UNARR_DEPENDS_7zip} find_dependency(7zip)")
    target_compile_definitions(unarr PRIVATE -DHAVE_7Z -DZ7_PPMD_SUPPORT)
  endif()
  
+diff --git a/_7z/_7z.h b/_7z/_7z.h
+index 7f207e1..f488e42 100644
+--- a/_7z/_7z.h
++++ b/_7z/_7z.h
+@@ -6,9 +6,9 @@
+ 
+ #include "../common/unarr-imp.h"
+ 
+-#include "../lzmasdk/7zTypes.h"
++#include <7zip/C/7zTypes.h>
+ #ifdef HAVE_7Z
+-#include "../lzmasdk/7z.h"
++#include <7zip/C/7z.h>
+ #endif
+ 
+ typedef struct ar_archive_7z_s ar_archive_7z;
+diff --git a/rar/rar.h b/rar/rar.h
+index a0a420a..b522a33 100644
+--- a/rar/rar.h
++++ b/rar/rar.h
+@@ -7,7 +7,7 @@
+ #include "../common/unarr-imp.h"
+ 
+ #include "lzss.h"
+-#include "../lzmasdk/Ppmd7.h"
++#include <7zip/C/Ppmd7.h>
+ #include <limits.h>
+ 
+ static inline size_t smin(size_t a, size_t b) { return a < b ? a : b; }
 diff --git a/unarr-config.cmake.in b/unarr-config.cmake.in
 index 1c95f9b..4d82965 100644
 --- a/unarr-config.cmake.in
@@ -48,3 +105,19 @@ index 1c95f9b..4d82965 100644
  
  if (NOT TARGET unarr::unarr)
    include("${CMAKE_CURRENT_LIST_DIR}/unarr-targets.cmake")
+diff --git a/zip/zip.h b/zip/zip.h
+index b2ba34c..23da8d8 100644
+--- a/zip/zip.h
++++ b/zip/zip.h
+@@ -16,9 +16,9 @@
+ #ifdef HAVE_LIBLZMA
+ #include <lzma.h>
+ #else
+-#include "../lzmasdk/LzmaDec.h"
++#include <7zip/C/LzmaDec.h>
+ #endif
+-#include "../lzmasdk/Ppmd8.h"
++#include <7zip/C/Ppmd8.h>
+ 
+ typedef struct ar_archive_zip_s ar_archive_zip;
+ 

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f38b229..d16a222 100644
+index f38b229..9b30b35 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -52,19 +52,6 @@ add_library(
@@ -47,7 +47,7 @@ index f38b229..d16a222 100644
    set(UNARR_DEPENDS_BZip2 "find_dependency(BZip2)")
  endif()
  
-@@ -154,29 +150,7 @@ if(ZLIB_FOUND)
+@@ -154,28 +150,6 @@ if(ZLIB_FOUND)
  endif()
  
  if(ENABLE_7Z)
@@ -73,11 +73,9 @@ index f38b229..d16a222 100644
 -  if(LIBLZMA_FOUND) # TODO: Replace 7z lzma with system lzma
 -    target_sources(unarr PRIVATE lzmasdk/LzmaDec.h lzmasdk/LzmaDec.c)
 -  endif()
--  target_compile_definitions(unarr PRIVATE -DHAVE_7Z -DZ7_PPMD_SUPPORT)
-+  target_compile_definitions(unarr PRIVATE -DHAVE_7Z -DZ7_PPMD_SUPPORT -DZ7_EXTERNAL_CODECS)
+   target_compile_definitions(unarr PRIVATE -DHAVE_7Z -DZ7_PPMD_SUPPORT)
  endif()
  
- # Compiler specific settings
 @@ -194,8 +168,7 @@ if(UNIX
              -Werror-implicit-function-declaration
              $<$<CONFIG:Release>:-fomit-frame-pointer>

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5e61516..6c16a64 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -154,28 +154,11 @@ if(ZLIB_FOUND)
+ endif()
+ 
+ if(ENABLE_7Z)
+-  target_sources(
+-    unarr
+-    PRIVATE lzmasdk/7z.h
+-            lzmasdk/7zArcIn.c
+-            lzmasdk/7zBuf.h
+-            lzmasdk/7zBuf.c
+-            lzmasdk/7zDec.c
+-            lzmasdk/7zStream.c
+-            lzmasdk/7zWindows.h
+-            lzmasdk/Bcj2.h
+-            lzmasdk/Bcj2.c
+-            lzmasdk/Bra.c
+-            lzmasdk/Bra.h
+-            lzmasdk/Bra86.c
+-            lzmasdk/7zCrc.h
+-            lzmasdk/Delta.h
+-            lzmasdk/Delta.c
+-            lzmasdk/Lzma2Dec.h
+-            lzmasdk/Lzma2Dec.c)
+-  if(LIBLZMA_FOUND) # TODO: Replace 7z lzma with system lzma
+-    target_sources(unarr PRIVATE lzmasdk/LzmaDec.h lzmasdk/LzmaDec.c)
+-  endif()
++  find_package(7zip CONFIG REQUIRED)
++  target_link_libraries(unarr PRIVATE 7zip::7zip)
++  # 7zip upstream does not supply a .pc file. Add it to Libs.private.
++  set(PROJECT_LIBS_PRIVATE "-I${7zip_INCLUDE_DIRS} -l${7zip_LIBRARIES}")
++  set(UNARR_DEPENDS_7zip "${UNARR_DEPENDS_7zip} find_dependency(7zip)")
+   target_compile_definitions(unarr PRIVATE -DHAVE_7Z -DZ7_PPMD_SUPPORT)
+ endif()
+ 
+diff --git a/unarr-config.cmake.in b/unarr-config.cmake.in
+index 1c95f9b..4d82965 100644
+--- a/unarr-config.cmake.in
++++ b/unarr-config.cmake.in
+@@ -5,6 +5,7 @@ include(CMakeFindDependencyMacro)
+ @UNARR_DEPENDS_BZip2@
+ @UNARR_DEPENDS_LibLZMA@
+ @UNARR_DEPENDS_ZLIB@
++@UNARR_DEPENDS_7zip@
+ 
+ if (NOT TARGET unarr::unarr)
+   include("${CMAKE_CURRENT_LIST_DIR}/unarr-targets.cmake")

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -28,7 +28,7 @@ index f38b229..9b30b35 100644
  endif()
 +# Debundle 7zip
 +find_package(7zip CONFIG REQUIRED)
-+target_link_libraries(unarr PUBLIC 7zip::7zip)
++target_link_libraries(unarr PRIVATE 7zip::7zip)
 +# 7zip upstream does not supply a .pc file. Add it to Libs.private.
 +set(PROJECT_LIBS_PRIVATE "${PROJECT_LIBS_PRIVATE} -l7zip")
 +set(UNARR_DEPENDS_7zip "find_dependency(7zip CONFIG)")

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f38b229..40160a0 100644
+index f38b229..fc598b8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -52,19 +52,6 @@ add_library(
@@ -22,21 +22,20 @@ index f38b229..40160a0 100644
    rar/lzss.h
    rar/rar.h
    rar/rarvm.h
-@@ -102,6 +89,13 @@ target_include_directories(
+@@ -102,6 +89,12 @@ target_include_directories(
  if(BUILD_SHARED_LIBS)
    target_compile_definitions(unarr PUBLIC UNARR_IS_SHARED_LIBRARY)
  endif()
 +# Debundle 7zip
 +find_package(7zip CONFIG REQUIRED)
 +target_link_libraries(unarr PRIVATE 7zip::7zip)
-+target_include_directories(unarr PRIVATE ${7zip_INCLUDE_DIRS})
 +# 7zip upstream does not supply a .pc file. Add it to Libs.private.
 +set(PROJECT_LIBS_PRIVATE "-I${7zip_INCLUDE_DIRS} -l${7zip_LIBRARIES}")
 +set(UNARR_DEPENDS_7zip "${UNARR_DEPENDS_7zip} find_dependency(7zip)")
  
  if(USE_SYSTEM_BZ2)
    find_package(BZip2)
-@@ -154,28 +148,6 @@ if(ZLIB_FOUND)
+@@ -154,28 +147,6 @@ if(ZLIB_FOUND)
  endif()
  
  if(ENABLE_7Z)

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f38b229..a56a098 100644
+index f38b229..3d5c150 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -52,19 +52,6 @@ add_library(
@@ -35,16 +35,17 @@ index f38b229..a56a098 100644
  
  if(USE_SYSTEM_BZ2)
    find_package(BZip2)
-@@ -115,7 +108,7 @@ if(BZIP2_FOUND)
+@@ -115,7 +108,8 @@ if(BZIP2_FOUND)
    endif()
    target_compile_definitions(unarr PRIVATE -DHAVE_BZIP2)
    # Bzip2 upstream does not supply a .pc file. Add it to Libs.private.
 -  set(PROJECT_LIBS_PRIVATE "-I${BZIP2_INCLUDE_DIRS} -l${BZIP2_LIBRARIES}")
-+  set(PROJECT_LIBS_PRIVATE "${PROJECT_LIBS_PRIVATE} -I${BZIP2_INCLUDE_DIRS} -l${BZIP2_LIBRARIES}")
++  set(PROJECT_CFLAGS "${PROJECT_CFLAGS} -I${BZIP2_INCLUDE_DIRS}")
++  set(PROJECT_LIBS_PRIVATE "${PROJECT_LIBS_PRIVATE} -l${BZIP2_LIBRARIES}")
    set(UNARR_DEPENDS_BZip2 "find_dependency(BZip2)")
  endif()
  
-@@ -154,28 +147,6 @@ if(ZLIB_FOUND)
+@@ -154,28 +148,6 @@ if(ZLIB_FOUND)
  endif()
  
  if(ENABLE_7Z)
@@ -73,7 +74,7 @@ index f38b229..a56a098 100644
    target_compile_definitions(unarr PRIVATE -DHAVE_7Z -DZ7_PPMD_SUPPORT)
  endif()
  
-@@ -194,8 +165,7 @@ if(UNIX
+@@ -194,8 +166,7 @@ if(UNIX
              -Werror-implicit-function-declaration
              $<$<CONFIG:Release>:-fomit-frame-pointer>
              $<$<C_COMPILER_ID:Clang,AppleClang>:
@@ -83,7 +84,7 @@ index f38b229..a56a098 100644
    if(BUILD_FUZZER)
      target_compile_options(unarr PUBLIC "${sanitize_opts}")
      target_compile_definitions(
-@@ -218,7 +188,7 @@ if(UNIX
+@@ -218,7 +189,7 @@ if(UNIX
  
    # Clang linker needs -flto too when doing lto
    if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
@@ -108,6 +109,19 @@ index 7f207e1..f488e42 100644
  #endif
  
  typedef struct ar_archive_7z_s ar_archive_7z;
+diff --git a/pkg-config.pc.cmake b/pkg-config.pc.cmake
+index 9055aef..a8581e0 100644
+--- a/pkg-config.pc.cmake
++++ b/pkg-config.pc.cmake
+@@ -5,7 +5,7 @@ libdir=@PROJECT_INSTALL_LIBDIR@
+ Name: @PROJECT_NAME@
+ Description: @PROJECT_DESCRIPTION@
+ Version: @PROJECT_VERSION@
+-Cflags: -I${includedir}
++Cflags: -I${includedir}@PROJECT_CFLAGS@
+ Requires.private: @PROJECT_REQUIRES_PRIVATE@
+ Libs: -L${libdir} -l@PROJECT_NAME@
+ Libs.private: @PROJECT_LIBS_PRIVATE@
 diff --git a/rar/rar.h b/rar/rar.h
 index a0a420a..b522a33 100644
 --- a/rar/rar.h

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -29,9 +29,6 @@ index f38b229..9b30b35 100644
 +# Debundle 7zip
 +find_package(7zip CONFIG REQUIRED)
 +target_link_libraries(unarr PUBLIC 7zip::7zip)
-+# Ensure 7zip headers are accessible
-+get_target_property(7ZIP_INCLUDE_DIRS 7zip::7zip INTERFACE_INCLUDE_DIRECTORIES)
-+target_include_directories(unarr PUBLIC ${7ZIP_INCLUDE_DIRS})
 +# 7zip upstream does not supply a .pc file. Add it to Libs.private.
 +set(PROJECT_LIBS_PRIVATE "${PROJECT_LIBS_PRIVATE} -l7zip")
 +set(UNARR_DEPENDS_7zip "find_dependency(7zip CONFIG)")

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f38b229..da527d4 100644
+index f38b229..6029798 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -52,19 +52,6 @@ add_library(
@@ -35,11 +35,8 @@ index f38b229..da527d4 100644
  
  if(USE_SYSTEM_BZ2)
    find_package(BZip2)
-@@ -152,30 +145,9 @@ if(ZLIB_FOUND)
-   set(PROJECT_REQUIRES_PRIVATE "${PROJECT_REQUIRES_PRIVATE} zlib")
-   set(UNARR_DEPENDS_ZLIB "find_dependency(ZLIB)")
+@@ -154,28 +147,6 @@ if(ZLIB_FOUND)
  endif()
-+target_include_directories(unarr PRIVATE "${ZLIB_INCLUDE_DIR}")
  
  if(ENABLE_7Z)
 -  target_sources(
@@ -67,6 +64,25 @@ index f38b229..da527d4 100644
    target_compile_definitions(unarr PRIVATE -DHAVE_7Z -DZ7_PPMD_SUPPORT)
  endif()
  
+@@ -194,8 +165,7 @@ if(UNIX
+             -Werror-implicit-function-declaration
+             $<$<CONFIG:Release>:-fomit-frame-pointer>
+             $<$<C_COMPILER_ID:Clang,AppleClang>:
+-            -Wno-missing-field-initializers>
+-            -flto)
++            -Wno-missing-field-initializers>)
+   if(BUILD_FUZZER)
+     target_compile_options(unarr PUBLIC "${sanitize_opts}")
+     target_compile_definitions(
+@@ -218,7 +188,7 @@ if(UNIX
+ 
+   # Clang linker needs -flto too when doing lto
+   if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+-    set(linker_opts "${linker_opts} -flto")
++    set(linker_opts "${linker_opts}")
+   endif()
+ 
+   set_target_properties(unarr PROPERTIES LINK_FLAGS "${linker_opts}")
 diff --git a/_7z/_7z.h b/_7z/_7z.h
 index 7f207e1..f488e42 100644
 --- a/_7z/_7z.h

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -34,7 +34,7 @@ index f38b229..9b30b35 100644
 +target_include_directories(unarr PUBLIC ${7ZIP_INCLUDE_DIRS})
 +# 7zip upstream does not supply a .pc file. Add it to Libs.private.
 +set(PROJECT_LIBS_PRIVATE "${PROJECT_LIBS_PRIVATE} -l7zip")
-+set(UNARR_DEPENDS_7zip "${UNARR_DEPENDS_7zip} find_dependency(7zip)")
++set(UNARR_DEPENDS_7zip "find_dependency(7zip CONFIG)")
  
  if(USE_SYSTEM_BZ2)
    find_package(BZip2)

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f38b229..9b30b35 100644
+index f38b229..a56a098 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -52,19 +52,6 @@ add_library(
@@ -22,7 +22,7 @@ index f38b229..9b30b35 100644
    rar/lzss.h
    rar/rar.h
    rar/rarvm.h
-@@ -102,6 +89,15 @@ target_include_directories(
+@@ -102,6 +89,12 @@ target_include_directories(
  if(BUILD_SHARED_LIBS)
    target_compile_definitions(unarr PUBLIC UNARR_IS_SHARED_LIBRARY)
  endif()
@@ -35,7 +35,7 @@ index f38b229..9b30b35 100644
  
  if(USE_SYSTEM_BZ2)
    find_package(BZip2)
-@@ -115,7 +111,7 @@ if(BZIP2_FOUND)
+@@ -115,7 +108,7 @@ if(BZIP2_FOUND)
    endif()
    target_compile_definitions(unarr PRIVATE -DHAVE_BZIP2)
    # Bzip2 upstream does not supply a .pc file. Add it to Libs.private.
@@ -44,7 +44,7 @@ index f38b229..9b30b35 100644
    set(UNARR_DEPENDS_BZip2 "find_dependency(BZip2)")
  endif()
  
-@@ -154,28 +150,6 @@ if(ZLIB_FOUND)
+@@ -154,28 +147,6 @@ if(ZLIB_FOUND)
  endif()
  
  if(ENABLE_7Z)
@@ -73,7 +73,7 @@ index f38b229..9b30b35 100644
    target_compile_definitions(unarr PRIVATE -DHAVE_7Z -DZ7_PPMD_SUPPORT)
  endif()
  
-@@ -194,8 +168,7 @@ if(UNIX
+@@ -194,8 +165,7 @@ if(UNIX
              -Werror-implicit-function-declaration
              $<$<CONFIG:Release>:-fomit-frame-pointer>
              $<$<C_COMPILER_ID:Clang,AppleClang>:
@@ -83,7 +83,7 @@ index f38b229..9b30b35 100644
    if(BUILD_FUZZER)
      target_compile_options(unarr PUBLIC "${sanitize_opts}")
      target_compile_definitions(
-@@ -218,7 +191,7 @@ if(UNIX
+@@ -218,7 +188,7 @@ if(UNIX
  
    # Clang linker needs -flto too when doing lto
    if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f38b229..f10083d 100644
+index f38b229..d16a222 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -52,19 +52,6 @@ add_library(
@@ -33,11 +33,20 @@ index f38b229..f10083d 100644
 +get_target_property(7ZIP_INCLUDE_DIRS 7zip::7zip INTERFACE_INCLUDE_DIRECTORIES)
 +target_include_directories(unarr PUBLIC ${7ZIP_INCLUDE_DIRS})
 +# 7zip upstream does not supply a .pc file. Add it to Libs.private.
-+set(PROJECT_LIBS_PRIVATE "-I${7zip_INCLUDE_DIRS} -l${7zip_LIBRARIES}")
++set(PROJECT_LIBS_PRIVATE "${PROJECT_LIBS_PRIVATE} -l7zip")
 +set(UNARR_DEPENDS_7zip "${UNARR_DEPENDS_7zip} find_dependency(7zip)")
  
  if(USE_SYSTEM_BZ2)
    find_package(BZip2)
+@@ -115,7 +111,7 @@ if(BZIP2_FOUND)
+   endif()
+   target_compile_definitions(unarr PRIVATE -DHAVE_BZIP2)
+   # Bzip2 upstream does not supply a .pc file. Add it to Libs.private.
+-  set(PROJECT_LIBS_PRIVATE "-I${BZIP2_INCLUDE_DIRS} -l${BZIP2_LIBRARIES}")
++  set(PROJECT_LIBS_PRIVATE "${PROJECT_LIBS_PRIVATE} -I${BZIP2_INCLUDE_DIRS} -l${BZIP2_LIBRARIES}")
+   set(UNARR_DEPENDS_BZip2 "find_dependency(BZip2)")
+ endif()
+ 
 @@ -154,29 +150,7 @@ if(ZLIB_FOUND)
  endif()
  

--- a/ports/unarr/debundle-7zip.patch
+++ b/ports/unarr/debundle-7zip.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f38b229..9d055f9 100644
+index f38b229..f10083d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -52,19 +52,6 @@ add_library(
@@ -28,10 +28,10 @@ index f38b229..9d055f9 100644
  endif()
 +# Debundle 7zip
 +find_package(7zip CONFIG REQUIRED)
-+target_link_libraries(unarr PRIVATE 7zip::7zip)
++target_link_libraries(unarr PUBLIC 7zip::7zip)
 +# Ensure 7zip headers are accessible
 +get_target_property(7ZIP_INCLUDE_DIRS 7zip::7zip INTERFACE_INCLUDE_DIRECTORIES)
-+target_include_directories(unarr PRIVATE ${7ZIP_INCLUDE_DIRS})
++target_include_directories(unarr PUBLIC ${7ZIP_INCLUDE_DIRS})
 +# 7zip upstream does not supply a .pc file. Add it to Libs.private.
 +set(PROJECT_LIBS_PRIVATE "-I${7zip_INCLUDE_DIRS} -l${7zip_LIBRARIES}")
 +set(UNARR_DEPENDS_7zip "${UNARR_DEPENDS_7zip} find_dependency(7zip)")

--- a/ports/unarr/portfile.cmake
+++ b/ports/unarr/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
         debundle-7zip.patch
 )
 
+file(REMOVE_RECURSE "${SOURCE_PATH}/lzmasdk")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/unarr/portfile.cmake
+++ b/ports/unarr/portfile.cmake
@@ -1,3 +1,7 @@
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO selmf/unarr

--- a/ports/unarr/portfile.cmake
+++ b/ports/unarr/portfile.cmake
@@ -1,0 +1,35 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO selmf/unarr
+    REF "v${VERSION}"
+    SHA512 da170e0391fbe92e9b2474beb6be9a96c9f905e4e572235aa839cda3f6faf3cb99773eede34e1054138a4997bf68a18ee84f4df47add202355449634c0fd6d93
+    HEAD_REF master
+    PATCHES
+        debundle-7zip.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "enable-7z"            ENABLE_7Z
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DUSE_SYSTEM_BZ2=ON
+        -DUSE_SYSTEM_LZMA=ON
+        -DUSE_SYSTEM_ZLIB=ON
+        -DUSE_ZLIB_CRC=ON
+        -DBUILD_INTEGRATION_TESTS=OFF
+        -DBUILD_FUZZER=OFF
+        -DBUILD_UNIT_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/unarr")
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/unarr/portfile.cmake
+++ b/ports/unarr/portfile.cmake
@@ -1,7 +1,3 @@
-if (VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO selmf/unarr
@@ -12,15 +8,11 @@ vcpkg_from_github(
         debundle-7zip.patch
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        "enable-7z"            ENABLE_7Z
-)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        -DENABLE_7Z=ON
         -DUSE_SYSTEM_BZ2=ON
         -DUSE_SYSTEM_LZMA=ON
         -DUSE_SYSTEM_ZLIB=ON

--- a/ports/unarr/portfile.cmake
+++ b/ports/unarr/portfile.cmake
@@ -1,7 +1,3 @@
-if (VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO selmf/unarr

--- a/ports/unarr/vcpkg.json
+++ b/ports/unarr/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "A decompression library for rar, tar, zip and 7z archives.",
   "homepage": "https://github.com/selmf/unarr",
   "license": "LGPL-3.0-only",
-  "supports": "!(windows & !static)",
+  "supports": "!windows | static",
   "dependencies": [
     "7zip",
     "bzip2",

--- a/ports/unarr/vcpkg.json
+++ b/ports/unarr/vcpkg.json
@@ -1,0 +1,28 @@
+{
+  "name": "unarr",
+  "version": "1.1.1",
+  "description": "A decompression library for rar, tar, zip and 7z archives.",
+  "homepage": "https://github.com/selmf/unarr",
+  "license": "LGPL-3.0-only",
+  "dependencies": [
+    "bzip2",
+    "liblzma",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ],
+  "features": {
+    "enable-7z": {
+      "description": "Build with 7z support",
+      "dependencies": [
+        "7zip"
+      ]
+    }
+  }
+}

--- a/ports/unarr/vcpkg.json
+++ b/ports/unarr/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "A decompression library for rar, tar, zip and 7z archives.",
   "homepage": "https://github.com/selmf/unarr",
   "license": "LGPL-3.0-only",
+  "supports": "!(windows & !static)",
   "dependencies": [
     "7zip",
     "bzip2",

--- a/ports/unarr/vcpkg.json
+++ b/ports/unarr/vcpkg.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/selmf/unarr",
   "license": "LGPL-3.0-only",
   "dependencies": [
+    "7zip",
     "bzip2",
     "liblzma",
     {
@@ -16,13 +17,5 @@
       "host": true
     },
     "zlib"
-  ],
-  "features": {
-    "enable-7z": {
-      "description": "Build with 7z support",
-      "dependencies": [
-        "7zip"
-      ]
-    }
-  }
+  ]
 }

--- a/scripts/test_ports/vcpkg-ci-unarr/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-unarr/portfile.cmake
@@ -1,0 +1,10 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+    OPTIONS
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-unarr/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-unarr/project/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(unarr-test LANGUAGES C)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+find_package(unarr CONFIG REQUIRED)
+add_executable(main main.c)
+target_link_libraries(main PRIVATE unarr::unarr)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(libunarr REQUIRED IMPORTED_TARGET libunarr)
+add_executable(main2 main.c)
+target_link_libraries(main2 PRIVATE PkgConfig::libunarr)

--- a/scripts/test_ports/vcpkg-ci-unarr/project/main.c
+++ b/scripts/test_ports/vcpkg-ci-unarr/project/main.c
@@ -1,0 +1,8 @@
+#include <unarr.h>
+int main()
+{
+   ar_stream *stream;
+   ar_archive *ar = ar_open_rar_archive(stream);
+   ar_close_archive(ar);
+   return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-unarr/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-unarr/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-unarr",
+  "version-string": "ci",
+  "description": "Validates unarr",
+  "dependencies": [
+    "unarr",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "181bb1c243122a292eef7567aa94476888b18465",
+      "version": "25.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "a92e7bbff417f0728def797557491c0251d2602e",
       "version": "25.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6,7 +6,7 @@
     },
     "7zip": {
       "baseline": "25.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ableton": {
       "baseline": "3.0.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9932,6 +9932,10 @@
       "baseline": "2022-01-21",
       "port-version": 1
     },
+    "unarr": {
+      "baseline": "1.1.1",
+      "port-version": 0
+    },
     "uni-algo": {
       "baseline": "1.2.0",
       "port-version": 0

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "59f967a31cdfc0139a67fce242e36d621b8cb089",
+      "git-tree": "29b243ff0933d86289bd73114e2eaa9fff83c11c",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8b7e36b88cd930d47de548a9c3e65eacccf4b9ce",
+      "git-tree": "97b57ded19515958165f862340d06cc63b480f1a",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1c18fde3f4df5c8d7162aafb71cdcefae30eb46a",
+      "git-tree": "3d49fd543b180134e24f760872d774367215df3a",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ea73dc0e6139b5b1b000af42cae066b0975d2857",
+      "git-tree": "07a342ea5fa3e4b58ccfe0db72d3cc8471d5c671",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "07a342ea5fa3e4b58ccfe0db72d3cc8471d5c671",
+      "git-tree": "8b7e36b88cd930d47de548a9c3e65eacccf4b9ce",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0471e6eda1bead3ec6f80fb0606aef263c0d4afc",
+      "git-tree": "00f1f2116e607b7a82c7869636372a98f93985c4",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c7d9f3cce3d057270b7d42fc3ffc1ccc1f9d43fb",
+      "git-tree": "59f967a31cdfc0139a67fce242e36d621b8cb089",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "170f0d3b035d87ec6bce0727986b0ff3fe633602",
+      "git-tree": "28de49cf2e6d910d14d25803e5b7e5b7e6687f09",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f456aecde5dc49ecefaaaec1256bfda4f0aab56",
+      "git-tree": "c7d9f3cce3d057270b7d42fc3ffc1ccc1f9d43fb",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9281d52dffbe8fad1beb49b7c158b09ec65764c5",
+      "git-tree": "ea73dc0e6139b5b1b000af42cae066b0975d2857",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "97b57ded19515958165f862340d06cc63b480f1a",
+      "git-tree": "28b1fc550899cb202a4a0b6f57748ca37beff08c",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "29b243ff0933d86289bd73114e2eaa9fff83c11c",
+      "git-tree": "1c18fde3f4df5c8d7162aafb71cdcefae30eb46a",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "28b1fc550899cb202a4a0b6f57748ca37beff08c",
+      "git-tree": "170f0d3b035d87ec6bce0727986b0ff3fe633602",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3d49fd543b180134e24f760872d774367215df3a",
+      "git-tree": "5300e67f7b0e4aed9f3f49176ef8e25ba09a11f9",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9281d52dffbe8fad1beb49b7c158b09ec65764c5",
+      "version": "1.1.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "28de49cf2e6d910d14d25803e5b7e5b7e6687f09",
+      "git-tree": "2f456aecde5dc49ecefaaaec1256bfda4f0aab56",
       "version": "1.1.1",
       "port-version": 0
     }

--- a/versions/u-/unarr.json
+++ b/versions/u-/unarr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5300e67f7b0e4aed9f3f49176ef8e25ba09a11f9",
+      "git-tree": "0471e6eda1bead3ec6f80fb0606aef263c0d4afc",
       "version": "1.1.1",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://repology.org/project/unarr/versions