### PR TITLE
[openssl] Limit OpenSSL command-line length under cygwin (not just msys)

### DIFF
--- a/ports/openssl/command-line-length.patch
+++ b/ports/openssl/command-line-length.patch
@@ -7,7 +7,7 @@ index 8ddb128..52b9ad6 100644
        my $deps = join(" \\\n" . ' ' x (length($lib) + 2),
                        fill_lines(' ', $COLUMNS - length($lib) - 2, @objs));
 -      my $max_per_call = 500;
-+      my $max_per_call = ($^O eq 'msys') ? 80 : 500;
++      my $max_per_call = ($^O eq 'msys' || $^O eq 'cygwin') ? 80 : 500;
        my @objs_grouped;
        push @objs_grouped, join(" ", splice @objs, 0, $max_per_call) while @objs;
        my $fill_lib =

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openssl",
   "version": "3.6.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7230,7 +7230,7 @@
     },
     "openssl": {
       "baseline": "3.6.0",
-      "port-version": 2
+      "port-version": 3
     },
     "opensubdiv": {
       "baseline": "3.5.0",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "21c1dabbf149eaa75b6c8b6ba9c3c6edb4f47ea7",
+      "version": "3.6.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "f6b1f0316e441f3db9debd95bb753c03eeadc592",
       "version": "3.6.0",
       "port-version": 2


### PR DESCRIPTION
#37076 added a patch to limit the OpenSSL command-line length on msys (Windows). In my attempt to build OpenSSL with Emscripten (v4.0.13), `$^O` is `cygwin` rather than `msys`, so that patch doesn't help. The build fails due to exceeding the command-line length limit. This PR changes the previous patch to also use a reduced command line length under cygwin. With this change, the build of this package for the `wasm32-emscripten` triplet succeeds on my Windows system.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] ~SHA512s are updated for each updated download.~
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
