### PR TITLE
[arrow] enable building on Windows ARM64

### DIFF
--- a/ports/arrow/0006-pcg-msvc-arm64.patch
+++ b/ports/arrow/0006-pcg-msvc-arm64.patch
@@ -1,0 +1,43 @@
+diff --git a/cpp/src/arrow/vendored/pcg/pcg_uint128.hpp b/cpp/src/arrow/vendored/pcg/pcg_uint128.hpp
+index 0181e69e4e..012f3d6682 100644
+--- a/cpp/src/arrow/vendored/pcg/pcg_uint128.hpp
++++ b/cpp/src/arrow/vendored/pcg/pcg_uint128.hpp
+@@ -67,7 +67,7 @@
+         #define PCG_LITTLE_ENDIAN 1
+     #elif __BIG_ENDIAN__ || _BIG_ENDIAN
+         #define PCG_LITTLE_ENDIAN 0
+-    #elif __x86_64 || __x86_64__ || _M_X64 || __i386 || __i386__ || _M_IX86
++    #elif __x86_64 || __x86_64__ || _M_X64 || __i386 || __i386__ || _M_IX86 || _M_ARM64
+         #define PCG_LITTLE_ENDIAN 1
+     #elif __powerpc__ || __POWERPC__ || __ppc__ || __PPC__ \
+           || __m68k__ || __mc68000__
+@@ -734,7 +734,13 @@ uint_x4<UInt,UIntX2> operator*(const uint_x4<UInt,UIntX2>& a,
+ 
+ #if PCG_64BIT_SPECIALIZATIONS
+ #if defined(_MSC_VER)
++#if defined(_M_X64) || defined(_M_IX86)
+ #pragma intrinsic(_umul128)
++#elif defined(_M_ARM64)
++#pragma intrinsic(__umulh)
++#else
++#error Unsupported architecture
++#endif
+ #endif
+ 
+ #if defined(_MSC_VER) || __SIZEOF_INT128__
+@@ -743,8 +749,15 @@ uint_x4<UInt32,uint64_t> operator*(const uint_x4<UInt32,uint64_t>& a,
+ 				   const uint_x4<UInt32,uint64_t>& b)
+ {
+ #if defined(_MSC_VER)
++#if defined(_M_X64) || defined(_M_IX86)
+     uint64_t hi;
+     uint64_t lo = _umul128(a.d.v01, b.d.v01, &hi);
++#elif defined(_M_ARM64)
++    uint64_t lo = a.d.v01 * b.d.v01;
++    uint64_t hi = __umulh(a.d.v01, b.d.v01);
++#else
++#error Unsupported architecture
++#endif
+ #else
+     __uint128_t r = __uint128_t(a.d.v01) * __uint128_t(b.d.v01);
+     uint64_t lo = uint64_t(r);

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_extract_source_archive(
         0003-android-musl.patch
         0004-android-datetime.patch
         0005-cmake-msvcruntime.patch
+        0006-pcg-msvc-arm64.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -37,6 +38,10 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     list(APPEND FEATURE_OPTIONS "-DARROW_USE_NATIVE_INT128=OFF")
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    list(APPEND FEATURE_OPTIONS "-DARROW_SIMD_LEVEL=NONE")
 endif()
 
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" ARROW_BUILD_SHARED)

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "arrow",
   "version": "21.0.0",
+  "port-version": 1,
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",
-  "supports": "x64 | (arm64 & !windows)",
+  "supports": "x64 | arm64",
   "dependencies": [
     "boost-filesystem",
     "boost-multiprecision",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -656,6 +656,7 @@ arrow[cuda]:x64-windows-static = feature-fails
 arrow[cuda]:x64-windows-static-md = feature-fails
 arrow[cuda](!(windows & x64 & !uwp & !xbox) & !(linux & x64) & !(linux & arm64)) = cascade
 arrow[orc]:arm64-android = cascade
+arrow[orc]:arm64-windows = feature-fails
 arrow[orc]:x64-android = cascade
 arrow[orc]:x64-windows = feature-fails
 asio[coroutine]:arm64-uwp = cascade

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ecab846d4b97453e26953dcf553f1df260901ff3",
+      "version": "21.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "44e37b3fb8df5a87f51550a11c1bd20af772a09a",
       "version": "21.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -270,7 +270,7 @@
     },
     "arrow": {
       "baseline": "21.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "arrow-adbc": {
       "baseline": "16",


### PR DESCRIPTION
### Changes
- vendored `pcg` is patched to support msvc arm64 intrinsics
- `ARROW_SIMD_LEVEL` is set to `NONE` to disable the use of `xsimd`, which
  does not yet support msvc arm64 intrinsics (non-trivial to add)

### Port update checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.