### PR TITLE
[bbalouki-itch] add new port

### DIFF
--- a/ports/bbalouki-itch/portfile.cmake
+++ b/ports/bbalouki-itch/portfile.cmake
@@ -1,0 +1,35 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bbalouki/itchcpp
+    REF "v${VERSION}"
+    SHA512 ce66984be3c70f83486e9b3f46227bff4d5456d73b58e70fe7f7d08c5fa5fe92a7222ee3c2ad81fda80a1c8e9f745f410d5ccc792bb40d52ef67422532355f65
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DITCH_BUILD_TESTS=OFF
+        -DITCH_BUILD_BENCHMARKS=OFF
+        -DITCH_BUILD_EXAMPLES=OFF
+        -DITCH_PROJECT_ENV=PROD
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "itch"
+    CONFIG_PATH "lib/cmake/itch"
+   
+)
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/bbalouki-itch/usage
+++ b/ports/bbalouki-itch/usage
@@ -1,0 +1,4 @@
+itch provides CMake targets:
+
+find_package(itch CONFIG REQUIRED)
+target_link_libraries(main PRIVATE itch::itch)

--- a/ports/bbalouki-itch/vcpkg.json
+++ b/ports/bbalouki-itch/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "bbalouki-itch",
   "version": "1.0.0",
+  "maintainers": "Bertin Balouki SIMYELI",
   "description": "A High-Performance C++ library for parsing the ITCH 5.0 protocol.",
   "homepage": "https://github.com/bbalouki/itchcpp",
-  "maintainers": "Bertin Balouki SIMYELI",
   "license": "MIT",
   "dependencies": [
     {

--- a/ports/bbalouki-itch/vcpkg.json
+++ b/ports/bbalouki-itch/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "bbalouki-itch",
+  "version": "1.0.0",
+  "description": "A High-Performance C++ library for parsing the ITCH 5.0 protocol.",
+  "homepage": "https://github.com/bbalouki/itchcpp",
+  "maintainers": "Bertin Balouki SIMYELI",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/b-/bbalouki-itch.json
+++ b/versions/b-/bbalouki-itch.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e56f81d89614cec83d8e1368b6a3711b75eccfe6",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -628,6 +628,10 @@
       "baseline": "1.60",
       "port-version": 0
     },
+    "bbalouki-itch": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "bcg729": {
       "baseline": "1.1.1",
       "port-version": 4


### PR DESCRIPTION
- [ x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x ] The license declaration in `vcpkg.json` matches what upstream says.
- [x ] The installed as the "copyright" file matches what upstream says.
- [ x] The source code of the component installed comes from an authoritative source.
- [x ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Only one version is in the new port's versions file.
- [ x] Only one version is added to each modified port's versions file.
