### PR TITLE
[sleef] Use SEH on Windows while checking for CPU extensions

### DIFF
--- a/ports/sleef/portfile.cmake
+++ b/ports/sleef/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         exclude-testerutil.diff
         export-link-libs.diff
         sleefdft.pc.diff
+        seh-cpu-ext.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS options

--- a/ports/sleef/seh-cpu-ext.diff
+++ b/ports/sleef/seh-cpu-ext.diff
@@ -1,0 +1,26 @@
+diff --git a/src/libm/dispatcher.h b/src/libm/dispatcher.h
+index 41b69d9..4d395c3 100644
+--- a/src/libm/dispatcher.h
++++ b/src/libm/dispatcher.h
+@@ -27,6 +27,14 @@ NOEXPORT int Sleef_internal_cpuSupportsExt(void (*tryExt)(), int *cache) {
+   static int cache = -1;
+   if (cache != -1) return cache;
+ 
++#ifdef _MSC_VER
++  __try {
++    (*tryExt)();
++    cache = 1;
++  } __except(1) {
++    cache = 0;
++  }
++#else
+   void (*org);
+   org = signal(SIGILL, sighandler);
+ 
+@@ -38,5 +46,6 @@ NOEXPORT int Sleef_internal_cpuSupportsExt(void (*tryExt)(), int *cache) {
+   }
+ 
+   signal(SIGILL, org);
++#endif
+   return cache;
+ }

--- a/ports/sleef/vcpkg.json
+++ b/ports/sleef/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sleef",
   "version": "3.9.0",
+  "port-version": 1,
   "description": "SIMD Library for Evaluating Elementary Functions, vectorized libm and DFT",
   "homepage": "https://sleef.org/",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9042,7 +9042,7 @@
     },
     "sleef": {
       "baseline": "3.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sleepy-discord": {
       "baseline": "2025-02-08",

--- a/versions/s-/sleef.json
+++ b/versions/s-/sleef.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "87a3b005437f19afd02da1e48810610db8fcd700",
+      "git-tree": "c20095f0ab0040ddf9f28377e35d670fbc720daa",
       "version": "3.9.0",
       "port-version": 1
     },

--- a/versions/s-/sleef.json
+++ b/versions/s-/sleef.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "87a3b005437f19afd02da1e48810610db8fcd700",
+      "version": "3.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "afcb099ce882dcb1b316af9efa306b6d9ec3ba69",
       "version": "3.9.0",
       "port-version": 0


### PR DESCRIPTION
MS Windows does not raise SIGILL to be caught as expected by sleef while checking for supported CPU extensions. We use standard SEH stuff on that platform. Otherwise this port is unusable on older CPUs.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
