### PR TITLE
[robin-hood-hashing] Add missing <cstdint> header as a patch

### DIFF
--- a/ports/robin-hood-hashing/fix-missing-stdint.patch
+++ b/ports/robin-hood-hashing/fix-missing-stdint.patch
@@ -1,0 +1,12 @@
+diff --git a/src/include/robin_hood.h b/src/include/robin_hood.h
+index b4e0fbc..405e67d 100644
+--- a/src/include/robin_hood.h
++++ b/src/include/robin_hood.h
+@@ -40,6 +40,7 @@
+ 
+ #include <algorithm>
+ #include <cstdlib>
++#include <cstdint>
+ #include <cstring>
+ #include <functional>
+ #include <limits>

--- a/ports/robin-hood-hashing/portfile.cmake
+++ b/ports/robin-hood-hashing/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
 	REF 3.11.5
 	SHA512 5f73e089b1e8ec41a9bedded22bc64a789d3a3d04873a2ad9f8cc2970797a473b0f4d3436c2324b3ced85a0d983998a75b1dfaf2b7f3b77235b29806ff2fd489
 	HEAD_REF master
+    PATCHES
+        fix-missing-stdint.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/robin-hood-hashing/portfile.cmake
+++ b/ports/robin-hood-hashing/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
 	OUT_SOURCE_PATH SOURCE_PATH
 	REPO martinus/robin-hood-hashing
 	REF 3.11.5
-	SHA512 0
+	SHA512 5f73e089b1e8ec41a9bedded22bc64a789d3a3d04873a2ad9f8cc2970797a473b0f4d3436c2324b3ced85a0d983998a75b1dfaf2b7f3b77235b29806ff2fd489
 	HEAD_REF master
     PATCHES
         fix-missing-stdint.patch

--- a/ports/robin-hood-hashing/portfile.cmake
+++ b/ports/robin-hood-hashing/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
 	OUT_SOURCE_PATH SOURCE_PATH
 	REPO martinus/robin-hood-hashing
 	REF 3.11.5
-	SHA512 5f73e089b1e8ec41a9bedded22bc64a789d3a3d04873a2ad9f8cc2970797a473b0f4d3436c2324b3ced85a0d983998a75b1dfaf2b7f3b77235b29806ff2fd489
+	SHA512 0
 	HEAD_REF master
     PATCHES
         fix-missing-stdint.patch

--- a/ports/robin-hood-hashing/vcpkg.json
+++ b/ports/robin-hood-hashing/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "robin-hood-hashing",
   "version": "3.11.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Fast & memory efficient hashtable based on robin hood hashing for C++11/14/17/20",
   "homepage": "https://github.com/martinus/robin-hood-hashing",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8542,7 +8542,7 @@
     },
     "robin-hood-hashing": {
       "baseline": "3.11.5",
-      "port-version": 1
+      "port-version": 2
     },
     "robin-map": {
       "baseline": "1.4.0",

--- a/versions/r-/robin-hood-hashing.json
+++ b/versions/r-/robin-hood-hashing.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1d1cf4ecfda26cc7953c491aa40ffd5fd6ddfc00",
+      "git-tree": "1a989171742275cc32060ed37157eeb0efcdc739",
       "version": "3.11.5",
       "port-version": 2
     },

--- a/versions/r-/robin-hood-hashing.json
+++ b/versions/r-/robin-hood-hashing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d1cf4ecfda26cc7953c491aa40ffd5fd6ddfc00",
+      "version": "3.11.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "25ce100807060e0a7cf0c0f8f0bed52bca9a4ea8",
       "version": "3.11.5",
       "port-version": 1


### PR DESCRIPTION
Added as a patch since the library is no longer maintained.

Fixes #46121

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
