### PR TITLE
[functionalplus] Bump to 0.2.26

### DIFF
--- a/ports/functionalplus/portfile.cmake
+++ b/ports/functionalplus/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Dobiasd/FunctionalPlus
     REF "v${VERSION}"
-    SHA512 61041dfc5af9c11ebed50016d258289f52c73717f57db9781b7dcc5c203959aff1a857e827bf426767e9683e1c99c10a7e33baf72ddcc554b7984e5b051cd167
+    SHA512 06eb3453cf2d1f8931223b8da9b6a5a6243cae99ce930b74cbd72a4e146eb10dc464f01021d5acbadfe75fe2d2b06580fbd3bb014792f000156ae05e5e3e3a64
     HEAD_REF master
 )
 
@@ -15,5 +15,6 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/functionalplus/vcpkg.json
+++ b/ports/functionalplus/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "functionalplus",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "This port is the new fplus port, the old fplus has been removed. Functional Programming Library for C++. Write concise and readable C++ code",
   "homepage": "https://github.com/Dobiasd/FunctionalPlus",
   "license": "BSL-1.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3121,7 +3121,7 @@
       "port-version": 0
     },
     "functionalplus": {
-      "baseline": "0.2.25",
+      "baseline": "0.2.26",
       "port-version": 0
     },
     "functions-framework-cpp": {

--- a/versions/f-/functionalplus.json
+++ b/versions/f-/functionalplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a64b6b202c26184b39a2025185eeccb9c2b5b93",
+      "version": "0.2.26",
+      "port-version": 0
+    },
+    {
       "git-tree": "14a02937a2a23219808420c03a7f96241abd251a",
       "version": "0.2.25",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
