### PR TITLE
Add re2c port

### DIFF
--- a/ports/re2c/portfile.cmake
+++ b/ports/re2c/portfile.cmake
@@ -1,0 +1,67 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO skvadrik/re2c
+    REF "${VERSION}"
+    SHA512 CB837B796D09F61E456F27FDCDB3CBFF804DDD85F7BAD1A5488769BED0467F7483F02E72B5F40FCD2DAA70DA9F9C48654E7DD9033C29DA715A0E1BDF1A6BAB09
+    HEAD_REF master
+)
+
+set(BUILD_OPTIONS
+    -DRE2C_BUILD_TESTS=OFF
+    -DRE2C_BUILD_BENCHMARKS=OFF
+    -DRE2C_REBUILD_DOCS=OFF
+    -DRE2C_REBUILD_LEXERS=OFF
+    -DRE2C_REBUILD_PARSERS=OFF
+    -DRE2C_BUILD_LIBS=OFF
+    # Disable building language-specific executables (re2go, re2rust, etc.)
+    # as they are just aliases for the main re2c executable with --lang flag
+    -DRE2C_BUILD_RE2D=OFF
+    -DRE2C_BUILD_RE2GO=OFF
+    -DRE2C_BUILD_RE2HS=OFF
+    -DRE2C_BUILD_RE2JAVA=OFF
+    -DRE2C_BUILD_RE2JS=OFF
+    -DRE2C_BUILD_RE2OCAML=OFF
+    -DRE2C_BUILD_RE2PY=OFF
+    -DRE2C_BUILD_RE2RUST=OFF
+    -DRE2C_BUILD_RE2SWIFT=OFF
+    -DRE2C_BUILD_RE2V=OFF
+    -DRE2C_BUILD_RE2ZIG=OFF
+)
+
+if(VCPKG_CROSSCOMPILING)
+    # When cross-compiling, we need the host re2c tool to be available
+    list(APPEND BUILD_OPTIONS
+        -DRE2C_FOR_BUILD=${CURRENT_HOST_INSTALLED_DIR}/tools/re2c/re2c${VCPKG_HOST_EXECUTABLE_SUFFIX}
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${BUILD_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# Install the re2c tool
+vcpkg_copy_tools(TOOL_NAMES re2c AUTO_CLEAN)
+
+# Fix pkgconfig files if they exist
+vcpkg_fixup_pkgconfig()
+
+# Remove duplicate files
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# re2c is a code generation tool, not a library
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include")
+
+# Install copyright/license
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+# Install usage
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/re2c/usage
+++ b/ports/re2c/usage
@@ -1,0 +1,19 @@
+re2c provides:
+  - re2c executable for generating lexers from regular expression specifications
+
+The executable is available in the tools/re2c directory.
+
+To use re2c in your CMake project:
+
+```cmake
+find_program(RE2C_EXE re2c)
+
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp
+    COMMAND ${RE2C_EXE} -o ${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp ${CMAKE_SOURCE_DIR}/lexer.re
+    DEPENDS ${CMAKE_SOURCE_DIR}/lexer.re
+    COMMENT "Generating lexer.cpp from lexer.re"
+    VERBATIM
+)
+
+add_executable(myapp main.cpp ${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp)

--- a/ports/re2c/vcpkg.json
+++ b/ports/re2c/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "re2c",
+  "version": "4.3",
+  "description": "re2c is a free and open-source lexer generator for C, C++, Go, and Rust. It compiles regular expression specifications to deterministic finite automata and encodes them in the form of a program in the target language.",
+  "homepage": "https://re2c.org/",
+  "license": "Unlicense",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "re2c",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #48100

I created this PR with github copilot and then manually inspected the results and verified that the port installed locally properly on Windows, but I didn't have a linux machine to test on.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
