### PR TITLE
[harfbuzz] Update to 12.1.0

### DIFF
--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -2,50 +2,31 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
     REF ${VERSION}
-    SHA512 1d0f19e6aebc6aa273e749fb7968eff851dcfb15a0b5ef6cf268c74e77a81175d845c20c9285be7e9a7cb79871cb08bdac5c9d802a50fc5bd11a7225d510f48f
+    SHA512 f6fb44f1eeecd94d169034f398fdc6c9e149244b7bb1cc72239e9bedd2074e5cbb36c9d37636cffc6d9cfc818a18dca290ee0e03b9f68a07c1a02bd416f7a2f8
     HEAD_REF master
     PATCHES
         fix-win32-build.patch
         add-parameter-name.patch
 )
 
-if("icu" IN_LIST FEATURES)
-    list(APPEND FEATURE_OPTIONS -Dicu=enabled) # Enable ICU library unicode functions
-else()
-    list(APPEND FEATURE_OPTIONS -Dicu=disabled)
-endif()
-if("graphite2" IN_LIST FEATURES)
-    list(APPEND FEATURE_OPTIONS -Dgraphite=enabled) #Enable Graphite2 complementary shaper
-else()
-    list(APPEND FEATURE_OPTIONS -Dgraphite=disabled)
-endif()
-if("coretext" IN_LIST FEATURES)
-    list(APPEND FEATURE_OPTIONS -Dcoretext=enabled) # Enable CoreText shaper backend on macOS
-else()
-    list(APPEND FEATURE_OPTIONS -Dcoretext=disabled)
-endif()
-if("directwrite" IN_LIST FEATURES)
-    list(APPEND FEATURE_OPTIONS -Ddirectwrite=enabled) # Enable DirectWrite support on Windows
-else()
-    list(APPEND FEATURE_OPTIONS -Ddirectwrite=disabled)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS MODE meson
+    FEATURES
+        icu         icu
+        graphite2   graphite
+        coretext    coretext
+        directwrite directwrite
+        glib        glib
+        glib        gobject
+        cairo       cairo
+        freetype    freetype
+        gdi         gdi
+)
+
 if("glib" IN_LIST FEATURES)
-    list(APPEND FEATURE_OPTIONS -Dglib=enabled) # Enable GLib unicode functions
     list(APPEND FEATURE_OPTIONS -Dgobject=enabled) #Enable GObject bindings
     list(APPEND FEATURE_OPTIONS -Dchafa=disabled)
 else()
-    list(APPEND FEATURE_OPTIONS -Dglib=disabled)
     list(APPEND FEATURE_OPTIONS -Dgobject=disabled)
-endif()
-if("cairo" IN_LIST FEATURES)
-    list(APPEND FEATURE_OPTIONS -Dcairo=enabled) # Enable Cairo graphics library support
-else()
-    list(APPEND FEATURE_OPTIONS -Dcairo=disabled)
-endif()
-if("freetype" IN_LIST FEATURES)
-    list(APPEND FEATURE_OPTIONS -Dfreetype=enabled) #Enable freetype interop helpers
-else()
-    list(APPEND FEATURE_OPTIONS -Dfreetype=disabled)
 endif()
 if("experimental-api" IN_LIST FEATURES)
     list(APPEND FEATURE_OPTIONS -Dexperimental_api=true) #Enable experimental api

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "harfbuzz",
-  "version": "11.3.3",
+  "version": "12.1.0",
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3685,7 +3685,7 @@
       "port-version": 2
     },
     "harfbuzz": {
-      "baseline": "11.3.3",
+      "baseline": "12.1.0",
       "port-version": 0
     },
     "hash-library": {

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d51379d842e9a444a9392196ba9908330f76b09b",
+      "version": "12.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "14f2e7630c576d41e7ae856b844423cb4a14b87a",
       "version": "11.3.3",
       "port-version": 0


### PR DESCRIPTION
This also has a concept of extending `vcpkg_check_features` to support meson flags as I feel there's no reason that should be CMake exclusive.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.