### PR TITLE
[hyperscan] Fix android build

### DIFF
--- a/ports/hyperscan/0002-fix-threads.patch
+++ b/ports/hyperscan/0002-fix-threads.patch
@@ -1,0 +1,40 @@
+diff --git a/tools/hscheck/CMakeLists.txt b/tools/hscheck/CMakeLists.txt
+index 2ae0613..3a47776 100644
+--- a/tools/hscheck/CMakeLists.txt
++++ b/tools/hscheck/CMakeLists.txt
+@@ -11,7 +11,7 @@ if (BUILD_CHIMERA)
+     add_definitions(-DHS_HYBRID)
+     add_executable(hscheck ${hscheck_SOURCES})
+     if(NOT WIN32)
+-        target_link_libraries(hscheck hs chimera ${PCRE_LDFLAGS} expressionutil pthread)
++        target_link_libraries(hscheck hs chimera ${PCRE_LDFLAGS} expressionutil Threads::Threads)
+     else()
+         target_link_libraries(hscheck hs chimera pcre expressionutil)
+     endif()
+@@ -22,7 +22,7 @@ else()
+         add_executable(hscheck ${hscheck_SOURCES})
+     endif()
+     if(NOT WIN32)
+-        target_link_libraries(hscheck hs expressionutil pthread)
++        target_link_libraries(hscheck hs expressionutil Threads::Threads)
+     else()
+         target_link_libraries(hscheck hs expressionutil)
+     endif()
+diff --git a/tools/hscollider/CMakeLists.txt b/tools/hscollider/CMakeLists.txt
+index a4d71b2..ca9fa0c 100644
+--- a/tools/hscollider/CMakeLists.txt
++++ b/tools/hscollider/CMakeLists.txt
+@@ -68,11 +68,11 @@ add_dependencies(hscollider ragel_ColliderCorporaParser)
+ if(NOT WIN32)
+     if (BUILD_CHIMERA)
+         target_link_libraries(hscollider hs chimera ${PCRE_LDFLAGS} databaseutil
+-            expressionutil corpusomatic crosscompileutil pthread
++            expressionutil corpusomatic crosscompileutil Threads::Threads
+         "${BACKTRACE_LDFLAGS}")
+     else()
+         target_link_libraries(hscollider hs ${PCRE_LDFLAGS} databaseutil
+-            expressionutil corpusomatic crosscompileutil pthread
++            expressionutil corpusomatic crosscompileutil Threads::Threads
+         "${BACKTRACE_LDFLAGS}")
+     endif()
+ 

--- a/ports/hyperscan/portfile.cmake
+++ b/ports/hyperscan/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         0001-remove-Werror.patch
+        0002-fix-threads.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)
@@ -14,6 +15,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DPYTHON_EXECUTABLE=${PYTHON3}"
+        "-DRAGEL=${CURRENT_HOST_INSTALLED_DIR}/tools/ragel${VCPKG_HOST_EXECUTABLE_SUFFIX}"
         -DBUILD_EXAMPLES=OFF
 )
 
@@ -25,3 +27,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 vcpkg_fixup_pkgconfig()
+

--- a/ports/hyperscan/vcpkg.json
+++ b/ports/hyperscan/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperscan",
   "version": "5.4.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A regular expression library with O(length of input) match times that takes advantage of Intel hardware to provide blazing speed.",
   "homepage": "https://www.hyperscan.io",
   "license": "BSD-3-Clause",
@@ -27,7 +27,10 @@
     "boost-unordered",
     "boost-utility",
     "pcre",
-    "ragel",
+    {
+      "name": "ragel",
+      "host": true
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -407,7 +407,6 @@ hexl:x64-android=fail
 hwloc:arm-neon-android=fail
 hwloc:arm64-android=fail
 hwloc:x64-android=fail
-hyperscan:x64-android=fail
 iceoryx:arm-neon-android=fail
 iceoryx:arm64-android=fail
 iceoryx:x64-android=fail

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -959,7 +959,6 @@ hikogui:x64-uwp = cascade
 hpx[cuda](!(windows & x64 & !uwp & !xbox) & !(linux & x64) & !(linux & arm64)) = cascade
 hpx[cuda](osx) = cascade
 hpx[mpi](windows & !(x64 | x86))=cascade
-hyperscan:x64-android=fail
 hyperscan:x64-uwp = cascade
 hypodermic:arm64-uwp = cascade
 hypodermic:x64-uwp = cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3818,7 +3818,7 @@
     },
     "hyperscan": {
       "baseline": "5.4.2",
-      "port-version": 1
+      "port-version": 2
     },
     "hypodermic": {
       "baseline": "2023-03-03",

--- a/versions/h-/hyperscan.json
+++ b/versions/h-/hyperscan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9dbae1281767ae0d017623fd79e4e46a54779b17",
+      "version": "5.4.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "778bdd34ac06dd066bc86f9d67807b09efbbe53d",
       "version": "5.4.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.