### PR TITLE
[rerun-sdk] Update to `v0.26.2`

### DIFF
--- a/ports/rerun-sdk/portfile.cmake
+++ b/ports/rerun-sdk/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS "https://github.com/rerun-io/rerun/releases/download/${VERSION}/rerun_cpp_sdk.zip"
     FILENAME "rerun_cpp_sdk_${VERSION}.zip"
-    SHA512 f281b9a4804c3446e3feb5d7a205ff62ce93001356f4c084f68ea2899a16800e7962bae4eaebafe31abf9bb49b157e4fa3ffcfba52f079d933f81a4d9b12532a
+    SHA512 2568e587ab4d0a430a31e59da89c106a5560627525aef69825443cc262a410db95f6012b749c27f33b77ac61cbd5322cda93234ef08b589798ce5f24c7d9a40e
 )
 
 # Workaround: The distributed SDK contains a prebuilt rerun_c that is built in Release mode.  On Windows, this means

--- a/ports/rerun-sdk/vcpkg.json
+++ b/ports/rerun-sdk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rerun-sdk",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Open source log handling and visualization for spatial and embodied AI. Managed infrastructure to ingest, store, analyze, and stream data at scale with built-in visual debugging. Fast, flexible, and easy to use.",
   "homepage": "https://rerun.io",
   "license": "MIT OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8461,7 +8461,7 @@
       "port-version": 0
     },
     "rerun-sdk": {
-      "baseline": "0.26.1",
+      "baseline": "0.26.2",
       "port-version": 0
     },
     "rest-rpc": {

--- a/versions/r-/rerun-sdk.json
+++ b/versions/r-/rerun-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8432f000770b0eeba6e5ce031f5508bf681b61f3",
+      "version": "0.26.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "7b4592332412517777cf6893892b6b2a3e918765",
       "version": "0.26.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
