### PR TITLE
[tsl-array-hash] add new port

### DIFF
--- a/ports/tsl-array-hash/portfile.cmake
+++ b/ports/tsl-array-hash/portfile.cmake
@@ -1,0 +1,20 @@
+set(VCPKG_BUILD_TYPE release) # Header-only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Tessil/array-hash
+    REF v${VERSION}
+    SHA512 7aee866aed1c21b838124fda6b11365fdbc04ec8fe7969fbb52c6a30fb81fa945130f85c596a06a9bd8b3235bb6f73444013c719de4fba2d7abc3be4549aa501
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/cmake/${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tsl-array-hash/vcpkg.json
+++ b/ports/tsl-array-hash/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "tsl-array-hash",
+  "version": "0.7.2",
+  "description": "C++ implementation of a memory efficient hash map and hash set",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9880,6 +9880,10 @@
       "baseline": "1.0.1",
       "port-version": 0
     },
+    "tsl-array-hash": {
+      "baseline": "0.7.2",
+      "port-version": 0
+    },
     "tsl-hopscotch-map": {
       "baseline": "2.3.1",
       "port-version": 0

--- a/versions/t-/tsl-array-hash.json
+++ b/versions/t-/tsl-array-hash.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "bdbc86ea89b5956f32644814ca14ba19349fcbc2",
+      "version": "0.7.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Tessil/array-hash
