### PR TITLE
[libhat]: add new package

### DIFF
--- a/ports/libhat/0001-CMakeLists.patch
+++ b/ports/libhat/0001-CMakeLists.patch
@@ -1,0 +1,44 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d04055c..ade5ce6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -81,12 +81,12 @@ target_compile_features(libhat PUBLIC cxx_std_20)
+ 
+ if (MSVC)
+     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+-        target_compile_options(libhat PRIVATE /clang:-Wall /clang:-Wextra /clang:-Wconversion /clang:-Werror)
++        target_compile_options(libhat PRIVATE /clang:-Wall /clang:-Wextra /clang:-Wconversion)
+     else()
+         target_compile_options(libhat PRIVATE /W3 /WX)
+     endif()
+ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+-    target_compile_options(libhat PRIVATE -Wall -Wextra -Wconversion -Werror
++    target_compile_options(libhat PRIVATE -Wall -Wextra -Wconversion
+             # temp fix for macOS CI failing due to incorrect LIBHAT_COMPILER_X86_OPTIONS value
+             -Wno-unused-command-line-argument
+     )
+@@ -155,10 +155,24 @@ if(LIBHAT_TESTING)
+ endif()
+ 
+ if(LIBHAT_INSTALL_TARGET)
++    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/libhat" DESTINATION "include")
+     install(TARGETS libhat
+         EXPORT libhat-targets
+         RUNTIME DESTINATION "bin"
+         ARCHIVE DESTINATION "lib"
+         LIBRARY DESTINATION "lib"
+     )
++    install(EXPORT libhat-targets NAMESPACE libhat:: DESTINATION "share/libhat")
++    include(CMakePackageConfigHelpers)
++    configure_package_config_file(
++        "${CMAKE_CURRENT_LIST_DIR}/libhat-config.cmake.in"
++        "${CMAKE_CURRENT_BINARY_DIR}/libhat-config.cmake"
++        INSTALL_DESTINATION "share/libhat"
++    )
++    write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/libhat-config-version.cmake" VERSION "${VERSION}" COMPATIBILITY SameMajorVersion)
++    install(FILES
++        "${CMAKE_CURRENT_BINARY_DIR}/libhat-config.cmake"
++        "${CMAKE_CURRENT_BINARY_DIR}/libhat-config-version.cmake"
++        DESTINATION "share/libhat"
++    )
+ endif()

--- a/ports/libhat/0002-fix-gcc.patch
+++ b/ports/libhat/0002-fix-gcc.patch
@@ -1,0 +1,24 @@
+diff --git a/include/libhat/compressed_pair.hpp b/include/libhat/compressed_pair.hpp
+index 7bf839a..1b2be6c 100644
+--- a/include/libhat/compressed_pair.hpp
++++ b/include/libhat/compressed_pair.hpp
+@@ -4,6 +4,7 @@
+     #include <tuple>
+ #endif
+ 
++#include <cstddef>
+ #include "defines.hpp"
+ #include "type_traits.hpp"
+ 
+diff --git a/include/libhat/strconv.hpp b/include/libhat/strconv.hpp
+index f23d096..ad527fb 100644
+--- a/include/libhat/strconv.hpp
++++ b/include/libhat/strconv.hpp
+@@ -5,6 +5,7 @@
+     #include <type_traits>
+ #endif
+ 
++#include <cstdint>
+ #include "concepts.hpp"
+ #include "export.hpp"
+ #include "result.hpp"

--- a/ports/libhat/libhat-config.cmake.in
+++ b/ports/libhat/libhat-config.cmake.in
@@ -1,3 +1,3 @@
 @PACKAGE_INIT@
-include(CMakeFindDependencyMacro)
 include("${CMAKE_CURRENT_LIST_DIR}/libhat-targets.cmake")
+check_required_components(libhat)

--- a/ports/libhat/libhat-config.cmake.in
+++ b/ports/libhat/libhat-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+include(CMakeFindDependencyMacro)
+include("${CMAKE_CURRENT_LIST_DIR}/libhat-targets.cmake")

--- a/ports/libhat/portfile.cmake
+++ b/ports/libhat/portfile.cmake
@@ -1,0 +1,41 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO BasedInc/libhat
+    REF "v${VERSION}"
+    SHA512 e2f3b06ea79436704b6f419370ca99e200d50c157f36492945006ce1b0bf5f7f924b601296babb3c2a6c0d50487c10551f7dfb5eeda51bd6c87044079be47db3
+    HEAD_REF master
+    PATCHES
+        0001-CMakeLists.patch
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/libhat-config.cmake.in" DESTINATION "${SOURCE_PATH}")
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic"   LIBHAT_BUILD_SHARED)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static"    LIBHAT_BUILD_STATIC)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "hint"  LIBHAT_HINT_X86_64
+    INVERTED_FEATURES
+        "sse"    LIBHAT_DISABLE_SSE
+        "avx"    LIBHAT_DISABLE_AVX512
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DLIBHAT_SHARED_C_LIB=${LIBHAT_BUILD_SHARED}
+        -DLIBHAT_STATIC_C_LIB=${LIBHAT_BUILD_STATIC}
+        -DLIBHAT_TESTING=OFF
+        -DLIBHAT_TESTING_ASAN=OFF
+        -DLIBHAT_TESTING_SDE=OFF
+        -DLIBHAT_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libhat/portfile.cmake
+++ b/ports/libhat/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BasedInc/libhat

