### PR TITLE
Lexilla

### DIFF
--- a/ports/lexilla/0003-fix-include-path.patch
+++ b/ports/lexilla/0003-fix-include-path.patch
@@ -8,7 +8,7 @@ index 82aa9b7..5eac42f 100644
       <WarningLevel>Level4</WarningLevel>
 -      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 -      <AdditionalIncludeDirectories>..\include;..\..\scintilla\include;..\lexlib;</AdditionalIncludeDirectories>
-+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_WINDOWS;_USRDLL;LEXILLA_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 +      <AdditionalIncludeDirectories>..\include;$(VcpkgInstalledDir)\$(VcpkgTriplet)\include\scintilla;..\lexlib;</AdditionalIncludeDirectories>
        <BrowseInformation>true</BrowseInformation>
        <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/ports/lexilla/vcpkg.json
+++ b/ports/lexilla/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "lexilla",
   "version": "5.4.5",
+  "port-version": 1,
   "description": "Lexilla is a free library of language lexers that can be used with the Scintilla editing component. It comes with complete source code and a license that permits use in any free project or commercial product.",
   "homepage": "https://www.scintilla.org/Lexilla.html",
   "supports": "windows & !uwp & !mingw",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4522,7 +4522,7 @@
     },
     "lexilla": {
       "baseline": "5.4.5",
-      "port-version": 0
+      "port-version": 1
     },
     "lfreist-hwinfo": {
       "baseline": "2025-07-10",

--- a/versions/l-/lexilla.json
+++ b/versions/l-/lexilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "15eba30d29c32623b2194b96fe4e283e27a0675f",
+      "version": "5.4.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "8f604b968642a903f1066078ab7b7c154a9736fb",
       "version": "5.4.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
