### PR TITLE
[nanobind] Update to version 2.9.2

### DIFF
--- a/ports/nanobind/portfile.cmake
+++ b/ports/nanobind/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wjakob/nanobind
     REF "v${VERSION}"
-    SHA512 885668ee4ea9c551ccd60d2e056a90021badfeb7b358aeace184a23f9c2d34cb31a81ebe84db33fd6f15b7983dbb455d9c11f9367de091cb9b56c99d7634f9a0
+    SHA512 05b2541896e64bb513f915ebc09820b2d3659efa9a1a4bdda9da79a761a23d84e41db22031c02ae816b1f729dab95efcb7c888e926dbb89fb4b34c8a329d59bf
     HEAD_REF master
 )
 

--- a/ports/nanobind/vcpkg.json
+++ b/ports/nanobind/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nanobind",
-  "version-semver": "2.5.0",
+  "version-semver": "2.9.2",
   "description": "Tiny and efficient C++/Python bindings",
   "homepage": "https://nanobind.readthedocs.io/en/latest/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6669,7 +6669,7 @@
       "port-version": 0
     },
     "nanobind": {
-      "baseline": "2.5.0",
+      "baseline": "2.9.2",
       "port-version": 0
     },
     "nanodbc": {

--- a/versions/n-/nanobind.json
+++ b/versions/n-/nanobind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ab4d9d4abcea0eb88685d6fcd01065bf2b5e76d",
+      "version-semver": "2.9.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "884c5529ce11c5cd2e0a5f7616227d3a3b95fbd1",
       "version-semver": "2.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.