### PR TITLE
[yandex-disk-cpp-client] update to 1.0.2

### DIFF
--- a/ports/yandex-disk-cpp-client/portfile.cmake
+++ b/ports/yandex-disk-cpp-client/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_POLICY_ALLOW_DEBUG_SHARE enabled)
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Krasnovvvvv/yandex-disk-cpp-client
-        REF v1.0.1
-        SHA512 6edbcbb793475e8b90ed33793dc9f0d092a4ad86290010afbf6839adc494bb712a939f651440cb55d315d7f4650437df132e64fdb241a3a8f3ba196b0a8d3332
+        REF v1.0.2
+        SHA512 a020f997063bff09f1962141fd9a69c6f7b564e25ffbb5f9de06a72b08054810578ecf48efe420c94327cfb2c65f1f5b2dde37dc6e03beb9a0ab5eba85a2d170
         HEAD_REF main
 )
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
@@ -13,10 +13,11 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
-        PACKAGE_NAME "yandex_disk_client"
-        CONFIG_PATH "lib/cmake/yandex_disk_client"
+        PACKAGE_NAME "yandex-disk-cpp-client"
+        CONFIG_PATH "lib/cmake/yandex-disk-cpp-client"
 )
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+

--- a/ports/yandex-disk-cpp-client/usage
+++ b/ports/yandex-disk-cpp-client/usage
@@ -1,4 +1,10 @@
-yandex-disk-cpp-client provides CMake targets:
+yandex-disk-cpp-client provides CMake targets.
+
+Example usage in your CMakeLists.txt:
 
 find_package(yandex-disk-cpp-client CONFIG REQUIRED)
-target_link_libraries(your_target PRIVATE yandex-disk-cpp-client)
+find_package(nlohmann_json CONFIG REQUIRED)
+find_package(CURL CONFIG REQUIRED)
+
+target_link_libraries(your_target PRIVATE yandex-disk-cpp-client::yandex-disk-cpp-client)
+

--- a/ports/yandex-disk-cpp-client/vcpkg.json
+++ b/ports/yandex-disk-cpp-client/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yandex-disk-cpp-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Modern C++ client for Yandex.Disk REST API",
   "homepage": "https://github.com/Krasnovvvvv/yandex-disk-cpp-client",
   "documentation": "https://krasnovvvvv.github.io/yandex-disk-cpp-client/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10661,7 +10661,7 @@
       "port-version": 3
     },
     "yandex-disk-cpp-client": {
-      "baseline": "1.0.1",
+      "baseline": "1.0.2",
       "port-version": 0
     },
     "yara": {

--- a/versions/y-/yandex-disk-cpp-client.json
+++ b/versions/y-/yandex-disk-cpp-client.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a625222bbb208e4a9f17d8e771ee596473275b8",
+      "version": "1.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "21a8e95af5af3f3a08df0a1136273af3d9e2da1f",
       "version": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
## Update: yandex-disk-cpp-client v1.0.2 — add CMake config support

This PR updates the [yandex-disk-cpp-client](https://github.com/Krasnovvvvv/yandex-disk-cpp-client) port to v1.0.2, enhancing CMake and vcpkg integration.

### What's new:
- Added CMake config files (`yandex-disk-cpp-clientConfig.cmake`, `yandex-disk-cpp-clientConfigVersion.cmake`) for modern find_package workflow
- Proper installation of CMake targets and headers
- Usage file updated to include all dependent find_package calls (`nlohmann_json`, `CURL`)
- Documentation and README mention new integration method
- Successfully built and tested on x64-mingw-static triplet

### Usage

```cmake
find_package(yandex-disk-cpp-client CONFIG REQUIRED)
find_package(nlohmann_json CONFIG REQUIRED)
find_package(CURL CONFIG REQUIRED)
target_link_libraries(your_target PRIVATE yandex-disk-cpp-client::yandex-disk-cpp-client)
```


---

### New Port/Update Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] Port name matches naming guidelines and repology/namespace standards
- [x] All optional dependencies resolved and required find_package calls listed
- [x] Versioning scheme in `vcpkg.json` matches upstream tag
- [x] License in `vcpkg.json` matches upstream (MIT)
- [x] Correct copyright
- [x] Source comes from authoritative repo and release tag
- [x] Usage file accurately reflects integration steps and dependencies
- [x] Version database generated with `./vcpkg x-add-version --all` and only one version per versions file
- [x] Post-build checks pass and the port is tested locally

---

If any further changes are needed for compliance or integration, please let me know!

