### PR TITLE
[projectm-eval] Update projectm-eval port to 1.0.4

### DIFF
--- a/ports/projectm-eval/portfile.cmake
+++ b/ports/projectm-eval/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO projectM-visualizer/projectm-eval
     REF "v${VERSION}"
-    SHA512 "4559ebf0b14ecc8ab2386a638616f322ec816659b7745d37abadb854b496d21202ab955ab812c2f28be085bbd46f7e83f358149d613f6f31a99068b4345e75a1"
+    SHA512 "cb5f4d1bfba30240e64bfd47076fbbfb3977e8dca95c6a2c1cce42e2f1201046ddcf60b494f13f0f291ad073f3b9387c83cbbd2e8dc1e94d69649a3fac7ec8c9"
     HEAD_REF master
 )
 

--- a/ports/projectm-eval/vcpkg.json
+++ b/ports/projectm-eval/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "projectm-eval",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "The projectM Expression Evaluation Library. A portable drop-in replacement of Milkdrop's \"ns-eel2\" expression parser for use in Milkdrop, projectM and other applications.",
   "homepage": "https://github.com/projectM-visualizer/projectm-eval",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7577,7 +7577,7 @@
       "port-version": 0
     },
     "projectm-eval": {
-      "baseline": "1.0.2",
+      "baseline": "1.0.3",
       "port-version": 0
     },
     "prometheus-cpp": {

--- a/versions/p-/projectm-eval.json
+++ b/versions/p-/projectm-eval.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f5999fde14fe3f3156193a826198d4e05149f7a",
+      "version": "1.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "250ce84de791f27d9f729a57283ca65bb7ff1525",
       "version": "1.0.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Small version bump to fix a memory leak if a syntax error is encountered while parsing expression code with projectm-eval.