### PR TITLE
[otl] update to 4.0.494

### DIFF
--- a/ports/otl/portfile.cmake
+++ b/ports/otl/portfile.cmake
@@ -1,9 +1,9 @@
-set(OTL_VERSION 40491)
+set(OTL_VERSION 40494)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "http://otl.sourceforge.net/otlv4_${OTL_VERSION}.zip"
     FILENAME "otlv4_${OTL_VERSION}.zip"
-    SHA512 11f6e11c2eb128dea5b6d1e9eef1f033deac02f7ed063e3709969f66963bf68162f06cb11332d14a2fe341df0fb28313be49ddac0b2264e7a10a624fe662e8b1
+    SHA512 1adf481e063c834b3124d449fc5db162ed7a8ec4b8dec52b30c9b58d65184d85312c255daab17465f5d3bf36bb747545b6223be05c337d181bf5381b33428fee
 )
 
 vcpkg_extract_source_archive(

--- a/ports/otl/vcpkg.json
+++ b/ports/otl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "otl",
-  "version": "4.0.491",
+  "version": "4.0.494",
   "description": "Oracle, Odbc and DB2-CLI Template Library",
   "homepage": "https://otl.sourceforge.net/",
   "license": "ISC"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7297,7 +7297,7 @@
       "port-version": 0
     },
     "otl": {
-      "baseline": "4.0.491",
+      "baseline": "4.0.494",
       "port-version": 0
     },
     "outcome": {

--- a/versions/o-/otl.json
+++ b/versions/o-/otl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20fefb711b31cee29eac033c9b7becf4a1ae2c8e",
+      "version": "4.0.494",
+      "port-version": 0
+    },
+    {
       "git-tree": "1599648151a781567250c9736b997bb9664c3d26",
       "version": "4.0.491",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.