### PR TITLE
[usd] Update to 25.8

### DIFF
--- a/ports/usd/003-fix-dep.patch
+++ b/ports/usd/003-fix-dep.patch
@@ -31,7 +31,7 @@ index 1b69cad..9494278 100644
              # Prioritize the VULKAN_SDK includes and packages before any system
              # installed headers. This is to prevent linking against older SDKs
              # that may be installed by the OS.
-@@ -215,8 +221,14 @@ if (PXR_BUILD_IMAGING)
+@@ -215,8 +221,12 @@ if (PXR_BUILD_IMAGING)
              endif()
  
 -            add_definitions(-DPXR_VULKAN_SUPPORT_ENABLED)
@@ -41,11 +41,9 @@ index 1b69cad..9494278 100644
 +        add_definitions(-DPXR_VULKAN_SUPPORT_ENABLED)
 +        find_package(Vulkan REQUIRED)
 +        find_package(unofficial-shaderc CONFIG REQUIRED)
-+        find_package(unofficial-spirv-reflect CONFIG REQUIRED)
 +        find_package(VulkanMemoryAllocator CONFIG REQUIRED)
 +        list(APPEND VULKAN_LIBS Vulkan::Vulkan)
 +        list(APPEND VULKAN_LIBS unofficial::shaderc::shaderc)
-+        list(APPEND VULKAN_LIBS unofficial::spirv-reflect)
 +        list(APPEND VULKAN_LIBS GPUOpen::VulkanMemoryAllocator)
      endif()
      # --Opensubdiv
@@ -53,7 +51,7 @@ diff --git a/pxr/imaging/hgiVulkan/CMakeLists.txt b/pxr/imaging/hgiVulkan/CMakeL
 index 00ad75448..dff475436 100644
 --- a/pxr/imaging/hgiVulkan/CMakeLists.txt
 +++ b/pxr/imaging/hgiVulkan/CMakeLists.txt
