### PR TITLE
[freerdp] Update to 3.17.2 and restrict the supports clause

### DIFF
--- a/ports/freerdp/vcpkg.json
+++ b/ports/freerdp/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "freerdp",
-  "version": "3.14.1",
+  "version": "3.17.2",
   "description": "A free implementation of the Remote Desktop Protocol (RDP)",
   "homepage": "https://github.com/FreeRDP/FreeRDP",
   "license": "Apache-2.0",
-  "supports": "!uwp",
+  "supports": "!uwp & (!bsd | freebsd)",
   "dependencies": [
     "cjson",
+    {
+      "name": "epoll-shim",
+      "platform": "bsd"
+    },
     "openssl",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3077,7 +3077,7 @@
       "port-version": 9
     },
     "freerdp": {
-      "baseline": "3.14.1",
+      "baseline": "3.17.2",
       "port-version": 0
     },
     "freetds": {

--- a/versions/f-/freerdp.json
+++ b/versions/f-/freerdp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a9d72b56a771354cf51d90840f64221861bea3a",
+      "version": "3.17.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "71cbb3510932d61e7c27d1a4937a1b6b473c7c88",
       "version": "3.14.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
