### PR TITLE
[libcoap] Add new port (#47602)

### DIFF
--- a/ports/libcoap/portfile.cmake
+++ b/ports/libcoap/portfile.cmake
@@ -1,0 +1,56 @@
+# dllexport is not supported.
+if(VCPKG_TARGET_IS_WINDOWS)
+  vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_download_distfile(DLLEXPORT_PATCH
+    URLS https://github.com/obgm/libcoap/commit/0bd03b658ed2d75fdb7cb8f6add201b39b428298.patch?full_index=1
+    FILENAME obgm-remove-self-configure-file-0bd03b658ed2d75fdb7cb8f6add201b39b428298.patch
+    SHA512 6c120dc278a5d73d0b9bd2f66468c822ccde80513262201119cdceb9ed6fdf2f84d473926373f18ef69d709d4e95212e484079072a52d5c65d09e4ccb82368e5
+)
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO obgm/libcoap
+  REF v4.3.5
+  SHA512 21332f4988c83cc3e26a70db6f2c3028e75fabc7990238d3c13666c5725674231799e147427b0fa827cf6c9e4d9f03d5176129f69425e2439ade13ea82267c05
+  HEAD_REF main
+  PATCHES
+      "${DLLEXPORT_PATCH}"
+      remove-hardcoded-tinydtls-path.patch)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+      examples ENABLE_EXAMPLES
+      dtls     ENABLE_DTLS
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH ${SOURCE_PATH}
+  OPTIONS
+      ${FEATURE_OPTIONS}
+      -DENABLE_DOCS=OFF
+      -DDTLS_BACKEND=openssl)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libcoap")
+
+if("examples" IN_LIST FEATURES)
+  vcpkg_copy_tools(
+      TOOL_NAMES coap-client coap-rd coap-server
+      AUTO_CLEAN
+  )
+  # Same condition in licoap/CMakeLists.txt
+  if(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_copy_tools(
+        TOOL_NAMES etsi_iot_01 tiny oscore-interop-server
+        AUTO_CLEAN
+    )
+  endif()
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libcoap/remove-hardcoded-tinydtls-path.patch
+++ b/ports/libcoap/remove-hardcoded-tinydtls-path.patch
@@ -1,0 +1,14 @@
+# A path to binary dir is hardcoded.
+# tinydtls is never used because openssl is forced.
+# Just remove the wrong line.
+--- v4.3.5-4285a765ed.clean/CMakeLists.old.txt	2024-09-06 12:13:56.000000000 +0200
++++ v4.3.5-4285a765ed.clean/CMakeLists.txt	2025-11-03 13:22:08.834295900 +0100
+@@ -808,7 +808,7 @@ target_include_directories(
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/>
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/>
+          $<INSTALL_INTERFACE:include/>
+-         $<$<AND:$<BOOL:${COAP_WITH_LIBTINYDTLS}>,$<BOOL:${USE_VENDORED_TINYDTLS}>>:${CMAKE_BINARY_DIR}/include/tinydtls>
++#         $<$<AND:$<BOOL:${COAP_WITH_LIBTINYDTLS}>,$<BOOL:${USE_VENDORED_TINYDTLS}>>:${CMAKE_BINARY_DIR}/include/tinydtls>
+         $<$<BOOL:${COAP_WITH_LIBGNUTLS}>:${GNUTLS_INCLUDE_DIR}>
+         $<$<BOOL:${COAP_WITH_LIBMBEDTLS}>:${MBEDTLS_INCLUDE_DIRS}>
+         $<$<BOOL:${COAP_WITH_LIBWOLFSSL}>:${WOLFSSL_INCLUDE_DIR}>)

--- a/ports/libcoap/vcpkg.json
+++ b/ports/libcoap/vcpkg.json
@@ -1,0 +1,31 @@
+{
+  "name": "libcoap",
+  "version": "4.3.5",
+  "description": "libcoap — A C implementation of the Constrained Application Protocol (RFC 7252)",
+  "homepage": "https://libcoap.net/",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "dtls"
+  ],
+  "features": {
+    "dtls": {
+      "description": "compile with dtls support",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "examples": {
+      "description": "Build examples"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4644,6 +4644,10 @@
       "baseline": "3.1.0",
       "port-version": 0
     },
+    "libcoap": {
+      "baseline": "4.3.5",
+      "port-version": 0
+    },
     "libconfig": {
       "baseline": "1.8.1",
       "port-version": 0

--- a/versions/l-/libcoap.json
+++ b/versions/l-/libcoap.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a36eef8ed6f57a404d25ccc9283727daed858c6e",
+      "version": "4.3.5",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #47602

Based on #24119

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
