### PR TITLE
[usd] Fix Vulkan support macro

### DIFF
--- a/ports/usd/003-fix-dep.patch
+++ b/ports/usd/003-fix-dep.patch
@@ -34,10 +34,11 @@ index 1b69cad..9494278 100644
 @@ -215,8 +221,14 @@ if (PXR_BUILD_IMAGING)
              endif()
  
-             add_definitions(-DPXR_VULKAN_SUPPORT_ENABLED)
+-            add_definitions(-DPXR_VULKAN_SUPPORT_ENABLED)
 -        else()
 -            message(FATAL_ERROR "VULKAN_SDK not valid")
          endif()
++        add_definitions(-DPXR_VULKAN_SUPPORT_ENABLED)
 +        find_package(Vulkan REQUIRED)
 +        find_package(unofficial-shaderc CONFIG REQUIRED)
 +        find_package(unofficial-spirv-reflect CONFIG REQUIRED)

--- a/ports/usd/vcpkg.json
+++ b/ports/usd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "usd",
   "version": "25.5.1",
+  "port-version": 1,
   "description": "Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.",
   "homepage": "https://github.com/PixarAnimationStudios/OpenUSD",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10006,7 +10006,7 @@
     },
     "usd": {
       "baseline": "25.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "usearch": {
       "baseline": "2.21.0",

--- a/versions/u-/usd.json
+++ b/versions/u-/usd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4404d2de56ca95ad4bb8141ac12c8a594af8fa70",
+      "version": "25.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "505c48b1d08309a49850738008e153d2a60dadce",
       "version": "25.5.1",
       "port-version": 0


### PR DESCRIPTION
`add_definitions(-DPXR_VULKAN_SUPPORT_ENABLED)` was accidentally disabled in the patch. Move it out of `if(0)/endif()`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

