### PR TITLE
[directxtk, directxtk12] Update for October 2025 releases

### DIFF
--- a/ports/directxtk/CMake-build-options-improvements.patch
+++ b/ports/directxtk/CMake-build-options-improvements.patch
@@ -1,0 +1,161 @@
+---
+ CMakeLists.txt    | 66 +++++++++++++++++++++++++++--------------------
+ CMakePresets.json |  6 +++--
+ 2 files changed, 42 insertions(+), 30 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 70db51f..de2ccfb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -60,14 +60,28 @@ if(XBOX_CONSOLE_TARGET STREQUAL "durango")
+   set(BUILD_GAMEINPUT OFF)
+   set(BUILD_WGI OFF)
+   set(BUILD_XINPUT OFF)
+-  set(BUILD_XBOXONE_SHADERS ON)
+   set(BUILD_XAUDIO_WIN10 OFF)
+   set(BUILD_XAUDIO_WIN8 ON)
++  set(BUILD_XAUDIO_REDIST OFF)
++  set(BUILD_XBOXONE_SHADERS ON)
+   set(BUILD_TOOLS OFF)
+ elseif(WINDOWS_STORE)
+   set(BUILD_GAMEINPUT OFF)
+   set(BUILD_WGI ON)
++  set(BUILD_XINPUT OFF)
++  set(BUILD_XAUDIO_WIN10 ON)
++  set(BUILD_XAUDIO_WIN8 OFF)
++  set(BUILD_XAUDIO_REDIST OFF)
+   set(BUILD_TOOLS OFF)
++elseif(MINGW)
++  set(BUILD_WGI OFF)
++  set(BUILD_XAUDIO_WIN10 OFF)
++  set(BUILD_XAUDIO_WIN8 OFF)
++  if (NOT BUILD_GAMEINPUT)
++    set(BUILD_XINPUT ON)
++  endif()
++elseif(WIN32 AND (NOT BUILD_GAMEINPUT) AND (NOT BUILD_WGI))
++  set(BUILD_XINPUT ON)
+ endif()
+ 
+ include(GNUInstallDirs)
+@@ -145,29 +159,14 @@ set(SHADER_SOURCES
+     Src/Shaders/SpriteEffect.fx
+     Src/Shaders/ToneMap.fx)
+ 
+-# Xbox-specific extensions
+-if(DEFINED XBOX_CONSOLE_TARGET)
+-  set(LIBRARY_HEADERS ${LIBRARY_HEADERS}
+-      Inc/XboxDDSTextureLoader.h)
+-
+-  set(LIBRARY_SOURCES ${LIBRARY_SOURCES}
+-      Src/XboxDDSTextureLoader.cpp)
+-endif()
+-
+ # These source files are identical in both DX11 and DX12 version.
+ set(LIBRARY_HEADERS ${LIBRARY_HEADERS}
+-    Inc/GamePad.h
+-    Inc/Keyboard.h
+-    Inc/Mouse.h
+     Inc/SimpleMath.h
+     Inc/SimpleMath.inl)
+ 
+ set(LIBRARY_SOURCES ${LIBRARY_SOURCES}
+     Src/BinaryReader.cpp
+-    Src/GamePad.cpp
+     Src/Geometry.cpp
+-    Src/Keyboard.cpp
+-    Src/Mouse.cpp
+     Src/SimpleMath.cpp)
+ 
+ set(LIBRARY_SOURCES ${LIBRARY_SOURCES}
+@@ -193,14 +192,28 @@ set(SHADER_SOURCES ${SHADER_SOURCES}
+     Src/Shaders/Structures.fxh
+     Src/Shaders/Utilities.fxh)
+ 
+-if(MINGW)
+-  set(BUILD_XAUDIO_WIN10 OFF)
+-  set(BUILD_XAUDIO_WIN8 OFF)
++# Xbox-specific extensions
++if(DEFINED XBOX_CONSOLE_TARGET)
++  set(LIBRARY_HEADERS ${LIBRARY_HEADERS}
++      Inc/XboxDDSTextureLoader.h)
++
++  set(LIBRARY_SOURCES ${LIBRARY_SOURCES}
++      Src/XboxDDSTextureLoader.cpp)
++endif()
++
++if(BUILD_XINPUT OR BUILD_WGI OR BUILD_GAMEINPUT)
++  set(LIBRARY_HEADERS ${LIBRARY_HEADERS}
++      Inc/GamePad.h
++      Inc/Keyboard.h
++      Inc/Mouse.h)
++
++  set(LIBRARY_SOURCES ${LIBRARY_SOURCES}
++      Src/GamePad.cpp
++      Src/Keyboard.cpp
++      Src/Mouse.cpp)
+ endif()
+ 
+-if(WINDOWS_STORE
+-   OR BUILD_XAUDIO_WIN10 OR BUILD_XAUDIO_WIN8
+-   OR BUILD_XAUDIO_REDIST)
++if(BUILD_XAUDIO_WIN10 OR BUILD_XAUDIO_WIN8 OR BUILD_XAUDIO_REDIST)
+     set(LIBRARY_HEADERS ${LIBRARY_HEADERS}
+         Inc/Audio.h)
+ 
+@@ -274,7 +287,7 @@ if(WIN32 AND BUILD_SHARED_LIBS)
+     target_link_libraries(${PROJECT_NAME} PRIVATE kernelx.lib combase.lib d3d12_x.lib xi.lib)
+   endif()
+ 
+-  if(MINGW)
++  if(MINGW AND BUILD_XINPUT)
+     target_link_libraries(${PROJECT_NAME} PRIVATE xinput1_4.lib)
+   endif()
+ else()
+@@ -297,9 +310,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
+ 
+ target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
+ 
+-if(WINDOWS_STORE
+-   OR BUILD_XAUDIO_WIN10 OR BUILD_XAUDIO_WIN8
+-   OR BUILD_XAUDIO_REDIST)
++if(BUILD_XAUDIO_WIN10 OR BUILD_XAUDIO_WIN8 OR BUILD_XAUDIO_REDIST)
+     target_include_directories(${PROJECT_NAME} PRIVATE Audio)
+ endif()
+ 
+@@ -315,8 +326,7 @@ if(directxmath_FOUND)
+     target_link_libraries(${PROJECT_NAME} PRIVATE Microsoft::DirectXMath)
+ endif()
+ 
+-if(BUILD_XAUDIO_REDIST
+-   AND (NOT BUILD_XAUDIO_WIN10) AND (NOT BUILD_XAUDIO_WIN8) AND (NOT WINDOWS_STORE))
++if(BUILD_XAUDIO_REDIST AND (NOT BUILD_XAUDIO_WIN10) AND (NOT BUILD_XAUDIO_WIN8))
+     message(STATUS "Using XAudio2Redist for DirectX Tool Kit for Audio.")
+     find_package(xaudio2redist CONFIG REQUIRED)
+     target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::XAudio2Redist)
+diff --git a/CMakePresets.json b/CMakePresets.json
+index 69e1cad..03b7c7a 100644
+--- a/CMakePresets.json
++++ b/CMakePresets.json
+@@ -122,8 +122,7 @@
+       "cacheVariables": {
+         "BUILD_XAUDIO_WIN10": false,
+         "BUILD_XAUDIO_WIN8": false,
+-        "BUILD_XAUDIO_REDIST": true,
+-        "BUILD_XINPUT": true
++        "BUILD_XAUDIO_REDIST": true
+       },
+       "hidden": true
+     },
+@@ -324,6 +323,9 @@
+     { "name": "x86-Debug-MinGW"  , "description": "MinG-W32 (Debug)", "inherits": [ "base", "x86", "Debug", "GNUC", "VCPKG", "XAudio2Redist", "MinGW32" ] },
+     { "name": "x86-Release-MinGW", "description": "MinG-W32 (Release)", "inherits": [ "base", "x86", "Release", "GNUC", "VCPKG", "XAudio2Redist", "MinGW32" ] },
+ 
++    { "name": "x64-Debug-MinGW-GI"  , "description": "MinG-W64 (Debug) using GameInput", "inherits": [ "base", "x64", "Debug", "GNUC", "VCPKG", "XAudio2Redist", "MinGW64" ], "cacheVariables": { "BUILD_GAMEINPUT": "true" } },
++    { "name": "x64-Release-MinGW-GI", "description": "MinG-W64 (Release) using GameInput", "inherits": [ "base", "x64", "Release", "GNUC", "VCPKG", "XAudio2Redist", "MinGW64" ], "cacheVariables": { "BUILD_GAMEINPUT": "true" } },
++
+     { "name": "x64-Debug-ICC"     , "description": "Intel Classic Compiler (Debug) for Windows 8", "inherits": [ "base", "x64", "Debug", "Intel" ] },
+     { "name": "x64-Release-ICC"   , "description": "Intel Classic Compiler (Release) for Windows 8", "inherits": [ "base", "x64", "Release", "Intel" ] },
+ 
+-- 
+2.51.2.windows.1
+

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -1,4 +1,4 @@
-set(DIRECTXTK_TAG jul2025)
+set(DIRECTXTK_TAG oct2025)
 
 if(VCPKG_TARGET_IS_MINGW)
     message(NOTICE "Building ${PORT} for MinGW requires the HLSL Compiler fxc.exe also be in the PATH. See https://aka.ms/windowssdk.")
