### PR TITLE
[clipboardxx] fix missing headers installation

### DIFF
--- a/ports/clipboardxx/fix-install.patch
+++ b/ports/clipboardxx/fix-install.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 07c06cc..a3d78ea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,6 +10,7 @@ target_include_directories(${PROJECT_NAME} INTERFACE include)
+ 
+ # install header files
+ install(FILES include/clipboardxx.hpp DESTINATION include)
++install(DIRECTORY include/detail DESTINATION include)
+ 
+ # dependencies
+ if(UNIX AND NOT APPLE)

--- a/ports/clipboardxx/portfile.cmake
+++ b/ports/clipboardxx/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_github(
   REF v${VERSION}
   SHA512 f5435698cf1c10609c22140974fc86c672a331c419e6c6faa94e9fdc14fb0b0dd59f1f16a062f18320d7c523ba1951d917ef607a307c1c3fa88c71ef8e34b4ca
   HEAD_REF master
+  PATCHES
+    fix-install.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/clipboardxx/unofficial-clipboardxx-config.cmake.in
+++ b/ports/clipboardxx/unofficial-clipboardxx-config.cmake.in
@@ -7,7 +7,7 @@ endif()
 
 add_library(unofficial::ClipboardXX INTERFACE IMPORTED)
 set_target_properties(unofficial::ClipboardXX PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/include"
+  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
 )
 
 if("@VCPKG_TARGET_IS_LINUX@")

--- a/ports/clipboardxx/vcpkg.json
+++ b/ports/clipboardxx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "clipboardxx",
   "version": "0.5",
+  "port-version": 1,
   "description": "Header only, lightweight and cross platform C++ library for copy and paste text from clipboard.",
   "homepage": "https://github.com/Arian8j2/ClipboardXX",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1786,7 +1786,7 @@
     },
     "clipboardxx": {
       "baseline": "0.5",
-      "port-version": 0
+      "port-version": 1
     },
     "clipp": {
       "baseline": "2019-04-30",

--- a/versions/c-/clipboardxx.json
+++ b/versions/c-/clipboardxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64c110cba862b1c13341f721f373c1b546387883",
+      "version": "0.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "16680f4a0a6beba9792b25f742e576123ee909c1",
       "version": "0.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Try to close https://github.com/microsoft/vcpkg/issues/47973.

