### PR TITLE
[projectm] Update projectm port to v4.1.5

### DIFF
--- a/ports/projectm/portfile.cmake
+++ b/ports/projectm/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO projectM-visualizer/projectm
     REF "v${VERSION}"
-    SHA512 "c59885d1b6c96372f451b436a47a10e72f94e114b0dad913aa91b3ee5b48ce77f8423c011f60786cb2a2577d3875cba8e58f2e70e60116672cbc49b2de695ad4"
+    SHA512 "2afc3d9cb8fd22042d3c7e083a39bf52acca038db02a41506996de3a7bc954138e940b686732d0b053f740180cb681636d96dd9595fb1916ac246ff3a5d6daff"
     HEAD_REF master
     PATCHES
         macos-pkgconfig.patch

--- a/ports/projectm/vcpkg.json
+++ b/ports/projectm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "projectm",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "The projectM Music Visualizer. A cross-platform, OpenGL-based reimplementation of Milkdrop as a reusable library.",
   "homepage": "https://github.com/projectM-visualizer/projectm",
   "license": "LGPL-2.1-only AND MIT AND MIT-0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7701,7 +7701,7 @@
       "port-version": 0
     },
     "projectm": {
-      "baseline": "4.1.4",
+      "baseline": "4.1.5",
       "port-version": 0
     },
     "projectm-eval": {

--- a/versions/p-/projectm.json
+++ b/versions/p-/projectm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0f644925322ae34990746d052031a285e03b5588",
+      "version": "4.1.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "2232688923256f7411cc89a6331fbdd9e1da3425",
       "version": "4.1.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Updating the projectm port to the latest maintenance release I've created a few minutes ago: https://github.com/projectM-visualizer/projectm/releases/tag/v4.1.5

The changes noted for projectm-eval are included in the PR created yesterday for the separate port: #48078 