### PR TITLE
[arun11299-cpp-subprocess] update to 2.5

### DIFF
--- a/ports/arun11299-cpp-subprocess/find-threads.patch
+++ b/ports/arun11299-cpp-subprocess/find-threads.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/subprocess-config.cmake b/cmake/subprocess-config.cmake
+index 004d900..99c7ff9 100644
+--- a/cmake/subprocess-config.cmake
++++ b/cmake/subprocess-config.cmake
+@@ -1,3 +1,7 @@
++include(CMakeFindDependencyMacro)
++
++find_dependency(Threads)
++
+ set(SUBPROCESS_VERSION @PROJECT_VERSION@)
+ 
+ @PACKAGE_INIT@

--- a/ports/arun11299-cpp-subprocess/fix-cmake-config-name.patch
+++ b/ports/arun11299-cpp-subprocess/fix-cmake-config-name.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c21809e..a5b1034 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,14 +28,14 @@ if(SUBPROCESS_INSTALL)
+     include(CMakePackageConfigHelpers)
+ 
+     configure_package_config_file(
+-        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/subprocess-config.cmake.in"
++        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/subprocess-config.cmake"
+         "${CMAKE_CURRENT_BINARY_DIR}/subprocess-config.cmake"
+         INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/subprocess"
+         PATH_VARS PROJECT_NAME PROJECT_VERSION
+     )
+ 
+     write_basic_package_version_file(
+-        "${CMAKE_CURRENT_BINARY_DIR}/beman.exemplar-version.cmake"
++        "${CMAKE_CURRENT_BINARY_DIR}/subprocess-version.cmake"
+         VERSION ${PROJECT_VERSION}
+         COMPATIBILITY ExactVersion
+     )
+@@ -50,7 +50,7 @@ if(SUBPROCESS_INSTALL)
+ 
+     install(
+         EXPORT subprocess
+-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/beman.exemplar"
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/subprocess"
+         NAMESPACE cpp-subprocess::
+         FILE subprocess-targets.cmake
+         COMPONENT subprocess

--- a/ports/arun11299-cpp-subprocess/portfile.cmake
+++ b/ports/arun11299-cpp-subprocess/portfile.cmake
@@ -2,8 +2,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO arun11299/cpp-subprocess
     REF "v${VERSION}"
-    SHA512 5be80a4a181f8534b6e2b36a2b192b77edd70b527ef881195ef02e915a1f78c894a804029a82f2f927c5194baef71a4f3184c124d42a6dd3c53cdc694410a576
+    SHA512 9901e97003276255fa4b7d97c9d1cc17f9c3a5b29a108ad3c4ed10c9794fb379a568ba587858a556630df2387cffd288e83fafeceae327aa7928635ba3121a49
     HEAD_REF master
+    PATCHES
+        fix-cmake-config-name.patch
+        find-threads.patch
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port
@@ -16,6 +19,8 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME subprocess CONFIG_PATH lib/cmake/subprocess)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 

--- a/ports/arun11299-cpp-subprocess/vcpkg.json
+++ b/ports/arun11299-cpp-subprocess/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "arun11299-cpp-subprocess",
-  "version": "2.1",
+  "version": "2.5",
   "description": "Subprocessing with modern C++ ",
   "homepage": "https://github.com/arun11299/cpp-subprocess",
   "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/a-/arun11299-cpp-subprocess.json
+++ b/versions/a-/arun11299-cpp-subprocess.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c4fac4523bb15be0c0ef151ae919ad604626cde6",
+      "version": "2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "7d613f0bdb1d9ccf52f8aa1bcaf6e31770bb9f40",
       "version": "2.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -281,7 +281,7 @@
       "port-version": 0
     },
     "arun11299-cpp-subprocess": {
-      "baseline": "2.1",
+      "baseline": "2.5",
       "port-version": 0
     },
     "ashes": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/arun11299/cpp-subprocess/releases/tag/v2.5
