### PR TITLE
[abseil] Remove the removed cxx17 feature from gtest

### DIFF
--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "abseil",
-  "version": "20250512.2",
+  "version": "20250512.1",
+  "port-version": 1,
   "description": [
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
     "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "abseil",
-  "version": "20250512.1",
+  "version": "20250512.2",
   "description": [
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
     "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",
@@ -23,9 +23,7 @@
       "description": "Build Abseil's test helpers",
       "dependencies": [
         "abseil",
-        {
-          "name": "gtest"
-        }
+        "gtest"
       ]
     }
   }

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -24,10 +24,7 @@
       "dependencies": [
         "abseil",
         {
-          "name": "gtest",
-          "features": [
-            "cxx17"
-          ]
+          "name": "gtest"
         }
       ]
     }

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "b1da0aef64445187772d35feb3bab59806e92396",
-      "version": "20250512.2",
-      "port-version": 0
+      "git-tree": "20bbb665cad5889db5e5f4beebad235d0d91a0bf",
+      "version": "20250512.1",
+      "port-version": 1
     },
     {
       "git-tree": "2999911d2655e693394770d9dd7600b277a86f37",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1da0aef64445187772d35feb3bab59806e92396",
+      "version": "20250512.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2999911d2655e693394770d9dd7600b277a86f37",
       "version": "20250512.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -17,7 +17,7 @@
       "port-version": 0
     },
     "abseil": {
-      "baseline": "20250512.1",
+      "baseline": "20250512.2",
       "port-version": 0
     },
     "absent": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -17,8 +17,8 @@
       "port-version": 0
     },
     "abseil": {
-      "baseline": "20250512.2",
-      "port-version": 0
+      "baseline": "20250512.1",
+      "port-version": 1
     },
     "absent": {
       "baseline": "0.3.1",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

I hit this error when I tried to install a port that depends on abseil.

```
  error: gtest@1.17.0#2 does not have required feature cxx17 needed by abseil:x64-windows@20250512.1
```

If I understand correctly, this is caused by the following change; `cxx17` feature no longer exists.

https://github.com/microsoft/vcpkg/pull/47593

This pull request attempts to fix it by removing the feature from the port JSON file. (I'm very new to vcpkg, so forgive me if I'm misunderstanding the mechanism...)

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
