### PR TITLE
[aws-c-cal] update to 0.9.6

### DIFF
--- a/ports/aws-c-cal/portfile.cmake
+++ b/ports/aws-c-cal/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-cal
     REF "v${VERSION}"
-    SHA512 5f0dfadc0a296b1d16d52262c8a33daf603613e1e5b593d3552453dcba3f6b09962f453cf11456046364309248ab032357093d907b1659e42086285bf243101f
+    SHA512 067cc744d55e2c9b72ffacdbab1e3d67ede9b53390f2c8dd5e0fddc3008ab7a20c810be416bf2cb331c92955ed5235e95b7b2bcde15ed66f0784b27a5ca813ac
     HEAD_REF master
     PATCHES remove-libcrypto-messages.patch
 )

--- a/ports/aws-c-cal/vcpkg.json
+++ b/ports/aws-c-cal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-cal",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "C99 wrapper for cryptography primitives.",
   "homepage": "https://github.com/awslabs/aws-c-cal",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-cal.json
+++ b/versions/a-/aws-c-cal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3f0ddb3f43edc0865558069243cfaac3e9c817eb",
+      "version": "0.9.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "7bf984f3f4ebb6cbfde19f4886846a9c56140abd",
       "version": "0.9.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -437,7 +437,7 @@
       "port-version": 0
     },
     "aws-c-cal": {
-      "baseline": "0.9.5",
+      "baseline": "0.9.6",
       "port-version": 0
     },
     "aws-c-common": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/awslabs/aws-c-cal/releases/tag/v0.9.6
