### PR TITLE
[libversion] add new port

### DIFF
--- a/ports/libversion/disable-test.patch
+++ b/ports/libversion/disable-test.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5309a30..f5fafa6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,9 +4,6 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
+ project(libversion VERSION 3.0.4)
+ 
+ include(GNUInstallDirs)
+-enable_testing()
+ 
+ # subdirs
+ add_subdirectory(libversion)
+-add_subdirectory(tests)
+-add_subdirectory(utils)

--- a/ports/libversion/portfile.cmake
+++ b/ports/libversion/portfile.cmake
@@ -18,6 +18,5 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libversion)
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libversion/portfile.cmake
+++ b/ports/libversion/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO repology/libversion
+    REF ${VERSION}
+    SHA512 5be723103f33d764ad9c426fb915144d7ab0ca0de9c2650099060a543d01184c68d0849325d964b4815372ae9d71c9dbcb114049828ccd87d6dd6ad186d91fee
+    HEAD_REF master
+    PATCHES
+        disable-test.patch
+        separate-build-type.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libversion)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libversion/separate-build-type.patch
+++ b/ports/libversion/separate-build-type.patch
@@ -1,0 +1,18 @@
+diff --git a/libversion/CMakeLists.txt b/libversion/CMakeLists.txt
+index 52a6ba7..71760dc 100644
+--- a/libversion/CMakeLists.txt
++++ b/libversion/CMakeLists.txt
+@@ -89,8 +89,11 @@ install(FILES
+ 	${CMAKE_CURRENT_BINARY_DIR}/export.h
+ 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libversion
+ )
+-install(TARGETS libversion libversion_static EXPORT libversion)
+-
++if(BUILD_SHARED_LIBS)
++install(TARGETS libversion EXPORT libversion)
++else()
++install(TARGETS libversion_static EXPORT libversion)
++endif()
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libversion.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ 
+ install(EXPORT libversion NAMESPACE libversion:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libversion FILE libversionConfig.cmake)

--- a/ports/libversion/vcpkg.json
+++ b/ports/libversion/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libversion",
+  "version": "3.0.4",
+  "description": "Advanced version string comparison library",
+  "homepage": "https://github.com/repology/libversion",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5672,6 +5672,10 @@
       "baseline": "0.63.0",
       "port-version": 0
     },
+    "libversion": {
+      "baseline": "3.0.4",
+      "port-version": 0
+    },
     "libvhdi": {
       "baseline": "20231127",
       "port-version": 0

--- a/versions/l-/libversion.json
+++ b/versions/l-/libversion.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e474f6cad66bd5738cb4c90ee07e93351171997a",
+      "git-tree": "0f42989b5eede826f634ebd8fc463b27f41b0f69",
       "version": "3.0.4",
       "port-version": 0
     }

--- a/versions/l-/libversion.json
+++ b/versions/l-/libversion.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e474f6cad66bd5738cb4c90ee07e93351171997a",
+      "version": "3.0.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpxg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/repology/libversion
