### PR TITLE
[webview2] Update to 1.0.3595.46

### DIFF
--- a/ports/webview2/portfile.cmake
+++ b/ports/webview2/portfile.cmake
@@ -2,11 +2,14 @@ if(VCPKG_TARGET_IS_UWP)
     vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 endif()
 
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${VERSION}"
-    FILENAME "microsoft.web.webview2.${VERSION}.zip"
-    SHA512 dd447d7526e82a0e4522447d0e861f347ad72f2a73dfa82cca2537f633afe54b2764c2d437f717cf22aeb339641f79c04f9cbce0b68a100eef716bd58c1a8989
+vcpkg_download_distfile(
+    ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/1.0.3595.46"
+    FILENAME "Microsoft.Web.WebView2.1.0.3595.46.nupkg"
+    SHA512 "cce1e82cc057469ada77c116b9192957e83553c32fb794874dc7723148a81408b1d9d544e6eb4b61c2fe1ce99b6b8a705068f8f0e037eb39b556f7a093674fad"
 )
+
+
 
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/webview2/vcpkg.json
+++ b/ports/webview2/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "webview2",
-  "version": "1.0.3240.44",
+  "version": "1.0.3595.46",
   "description": "The WebView2 control allows you to embed web technologies (HTML, CSS, and JavaScript) using Microsoft Edge",
-  "homepage": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",
-  "documentation": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",
+  "homepage": "https://learn.microsoft.com/en-us/microsoft-edge/webview2/",
+  "documentation": "https://learn.microsoft.com/en-us/microsoft-edge/webview2/",
   "license": "BSD-3-Clause",
   "supports": "windows & (x86 | x64 | arm64)",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10429,7 +10429,7 @@
       "port-version": 0
     },
     "webview2": {
-      "baseline": "1.0.3240.44",
+      "baseline": "1.0.3595.46",
       "port-version": 0
     },
     "wepoll": {

--- a/versions/w-/webview2.json
+++ b/versions/w-/webview2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2860b035602c8ba09e4bfb40a3cb4d5a9cd16283",
+      "version": "1.0.3595.46",
+      "port-version": 0
+    },
+    {
       "git-tree": "fb78e84ec816749c5862dae33417f25fc5362eaf",
       "version": "1.0.3240.44",
       "port-version": 0

--- a/versions/w-/webview2.json
+++ b/versions/w-/webview2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2860b035602c8ba09e4bfb40a3cb4d5a9cd16283",
+      "git-tree": "5814769dad3b4b52b963ef3abc54ff883764f23c",
       "version": "1.0.3595.46",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ x] SHA512s are updated for each updated download.
- [ x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ x] Any patches that are no longer applied are deleted from the port's directory.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x ] Only one version is added to each modified port's versions file.
