### PR TITLE
[libx11] fix permissions issue

### DIFF
--- a/ports/libx11/portfile.cmake
+++ b/ports/libx11/portfile.cmake
@@ -97,7 +97,7 @@ if(NOT VCPKG_CROSSCOMPILING)
     file(READ "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/config.log" config_contents)
     string(REGEX MATCH "ac_cv_objext=[^\n]+" objsuffix "${config_contents}")
     string(REPLACE "ac_cv_objext=" "." objsuffix "${objsuffix}")
-    file(INSTALL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/util/makekeys${VCPKG_TARGET_EXECUTABLE_SUFFIX}" DESTINATION "${CURRENT_PACKAGES_DIR}/manual-tools/${PORT}" PERMISSIONS OWNER_EXECUTE)
+    file(INSTALL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/util/makekeys${VCPKG_TARGET_EXECUTABLE_SUFFIX}" DESTINATION "${CURRENT_PACKAGES_DIR}/manual-tools/${PORT}" PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)
     file(INSTALL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/util/makekeys${objsuffix}" DESTINATION "${CURRENT_PACKAGES_DIR}/manual-tools/${PORT}")
 endif()
 

--- a/ports/libx11/vcpkg.json
+++ b/ports/libx11/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libx11",
   "version": "1.8.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The X Window System is a network-transparent window system that was designed at MIT.",
   "homepage": "https://www.x.org/wiki/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5710,7 +5710,7 @@
     },
     "libx11": {
       "baseline": "1.8.1",
-      "port-version": 3
+      "port-version": 4
     },
     "libxau": {
       "baseline": "1.0.9",

--- a/versions/l-/libx11.json
+++ b/versions/l-/libx11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a553d800600561fda8ef66498845899369edb84",
+      "version": "1.8.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "08535ebfb1b088293359a9ce56e4829a1d6f8479",
       "version": "1.8.1",
       "port-version": 3


### PR DESCRIPTION
Looks like you need to specify all the permissions when doing file(INSTALL...) Otherwise you receive this error when building libx11 for arm64 when taking libx11 for x64 from the archive:

```
CMake Error at ports/libx11/portfile.cmake:78 (file):
  file COPY cannot find
  /home/runner/work/boinc/boinc/3rdParty/linux/vcpkg/installed/x64-linux/manual-tools/libx11/makekeys:
  Permission denied.
```

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

CC: @BillyONeal 

Ref: https://github.com/BOINC/boinc/actions/runs/18505909319/job/52737841381