### PR TITLE
[htslib] Find bzip2 with pkgconfig.

### DIFF
--- a/ports/htslib/bzip2-use-pkgconfig.diff
+++ b/ports/htslib/bzip2-use-pkgconfig.diff
@@ -1,0 +1,27 @@
+diff --git a/configure.ac b/configure.ac
+index 593a664..eddf661 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -412,8 +412,7 @@ fi],
+ 
+ if test "$enable_bz2" != no; then
+   bz2_devel=ok
+-  AC_CHECK_HEADER([bzlib.h], [], [bz2_devel=missing], [;])
+-  AC_CHECK_LIB([bz2], [BZ2_bzBuffToBuffCompress], [], [bz2_devel=missing])
++  PKG_CHECK_MODULES([BZ2_PKG], [bzip2], [], [bz2_devel=missing])
+   if test $bz2_devel != ok; then
+     MSG_ERROR([libbzip2 development files not found
+ 
+@@ -430,12 +429,7 @@ produced elsewhere unreadable) or resolve this error to build HTSlib.])
+   fi
+ dnl Unfortunately the 'bzip2' package-cfg module is not standard.
+ dnl Redhat/Fedora has it; Debian/Ubuntu does not.
+-  if test -n "$PKG_CONFIG" && "$PKG_CONFIG" --exists bzip2; then
+      pc_requires="$pc_requires bzip2"
+-  else
+-     private_LIBS="$private_LIBS -lbz2"
+-  fi
+-  static_LIBS="$static_LIBS -lbz2"
+ fi
+ 
+ if test "$enable_lzma" != no; then

--- a/ports/htslib/portfile.cmake
+++ b/ports/htslib/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         0003-no-tests.patch
         0004-fix-find-htscodecs.patch
         0005-remove-duplicate-lhts.patch # https://github.com/samtools/htslib/pull/1852
+        bzip2-use-pkgconfig.diff
 )
 
 set(FEATURE_OPTIONS "")

--- a/ports/htslib/vcpkg.json
+++ b/ports/htslib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "htslib",
   "version": "1.21",
+  "port-version": 1,
   "description": "C library for high-throughput sequencing data formats",
   "homepage": "https://github.com/samtools/htslib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3806,7 +3806,7 @@
     },
     "htslib": {
       "baseline": "1.21",
-      "port-version": 0
+      "port-version": 1
     },
     "http-parser": {
       "baseline": "2.9.4",

--- a/versions/h-/htslib.json
+++ b/versions/h-/htslib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4c16d6fcbb137c5fa7c1f65c93df7304ca3a492",
+      "version": "1.21",
+      "port-version": 1
+    },
+    {
       "git-tree": "76f12c76144128b5c812e8c80957daa446b8b29e",
       "version": "1.21",
       "port-version": 0


### PR DESCRIPTION
See build failures in https://github.com/microsoft/vcpkg/pull/48178/

I'm fairly certain that this feature never worked because the bzip2 library for debug is `libbz2d.a` which would never be found by the hard-coded `-lbz2`.

This is probably the first meaningful autotools change I've ever tried to make so I'd appreciate folks who know that better commenting.