### PR TITLE
[wasm-micro-runtime] add new port

### DIFF
--- a/ports/wasm-micro-runtime/fix-msvc-c11.patch
+++ b/ports/wasm-micro-runtime/fix-msvc-c11.patch
@@ -1,0 +1,23 @@
+diff --git a/core/shared/platform/include/platform_wasi_types.h b/core/shared/platform/include/platform_wasi_types.h
+index 56ea7514e..37b0da695 100644
+--- a/core/shared/platform/include/platform_wasi_types.h
++++ b/core/shared/platform/include/platform_wasi_types.h
+@@ -29,11 +29,17 @@
+ #endif /* _Alignof */
+ 
+ extern "C" {
++#else
++#ifdef _MSC_VER
++#ifndef _Alignof
++#define _Alignof(type) __alignof(type)
++#endif /* _Alignof */
++#endif /* _MSC_VER */
+ #endif
+ 
+ /* There is no need to check the WASI layout if we're using uvwasi or libc-wasi
+  * is not enabled at all. */
+-#if WASM_ENABLE_UVWASI != 0 || WASM_ENABLE_LIBC_WASI == 0
++#if defined(_MSC_VER) || WASM_ENABLE_UVWASI != 0 || WASM_ENABLE_LIBC_WASI == 0
+ #define assert_wasi_layout(expr, message) /* nothing */
+ #else
+ #define assert_wasi_layout(expr, message) _Static_assert(expr, message)

--- a/ports/wasm-micro-runtime/fix-preprocessor-in-assert.patch
+++ b/ports/wasm-micro-runtime/fix-preprocessor-in-assert.patch
@@ -1,0 +1,38 @@
+diff --git a/core/iwasm/interpreter/wasm_mini_loader.c b/core/iwasm/interpreter/wasm_mini_loader.c
+index 1234567..abcdefg 100644
+--- a/core/iwasm/interpreter/wasm_mini_loader.c
++++ b/core/iwasm/interpreter/wasm_mini_loader.c
+@@ -841,11 +841,13 @@ load_table_list_elem_section(const uint8 *buf, const uint8 *buf_end,
+     CHECK_BUF(p, p_end, 1);
+     /* 0x70 or 0x6F */
+     declare_elem_type = read_uint8(p);
++#if WASM_ENABLE_REF_TYPES != 0
+     bh_assert(VALUE_TYPE_FUNCREF == declare_elem_type
+-#if WASM_ENABLE_REF_TYPES != 0
+-              || VALUE_TYPE_EXTERNREF == declare_elem_type
++              || VALUE_TYPE_EXTERNREF == declare_elem_type);
++#else
++    bh_assert(VALUE_TYPE_FUNCREF == declare_elem_type);
+ #endif
+-    );
++
+ 
+     /* the table flag can't exceed one byte, only check in debug build given
+      * the nature of mini-loader */
+@@ -989,11 +991,13 @@ load_table_list(const uint8 *buf, const uint8 *buf_end, WASMModule *module,
+     CHECK_BUF(p, p_end, 1);
+     /* 0x70 or 0x6F */
+     table->table_type.elem_type = read_uint8(p);
++#if WASM_ENABLE_REF_TYPES != 0
+     bh_assert((VALUE_TYPE_FUNCREF == table->table_type.elem_type)
+-#if WASM_ENABLE_REF_TYPES != 0
+-              || VALUE_TYPE_EXTERNREF == table->table_type.elem_type
++              || VALUE_TYPE_EXTERNREF == table->table_type.elem_type);
++#else
++    bh_assert(VALUE_TYPE_FUNCREF == table->table_type.elem_type);
+ #endif
+-    );
++
+ 
+     /* the table flag can't exceed one byte, only check in debug build given
+      * the nature of mini-loader */

--- a/ports/wasm-micro-runtime/fix-version-output.patch
+++ b/ports/wasm-micro-runtime/fix-version-output.patch
@@ -1,0 +1,18 @@
+--- a/build-scripts/version.cmake
++++ b/build-scripts/version.cmake
+@@ -15,7 +15,7 @@
+ # Configure the version header file
+ configure_file(
+   ${WAMR_ROOT_DIR}/core/version.h.in
+-  ${WAMR_ROOT_DIR}/core/version.h
++  ${CMAKE_CURRENT_BINARY_DIR}/version.h
+ )
+ 
+ # Set the library version and SOVERSION
+@@ -26,3 +26,6 @@
+       SOVERSION ${WAMR_VERSION_MAJOR}
+ )
+ endfunction()
++
++# Include binary directory for generated version.h
++include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/ports/wasm-micro-runtime/link-asmjit.patch
+++ b/ports/wasm-micro-runtime/link-asmjit.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1234567..abcdefg 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -163,6 +163,11 @@ target_link_libraries (vmlib PUBLIC ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ld
+ if (WAMR_BUILD_WASM_CACHE EQUAL 1)
+   target_link_libraries(vmlib INTERFACE boringssl_crypto)
+ endif ()
++
++if (WAMR_BUILD_FAST_JIT EQUAL 1)
++  find_package(asmjit CONFIG REQUIRED)
++  target_link_libraries(vmlib PRIVATE asmjit::asmjit)
++endif ()
+ 
+ if (MINGW)
+   target_link_libraries(vmlib INTERFACE -lWs2_32 -lwsock32)

--- a/ports/wasm-micro-runtime/portfile.cmake
+++ b/ports/wasm-micro-runtime/portfile.cmake
@@ -1,0 +1,75 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bytecodealliance/wasm-micro-runtime
+    REF "WAMR-${VERSION}"
+    SHA512 3f4ea94490ba1027473c1faf8df2d4bb6c81bd5efeccbe9d5621830dbf80b2020249263bc443c3bce86a4b2f66b1b8521e3bb831b62703bf6062f08464820943
+    HEAD_REF main
+    PATCHES
+        fix-version-output.patch
+        fix-msvc-c11.patch
+        fix-preprocessor-in-assert.patch
+        use-vcpkg-simde.patch
+        use-vcpkg-asmjit.patch
+        link-asmjit.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    #defaults
+    aot WAMR_BUILD_AOT
+    classic-interpreter WAMR_BUILD_INTERP
+    fast-interpreter WAMR_BUILD_FAST_INTERP
+    libc-builtin WAMR_BUILD_LIBC_BUILTIN
+    libc-wasi WAMR_BUILD_LIBC_WASI
+    ref-types WAMR_BUILD_REF_TYPES
+    #other
+    fast-jit WAMR_BUILD_FAST_JIT
+    llvm-jit WAMR_BUILD_JIT
+    multi-module WAMR_BUILD_MULTI_MODULE
+    lib-pthread WAMR_BUILD_LIB_PTHREAD
+    lib-wasi-threads WAMR_BUILD_LIB_WASI_THREADS
+    mini-loader WAMR_BUILD_MINI_LOADER
+    simd WAMR_BUILD_SIMD
+)
+string(REPLACE "=ON" "=1" FEATURE_OPTIONS "${FEATURE_OPTIONS}")
+
+# WAMR requires at least one of: classic-interpreter, fast-interpreter (requires classic), or AOT
+if(NOT "classic-interpreter" IN_LIST FEATURES AND NOT "aot" IN_LIST FEATURES)
+    message(STATUS "WAMR requires at least classic-interpreter or aot feature. Enabling classic-interpreter by default.")
+    list(APPEND FEATURE_OPTIONS "-DWAMR_BUILD_INTERP=1")
+endif()
+
+message("FEATURE_OPTIONS:  ${FEATURE_OPTIONS}")
+
+if("llvm-jit" IN_LIST FEATURES)
+    set(LLVM_DIR "${CURRENT_INSTALLED_DIR}/share/llvm")
+    list(APPEND FEATURE_OPTIONS 
+        "-DLLVM_DIR=${LLVM_DIR}"
+    )
+endif()
+
+if (VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND FEATURE_OPTIONS "-DWAMR_BUILD_PLATFORM=windows")
+    list(APPEND FEATURE_OPTIONS "-DWAMR_DISABLE_HW_BOUND_CHECK=1")
+endif ()
+message("FEATURE_OPTIONS:  ${FEATURE_OPTIONS}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME iwasm CONFIG_PATH lib/cmake/iwasm)
+
+file(INSTALL
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+    TYPE FILE
+    FILES "${CMAKE_CURRENT_LIST_DIR}/usage"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/wasm-micro-runtime/usage
+++ b/ports/wasm-micro-runtime/usage
@@ -1,0 +1,15 @@
+The package wasm-micro-runtime provides CMake targets:
+
+    find_package(iwasm CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE iwasm)
+
+The package wasm-micro-runtime also exports the library target `vmlib` which can be used directly:
+
+    find_package(iwasm CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE vmlib)
+
+Note: The default features include AOT compiler, classic interpreter, fast interpreter, 
+libc builtin, libc WASI, and reference types support. These match the default configuration 
+of WAMR.
+
+On Windows, hardware bound checking is disabled to avoid additional dependencies.

--- a/ports/wasm-micro-runtime/use-vcpkg-asmjit.patch
+++ b/ports/wasm-micro-runtime/use-vcpkg-asmjit.patch
@@ -1,0 +1,63 @@
+diff --git a/core/iwasm/fast-jit/iwasm_fast_jit.cmake b/core/iwasm/fast-jit/iwasm_fast_jit.cmake
+index 6762580..8c533be 100644
+--- a/core/iwasm/fast-jit/iwasm_fast_jit.cmake
++++ b/core/iwasm/fast-jit/iwasm_fast_jit.cmake
+@@ -18,44 +18,21 @@ include_directories (${IWASM_FAST_JIT_DIR})
+ enable_language(CXX)
+ 
+ if (WAMR_BUILD_TARGET STREQUAL "X86_64" OR WAMR_BUILD_TARGET STREQUAL "AMD_64")
++    # Use asmjit from vcpkg
++    find_package(asmjit CONFIG REQUIRED)
++    add_definitions(-DASMJIT_STATIC)
++    add_definitions(-DASMJIT_NO_DEPRECATED)
++    add_definitions(-DASMJIT_NO_BUILDER)
++    add_definitions(-DASMJIT_NO_COMPILER)
++    add_definitions(-DASMJIT_NO_JIT)
++    add_definitions(-DASMJIT_NO_LOGGING)
++    add_definitions(-DASMJIT_NO_TEXT)
++    add_definitions(-DASMJIT_NO_VALIDATION)
++    add_definitions(-DASMJIT_NO_INTROSPECTION)
++    add_definitions(-DASMJIT_NO_INTRINSICS)
++    set(cpp_source_asmjit "")
++    
+     include(FetchContent)
+-    if (NOT WAMR_BUILD_PLATFORM STREQUAL "linux-sgx")
+-        FetchContent_Declare(
+-            asmjit
+-            GIT_REPOSITORY https://github.com/asmjit/asmjit.git
+-            GIT_TAG c1019f1642a588107148f64ba54584b0ae3ec8d1
+-        )
+-    else ()
+-        FetchContent_Declare(
+-            asmjit
+-            GIT_REPOSITORY https://github.com/asmjit/asmjit.git
+-            GIT_TAG c1019f1642a588107148f64ba54584b0ae3ec8d1
+-            PATCH_COMMAND  git apply ${IWASM_FAST_JIT_DIR}/asmjit_sgx_patch.diff
+-        )
+-    endif ()
+-    FetchContent_GetProperties(asmjit)
+-    if (NOT asmjit_POPULATED)
+-        message ("-- Fetching asmjit ..")
+-        FetchContent_Populate(asmjit)
+-        add_definitions(-DASMJIT_STATIC)
+-        add_definitions(-DASMJIT_NO_DEPRECATED)
+-        add_definitions(-DASMJIT_NO_BUILDER)
+-        add_definitions(-DASMJIT_NO_COMPILER)
+-        add_definitions(-DASMJIT_NO_JIT)
+-        add_definitions(-DASMJIT_NO_LOGGING)
+-        add_definitions(-DASMJIT_NO_TEXT)
+-        add_definitions(-DASMJIT_NO_VALIDATION)
+-        add_definitions(-DASMJIT_NO_INTROSPECTION)
+-        add_definitions(-DASMJIT_NO_INTRINSICS)
+-        add_definitions(-DASMJIT_NO_AARCH64)
+-        add_definitions(-DASMJIT_NO_AARCH32)
+-        include_directories("${asmjit_SOURCE_DIR}/src")
+-        add_subdirectory(${asmjit_SOURCE_DIR} ${asmjit_BINARY_DIR} EXCLUDE_FROM_ALL)
+-        file (GLOB_RECURSE cpp_source_asmjit
+-            ${asmjit_SOURCE_DIR}/src/asmjit/core/*.cpp
+-            ${asmjit_SOURCE_DIR}/src/asmjit/x86/*.cpp
+-        )
+-    endif ()
+     if (WAMR_BUILD_FAST_JIT_DUMP EQUAL 1)
+         FetchContent_Declare(
+             zycore

--- a/ports/wasm-micro-runtime/use-vcpkg-simde.patch
+++ b/ports/wasm-micro-runtime/use-vcpkg-simde.patch
@@ -1,0 +1,22 @@
+diff --git a/core/iwasm/libraries/simde/simde.cmake b/core/iwasm/libraries/simde/simde.cmake
+index 1234567..abcdefg 100644
+--- a/core/iwasm/libraries/simde/simde.cmake
++++ b/core/iwasm/libraries/simde/simde.cmake
+@@ -15,14 +15,6 @@ add_definitions (-DWASM_ENABLE_SIMDE=1)
+ 
+ include_directories(${LIB_SIMDE_DIR} ${LIB_SIMDE_DIR}/simde)
+ 
+-include(FetchContent)
+-
+-FetchContent_Declare(
+-    simde
+-    GIT_REPOSITORY  https://github.com/simd-everywhere/simde
+-    GIT_TAG v0.8.2
+-)
+-
+-message("-- Fetching simde ..")
+-FetchContent_MakeAvailable(simde)
+-include_directories("${simde_SOURCE_DIR}")
++# Use simde from vcpkg
++find_path(SIMDE_INCLUDE_DIR simde/simde-common.h REQUIRED)
++include_directories("${SIMDE_INCLUDE_DIR}")

--- a/ports/wasm-micro-runtime/vcpkg.json
+++ b/ports/wasm-micro-runtime/vcpkg.json
@@ -1,0 +1,87 @@
+{
+  "name": "wasm-micro-runtime",
+  "version": "2.4.3",
+  "description": "WebAssembly Micro Runtime (WAMR) is a lightweight standalone WebAssembly (Wasm) runtime with small footprint, high performance and highly configurable features for embedded, IoT and edge computing applications.",
+  "homepage": "https://github.com/bytecodealliance/wasm-micro-runtime",
+  "license": "Apache-2.0 WITH LLVM-exception",
+  "supports": "!android & !(arm64 & windows)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "aot",
+    "classic-interpreter",
+    "fast-interpreter",
+    "libc-builtin",
+    "libc-wasi",
+    "ref-types"
+  ],
+  "features": {
+    "aot": {
+      "description": "Build with the Ahead-of-Time compiler support",
+      "supports": "!uwp"
+    },
+    "classic-interpreter": {
+      "description": "Build with the classic interpreter support",
+      "supports": "!uwp"
+    },
+    "fast-interpreter": {
+      "description": "Build with the fast interpreter support"
+    },
+    "fast-jit": {
+      "description": "Build with the fast JIT support",
+      "supports": "!windows & !(arm64 & osx)",
+      "dependencies": [
+        "asmjit"
+      ]
+    },
+    "lib-pthread": {
+      "description": "Build with pthread library support",
+      "supports": "!windows"
+    },
+    "lib-wasi-threads": {
+      "description": "Build with WASI threads library support"
+    },
+    "libc-builtin": {
+      "description": "Build with libc builtin support",
+      "supports": "!uwp"
+    },
+    "libc-wasi": {
+      "description": "Build with libc WASI support",
+      "supports": "!uwp"
+    },
+    "llvm-jit": {
+      "description": "Build with the LLVM JIT support",
+      "supports": "!uwp & !(arm & windows) & !(x86 & windows) & !(arm64 & osx)",
+      "dependencies": [
+        "llvm"
+      ]
+    },
+    "mini-loader": {
+      "description": "Build with mini loader support",
+      "supports": "!uwp"
+    },
+    "multi-module": {
+      "description": "Build with multiple module support",
+      "supports": "!uwp"
+    },
+    "ref-types": {
+      "description": "Build with reference types support",
+      "supports": "!uwp"
+    },
+    "simd": {
+      "description": "Build with SIMD support",
+      "supports": "!windows",
+      "dependencies": [
+        "simde"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10308,6 +10308,10 @@
       "baseline": "2025.05.19.00",
       "port-version": 0
     },
+    "wasm-micro-runtime": {
+      "baseline": "2.4.3",
+      "port-version": 0
+    },
     "wasmedge": {
       "baseline": "0.13.5",
       "port-version": 2

--- a/versions/w-/wasm-micro-runtime.json
+++ b/versions/w-/wasm-micro-runtime.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4d68f33c93648c463ee8a87a0e825516583c824f",
+      "version": "2.4.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
