### PR TITLE
Update to CMake 3.31.10

### DIFF
--- a/ports/quickjs-ng/pdb_name_conflict.patch
+++ b/ports/quickjs-ng/pdb_name_conflict.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f49a052..8e3c74c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -304,6 +304,7 @@ add_qjs_libc_if_needed(qjs_exe)
+ add_static_if_needed(qjs_exe)
+ set_target_properties(qjs_exe PROPERTIES
+     OUTPUT_NAME "qjs"
++    PDB_NAME "qjs_exe"
+ )
+ target_compile_definitions(qjs_exe PRIVATE ${qjs_defines})
+ target_link_libraries(qjs_exe qjs)

--- a/ports/quickjs-ng/portfile.cmake
+++ b/ports/quickjs-ng/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF v${VERSION}
     SHA512 c8b1920bab954f5fa891956f330875478e5b17161d24f8b96db05108d61354dab0621f2a36c5ae421ffbfb9817d90c7a62fe1bd4f84ad149dd2d569c356a2788
     HEAD_REF master
+    PATCHES
+        pdb_name_conflict.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/quickjs-ng/vcpkg.json
+++ b/ports/quickjs-ng/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "quickjs-ng",
   "version": "0.11.0",
+  "port-version": 1,
   "description": "QuickJS, the Next Generation: a mighty JavaScript engine. A small and embeddable JavaScript engine supporting the latest ECMAScript specification.",
   "homepage": "https://github.com/quickjs-ng/quickjs",
   "license": "MIT",

--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -24,7 +24,7 @@ function(vcpkg_from_git)
     if(DEFINED arg_FETCH_REF AND NOT DEFINED arg_REF)
         message(FATAL_ERROR "REF must be specified if FETCH_REF is specified")
     endif()
-    if(NOT DEFINED arg_LFS AND "LFS" IN_LIST arg_KEYWORDS_MISSING_VALUES)
+    if(DEFINED arg_LFS AND arg_LFS STREQUAL "")
         set(arg_LFS "${arg_URL}")
     endif()
 

--- a/scripts/vcpkg-tools.json
+++ b/scripts/vcpkg-tools.json
@@ -23,50 +23,50 @@
       "name": "cmake",
       "os": "windows",
       "arch": "amd64",
