### PR TITLE
[skia] Move some stuff to features, devendor abseil, fix NetBSD support

### DIFF
--- a/ports/skia/always-build-pathops.patch
+++ b/ports/skia/always-build-pathops.patch
@@ -1,0 +1,12 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index 2a04c9f..8d0e7ec 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -1663,6 +1663,7 @@ skia_component("skia") {
+     ":gpu",
+     ":graphite",
+     ":jpeg_encode",
++    ":pathops",
+     ":pdf",
+     ":pdf_jpeg_helpers",
+     ":webp_encode",

--- a/ports/skia/fix-bsd.patch
+++ b/ports/skia/fix-bsd.patch
@@ -1,5 +1,18 @@
+diff --git a/src/gpu/ganesh/GrAutoLocaleSetter.h b/src/gpu/ganesh/GrAutoLocaleSetter.h
+index 13a2ab37f9..96968f6779 100644
+--- a/src/gpu/ganesh/GrAutoLocaleSetter.h
++++ b/src/gpu/ganesh/GrAutoLocaleSetter.h
+@@ -27,7 +27,7 @@
+ #define HAVE_XLOCALE 0
+ #endif
+ 
+-#if defined(SK_BUILD_FOR_ANDROID) || defined(__UCLIBC__) || defined(_NEWLIB_VERSION)
++#if defined(SK_BUILD_FOR_ANDROID) || defined(__UCLIBC__) || defined(_NEWLIB_VERSION) || defined(__NetBSD__)
+ #define HAVE_LOCALE_T 0
+ #else
+ #define HAVE_LOCALE_T 1
 diff --git a/src/ports/SkMemory_malloc.cpp b/src/ports/SkMemory_malloc.cpp
-index d784af53ef..df1eee3ff9 100644
+index d784af53ef..8bb21406dd 100644
 --- a/src/ports/SkMemory_malloc.cpp
 +++ b/src/ports/SkMemory_malloc.cpp
 @@ -15,7 +15,7 @@
@@ -7,7 +20,7 @@ index d784af53ef..df1eee3ff9 100644
  #if defined(SK_BUILD_FOR_MAC) || defined(SK_BUILD_FOR_IOS)
  #include <malloc/malloc.h>
 -#elif defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_UNIX)
-+#elif defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_UNIX) && !defined(__OpenBSD__)
++#elif defined(SK_BUILD_FOR_ANDROID) || defined(SK_BUILD_FOR_UNIX) && !defined(__OpenBSD__) && !defined(__NetBSD__)
  #include <malloc.h>
  #elif defined(SK_BUILD_FOR_WIN)
  #include <malloc.h>
@@ -16,7 +29,7 @@ index d784af53ef..df1eee3ff9 100644
          completeSize = malloc_usable_size(addr);
          SkASSERT(completeSize >= size);
 -    #elif defined(SK_BUILD_FOR_UNIX)
-+    #elif defined(SK_BUILD_FOR_UNIX) && !defined(__OpenBSD__)
++    #elif defined(SK_BUILD_FOR_UNIX) && !defined(__OpenBSD__) && !defined(__NetBSD__)
          completeSize = malloc_usable_size(addr);
          SkASSERT(completeSize >= size);
      #elif defined(SK_BUILD_FOR_WIN)

--- a/ports/skia/remove-directwrite-png-dependency.patch
+++ b/ports/skia/remove-directwrite-png-dependency.patch
@@ -1,0 +1,48 @@
+From 85f9aa5907e3e445dabdf24be64032b8a76455ce Mon Sep 17 00:00:00 2001
+From: Ben Wagner <bungeman@google.com>
+Date: Thu, 9 Oct 2025 10:55:24 -0400
+Subject: [PATCH] Remove DirectWrite direct dependency on png codec
+
+SkScalerContext_DW::generatePngMetrics was still calling the png codec
+directly, while SkScalerContext_DW::drawPngImage used the png codec
+indirectly already. Make generatePngMetrics work like drawPngImage.
+
+Bug: 446241210
+Change-Id: Iddbc76f80e85a12fac2be8126d1efb102fc79d2c
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1070816
+Auto-Submit: Ben Wagner <bungeman@google.com>
+Reviewed-by: Kaylee Lubick <kjlubick@google.com>
+Commit-Queue: Kaylee Lubick <kjlubick@google.com>
+---
+ src/ports/SkScalerContext_win_dw.cpp | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/src/ports/SkScalerContext_win_dw.cpp b/src/ports/SkScalerContext_win_dw.cpp
+index b6fc437f3922..deaea1f48993 100644
+--- a/src/ports/SkScalerContext_win_dw.cpp
++++ b/src/ports/SkScalerContext_win_dw.cpp
+@@ -11,8 +11,6 @@
+ 
+ #undef GetGlyphIndices
+ 
+-#include "include/codec/SkCodec.h"
+-#include "include/codec/SkPngDecoder.h"
+ #include "include/core/SkBBHFactory.h"
+ #include "include/core/SkBitmap.h"
+ #include "include/core/SkData.h"
+@@ -1737,12 +1735,12 @@ bool SkScalerContext_DW::generatePngMetrics(const SkGlyph& glyph, SkRect* bounds
+                                               &ReleaseProc,
+                                               context);
+ 
+-    std::unique_ptr<SkCodec> codec = SkPngDecoder::Decode(std::move(data), nullptr);
+-    if (!codec) {
++    sk_sp<SkImage> image = SkImages::DeferredFromEncodedData(std::move(data));
++    if (!image) {
+         return false;
+     }
+ 
+-    SkImageInfo info = codec->getInfo();
++    SkImageInfo info = image->imageInfo();
+     *bounds = SkRect::Make(info.bounds());
+ 
+     SkMatrix matrix = fSkXform;

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "skia",
   "version": "140",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",
@@ -11,10 +11,8 @@
   "license": "BSD-3-Clause",
   "supports": "!(windows & arm32) & !mingw",
   "dependencies": [
+    "abseil",
     "expat",
-    "libjpeg-turbo",
-    "libpng",
-    "libwebp",
     {
       "name": "opengl",
       "default-features": false,
@@ -49,11 +47,11 @@
     },
     {
       "name": "dng",
-      "platform": "!(freebsd | openbsd)"
+      "platform": "!bsd"
     },
     {
       "name": "fontconfig",
-      "platform": "linux | freebsd | openbsd"
+      "platform": "linux | bsd"
     },
     {
       "name": "freetype",
@@ -70,24 +68,33 @@
     {
       "name": "icu",
       "platform": "!uwp"
-    }
+    },
+    "jpeg",
+    "png",
+    "webp"
   ],
   "features": {
+    "avif": {
+      "description": "AVIF support",
+      "dependencies": [
+        "libavif"
+      ]
+    },
     "dawn": {
       "description": "dawn support for skia",
       "supports": "!android & !uwp",
       "dependencies": [
         {
           "name": "dawn",
-          "platform": "osx | windows"
-        },
-        {
-          "name": "dawn",
           "default-features": false,
           "features": [
             "x11"
           ],
-          "platform": "linux | freebsd | openbsd"
+          "platform": "linux | bsd"
+        },
+        {
+          "name": "dawn",
+          "platform": "osx | windows"
         },
         {
           "name": "skia",
@@ -104,7 +111,7 @@
     },
     "dng": {
       "description": "Support for DNG files",
-      "supports": "!(freebsd | openbsd)"
+      "supports": "!bsd"
     },
     "fontconfig": {
       "description": "Fontconfig support",
@@ -173,15 +180,36 @@
         "icu"
       ]
     },
+    "jpeg": {
+      "description": "Jpeg support",
+      "dependencies": [
+        "libjpeg-turbo"
+      ]
+    },
     "metal": {
       "description": "Metal support for skia",
       "supports": "ios, osx"
+    },
+    "pdf": {
+      "description": "PDF backend"
+    },
+    "png": {
+      "description": "PNG support",
+      "dependencies": [
+        "libpng"
+      ]
     },
     "vulkan": {
       "description": "Vulkan support for skia",
       "dependencies": [
         "vulkan-headers",
         "vulkan-memory-allocator"
+      ]
+    },
+    "webp": {
+      "description": "WebP support",
+      "dependencies": [
+        "libwebp"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9002,7 +9002,7 @@
     },
     "skia": {
       "baseline": "140",
-      "port-version": 1
+      "port-version": 2
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6fd733c194f2bdf62c496ecbddba0a9b1000ef38",
+      "version": "140",
+      "port-version": 2
+    },
+    {
       "git-tree": "a175473c2c239039081f87398bf806da330a693e",
       "version": "140",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.