### PR TITLE
[pkgconf] Add paths for NetBSD

### DIFF
--- a/ports/pkgconf/portfile.cmake
+++ b/ports/pkgconf/portfile.cmake
@@ -24,16 +24,19 @@ set(SYSTEM_INCLUDEDIR "")
 set(PERSONALITY_PATH "personality.d")
 
 if(NOT VCPKG_CROSSCOMPILING)
-    if(VCPKG_TARGET_IS_FREEBSD)
-        # These are taken from the FreeBSD port of pkgconf
+    if(VCPKG_TARGET_IS_BSD)
         set(SYSTEM_INCLUDEDIR "/usr/include")
         set(SYSTEM_LIBDIR "/usr/lib")
-        set(PKG_DEFAULT_PATH "/usr/libdata/pkgconfig:/usr/local/libdata/pkgconfig:/usr/local/share/pkgconfig")
-    elseif(VCPKG_TARGET_IS_OPENBSD)
-        # Based on how new OpenBSD builds their version of pkgconf
-        set(SYSTEM_INCLUDEDIR "/usr/include")
-        set(SYSTEM_LIBDIR "/usr/lib")
-        set(PKG_DEFAULT_PATH "/usr/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/X11R6/lib/pkgconfig:/usr/X11R6/share/pkgconfig")
+        if(VCPKG_TARGET_IS_FREEBSD)
+            # These are taken from the FreeBSD port of pkgconf
+            set(PKG_DEFAULT_PATH "/usr/libdata/pkgconfig:/usr/local/libdata/pkgconfig:/usr/local/share/pkgconfig")
+        elseif(VCPKG_TARGET_IS_OPENBSD)
+            # Based on how new OpenBSD builds their version of pkgconf
+            set(PKG_DEFAULT_PATH "/usr/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/X11R6/lib/pkgconfig:/usr/X11R6/share/pkgconfig")
+        elseif(VCPKG_TARGET_IS_NETBSD)
+            # Based on NetBSD's pkgconf default values
+            set(PKG_DEFAULT_PATH "/usr/pkg/lib/pkgconfig:/usr/pkg/share/pkgconfig:/usr/lib/pkgconfig:/usr/X11R7/lib/pkgconfig")
+        endif()
     elseif(NOT VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
         # These defaults are obtained from pkgconf/pkg-config on Ubuntu and OpenSuse
         # vcpkg cannot do system introspection to obtain/set these values since it would break binary caching.

--- a/ports/pkgconf/vcpkg.json
+++ b/ports/pkgconf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pkgconf",
   "version": "2.5.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "pkgconf is a program which helps to configure compiler and linker flags for development libraries. It is similar to pkg-config from freedesktop.org.",
   "homepage": "https://github.com/pkgconf/pkgconf",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7494,7 +7494,7 @@
     },
     "pkgconf": {
       "baseline": "2.5.1",
-      "port-version": 3
+      "port-version": 4
     },
     "plasma-wayland-protocols": {
       "baseline": "1.14.0",

--- a/versions/p-/pkgconf.json
+++ b/versions/p-/pkgconf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e3bcce12697924fae59f8567477d1a4cc2de04f",
+      "version": "2.5.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "64596d00121be1e7c6109d1409b1e87dea8b8d0c",
       "version": "2.5.1",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.