### PR TITLE
[aws-c-http] update to 0.10.6

### DIFF
--- a/ports/aws-c-http/portfile.cmake
+++ b/ports/aws-c-http/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-http
     REF "v${VERSION}"
-    SHA512 8cc2ad5acc5af33552b9f1e72678e92ebef072eaff93071a15c5a77a04c6367b8223e281dbbf5a1d5e4714f4e4e344ffd1f045c4a10fe55a75f8d00bb72179d5
+    SHA512 a4c0bb1ab69c158b3ff6ca98bf9bd29400e2fb35a0d2cea3e3b7e8238580802d967b1a0d5127105bf4fc8aa74748f96dcd16131a9ed04c1a218d072f5ffbb5b3
     HEAD_REF master
 )
 

--- a/ports/aws-c-http/vcpkg.json
+++ b/ports/aws-c-http/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-http",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "C99 implementation of the HTTP/1.1 and HTTP/2 specifications",
   "homepage": "https://github.com/awslabs/aws-c-http",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-http.json
+++ b/versions/a-/aws-c-http.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8b075c958d4584c8007db00bf890f5c93419ee97",
+      "version": "0.10.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "15608b5014d67ddd4e5981a073b0d4a4fba716a9",
       "version": "0.10.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -453,7 +453,7 @@
       "port-version": 0
     },
     "aws-c-http": {
-      "baseline": "0.10.5",
+      "baseline": "0.10.6",
       "port-version": 0
     },
     "aws-c-io": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/awslabs/aws-c-http/releases/tag/v0.10.6
