### PR TITLE
[dpdk] update to 24.11.3

### DIFF
--- a/ports/dpdk/0001-enable-either-static-or-shared-build.patch
+++ b/ports/dpdk/0001-enable-either-static-or-shared-build.patch
@@ -1,5 +1,5 @@
 diff --git a/config/meson.build b/config/meson.build
-index 9484987..722e114 100644
+index b6b3558e11..34b85f10b5 100644
 --- a/config/meson.build
 +++ b/config/meson.build
 @@ -94,7 +94,9 @@ eal_pmd_path = join_paths(get_option('prefix'), driver_install_path)
@@ -10,14 +10,14 @@ index 9484987..722e114 100644
 +if get_option('default_library') == 'static'
 +    # skip
 +elif not is_windows
-     meson.add_install_script('../buildtools/symlink-drivers-solibs.sh',
-             get_option('libdir'), pmd_subdir_opt)
- elif meson.version().version_compare('>=0.55.0')
+     # skip symlink-drivers-solibs.sh execution on no sub directory
+     if pmd_subdir_opt != '' and pmd_subdir_opt != '.'
+         meson.add_install_script('../buildtools/symlink-drivers-solibs.sh',
 diff --git a/drivers/meson.build b/drivers/meson.build
-index 66931d4..65ded2e 100644
+index 495e21b54a..ff7b5983cb 100644
 --- a/drivers/meson.build
 +++ b/drivers/meson.build
-@@ -247,7 +247,7 @@ foreach subpath:subdirs
+@@ -252,7 +252,7 @@ foreach subpath:subdirs
                  include_directories: includes,
                  dependencies: static_deps,
                  c_args: cflags,
@@ -26,7 +26,7 @@ index 66931d4..65ded2e 100644
  
          # now build the shared driver
          version_map = '@0@/@1@/version.map'.format(meson.current_source_dir(), drv_path)
-@@ -295,7 +295,7 @@ foreach subpath:subdirs
+@@ -297,7 +297,7 @@ foreach subpath:subdirs
          else
              lk_args = ['-Wl,--version-script=' + version_map]
          endif
@@ -35,7 +35,7 @@ index 66931d4..65ded2e 100644
          shared_lib = shared_library(lib_name, sources,
                  objects: objs,
                  include_directories: includes,
-@@ -313,10 +313,13 @@ foreach subpath:subdirs
+@@ -315,10 +315,14 @@ foreach subpath:subdirs
          shared_dep = declare_dependency(link_with: shared_lib,
                  include_directories: includes,
                  dependencies: shared_deps)
@@ -43,7 +43,7 @@ index 66931d4..65ded2e 100644
          static_dep = declare_dependency(
                  include_directories: includes,
                  dependencies: static_deps)
--
+ 
 +      if get_option('default_library') == 'static'
 +        shared_dep = static_dep
 +      endif
@@ -51,7 +51,7 @@ index 66931d4..65ded2e 100644
  
          set_variable('shared_@0@'.format(lib_name), shared_dep)
 diff --git a/lib/meson.build b/lib/meson.build
-index 1622877..8ca5780 100644
+index ce92cb5537..40880bbf02 100644
 --- a/lib/meson.build
 +++ b/lib/meson.build
 @@ -249,7 +249,7 @@ foreach l:libraries
@@ -63,7 +63,7 @@ index 1622877..8ca5780 100644
      static_dep = declare_dependency(
              include_directories: includes,
              dependencies: static_deps)
-@@ -311,6 +311,7 @@ foreach l:libraries
+@@ -305,6 +305,7 @@ foreach l:libraries
                  output: name + '.sym_chk')
      endif
  
@@ -71,7 +71,7 @@ index 1622877..8ca5780 100644
      shared_lib = shared_library(libname,
              sources,
              objects: objs,
-@@ -327,6 +328,9 @@ foreach l:libraries
+@@ -321,6 +322,9 @@ foreach l:libraries
              dependencies: shared_deps)
  
      dpdk_libraries = [shared_lib] + dpdk_libraries

--- a/ports/dpdk/0002-fix-dependencies.patch
+++ b/ports/dpdk/0002-fix-dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/config/meson.build b/config/meson.build
-index 722e114..0eb717b 100644
+index 34b85f10b5..5ed4625d9e 100644
 --- a/config/meson.build
 +++ b/config/meson.build
-@@ -234,12 +234,10 @@ if meson.is_cross_build() and not meson.get_cross_property('numa', true)
+@@ -236,12 +236,10 @@ if meson.is_cross_build() and not meson.get_external_property('numa', true)
      find_libnuma = false
  endif
  if find_libnuma
@@ -18,7 +18,7 @@ index 722e114..0eb717b 100644
  endif
  
 diff --git a/lib/eal/linux/meson.build b/lib/eal/linux/meson.build
-index e99ebed..672c705 100644
+index e99ebed256..672c70547b 100644
 --- a/lib/eal/linux/meson.build
 +++ b/lib/eal/linux/meson.build
 @@ -21,5 +21,6 @@ sources += files(
@@ -29,7 +29,7 @@ index e99ebed..672c705 100644
      dpdk_conf.set10('RTE_EAL_NUMA_AWARE_HUGEPAGES', true)
  endif
 diff --git a/lib/vhost/meson.build b/lib/vhost/meson.build
-index 41b622a..afff033 100644
+index 51bcf17244..1099a0232f 100644
 --- a/lib/vhost/meson.build
 +++ b/lib/vhost/meson.build
 @@ -6,6 +6,7 @@ if not is_linux

--- a/ports/dpdk/0003-remove-examples-src-from-datadir.patch
+++ b/ports/dpdk/0003-remove-examples-src-from-datadir.patch
@@ -1,15 +1,18 @@
 diff --git a/meson.build b/meson.build
-index 8b248d4..c546c62 100644
+index 8436d1dff8..5e704e37d5 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -90,10 +90,6 @@ subdir('doc')
-
- # build any examples explicitly requested - useful for developers - and
- # install any example code into the appropriate install path
+@@ -89,13 +89,6 @@ subdir('app')
+ # build docs
+ subdir('doc')
+ 
+-# build any examples explicitly requested - useful for developers - and
+-# install any example code into the appropriate install path
 -subdir('examples')
 -install_subdir('examples',
 -        install_dir: get_option('datadir') + '/dpdk',
 -        exclude_files: ex_file_excludes)
-
+-
  # build kernel modules
  subdir('kernel')
+ 

--- a/ports/dpdk/0004-stop-building-apps.patch
+++ b/ports/dpdk/0004-stop-building-apps.patch
@@ -1,13 +1,13 @@
 diff --git a/app/meson.build b/app/meson.build
-index 5b2c80c..d3ec534 100644
+index e2db888ae1..5e28824780 100644
 --- a/app/meson.build
 +++ b/app/meson.build
 @@ -52,7 +52,7 @@ endif
-
+ 
  foreach app:apps
      name = app
 -    build = true
 +    build = false
      reason = '<unknown reason>' # set if build == false to explain
      sources = []
-     includes = []
+     resources = []

--- a/ports/dpdk/0005-no-absolute-driver-path.patch
+++ b/ports/dpdk/0005-no-absolute-driver-path.patch
@@ -1,8 +1,8 @@
 diff --git a/config/meson.build b/config/meson.build
-index 7f7b6c92fd..51c3572793 100644
+index 5ed4625d9e..3f89fd0768 100644
 --- a/config/meson.build
 +++ b/config/meson.build
-@@ -375,7 +375,7 @@ if not dpdk_conf.has('RTE_MAX_NUMA_NODES')
+@@ -445,7 +445,7 @@ Please install libnuma, or set 'max_numa_nodes' option to '1' to build without N
  endif
  
  # set the install path for the drivers

--- a/ports/dpdk/portfile.cmake
+++ b/ports/dpdk/portfile.cmake
@@ -28,14 +28,14 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO DPDK/dpdk
   REF "v${VERSION}"
-  SHA512 1599ae78228307f612776e43160e8002c71024940813bc655b3e2631bfe3de9a93b09f2d5caae48d3d83e07c48e953838ba45f4965d2eb21d1e7955edbaa7d0d
+  SHA512 0d0ee4eb70e8021882a1d6548cf757972388c0a561ee71bb0e4b330be61f1463f4eaec55202d7a35eef8b392ecf0b3888713692ba8cd88f850e7b9072504733e
   HEAD_REF main
   PATCHES
-      enable-either-static-or-shared-build.patch
-      fix-dependencies.patch
-      remove-examples-src-from-datadir.patch
-      stop-building-apps.patch
-      no-absolute-driver-path.patch
+      0001-enable-either-static-or-shared-build.patch
+      0002-fix-dependencies.patch
+      0003-remove-examples-src-from-datadir.patch
+      0004-stop-building-apps.patch
+      0005-no-absolute-driver-path.patch
 )
 
 macro(append_bool_option feature_name option_name)
@@ -70,7 +70,15 @@ vcpkg_configure_meson(SOURCE_PATH "${SOURCE_PATH}"
 )
 vcpkg_install_meson()
 
-set(tools dpdk-devbind.py dpdk-pmdinfo.py dpdk-telemetry.py dpdk-hugepages.py)
+set(tools
+  dpdk-cmdline-gen.py
+  dpdk-devbind.py
+  dpdk-pmdinfo.py
+  dpdk-telemetry.py
+  dpdk-hugepages.py
+  dpdk-rss-flows.py
+  dpdk-telemetry-exporter.py
+)
 vcpkg_copy_tools(TOOL_NAMES ${tools} AUTO_CLEAN)
 
 vcpkg_fixup_pkgconfig()

--- a/ports/dpdk/vcpkg.json
+++ b/ports/dpdk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dpdk",
-  "version-string": "24.07",
+  "version-string": "24.11.3",
   "description": "A set of libraries and drivers for fast packet processing",
   "homepage": "https://www.dpdk.org/",
   "documentation": "https://doc.dpdk.org/guides/index.html",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -86,6 +86,7 @@ discord-game-sdk:x64-windows-static-md=fail
 discord-game-sdk:x64-windows-static=fail
 discord-rpc(uwp)=fail
 dmlc(uwp) = fail
+dpdk[docs]:x64-linux = feature-fails # doxygen required to build docs
 ensmallen[openmp](osx) = feature-fails # No openmp on default osx toolchain
 epsilon(uwp)=fail
 faiss:arm64-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2525,7 +2525,7 @@
       "port-version": 1
     },
     "dpdk": {
-      "baseline": "24.07",
+      "baseline": "24.11.3",
       "port-version": 0
     },
     "dpp": {

--- a/versions/d-/dpdk.json
+++ b/versions/d-/dpdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "688a23c5e2022b2bfec803eb636b87e6d7655f34",
+      "version-string": "24.11.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "a4d23173aedf2ba7b16305a9bb0b110bd8b05026",
       "version-string": "24.07",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.