### PR TITLE
[colm] Add new port

### DIFF
--- a/ports/colm/fixup-build.patch
+++ b/ports/colm/fixup-build.patch
@@ -1,0 +1,64 @@
+diff --git a/Makefile.am b/Makefile.am
+index 0eb09cb4..0c71bac1 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -19,8 +19,6 @@
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ 
+-SUBDIRS = src doc test
++SUBDIRS = src doc
+ 
+-dist_doc_DATA = colm.vim
+-EXTRA_DIST = colm.vim sedsubst
+ ACLOCAL_AMFLAGS = -I m4
+diff --git a/configure.ac b/configure.ac
+index 4f4c4d1a..715c5674 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -424,6 +424,13 @@ test -e src/include/colm || ln -s .. src/include/colm
+ echo "#define VERSION \"$VERSION\"" > src/version.h
+ echo "#define PUBDATE \"$PUBDATE\"" >> src/version.h
+ 
++if test "x$enable_static" = "xyes"; then
++	AC_DEFINE([LINK_STATIC], [1], [Link static lib when invoking C compile and link])
++fi
++
++if test "x$enable_shared" = "xyes"; then
++	AC_DEFINE([LINK_SHARED], [1], [Link shared lib when invoking C compile and link])
++fi
+ 
+ dnl
+ dnl Wrap up.
+@@ -437,12 +444,6 @@ AC_OUTPUT([
+ 	src/libfsm/Makefile
+ 	src/cgil/Makefile
+ 	src/Makefile
+-	test/Makefile
+-	test/aapl.d/Makefile
+-	test/colm.d/Makefile
+-	test/rlhc.d/Makefile
+-	test/rlparse.d/Makefile
+-	test/trans.d/Makefile
+ 	doc/Makefile
+ 	doc/colm/Makefile
+ ])
+diff --git a/src/main.cc b/src/main.cc
+index 301fae91..8ca395f0 100644
+--- a/src/main.cc
++++ b/src/main.cc
+@@ -485,7 +485,14 @@ void compileOutput( const char *argv0, const bool inSource, char *srcLocation )
+ 				" -I%s/../aapl"
+ 				" -I%s/include"
+ 				" -L%s"
++#if defined(LINK_STATIC)
+ 				" %s/libcolm.a",
++#elif defined(LINK_SHARED)
++				" %s/libcolm.so",
++#else
++#				error "must enabled at least one of shared or static libs"
++#endif
++
+ 				binaryFn, intermedFn, srcLocation,
+ 				srcLocation, location, location );
+ 	}

--- a/ports/colm/portfile.cmake
+++ b/ports/colm/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO adrian-thurston/colm
+    REF "${VERSION}"
+    SHA512 9328689be147ec5310a45e5a1adf8e420c01cc5c1a10def22229721698fabb320d99f4ecd3a599b1d92abc75e579d46a73a6a1fc16f9c6c46f1f5da9c39cbdf4
+    HEAD_REF master
+    PATCHES
+        fixup-build.patch
+)
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+    COPY_SOURCE
+    OPTIONS
+        --disable-manual
+        --disable-debug
+)
+
+vcpkg_make_install()
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/colm-wrap" "COLM=${CURRENT_INSTALLED_DIR}/bin/\$CMD" "echo unable to find colm\n\t\t\texit 1")
+if(NOT VCPKG_BUILD_TYPE)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/colm-wrap" "COLM=${CURRENT_INSTALLED_DIR}/debug/bin/\$CMD" "echo unable to find colm\n\t\t\texit 1")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/colm/vcpkg.json
+++ b/ports/colm/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "colm",
+  "version": "0.14.7",
+  "description": "Colm Programming Language",
+  "homepage": "https://www.colm.net/open-source/colm/",
+  "license": "MIT",
+  "supports": "native",
+  "dependencies": [
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1892,6 +1892,10 @@
       "baseline": "2.5.0",
       "port-version": 11
     },
+    "colm": {
+      "baseline": "0.14.7",
+      "port-version": 0
+    },
     "colmap": {
       "baseline": "3.11.1",
       "port-version": 4

--- a/versions/c-/colm.json
+++ b/versions/c-/colm.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "bd95e0783f6bd851e33aa085062252eede8aeb93",
+      "version": "0.14.7",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.