### PR TITLE
[cryptopp] fix pem-pack feature

### DIFF
--- a/ports/cryptopp/cmake-support-pem-pack.patch
+++ b/ports/cryptopp/cmake-support-pem-pack.patch
@@ -1,0 +1,33 @@
+diff --git a/cryptopp/sources.cmake b/cryptopp/sources.cmake
+index 7918f03..58d74e2 100644
+--- a/cryptopp/sources.cmake
++++ b/cryptopp/sources.cmake
+@@ -182,6 +182,14 @@ set(cryptopp_SOURCES
+     zlib.cpp
+ )
+ 
++if (CRYPTOPP_PEM_PACK)
++    list(APPEND cryptopp_SOURCES
++        pem-com.cpp
++        pem-rd.cpp
++        pem-wr.cpp
++    )
++endif()
++
+ # ***** Library headers *****
+ set(cryptopp_HEADERS
+     3way.h
+@@ -374,6 +382,13 @@ set(cryptopp_HEADERS
+     zlib.h
+ )
+ 
++if (CRYPTOPP_PEM_PACK)
++    list(APPEND cryptopp_HEADERS
++        pem-com.h
++        pem.h
++    )
++endif()
++
+ # ***** Test sources *****
+ set(cryptopp_SOURCES_TEST
+     # adhoc.cpp

--- a/ports/cryptopp/portfile.cmake
+++ b/ports/cryptopp/portfile.cmake
@@ -7,6 +7,8 @@ vcpkg_from_github(
   REF "CRYPTOPP_${CRYPTOPP_VERSION}"
   SHA512 3ec33b107ab627a514e1ebbc4b6522ee8552525f36730d9b5feb85e61ba7fc24fd36eb6050e328c6789ff60d47796beaa8eebf7dead787a34395294fae9bb733
   HEAD_REF master
+  PATCHES
+    cmake-support-pem-pack.patch
 )
 
 vcpkg_from_github(
@@ -26,6 +28,11 @@ file(COPY "${CMAKE_SOURCE_PATH}/test" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_SOURCE_PATH}/cryptopp/cryptoppConfig.cmake" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CMAKE_SOURCE_PATH}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        pem-pack     CRYPTOPP_PEM_PACK
+)
+
 if("pem-pack" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH PEM_PACK_SOURCE_PATH
@@ -39,7 +46,7 @@ if("pem-pack" IN_LIST FEATURES)
         ${PEM_PACK_SOURCE_PATH}/*.h
         ${PEM_PACK_SOURCE_PATH}/*.cpp
     )
-    file(INSTALL ${PEM_PACK_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+    file(COPY ${PEM_PACK_FILES} DESTINATION ${SOURCE_PATH})
 endif()
 
 # disable assembly on ARM Windows to fix broken build
@@ -66,6 +73,7 @@ vcpkg_cmake_configure(
         -DDISABLE_ASM=${CRYPTOPP_DISABLE_ASM}
         -DUSE_INTERMEDIATE_OBJECTS_TARGET=OFF # Not required when we build static only
         -DCMAKE_POLICY_DEFAULT_CMP0063=NEW # Honor "<LANG>_VISIBILITY_PRESET" properties
+        ${FEATURE_OPTIONS}
     MAYBE_UNUSED_VARIABLES
         BUILD_STATIC
         USE_INTERMEDIATE_OBJECTS_TARGET

--- a/ports/cryptopp/vcpkg.json
+++ b/ports/cryptopp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cryptopp",
   "version": "8.9.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Crypto++ is a free C++ class library of cryptographic schemes.",
   "homepage": "https://github.com/weidai11/cryptopp",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2170,7 +2170,7 @@
     },
     "cryptopp": {
       "baseline": "8.9.0",
-      "port-version": 1
+      "port-version": 2
     },
     "cserialport": {
       "baseline": "4.3.3",

--- a/versions/c-/cryptopp.json
+++ b/versions/c-/cryptopp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a43c1863687809d90c65c768b70eb0add5aacc6",
+      "version": "8.9.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "d0e6dbcd3cb14acffac5ce963dc8fcd1178101fc",
       "version": "8.9.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The current pem-pack feature only installed the pem-pack source code.
As a result, the .cpp files were merely copied into the include folder and were not compiled.
This PR addresses this issue and builds the .cpp files.
