### PR TITLE
[vcpkg-make] Check system deps by running aclocal

### DIFF
--- a/ports/libxcrypt/portfile.cmake
+++ b/ports/libxcrypt/portfile.cmake
@@ -1,7 +1,5 @@
 set(VCPKG_POLICY_ALLOW_RESTRICTED_HEADERS enabled)
 
-message(STATUS "${PORT} requires libltdl-dev from the system package manager (example: \"sudo apt install libltdl-dev\")")
-
 vcpkg_find_acquire_program(PERL)
 set(ENV{PERL} "${PERL}")
 

--- a/ports/libxcrypt/vcpkg.json
+++ b/ports/libxcrypt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libxcrypt",
   "version": "4.4.38",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libxcrypt is a modern library for one-way hashing of passwords. On Linux-based systems, by default libxcrypt will be binary backward compatible with the libcrypt.so.1 shipped as part of the GNU C Library.",
   "homepage": "https://github.com/besser82/libxcrypt",
   "license": null,

--- a/ports/vcpkg-make/configure.ac
+++ b/ports/vcpkg-make/configure.ac
@@ -1,0 +1,8 @@
+AC_INIT([check-autoconf], [1.0])
+AM_INIT_AUTOMAKE
+# vcpkg begin
+m4_ifndef([AX_CHECK_COMPILE_FLAG], [m4_errprintn([System package autoconf-archive is missing.])])
+m4_ifndef([LT_INIT],               [m4_errprintn([System package libtool is missing.])])
+m4_ifndef([LTDL_INIT],             [m4_errprintn([System package libltdl-dev is missing.])])
+# vcpkg end
+AC_OUTPUT

