### PR TITLE
[lief] update to 0.17.1

### DIFF
--- a/ports/lief/portfile.cmake
+++ b/ports/lief/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lief-project/LIEF
     REF ${VERSION}
-    SHA512 deb81b887f328baa571b8c98d58be48ccc249b9145b241054743e47dae50bf301f62bfd6649647358769c10ca81c990cbd026ac5df45b4ebe5d1bce0f5b90e2d
+    SHA512 1e00dcb6d4fb06df5bc74c457d846f2d84cb3200679138cb0d87cbe38de27598207cbb159bc4090312d5f299d1541a8aa461b2fc70a6f725440fb9fbf4c35f45
     HEAD_REF master
     PATCHES
         fix-cmakelists.patch

--- a/ports/lief/vcpkg.json
+++ b/ports/lief/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lief",
-  "version-semver": "0.17.0",
+  "version-semver": "0.17.1",
   "description": "LIEF - Library to Instrument Executable Formats",
   "homepage": "https://lief.quarkslab.com",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5861,7 +5861,7 @@
       "port-version": 1
     },
     "lief": {
-      "baseline": "0.17.0",
+      "baseline": "0.17.1",
       "port-version": 0
     },
     "lightgbm": {

--- a/versions/l-/lief.json
+++ b/versions/l-/lief.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0573ff510edd3f39a2b5abd485b2ea0e3bcb2cbb",
+      "version-semver": "0.17.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6010290f828d52bd60856596ad56990f1685566e",
       "version-semver": "0.17.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/lief-project/LIEF/releases/tag/0.17.1
