### PR TITLE
[dacap-clip] update 1.12

### DIFF
--- a/ports/dacap-clip/portfile.cmake
+++ b/ports/dacap-clip/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO dacap/clip
   REF v${VERSION}
-  SHA512 450653964c4c943daf47fca32f63d9de40aa6e2daf1cb96e3d71543d4919352adca3b6db529c4de985a72ec21166f97974484114d23e12ea73da31cc1d536481
+  SHA512 8cbe79d6189449be2a96141f97514e393ab7baccdcf37727f6dd54a3d5dacfe293ede39690d62dd4b7d346876973227dd9e29e14c7e8ca928223e6459005284c
   PATCHES
     "fix-install-header-and-force-static-compilation.patch")
 

--- a/ports/dacap-clip/vcpkg.json
+++ b/ports/dacap-clip/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dacap-clip",
-  "version": "1.11",
+  "version": "1.12",
   "description": "Cross-platform C++ library to copy/paste clipboard content.",
   "homepage": "https://github.com/dacap/clip",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2309,7 +2309,7 @@
       "port-version": 1
     },
     "dacap-clip": {
-      "baseline": "1.11",
+      "baseline": "1.12",
       "port-version": 0
     },
     "darknet": {

--- a/versions/d-/dacap-clip.json
+++ b/versions/d-/dacap-clip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b806db9edf4f005f7de9921b8c952eededdee146",
+      "version": "1.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "572ce455e5fa4df4f83a2f62a8bf5c617107c0c9",
       "version": "1.11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/dacap/clip/releases/tag/v1.12
