### PR TITLE
[htscodecs] update to 1.6.5

### DIFF
--- a/ports/htscodecs/portfile.cmake
+++ b/ports/htscodecs/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO samtools/htscodecs
     REF "v${VERSION}"
-    SHA512 3f3c249086a740be5e03ce81907f48f131758bffd43305e396f75b27fc3de6f71903a019f2b36ef0b361a1b3ff4a2da21a2bdf9be2eb6c0a2d7470687a04929a
+    SHA512 ef1017c432937926a6d7723e5e012a5e38bdbbf3ffd2f35b0cbac4a804f8f3163058c4f736a6998151eb4e73a127fa52d1ac4d734d05a35d7e5b3fa60ebf2a28
     HEAD_REF master
     PATCHES
         0001-no-tests.patch # https://github.com/samtools/htscodecs/pull/120

--- a/ports/htscodecs/portfile.cmake
+++ b/ports/htscodecs/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO samtools/htscodecs
     REF "v${VERSION}"
-    SHA512 5e3e1f916cb14fe7e1292f3a07e9d9704b11be38014db5884b334235c25dbe61dffecf3f12c448a7a13f65c6d19dbc7cc5c77ba0861b31a0375d71030dd02480
+    SHA512 3f3c249086a740be5e03ce81907f48f131758bffd43305e396f75b27fc3de6f71903a019f2b36ef0b361a1b3ff4a2da21a2bdf9be2eb6c0a2d7470687a04929a
     HEAD_REF master
     PATCHES
         0001-no-tests.patch # https://github.com/samtools/htscodecs/pull/120

--- a/ports/htscodecs/vcpkg.json
+++ b/ports/htscodecs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "htscodecs",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Custom compression for CRAM and others.",
   "homepage": "https://github.com/samtools/htscodecs",
   "license": "MIT",

--- a/ports/htscodecs/vcpkg.json
+++ b/ports/htscodecs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "htscodecs",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "description": "Custom compression for CRAM and others.",
   "homepage": "https://github.com/samtools/htscodecs",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3801,7 +3801,7 @@
       "port-version": 0
     },
     "htscodecs": {
-      "baseline": "1.6.1",
+      "baseline": "1.6.4",
       "port-version": 0
     },
     "htslib": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3801,7 +3801,7 @@
       "port-version": 0
     },
     "htscodecs": {
-      "baseline": "1.6.4",
+      "baseline": "1.6.5",
       "port-version": 0
     },
     "htslib": {

--- a/versions/h-/htscodecs.json
+++ b/versions/h-/htscodecs.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "01015be3bbd18acf31f37cb0b74e070ebeb5d470",
-      "version": "1.6.4",
+      "git-tree": "9447530e95610603bcca40e0edda620758bbcdde",
+      "version": "1.6.5",
       "port-version": 0
     },
     {

--- a/versions/h-/htscodecs.json
+++ b/versions/h-/htscodecs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "01015be3bbd18acf31f37cb0b74e070ebeb5d470",
+      "version": "1.6.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "a7eaba66bb4d3bf35e1a6b9b70e91edccaccf071",
       "version": "1.6.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/samtools/htscodecs/releases/tag/v1.6.5
https://github.com/samtools/htscodecs/releases/tag/v1.6.4
https://github.com/samtools/htscodecs/releases/tag/v1.6.3
https://github.com/samtools/htscodecs/releases/tag/v1.6.2
