### PR TITLE
[libzim] update to 9.4.0

### DIFF
--- a/ports/libzim/cross-builds.diff
+++ b/ports/libzim/cross-builds.diff
@@ -1,10 +1,10 @@
 diff --git a/meson.build b/meson.build
-index f3e7a27..d946c49 100644
+index 71300d3..25bbf9f 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -1,9 +1,9 @@
  project('libzim', ['c', 'cpp'],
-   version : '9.0.0',
+   version : '9.4.0',
    license : 'GPL2',
 -  default_options : ['c_std=c11', 'cpp_std=c++17', 'werror=true'])
 +  default_options : ['c_std=c11', 'cpp_std=c++17'])
@@ -14,18 +14,7 @@ index f3e7a27..d946c49 100644
    add_project_arguments('-D_LARGEFILE64_SOURCE=1', '-D_FILE_OFFSET_BITS=64', language: 'cpp')
  endif
  
-@@ -56,8 +56,8 @@ private_conf.set('ENABLE_XAPIAN', xapian_dep.found())
- public_conf.set('LIBZIM_WITH_XAPIAN', xapian_dep.found())
- 
- pkg_requires = ['liblzma', 'libzstd']
--if build_machine.system() == 'windows'
--    extra_link_args = ['-lRpcrt4', '-lWs2_32', '-lwinmm', '-licuuc', '-licuin']
-+if host_machine.system() == 'windows'
-+    extra_link_args = ['-lrpcrt4', '-lws2_32', '-lwinmm']
-     extra_cpp_args = ['-DSORTPP_PASS']
- else
-     extra_link_args = []
-@@ -65,7 +65,7 @@ else
+@@ -69,7 +69,7 @@ else
  endif
  
  compiler = meson.get_compiler('cpp')
@@ -33,13 +22,4 @@ index f3e7a27..d946c49 100644
 +if (compiler.get_id() == 'gcc' and host_machine.system() == 'linux') or host_machine.system() == 'freebsd'
    # C++ std::thread is implemented using pthread on linux by gcc
    thread_dep = dependency('threads')
- else
-@@ -74,6 +74,8 @@ endif
- 
- if xapian_dep.found()
-     pkg_requires += ['xapian-core']
-+endif
-+if true
-     icu_dep = dependency('icu-i18n', static:static_linkage)
-     pkg_requires += ['icu-i18n']
  else

--- a/ports/libzim/portfile.cmake
+++ b/ports/libzim/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openzim/libzim
     REF "${VERSION}"
-    SHA512 55d18535d677d3249c8331ceac1acd4afa650de1f61a0aa3ffc1c98ca2a395bc657c774d01780f1a2c2aedd7d9c5d2e7d9f5e717ed879de84dc6d1be6accfe5e
+    SHA512 de1588addec8b2398912a99cc5b46c1fa156d1ce01d2db1544b40c966bf305d859a52b51b8532d74cdba3c4e3392a3f4be68f4e8ac93392c56c3a24fa6b135c8
     HEAD_REF main
     PATCHES
         cross-builds.diff

--- a/ports/libzim/vcpkg.json
+++ b/ports/libzim/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libzim",
-  "version": "9.0.0",
+  "version": "9.4.0",
   "description": "The Libzim is the reference implementation for the ZIM file format. It's a software library to read and write ZIM files on many systems and architectures. More information about the ZIM format and the openZIM project at https://openzim.org/.",
   "homepage": "https://github.com/openzim/libzim",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5881,7 +5881,7 @@
       "port-version": 0
     },
     "libzim": {
-      "baseline": "9.0.0",
+      "baseline": "9.4.0",
       "port-version": 0
     },
     "libzip": {

--- a/versions/l-/libzim.json
+++ b/versions/l-/libzim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c327e69f6f675cfa31d833aa26ae0c96366366b3",
+      "version": "9.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1b50ef00c5ff7e2ba8f3b064c8ffe6eb14a74f28",
       "version": "9.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/openzim/libzim/blob/9.4.0/ChangeLog#L1-L66

