### PR TITLE
[relno-d1] Add new port for Relative Noise Dimension 1

### DIFF
--- a/ports/relno-d1/portfile.cmake
+++ b/ports/relno-d1/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO adi5423/RelNo_D1
+    REF v1.0.0
+    SHA512 0fd5db9d72eb96ac4c22fd549891a7e9394d55da6121a16b36f4650b85254d536fadcaf610efeb004ed78678d9c2bac9ed53e18d09abcd215a4e7a2d1d67cd67
+)
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_cmake_build()
+vcpkg_cmake_install()
+
+# Always run fixup even if lib/cmake doesn’t exist (it no-ops safely)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/RelNo_D1)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# License
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/relno-d1 RENAME copyright)

--- a/ports/relno-d1/vcpkg.json
+++ b/ports/relno-d1/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "relno-d1",
+  "version": "1.0.0",
+  "description": "RelNo_D1 - Relative Noise Dimension 1: 2D procedural noise generation library (White, Perlin, Simplex).",
+  "homepage": "https://github.com/adi5423/RelNo_D1",
+  "license": "MIT",
+  "dependencies": [
+    { "name": "vcpkg-cmake", "host": true },
+    { "name": "vcpkg-cmake-config", "host": true }
+  ]
+}


### PR DESCRIPTION
Adds the `relno-d1` port — a lightweight C++ procedural noise map generation library (White, Perlin, and Simplex noise).

Features:
- Header-focused library
- stb_image.h as the only dependency
- MIT licensed

Homepage: [adi5423/RelNo_D1](https://github.com/adi5423/RelNo_D1)

Tested on:
- Windows 11 x64
- Visual Studio 2022 (MSVC v143)
- vcpkg build and install successful (`vcpkg install relno-d1`)

Build: Uses CMake; automatically builds static `.a` library and installs headers to `include/RelNo_D1/`.

License: MIT