### PR TITLE
[sentry-native] update to 0.11.3

### DIFF
--- a/ports/sentry-native/fix-crashpad-wer.patch
+++ b/ports/sentry-native/fix-crashpad-wer.patch
@@ -57,7 +57,7 @@ diff --git a/src/backends/sentry_backend_crashpad.cpp b/src/backends/sentry_back
 index 9ddca42..4fa1e4e 100644
 --- a/src/backends/sentry_backend_crashpad.cpp
 +++ b/src/backends/sentry_backend_crashpad.cpp
-@@ -138,7 +138,7 @@ crashpad_backend_user_consent_changed(sentry_backend_t *backend)
+@@ -142,7 +142,7 @@ crashpad_backend_user_consent_changed(sentry_backend_t *backend)
      data->db->GetSettings()->SetUploadsEnabled(!sentry__should_skip_upload());
  }
 
@@ -66,8 +66,8 @@ index 9ddca42..4fa1e4e 100644
  static void
  crashpad_register_wer_module(
      const sentry_path_t *absolute_handler_path, const crashpad_state_t *data)
-@@ -483,7 +483,7 @@ crashpad_backend_startup(
-         options->crashpad_wait_for_upload);
+@@ -545,7 +545,7 @@ crashpad_backend_startup(
+         options->crashpad_wait_for_upload, crash_reporter, crash_envelope);
      sentry_free(minidump_url);
 
 -#ifdef SENTRY_PLATFORM_WINDOWS

--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 ce2fabed4502b90e14dc5c83dc592fcdd09e8c06d97342ae92ae886d99a5896df07a231bc53c4344d705e071dfab731b357c1c660ecd3966076a04f4301d1bf0
+    SHA512 da716e1c4976079793b4796b1a3d05c8691674b35044e066847d94298eab12df6d9ead1bdcca545098a0d1af24c087d5083f6a1b2fa5b2e2e6f5e662b39383b2
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8865,7 +8865,7 @@
       "port-version": 0
     },
     "sentry-native": {
-      "baseline": "0.11.2",
+      "baseline": "0.11.3",
       "port-version": 0
     },
     "septag-dmon": {

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cdd0d9dcb3770c08a965f180089a39693bfb3cb2",
+      "version": "0.11.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "fee2f44479858c390919dd55652704feb95e1b54",
       "version": "0.11.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
