### PR TITLE
[sbp] Add unofficial CMake config

### DIFF
--- a/ports/sbp/portfile.cmake
+++ b/ports/sbp/portfile.cmake
@@ -39,6 +39,15 @@ vcpkg_cmake_configure(
       -Dlibsbp_ENABLE_DOCS=OFF
 )
 
+set(_LIB_NAME unofficial-sbp)
+set(_LIB_TARGET unofficial::sbp::sbp)
+set(_PACKAGE_CONFIG_DIR "${CURRENT_PACKAGES_DIR}/share/${_LIB_NAME}")
+configure_file(
+    ${CMAKE_CURRENT_LIST_DIR}/${_LIB_NAME}Config.cmake.in
+    ${_PACKAGE_CONFIG_DIR}/${_LIB_NAME}Config.cmake
+    @ONLY
+)
+
 vcpkg_cmake_install()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 

--- a/ports/sbp/unofficial-sbpConfig.cmake.in
+++ b/ports/sbp/unofficial-sbpConfig.cmake.in
@@ -1,0 +1,30 @@
+# Template for unofficial-sbpConfig.cmake
+
+# Protect against multiple inclusion
+if(TARGET @_LIB_TARGET@)
+    return()
+endif()
+
+# Compute the installation prefix relative to this file, which is located in ${_IMPORT_PREFIX}/share/@_LIB_NAME@
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+
+# Find the installed library.
+find_path(
+    UNOFFICIAL_SBP_INCLUDE_DIR
+    NAMES libsbp/sbp.h
+    PATHS "${_IMPORT_PREFIX}/include"
+)
+find_library(
+    UNOFFICIAL_SBP_LIBRARY
+    NAMES libsbp.a libsbp.so libsbp.dll libsbp.lib libsbp.dylib
+    PATHS "${_IMPORT_PREFIX}/lib" "${_IMPORT_PREFIX}/bin"
+)
+
+# Create an unofficial library target.
+if(UNOFFICIAL_SBP_INCLUDE_DIR AND UNOFFICIAL_SBP_LIBRARY)
+    add_library(@_LIB_TARGET@ UNKNOWN IMPORTED)
+    set_target_properties(@_LIB_TARGET@ PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${UNOFFICIAL_SBP_INCLUDE_DIR}"
+        IMPORTED_LOCATION "${UNOFFICIAL_SBP_LIBRARY}"
+    )
+endif()

--- a/ports/sbp/vcpkg.json
+++ b/ports/sbp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sbp",
   "version-semver": "6.3.1",
+  "port-version": 1,
   "description": "Swift Navigation Binary Protocol (SBP) is a binary protocol for communicating GNSS data used by Piksi devices.",
   "homepage": "https://github.com/swift-nav/libsbp",
   "documentation": "https://swift-nav.github.io/libsbp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8738,7 +8738,7 @@
     },
     "sbp": {
       "baseline": "6.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "scenepic": {
       "baseline": "1.1.1",

--- a/versions/s-/sbp.json
+++ b/versions/s-/sbp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0a92d7cb1c4b6c2808b821209a3b1aa1f9c91875",
+      "git-tree": "45436cf38e7b7ee8cfc135ced6a90812fb1e40c0",
       "version-semver": "6.3.1",
       "port-version": 1
     },

--- a/versions/s-/sbp.json
+++ b/versions/s-/sbp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a92d7cb1c4b6c2808b821209a3b1aa1f9c91875",
+      "version-semver": "6.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "acb3bbd2ee6a15dd3254417f32b2268490b1be6c",
       "version-semver": "6.3.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->

## Description

Duplicate of #48165 but with the addition of an unofficial CMake target to simplify usage by consumers.