### PR TITLE
[inflatelib] Add new port

### DIFF
--- a/ports/inflatelib/portfile.cmake
+++ b/ports/inflatelib/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/inflatelib
+    REF "v${VERSION}"
+    SHA512 75c9bd5cca52813ccb7ff5dd048783c8865b7fdcdab406849019a321c49c3b74b831d0529549168b78bb4a51fcebbe6e945ca6309e60c4c5a3c0290d17d07cee
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DINFLATELIB_TEST=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "cmake")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/inflatelib/usage
+++ b/ports/inflatelib/usage
@@ -1,0 +1,4 @@
+inflatelib provides CMake targets:
+
+    find_package(inflatelib CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE inflatelib::inflatelib)

--- a/ports/inflatelib/vcpkg.json
+++ b/ports/inflatelib/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "inflatelib",
+  "version": "0.1.0",
+  "description": "A Deflate and Deflate64 decompression library",
+  "homepage": "https://github.com/microsoft/inflatelib",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3936,6 +3936,10 @@
       "baseline": "2023-06-01",
       "port-version": 0
     },
+    "inflatelib": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "influxdb-cxx": {
       "baseline": "0.7.4",
       "port-version": 1

--- a/versions/i-/inflatelib.json
+++ b/versions/i-/inflatelib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ab4d7452b4ad1c85dabf8a9726655396122e3f8d",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This is for https://github.com/microsoft/inflatelib

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


