### PR TITLE
[sdflib]: fix-render_engine-install

### DIFF
--- a/ports/sdflib/fix-build.patch
+++ b/ports/sdflib/fix-build.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a685c60..43f4d97 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,7 +70,7 @@ file(GLOB SHADER_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/src/render_engine/sh
+ 
+ foreach(SHADER IN LISTS SHADER_FILES)
+     add_custom_command(OUTPUT ${SHADER}
+-            COMMAND cmake -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/src/render_engine/shaders/${SHADER} $<TARGET_FILE_DIR:${PROJECT_NAME}>/shaders/${SHADER}
++            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/src/render_engine/shaders/${SHADER} $<TARGET_FILE_DIR:${PROJECT_NAME}>/shaders/${SHADER}
+             DEPENDS src/render_engine/shaders/${SHADER}
+         )
+ endforeach()

--- a/ports/sdflib/portfile.cmake
+++ b/ports/sdflib/portfile.cmake
@@ -3,7 +3,8 @@ vcpkg_from_github(
     REPO UPC-ViRVIG/SdfLib
     REF 109e9828710fa581616f7fdd6ed1c87d5cb11e2b
     SHA512 6908fb57de26da32de2b04c1202531d5e01f5135357e94a4a1141d9588c19d51be2d8b9a11f89b6f2c7884a46778775cc4f1156966cdcb3095578de0478792ec
-    PATCHES
+    PATCHES 
+        fix-build.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/sdflib/vcpkg.json
+++ b/ports/sdflib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdflib",
   "version-date": "2025-01-25",
+  "port-version": 1,
   "description": "Library for accelerating the queries of signed distance fields from triangle meshes.",
   "homepage": "https://github.com/UPC-ViRVIG/SdfLib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8758,7 +8758,7 @@
     },
     "sdflib": {
       "baseline": "2025-01-25",
-      "port-version": 0
+      "port-version": 1
     },
     "sdformat": {
       "baseline": "15.1.1",

--- a/versions/s-/sdflib.json
+++ b/versions/s-/sdflib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e08e82a1764c344dd271e69bb398b63e23e27567",
+      "version-date": "2025-01-25",
+      "port-version": 1
+    },
+    {
       "git-tree": "b15f316b5ce3e341ab53fb78a6259cc6a5a509c4",
       "version-date": "2025-01-25",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
#45039
#48055
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