@@ -8,14 +8,16 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
     REF ${DIRECTXTK_TAG}
-    SHA512 b91bed656306e9fdcba5a0de20c32c53f3783a51fe9283c4ee04362941e4e039787ca050c7a7effb35a30a274b4b3235738cb73acdc0e31aba714ad87bc7dbfe
+    SHA512 3be2fce3c3a34a22b7bdfda914ca45930c5b979bb467530b8cbb510c0f58485056c285ff86ddaecbc5aac95ae67f0b92c4e1dd8261cee4a87cf3e7056329ac28
     HEAD_REF main
+    PATCHES CMake-build-options-improvements.patch
 )
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         gameinput BUILD_GAMEINPUT
+        windows-gaming-input BUILD_WGI
         spectre ENABLE_SPECTRE_MITIGATION
         tools BUILD_TOOLS
         xaudio2-9 BUILD_XAUDIO_WIN10
@@ -38,7 +40,7 @@ if("tools" IN_LIST FEATURES)
     MAKESPRITEFONT_EXE
     URLS "https://github.com/Microsoft/DirectXTK/releases/download/${DIRECTXTK_TAG}/MakeSpriteFont.exe"
     FILENAME "makespritefont-${DIRECTXTK_TAG}.exe"
-    SHA512 ff52a77e6d9d86db58044ebf7b4fd4eeeffb210eefeb78b2147050c704c7968e80278e8d3d89bbde2d604ad6fd5b815d37a74cf6bbf6dc7458f7a49b78f3cf20
+    SHA512 edec18a1c7790d6f27f8d910307a38a037784cc974b38debb8ef6eb77369941b60bf7cb52de4150f80bca4ab541d76d54f21ef91524b83b11b684f0a92e1c879
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -53,7 +55,7 @@ if("tools" IN_LIST FEATURES)
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK/releases/download/${DIRECTXTK_TAG}/XWBTool.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}.exe"
-      SHA512 c2213127cef40a2d233f512c5f04a6f8ce62c3112b3b202f901ef18b36549f7974d8b102930a6f9b5023c2ed2423b5e1755914bfe9a00a1aa9080d83f8a05017
+      SHA512 68ff3f4a99585e08698c6385550628341e31218315029700c9b8d9a17118ba964856358bc2bebc951b6ec8d1584e8d62138505780897430509dca2652832384b
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -66,7 +68,7 @@ if("tools" IN_LIST FEATURES)
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK/releases/download/${DIRECTXTK_TAG}/XWBTool_arm64.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}-arm64.exe"
-      SHA512 8387b1aa0d1dd7e9385d71ba04e5c96e3dcb8a786c17ecb09bd5effc8434c9f6ec3c9b9cee98537729626776092b8f205b91c291acdb4806d16e895c02a10ca3
+      SHA512 8e9d0fdd206bff4e3c0b344ed754a16cee913833be205c822d41ed3264d3578ae168ef415043ff8f95b38890c37457a56ee7677b26d95b8afd60dd307bffb9e0
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk",
-  "version-date": "2025-07-10",
+  "version-date": "2025-10-27",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",
@@ -31,6 +31,10 @@
     "tools": {
       "description": "MakeSpriteFont and xwbtool command-line tools",
       "supports": "windows & !uwp & !xbox"
+    },
+    "windows-gaming-input": {
+      "description": "Build using Windows.Gaming.Input for input processing",
+      "supports": "windows & !xbox"
     },
     "xaudio2-8": {
       "description": "Build with XAudio 2.8 support for Windows 8.x or later"

--- a/ports/directxtk12/CMake-build-options-improvements.patch
+++ b/ports/directxtk12/CMake-build-options-improvements.patch
@@ -1,0 +1,152 @@
+---
+ CMakeLists.txt    | 55 ++++++++++++++++++++++++++++-------------------
+ CMakePresets.json |  3 +++
+ 2 files changed, 36 insertions(+), 22 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8a353f8..0b62d4d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -59,24 +59,38 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+ 
+ if(XBOX_CONSOLE_TARGET STREQUAL "scarlett")
+   set(BUILD_GAMEINPUT ON)
+-  set(BUILD_SCARLETT_SHADERS ON)
++  set(BUILD_WGI OFF)
++  set(BUILD_XINPUT OFF)
+   set(BUILD_XAUDIO_REDIST OFF)
++  set(BUILD_SCARLETT_SHADERS ON)
+ elseif(XBOX_CONSOLE_TARGET STREQUAL "xboxone")
+   set(BUILD_GAMEINPUT ON)
+-  set(BUILD_XBOXONE_SHADERS ON)
++  set(BUILD_WGI OFF)
++  set(BUILD_XINPUT OFF)
+   set(BUILD_XAUDIO_REDIST OFF)
++  set(BUILD_XBOXONE_SHADERS ON)
+ elseif(XBOX_CONSOLE_TARGET STREQUAL "durango")
+   set(BUILD_GAMEINPUT OFF)
+   set(BUILD_WGI OFF)
+   set(BUILD_XINPUT OFF)
++  set(BUILD_XAUDIO_WIN10 ON)
++  set(BUILD_XAUDIO_REDIST OFF)
+   set(BUILD_XBOXONE_SHADERS ON)
+   set(BUILD_DXIL_SHADERS OFF)
+-  set(BUILD_XAUDIO_WIN10 OFF)
+-  set(BUILD_XAUDIO_WIN8 ON)
+ elseif(WINDOWS_STORE)
+   set(BUILD_GAMEINPUT OFF)
+   set(BUILD_WGI ON)
++  set(BUILD_XINPUT OFF)
++  set(BUILD_XAUDIO_WIN10 ON)
+   set(BUILD_XAUDIO_REDIST OFF)
++elseif(MINGW)
++  set(BUILD_WGI OFF)
++  set(BUILD_XAUDIO_WIN10 OFF)
++  if (NOT BUILD_GAMEINPUT)
++    set(BUILD_XINPUT ON)
++  endif()
++elseif(WIN32 AND (NOT BUILD_GAMEINPUT) AND (NOT BUILD_XINPUT))
++  set(BUILD_WGI ON)
+ endif()
+ 
+ include(GNUInstallDirs)
+@@ -164,18 +178,12 @@ set(SHADER_SOURCES
+ # These source files are identical in both DX11 and DX12 version.
+ if(NOT BUILD_MIXED_DX11)
+     set(LIBRARY_HEADERS ${LIBRARY_HEADERS}
+-      Inc/GamePad.h
+-      Inc/Keyboard.h
+-      Inc/Mouse.h
+       Inc/SimpleMath.h
+       Inc/SimpleMath.inl)
+ 
+     set(LIBRARY_SOURCES ${LIBRARY_SOURCES}
+       Src/BinaryReader.cpp
+-      Src/GamePad.cpp
+       Src/Geometry.cpp
+-      Src/Keyboard.cpp
+-      Src/Mouse.cpp
+       Src/SimpleMath.cpp)
+ endif()
+ 
+@@ -211,13 +219,19 @@ if(DEFINED XBOX_CONSOLE_TARGET)
+       Src/XboxDDSTextureLoader.cpp)
+ endif()
+ 
+-if(MINGW)
+-  set(BUILD_XAUDIO_WIN10 OFF)
++if(BUILD_XINPUT OR BUILD_WGI OR BUILD_GAMEINPUT)
++  set(LIBRARY_HEADERS ${LIBRARY_HEADERS}
++      Inc/GamePad.h
++      Inc/Keyboard.h
++      Inc/Mouse.h)
++
++  set(LIBRARY_SOURCES ${LIBRARY_SOURCES}
++      Src/GamePad.cpp
++      Src/Keyboard.cpp
++      Src/Mouse.cpp)
+ endif()
+ 
+-if(WINDOWS_STORE
+-   OR BUILD_XAUDIO_WIN10 OR BUILD_XAUDIO_WIN8
+-   OR BUILD_XAUDIO_REDIST)
++if(BUILD_XAUDIO_WIN10 OR BUILD_XAUDIO_REDIST)
+     set(LIBRARY_HEADERS ${LIBRARY_HEADERS}
+         Inc/Audio.h)
+ 
+@@ -319,7 +333,7 @@ if(WIN32 AND BUILD_SHARED_LIBS)
+     target_link_libraries(${PROJECT_NAME} PRIVATE d3d12.lib)
+   endif()
+ 
+-  if(MINGW)
++  if(MINGW AND BUILD_XINPUT)
+     target_link_libraries(${PROJECT_NAME} PRIVATE xinput1_4.lib)
+   endif()
+ else()
+@@ -342,9 +356,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
+ 
+ target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
+ 
+-if(WINDOWS_STORE
+-   OR BUILD_XAUDIO_WIN10 OR BUILD_XAUDIO_WIN8
+-   OR BUILD_XAUDIO_REDIST)
++if(BUILD_XAUDIO_WIN10 OR BUILD_XAUDIO_REDIST)
+     target_include_directories(${PROJECT_NAME} PRIVATE Audio)
+ endif()
+ 
+@@ -371,8 +383,7 @@ if(directx-headers_FOUND)
+     target_compile_definitions(${PROJECT_NAME} PRIVATE USING_DIRECTX_HEADERS)
+ endif()
+ 
+-if(BUILD_XAUDIO_REDIST
+-   AND (NOT BUILD_XAUDIO_WIN10) AND (NOT BUILD_XAUDIO_WIN8) AND (NOT WINDOWS_STORE))
++if(BUILD_XAUDIO_REDIST AND (NOT BUILD_XAUDIO_WIN10))
+     message(STATUS "Using XAudio2Redist for DirectX Tool Kit for Audio.")
+     find_package(xaudio2redist CONFIG REQUIRED)
+     target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::XAudio2Redist)
+@@ -532,7 +543,7 @@ if(WIN32)
+ 
+     target_compile_definitions(${PROJECT_NAME} PRIVATE _WIN32_WINNT=${WINVER})
+ 
+-    if(WINDOWS_STORE OR BUILD_XAUDIO_WIN10)
++    if(BUILD_XAUDIO_WIN10)
+       message(STATUS "Using DirectX Tool Kit for Audio on XAudio 2.9 (Windows 10/Windows 11).")
+     endif()
+ 
+diff --git a/CMakePresets.json b/CMakePresets.json
+index eed1f1b..b7ab045 100644
+--- a/CMakePresets.json
++++ b/CMakePresets.json
+@@ -381,6 +381,9 @@
+     { "name": "x86-Debug-MinGW"  , "description": "MinG-W32 (Debug)", "inherits": [ "base", "x86", "Debug", "GNUC", "VCPKG", "XAudio2Redist", "MinGW32" ] },
+     { "name": "x86-Release-MinGW", "description": "MinG-W32 (Release)", "inherits": [ "base", "x86", "Release", "GNUC", "VCPKG", "XAudio2Redist", "MinGW32" ] },
+ 
++    { "name": "x64-Debug-MinGW-GI"  , "description": "MinG-W64 (Debug) using GameInput", "inherits": [ "base", "x64", "Debug", "GNUC", "VCPKG", "XAudio2Redist", "MinGW64" ], "cacheVariables": { "BUILD_GAMEINPUT": "true" }  },
++    { "name": "x64-Release-MinGW-GI", "description": "MinG-W64 (Release) using GameInput", "inherits": [ "base", "x64", "Release", "GNUC", "VCPKG", "XAudio2Redist", "MinGW64" ], "cacheVariables": { "BUILD_GAMEINPUT": "true" }  },
++
+     { "name": "x64-Debug-ICC"     , "description": "Intel Classic Compiler (Debug) for Windows 10", "inherits": [ "base", "x64", "Debug", "Intel" ] },
+     { "name": "x64-Release-ICC"   , "description": "Intel Classic Compiler (Release) for Windows 10", "inherits": [ "base", "x64", "Release", "Intel" ] },
+ 
+-- 
+2.51.2.windows.1
+

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -1,17 +1,19 @@
-set(DIRECTXTK_TAG jul2025)
+set(DIRECTXTK_TAG oct2025)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
     REF ${DIRECTXTK_TAG}
