### PR TITLE
[libpopcnt] add new port

### DIFF
--- a/ports/libpopcnt/portfile.cmake
+++ b/ports/libpopcnt/portfile.cmake
@@ -1,0 +1,13 @@
+set(VCPKG_BUILD_TYPE release) # Header-only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kimwalisch/libpopcnt
+    REF "v${VERSION}"
+    SHA512 b01f1446c951b848357ed01e31cb2d1014639ba854710edcc5703b69226b9ca2e65c84d78308cf345654fbfc92ce467bb5a5171158db5b94f979674efb59f6dc
+    HEAD_REF master
+)
+
+file(COPY "${SOURCE_PATH}/libpopcnt.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libpopcnt/vcpkg.json
+++ b/ports/libpopcnt/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "libpopcnt",
+  "version": "3.1",
+  "description": "Fast C/C++ bit population count library",
+  "homepage": "https://github.com/kimwalisch/libpopcnt",
+  "license": "BSD-2-Clause"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5332,6 +5332,10 @@
       "baseline": "1.6.50",
       "port-version": 0
     },
+    "libpopcnt": {
+      "baseline": "3.1",
+      "port-version": 0
+    },
     "libpopt": {
       "baseline": "1.16",
       "port-version": 18

--- a/versions/l-/libpopcnt.json
+++ b/versions/l-/libpopcnt.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "75540d799c09ac684dcd0e1503129e471621e626",
+      "version": "3.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/kimwalisch/libpopcnt