### PR TITLE
[coin-or-*] Disable finding mkl, always use lapack.pc

### DIFF
--- a/ports/coin-or-buildtools/disable-mkl.diff
+++ b/ports/coin-or-buildtools/disable-mkl.diff
@@ -1,0 +1,60 @@
+diff --git a/coin_chk_lapack.m4 b/coin_chk_lapack.m4
+index 3314f97..0156a0e 100644
+--- a/coin_chk_lapack.m4
++++ b/coin_chk_lapack.m4
+@@ -113,55 +113,7 @@ dnl can arrange that explicitly.
+         esac
+       ;;
+ 
+-      *-cygwin* | *-mingw* | *-msys*)
+-dnl Check for 64-bit sequential MKL in $LIB
+-        old_IFS="$IFS"
+-        IFS=";"
+-        coin_mkl=""
+-        for d in $LIB ; do
+-          # turn $d into unix-style short path (no spaces); cannot do -us,
+-          # so first do -ws, then -u
+-          d=`cygpath -ws "$d"`
+-          d=`cygpath -u "$d"`
+-          if test "$enable_shared" = yes ; then
+-            if test -e "$d/mkl_core_dll.lib" ; then
+-              case " $2 " in
+-                *\ int64\ * ) coin_mkl="$d/mkl_intel_ilp64_dll.lib $d/mkl_sequential_dll.lib $d/mkl_core_dll.lib" ;;
+-                *)          coin_mkl="$d/mkl_intel_lp64_dll.lib $d/mkl_sequential_dll.lib $d/mkl_core_dll.lib" ;;
+-              esac
+-              break
+-            fi
+-          else
+-            if test -e "$d/mkl_core.lib" ; then
+-              case " $2 " in
+-                *\ int64\ * ) coin_mkl="$d/mkl_intel_ilp64.lib $d/mkl_sequential.lib $d/mkl_core.lib" ;;
+-                *)          coin_mkl="$d/mkl_intel_lp64.lib $d/mkl_sequential.lib $d/mkl_core.lib" ;;
+-              esac
+-              break
+-            fi
+-          fi
+-        done
+-        IFS="$old_IFS"
+-        if test -n "$coin_mkl" ; then
+-           AC_COIN_TRY_LINK([dsyev],[$coin_mkl],[],
+-               [coin_has_lapack=yes
+-                lapack_lflags="$coin_mkl"
+-                lapack_what="Intel MKL ($lapack_lflags)"
+-               ],,no)
+-        fi
+-      ;;
+-
+       *-darwin*)
+-        case " $2 " in
+-          *\ int64\ * ) coin_mkl="-lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lm" ;;
+-          *)          coin_mkl="-lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lm" ;;
+-        esac
+-        AC_COIN_TRY_LINK([dsyev],
+-          [$coin_mkl],[],
+-          [coin_has_lapack=yes
+-           lapack_lflags="$coin_mkl"
+-           lapack_what="Intel MKL ($lapack_lflags)"
+-          ],,no)
+         if test "$coin_has_lapack" = no ; then
+           case " $2 " in
+             *\ int64\ * ) ;;

--- a/ports/coin-or-buildtools/portfile.cmake
+++ b/ports/coin-or-buildtools/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     SHA512 c142163a270848d1e1300a70713ee03ec822cc9d7583ba7aa685c02b7c25e0d4c0f7d958aad320dbf1824cc88fe0a49dc3357e0fe11588dc8c30e7fec8d239f6
     PATCHES buildtools.patch
             buildtools2.patch
+            disable-mkl.diff
 )
 
 file(COPY "${BUILD_SCRIPTS_PATH}/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/BuildTools")

--- a/ports/coin-or-buildtools/vcpkg.json
+++ b/ports/coin-or-buildtools/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "coin-or-buildtools",
   "version-date": "2023-02-02",
+  "port-version": 1,
   "description": "Macros and patches for GNU autotools ",
   "homepage": "https://coin-or-tools.github.io/BuildTools/",
   "license": "EPL-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1862,7 +1862,7 @@
     },
     "coin-or-buildtools": {
       "baseline": "2023-02-02",
-      "port-version": 0
+      "port-version": 1
     },
     "coin-or-cbc": {
       "baseline": "2024-06-04",

--- a/versions/c-/coin-or-buildtools.json
+++ b/versions/c-/coin-or-buildtools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9c512b1216f88b2c98a9944c43131fad4de9fdd5",
+      "version-date": "2023-02-02",
+      "port-version": 1
+    },
+    {
       "git-tree": "b0d17057d8452f7e7fa4a3bfe6a2fab3520be6e9",
       "version-date": "2023-02-02",
       "port-version": 0


### PR DESCRIPTION
This removes explicit detection in coin-or-buildtools that started picking up intel-mkl.lib after https://github.com/microsoft/vcpkg/pull/47633

Related https://github.com/microsoft/vcpkg/pull/47764
