### PR TITLE
[tsl-hopscotch-map] update to 2.4.0

### DIFF
--- a/ports/tsl-hopscotch-map/portfile.cmake
+++ b/ports/tsl-hopscotch-map/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Tessil/hopscotch-map
     REF "v${VERSION}"
-    SHA512 e2f215d93c84606e8dc71c3403f60a589bd7f78922b5b90afcd0c9d7cbea7ff2e9c6fdb17a6444d4f4b8c9b42a47066995640cd093d8a32a4dabc8c03262e7d5
+    SHA512 22a2ea5089ef6ef7afb872f6785a1f1d063660a7cb22ccfd4ccbecf95fd0a71ffc72fbb814ac51be8ed7445e75d0d8b79e619d08d7ddf063968fe6e7bf995932
 )
 
 vcpkg_cmake_configure(
@@ -10,6 +10,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/tsl-hopscotch-map/vcpkg.json
+++ b/ports/tsl-hopscotch-map/vcpkg.json
@@ -1,10 +1,15 @@
 {
   "name": "tsl-hopscotch-map",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "C++ implementation of a fast hash map and hash set using hopscotch hashing",
+  "homepage": "https://github.com/Tessil/hopscotch-map",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9881,7 +9881,7 @@
       "port-version": 0
     },
     "tsl-hopscotch-map": {
-      "baseline": "2.3.1",
+      "baseline": "2.4.0",
       "port-version": 0
     },
     "tsl-ordered-map": {

--- a/versions/t-/tsl-hopscotch-map.json
+++ b/versions/t-/tsl-hopscotch-map.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1997796d2880f2f166dc08436c723c8019521a7f",
+      "version": "2.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "bda0cdc786b728426f6f9beffd826207b93d6c21",
       "version": "2.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Tessil/hopscotch-map/releases/tag/v2.4.0
