### PR TITLE
[tsl-hat-trie] add new port

### DIFF
--- a/ports/tsl-hat-trie/portfile.cmake
+++ b/ports/tsl-hat-trie/portfile.cmake
@@ -1,0 +1,13 @@
+set(VCPKG_BUILD_TYPE release) # Header-only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Tessil/hat-trie
+    REF "v${VERSION}"
+    SHA512 24b7f2fd83f03ff30cfa186cd68b8110ee7ed40c378861de750c1c0957e3a9870dc434ee3ae184d8ce4b07687cb0ffa83e8c7ddadccd57d8e87c97ae7b066115
+    HEAD_REF master
+)
+
+file(COPY "${SOURCE_PATH}/include/tsl" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/tsl-hat-trie/vcpkg.json
+++ b/ports/tsl-hat-trie/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "tsl-hat-trie",
+  "version": "0.7.0",
+  "description": "C++ implementation of a fast and memory efficient HAT-trie",
+  "homepage": "https://github.com/Tessil/hat-trie",
+  "license": "MIT"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9904,6 +9904,10 @@
       "baseline": "0.7.2",
       "port-version": 0
     },
+    "tsl-hat-trie": {
+      "baseline": "0.7.0",
+      "port-version": 0
+    },
     "tsl-hopscotch-map": {
       "baseline": "2.4.0",
       "port-version": 0

--- a/versions/t-/tsl-hat-trie.json
+++ b/versions/t-/tsl-hat-trie.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ab3aec7490ecf90ca2f5da33686997d2defb93c2",
+      "version": "0.7.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Tessil/hat-trie/

`hat-trie` is also a policy-compliant name, but since most libraries by the same author have `tsl-` prefixes, I determined that following this convention would avoid confusion.

`tsl-hat-trie` includes `tsl-array-hash`, but it is provided under a different path to `tsl-array-hash` port. While devendoring would be the common approach, since `tsl-hat-trie` does not provide an install target, I chose not to provide a patch creating an install target and an unofficial CMake config.