-    SHA512 cedd2215ecdd4a721fd84b0d7a5decdb893a27391338fd31e4de2b767b3ff96610941e52697f4210360f6a3ba45ea290ee8d827e05eb5de957e6564c3922b6b9
+    SHA512 8ecb03c2773f68b42959940004b483c5978a4e933ddd24ef0db9ecec721daf691927b64d1d4c00430df5569bf0358874fc565bf4225c336b4846f353fef5088c
     HEAD_REF main
+    PATCHES CMake-build-options-improvements.patch
 )
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         gameinput BUILD_GAMEINPUT
+        xinput BUILD_XINPUT
         spectre ENABLE_SPECTRE_MITIGATION
         xaudio2-9 BUILD_XAUDIO_WIN10
         xaudio2redist BUILD_XAUDIO_REDIST
@@ -39,7 +41,7 @@ if("tools" IN_LIST FEATURES)
     MAKESPRITEFONT_EXE
     URLS "https://github.com/Microsoft/DirectXTK12/releases/download/${DIRECTXTK_TAG}/MakeSpriteFont.exe"
     FILENAME "makespritefont-${DIRECTXTK_TAG}.exe"
-    SHA512 ff52a77e6d9d86db58044ebf7b4fd4eeeffb210eefeb78b2147050c704c7968e80278e8d3d89bbde2d604ad6fd5b815d37a74cf6bbf6dc7458f7a49b78f3cf20
+    SHA512 edec18a1c7790d6f27f8d910307a38a037784cc974b38debb8ef6eb77369941b60bf7cb52de4150f80bca4ab541d76d54f21ef91524b83b11b684f0a92e1c879
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -54,7 +56,7 @@ if("tools" IN_LIST FEATURES)
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK12/releases/download/${DIRECTXTK_TAG}/XWBTool.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}.exe"
-      SHA512 c2213127cef40a2d233f512c5f04a6f8ce62c3112b3b202f901ef18b36549f7974d8b102930a6f9b5023c2ed2423b5e1755914bfe9a00a1aa9080d83f8a05017
+      SHA512 68ff3f4a99585e08698c6385550628341e31218315029700c9b8d9a17118ba964856358bc2bebc951b6ec8d1584e8d62138505780897430509dca2652832384b
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -67,7 +69,7 @@ if("tools" IN_LIST FEATURES)
       XWBTOOL_EXE
       URLS "https://github.com/Microsoft/DirectXTK12/releases/download/${DIRECTXTK_TAG}/XWBTool_arm64.exe"
       FILENAME "xwbtool-${DIRECTXTK_TAG}-arm64.exe"
