### PR TITLE
[nuklear] update to 4.12.8

### DIFF
--- a/ports/nuklear/portfile.cmake
+++ b/ports/nuklear/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Immediate-Mode-UI/Nuklear
     REF "${VERSION}"
-    SHA512 91ecd8237185d57ebdbae0f314cadcd88686a6aba76ad069e00f7fd35e770aa0f2f8fb62446b58b6fe6ca75522cdad6be2402bd7b469d21d7aa19f8ef31cc93b
+    SHA512 fc3613fc579825d22c103225bcca72d1e9fbb349fe06237e4d77652d7af3293e33e983be03dd4180c93c4c7602a2529c5c1edd87cde3d5efe09ec787818bac48
     HEAD_REF master
 )
 

--- a/ports/nuklear/vcpkg.json
+++ b/ports/nuklear/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.12.7",
+  "version": "4.12.8",
   "description": "This is a minimal state immediate mode graphical user interface toolkit written in ANSI C and licensed under public domain",
   "homepage": "https://github.com/Immediate-Mode-UI/Nuklear",
   "license": "Unlicense OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6889,7 +6889,7 @@
       "port-version": 0
     },
     "nuklear": {
-      "baseline": "4.12.7",
+      "baseline": "4.12.8",
       "port-version": 0
     },
     "numactl": {

--- a/versions/n-/nuklear.json
+++ b/versions/n-/nuklear.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4259b1f7b07c9a766c7501a92df049e6dcfd80a",
+      "version": "4.12.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "1c55fda3248b3eaf98b57595e3a5ef4aac4278fc",
       "version": "4.12.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Immediate-Mode-UI/Nuklear/releases/tag/4.12.8
