### PR TITLE
[libheif] support openjph

### DIFF
--- a/ports/libheif/find-modules.diff
+++ b/ports/libheif/find-modules.diff
@@ -36,3 +36,28 @@ index ae8d8be..95898fe 100644
      HINTS ${X265_PKGCONF_LIBRARY_DIRS} ${X265_PKGCONF_LIBDIR}
  )
  
+diff --git a/cmake/modules/FindOPENJPH.cmake b/cmake/modules/FindOPENJPH.cmake
+index 443f9d6..fbb11ae 100644
+--- a/cmake/modules/FindOPENJPH.cmake
++++ b/cmake/modules/FindOPENJPH.cmake
+@@ -9,15 +9,16 @@ find_path(OPENJPH_INCLUDE_DIR
+ 
+ find_library(OPENJPH_LIBRARY
+     NAMES libopenjph openjph
++    NAMES_PER_DIR
+     HINTS ${OPENJPH_PKGCONF_LIBRARY_DIRS} ${OPENJPH_PKGCONF_LIBDIR}
+ )
+ 
+ set(OPENJPH_PROCESS_LIBS OPENJPH_LIBRARY)
+-set(OPENJPH_PROCESS_INCLUDES OPENJPH_INCLUDE_DIR)
+-libfind_process(OPENJPH)
++set(OPENJPH_PROCESS_INCLUDES openjph_INCLUDE_DIR)
++libfind_process(openjph)
+ 
+ include(FindPackageHandleStandardArgs)
+-find_package_handle_standard_args(OPENJPH
++find_package_handle_standard_args(openjph
+     REQUIRED_VARS
+-        OPENJPH_INCLUDE_DIR
++        openjph_INCLUDE_DIR
+         OPENJPH_LIBRARY

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -27,6 +27,9 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         openjpeg    WITH_OpenJPEG_DECODER
         openjpeg    WITH_OpenJPEG_ENCODER
         openjpeg    VCPKG_LOCK_FIND_PACKAGE_OpenJPEG
+        openjph     WITH_OPENJPH_ENCODER
+        openjph     WITH_OPENJPH_DECODER
+        openjph     VCPKG_LOCK_FIND_PACKAGE_OPENJPH
 )
 
 vcpkg_find_acquire_program(PKGCONFIG)

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libheif",
   "version": "1.20.2",
+  "port-version": 1,
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",
@@ -60,6 +61,13 @@
       "license": "BSD-2-Clause",
       "dependencies": [
         "openjpeg"
+      ]
+    },
+    "openjph": {
+      "description": "OpenJPH HT-J2K decoding and encoding via OpenJPH",
+      "license": "BSD-2-Clause",
+      "dependencies": [
+        "openjph"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4934,7 +4934,7 @@
     },
     "libheif": {
       "baseline": "1.20.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libhsplasma": {
       "baseline": "2024-03-07",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "caff05b0f8d8e68f0be9efce0d92c1a490170f59",
+      "git-tree": "a6ba070bb3076789c373a4881a1479d8e90cda07",
       "version": "1.20.2",
       "port-version": 1
     },

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "caff05b0f8d8e68f0be9efce0d92c1a490170f59",
+      "version": "1.20.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "71519f65f5aa00ded247297c0c899ff679d869b9",
       "version": "1.20.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/strukturag/libheif/blob/v1.20.2/CMakeLists.txt#L272