--- a/ports/libhat/portfile.cmake
+++ b/ports/libhat/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         0001-CMakeLists.patch
+        0002-fix-gcc.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/libhat-config.cmake.in" DESTINATION "${SOURCE_PATH}")

--- a/ports/libhat/vcpkg.json
+++ b/ports/libhat/vcpkg.json
@@ -1,0 +1,31 @@
+{
+  "name": "libhat",
+  "version": "0.7.0",
+  "description": "A high-performance, modern, C++20 library designed around game hacking.",
+  "homepage": "https://github.com/BasedInc/libhat",
+  "license": "MIT",
+  "supports": "windows | linux",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "avx": {
+      "description": "Enables AVX512 scanning",
+      "supports": "!arm"
+    },
+    "hint": {
+      "description": "Enables support for the x86_64 scan hint, requires a small (2KB) data table"
+    },
+    "sse": {
+      "description": "Enables SSE scanning",
+      "supports": "!arm"
+    }
+  }
+}

--- a/scripts/test_ports/vcpkg-ci-libhat/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-libhat/portfile.cmake
@@ -1,0 +1,5 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-libhat/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-libhat/project/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(libhat-test LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+find_package(libhat CONFIG REQUIRED)
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE libhat::libhat)

--- a/scripts/test_ports/vcpkg-ci-libhat/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-libhat/project/main.cpp
@@ -1,0 +1,6 @@
+#include <libhat/signature.hpp>
+int main()
+{
+   auto sig = hat::parse_signature("01 02 03 04 05 06 07 08 09").value();
+   return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-libhat/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-libhat/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-libhat",
+  "version-string": "ci",
+  "description": "Validates libhat",
+  "dependencies": [
+    "libhat",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4948,6 +4948,10 @@
       "baseline": "2.4.4",
       "port-version": 1
     },
+    "libhat": {
+      "baseline": "0.7.0",
+      "port-version": 0
+    },
     "libhdfs3": {
       "baseline": "2019-11-05",
       "port-version": 6

--- a/versions/l-/libhat.json
+++ b/versions/l-/libhat.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "25c4fb2bffda1c7bc9272bec38a0d22a7f81a6ef",
+      "git-tree": "64a62e75e0bd30a7f6d5674564b37a6585618666",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/l-/libhat.json
+++ b/versions/l-/libhat.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5c169e535ac3381253200d9cd58868709afb2714",
+      "git-tree": "25c4fb2bffda1c7bc9272bec38a0d22a7f81a6ef",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/l-/libhat.json
+++ b/versions/l-/libhat.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a0545307949ec6397cdb18ed87a5cb2b5a40ed13",
+      "git-tree": "f9e25beff4afab5ea052f12b085afbcb7c96f9a1",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/l-/libhat.json
+++ b/versions/l-/libhat.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a0545307949ec6397cdb18ed87a5cb2b5a40ed13",
+      "version": "0.7.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libhat.json
+++ b/versions/l-/libhat.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f9e25beff4afab5ea052f12b085afbcb7c96f9a1",
+      "git-tree": "5c169e535ac3381253200d9cd58868709afb2714",
       "version": "0.7.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