-      "version": "3.30.1",
-      "executable": "cmake-3.30.1-windows-i386/bin/cmake.exe",
-      "url": "https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-windows-i386.zip",
-      "sha512": "0b74bd4222064cfb6e42838987704eb21d57ad5f7bbd87714ab570f1d107fa19bd2f14316475338518292bc377bf38b581a07c73267a775cd385bbd1800879b4",
-      "archive": "cmake-3.30.1-windows-i386.zip"
+      "version": "3.31.10",
+      "executable": "cmake-3.31.10-windows-x86_64/bin/cmake.exe",
+      "url": "https://github.com/Kitware/CMake/releases/download/v3.31.10/cmake-3.31.10-windows-x86_64.zip",
+      "sha512": "50c71aa15a05eaf8d7592d9648efb986df74ab716dc1f1a03795351284c6212b70ad439a1d9f3575d60cf49b0a5579cad551cc6a3fe2911ae8ecb08add60fc60",
+      "archive": "cmake-3.31.10-windows-x86_64.zip"
     },
     {
       "name": "cmake",
       "os": "windows",
       "arch": "arm64",
-      "version": "3.30.1",
-      "executable": "cmake-3.30.1-windows-arm64/bin/cmake.exe",
-      "url": "https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-windows-arm64.zip",
-      "sha512": "40bcdeff5ff40044629f49e0effc958a719353330ea39876b919fb7c2d441885c884acf43e644ab5dedcb95503d211c895da1c0b6360e71449bea6a981f8e128",
-      "archive": "cmake-3.30.1-windows-arm64.zip"
+      "version": "3.31.10",
+      "executable": "cmake-3.31.10-windows-arm64/bin/cmake.exe",
+      "url": "https://github.com/Kitware/CMake/releases/download/v3.31.10/cmake-3.31.10-windows-arm64.zip",
+      "sha512": "a894518004b1e99c008e2554fd7a0b2f714ad6bf12e9c0bd34f62d808546e5773845e3f4c2a44f03cae30fa52bb604760aec6a452327ef38c5cf94e593eb8587",
+      "archive": "cmake-3.31.10-windows-arm64.zip"
     },
     {
       "name": "cmake",
       "os": "osx",
-      "version": "3.30.1",
-      "executable": "cmake-3.30.1-macos-universal/CMake.app/Contents/bin/cmake",
-      "url": "https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-macos-universal.tar.gz",
-      "sha512": "71290d3b5e51724711e8784f5b21100cb0cffdbb889da7572a26dd171d9052601496de8d39c42d76ef3a9245af2ab35a590bf53ad68d7bb8a2047b64272d2647",
-      "archive": "cmake-3.30.1-macos-universal.tar.gz"
+      "version": "3.31.10",
+      "executable": "cmake-3.31.10-macos-universal/CMake.app/Contents/bin/cmake",
+      "url": "https://github.com/Kitware/CMake/releases/download/v3.31.10/cmake-3.31.10-macos-universal.tar.gz",
+      "sha512": "5960326dee8227bf27cdd2d94c336835b7bf1b11c443c35ecf2b50a811c7874fcc3400a3b793e4720ef6505d66aed597ecdaf6c77b12db69abafcccd0659182d",
+      "archive": "cmake-3.31.10-macos-universal.tar.gz"
     },
     {
       "name": "cmake",
       "os": "linux",
       "arch": "arm64",
-      "version": "3.30.1",
-      "executable": "cmake-3.30.1-linux-aarch64/bin/cmake",
-      "url": "https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-linux-aarch64.tar.gz",
-      "sha512": "ec6c1c682dda2381aa5ebef98a2597e4ab6b4563639c28b2f30c20360694b902a7b33c175c796169a9f99ed139f053916042caed58d83298680894c2840dbb87",
-      "archive": "cmake-3.30.1-linux-aarch64.tar.gz"
+      "version": "3.31.10",
+      "executable": "cmake-3.31.10-linux-aarch64/bin/cmake",
+      "url": "https://github.com/Kitware/CMake/releases/download/v3.31.10/cmake-3.31.10-linux-aarch64.tar.gz",
+      "sha512": "e45c23cd756a9b4699a54d52bd196e3c1c2e63fab893846eeb8a0e1eabb2caa54629bd857518ab5ce5701d9179bb308bf6b4866d07bb8d7b87e04d895d10289d",
+      "archive": "cmake-3.31.10-linux-aarch64.tar.gz"
     },
     {
       "name": "cmake",
       "os": "linux",
-      "version": "3.30.1",
+      "version": "3.31.10",
       "arch": "amd64",
-      "executable": "cmake-3.30.1-linux-x86_64/bin/cmake",
-      "url": "https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-linux-x86_64.tar.gz",
-      "sha512": "84ce1333ed696a1736986fba2853c5d8db0e4c9addaf4a4723911248c6d49ecf545adf8bd46091d198fc7bd1e6c896798661463aa1ce3a726a093883aaa19adf",
-      "archive": "cmake-3.30.1-linux-x86_64.tar.gz"
+      "executable": "cmake-3.31.10-linux-x86_64/bin/cmake",
+      "url": "https://github.com/Kitware/CMake/releases/download/v3.31.10/cmake-3.31.10-linux-x86_64.tar.gz",
+      "sha512": "2555ae413b19a2acfc8d3c4520f0ecc87811ac1e121bec718b679006d03083dfe7218a68e0af0263a80bd8fbb2d23b5975f4533638b71ef9ad62272640f62356",
+      "archive": "cmake-3.31.10-linux-x86_64.tar.gz"
     },
     {
       "name": "git",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8326,7 +8326,7 @@
     },
     "quickjs-ng": {
       "baseline": "0.11.0",
-      "port-version": 0
+      "port-version": 1
     },
     "quill": {
       "baseline": "11.0.1",

--- a/versions/q-/quickjs-ng.json
+++ b/versions/q-/quickjs-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5c4169e09b13642be14ccbecc0cf253367fee229",
+      "version": "0.11.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d060749a62c2f7e9888fd408c9a6d1dbf0b1c8d4",
       "version": "0.11.0",
       "port-version": 0


### PR DESCRIPTION
I just checked to see if anyone has already tested CMake 4 here, as some ports are not yet compatible with it, but this has not been particularly relevant so far, as it has been possible to stick with CMake 3. However, with MSVC 2026, CMake 4.2 will become necessary. During my search, I only came across a request from someone who wanted a newer version of CMake 3 (see #48216). Hopefully, no ports will be broken by updating CMake 3, so I'll update it first, as the switch to CMake 4 will probably take longer.

Note: Using x64 binary for windows amd64 now.

Fixes: #43816, #48216

Not sure which version of CMake the CI is currently testing, due to first downloading 3.31.9 and then 3.30.1
```
A suitable version of cmake was not found (required v3.31.9).
Trying to download cmake-3.31.9-windows-x86_64.zip using asset cache https://vcpkgassetcachewus.blob.core.windows.net/cache/b82a496fb94376dae5d7f6824631f59d75891628a9c25f0e5a798dc350a05fd73d2b572bb44009e5a73222f4f98faf927d938acda3d3ec82ea1c175fd462f664?*** SECRET ***
Download successful! Asset cache hit, did not try authoritative source https://github.com/Kitware/CMake/releases/download/v3.31.9/cmake-3.31.9-windows-x86_64.zip
Extracting cmake...
Computing 0 install plans...
Computing all ABI hashes...
Checking the binary cache...
All feature tests passed.
Clearing contents of D:\b
Clearing contents of D:\installed
Skipping clearing contents of D:\p because it was not a directory.
Comparing with HEAD~1
CI baseline unchanged, determining parent hashes
warning: vcpkg ci is an internal command which will change incompatibly or be removed at any time.
Loading dependency information for 1141 packages...
A suitable version of cmake was not found (required v3.30.1).
Trying to download cmake-3.30.1-windows-i386.zip using asset cache https://vcpkgassetcachewus.blob.core.windows.net/cache/0b74bd4222064cfb6e42838987704eb21d57ad5f7bbd87714ab570f1d107fa19bd2f14316475338518292bc377bf38b581a07c73267a775cd385bbd1800879b4?*** SECRET ***
Download successful! Asset cache hit, did not try authoritative source https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-windows-i386.zip
Extracting cmake...
Detecting compiler hash for triplet x64-windows...
```