### PR TITLE
[sdl3] Fix pkgconfig file path for FreeBSD

### DIFF
--- a/ports/sdl3/fix-freebsd.patch
+++ b/ports/sdl3/fix-freebsd.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9e19336..ff6424b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4038,7 +4038,7 @@ else()
+ endif()
+ set(SDL_INSTALL_CMAKEDIR_ROOT "${SDL_INSTALL_CMAKEDIR_ROOT_DEFAULT}" CACHE STRING "Root folder where to install SDL3Config.cmake related files (SDL3 subfolder for MSVC projects)")
+ 
+-if(FREEBSD)
++if(0)
+   # FreeBSD uses ${PREFIX}/libdata/pkgconfig
+   set(SDL_PKGCONFIG_INSTALLDIR "libdata/pkgconfig")
+ else()

--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "release-${VERSION}"
     SHA512 93766ed1f2be0af75e82c05fcb1dc0aac29ded4d0ae9a98137edfc6a4ab85412ea51199d0469254e7e5751fb37d78daff8bc0cbbc20650972f182d976c6bcc61
     HEAD_REF main
+    PATCHES
+        fix-freebsd.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)

--- a/ports/sdl3/vcpkg.json
+++ b/ports/sdl3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl3",
   "version": "3.2.24",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
   "license": "Zlib AND MIT AND Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8794,7 +8794,7 @@
     },
     "sdl3": {
       "baseline": "3.2.24",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl3-image": {
       "baseline": "3.2.4",

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ecf606747059664cf762c48480ca56d4830fa0fc",
+      "version": "3.2.24",
+      "port-version": 1
+    },
+    {
       "git-tree": "adcd29385eeee94cb1f5c936eaa6c37d58c48986",
       "version": "3.2.24",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.