### PR TITLE
[alsa] Add Android as supported platform

### DIFF
--- a/ports/alsa/vcpkg.json
+++ b/ports/alsa/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "alsa",
   "version": "1.2.14",
+  "port-version": 1,
   "description": "The Advanced Linux Sound Architecture (ALSA) - library",
   "homepage": "https://www.alsa-project.org/",
   "license": "LGPL-2.1-or-later",
-  "supports": "linux"
+  "supports": "linux | android"
 }

--- a/ports/portmidi/android-support.patch
+++ b/ports/portmidi/android-support.patch
@@ -1,0 +1,13 @@
+diff --git a/pm_common/pmutil.c b/pm_common/pmutil.c
+index b7047e9..8d8817d 100755
+--- a/pm_common/pmutil.c
++++ b/pm_common/pmutil.c
+@@ -8,7 +8,7 @@
+ #include "pmutil.h"
+ #include "pminternal.h"
+ 
+-#ifdef WIN32
++#if defined(WIN32) | defined(ANDROID)
+ #define bzero(addr, siz) memset(addr, 0, siz)
+ #endif
+ 

--- a/ports/portmidi/portfile.cmake
+++ b/ports/portmidi/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 00d7cec97b58c074d484793b6097f4e60d061a9d680940bbcdb6670b287b78dbc099af378fb2e066c61f1c26e5060ded9c8f78c80fc03518b33e43f830e34a27 
     HEAD_REF master
+    PATCHES    
+        "android-support.patch"
 )
 
 if(VCPKG_CRT_LINKAGE STREQUAL static)

--- a/ports/portmidi/vcpkg.json
+++ b/ports/portmidi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "portmidi",
   "version": "2.0.6",
+  "port-version": 1,
   "description": "PortMidi is a cross platform (Windows, macOS, Linux, and BSDs which support alsalib) library for interfacing with operating systems' MIDI I/O APIs.",
   "homepage": "https://github.com/PortMidi/portmidi",
   "license": "MIT",

--- a/versions/a-/alsa.json
+++ b/versions/a-/alsa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ada7fb50cf76c48bc6455ccaf2f1250c1db0669",
+      "version": "1.2.14",
+      "port-version": 1
+    },
+    {
       "git-tree": "9223bc5a763317f67624c922cd4943629c7b4646",
       "version": "1.2.14",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7654,7 +7654,7 @@
     },
     "portmidi": {
       "baseline": "2.0.6",
-      "port-version": 0
+      "port-version": 1
     },
     "portsmf": {
       "baseline": "239",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -106,7 +106,7 @@
     },
     "alsa": {
       "baseline": "1.2.14",
-      "port-version": 0
+      "port-version": 1
     },
     "amd-adl-sdk": {
       "baseline": "17.1",

--- a/versions/p-/portmidi.json
+++ b/versions/p-/portmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3aaa66ea0134b42945c2717cba1a373e71bb3bcf",
+      "version": "2.0.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "11e00d0d1e9938198233302016060c6b7bbb39ff",
       "version": "2.0.6",
       "port-version": 0


### PR DESCRIPTION
ALSA is also supported on Android: https://source.android.com/docs/core/audio
Patching Portmidi to work with Android/ALSA was needed too