### PR TITLE
Add cutecpp to vcpkg

### DIFF
--- a/ports/cutecpp/portfile.cmake
+++ b/ports/cutecpp/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jkCXf9X4/cutecpp
+    REF "${VERSION}"
+    SHA512 0b67421246a83ee32fa28b0e88369f07390c863e8e1aa4c34b2e210156ebf4c671139e2e173a7d5d6b1f938bc52184c3cc5fbe81f360a4398bb7efc6f63e67d4
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCUTECPP_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME cutecpp
+    CONFIG_PATH lib/cmake/cutecpp
+)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(
+    FILE_LIST "${SOURCE_PATH}/LICENSE"
+)

--- a/ports/cutecpp/usage
+++ b/ports/cutecpp/usage
@@ -1,0 +1,8 @@
+The package cutecpp provides CMake targets:
+
+    find_package(cutecpp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE cutecpp::cutecpp)
+
+Public headers live under the `cutecpp/` include directory, for example:
+
+    #include <cutecpp/log.hpp>

--- a/ports/cutecpp/vcpkg.json
+++ b/ports/cutecpp/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "cutecpp",
+  "version": "0.1.1",
+  "description": "Lightweight C++23 logging library that forwards structured telemetry to Cutelog.",
+  "homepage": "https://github.com/jkCXf9X4/cutecpp",
+  "license": "MIT",
+  "dependencies": [
+    "kissnet",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2252,6 +2252,10 @@
       "baseline": "2019-09-20",
       "port-version": 2
     },
+    "cutecpp": {
+      "baseline": "0.1.1",
+      "port-version": 0
+    },
     "cutelyst2": {
       "baseline": "2.12.0",
       "port-version": 2

--- a/versions/c-/cutecpp.json
+++ b/versions/c-/cutecpp.json
@@ -1,0 +1,14 @@
+{
+  "versions": [
+    {
+      "git-tree": "7090f44646e546086bfea424e1581eef1d2b9577",
+      "version": "0.1.1",
+      "port-version": 0
+    },
+    {
+      "git-tree": "7b912788b4a5cbe671f8e23b8eaa187ada1481e3",
+      "version-semver": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

- [ x ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ x ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ x ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ x ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ x ] The license declaration in `vcpkg.json` matches what upstream says.
- [ x ] The installed as the "copyright" file matches what upstream says.
- [ x ] The source code of the component installed comes from an authoritative source.
- [ x ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ x ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x ] Only one version is in the new port's versions file.
- [ x ] Only one version is added to each modified port's versions file.
