### PR TITLE
[mcap] update to 2.1.1

### DIFF
--- a/ports/mcap/portfile.cmake
+++ b/ports/mcap/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO foxglove/mcap
     REF "releases/cpp/v${VERSION}"
-    SHA512 99bfc99cd02fd946ac437a6bd2c71faec2083ccc1d81131e2978c72285d57b53f8c92a5d2b7cabef0c79056882aebfb1e2951479c47f5c7b99c44227c4b826e5
+    SHA512 846c21bbe4156f6b658825f5d6d9e39ad2d4206869701fe9469fed60ef9904c3ef6bf8f73bcb86ae46120189fcddda7f111674f04bca91a58bb7c6d574f4dc64
     HEAD_REF main
 )
 

--- a/ports/mcap/vcpkg.json
+++ b/ports/mcap/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mcap",
-  "version": "2.0.2",
+  "version": "2.1.1",
   "description": "MCAP is a modular, performant, and serialization-agnostic container file format, useful for pub/sub and robotics applications.",
   "homepage": "https://mcap.dev/",
   "documentation": "https://mcap.dev/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6221,7 +6221,7 @@
       "port-version": 0
     },
     "mcap": {
-      "baseline": "2.0.2",
+      "baseline": "2.1.1",
       "port-version": 0
     },
     "mchehab-zbar": {

--- a/versions/m-/mcap.json
+++ b/versions/m-/mcap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3d542a6bee80c8b72c3bfdee2ffa1b88395c8db",
+      "version": "2.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f84148fd573f435eae85e8b62f66a902a545b654",
       "version": "2.0.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/foxglove/mcap/releases/tag/releases%2Fcpp%2Fv2.1.1
