### PR TITLE
[libhsplasma] update to 2025.11.04

### DIFF
--- a/ports/libhsplasma/portfile.cmake
+++ b/ports/libhsplasma/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO H-uru/libhsplasma
     REF "${REF_DOT_VERSION_DATE}"
-    SHA512 2edf124fe583e053c078f58d94110ed2285e1f02a34cc7607dfc79f8ab587e173e5782af5d4e2846613d7d6b3e1a27a319fdf138c7546c1c6257b5c8422c2f5a
+    SHA512 bf882347b8272a06335776454c339ccb36edcc4068978c2675700cf124f319eccc23a739427a3e2f57e1f27c3f4c5281db9ce5a914de78e97704f8b94af61d8e
     HEAD_REF master
 )
 
@@ -20,6 +20,10 @@ vcpkg_cmake_configure(
         -DENABLE_PHYSX=OFF
         -DENABLE_PYTHON=OFF
         -DENABLE_TOOLS=OFF
+
+        # Catch2 test discovery has some odd interactions with PATH, which
+        # appear to still be unresolved.  For simplicity, just skip tests.
+        -DENABLE_TESTS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/libhsplasma/vcpkg.json
+++ b/ports/libhsplasma/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libhsplasma",
-  "version-date": "2024-03-07",
+  "version-date": "2025-11-04",
   "description": "Cross-platform Plasma data and network library",
   "homepage": "https://github.com/H-uru/libhsplasma",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4953,7 +4953,7 @@
       "port-version": 0
     },
     "libhsplasma": {
-      "baseline": "2024-03-07",
+      "baseline": "2025-11-04",
       "port-version": 0
     },
     "libhv": {

--- a/versions/l-/libhsplasma.json
+++ b/versions/l-/libhsplasma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d58658456457d9b6f27a33864b6b9ad071acdef5",
+      "version-date": "2025-11-04",
+      "port-version": 0
+    },
+    {
       "git-tree": "76d1885f3b8855729332ec228da966024994716c",
       "version-date": "2024-03-07",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.