-@@ -40,14 +40,11 @@ pxr_library(hgiVulkan
+@@ -40,8 +40,7 @@ pxr_library(hgiVulkan
          shaderProgram
          shaderSection
          texture
@@ -62,25 +60,6 @@ index 00ad75448..dff475436 100644
      PUBLIC_HEADERS
          api.h
          vulkan.h
- 
--    PRIVATE_CLASSES
--        spirv_reflect
- 
-     RESOURCE_FILES
-         plugInfo.json
-diff --git a/pxr/imaging/hgiVulkan/shaderCompiler.cpp b/pxr/imaging/hgiVulkan/shaderCompiler.cpp
-index cb527e4d7..ee8e3be25 100644
---- a/pxr/imaging/hgiVulkan/shaderCompiler.cpp
-+++ b/pxr/imaging/hgiVulkan/shaderCompiler.cpp
-@@ -10,7 +10,7 @@
- #include "pxr/imaging/hgiVulkan/device.h"
- #include "pxr/imaging/hgiVulkan/diagnostic.h"
- #include "pxr/imaging/hgiVulkan/shaderCompiler.h"
--#include "pxr/imaging/hgiVulkan/spirv_reflect.h"
-+#include <spirv_reflect.h>
- 
- #include <shaderc/shaderc.hpp>
- 
 diff --git a/pxr/imaging/hgiVulkan/device.cpp b/pxr/imaging/hgiVulkan/device.cpp
 index 08bf8e0a7..bfc368169 100644
 --- a/pxr/imaging/hgiVulkan/device.cpp
@@ -100,8 +79,8 @@ index 1f527b9cb..b5ffd314f 100644
 --- a/pxr/imaging/hgiVulkan/vulkan.h
 +++ b/pxr/imaging/hgiVulkan/vulkan.h
 @@ -24,7 +24,7 @@
- 
- #include <vulkan/vulkan.h>
+     #define VK_EXTERNAL_MEMORY_HANDLE_AUTO 0
+ #endif
  
 -#include "pxr/imaging/hgiVulkan/vk_mem_alloc.h"
 +#include <vk_mem_alloc.h>
@@ -132,7 +111,7 @@ diff --git a/pxr/pxrConfig.cmake.in b/pxr/pxrConfig.cmake.in
 index a7e566bac..559f50b9c 100644
 --- a/pxr/pxrConfig.cmake.in
 +++ b/pxr/pxrConfig.cmake.in
-@@ -18,6 +18,26 @@ set(PXR_VERSION "@PXR_VERSION@")
+@@ -18,6 +18,25 @@ set(PXR_VERSION "@PXR_VERSION@")
  
  include(CMakeFindDependencyMacro)
  
@@ -151,7 +130,6 @@ index a7e566bac..559f50b9c 100644
 +        endif()
 +        find_dependency(Vulkan REQUIRED)
 +        find_dependency(unofficial-shaderc CONFIG)
-+        find_dependency(unofficial-spirv-reflect CONFIG)
 +        find_dependency(VulkanMemoryAllocator CONFIG)
 +    endif()
 +endif()
@@ -159,12 +137,17 @@ index a7e566bac..559f50b9c 100644
  # If Python support was enabled for this USD build, find the import
  # targets by invoking the appropriate FindPython module. Use the same
  # LIBRARY and INCLUDE_DIR settings from the original build if they
-@@ -75,17 +95,17 @@ if(@Imath_FOUND@)
+@@ -101,7 +120,7 @@ if(@Imath_FOUND@)
              set(Imath_DIR [[@Imath_DIR@]])
          endif()
      endif()
 -    find_dependency(Imath)
 +    find_dependency(Imath CONFIG)
+ endif()
+ 
+ # If this build is using a custom work implementation, find the package
+@@ -115,14 +134,14 @@ if(NOT "@PXR_WORK_IMPL_PACKAGE@" STREQUAL "")
+     find_dependency(@PXR_WORK_IMPL_PACKAGE@)
  endif()
  
 -include("${PXR_CMAKE_DIR}/cmake/pxrTargets.cmake")

--- a/ports/usd/004-fix_cmake_package.patch
+++ b/ports/usd/004-fix_cmake_package.patch
@@ -1,14 +1,20 @@
 diff --git a/pxr/CMakeLists.txt b/pxr/CMakeLists.txt
-index 4c7301b..94d2f2a 100644
+index b735c86ea..d30354114 100644
 --- a/pxr/CMakeLists.txt
 +++ b/pxr/CMakeLists.txt
-@@ -17,13 +17,31 @@ endif()
+@@ -23,7 +23,8 @@ endif()
  
  pxr_core_epilogue()
  
 -export(PACKAGE pxr)
 +include(GNUInstallDirs)
 +include(CMakePackageConfigHelpers)
+ 
+ # XXX:
+ # Libraries specify the TBB::tbb target to link against TBB. This target
+@@ -59,11 +60,28 @@ foreach(property IN ITEMS
+     endif()
+ endforeach()
  
 -configure_file(pxrConfig.cmake.in
 -  "${PROJECT_BINARY_DIR}/pxrConfig.cmake" @ONLY)

--- a/ports/usd/portfile.cmake
+++ b/ports/usd/portfile.cmake
@@ -20,7 +20,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PixarAnimationStudios/OpenUSD
     REF "v${USD_VERSION}"
-    SHA512 66bf75486f09dce7085c5c80cc3e005c02c1dfbbfbd02c8e2e8fd9498030ca49cd6bc0a9b9db930d0559c745cf77ebaf822018de4bf798cce84fdf0aa89f0d84
+    SHA512 fbe1e632473883e47f4bfeb16cab314bbbe8a7b404a5c071ca613bbf288526e505edd7a5edfdd9f85dd16da6d0d91fa0d4f8c783882094d3691f77685817fea6
     HEAD_REF release
     PATCHES
         003-fix-dep.patch
@@ -35,8 +35,6 @@ vcpkg_from_github(
 # Changes accompanying 003-fix-dep.patch
 file(REMOVE
     "${SOURCE_PATH}/cmake/modules/FindOpenColorIO.cmake"
-    "${SOURCE_PATH}/pxr/imaging/hgiVulkan/spirv_reflect.cpp"
-    "${SOURCE_PATH}/pxr/imaging/hgiVulkan/spirv_reflect.h"
     "${SOURCE_PATH}/pxr/imaging/hgiVulkan/vk_mem_alloc.cpp"
     "${SOURCE_PATH}/pxr/imaging/hgiVulkan/vk_mem_alloc.h"
 )

--- a/ports/usd/vcpkg.json
+++ b/ports/usd/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "usd",
-  "version": "25.5.1",
-  "port-version": 1,
+  "version": "25.8",
   "description": "Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.",
   "homepage": "https://github.com/PixarAnimationStudios/OpenUSD",
   "license": null,
@@ -66,7 +65,6 @@
           ]
         },
         "shaderc",
-        "spirv-reflect",
         "vulkan",
         "vulkan-memory-allocator",
         "vulkan-utility-libraries"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10005,8 +10005,8 @@
       "port-version": 1
     },
     "usd": {
-      "baseline": "25.5.1",
-      "port-version": 1
+      "baseline": "25.8",
+      "port-version": 0
     },
     "usearch": {
       "baseline": "2.21.0",

--- a/versions/u-/usd.json
+++ b/versions/u-/usd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "caaa7a00ad01c9ce295bb20df86c70cb7d937c8e",
+      "version": "25.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "4404d2de56ca95ad4bb8141ac12c8a594af8fa70",
       "version": "25.5.1",
       "port-version": 1


### PR DESCRIPTION
Biggest change is removal of the SPIRV-Reflect dependency. Otherwise it's just updating the patch lines and contexts.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
