### PR TITLE
[bitmagic] Fix compilation with clang 21

### DIFF
--- a/ports/bitmagic/fix-clang.patch
+++ b/ports/bitmagic/fix-clang.patch
@@ -1,0 +1,16 @@
+diff --git a/src/bmsparsevec_compr.h b/src/bmsparsevec_compr.h
+index ed774c6d..5dbaf09f 100644
+--- a/src/bmsparsevec_compr.h
++++ b/src/bmsparsevec_compr.h
+@@ -280,7 +280,10 @@ public:
+         
+         /** add a series of consequitve NULLs (no-value) to the container */
+         void add_null(size_type count) BMNOEXCEPT;
+-        
++
++        /** return true if insertion buffer is empty */
++        bool empty() const { return sv_bi_.empty(); }
++
+         /** flush the accumulated buffer */
+         void flush();
+     protected:

--- a/ports/bitmagic/portfile.cmake
+++ b/ports/bitmagic/portfile.cmake
@@ -5,7 +5,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 49e1fe4b1628d54ca6b45d8b2a5a1f31aaec67a949630b3ca60c2e70af536d7954fbf8577cf26981436339818ddf243c5c2579585755f42c9dc6a87e0e6d9548
     HEAD_REF master
-        fix-clang.patch #https://github.com/tlk00/BitMagic/commit/fab01f43eca266bf56efb1aca659773c911a83fb
+    PATCHES
+        fix-clang.patch #https://github.com/tlk00/BitMagic/commit/6dfdcbd1222b3919c2a3b71bfde38db5c7862f97
 )
 
 file(GLOB HEADER_LIST "${SOURCE_PATH}/src/*.h")

--- a/ports/bitmagic/vcpkg.json
+++ b/ports/bitmagic/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "bitmagic",
   "version": "8.0.1",
+  "port-version": 1,
   "description": "Algorithms and tools for Algebra of Sets for information retrieval, indexing of databases, scientific algorithms, ranking, clustering, unsupervised machine learning and signal processing.",
   "homepage": "http://bitmagic.io",
   "license": "Apache-2.0"

--- a/versions/b-/bitmagic.json
+++ b/versions/b-/bitmagic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8112a1ee30dc07987204b0599d20a1800a0ebd1c",
+      "version": "8.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e99ecd5760a75e09682d6e1485ebbdde4cfa51a5",
       "version": "8.0.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -722,7 +722,7 @@
     },
     "bitmagic": {
       "baseline": "8.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "bitserializer": {
       "baseline": "0.80",


### PR DESCRIPTION
[Apply fix on last release](https://github.com/tlk00/BitMagic/commit/6dfdcbd1222b3919c2a3b71bfde38db5c7862f97)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
