### PR TITLE
[libxcrypt] update to 4.5.2

### DIFF
--- a/ports/libxcrypt/portfile.cmake
+++ b/ports/libxcrypt/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO besser82/libxcrypt
     REF "v${VERSION}"
-    SHA512 3ed21737facf48cac24a667dbaed84aa4d41e2bb0c532abba7c60c5bb5d78a416dcd402ed0ebbe1a8c46b54787fb35782a3ec35f69a96fffd2d01ee87987fa92
+    SHA512 00ea73f2546ddbc191e30be4db897fffb5c9da1be03781c3b3b00514c621ec0d10cee7bbfc2a53a0d79ded62e372d6b7ad93289e5f44475ddfc43816b1a31651
 )
 
 vcpkg_make_configure(

--- a/ports/libxcrypt/vcpkg.json
+++ b/ports/libxcrypt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxcrypt",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "libxcrypt is a modern library for one-way hashing of passwords. On Linux-based systems, by default libxcrypt will be binary backward compatible with the libcrypt.so.1 shipped as part of the GNU C Library.",
   "homepage": "https://github.com/besser82/libxcrypt",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5745,7 +5745,7 @@
       "port-version": 0
     },
     "libxcrypt": {
-      "baseline": "4.5.1",
+      "baseline": "4.5.2",
       "port-version": 0
     },
     "libxcvt": {

--- a/versions/l-/libxcrypt.json
+++ b/versions/l-/libxcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cbbde771619d6fbaa5c8dcf620a2fb000736da24",
+      "version": "4.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "fb4838146f6d555070fcd1b49ac669c8a5d4ee8b",
       "version": "4.5.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/besser82/libxcrypt/releases/tag/v4.5.2
