### PR TITLE
[vcpkg baseline][vsg] Features for installation order control

### DIFF
--- a/ports/vsg/cmakedefine01.diff
+++ b/ports/vsg/cmakedefine01.diff
@@ -1,0 +1,13 @@
+diff --git a/src/vsg/core/Version.h.in b/src/vsg/core/Version.h.in
+index 1926da82..2c492bdb 100644
+--- a/src/vsg/core/Version.h.in
++++ b/src/vsg/core/Version.h.in
+@@ -43,7 +43,7 @@ extern "C"
+     #cmakedefine01 VSG_SUPPORTS_ShaderOptimizer
+ 
+     /// Native Windowing support provided with vsg::Window::create(windowTraits) enabled when 1, disabled when 0
+-    #define VSG_SUPPORTS_Windowing @VSG_SUPPORTS_Windowing@
++    #cmakedefine01 VSG_SUPPORTS_Windowing
+ 
+     struct VsgVersion
+     {

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 997ba97c4860c2b9e79589358b1471df5ec14e64329bc8c5e23b1db2e855e63433cc5141f5fe34f785f88c9b3bcfc27f6aa8e9f5fc5d11cfdd1dab43f0e448cc
     HEAD_REF master
+    PATCHES
+        cmakedefine01.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS options

--- a/ports/vsg/portfile.cmake
+++ b/ports/vsg/portfile.cmake
@@ -6,14 +6,26 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS options
+    FEATURES
+        shader-optimizer    VSG_SUPPORTS_ShaderOptimizer
+        windowing           VSG_SUPPORTS_Windowing
+)
+
+if("windowing" IN_LIST FEATURES AND NOT (VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_WINDOWS))
+    vcpkg_find_acquire_program(PKGCONFIG)
+    set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+endif()
+
 # added -DGLSLANG_MIN_VERSION=15 to sync with vcpkg version of glslang
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${options}
         -DGLSLANG_MIN_VERSION=
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME "vsg" CONFIG_PATH "lib/cmake/vsg")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/vsg")
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/vsg/vcpkg.json
+++ b/ports/vsg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vsg",
   "version": "1.1.11",
+  "port-version": 1,
   "description": "A modern, cross platform, high performance scene graph library built upon Vulkan.",
   "homepage": "http://www.vulkanscenegraph.org/",
   "license": "MIT",
@@ -19,5 +20,27 @@
       "name": "xcb",
       "platform": "!(android | windows | osx)"
     }
-  ]
+  ],
+  "features": {
+    "shader-optimizer": {
+      "description": "shader optimizer support",
+      "dependencies": [
+        {
+          "name": "glslang",
+          "features": [
+            "opt"
+          ]
+        }
+      ]
+    },
+    "windowing": {
+      "description": "native windowing support providing a default implementation of vsg::Window::create()",
+      "dependencies": [
+        {
+          "name": "xcb",
+          "platform": "!(android | ios | osx | windows)"
+        }
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10226,7 +10226,7 @@
     },
     "vsg": {
       "baseline": "1.1.11",
-      "port-version": 0
+      "port-version": 1
     },
     "vsgimgui": {
       "baseline": "0.3.0",

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "76e5b7f9ccadb39fa7a7a1dc65f739957db5893c",
+      "git-tree": "9c91ca2678db4fa28b5acc46326a56fa3e19ec4e",
       "version": "1.1.11",
       "port-version": 1
     },

--- a/versions/v-/vsg.json
+++ b/versions/v-/vsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "76e5b7f9ccadb39fa7a7a1dc65f739957db5893c",
+      "version": "1.1.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "eb536c895926da4dc9b4b6adba04d8f1bcb07ea1",
       "version": "1.1.11",
       "port-version": 0


### PR DESCRIPTION
Fixes occassional regressions when using vsgimgui depending on vsg depending on glslang[opt], e.g. https://dev.azure.com/vcpkg/public/_build/results?buildId=121648&view=results.
Enables build without xcb.