### PR TITLE
[libversion] Rename version.lib.

### DIFF
--- a/ports/libversion/portfile.cmake
+++ b/ports/libversion/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         disable-test.patch
         separate-build-type.patch
+        rename-static-lib.diff
 )
 
 vcpkg_cmake_configure(

--- a/ports/libversion/rename-static-lib.diff
+++ b/ports/libversion/rename-static-lib.diff
@@ -1,0 +1,45 @@
+diff --git a/libversion/CMakeLists.txt b/libversion/CMakeLists.txt
+index 52a6ba7..f05c54e 100644
+--- a/libversion/CMakeLists.txt
++++ b/libversion/CMakeLists.txt
+@@ -35,8 +35,7 @@ set_target_properties(libversion PROPERTIES
+ )
+ generate_export_header(libversion EXPORT_FILE_NAME export.h)
+ if(WIN32)
+-	# avoid clash with both c:/windows/system32/version.dll
+-	# and static version.lib from the next target
++	# avoid clash with both c:/windows/system32/version.dll and version.lib from the Windows SDK
+ 	set_target_properties(libversion PROPERTIES OUTPUT_NAME libversion)
+ endif()
+ 
+@@ -51,9 +50,17 @@ target_include_directories(libversion_static PUBLIC
+ target_compile_definitions(libversion_static PUBLIC
+ 	LIBVERSION_STATIC_DEFINE
+ )
++
++if(WIN32)
++	# avoid clash with version.lib from the Windows SDK and the dynamic target above
++	set(LIBVERSION_STATIC_OUTPUT_NAME libversion_static)
++else()
++	set(LIBVERSION_STATIC_OUTPUT_NAME version)
++endif()
++
+ set_target_properties(libversion_static PROPERTIES
+ 	POSITION_INDEPENDENT_CODE ON
+-	OUTPUT_NAME version
++	OUTPUT_NAME "${LIBVERSION_STATIC_OUTPUT_NAME}"
+ )
+ 
+ # object library
+diff --git a/libversion/libversion.pc.in b/libversion/libversion.pc.in
+index 4da0cb6..809962c 100644
+--- a/libversion/libversion.pc.in
++++ b/libversion/libversion.pc.in
+@@ -6,6 +6,6 @@ includedir=@includedir_for_pc_file@
+ Name: libversion
+ Description: Version comparison library
+ Version: @libversion_VERSION@
+-Libs: -L${libdir} -lversion
++Libs: -L${libdir} -l@LIBVERSION_STATIC_OUTPUT_NAME@
+ Cflags: -I${includedir}
+ Cflags.private: -DLIBVERSION_STATIC_DEFINE

--- a/ports/libversion/vcpkg.json
+++ b/ports/libversion/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libversion",
   "version": "3.0.4",
+  "port-version": 1,
   "description": "Advanced version string comparison library",
   "homepage": "https://github.com/repology/libversion",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5694,7 +5694,7 @@
     },
     "libversion": {
       "baseline": "3.0.4",
-      "port-version": 0
+      "port-version": 1
     },
     "libvhdi": {
       "baseline": "20231127",

--- a/versions/l-/libversion.json
+++ b/versions/l-/libversion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aad15390e43582ad0e9b2064768a9ffd3767f8b5",
+      "version": "3.0.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "0f42989b5eede826f634ebd8fc463b27f41b0f69",
       "version": "3.0.4",
       "port-version": 0


### PR DESCRIPTION
Applies https://github.com/repology/libversion/pull/40 as a patch.

See Windows SDK conflict from new port: https://github.com/microsoft/vcpkg/pull/48066

Under https://learn.microsoft.com/vcpkg/contributing/maintainer-guide#do-not-rename-binaries-outside-the-names-given-by-upstream I want to give upstream a chance to merge this.

Thanks for figuring out the problem @dg0yt !