### PR TITLE
[fastcdr] update to 2.3.4

### DIFF
--- a/ports/fastcdr/portfile.cmake
+++ b/ports/fastcdr/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eProsima/Fast-CDR
     REF "v${VERSION}"
-    SHA512 e075e5e90c593c0b0a24327bd06b8deb464c6be8d99b9e3155372c7391f07e08411e904256a69ba6a0bc61a69a4393edfe0cdc78c36be2771c51ed8aa0c2e189
+    SHA512 49ffa82bca0db4968ba2baecbf46c020ac1b072226486678cfe26ab7c023ab6cbcb1b48c48d9ac2e7254ef6ce0c61f717c3cbbc5f546a13d8dff299ce382580c
     HEAD_REF master
     PATCHES
         pdb-file.patch

--- a/ports/fastcdr/vcpkg.json
+++ b/ports/fastcdr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastcdr",
-  "version-semver": "2.3.3",
+  "version-semver": "2.3.4",
   "description": "eProsima FastCDR is a C++ library that provides two serialization mechanisms. One is the standard CDR serialization mechanism, while the other is a faster implementation that modifies the standard.",
   "homepage": "https://github.com/eProsima/Fast-CDR",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2845,7 +2845,7 @@
       "port-version": 0
     },
     "fastcdr": {
-      "baseline": "2.3.3",
+      "baseline": "2.3.4",
       "port-version": 0
     },
     "fastcgi": {

--- a/versions/f-/fastcdr.json
+++ b/versions/f-/fastcdr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aee4d40e657f6a79ca4b04d080aafc4c4f226237",
+      "version-semver": "2.3.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "5f2d895d6fb813e03f57e8695ecef3144007546c",
       "version-semver": "2.3.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/eProsima/Fast-CDR/releases/tag/v2.3.4
