### PR TITLE
[libdeflate] update 1.25

### DIFF
--- a/ports/libdeflate/portfile.cmake
+++ b/ports/libdeflate/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ebiggers/libdeflate
     REF "v${VERSION}"
-    SHA512 c20a772aeeac593c34e8a68be80b23cb116699141de269d94df072636b6c90572f541b3344d830325cf45b03e7a1303e0274d79ce96c360fd421d4eb05ae1f92
+    SHA512 fa02fa0a6d241d3f71cf4238a3ac58968cbea0b66613c1647d6eea575379d60e93f4647f8b3921e8c31322e20521aa9953213d5465f7d10a27c57bdd7186d318
     HEAD_REF master
     PATCHES
         remove_wrong_c_flags_modification.diff

--- a/ports/libdeflate/vcpkg.json
+++ b/ports/libdeflate/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdeflate",
-  "version": "1.24",
+  "version": "1.25",
   "description": "libdeflate is a library for fast, whole-buffer DEFLATE-based compression and decompression.",
   "homepage": "https://github.com/ebiggers/libdeflate",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4725,7 +4725,7 @@
       "port-version": 1
     },
     "libdeflate": {
-      "baseline": "1.24",
+      "baseline": "1.25",
       "port-version": 0
     },
     "libdicom": {

--- a/versions/l-/libdeflate.json
+++ b/versions/l-/libdeflate.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ceffc2e1864a1a1da49e655da03c323723a9816d",
+      "version": "1.25",
+      "port-version": 0
+    },
+    {
       "git-tree": "57bfea438c023e4d0ca593f215a5f81eaa390151",
       "version": "1.24",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ebiggers/libdeflate/releases/tag/v1.25
