### PR TITLE
[skia] disable atlas renderer to fix font rendering

### DIFF
--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_from_github(
         allow-disabling-lib-dl.patch
         always-build-pathops.patch
         remove-directwrite-png-dependency.patch # merged in newer versions on upstream
+        skia-disable-atlas-renderer.patch
 )
 
 # De-vendor

--- a/ports/skia/skia-disable-atlas-renderer.patch
+++ b/ports/skia/skia-disable-atlas-renderer.patch
@@ -1,0 +1,23 @@
+diff --git a/src/gpu/ganesh/PathRendererChain.cpp b/src/gpu/ganesh/PathRendererChain.cpp
+index d248e7bab5..2c55a6c15a 100644
+--- a/src/gpu/ganesh/PathRendererChain.cpp
++++ b/src/gpu/ganesh/PathRendererChain.cpp
+@@ -40,6 +40,9 @@ PathRendererChain::PathRendererChain(GrRecordingContext* context, const Options&
+     if (options.fGpuPathRenderers & GpuPathRenderers::kAALinearizing) {
+         fChain.push_back(sk_make_sp<AALinearizingConvexPathRenderer>());
+     }
++#if 0
++    // Disable the Atlas path renderer because it does not work correctly on many GPUs:
++    // https://issues.skia.org/issues/394350438
+     if (options.fGpuPathRenderers & GpuPathRenderers::kAtlas) {
+         if (auto atlasPathRenderer = AtlasPathRenderer::Make(context)) {
+             fAtlasPathRenderer = atlasPathRenderer.get();
+@@ -47,6 +50,7 @@ PathRendererChain::PathRendererChain(GrRecordingContext* context, const Options&
+             fChain.push_back(std::move(atlasPathRenderer));
+         }
+     }
++#endif
+ #if !defined(SK_ENABLE_OPTIMIZE_SIZE)
+     if (options.fGpuPathRenderers & GpuPathRenderers::kSmall) {
+         fChain.push_back(sk_make_sp<SmallPathRenderer>());
+

--- a/ports/skia/vcpkg.json
+++ b/ports/skia/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "skia",
   "version": "140",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.",
     "It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9034,7 +9034,7 @@
     },
     "skia": {
       "baseline": "140",
-      "port-version": 2
+      "port-version": 3
     },
     "skyr-url": {
       "baseline": "1.13.0",

--- a/versions/s-/skia.json
+++ b/versions/s-/skia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "946a554dba8a21799c34f90554f30f7edd984b34",
+      "version": "140",
+      "port-version": 3
+    },
+    {
       "git-tree": "6fd733c194f2bdf62c496ecbddba0a9b1000ef38",
       "version": "140",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->


On many PC GPUs, font rendering at some sizes is badly broken with the Ganes/OpenGL backend, resulting in no output at all.
This was reported in https://issues.skia.org/issues/394350438
This patch eliminates this problem by disabling the Atlas-based renderer until the issue is resolved upstream.
