### PR TITLE
[openjph] add new port

### DIFF
--- a/ports/openjph/portfile.cmake
+++ b/ports/openjph/portfile.cmake
@@ -1,0 +1,35 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO aous72/OpenJPH
+    REF "${VERSION}"
+    SHA512 081ae567beeefec550b55585b1b31534fa3bc798a9372659d7d621342d0c3a6d673b7afe636c68785e17a64cc8a29b0869ab08b2d520c4ed53597b9d6b7edc20
+    HEAD_REF master
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tool OJPH_BUILD_EXECUTABLES
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DOJPH_ENABLE_TIFF_SUPPORT=ON
+        -DOJPH_BUILD_TESTS=OFF
+        -DOJPH_BUILD_STREAM_EXPAND=ON
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/openjph)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+if("tool" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES ojph_expand ojph_compress ojph_stream_expand AUTO_CLEAN)
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/openjph/portfile.cmake
+++ b/ports/openjph/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        tool OJPH_BUILD_EXECUTABLES
+        tools OJPH_BUILD_EXECUTABLES
 )
 
 vcpkg_cmake_configure(
@@ -30,7 +30,7 @@ vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-if("tool" IN_LIST FEATURES)
+if("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES ojph_expand ojph_compress ojph_stream_expand AUTO_CLEAN)
 endif()
 

--- a/ports/openjph/portfile.cmake
+++ b/ports/openjph/portfile.cmake
@@ -19,6 +19,8 @@ vcpkg_cmake_configure(
         -DOJPH_BUILD_TESTS=OFF
         -DOJPH_BUILD_STREAM_EXPAND=ON
         ${FEATURE_OPTIONS}
+    OPTIONS_DEBUG
+        -DOJPH_BUILD_EXECUTABLES=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/openjph/vcpkg.json
+++ b/ports/openjph/vcpkg.json
@@ -18,7 +18,10 @@
     "tool": {
       "description": "Enables building command line executables",
       "dependencies": [
-        "tiff"
+        {
+          "name": "tiff",
+          "default-features": false
+        }
       ]
     }
   }

--- a/ports/openjph/vcpkg.json
+++ b/ports/openjph/vcpkg.json
@@ -15,7 +15,7 @@
     }
   ],
   "features": {
-    "tool": {
+    "tools": {
       "description": "Enables building command line executables",
       "supports": "!uwp",
       "dependencies": [

--- a/ports/openjph/vcpkg.json
+++ b/ports/openjph/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "openjph",
+  "version": "0.24.2",
+  "description": "Open-source implementation of JPEG2000 Part-15 (or JPH or HTJ2K)",
+  "homepage": "https://github.com/aous72/OpenJPH",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tool": {
+      "description": "Enables building command line executables",
+      "dependencies": [
+        "tiff"
+      ]
+    }
+  }
+}

--- a/ports/openjph/vcpkg.json
+++ b/ports/openjph/vcpkg.json
@@ -17,6 +17,7 @@
   "features": {
     "tool": {
       "description": "Enables building command line executables",
+      "supports": "!uwp",
       "dependencies": [
         {
           "name": "tiff",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7164,6 +7164,10 @@
       "baseline": "2.5.4",
       "port-version": 0
     },
+    "openjph": {
+      "baseline": "0.24.2",
+      "port-version": 0
+    },
     "openldap": {
       "baseline": "2.6.10",
       "port-version": 0

--- a/versions/o-/openjph.json
+++ b/versions/o-/openjph.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "609d45d3a0be5f55c9633564c796ee1f63c2bc0a",
+      "git-tree": "408235d9a00fecb6988748bbe891f16ecf6e7171",
       "version": "0.24.2",
       "port-version": 0
     }

--- a/versions/o-/openjph.json
+++ b/versions/o-/openjph.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b483d5e51895f0b06aef95fda78b3a9ace476687",
+      "git-tree": "02cc779a428375ca7aacde4547a7ff66db49f45c",
       "version": "0.24.2",
       "port-version": 0
     }

--- a/versions/o-/openjph.json
+++ b/versions/o-/openjph.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "02cc779a428375ca7aacde4547a7ff66db49f45c",
+      "git-tree": "609d45d3a0be5f55c9633564c796ee1f63c2bc0a",
       "version": "0.24.2",
       "port-version": 0
     }

--- a/versions/o-/openjph.json
+++ b/versions/o-/openjph.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b483d5e51895f0b06aef95fda78b3a9ace476687",
+      "version": "0.24.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/aous72/OpenJPH