-      SHA512 8387b1aa0d1dd7e9385d71ba04e5c96e3dcb8a786c17ecb09bd5effc8434c9f6ec3c9b9cee98537729626776092b8f205b91c291acdb4806d16e895c02a10ca3
+      SHA512 8e9d0fdd206bff4e3c0b344ed754a16cee913833be205c822d41ed3264d3578ae168ef415043ff8f95b38890c37457a56ee7677b26d95b8afd60dd307bffb9e0
     )
 
     file(INSTALL "${XWBTOOL_EXE}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk12",
-  "version-date": "2025-07-10",
+  "version-date": "2025-10-27",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",
@@ -56,6 +56,10 @@
       "dependencies": [
         "xaudio2redist"
       ]
+    },
+    "xinput": {
+      "description": "Build using XInput for input processing",
+      "supports": "windows & !uwp & !xbox"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2457,11 +2457,11 @@
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "2025-07-10",
+      "baseline": "2025-10-27",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "2025-07-10",
+      "baseline": "2025-10-27",
       "port-version": 0
     },
     "dirent": {

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75f06c1ce10a74ca4f85fee00f4c998ce963c3ea",
+      "version-date": "2025-10-27",
+      "port-version": 0
+    },
+    {
       "git-tree": "f6f3c7e59b0a374238c65805c3f2ce12d9e7d052",
       "version-date": "2025-07-10",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6126b3a9e1c4831a4ad1c176fdb34989a1564f80",
+      "version-date": "2025-10-27",
+      "port-version": 0
+    },
+    {
       "git-tree": "5b13bd42679ac39dddc6e6bbda274f35d1aca531",
       "version-date": "2025-07-10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Adds *xinput* feature for *directxtk12* to prefer XInput over Windows.Gaming.Input. Adds *windows-gaming-input* feature for *directxtk* to prefer Windows.Gaming.Input over XInput.
