### PR TITLE
Lexilla

### DIFF
--- a/ports/lexilla/0001-static-lib.patch
+++ b/ports/lexilla/0001-static-lib.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Lexilla.vcxproj b/src/Lexilla.vcxproj
+index 82aa9b7..5eac42f 100644
+--- a/src/Lexilla.vcxproj
++++ b/src/Lexilla.vcxproj
+@@ -36,7 +36,7 @@
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup>
+-    <ConfigurationType>DynamicLibrary</ConfigurationType>
++    <ConfigurationType>StaticLibrary</ConfigurationType>
+     <CharacterSet>Unicode</CharacterSet>
+     <PlatformToolset>v143</PlatformToolset>
+   </PropertyGroup>

--- a/ports/lexilla/0002-static-crt.patch
+++ b/ports/lexilla/0002-static-crt.patch
@@ -1,0 +1,52 @@
+diff --git a/src/Lexilla.vcxproj b/src/Lexilla.vcxproj
+index 82aa9b7..6b6f340 100644
+--- a/src/Lexilla.vcxproj
++++ b/src/Lexilla.vcxproj
+@@ -95,6 +95,7 @@
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <ClCompile>
+       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+@@ -103,6 +104,7 @@
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+     <ClCompile>
+       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+@@ -111,6 +113,7 @@
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+     <ClCompile>
+       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+@@ -122,6 +125,7 @@
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+@@ -133,6 +137,7 @@
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+@@ -144,6 +149,7 @@
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/ports/lexilla/0003-fix-include-path.patch
+++ b/ports/lexilla/0003-fix-include-path.patch
@@ -1,0 +1,14 @@
+diff --git a/src/Lexilla.vcxproj b/src/Lexilla.vcxproj
+index 82aa9b7..5eac42f 100644
+--- a/src/Lexilla.vcxproj
++++ b/src/Lexilla.vcxproj
+@@ -75,7 +75,7 @@
+   <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+-      <AdditionalIncludeDirectories>..\include;..\..\scintilla\include;..\lexlib;</AdditionalIncludeDirectories>
++      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_WINDOWS;_USRDLL;LEXILLA_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <AdditionalIncludeDirectories>..\include;$(VcpkgInstalledDir)\$(VcpkgTriplet)\include\scintilla;..\lexlib;</AdditionalIncludeDirectories>
+       <BrowseInformation>true</BrowseInformation>
+       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/ports/lexilla/portfile.cmake
+++ b/ports/lexilla/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-  URLS "https://www.scintilla.org/scintilla556.zip"
-  FILENAME "scintilla556.zip"
-  SHA512 8e845a94379fff88222fa9e4e5f534f62595420dd933166e4d9cc67b197c79f578405cb020892142ead1afd85bd42f1dc4361a339134a087e14760ff33d0a1cf
+  URLS "https://www.scintilla.org/lexilla545.zip"
+  FILENAME "lexilla545.zip"
+  SHA512 03e590a883e31135abc7eccdd089fbe3fe074955db70cbd546b58f32a77109f252c2283519e43f6a6e4c69fae9a99912c2bd828a771ceebeabf67655dde45877
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
@@ -12,6 +12,8 @@ if(VCPKG_CRT_LINKAGE STREQUAL "static")
   list(APPEND PATCHES 0002-static-crt.patch)
 endif()
 
+list(APPEND PATCHES 0003-fix-include-path.patch)
+
 vcpkg_extract_source_archive(
   SOURCE_PATH
   ARCHIVE ${ARCHIVE}
@@ -21,8 +23,9 @@ vcpkg_extract_source_archive(
 
 vcpkg_install_msbuild(
   SOURCE_PATH "${SOURCE_PATH}"
-  PROJECT_SUBPATH Win32/Scintilla.vcxproj
+  PROJECT_SUBPATH src/Lexilla.vcxproj
 )
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License.txt")
 file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}" FILES_MATCHING PATTERN "*.*")
+file(INSTALL "${SOURCE_PATH}/lexlib/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/lexlib" FILES_MATCHING PATTERN "*.h")

--- a/ports/lexilla/vcpkg.json
+++ b/ports/lexilla/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "lexilla",
+  "version": "5.4.5",
+  "description": "Lexilla is a free library of language lexers that can be used with the Scintilla editing component. It comes with complete source code and a license that permits use in any free project or commercial product.",
+  "homepage": "https://www.scintilla.org/Lexilla.html",
+  "supports": "windows & !uwp & !mingw",
+  "dependencies": [
+    "scintilla",
+    {
+      "name": "vcpkg-msbuild",
+      "host": true,
+      "platform": "windows"
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4520,6 +4520,10 @@
       "baseline": "2.5.0",
       "port-version": 0
     },
+    "lexilla": {
+      "baseline": "5.4.5",
+      "port-version": 0
+    },
     "lfreist-hwinfo": {
       "baseline": "2025-07-10",
       "port-version": 0

--- a/versions/l-/lexilla.json
+++ b/versions/l-/lexilla.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8f604b968642a903f1066078ab7b7c154a9736fb",
+      "version": "5.4.5",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
