### PR TITLE
[bgfx] Update to 1.129.8940-496 and update supports clause

### DIFF
--- a/ports/bgfx/portfile.cmake
+++ b/ports/bgfx/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_download_distfile(
   ARCHIVE_FILE
   URLS https://github.com/bkaradzic/bgfx.cmake/releases/download/v${VERSION}/bgfx.cmake.v${VERSION}.tar.gz
   FILENAME bgfx.cmake.v${VERSION}.tar.gz
-  SHA512 f9131426eeb8eee71441a6cce7fb810843879b02531640cf749c5855b9278bf2608dbe089b093317e4e9b350260d9c2b9ffe3ccf950f721096f8269f17d68f50
+  SHA512 520c542b65e76e92eae818e32eeb62bb2347ac89a1e10fc07cd5059a3b8a9a543cadca87d451a3bc157c415f6183b1f0e5031248e38fae704b8efd54679d482b
 )
 
 vcpkg_extract_source_archive(
@@ -46,7 +46,6 @@ vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS
     -DBGFX_LIBRARY_TYPE=${BGFX_LIBRARY_TYPE}
-    -DBX_AMALGAMATED=ON
     -DBGFX_AMALGAMATED=ON
     -DBGFX_BUILD_EXAMPLES=OFF
     -DBGFX_OPENGLES_VERSION=30

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,12 +1,12 @@
 {
   "name": "bgfx",
-  "version": "1.129.8930-495",
-  "port-version": 1,
+  "version": "1.129.8940-496",
   "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
   "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
   "homepage": "https://bkaradzic.github.io/bgfx/overview.html",
   "documentation": "https://bkaradzic.github.io/bgfx",
   "license": "BSD-2-Clause AND CC0-1.0",
+  "supports": "!bsd",
   "dependencies": [
     "libsquish",
     "lodepng",

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0649ad4eb640389c105dbac3a302e9c27e0a04b0",
+      "version": "1.129.8940-496",
+      "port-version": 0
+    },
+    {
       "git-tree": "ad65f26a5c23cf2cc089bfd303882b9f8ab17d57",
       "version": "1.129.8930-495",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -697,8 +697,8 @@
       "port-version": 0
     },
     "bgfx": {
-      "baseline": "1.129.8930-495",
-      "port-version": 1
+      "baseline": "1.129.8940-496",
+      "port-version": 0
     },
     "bigint": {
       "baseline": "2010.04.30",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.