### PR TITLE
[yandex-disk-cpp-client] Add new port

### DIFF
--- a/ports/yandex-disk-cpp-client/portfile.cmake
+++ b/ports/yandex-disk-cpp-client/portfile.cmake
@@ -1,0 +1,22 @@
+set(VCPKG_POLICY_ALLOW_DEBUG_SHARE enabled)
+
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Krasnovvvvv/yandex-disk-cpp-client
+        REF v1.0.1
+        SHA512 6edbcbb793475e8b90ed33793dc9f0d092a4ad86290010afbf6839adc494bb712a939f651440cb55d315d7f4650437df132e64fdb241a3a8f3ba196b0a8d3332
+        HEAD_REF main
+)
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+        PACKAGE_NAME "yandex_disk_client"
+        CONFIG_PATH "lib/cmake/yandex_disk_client"
+)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/yandex-disk-cpp-client/usage
+++ b/ports/yandex-disk-cpp-client/usage
@@ -1,0 +1,4 @@
+yandex-disk-cpp-client provides CMake targets:
+
+find_package(yandex-disk-cpp-client CONFIG REQUIRED)
+target_link_libraries(your_target PRIVATE yandex-disk-cpp-client)

--- a/ports/yandex-disk-cpp-client/vcpkg.json
+++ b/ports/yandex-disk-cpp-client/vcpkg.json
@@ -5,5 +5,10 @@
   "homepage": "https://github.com/Krasnovvvvv/yandex-disk-cpp-client",
   "documentation": "https://krasnovvvvv.github.io/yandex-disk-cpp-client/",
   "license": "MIT",
-  "dependencies": ["nlohmann-json", "curl", "vcpkg-cmake", "vcpkg-cmake-config"]
+  "dependencies": [
+    "curl",
+    "nlohmann-json",
+    "vcpkg-cmake",
+    "vcpkg-cmake-config"
+  ]
 }

--- a/ports/yandex-disk-cpp-client/vcpkg.json
+++ b/ports/yandex-disk-cpp-client/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "yandex-disk-cpp-client",
+  "version": "1.0.1",
+  "description": "Modern C++ client for Yandex.Disk REST API",
+  "homepage": "https://github.com/Krasnovvvvv/yandex-disk-cpp-client",
+  "documentation": "https://krasnovvvvv.github.io/yandex-disk-cpp-client/",
+  "license": "MIT",
+  "dependencies": ["nlohmann-json", "curl", "vcpkg-cmake", "vcpkg-cmake-config"]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10644,6 +10644,10 @@
       "baseline": "0.8.0",
       "port-version": 3
     },
+    "yandex-disk-cpp-client": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "yara": {
       "baseline": "4.5.4",
       "port-version": 0

--- a/versions/y-/yandex-disk-cpp-client.json
+++ b/versions/y-/yandex-disk-cpp-client.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "21a8e95af5af3f3a08df0a1136273af3d9e2da1f",
+      "version": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a port for [yandex-disk-cpp-client](https://github.com/Krasnovvvvv/yandex-disk-cpp-client), a modern C++ client for the Yandex.Disk REST API.

- Supports Windows (MinGW) and Linux
- Depends on nlohmann-json and curl
- Provides CMake config and usage file for easy integration
- All post-build checks passed, tested on x64-mingw-static

---

### New Port Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on [https://repology.org/](https://repology.org/) if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. All `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with `CMAKE_DISABLE_FIND_PACKAGE_Xxx`.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

---

Please let me know if any further changes are required!

