### PR TITLE
[libxcrypt] update to 4.5.0

### DIFF
--- a/ports/libxcrypt/portfile.cmake
+++ b/ports/libxcrypt/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO besser82/libxcrypt
     REF "v${VERSION}"
-    SHA512 05b0288ca1f1371674516df2e6cc9034f34057bb86a4b1702577dcf1eb7ce4730fad3e660d69123f108aec1f1ab8a0f84aec50ada012fe523e94d10e2303835e
+    SHA512 e66f78adda1989e635d8df3f0273816c979d9bcb0396ed8bfa326541e7e8e0d092d63d19dba3dd5aafb887f74eff835d344d4cffc0a98d7e8ee8b2de3b88fabc
 )
 
 vcpkg_make_configure(

--- a/ports/libxcrypt/vcpkg.json
+++ b/ports/libxcrypt/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxcrypt",
-  "version": "4.4.38",
-  "port-version": 2,
+  "version": "4.5.0",
   "description": "libxcrypt is a modern library for one-way hashing of passwords. On Linux-based systems, by default libxcrypt will be binary backward compatible with the libcrypt.so.1 shipped as part of the GNU C Library.",
   "homepage": "https://github.com/besser82/libxcrypt",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5741,8 +5741,8 @@
       "port-version": 0
     },
     "libxcrypt": {
-      "baseline": "4.4.38",
-      "port-version": 2
+      "baseline": "4.5.0",
+      "port-version": 0
     },
     "libxcvt": {
       "baseline": "0.1.2",

--- a/versions/l-/libxcrypt.json
+++ b/versions/l-/libxcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41cb93cc1953d2dadda6d4df099671481f92db6e",
+      "version": "4.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2130f0d0eeac155bbeca85087059aa313920d900",
       "version": "4.4.38",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/besser82/libxcrypt/releases/tag/v4.5.0
