### PR TITLE
[xmlsec] Update to version 1.3.9

### DIFF
--- a/ports/xmlsec/CMakeLists.txt
+++ b/ports/xmlsec/CMakeLists.txt
@@ -3,8 +3,9 @@ project (xmlsec1 C CXX) # CXX needed when libxml2 is built with icu
 
 include(CMakeDependentOption)
 
+option(INSTALL_HEADERS "Install headers" ON)
 cmake_dependent_option(BUILD_WITH_DYNAMIC_LOADING "Enable dynamic loading of xmlsec-crypto libraries" OFF BUILD_SHARED_LIBS OFF)
-option(INSTALL_HEADERS_TOOLS "Install public header files and tools" ON)
+cmake_dependent_option(BUILD_WITH_TOOLS "Build tools" ON INSTALL_HEADERS OFF)
 
 find_package(LibXml2 REQUIRED)
 find_package(OpenSSL REQUIRED)
@@ -17,15 +18,6 @@ FILE(GLOB SOURCESXMLSECOPENSSL
     src/openssl/*.c
     src/strings.c
 )
-
-# Generate xmlexports with fixed definition of XMLSEC_STATIC
-file(READ include/xmlsec/exports.h EXPORTS_H)
-if(BUILD_SHARED_LIBS)
-    string(REPLACE "!defined(XMLSEC_STATIC)" "1" EXPORTS_H "${EXPORTS_H}")
-else()
-    string(REPLACE "!defined(XMLSEC_STATIC)" "0" EXPORTS_H "${EXPORTS_H}")
-endif()
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/exports.h "${EXPORTS_H}")
 
 message(STATUS "Reading version info from configure.ac")
 
@@ -71,20 +63,20 @@ target_link_libraries(xmlsec1 PUBLIC LibXml2::LibXml2)
 target_link_libraries(xmlsec1-openssl PUBLIC xmlsec1 OpenSSL::Crypto)
 
 add_compile_definitions(
-	inline=__inline
-	PACKAGE="xmlsec1"
-	HAVE_STDIO_H
-	HAVE_STDLIB_H
-	HAVE_STRING_H
-	HAVE_CTYPE_H
-	HAVE_MALLOC_H
-	HAVE_MEMORY_H
-	XMLSEC_DEFAULT_CRYPTO="openssl"
-	UNICODE
-	_UNICODE
-	_MBCS
-	_REENTRANT
-	WIN32_LEAN_AND_MEAN
+    inline=__inline
+    PACKAGE="xmlsec1"
+    HAVE_STDIO_H
+    HAVE_STDLIB_H
+    HAVE_STRING_H
+    HAVE_CTYPE_H
+    HAVE_MALLOC_H
+    HAVE_MEMORY_H
+    XMLSEC_DEFAULT_CRYPTO="openssl"
+    UNICODE
+    _UNICODE
+    _MBCS
+    _REENTRANT
+    WIN32_LEAN_AND_MEAN
 )
 
 set_target_properties(xmlsec1 xmlsec1-openssl PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
@@ -130,32 +122,23 @@ install(EXPORT unofficial-xmlsec-targets
     DESTINATION share/unofficial-xmlsec
 )
 
-if(INSTALL_HEADERS_TOOLS)
-	file(GLOB PUBLIC_HEADERS
-		include/xmlsec/*.h
-		include/xmlsec/openssl/*.h)
-	list(FILTER PUBLIC_HEADERS EXCLUDE REGEX "exports\\.h$")
+if(INSTALL_HEADERS)
+    install(DIRECTORY include/xmlsec DESTINATION include FILES_MATCHING PATTERN "*.h")
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/xmlsec DESTINATION include)
+endif()
 
-	foreach(file IN LISTS PUBLIC_HEADERS)
-		get_filename_component(dir ${file} DIRECTORY)
-		file(RELATIVE_PATH rel_dir ${CMAKE_SOURCE_DIR}/xmlsec/${LIB} ${dir})
-		install(FILES ${file} DESTINATION "include/${rel_dir}")
-	endforeach()
+if(BUILD_WITH_TOOLS)
+    # xmlsec application
+    add_executable(xmlsec
+        apps/crypto.c
+        apps/cmdline.c
+        apps/xmlsec.c)
 
-	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/xmlsec/version.h DESTINATION "include/xmlsec")
-	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/exports.h DESTINATION "include/xmlsec")
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+        target_link_libraries(xmlsec PRIVATE crypt32.lib)
+    endif()
 
-	# xmlsec application
-	add_executable(xmlsec
-		apps/crypto.c
-		apps/cmdline.c
-		apps/xmlsec.c)
-
-	if(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-		target_link_libraries(xmlsec PRIVATE crypt32.lib)
-	endif()
-
-	target_link_libraries(xmlsec PRIVATE xmlsec1-openssl)
+    target_link_libraries(xmlsec PRIVATE xmlsec1-openssl)
 
     if(NOT BUILD_SHARED_LIBS)
         # needed when libxml2 is built with icu

--- a/ports/xmlsec/portfile.cmake
+++ b/ports/xmlsec/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lsh123/xmlsec
     REF "${release_tag}"
-    SHA512 40a6d73c308408f5bea71b779ad070b74609f7bff2cd28f6c4191e8a67981d81041b9c7acbdba36192ce7bcaac21e55c5ad58096d20d613c1a010d45491c7ba4
+    SHA512 1c5f0c0dc667cabaedce9e26b988a82a19677647c530ea16959a499472eb1de2338a0b3b0d74a6ff5320efd65c6eae55f98919f371a89d0ad40e0253909d4fbe
     HEAD_REF master
     PATCHES 
         pkgconfig_fixes.patch
@@ -11,12 +11,15 @@ vcpkg_from_github(
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES "with-dl" BUILD_WITH_DYNAMIC_LOADING
+    FEATURES
+        "tools"     BUILD_WITH_TOOLS
+        "with-dl"   BUILD_WITH_DYNAMIC_LOADING
 )
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS}
-    OPTIONS_DEBUG -DINSTALL_HEADERS_TOOLS=OFF
+    OPTIONS_DEBUG -DINSTALL_HEADERS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xmlsec",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
   "homepage": "https://www.aleksey.com/xmlsec/",
   "license": "X11 AND MPL-1.1",
@@ -21,6 +21,9 @@
     }
   ],
   "features": {
+    "tools": {
+      "description": "Build tools"
+    },
     "with-dl": {
       "description": "Build with dynamic loading of xmlsec-crypto libraries",
       "supports": "!static",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10653,7 +10653,7 @@
       "port-version": 0
     },
     "xmlsec": {
-      "baseline": "1.3.8",
+      "baseline": "1.3.9",
       "port-version": 0
     },
     "xnnpack": {

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "290baabd8a6fe15c014614c336c4e3fdc95f4338",
+      "version": "1.3.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "6ad3b4bdc5d9e45fca37d3da96010686fd2dce88",
       "version": "1.3.8",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
Signed-off-by: Raul Metsma <raul@metsma.ee>