### PR TITLE
[imgui] Update to version 1.92.4

### DIFF
--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -5,7 +5,7 @@ if ("docking-experimental" IN_LIST FEATURES)
         OUT_SOURCE_PATH SOURCE_PATH
         REPO ocornut/imgui
         REF "v${VERSION}-docking"
-        SHA512 3a019533e638b2023e0c71d0455561ee9d589ff33b677c8135345e85c28edb7b83580271d49a787e0e838fd6217d1625baad65e6559ae7faec53f3a309917ecd 
+        SHA512 ed9ce3dfc75f5da3afcb0dce5bcbd72b31c8ef2316e3ae07ad6e7fe9a87a910862890ebab62b451035315b95bdbb70bbe82bf3ec9f584470f75f7d73fa10f044 
         HEAD_REF docking
     )
 else()
@@ -13,7 +13,7 @@ else()
         OUT_SOURCE_PATH SOURCE_PATH
         REPO ocornut/imgui
         REF "v${VERSION}"
-        SHA512 c9393bd9f6b49b036ad6ab3ba4d972876c6f60ce7f5c13a7a56ff11b3559ea3211b0caa03eed10b4f4fbe9c371e14f7f24866bd476652f543f3ed3aa878ea930
+        SHA512 38eb2f179abd00f74f5cc19afd0f079f29a5786a966398438b668653ca08f657c18a362017144ed9a3299398b1caf17cedcef1c2bf1212e8c0b6cca0abc258b5
         HEAD_REF master
     )
 endif()
@@ -64,7 +64,7 @@ if ("test-engine" IN_LIST FEATURES)
         OUT_SOURCE_PATH TEST_ENGINE_SOURCE_PATH
         REPO ocornut/imgui_test_engine
         REF "v${VERSION}"
-        SHA512 44d6fd1c26c9c2cb3fcbd1560dba8e056f84dc170051dcb8db5d642945fb26475006a8166486f7f62e900a97d65f2f98d364ac06c121a57309b3229cc41556a4
+        SHA512 0
         HEAD_REF master
     )
 

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -64,7 +64,7 @@ if ("test-engine" IN_LIST FEATURES)
         OUT_SOURCE_PATH TEST_ENGINE_SOURCE_PATH
         REPO ocornut/imgui_test_engine
         REF "v${VERSION}"
-        SHA512 0
+        SHA512 19ae6e119909a853ce891544f134543c17ed1142dea61a949422395a1f3be4e22cbfba22637486629ddd2955e7921508b8e7b6f76f442a7a06898057c5bfb878
         HEAD_REF master
     )
 

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui",
   "version": "1.92.4",
+  "port-version": 1,
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.91.9",
+  "version": "1.92.4",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3893,7 +3893,7 @@
       "port-version": 0
     },
     "imgui": {
-      "baseline": "1.91.9",
+      "baseline": "1.92.4",
       "port-version": 0
     },
     "imgui-node-editor": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3894,7 +3894,7 @@
     },
     "imgui": {
       "baseline": "1.92.4",
-      "port-version": 0
+      "port-version": 1
     },
     "imgui-node-editor": {
       "baseline": "0.9.3",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc379ae90fe0c6dd2e0772e1e2f5ed41c81d3834",
+      "version": "1.92.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "1794567a9424d7660042df30b03332259ac1fe9d",
       "version": "1.92.4",
       "port-version": 0

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1794567a9424d7660042df30b03332259ac1fe9d",
+      "version": "1.92.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "cecad336497c19491c07fead1897ac139a173ed2",
       "version": "1.91.9",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
