### PR TITLE
[reflectcpp] update to 0.22.0

### DIFF
--- a/ports/reflectcpp/portfile.cmake
+++ b/ports/reflectcpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO getml/reflect-cpp
     REF "v${VERSION}"
-    SHA512 3fb7235a72738dc21659a9b1cbdc5b783b1b5eb7eb4af8de35e0e6d5a886822c88cdd2a58b181c036ab36eac9892e65a9c9e260bf09d21f577bdd01e8d120410 
+    SHA512 ef157de2426c2961a04cfc3bef6c6dd86b76b44e18f1c7b76cbe7d1bd78efa1b2e236fe4fdefbd2ae4a1d876231916b2338d062d0837d1c1cb8e29f14110bb2c
     HEAD_REF main
 )
 

--- a/ports/reflectcpp/vcpkg.json
+++ b/ports/reflectcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectcpp",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A C++ library for serialization and deserialization using reflection. Supports JSON, Avro, BSON, Cap'n Proto, CBOR, CSV, flexbuffers, msgpack, parquet, TOML, UBJSON, XML, YAML.",
   "homepage": "https://github.com/getml/reflect-cpp/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8433,7 +8433,7 @@
       "port-version": 0
     },
     "reflectcpp": {
-      "baseline": "0.21.0",
+      "baseline": "0.22.0",
       "port-version": 0
     },
     "refprop-headers": {

--- a/versions/r-/reflectcpp.json
+++ b/versions/r-/reflectcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb6b642c40bce8bea185e664f56021e944b5dc0c",
+      "version": "0.22.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "10079b349a09eabd7029392b2693db5256129c43",
       "version": "0.21.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/getml/reflect-cpp/releases/tag/v0.22.0
