### PR TITLE
[tsl-ordered-map] update to 1.2.0

### DIFF
--- a/ports/tsl-ordered-map/portfile.cmake
+++ b/ports/tsl-ordered-map/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Tessil/ordered-map
     REF "v${VERSION}"
-    SHA512 1ae4f8876b13aaf5a9b08f8075299255a51e64fac8ca1c46813294e374b8c9334a7bd1b22618719fab2a8dced42be91e96d8b15595ce3dd8a6d726dadba52ce9
+    SHA512 19076fd40e0a4baad58a5cc6f9c906f38167e6c5474e461e982d0e0ea2adeb21fa8acf669145ac033338bf53cc3dc178782d54a9bcf7f835a62b07983da00253
 )
 
 vcpkg_cmake_configure(
@@ -10,6 +10,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/tsl-ordered-map/vcpkg.json
+++ b/ports/tsl-ordered-map/vcpkg.json
@@ -1,10 +1,15 @@
 {
   "name": "tsl-ordered-map",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "C++ hash map and hash set which preserve the order of insertion",
+  "homepage": "https://github.com/Tessil/ordered-map",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9885,7 +9885,7 @@
       "port-version": 0
     },
     "tsl-ordered-map": {
-      "baseline": "1.1.0",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "tsl-sparse-map": {

--- a/versions/t-/tsl-ordered-map.json
+++ b/versions/t-/tsl-ordered-map.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d7119d628e4e4295438f2f04fdbb57b7ba4e019d",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "42c785ae9a220a67e346002c609752fd4b6224bd",
       "version": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Tessil/ordered-map/releases/tag/v1.2.0
