### PR TITLE
[libressl] update libressl to version 4.2.0

### DIFF
--- a/ports/libressl/aarch64-windows.diff
+++ b/ports/libressl/aarch64-windows.diff
@@ -1,0 +1,42 @@
+diff --git a/crypto/arch/aarch64/crypto_cpu_caps_windows.c b/crypto/arch/aarch64/crypto_cpu_caps_windows.c
+new file mode 100644
+index 0000000..e7cdded
+--- /dev/null
++++ b/crypto/arch/aarch64/crypto_cpu_caps_windows.c
+@@ -0,0 +1,36 @@
++/* $OpenBSD: crypto_cpu_caps.c,v 1.2 2024/11/12 13:52:31 jsing Exp $ */
++/*
++ * Copyright (c) 2025 Brent Cook <bcook@openbsd.org>
++ *
++ * Permission to use, copy, modify, and distribute this software for any
++ * purpose with or without fee is hereby granted, provided that the above
++ * copyright notice and this permission notice appear in all copies.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
++ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ */
++
++#include <windows.h>
++
++#include "crypto_arch.h"
++
++/* Machine dependent CPU capabilities. */
++uint64_t crypto_cpu_caps_aarch64;
++
++void
++crypto_cpu_caps_init(void)
++{
++	crypto_cpu_caps_aarch64 = 0;
++
++	if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE)) {
++		crypto_cpu_caps_aarch64 |= CRYPTO_CPU_CAPS_AARCH64_AES;
++		crypto_cpu_caps_aarch64 |= CRYPTO_CPU_CAPS_AARCH64_PMULL;
++		crypto_cpu_caps_aarch64 |= CRYPTO_CPU_CAPS_AARCH64_SHA1;
++		crypto_cpu_caps_aarch64 |= CRYPTO_CPU_CAPS_AARCH64_SHA2;
++	}
++}

--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_extract_source_archive(
     ARCHIVE "${LIBRESSL_SOURCE_ARCHIVE}"
     PATCHES
         pkgconfig.diff
+        aarch64-windows.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_download_distfile(
     URLS "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${PORT}-${VERSION}.tar.gz"
          "https://github.com/libressl/portable/releases/download/v${VERSION}/${PORT}-${VERSION}.tar.gz"
     FILENAME "${PORT}-${VERSION}.tar.gz"
-    SHA512 01c74c6cafc4274f2c1c2c88b897f2f21eafa4ccdd952dae72065366032ec5efdefbb4f809bca66da5b2f2cef426cf378181ae13c2daf7f3dcc67fab7daf9d51
+    SHA512 b06eccff7b332da38efbc5a039d8ee54bd26437f3d5957f59ac2d93b4464f181c9a665a2c957272be5d9f91f447720f6dfa29b4b72407279ac8a7722c322dac0
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libressl/vcpkg.json
+++ b/ports/libressl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libressl",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": [
     "LibreSSL is a TLS/crypto stack.",
     "It was forked from OpenSSL in 2014 by the OpenBSD project, with goals of modernizing the codebase, improving security, and applying best practice development processes.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5381,7 +5381,7 @@
       "port-version": 2
     },
     "libressl": {
-      "baseline": "4.1.1",
+      "baseline": "4.2.0",
       "port-version": 0
     },
     "librsvg": {

--- a/versions/l-/libressl.json
+++ b/versions/l-/libressl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9540470d2145e2ccdfbc9e7fb3cb52a6796e013d",
+      "git-tree": "29d9b59ae2e3ab8f916d806eccf19f26253312ce",
       "version": "4.2.0",
       "port-version": 0
     },

--- a/versions/l-/libressl.json
+++ b/versions/l-/libressl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9540470d2145e2ccdfbc9e7fb3cb52a6796e013d",
+      "version": "4.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "bc7b120ae250132a5180932927dbee09de661675",
       "version": "4.1.1",
       "port-version": 0


### PR DESCRIPTION
fixes #47804 
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
