### PR TITLE
[aws-c-cal] update to 0.9.10

### DIFF
--- a/ports/aws-c-cal/portfile.cmake
+++ b/ports/aws-c-cal/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-cal
     REF "v${VERSION}"
-    SHA512 e5fa5299164f4ce7860ada9a1c56ba74d6f68ca82cb1e09c53098f7642cb3541efe2c394fad2ff77716f795f813d87dff3ccd6df582b49a6fdca785531150d7a
+    SHA512 50e146a3c3ca62347e68d1a30323c8b095d78e31e5f3d0f3c66f87acac684338fef352225d0af94768b4a4bc182193a1b4d198b78385d97c00933f795869ab47
     HEAD_REF master
     PATCHES remove-libcrypto-messages.patch
 )

--- a/ports/aws-c-cal/vcpkg.json
+++ b/ports/aws-c-cal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-cal",
-  "version": "0.9.8",
+  "version": "0.9.10",
   "description": "C99 wrapper for cryptography primitives.",
   "homepage": "https://github.com/awslabs/aws-c-cal",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-cal.json
+++ b/versions/a-/aws-c-cal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "729cfd129f9910181344accad4dc0579593ddb89",
+      "version": "0.9.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a249d518e2af42bc02f1dd243c5c1d07fee65b5",
       "version": "0.9.8",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -441,7 +441,7 @@
       "port-version": 0
     },
     "aws-c-cal": {
-      "baseline": "0.9.8",
+      "baseline": "0.9.10",
       "port-version": 0
     },
     "aws-c-common": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/awslabs/aws-c-cal/releases/tag/v0.9.10
