### PR TITLE
Prefix azcopy logs with 'z' for sorting

### DIFF
--- a/scripts/azure-pipelines/android/azure-pipelines.yml
+++ b/scripts/azure-pipelines/android/azure-pipelines.yml
@@ -111,7 +111,7 @@ jobs:
     displayName: "Publish Artifact: azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     inputs:
       targetPath: '$(WORKING_ROOT)/azcopy-logs'
-      artifactName: "azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
+      artifactName: "z azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     condition: ne(variables['AZCOPY_LOGS_EMPTY'], 'True')
   - task: UseNode@1
     displayName: 'Ensure Node.js is available'

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -108,7 +108,7 @@ jobs:
     displayName: "Publish Artifact: azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     inputs:
       targetPath: '$(WORKING_ROOT)/azcopy-logs'
-      artifactName: "azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
+      artifactName: "z azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     condition: ne(variables['AZCOPY_LOGS_EMPTY'], 'True')
   - task: UseNode@1
     displayName: 'Ensure Node.js is available'

--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -71,7 +71,7 @@ jobs:
     displayName: "Publish Artifact: azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     inputs:
       targetPath: '$(WORKING_ROOT)/azcopy-logs'
-      artifactName: "azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
+      artifactName: "z azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     condition: ne(variables['AZCOPY_LOGS_EMPTY'], 'True')
   - task: UseNode@1
     displayName: 'Ensure Node.js is available'

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
     displayName: "Publish Artifact: azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     inputs:
       targetPath: '$(WORKING_ROOT)/azcopy-logs'
-      artifactName: "azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
+      artifactName: "z azcopy logs for ${{ replace(parameters.jobName, '_', '-') }}"
     condition: ne(variables['AZCOPY_LOGS_EMPTY'], 'True')
   - task: UseNode@1
     displayName: 'Ensure Node.js is available'


### PR DESCRIPTION
Let failure logs appear at the top of the list again, instead of this:
<img width="372" height="952" alt="grafik" src="https://github.com/user-attachments/assets/06a82a24-c087-4e28-a6ba-7e7d25917fea" />
