### PR TITLE
[aws-c-s3] update to 0.10.1

### DIFF
--- a/ports/aws-c-s3/portfile.cmake
+++ b/ports/aws-c-s3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-s3
     REF "v${VERSION}"
-    SHA512 45ffe8e7c8eeee5f927ee81ee52e0d9f0f836b40b899a7a117d58ed1d2533c4b5dd7fec5e21ed5aa2e19fab7f3a559df0105437a92b5e5978422f9d302737969
+    SHA512 d1a7d2d92c43a29e0044afe65fe625fdec2f0ea2182eece5dd8e757a16bd782b7440d3f14fb43c1ad17c59240181d35e2868fb6a20ce71dab53dfaa6259300c9
     HEAD_REF master
 )
 

--- a/ports/aws-c-s3/vcpkg.json
+++ b/ports/aws-c-s3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-s3",
-  "version": "0.9.2",
+  "version": "0.10.1",
   "description": "C99 library implementation for communicating with the S3 service, designed for maximizing throughput on high bandwidth EC2 instances.",
   "homepage": "https://github.com/awslabs/aws-c-s3",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-s3.json
+++ b/versions/a-/aws-c-s3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "42a144ec16bdfb1ca95f904bace10b050daa09e9",
+      "version": "0.10.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ad4de77f20cf626788ba510c6f539aa081bce66a",
       "version": "0.9.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -469,7 +469,7 @@
       "port-version": 0
     },
     "aws-c-s3": {
-      "baseline": "0.9.2",
+      "baseline": "0.10.1",
       "port-version": 0
     },
     "aws-c-sdkutils": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/awslabs/aws-c-s3/releases/tag/v0.10.1
