### PR TITLE
[systemc] update to 3.0.2

### DIFF
--- a/ports/systemc/portfile.cmake
+++ b/ports/systemc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO accellera-official/systemc
     REF "${VERSION}"
-    SHA512 baeadd0318b9ab47fc559a2ab6bd880ac506ac5d858cdcf081a7544ca01688f2e798549655ff7546d02feba120c084951f834b69678a0bb984299bff25a4e21b
+    SHA512 50ebda68ef253a4ddbbafaabf2f1351a31c43e92198e161e19b63165426357b20f137c8b4b03b9f6ebfd56b2170d8ab2b256392e21e9e4ad9a4e7aa65a262d7d
     HEAD_REF main
     PATCHES
         install.patch

--- a/ports/systemc/vcpkg.json
+++ b/ports/systemc/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "name": "systemc",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A set of C++ classes and macros which provide an event-driven simulation kernel in C++",
+  "homepage": "https://systemc.org/overview/systemc/",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9501,7 +9501,7 @@
       "port-version": 0
     },
     "systemc": {
-      "baseline": "3.0.1",
+      "baseline": "3.0.2",
       "port-version": 0
     },
     "tabulate": {

--- a/versions/s-/systemc.json
+++ b/versions/s-/systemc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "57a72011666c4db8e2108a39d2f4aefe9865d43b",
+      "version": "3.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "be257d75161eb8dbd41c9e63382afe974c96ee94",
       "version": "3.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/accellera-official/systemc/releases/tag/3.0.2
