### PR TITLE
[luau] update to 0.698

### DIFF
--- a/ports/luau/cmake-config-export.patch
+++ b/ports/luau/cmake-config-export.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 03f235c..75aa1ec 100644
+index 4fb21c3..5ce6814 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -67,31 +67,31 @@ add_library(Luau.VM.Internals INTERFACE)
+@@ -66,41 +66,41 @@ add_library(Luau.VM.Internals INTERFACE)
  
  include(Sources.cmake)
  
@@ -28,6 +28,7 @@ index 03f235c..75aa1ec 100644
 -target_include_directories(Luau.Config PUBLIC Config/include)
 +target_include_directories(Luau.Config PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Config/include> $<INSTALL_INTERFACE:include/luau>)
  target_link_libraries(Luau.Config PUBLIC Luau.Ast)
+ target_link_libraries(Luau.Config PRIVATE Luau.Compiler Luau.VM)
  
  target_compile_features(Luau.Analysis PUBLIC cxx_std_17)
 -target_include_directories(Luau.Analysis PUBLIC Analysis/include)
@@ -41,7 +42,9 @@ index 03f235c..75aa1ec 100644
  target_link_libraries(Luau.EqSat PUBLIC Luau.Common)
  
  target_compile_features(Luau.CodeGen PRIVATE cxx_std_17)
-@@ -100,7 +100,7 @@ target_link_libraries(Luau.CodeGen PRIVATE Luau.VM Luau.VM.Internals) # Code gen
+-target_include_directories(Luau.CodeGen PUBLIC CodeGen/include)
++target_include_directories(Luau.VM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CodeGen/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ target_link_libraries(Luau.CodeGen PRIVATE Luau.VM Luau.VM.Internals) # Code generation needs VM internals
  target_link_libraries(Luau.CodeGen PUBLIC Luau.Common)
  
  target_compile_features(Luau.VM PRIVATE cxx_std_11)
@@ -50,7 +53,7 @@ index 03f235c..75aa1ec 100644
  target_link_libraries(Luau.VM PUBLIC Luau.Common)
  
  target_compile_features(Luau.Require PUBLIC cxx_std_17)
-@@ -194,22 +194,6 @@ if(MSVC AND LUAU_BUILD_CLI)
+@@ -189,22 +189,6 @@ if(MSVC AND LUAU_BUILD_CLI)
      set_target_properties(Luau.Repl.CLI PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
  endif()
  
@@ -73,7 +76,7 @@ index 03f235c..75aa1ec 100644
  # On Windows and Android threads are provided, on Linux/Mac/iOS we use pthreads
  add_library(osthreads INTERFACE)
  if(CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin|iOS")
-@@ -299,3 +283,54 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.EqSat Luau.Cod
+@@ -297,3 +281,54 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.EqSat Luau.Cod
          endif()
      endif()
  endforeach()

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 15b1880b82e5d3dc2ad1a483b4a6a0280778a20fc1b96408f01ce87e423c5c40b574f99929e1ca401189486c466ec5ffd4f4cf98d42df8089426973436e5c4d8
+    SHA512 74e4ffc8dbd3f05bcd92fa0e0e75a96b393dc738ec3ccacacf3de58738ba2fa65c5aeaa4da7e317c06ce43deb66635dce34d777a91d4e41f4ac9a13186168c69
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.695",
+  "version": "0.698",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6069,7 +6069,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.695",
+      "baseline": "0.698",
       "port-version": 0
     },
     "luminoengine": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5875c935febb8f8d7b18f91e1c518e51aabb6762",
+      "version": "0.698",
+      "port-version": 0
+    },
+    {
       "git-tree": "69f3300b2df862c37e276962c647879466b1843b",
       "version": "0.695",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/luau-lang/luau/releases/tag/0.698
