### PR TITLE
[libhv] Add mbedtls feature.

### DIFF
--- a/ports/libhv/portfile.cmake
+++ b/ports/libhv/portfile.cmake
@@ -12,6 +12,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         ssl WITH_OPENSSL
+        mbedtls WITH_MBEDTLS
 )
 
 vcpkg_cmake_configure(

--- a/ports/libhv/vcpkg.json
+++ b/ports/libhv/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libhv",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Libhv is a C/C++ network library similar to libevent/libuv.",
   "homepage": "https://github.com/ithewei/libhv",
   "license": "BSD-3-Clause",

--- a/ports/libhv/vcpkg.json
+++ b/ports/libhv/vcpkg.json
@@ -21,6 +21,12 @@
       "dependencies": [
         "openssl"
       ]
+    },
+    "mbedtl": {
+      "description": "with MbedTLS library",
+      "dependencies": [
+        "mbedtls"
+      ]
     }
   }
 }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
