### PR TITLE
[aws-c-cal] update to 0.9.8

### DIFF
--- a/ports/aws-c-cal/portfile.cmake
+++ b/ports/aws-c-cal/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-cal
     REF "v${VERSION}"
-    SHA512 75581decf739351cc566bc645a6c5bd26ac576dcee4568ca5c74f5f18417d329715837f5393362a109a80f04c945ea2d90503ea791dccadb13ad6d1904a4b39e
+    SHA512 e5fa5299164f4ce7860ada9a1c56ba74d6f68ca82cb1e09c53098f7642cb3541efe2c394fad2ff77716f795f813d87dff3ccd6df582b49a6fdca785531150d7a
     HEAD_REF master
     PATCHES remove-libcrypto-messages.patch
 )

--- a/ports/aws-c-cal/vcpkg.json
+++ b/ports/aws-c-cal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-cal",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "C99 wrapper for cryptography primitives.",
   "homepage": "https://github.com/awslabs/aws-c-cal",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-cal.json
+++ b/versions/a-/aws-c-cal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a249d518e2af42bc02f1dd243c5c1d07fee65b5",
+      "version": "0.9.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "9040265c67369cd6698288f6b3e0da6da11cba2a",
       "version": "0.9.7",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -441,7 +441,7 @@
       "port-version": 0
     },
     "aws-c-cal": {
-      "baseline": "0.9.7",
+      "baseline": "0.9.8",
       "port-version": 0
     },
     "aws-c-common": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/awslabs/aws-c-cal/releases/tag/v0.9.8
