### PR TITLE
[trantor] update to 1.5.25

### DIFF
--- a/ports/trantor/portfile.cmake
+++ b/ports/trantor/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO an-tao/trantor
     REF "v${VERSION}"
-    SHA512 a875e5bf8c8d871d1a3ddeeb79891773eed4f13772aa8c09ce6bdd60fa7af621eed6986935c0b70b58e790618934ca82a7ebd4ba5faf2b534b8ecb6f74d6bad1
+    SHA512 3f81d6f1b0360ee35b1c0a3267a7626de9db1ac99009d488e15470d8d1c3da8301e7ff7deeeba0760fa147429dec377361bab3a3f7566d063cd76724b0772e6d
     HEAD_REF master
     PATCHES
         000-fix-deps.patch

--- a/ports/trantor/vcpkg.json
+++ b/ports/trantor/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "trantor",
-  "version-semver": "1.5.24",
+  "version-semver": "1.5.25",
   "description": "A non-blocking I/O cross-platform TCP network library, using C++14",
   "homepage": "https://github.com/an-tao/trantor",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9817,7 +9817,7 @@
       "port-version": 0
     },
     "trantor": {
-      "baseline": "1.5.24",
+      "baseline": "1.5.25",
       "port-version": 0
     },
     "tre": {

--- a/versions/t-/trantor.json
+++ b/versions/t-/trantor.json
@@ -8,37 +8,37 @@
     {
       "git-tree": "e45f9f108809b8325d96eb0ea3cc8d123c76d0f4",
       "version-semver": "1.5.24",
-      "port-version": 0
+      "port-version": 0 
     },
     {
       "git-tree": "bba23ca39aca1b346d0f5c0f46d3e0a95be34e30",
       "version-semver": "1.5.23",
-      "port-version": 0
+      "port-version": 0 
     },
     {
       "git-tree": "171e9e59a73d94138de424aeb566491c73c6a25c",
       "version-semver": "1.5.22",
-      "port-version": 0
+      "port-version": 0 
     },
     {
       "git-tree": "3468a2a6cbe9d3d132cb5240edca85b2947d2396",
       "version-semver": "1.5.21",
-      "port-version": 0
+      "port-version": 0 
     },
     {
       "git-tree": "c918dd94f5061cf75dad87946390914bb8d55d5c",
       "version-semver": "1.5.20",
-      "port-version": 0
+      "port-version": 0 
     },
     {
       "git-tree": "559a4890e9821270f388b9bb198591b6a5cc4b66",
       "version-semver": "1.5.19",
-      "port-version": 0
+      "port-version": 0 
     },
     {
       "git-tree": "4640cf021e9c3dcc039d208d3dc6706091b5c00f",
       "version-semver": "1.5.18",
-      "port-version": 0
+      "port-version": 0 
     },
     {
       "git-tree": "ae8e025e733710e1ff877d967abe2d9a29dc19d1",

--- a/versions/t-/trantor.json
+++ b/versions/t-/trantor.json
@@ -1,39 +1,44 @@
 {
   "versions": [
     {
+      "git-tree": "f7fa855b11e9dfa36bb95be8f0595a61aa078f16",
+      "version-semver": "1.5.25",
+      "port-version": 0
+    },
+    {
       "git-tree": "e45f9f108809b8325d96eb0ea3cc8d123c76d0f4",
       "version-semver": "1.5.24",
-      "port-version": 0 
+      "port-version": 0
     },
     {
       "git-tree": "bba23ca39aca1b346d0f5c0f46d3e0a95be34e30",
       "version-semver": "1.5.23",
-      "port-version": 0 
+      "port-version": 0
     },
     {
       "git-tree": "171e9e59a73d94138de424aeb566491c73c6a25c",
       "version-semver": "1.5.22",
-      "port-version": 0 
+      "port-version": 0
     },
     {
       "git-tree": "3468a2a6cbe9d3d132cb5240edca85b2947d2396",
       "version-semver": "1.5.21",
-      "port-version": 0 
+      "port-version": 0
     },
     {
       "git-tree": "c918dd94f5061cf75dad87946390914bb8d55d5c",
       "version-semver": "1.5.20",
-      "port-version": 0 
+      "port-version": 0
     },
     {
       "git-tree": "559a4890e9821270f388b9bb198591b6a5cc4b66",
       "version-semver": "1.5.19",
-      "port-version": 0 
+      "port-version": 0
     },
     {
       "git-tree": "4640cf021e9c3dcc039d208d3dc6706091b5c00f",
       "version-semver": "1.5.18",
-      "port-version": 0 
+      "port-version": 0
     },
     {
       "git-tree": "ae8e025e733710e1ff877d967abe2d9a29dc19d1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/an-tao/trantor/releases/tag/v1.5.25
