### PR TITLE
[nonstd-scope-lite] Add new port at v0.3.0

### DIFF
--- a/ports/nonstd-scope-lite/portfile.cmake
+++ b/ports/nonstd-scope-lite/portfile.cmake
@@ -1,0 +1,29 @@
+set(VCPKG_BUILD_TYPE release)  # header-only
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nonstd-lite/scope-lite
+    REF "v${VERSION}"
+    SHA512 e159d7e31e0b9690b38ad9ee22368e9b230dd89419ac4198b0f64923b42acce24c1a6ebf3fcc4e7fed8a3942bb9b2d666d8098ae1a5f35f6f099343b22f646fe
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSCOPE_LITE_OPT_BUILD_TESTS=OFF
+        -DSCOPE_LITE_OPT_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME scope-lite
+    CONFIG_PATH lib/cmake/scope-lite
+)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/nonstd-scope-lite/vcpkg.json
+++ b/ports/nonstd-scope-lite/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "nonstd-scope-lite",
+  "version": "0.3.0",
+  "description": "C++ standard libraries extensions (version 3) scope_exit, scope_fail, scope_success, unique_resource for C++98 and later in a single-file header-only library",
+  "homepage": "https://github.com/nonstd-lite/scope-lite",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6872,6 +6872,10 @@
       "baseline": "1.2.0",
       "port-version": 0
     },
+    "nonstd-scope-lite": {
+      "baseline": "0.3.0",
+      "port-version": 0
+    },
     "nowide": {
       "baseline": "11.3.0",
       "port-version": 0

--- a/versions/n-/nonstd-scope-lite.json
+++ b/versions/n-/nonstd-scope-lite.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ff37e7886f713b8c8680d70264c3e894ccafbb23",
+      "version": "0.3.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

c.f. `nonstd-bit-lite` and `any-lite` etc.