### PR TITLE
[ncnn] Update to 20250916

### DIFF
--- a/ports/ncnn/portfile.cmake
+++ b/ports/ncnn/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Tencent/ncnn
     REF "${VERSION}"
-    SHA512 decc841dc353bf0ff6f33456741547f0afaa8ed9d381ca3546b319dcd1c6db8ed4d35e001cd7adcea68970ebe2f14cbacf3053a23e37991c7466bc7060490286
+    SHA512 bb20d8ece3dcddf49530e1ca44eaad1045702b5fb7a7c9cfd6754eb158c7349bba7d63a3ef1e1a4a6e30ed59622367b802f98bf8343bd30ff0cb6def734757c4
     HEAD_REF master
 )
 

--- a/ports/ncnn/vcpkg.json
+++ b/ports/ncnn/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ncnn",
-  "version": "20250503",
+  "version": "20250916",
   "description": "ncnn is a high-performance neural network inference computing framework.",
   "homepage": "https://github.com/Tencent/ncnn",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6761,7 +6761,7 @@
       "port-version": 2
     },
     "ncnn": {
-      "baseline": "20250503",
+      "baseline": "20250916",
       "port-version": 0
     },
     "ncurses": {

--- a/versions/n-/ncnn.json
+++ b/versions/n-/ncnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "279f3db36dbce2acd9a68108270c4ff0980d7638",
+      "version": "20250916",
+      "port-version": 0
+    },
+    {
       "git-tree": "25c19c55c96b791bfac8480273b2cf0a509556cd",
       "version": "20250503",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.