### PR TITLE
[task-thread-pool] update to 1.0.10

### DIFF
--- a/ports/task-thread-pool/find-threads.patch
+++ b/ports/task-thread-pool/find-threads.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/config.cmake.in b/cmake/config.cmake.in
+index 6e1cd02..712ed1b 100644
+--- a/cmake/config.cmake.in
++++ b/cmake/config.cmake.in
+@@ -1,6 +1,9 @@
+ 
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(Threads)
++
+ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+ 
+ set_and_check(@PROJECT_NAME@_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")

--- a/ports/task-thread-pool/fix-header-file-path.patch
+++ b/ports/task-thread-pool/fix-header-file-path.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c155ade..319351c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,7 +23,7 @@ target_include_directories(
+         $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include>)
+ 
+-set(HEADER_FILES task_thread_pool.hpp)
++set(HEADER_FILES include/task_thread_pool.hpp)
+ 
+ set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
+ 

--- a/ports/task-thread-pool/portfile.cmake
+++ b/ports/task-thread-pool/portfile.cmake
@@ -1,13 +1,25 @@
+set(VCPKG_BUILD_TYPE release) # Header-only library
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alugowski/task-thread-pool
     REF v${VERSION}
-    SHA512 8f67e4d467c16bd0986f4fbfda6e7ca74760ddf3c4333660c764c97df0a21a40f36dc5af11c47f41e1cc0eb9c498ff2ca7b93a11a32dea296181592f5a05fd1d
+    SHA512 9ab656fe75dcdafa1fee3fe3d227e8302628894b8dc7d65f80f5d28e7b989dfe299f4f1b5d9c179f238b46b60315fc0be0ff30fdbde570c5709cf2fa4251042e
     HEAD_REF main
+    PATCHES
+        fix-header-file-path.patch
+        find-threads.patch
 )
 
-file(GLOB HEADER_FILES LIST_DIRECTORIES false "${SOURCE_PATH}/include/*.hpp")
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DTASK_THREAD_POOL_TEST=OFF
+        -DTASK_THREAD_POOL_BENCH=OFF
+)
 
-file(INSTALL ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME task_thread_pool CONFIG_PATH share/cmake/task_thread_pool)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-BSD.txt" "${SOURCE_PATH}/LICENSE-Boost.txt" "${SOURCE_PATH}/LICENSE-MIT.txt")

--- a/ports/task-thread-pool/vcpkg.json
+++ b/ports/task-thread-pool/vcpkg.json
@@ -1,8 +1,18 @@
 {
   "name": "task-thread-pool",
-  "version": "1.0.7",
+  "version": "1.0.10",
   "description": "Fast and lightweight thread pool for C++11 and newer.",
   "homepage": "https://github.com/alugowski/task-thread-pool",
   "documentation": "https://github.com/alugowski/task-thread-pool/blob/main/README.md",
-  "license": "BSD-2-Clause OR MIT OR BSL-1.0"
+  "license": "BSD-2-Clause OR MIT OR BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9545,7 +9545,7 @@
       "port-version": 2
     },
     "task-thread-pool": {
-      "baseline": "1.0.7",
+      "baseline": "1.0.10",
       "port-version": 0
     },
     "taskflow": {

--- a/versions/t-/task-thread-pool.json
+++ b/versions/t-/task-thread-pool.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c87e3128612e25caeda444345357d4d5de1b3055",
+      "version": "1.0.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "b64ff5ad8b40dbfe129aabe53f11b81ba71e4743",
       "version": "1.0.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/alugowski/task-thread-pool/releases/tag/v1.0.10
