### PR TITLE
Temporarily revert the vcpkg-cmake changes in #30396

### DIFF
--- a/ports/vcpkg-cmake/vcpkg.json
+++ b/ports/vcpkg-cmake/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-cmake",
-  "version-date": "2025-08-07",
+  "version-date": "2024-04-23",
   "documentation": "https://learn.microsoft.com/vcpkg/maintainers/functions/vcpkg_cmake_configure",
   "license": "MIT"
 }

--- a/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
@@ -243,8 +243,6 @@ function(vcpkg_cmake_configure)
         "-DCMAKE_INSTALL_PREFIX=${CURRENT_PACKAGES_DIR}/debug"
         ${arg_OPTIONS} ${arg_OPTIONS_DEBUG})
 
-    vcpkg_host_path_list(REMOVE_DUPLICATES ENV{PATH})
-
     if(NOT arg_DISABLE_PARALLEL_CONFIGURE)
         vcpkg_list(APPEND arg_OPTIONS "-DCMAKE_DISABLE_SOURCE_CHANGES=ON")
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10077,7 +10077,7 @@
       "port-version": 0
     },
     "vcpkg-cmake": {
-      "baseline": "2025-08-07",
+      "baseline": "2024-04-23",
       "port-version": 0
     },
     "vcpkg-cmake-config": {


### PR DESCRIPTION
See bug report: https://github.com/microsoft/vcpkg/pull/30396#issuecomment-3445282849

Will revert this revert as soon as we can service the copy of vcpkg embedded in Visual Studio.

If I can get VS serviced relatively quickly we might not merge this but I wanted to have it out for discussion in case the answer is "servicing VS takes too long"