### PR TITLE
[libqrencode] cleanup dependencies

### DIFF
--- a/ports/libqrencode/vcpkg.json
+++ b/ports/libqrencode/vcpkg.json
@@ -5,7 +5,6 @@
   "description": "libqrencode - a fast and compact QR Code encoding library",
   "homepage": "https://github.com/fukuchi/libqrencode",
   "dependencies": [
-    "libpng",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -15,6 +14,7 @@
     "tool": {
       "description": "Build qrencode tool",
       "dependencies": [
+        "libpng",
         {
           "name": "getopt",
           "platform": "windows"

--- a/ports/libqrencode/vcpkg.json
+++ b/ports/libqrencode/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libqrencode",
   "version-semver": "4.1.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "libqrencode - a fast and compact QR Code encoding library",
   "homepage": "https://github.com/fukuchi/libqrencode",
   "dependencies": [
@@ -14,11 +14,11 @@
     "tool": {
       "description": "Build qrencode tool",
       "dependencies": [
-        "libpng",
         {
           "name": "getopt",
           "platform": "windows"
-        }
+        },
+        "libpng"
       ]
     }
   }

--- a/ports/libqrencode/vcpkg.json
+++ b/ports/libqrencode/vcpkg.json
@@ -5,7 +5,6 @@
   "description": "libqrencode - a fast and compact QR Code encoding library",
   "homepage": "https://github.com/fukuchi/libqrencode",
   "dependencies": [
-    "libiconv",
     "libpng",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5370,7 +5370,7 @@
     },
     "libqrencode": {
       "baseline": "4.1.1",
-      "port-version": 2
+      "port-version": 3
     },
     "libqtrest": {
       "baseline": "0.4.0",

--- a/versions/l-/libqrencode.json
+++ b/versions/l-/libqrencode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "597b668f55e912cd6687526ace66d83065321cd1",
+      "version-semver": "4.1.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "95a96c8314e54441e3ee64dd92d3c7b9d9f409f1",
       "version-semver": "4.1.1",
       "port-version": 2


### PR DESCRIPTION
These are some fixes we found useful in Prism Launcher during https://github.com/PrismLauncher/PrismLauncher/pull/3956. Thought it'd be a good idea to upstream :)