--- a/ports/vcpkg-make/portfile.cmake
+++ b/ports/vcpkg-make/portfile.cmake
@@ -15,9 +15,10 @@ vcpkg_extract_source_archive(
 )
 
 file(COPY
+        "${CMAKE_CURRENT_LIST_DIR}/configure.ac"
+        "${CMAKE_CURRENT_LIST_DIR}/vcpkg_make_common.cmake"
         "${CMAKE_CURRENT_LIST_DIR}/vcpkg_make_configure.cmake"
         "${CMAKE_CURRENT_LIST_DIR}/vcpkg_make_install.cmake"
-        "${CMAKE_CURRENT_LIST_DIR}/vcpkg_make_common.cmake"
         "${CMAKE_CURRENT_LIST_DIR}/vcpkg_make.cmake"
         "${CMAKE_CURRENT_LIST_DIR}/vcpkg_scripts.cmake"
         "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake"

--- a/ports/vcpkg-make/vcpkg.json
+++ b/ports/vcpkg-make/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-make",
-  "version-date": "2025-09-29",
+  "version-date": "2025-10-26",
   "documentation": "https://learn.microsoft.com/vcpkg/maintainers/functions/vcpkg_make_configure",
   "license": null,
   "supports": "native",

--- a/ports/vcpkg-make/vcpkg_make.cmake
+++ b/ports/vcpkg-make/vcpkg_make.cmake
@@ -75,15 +75,42 @@ function(vcpkg_run_shell_as_build)
 endfunction()
 
 function(vcpkg_run_autoreconf shell_cmd work_dir)
-    find_program(AUTOCONF NAMES autoconf)
-    find_program(AUTOMAKE NAMES automake)
-    find_program(AUTORECONF NAMES autoreconf)
-    find_program(LIBTOOLIZE NAMES libtoolize glibtoolize)
-    if(NOT AUTOCONF OR NOT AUTOMAKE OR NOT AUTORECONF OR NOT LIBTOOLIZE)
+    find_program(ACLOCAL NAMES aclocal)
+    find_program(AUTORECONF NAMES autoreconf)             # from autoconf
+    find_program(LIBTOOLIZE NAMES libtoolize glibtoolize) # from libtool
+
+    set(missing "")
+    if(NOT AUTORECONF)
+        list(APPEND missing "autoconf")
+    endif()
+    if(NOT ACLOCAL)
+        list(APPEND missing "automake")
+    else()
+        set(aclocal_check_dir "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vcpkg-aclocal")
+        file(REMOVE_RECURSE "${aclocal_check_dir}")
+        file(MAKE_DIRECTORY "${aclocal_check_dir}")
+        file(COPY_FILE "${CURRENT_HOST_INSTALLED_DIR}/share/vcpkg-make/configure.ac" "${aclocal_check_dir}/configure.ac")
+        vcpkg_run_shell(
+            SHELL ${shell_cmd}
+            COMMAND "${ACLOCAL}" --dry-run
+            WORKING_DIRECTORY "${aclocal_check_dir}"
+            LOGNAME "aclocal-${TARGET_TRIPLET}"
+        )
+        file(STRINGS "${CURRENT_BUILDTREES_DIR}/aclocal-${TARGET_TRIPLET}-err.log" autoconf_archive REGEX "autoconf-archive")
+        if(autoconf_archive MATCHES "missing")
+            string(APPEND missing "autoconf-archive")
+        endif()
+    endif()
+    if(NOT LIBTOOLIZE)
+        list(APPEND missing "libtool")
+    endif()
+    if(missing)
+        list(JOIN missing " " missing)
         message(FATAL_ERROR "${PORT} currently requires the following programs from the system package manager:
-        autoconf autoconf-archive automake libtoolize
+    autoconf autoconf-archive automake libtoolize
+
     On Debian and Ubuntu derivatives:
-        sudo apt-get install autoconf autoconf-archive automake libtool
+        sudo apt install autoconf autoconf-archive automake libtool
     On recent Red Hat and Fedora derivatives:
         sudo dnf install autoconf autoconf-archive automake libtool
     On Arch Linux and derivatives:
@@ -106,13 +133,14 @@ function(vcpkg_run_autoreconf shell_cmd work_dir)
             message(STATUS "${PORT} depends on gtk-doc infrastructure.")
             message(STATUS "'set(ENV{GTKDOCIZE} true)' might disable this dependency.")
         endif()
-        if(configure_ac MATCHES "LT_CONFIG_LTDL_DIR")
-            message(STATUS "${PORT} depends on ltdl development files.")
-            message([[
-        On Debian and Ubuntu derivatives:
-            sudo apt-get install libltdl-dev
-        On recent Red Hat and Fedora derivatives:
-            sudo dnf install libtool-ltdl-devel]])
+        file(STRINGS "${CURRENT_BUILDTREES_DIR}/aclocal-${TARGET_TRIPLET}-err.log" libltdl REGEX "libltdl")
+        if(configure_ac MATCHES "LT_CONFIG_LTDL_DIR|LT_SYS_SYMBOL_USCORE" AND libltdl MATCHES "missing")
+            message(FATAL_ERROR "${PORT} depends on ltdl development files from the system package manager:
+        
+    On Debian and Ubuntu derivatives:
+        sudo apt install libltdl-dev
+    On recent Red Hat and Fedora derivatives:
+        sudo dnf install libtool-ltdl-devel\n")
         endif()
     endif()
     message(STATUS "Generating configure for ${TARGET_TRIPLET}")

--- a/ports/vcpkg-make/vcpkg_make.cmake
+++ b/ports/vcpkg-make/vcpkg_make.cmake
@@ -76,8 +76,8 @@ endfunction()
 
 function(vcpkg_run_autoreconf shell_cmd work_dir)
     find_program(ACLOCAL NAMES aclocal)
-    find_program(AUTORECONF NAMES autoreconf)             # from autoconf
-    find_program(LIBTOOLIZE NAMES libtoolize glibtoolize) # from libtool
+    find_program(AUTORECONF NAMES autoreconf)
+    find_program(LIBTOOLIZE NAMES libtoolize glibtoolize)
 
     set(missing "")
     if(NOT AUTORECONF)
@@ -105,7 +105,6 @@ function(vcpkg_run_autoreconf shell_cmd work_dir)
         list(APPEND missing "libtool")
     endif()
     if(missing)
-        list(JOIN missing " " missing)
         message(FATAL_ERROR "${PORT} currently requires the following programs from the system package manager:
     autoconf autoconf-archive automake libtoolize
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10105,7 +10105,7 @@
       "port-version": 0
     },
     "vcpkg-make": {
-      "baseline": "2025-09-29",
+      "baseline": "2025-10-26",
       "port-version": 0
     },
     "vcpkg-msbuild": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5714,7 +5714,7 @@
     },
     "libxcrypt": {
       "baseline": "4.4.38",
-      "port-version": 1
+      "port-version": 2
     },
     "libxcvt": {
       "baseline": "0.1.2",

--- a/versions/l-/libxcrypt.json
+++ b/versions/l-/libxcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2130f0d0eeac155bbeca85087059aa313920d900",
+      "version": "4.4.38",
+      "port-version": 2
+    },
+    {
       "git-tree": "aaeafd38f470fad91c0372b06a34c71f491457bd",
       "version": "4.4.38",
       "port-version": 1

--- a/versions/v-/vcpkg-make.json
+++ b/versions/v-/vcpkg-make.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3289b4655cc24e18d06339987a6b44ca20033ad",
+      "version-date": "2025-10-26",
+      "port-version": 0
+    },
+    {
       "git-tree": "73a90e27dfaf176bb25ec339e8b3077054de52da",
       "version-date": "2025-09-29",
       "port-version": 0

--- a/versions/v-/vcpkg-make.json
+++ b/versions/v-/vcpkg-make.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d3289b4655cc24e18d06339987a6b44ca20033ad",
+      "git-tree": "f5115f8cfeae1176d98357dcdc29535bfe33b9ad",
       "version-date": "2025-10-26",
       "port-version": 0
     },


### PR DESCRIPTION
Improve diagnostics for missing system autoconf-archive (popular: icu) and libltdl-dev (which comes with LT_SYS_SYMBOL_USCORE for libxcrypt).

For #47920.