### PR TITLE
[vcpkg baseline][sdl1-mixer] Update, control fluidsynth dependency

### DIFF
--- a/ports/sdl1-mixer/portfile.cmake
+++ b/ports/sdl1-mixer/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL_mixer
-    REF d8b2c98ca3db62fa3d4e1dbb8801c6f57a10b8bf
-    SHA512 e22b2e26d9c7296e79589d5108118c65f5fb76e7e9d6996129e19b63313f9aa3a4c0657010e45fa040792fa81c488dae3ec6fac09e147d3b4430d612837e0132
+    REF 4c93e0b4bcc3d5ecfd865190f664de6b2c837018
+    SHA512 a6beed48c7a804aa5e52c3883edb6edd09b073ffec3481ce5fb27fee020ca4364525d0760e0532d3233a5e0f1500780c2994d9bb9ffcf79047bb6766b818bb0e
     HEAD_REF SDL-1.2
     PATCHES
         mpg123_ssize_t.patch
@@ -66,14 +66,17 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     )
     file(COPY "${SOURCE_PATH}/SDL_mixer.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/SDL")
 else()
-    vcpkg_configure_make(
+    vcpkg_make_configure(
         SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+            --enable-music-fluidsynth-midi=no
+            INCLUDE=#[[ empty ]]
     )
-    
-    vcpkg_install_make()
+    vcpkg_make_install()
     vcpkg_fixup_pkgconfig()
     
-    vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 endif()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/sdl1-mixer/portfile.cmake
+++ b/ports/sdl1-mixer/portfile.cmake
@@ -57,12 +57,9 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
                                                      </ItemDefinitionGroup>
                                                      </Project>")
 
-    vcpkg_install_msbuild(
+    vcpkg_msbuild_install(
         SOURCE_PATH "${SOURCE_PATH}"
         PROJECT_SUBPATH VisualC/SDL_mixer_2017.sln
-        #INCLUDES_SUBPATH include
-        LICENSE_SUBPATH COPYING
-        #ALLOW_ROOT_INCLUDES
     )
     file(COPY "${SOURCE_PATH}/SDL_mixer.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/SDL")
 else()
@@ -74,7 +71,6 @@ else()
     )
     vcpkg_make_install()
     vcpkg_fixup_pkgconfig()
-    
 endif()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/sdl1-mixer/usage
+++ b/ports/sdl1-mixer/usage
@@ -1,4 +1,5 @@
-The package sdl1-mixer is compatible with built-in CMake targets:
+sdl1-mixer is compatible with built-in CMake variables:
 
-    find_package(SDL_mixer REQUIRED)
-    target_link_libraries(main PRIVATE ${SDL_MIXER_LIBRARY})
+  find_package(SDL_mixer REQUIRED)
+  target_include_directories(main PRIVATE ${SDL_MIXER_INCLUDE_DIRS})
+  target_link_libraries(main PRIVATE ${SDL_MIXER_LIBRARIES})

--- a/ports/sdl1-mixer/vcpkg.json
+++ b/ports/sdl1-mixer/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sdl1-mixer",
-  "version-date": "2023-03-25",
-  "port-version": 2,
+  "version-date": "2025-09-10",
   "description": "An audio mixer that supports various file formats for Simple Directmedia Layer.",
   "homepage": "https://www.libsdl.org",
   "license": "Zlib",
@@ -12,6 +11,10 @@
     "libogg",
     "libvorbis",
     "mpg123",
-    "sdl1"
+    "sdl1",
+    {
+      "name": "vcpkg-make",
+      "platform": "!windows | mingw"
+    }
   ]
 }

--- a/ports/sdl1-mixer/vcpkg.json
+++ b/ports/sdl1-mixer/vcpkg.json
@@ -15,6 +15,11 @@
     {
       "name": "vcpkg-make",
       "platform": "!windows | mingw"
+    },
+    {
+      "name": "vcpkg-msbuild",
+      "host": true,
+      "platform": "windows & !mingw"
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8753,8 +8753,8 @@
       "port-version": 22
     },
     "sdl1-mixer": {
-      "baseline": "2023-03-25",
-      "port-version": 2
+      "baseline": "2025-09-10",
+      "port-version": 0
     },
     "sdl1-net": {
       "baseline": "1.2.8",

--- a/versions/s-/sdl1-mixer.json
+++ b/versions/s-/sdl1-mixer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0854db1b38fbcb14c3e8e06dc43a07880612c166",
+      "version-date": "2025-09-10",
+      "port-version": 0
+    },
+    {
       "git-tree": "d9948f6d30a19d1be8d0de5406f7874c5991aec1",
       "version-date": "2023-03-25",
       "port-version": 2

--- a/versions/s-/sdl1-mixer.json
+++ b/versions/s-/sdl1-mixer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0854db1b38fbcb14c3e8e06dc43a07880612c166",
+      "git-tree": "2d8ee712ae609b824aabc26d3fa206aa17243c21",
       "version-date": "2025-09-10",
       "port-version": 0
     },


### PR DESCRIPTION
The new C++ linkage of fluidsynth uncovered sdl1-mixers hidden installation order problem:
https://dev.azure.com/vcpkg/public/_build/results?buildId=121604&view=logs&j=f79cfdd7-47a8-597f-8f57-dc3e21a8f2ad