### PR TITLE
[xmlsec] Update to 1.3.8

### DIFF
--- a/ports/xmlsec/CMakeLists.txt
+++ b/ports/xmlsec/CMakeLists.txt
@@ -1,18 +1,21 @@
 cmake_minimum_required (VERSION 3.8)
-project (xmlsec1 C CXX)
+project (xmlsec1 C CXX) # CXX needed when libxml2 is built with icu
 
+include(CMakeDependentOption)
+
+cmake_dependent_option(BUILD_WITH_DYNAMIC_LOADING "Enable dynamic loading of xmlsec-crypto libraries" OFF BUILD_SHARED_LIBS OFF)
 option(INSTALL_HEADERS_TOOLS "Install public header files and tools" ON)
 
 find_package(LibXml2 REQUIRED)
 find_package(OpenSSL REQUIRED)
 
 FILE(GLOB SOURCESXMLSEC
-	src/*.c
+    src/*.c
 )
 
 FILE(GLOB SOURCESXMLSECOPENSSL
-	src/openssl/*.c
-	src/strings.c
+    src/openssl/*.c
+    src/strings.c
 )
 
 # Generate xmlexports with fixed definition of XMLSEC_STATIC
@@ -36,8 +39,7 @@ foreach(ver ${_xmlsec_version_defines})
 endforeach()
 
 set(XMLSEC_VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR}.${XMLSEC_VERSION_SUBMINOR})
-math(EXPR XMLSEC_VERSION_INFO_NUMBER
-	"${XMLSEC_VERSION_MAJOR} + ${XMLSEC_VERSION_MINOR}")
+math(EXPR XMLSEC_VERSION_INFO_NUMBER "${XMLSEC_VERSION_MAJOR} + ${XMLSEC_VERSION_MINOR}")
 set(XMLSEC_VERSION_INFO ${XMLSEC_VERSION_INFO_NUMBER}:${XMLSEC_VERSION_SUBMINOR}:${XMLSEC_VERSION_MINOR})
 
 message(STATUS "XMLSEC_VERSION: ${XMLSEC_VERSION}")
@@ -51,7 +53,7 @@ message(STATUS "Generating version.h")
 configure_file(include/xmlsec/version.h.in include/xmlsec/version.h)
 
 if(MSVC)
-  add_compile_options(/wd4130 /wd4127 /wd4152)
+    add_compile_options(/wd4130 /wd4127 /wd4152)
 endif()
 
 set(CMAKE_SHARED_LIBRARY_PREFIX "lib")
@@ -89,13 +91,30 @@ set_target_properties(xmlsec1 xmlsec1-openssl PROPERTIES VERSION ${XMLSEC_VERSIO
 
 set(XMLSEC_CORE_CFLAGS XMLSEC_NO_XSLT XMLSEC_CRYPTO_OPENSSL XMLSEC_NO_FTP XMLSEC_NO_HTTP)
 if(NOT BUILD_SHARED_LIBS)
-    list(APPEND XMLSEC_CORE_CFLAGS XMLSEC_STATIC XMLSEC_NO_CRYPTO_DYNAMIC_LOADING)
+    list(APPEND XMLSEC_CORE_CFLAGS XMLSEC_STATIC)
 endif()
 set(XMLSEC_OPENSSL_CFLAGS XMLSEC_NO_MD5 XMLSEC_NO_RIPEMD160 XMLSEC_NO_GOST XMLSEC_NO_GOST2012)
 
+if(BUILD_WITH_DYNAMIC_LOADING)
+    if(NOT WIN32)
+        find_path(LTDL_INCLUDE_DIR NAMES ltdl.h)
+        find_library(LTDL_LIBRARY NAMES ltdl)
+
+        if(NOT LTDL_INCLUDE_DIR OR NOT LTDL_LIBRARY)
+            message(FATAL_ERROR "libltdl not found (headers or library missing)")
+        endif()
+
+        target_include_directories(xmlsec1 PRIVATE ${LTDL_INCLUDE_DIR})
+        target_link_libraries(xmlsec1 PRIVATE ${LTDL_LIBRARY})
+    endif()
+    list(APPEND XMLSEC_CORE_CFLAGS XMLSEC_CRYPTO_DYNAMIC_LOADING)
+else()
+    list(APPEND XMLSEC_CORE_CFLAGS XMLSEC_NO_CRYPTO_DYNAMIC_LOADING)
+endif()
+
 target_compile_definitions(xmlsec1
-    PRIVATE $<$<PLATFORM_ID:Windows>:XMLSEC_DL_WIN32>
-    PUBLIC ${XMLSEC_CORE_CFLAGS} 
+    PRIVATE $<IF:$<PLATFORM_ID:Windows>,XMLSEC_DL_WIN32,XMLSEC_DL_LIBLTDL>
+    PUBLIC ${XMLSEC_CORE_CFLAGS}
 )
 target_compile_definitions(xmlsec1-openssl PUBLIC ${XMLSEC_OPENSSL_CFLAGS})
 
@@ -138,13 +157,12 @@ if(INSTALL_HEADERS_TOOLS)
 
 	target_link_libraries(xmlsec PRIVATE xmlsec1-openssl)
 
-	if(BUILD_SHARED_LIBS)
-		target_compile_definitions(xmlsec PRIVATE -DXMLSEC_CRYPTO_DYNAMIC_LOADING)
-	else()
-		find_package(Threads REQUIRED)
-		target_link_libraries(xmlsec PUBLIC Threads::Threads)
-	endif()
-	install(TARGETS xmlsec DESTINATION tools/xmlsec)
+    if(NOT BUILD_SHARED_LIBS)
+        # needed when libxml2 is built with icu
+        find_package(Threads REQUIRED)
+        target_link_libraries(xmlsec PRIVATE Threads::Threads)
+    endif()
+    install(TARGETS xmlsec DESTINATION tools/xmlsec)
 endif()
 
 message(STATUS "Generating pkgconfig files")
@@ -157,7 +175,7 @@ set(VERSION ${XMLSEC_VERSION})
 set(LIBXML_MIN_VERSION ${LIBXML2_VERSION_STRING})
 list(JOIN XMLSEC_CORE_CFLAGS " -D" XMLSEC_CORE_CFLAGS)
 set(XMLSEC_CORE_CFLAGS "-D${XMLSEC_CORE_CFLAGS} -I\${includedir}/xmlsec1")
-set(XMLSEC_CORE_LIBS "-lxmlsec1 -lltdl")
+set(XMLSEC_CORE_LIBS "-lxmlsec1")
 list(JOIN XMLSEC_OPENSSL_CFLAGS " -D" XMLSEC_OPENSSL_CFLAGS)
 set(XMLSEC_OPENSSL_CFLAGS "${XMLSEC_CORE_CFLAGS} -D${XMLSEC_OPENSSL_CFLAGS}")
 set(XMLSEC_OPENSSL_LIBS "-L\${libdir} -lxmlsec1-openssl ${XMLSEC_CORE_LIBS} -lcrypto")

--- a/ports/xmlsec/portfile.cmake
+++ b/ports/xmlsec/portfile.cmake
@@ -3,15 +3,19 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lsh123/xmlsec
     REF "${release_tag}"
-    SHA512 28130c10d79f652e3533e6ede5fdaab0f6db5a4bbaaca4713b62df9af2ae2d5314acf82d01f344f87faf95c12099fd77e0858cbe5232a96de1d531e6284ede1b
+    SHA512 40a6d73c308408f5bea71b779ad070b74609f7bff2cd28f6c4191e8a67981d81041b9c7acbdba36192ce7bcaac21e55c5ad58096d20d613c1a010d45491c7ba4
     HEAD_REF master
     PATCHES 
         pkgconfig_fixes.patch
 )
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES "with-dl" BUILD_WITH_DYNAMIC_LOADING
+)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
     OPTIONS_DEBUG -DINSTALL_HEADERS_TOOLS=OFF
 )
 

--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "xmlsec",
-  "version": "1.3.7",
-  "port-version": 1,
+  "version": "1.3.8",
   "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
   "homepage": "https://www.aleksey.com/xmlsec/",
   "license": "X11 AND MPL-1.1",
@@ -20,5 +19,17 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "with-dl": {
+      "description": "Build with dynamic loading of xmlsec-crypto libraries",
+      "supports": "!static",
+      "dependencies": [
+        {
+          "name": "libltdl",
+          "platform": "!windows"
+        }
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10601,8 +10601,8 @@
       "port-version": 0
     },
     "xmlsec": {
-      "baseline": "1.3.7",
-      "port-version": 1
+      "baseline": "1.3.8",
+      "port-version": 0
     },
     "xnnpack": {
       "baseline": "2024-08-20",

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ad3b4bdc5d9e45fca37d3da96010686fd2dce88",
+      "version": "1.3.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "578ff1829c8219632473d3b587e419a3d4d5e21c",
       "version": "1.3.7",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
