### PR TITLE
[tsl-sparse-map] update  to 0.7.0

### DIFF
--- a/ports/tsl-sparse-map/portfile.cmake
+++ b/ports/tsl-sparse-map/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Tessil/sparse-map
-    REF d71e6fd75f4970f07f4f1fe67438055be70d0945 # v0.6.2
-    SHA512 ad270be66b3d5f96cb0305f0e086807aee1c909dd022c19ca99e5f7a72d5116f2ecb4b67fcb80e8bdb4f98925387d95bdc0bcc450a10b97c61f9b92c681f95b5
+    REF v${VERSION}
+    SHA512 dee8090d8e8d797e0a535d331e49ef48838b038af8fecbc982852ec559aaffd65e12c9efc5ebb6d74bf5f46e7f9df2c1680998909ef7a9062b0954cfabd02706
 )
 
 vcpkg_cmake_configure(
@@ -10,6 +10,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/tsl-sparse-map/vcpkg.json
+++ b/ports/tsl-sparse-map/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "tsl-sparse-map",
-  "version": "0.6.2",
-  "port-version": 3,
+  "version": "0.7.0",
   "description": "C++ implementation of a memory efficient hash map and hash set",
+  "homepage": "https://github.com/Tessil/sparse-map",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9889,8 +9889,8 @@
       "port-version": 0
     },
     "tsl-sparse-map": {
-      "baseline": "0.6.2",
-      "port-version": 3
+      "baseline": "0.7.0",
+      "port-version": 0
     },
     "ttauri": {
       "baseline": "0.5.0",

--- a/versions/t-/tsl-sparse-map.json
+++ b/versions/t-/tsl-sparse-map.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "957f9ae8f48e90f3121f028dc9e0e382b6b1a0b6",
+      "version": "0.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "71fff3f16d7b3d0d58d918e57d619225ffd1ff6e",
       "version": "0.6.2",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Tessil/sparse-map/releases/tag/v0.7.0
