### PR TITLE
Enable AzCopy for all triplets and fix logs location

### DIFF
--- a/scripts/azure-pipelines/android/azure-pipelines.yml
+++ b/scripts/azure-pipelines/android/azure-pipelines.yml
@@ -99,7 +99,7 @@ jobs:
          -File scripts/azure-pipelines/test-modified-ports.ps1 \
          -Triplet ${{ replace(parameters.jobName, '_', '-') }} \
          -BuildReason $(Build.Reason) \
-         -BinarySourceStub "x-azblob,https://vcpkgbinarycachewus.blob.core.windows.net/cache,$binarySas" \
+         -BinarySourceStub "x-azcopy-sas,https://vcpkgbinarycachewus.blob.core.windows.net/cache,$binarySas" \
          -WorkingRoot ${{ variables.WORKING_ROOT }}
   - task: PublishPipelineArtifact@1
     displayName: "Publish Artifact: failure logs for ${{ replace(parameters.jobName, '_', '-') }}"
@@ -110,7 +110,7 @@ jobs:
   - task: PublishPipelineArtifact@1
     displayName: "Publish Artifact: azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)/azcopy-logs'
+      targetPath: '$(WORKING_ROOT)/azcopy-logs'
       artifactName: "azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     condition: ne(variables['AZCOPY_LOGS_EMPTY'], 'True')
   - task: UseNode@1

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
          -File scripts/azure-pipelines/test-modified-ports.ps1 \
          -Triplet ${{ replace(parameters.jobName, '_', '-') }} \
          -BuildReason $(Build.Reason) \
-         -BinarySourceStub "x-azblob,https://vcpkgbinarycachewus.blob.core.windows.net/cache,$binarySas" \
+         -BinarySourceStub "x-azcopy-sas,https://vcpkgbinarycachewus.blob.core.windows.net/cache,$binarySas" \
          -WorkingRoot ${{ variables.WORKING_ROOT }}
   - task: PublishPipelineArtifact@1
     displayName: "Publish Artifact: failure logs for ${{ replace(parameters.jobName, '_', '-') }}"
@@ -107,7 +107,7 @@ jobs:
   - task: PublishPipelineArtifact@1
     displayName: "Publish Artifact: azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)/azcopy-logs'
+      targetPath: '$(WORKING_ROOT)/azcopy-logs'
       artifactName: "azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     condition: ne(variables['AZCOPY_LOGS_EMPTY'], 'True')
   - task: UseNode@1

--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
           # Persist the binary SAS as a secret pipeline variable for the owners-db step
           Write-Host "##vso[task.setvariable variable=BCACHE_SAS_TOKEN;issecret=true]$binarySas"
           $env:X_VCPKG_ASSET_SOURCES = "x-azurl,https://vcpkgassetcachewus.blob.core.windows.net/cache,$assetSas,readwrite"
-          & scripts/azure-pipelines/test-modified-ports.ps1 -Triplet ${{ replace(parameters.jobName, '_', '-') }} -BuildReason $(Build.Reason) -BinarySourceStub "x-azblob,https://vcpkgbinarycachewus.blob.core.windows.net/cache,$binarySas" -WorkingRoot $env:WORKING_ROOT -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)
+          & scripts/azure-pipelines/test-modified-ports.ps1 -Triplet ${{ replace(parameters.jobName, '_', '-') }} -BuildReason $(Build.Reason) -BinarySourceStub "x-azcopy-sas,https://vcpkgbinarycachewus.blob.core.windows.net/cache,$binarySas" -WorkingRoot $env:WORKING_ROOT -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)
   - task: PublishPipelineArtifact@1
     displayName: "Publish Artifact: failure logs for ${{ replace(parameters.jobName, '_', '-') }}"
     inputs:
@@ -70,7 +70,7 @@ jobs:
   - task: PublishPipelineArtifact@1
     displayName: "Publish Artifact: azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)/azcopy-logs'
+      targetPath: '$(WORKING_ROOT)/azcopy-logs'
       artifactName: "azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     condition: ne(variables['AZCOPY_LOGS_EMPTY'], 'True')
   - task: UseNode@1

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -85,12 +85,18 @@ $buildtreesRoot = Join-Path $WorkingRoot 'b'
 $installRoot = Join-Path $WorkingRoot 'installed'
 $packagesRoot = Join-Path $WorkingRoot 'p'
 
-$env:AZCOPY_LOG_LOCATION = Join-Path $ArtifactStagingDirectory 'azcopy-logs'
+$env:AZCOPY_LOG_LOCATION = Join-Path $WorkingRoot 'azcopy-logs'
 $env:AZCOPY_JOB_PLAN_LOCATION = Join-Path $WorkingRoot 'azcopy-plans'
 if ($Triplet -eq 'x64-osx') {
     $env:AZCOPY_BUFFER_GB = 2
     $env:AZCOPY_CONCURRENCY_VALUE = 8
 }
