### PR TITLE
muda: Fix CUDA 12.0+ header compatibility issues

### DIFF
--- a/ports/muda/portfile.cmake
+++ b/ports/muda/portfile.cmake
@@ -11,14 +11,11 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS options
         compute-graph   MUDA_WITH_COMPUTE_GRAPH
 )
 
-vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT cuda_toolkit_root)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${options}
-        "-DCMAKE_CUDA_COMPILER=${NVCC}"
-        "-DCUDAToolkit_ROOT=${cuda_toolkit_root}"
         "-DMUDA_BUILD_EXAMPLE=OFF"
         "-DMUDA_BUILD_TEST=OFF"
         "-DMUDA_WITH_CHECK=ON"

--- a/ports/muda/vcpkg.json
+++ b/ports/muda/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "muda",
   "version": "2025.10.9",
+  "port-version": 1,
   "description": "μ-Cuda, COVER THE LAST MILE OF CUDA. With features: intellisense-friendly, structured launch, automatic cuda graph generation and updating.",
   "license": "Apache-2.0",
   "supports": "(windows & x64 & !uwp & !xbox) | (linux & x64) | (linux & arm64)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6602,7 +6602,7 @@
     },
     "muda": {
       "baseline": "2025.10.9",
-      "port-version": 0
+      "port-version": 1
     },
     "mujoco": {
       "baseline": "3.3.0",

--- a/versions/m-/muda.json
+++ b/versions/m-/muda.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89a807aea88887b71d94dbd190747bd066342e11",
+      "version": "2025.10.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "4a37a180362c604fd31b90f6c57cf5a82b4cd1ed",
       "version": "2025.10.9",
       "port-version": 0


### PR DESCRIPTION
This PR updates the 'muda' port to resolve a compilation error when using CUDA 12.0 or newer toolkits.

**Problem:**
The port was explicitly calling `vcpkg_find_cuda()` and passing the discovered path via `-DCUDAToolkit_ROOT`. If the system had an older CUDA version installed (e.g., 11.8) but the user was compiling with a newer version (e.g., 12.8), the older CUDA 11.8 header files were incorrectly included in the build. This caused an error because newer CUDA features (like `CUDA_GRAPH_INSTANTIATE_FLAG_UPLOAD`) were missing in the older headers.

**Solution:**
Removed the explicit calls to `vcpkg_find_cuda()`, `-DCUDAToolkit_ROOT`, and `-DCMAKE_CUDA_COMPILER`. This allows CMake's native CUDA language support (which is used by the consumer's build system) to correctly manage the CUDA paths, ensuring the compiler uses headers matching the actual toolkit version (12.8).

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md).
- [x] SHA512s are updated for each updated download. (I assume you updated the `REF` in `vcpkg_from_github` to a newer version to get the fix, requiring a new SHA512. If you only patched, mark this N/A.)
- [ ] The "supports" clause reflects platforms that may be fixed by this new version. (If this PR fixes a platform, you might need to adjust the `supports` field in `vcpkg.json`/`CONTROL`. If not, mark N/A.)
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/eng/ci/baseline.txt) entries are removed from that file. (Check if `muda` has an entry in `baseline.txt` and remove it if your fix resolves that specific error.)
- [ ] Any patches that are no longer applied are deleted from the port's directory. (If you added a patch before that is now integrated upstream, delete your patch file.)
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result. **(This step is MANDATORY for port updates.)**
- [x] Only one version is added to each modified port's versions file. **(MANDATORY: `x-add-version` handles this.)**
END OF PORT UPDATE CHECKLIST (delete this line)

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
