### PR TITLE
Update asiosdk version

### DIFF
--- a/ports/asiosdk/portfile.cmake
+++ b/ports/asiosdk/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://download.steinberg.net/sdk_downloads/asiosdk_2.3.3_2019-06-14.zip"
-    FILENAME "asiosdk_2.3.3_2019-06-14-d74c0bc09162.zip"
-    SHA512 d74c0bc09162640a377aaab2f2ce716f9ee7a6ef8d1aa1aa6bc223a4748c60fa900cc77b1cf6db66f8a4064a074b31a71d75cccc7de3634347865238d9c039af
+    URLS "https://download.steinberg.net/sdk_downloads/ASIO-SDK_2.3.4_2025-10-15.zip"
+    FILENAME "ASIO-SDK_2.3.4_2025-10-15-57de2c0cd0df.zip"
+    SHA512 57de2c0cd0df0783275987e08255abfa49da12982f9d462ac40b7f57300c36e024dcb65d100b799fb3c96a9c7c5ee86e61ceb0e68d2839324206c1629d3905ed
 )
 
 vcpkg_extract_source_archive(
@@ -15,14 +15,16 @@ file(INSTALL "${SOURCE_PATH}/common/" DESTINATION "${CURRENT_PACKAGES_DIR}/inclu
 file(INSTALL "${SOURCE_PATH}/driver/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/driver")
 file(INSTALL "${SOURCE_PATH}/host/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/host")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/readme.txt")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
 
 file(
     INSTALL
         "${SOURCE_PATH}/changes.txt"
-        "${SOURCE_PATH}/Steinberg ASIO Logo Artwork.zip"
-        "${SOURCE_PATH}/Steinberg ASIO 2.3.3 Licensing Agreement V2.0.3 - 2023.pdf"
-        "${SOURCE_PATH}/ASIO SDK 2.3.pdf"
+        "${SOURCE_PATH}/Steinberg ASIO Logo Artwork"
+        "${SOURCE_PATH}/Steinberg ASIO Usage Guidelines.pdf"
+        "${SOURCE_PATH}/Steinberg ASIO Licensing Agreement.pdf"
+        "${SOURCE_PATH}/Steinberg ASIO SDK 2.3.pdf"
+        "${SOURCE_PATH}/README.md"
         "${CMAKE_CURRENT_LIST_DIR}/Findasiosdk.cmake"
         "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
     DESTINATION

--- a/ports/asiosdk/vcpkg.json
+++ b/ports/asiosdk/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "name": "asiosdk",
-  "version": "2.3.3",
-  "port-version": 7,
+  "version": "2.3.4",
   "description": "ASIO is a low latency audio API from Steinberg.",
-  "homepage": "https://www.steinberg.net/en/company/developers.html",
+  "homepage": "https://www.steinberg.net/developers/asiosdk-open/",
   "supports": "windows & !(arm | uwp)"
 }

--- a/versions/a-/asiosdk.json
+++ b/versions/a-/asiosdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "995bc94ecf43d85d36831f063d9c11d3710a88e5",
+      "version": "2.3.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "798527dff966ba5c7ef8aab89eb941791d682090",
       "version": "2.3.3",
       "port-version": 7

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -301,8 +301,8 @@
       "port-version": 1
     },
     "asiosdk": {
-      "baseline": "2.3.3",
-      "port-version": 7
+      "baseline": "2.3.4",
+      "port-version": 0
     },
     "asmjit": {
       "baseline": "2025-01-22",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

