### PR TITLE
[pkgconf] Add paths for OpenBSD and fix unveil related bugs

### DIFF
--- a/ports/pkgconf/001-unveil-fixes.patch
+++ b/ports/pkgconf/001-unveil-fixes.patch
@@ -1,0 +1,50 @@
+diff --git a/cli/main.c b/cli/main.c
+index a1cf90e..3ab2092 100644
+--- a/cli/main.c
++++ b/cli/main.c
+@@ -1055,7 +1055,7 @@ unveil_search_paths(const pkgconf_client_t *client, const pkgconf_cross_personal
+ 	{
+ 		pkgconf_path_t *pn = n->data;
+ 
+-		if (pkgconf_unveil(pn->path, "r") == -1)
++		if (pkgconf_unveil(pn->path, "r") == -1 && errno != ENOENT)
+ 			return false;
+ 	}
+ 
+@@ -1063,7 +1063,7 @@ unveil_search_paths(const pkgconf_client_t *client, const pkgconf_cross_personal
+ 	{
+ 		pkgconf_path_t *pn = n->data;
+ 
+-		if (pkgconf_unveil(pn->path, "r") == -1)
++		if (pkgconf_unveil(pn->path, "r") == -1 && errno != ENOENT)
+ 			return false;
+ 	}
+ 
+@@ -1276,13 +1276,6 @@ main(int argc, char *argv[])
+ 	/* now, bring up the client.  settings are preserved since the client is prealloced */
+ 	pkgconf_client_init(&pkg_client, error_handler, NULL, personality);
+ 
+-	/* unveil the entire search path now that we have loaded the personality data. */
+-	if (!unveil_search_paths(&pkg_client, personality))
+-	{
+-		fprintf(stderr, "pkgconf: unveil failed: %s\n", strerror(errno));
+-		return EXIT_FAILURE;
+-	}
+-
+ #ifndef PKGCONF_LITE
+ 	if ((want_flags & PKG_MSVC_SYNTAX) == PKG_MSVC_SYNTAX || getenv("PKG_CONFIG_MSVC_SYNTAX") != NULL)
+ 		want_render_ops = msvc_renderer_get();
+@@ -1452,6 +1445,13 @@ main(int argc, char *argv[])
+ 	/* at this point, want_client_flags should be set, so build the dir list */
+ 	pkgconf_client_dir_list_build(&pkg_client, personality);
+ 
++	/* unveil the entire search path now that we have loaded the personality data. */
++	if (!unveil_search_paths(&pkg_client, personality))
++	{
++		fprintf(stderr, "pkgconf: unveil failed: %s\n", strerror(errno));
++		return EXIT_FAILURE;
++	}
++
+ 	/* preload any files in PKG_CONFIG_PRELOADED_FILES */
+ 	pkgconf_client_preload_from_environ(&pkg_client, "PKG_CONFIG_PRELOADED_FILES");
+ 

--- a/ports/pkgconf/portfile.cmake
+++ b/ports/pkgconf/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "pkgconf-${VERSION}"
     SHA512 53244f372ea21125a1d97c5b89a84299740b55a66165782e807ed23adab3a07408a1547f1f40156e3060359660d07f49846c8b4893beef10ac9440ab7e8611cc
     HEAD_REF master
+    PATCHES
+        001-unveil-fixes.patch # https://github.com/pkgconf/pkgconf/pull/430
 )
 
 vcpkg_configure_meson(
@@ -21,25 +23,32 @@ set(PKG_DEFAULT_PATH "")
 set(SYSTEM_INCLUDEDIR "")
 set(PERSONALITY_PATH "personality.d")
 
-if(VCPKG_TARGET_IS_FREEBSD)
-    # These are taken from the FreeBSD port of pkgconf
-    set(SYSTEM_INCLUDEDIR "/usr/include")
-    set(SYSTEM_LIBDIR "/usr/lib")
-    set(PKG_DEFAULT_PATH "/usr/libdata/pkgconfig:/usr/local/libdata/pkgconfig:/usr/local/share/pkgconfig")
-elseif(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_CROSSCOMPILING AND VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
-    # These defaults are obtained from pkgconf/pkg-config on Ubuntu and OpenSuse
-    # vcpkg cannot do system introspection to obtain/set these values since it would break binary caching.
-    set(SYSTEM_INCLUDEDIR "/usr/include")
-    # System lib dirs will be stripped from -L from the pkg-config output
-    set(SYSTEM_LIBDIR "/lib:/lib/i386-linux-gnu:/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnux32:/lib64:/lib32:/libx32:/usr/lib:/usr/lib/i386-linux-gnu:/usr/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnux32:/usr/lib64:/usr/lib32:/usr/libx32")
-    set(PKG_DEFAULT_PATH "/usr/local/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig")
-    set(PERSONALITY_PATH "/usr/share/pkgconfig/personality.d:/etc/pkgconfig/personality.d")
-elseif(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_CROSSCOMPILING AND VCPKG_TARGET_ARCHITECTURE MATCHES "riscv64")
-    # These defaults are obtained from pkgconf/pkg-config on Ubuntu
-    set(SYSTEM_INCLUDEDIR "/usr/include")
-    set(SYSTEM_LIBDIR "/lib:/lib/riscv64-linux-gnu:/usr/lib:/usr/lib/riscv64-linux-gnu")
-    set(PKG_DEFAULT_PATH "/usr/local/lib/riscv64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/lib/riscv64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig")
-    set(PERSONALITY_PATH "/usr/share/pkgconfig/personality.d:/etc/pkgconfig/personality.d")
+if(NOT VCPKG_CROSSCOMPILING)
+    if(VCPKG_TARGET_IS_FREEBSD)
+        # These are taken from the FreeBSD port of pkgconf
+        set(SYSTEM_INCLUDEDIR "/usr/include")
+        set(SYSTEM_LIBDIR "/usr/lib")
+        set(PKG_DEFAULT_PATH "/usr/libdata/pkgconfig:/usr/local/libdata/pkgconfig:/usr/local/share/pkgconfig")
+    elseif(VCPKG_TARGET_IS_OPENBSD)
+        # Based on how new OpenBSD builds their version of pkgconf
+        set(SYSTEM_INCLUDEDIR "/usr/include")
+        set(SYSTEM_LIBDIR "/usr/lib")
+        set(PKG_DEFAULT_PATH "/usr/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/X11R6/lib/pkgconfig:/usr/X11R6/share/pkgconfig")
+    elseif(NOT VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
+        # These defaults are obtained from pkgconf/pkg-config on Ubuntu and OpenSuse
+        # vcpkg cannot do system introspection to obtain/set these values since it would break binary caching.
+        set(SYSTEM_INCLUDEDIR "/usr/include")
+        # System lib dirs will be stripped from -L from the pkg-config output
+        set(SYSTEM_LIBDIR "/lib:/lib/i386-linux-gnu:/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnux32:/lib64:/lib32:/libx32:/usr/lib:/usr/lib/i386-linux-gnu:/usr/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnux32:/usr/lib64:/usr/lib32:/usr/libx32")
+        set(PKG_DEFAULT_PATH "/usr/local/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig")
+        set(PERSONALITY_PATH "/usr/share/pkgconfig/personality.d:/etc/pkgconfig/personality.d")
+    elseif(NOT VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE MATCHES "riscv64")
+        # These defaults are obtained from pkgconf/pkg-config on Ubuntu
+        set(SYSTEM_INCLUDEDIR "/usr/include")
+        set(SYSTEM_LIBDIR "/lib:/lib/riscv64-linux-gnu:/usr/lib:/usr/lib/riscv64-linux-gnu")
+        set(PKG_DEFAULT_PATH "/usr/local/lib/riscv64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/lib/riscv64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig")
+        set(PERSONALITY_PATH "/usr/share/pkgconfig/personality.d:/etc/pkgconfig/personality.d")
+    endif()
 endif()
 
 if(DEFINED VCPKG_pkgconf_SYSTEM_LIBDIR)

--- a/ports/pkgconf/vcpkg.json
+++ b/ports/pkgconf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pkgconf",
   "version": "2.5.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "pkgconf is a program which helps to configure compiler and linker flags for development libraries. It is similar to pkg-config from freedesktop.org.",
   "homepage": "https://github.com/pkgconf/pkgconf",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7498,7 +7498,7 @@
     },
     "pkgconf": {
       "baseline": "2.5.1",
-      "port-version": 2
+      "port-version": 3
     },
     "plasma-wayland-protocols": {
       "baseline": "1.14.0",

--- a/versions/p-/pkgconf.json
+++ b/versions/p-/pkgconf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64596d00121be1e7c6109d1409b1e87dea8b8d0c",
+      "version": "2.5.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "12ad1f6607cde3d779367e4d9d728edc9fbb6cdd",
       "version": "2.5.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.