### PR TITLE
[yandex-disk-cpp-client] update to v1.0.3

### DIFF
--- a/ports/yandex-disk-cpp-client/portfile.cmake
+++ b/ports/yandex-disk-cpp-client/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_POLICY_ALLOW_DEBUG_SHARE enabled)
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Krasnovvvvv/yandex-disk-cpp-client
-        REF v1.0.1
-        SHA512 6edbcbb793475e8b90ed33793dc9f0d092a4ad86290010afbf6839adc494bb712a939f651440cb55d315d7f4650437df132e64fdb241a3a8f3ba196b0a8d3332
+        REF v1.0.3
+        SHA512 de0e68aa0419f9918afea9fa7741477941d63c21e08cbe50d27a5fe9de7160a7a1f5ce4d307c906001aa757f82951295189c5d213b788987449d1a1b102da945
         HEAD_REF main
 )
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
@@ -13,8 +13,8 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
-        PACKAGE_NAME "yandex_disk_client"
-        CONFIG_PATH "lib/cmake/yandex_disk_client"
+        PACKAGE_NAME "yandex-disk-cpp-client"
+        CONFIG_PATH "lib/cmake/yandex-disk-cpp-client"
 )
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/yandex-disk-cpp-client/usage
+++ b/ports/yandex-disk-cpp-client/usage
@@ -1,4 +1,4 @@
 yandex-disk-cpp-client provides CMake targets:
 
 find_package(yandex-disk-cpp-client CONFIG REQUIRED)
-target_link_libraries(your_target PRIVATE yandex-disk-cpp-client)
+target_link_libraries(your_target PRIVATE yandex-disk-cpp-client::yandex-disk-cpp-client)

--- a/ports/yandex-disk-cpp-client/vcpkg.json
+++ b/ports/yandex-disk-cpp-client/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yandex-disk-cpp-client",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "Modern C++ client for Yandex.Disk REST API",
   "homepage": "https://github.com/Krasnovvvvv/yandex-disk-cpp-client",
   "documentation": "https://krasnovvvvv.github.io/yandex-disk-cpp-client/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10661,7 +10661,7 @@
       "port-version": 3
     },
     "yandex-disk-cpp-client": {
-      "baseline": "1.0.1",
+      "baseline": "1.0.3",
       "port-version": 0
     },
     "yara": {

--- a/versions/y-/yandex-disk-cpp-client.json
+++ b/versions/y-/yandex-disk-cpp-client.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ddb20a4777c4b753db8bb364238b33e36dee2ca",
+      "version": "1.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "21a8e95af5af3f3a08df0a1136273af3d9e2da1f",
       "version": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
## Update: yandex-disk-cpp-client v1.0.3 — improved CMake integration and automatic dependency handling

This PR updates the [yandex-disk-cpp-client](https://github.com/Krasnovvvvv/yandex-disk-cpp-client) port to v1.0.3, further enhancing CMake and vcpkg integration.

> **Note:** Version 1.0.2 was intentionally skipped in the vcpkg registry. See [closed PR #47900](https://github.com/microsoft/vcpkg/pull/47900) — it was closed to address a configuration improvement. v1.0.3 includes all changes from 1.0.2 and adds automated dependency discovery.

### What's new:
- The CMake package config now uses automatic dependency discovery:
    - Added `find_dependency(nlohmann_json CONFIG)` and `find_dependency(CURL CONFIG)` in the CMake config to automatically import required targets when consuming the library.
    - Users now only need:
    
      ```cmake
      find_package(yandex-disk-cpp-client CONFIG REQUIRED)
      target_link_libraries(your_target PRIVATE yandex-disk-cpp-client::yandex-disk-cpp-client)
      ```
      All required dependencies are imported automatically.
- Proper installation of CMake targets and headers
- Usage file updated to reflect simplified integration
- Successfully built and tested on x64-mingw-static triplet

---

### New Port/Update Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [x] Port name matches naming guidelines and repology/namespace standards
- [x] All optional dependencies resolved and required find_package calls handled automatically via find_dependency
- [x] Versioning scheme in vcpkg.json matches upstream tag
- [x] License in vcpkg.json matches upstream (MIT)
- [x] Copyright matches upstream
- [x] Source comes from authoritative repo and release tag
- [x] Usage file accurately reflects new integration steps
- [x] Version database generated with ./vcpkg x-add-version --all and only one version per versions file
- [x] Post-build checks pass and the port is tested locally

---

If any further changes are needed for compliance or integration, please let me know!



