### PR TITLE
[blosc2] Fix removal of installed find modules.

### DIFF
--- a/ports/blosc2/portfile.cmake
+++ b/ports/blosc2/portfile.cmake
@@ -51,6 +51,6 @@ vcpkg_fixup_pkgconfig()
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/Modules") # Find modules that should not be used by vcpkg.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}/Modules") # Find modules that should not be used by vcpkg.
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/blosc2/vcpkg.json
+++ b/ports/blosc2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "blosc2",
   "version": "2.22.0",
+  "port-version": 1,
   "description": "A fast, compressed, persistent binary data store library for C.",
   "homepage": "https://github.com/Blosc/c-blosc2",
   "license": "BSD-3-Clause",

--- a/versions/b-/blosc2.json
+++ b/versions/b-/blosc2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6869e54beb61b028ca8d5f54362b3988a7e7fcc",
+      "version": "2.22.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1cf0bc3f861ba73ecafae6db6e7491a73bff8e0a",
       "version": "2.22.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -774,7 +774,7 @@
     },
     "blosc2": {
       "baseline": "2.22.0",
-      "port-version": 0
+      "port-version": 1
     },
     "blpapi": {
       "baseline": "3.25.1",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.