### PR TITLE
[restinio] update to 0.7.8

### DIFF
--- a/ports/restinio/fix-cmake-policy.patch
+++ b/ports/restinio/fix-cmake-policy.patch
@@ -1,0 +1,14 @@
+diff --git a/dev/restinio/CMakeLists.txt b/dev/restinio/CMakeLists.txt
+index 4a5b480..9c280d6 100644
+--- a/dev/restinio/CMakeLists.txt
++++ b/dev/restinio/CMakeLists.txt
+@@ -1,6 +1,8 @@
+ cmake_minimum_required(VERSION 3.10)
+ 
+-cmake_policy(SET CMP0177 NEW)
++if(POLICY CMP0177)
++    cmake_policy(SET CMP0177 NEW)
++endif()
+ 
+ if(NOT RESTINIO_LIBRARY_NAME)
+     # That must be the case when RESTinio is used as a dependency.

--- a/ports/restinio/portfile.cmake
+++ b/ports/restinio/portfile.cmake
@@ -2,7 +2,9 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stiffstream/restinio
     REF "v${VERSION}"
-    SHA512 02427f50c725ad15ba16518d946dbeea881d9ba0c5d1783c0645ca3e6c684ab4063f6fac9c69dd74366d4aef53a6b3333ec31cbb5b8ca3935c7ab427f24f8738
+    SHA512 66b1b2109258179685e2daa7f08d6684c2900a65a7e427e2c9ff7671571eafff102d19da7c1a9ac76cefa21d5cfce66b88ea0ed0ee4be614392e6fccb6d07bf4
+    PATCHES
+        fix-cmake-policy.patch
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only

--- a/ports/restinio/vcpkg.json
+++ b/ports/restinio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "restinio",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "A header-only C++14 library that gives you an embedded HTTP/Websocket server targeted primarily for asynchronous processing of HTTP-requests.",
   "homepage": "https://github.com/Stiffstream/restinio",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8461,7 +8461,7 @@
       "port-version": 0
     },
     "restinio": {
-      "baseline": "0.7.7",
+      "baseline": "0.7.8",
       "port-version": 0
     },
     "resultlib": {

--- a/versions/r-/restinio.json
+++ b/versions/r-/restinio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b671cde8462a6ed06a632cd1430c4e9818d66b06",
+      "version": "0.7.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "6e7b752fc58f684c95116d8c8bdc2ba860ea9889",
       "version": "0.7.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Stiffstream/restinio/releases/tag/v0.7.8
