### PR TITLE
[cspice] Install headers under the standard install location

### DIFF
--- a/ports/cspice/CMakeLists.txt
+++ b/ports/cspice/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required(VERSION 3.1)
-project(cspice LANGUAGES C)
+project(cspice
+    VERSION 67
+    DESCRIPTION "The NAIF SPICE Toolkit (C version)"
+    HOMEPAGE_URL "https://naif.jpl.nasa.gov/naif/toolkit.html"
+    LANGUAGES C
+)
 
-set(SOVERSION 67)
+set(SOVERSION ${PROJECT_VERSION})
+
+include(GNUInstallDirs)
 
 # Include all *.c files from the library
 file(GLOB CSPICE_SOURCE ${PROJECT_SOURCE_DIR}/cspice/src/cspice/*.c)
@@ -29,7 +36,7 @@ endif ()
 
 if (NOT _SKIP_HEADERS)
     file(GLOB SPICE_HEADERS ${INCLUDE_PATH}/*.h)
-    install(FILES ${SPICE_HEADERS} DESTINATION include/cspice)
+    install(FILES ${SPICE_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cspice)
 endif()
 
 set_target_properties(

--- a/ports/cspice/CMakeLists.txt
+++ b/ports/cspice/CMakeLists.txt
@@ -14,11 +14,7 @@ include(GNUInstallDirs)
 file(GLOB CSPICE_SOURCE ${PROJECT_SOURCE_DIR}/cspice/src/cspice/*.c)
 set(INCLUDE_PATH "${PROJECT_SOURCE_DIR}/cspice/include")
 
-if (_STATIC_BUILD)
-    add_library(cspice STATIC ${CSPICE_SOURCE})
-else()
-    add_library(cspice SHARED ${CSPICE_SOURCE})
-endif()
+add_library(cspice ${CSPICE_SOURCE})
 target_include_directories(cspice PUBLIC "${INCLUDE_PATH}")
 
 if (WIN32)

--- a/ports/cspice/CMakeLists.txt
+++ b/ports/cspice/CMakeLists.txt
@@ -15,17 +15,17 @@ file(GLOB CSPICE_SOURCE ${PROJECT_SOURCE_DIR}/cspice/src/cspice/*.c)
 set(INCLUDE_PATH "${PROJECT_SOURCE_DIR}/cspice/include")
 
 add_library(cspice ${CSPICE_SOURCE})
-target_include_directories(cspice PUBLIC "${INCLUDE_PATH}")
+target_include_directories(cspice PRIVATE "${INCLUDE_PATH}")
 
 if (WIN32)
-    target_compile_definitions(cspice PUBLIC "_COMPLEX_DEFINED;MSDOS;OMIT_BLANK_CC;NON_ANSI_STDIO;_CRT_SECURE_NO_WARNINGS")
+    target_compile_definitions(cspice PRIVATE "_COMPLEX_DEFINED;MSDOS;OMIT_BLANK_CC;NON_ANSI_STDIO;_CRT_SECURE_NO_WARNINGS")
     set_target_properties(cspice PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 elseif (UNIX)
-    target_compile_definitions(cspice PUBLIC "NON_UNIX_STDIO")
+    target_compile_definitions(cspice PRIVATE "NON_UNIX_STDIO")
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        target_compile_options(cspice PUBLIC -m64 -ansi -fPIC)
+        target_compile_options(cspice PRIVATE -m64 -ansi)
     elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
-        target_compile_options(cspice PUBLIC -m32 -ansi -fPIC) 
+        target_compile_options(cspice PRIVATE -m32 -ansi) 
     endif()
     target_compile_options(cspice PRIVATE -Wno-error=implicit-function-declaration)
 endif ()
@@ -35,9 +35,10 @@ if (NOT _SKIP_HEADERS)
     install(FILES ${SPICE_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cspice)
 endif()
 
-set_target_properties(
-    cspice
-    PROPERTIES SOVERSION ${SOVERSION}
+set_target_properties(cspice PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${SOVERSION}
+    POSITION_INDEPENDENT_CODE ON
 )
 
 install(

--- a/ports/cspice/portfile.cmake
+++ b/ports/cspice/portfile.cmake
@@ -44,10 +44,6 @@ vcpkg_extract_source_archive(
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    set(_STATIC_BUILD ON)
-endif()
-
 if (VCPKG_TARGET_IS_UWP)
     set(VCPKG_C_FLAGS "/sdl- ${VCPKG_C_FLAGS}")
     set(VCPKG_CXX_FLAGS "/sdl- ${VCPKG_CXX_FLAGS}")
@@ -55,7 +51,6 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS -D_STATIC_BUILD=${_STATIC_BUILD}
     OPTIONS_DEBUG -D_SKIP_HEADERS=ON
 )
 

--- a/ports/cspice/vcpkg.json
+++ b/ports/cspice/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cspice",
   "version": "67",
-  "port-version": 3,
+  "port-version": 4,
   "description": "NASA C SPICE toolkit",
   "homepage": "https://naif.jpl.nasa.gov/naif/toolkit_C.html",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2178,7 +2178,7 @@
     },
     "cspice": {
       "baseline": "67",
-      "port-version": 3
+      "port-version": 4
     },
     "ctbench": {
       "baseline": "1.3.4",

--- a/versions/c-/cspice.json
+++ b/versions/c-/cspice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a3135f1354236ddb97d6ce9d7a48effe21c56315",
+      "git-tree": "77abf7ea346da954da35511c138268e7014b86b0",
       "version": "67",
       "port-version": 4
     },

--- a/versions/c-/cspice.json
+++ b/versions/c-/cspice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3135f1354236ddb97d6ce9d7a48effe21c56315",
+      "version": "67",
+      "port-version": 4
+    },
+    {
       "git-tree": "a87828fb249f8a2f9d6ded34e0c8e79f4349d842",
       "version": "67",
       "port-version": 3

--- a/versions/c-/cspice.json
+++ b/versions/c-/cspice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "77abf7ea346da954da35511c138268e7014b86b0",
+      "git-tree": "4d85cfbe9506eb213eea260b99d8a73b9f30d3c7",
       "version": "67",
       "port-version": 4
     },


### PR DESCRIPTION
This PR fixes the install location of the CSPICE headers so dependent packages can find them. Prior to the change the headers were installed under the vcpkg build directory, instead of `CMAKE_INSTALL_INCLUDEDIR`. Also:

- complete the project metadata in `vcpkg.json`.
- let cmake handle building static vs shared libs automatically
- use `PRIVATE` settings for build configs
- set target property `POSITION_INDEPENDENT_CODE=ON` instead of `-fPIC` compile option.

The update fixes only the vcpkg config, no change to upstream.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