+if (!(Test-Path $env:AZCOPY_LOG_LOCATION))
+{
+    New-Item -ItemType Directory -Path $env:AZCOPY_LOG_LOCATION | Out-Null
+}
+Write-Host "AzCopy logs location: $env:AZCOPY_LOG_LOCATION"
+Write-Host "##vso[task.setvariable variable=AZCOPY_LOGS_EMPTY]$true"
 
 $commonArgs = @(
     "--x-buildtrees-root=$buildtreesRoot",
@@ -152,9 +158,9 @@ if ($testFeatures) {
     $knownFailingAbisFile = Join-Path $ArtifactStagingDirectory 'failing-abi-log.txt'
     $failingAbiLogArg = "--failing-abi-log=$knownFailingAbisFile"
     & $vcpkgExe x-test-features --for-merge-with origin/master $tripletArg $failureLogsArg $ciBaselineArg $failingAbiLogArg $ciFeatureBaselineArg @commonArgs @cachingArgs
-    $azcopyLogsEmpty = (-Not (Test-Path $env:AZCOPY_LOG_LOCATION) -Or ((Get-ChildItem $env:AZCOPY_LOG_LOCATION).Count -eq 0))
-    Write-Host "##vso[task.setvariable variable=AZCOPY_LOGS_EMPTY]$azcopyLogsEmpty"
     $lastLastExitCode = $LASTEXITCODE
+    $azcopyLogsEmpty = ((Get-ChildItem $env:AZCOPY_LOG_LOCATION).Count -eq 0)
+    Write-Host "##vso[task.setvariable variable=AZCOPY_LOGS_EMPTY]$azcopyLogsEmpty"
     if ($lastLastExitCode -ne 0)
     {
         Write-Host "##vso[task.setvariable variable=FAILURE_LOGS_EMPTY]$false"
@@ -254,7 +260,7 @@ $prHashesFile = Join-Path $ArtifactStagingDirectory "pr-hashes.json"
 $lastLastExitCode = $LASTEXITCODE
 $failureLogsEmpty = (-Not (Test-Path $failureLogs) -Or ((Get-ChildItem $failureLogs).Count -eq 0))
 Write-Host "##vso[task.setvariable variable=FAILURE_LOGS_EMPTY]$failureLogsEmpty"
-$azcopyLogsEmpty = (-Not (Test-Path $env:AZCOPY_LOG_LOCATION) -Or ((Get-ChildItem $env:AZCOPY_LOG_LOCATION).Count -eq 0))
+$azcopyLogsEmpty = ((Get-ChildItem $env:AZCOPY_LOG_LOCATION).Count -eq 0)
 Write-Host "##vso[task.setvariable variable=AZCOPY_LOGS_EMPTY]$azcopyLogsEmpty"
 Write-Host "##vso[task.setvariable variable=XML_RESULTS_FILE]$xunitFile"
 

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
           # Persist the binary SAS as a secret pipeline variable for the owners-db step
           Write-Host "##vso[task.setvariable variable=BCACHE_SAS_TOKEN;issecret=true]$binarySas"
           $env:X_VCPKG_ASSET_SOURCES = "x-azurl,https://vcpkgassetcachewus.blob.core.windows.net/cache,$assetSas,readwrite"
-          & scripts/azure-pipelines/test-modified-ports.ps1 -Triplet ${{ replace(parameters.jobName, '_', '-') }} -BuildReason $(Build.Reason) -BinarySourceStub "x-azblob,https://vcpkgbinarycachewus.blob.core.windows.net/cache,$binarySas" -WorkingRoot $env:WORKING_ROOT -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)
+          & scripts/azure-pipelines/test-modified-ports.ps1 -Triplet ${{ replace(parameters.jobName, '_', '-') }} -BuildReason $(Build.Reason) -BinarySourceStub "x-azcopy-sas,https://vcpkgbinarycachewus.blob.core.windows.net/cache,$binarySas" -WorkingRoot $env:WORKING_ROOT -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)
   - task: PowerShell@2
     displayName: 'Validate version files'
     condition: eq('${{ replace(parameters.jobName, '_', '-') }}', '${{ variables.ExtraChecksTriplet }}')
@@ -90,7 +90,7 @@ jobs:
   - task: PublishPipelineArtifact@1
     displayName: "Publish Artifact: azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)/azcopy-logs'
+      targetPath: '$(WORKING_ROOT)/azcopy-logs'
       artifactName: "azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     condition: ne(variables['AZCOPY_LOGS_EMPTY'], 'True')
   - task: UseNode@1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
