### PR TITLE
[yaml-schema-cpp] add new port

### DIFF
--- a/ports/yaml-schema-cpp/fix-windows-build.patch
+++ b/ports/yaml-schema-cpp/fix-windows-build.patch
@@ -1,5 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0399267..afd6ef7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -37,6 +37,11 @@ SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+ SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+ SET(LIB_INSTALL_DIR lib)
+ 
++# support alternative tokens in MSVC
++if(MSVC)
++  add_compile_options(/permissive-)
++endif()
++
+ # ------ PROJECT OPTIONS ------
+ IF(NOT BUILD_TESTS)
+     OPTION(BUILD_TESTS "Build Unit tests" ON)
 diff --git a/include/yaml-schema-cpp/type_check.hpp b/include/yaml-schema-cpp/type_check.hpp
-index a73df4c..3c50cfb 100644
+index a73df4c..0f769e9 100644
 --- a/include/yaml-schema-cpp/type_check.hpp
 +++ b/include/yaml-schema-cpp/type_check.hpp
 @@ -18,12 +18,12 @@ namespace yaml_schema_cpp
@@ -44,10 +60,19 @@ index a73df4c..3c50cfb 100644
      {
          // both sequences
 -        if (not node1.IsSequence() or not node2.IsSequence()) return false;
-+        if (not node1.IsSequence() || not node2.IsSequence()) return false;
++        if (!node1.IsSequence() || !node2.IsSequence()) return false;
  
          // same size
          if (node1.size() != node2.size()) return false;
+@@ -149,7 +149,7 @@ static bool compare(const YAML::Node& node1, const YAML::Node& node2, const std:
+         // compare all elements
+         for (auto i = 0; i < node1.size(); i++)
+         {
+-            if (not compare(node1[i], node2[i], type.substr(1, type.size() - 2))) return false;
++            if (!compare(node1[i], node2[i], type.substr(1, type.size() - 2))) return false;
+         }
+         return true;
+     }
 @@ -185,11 +185,11 @@ static bool compare(const YAML::Node& node1, const YAML::Node& node2, const std:
  }
  
@@ -128,118 +153,3 @@ index 81114e8..d660f8a 100644
              {
                  std::cout << "Empty input sequence with not dynamic matrix" << std::endl;
                  return false;
-diff --git a/src/expression.cpp b/src/expression.cpp
-index 1117b65..849d0bd 100644
---- a/src/expression.cpp
-+++ b/src/expression.cpp
-@@ -93,8 +93,8 @@ struct schema_USR : public parser_t::unknown_symbol_resolver
-             error_message = "checkExpression: The parameter '" + unknown_symbol + "' is not a basic type";
-         }
-         // mandatory (bool and true or with default
--        else if (not(tryNodeAs(schema_[unknown_symbol][MANDATORY], "bool") and
--                     (schema_[unknown_symbol][MANDATORY].as<bool>() or schema_[unknown_symbol][DEFAULT])))
-+        else if (not(tryNodeAs(schema_[unknown_symbol][MANDATORY], "bool") &&
-+                     (schema_[unknown_symbol][MANDATORY].as<bool>() || schema_[unknown_symbol][DEFAULT])))
-         {
-             error_message = "checkExpression: The parameter '" + unknown_symbol +
-                             "' is not mandatory (expressions with optional parameters not implemented yet)";
-diff --git a/src/yaml_schema.cpp b/src/yaml_schema.cpp
-index 0089c43..1e0d454 100644
---- a/src/yaml_schema.cpp
-+++ b/src/yaml_schema.cpp
-@@ -70,7 +70,7 @@ void checkSchema(const YAML::Node&               node_schema,
-                  const std::vector<std::string>& folders_schema)
- {
-     // skip scalars and not defined (empty schemas)
--    if (node_schema.IsScalar() or node_schema.IsNull()) return;
-+    if (node_schema.IsScalar() || node_schema.IsNull()) return;
- 
-     // Check that node_schema is map
-     if (not node_schema.IsMap())
-@@ -209,7 +209,7 @@ void checkSchema(const YAML::Node&               node_schema,
- 
-             // if 'value', 'mandatory' should be false (no sense requiring user to define something already
-             // defined)
--            if (isExpression(node_schema[MANDATORY]) or node_schema[MANDATORY].as<bool>())
-+            if (isExpression(node_schema[MANDATORY]) || node_schema[MANDATORY].as<bool>())
-             {
-                 throw std::runtime_error("YAML schema: " + node_field + ", if " + VALUE + " defined, " + MANDATORY +
-                                          " should be false");
-@@ -624,7 +624,7 @@ bool applySchemaRecursive(YAML::Node&                     node_input,
-             // Check if it is mandatory
-             else
-             {
--                assert(tryNodeAs(node_schema[MANDATORY], "bool") or isExpression(node_schema[MANDATORY]));
-+                assert(tryNodeAs(node_schema[MANDATORY], "bool") || isExpression(node_schema[MANDATORY]));
-                 bool mandatory;
-                 if (isExpression(node_schema[MANDATORY]))
-                 {
-diff --git a/src/yaml_template_generator.cpp b/src/yaml_template_generator.cpp
-index 71182a3..c524f0d 100644
---- a/src/yaml_template_generator.cpp
-+++ b/src/yaml_template_generator.cpp
-@@ -27,7 +27,7 @@ int main(int argc, char* argv[])
-      */
- 
-     // HELP
--    if (argc == 2 and (std::string(argv[1]) == "-h" or std::string(argv[1]) == "--help"))
-+    if (argc == 2 && (std::string(argv[1]) == "-h" || std::string(argv[1]) == "--help"))
-     {
-         cout << "--------- yaml_template_generator HELP ---------- \nCall it with:" << endl;
-         cout << "yaml_template_generator schema_name schema_folders output_file" << endl << endl;
-@@ -44,7 +44,7 @@ int main(int argc, char* argv[])
-         return 0;
-     }
-     // Call
--    if (argc == 3 or argc == 4)
-+    if (argc == 3 || argc == 4)
-     {
-         filesystem::path current_path(filesystem::current_path());
- 
-@@ -54,7 +54,7 @@ int main(int argc, char* argv[])
-         // schema folders
-         std::string              schema_folders_input(argv[2]);
-         std::vector<std::string> schema_folders;
--        if (schema_folders_input.front() == '[' and schema_folders_input.back() == ']')
-+        if (schema_folders_input.front() == '[' && schema_folders_input.back() == ']')
-         {
-             // remove '[' and ']'
-             schema_folders_input.erase(0, 1);
-diff --git a/src/yaml_utils.cpp b/src/yaml_utils.cpp
-index ad14bd2..5047188 100644
---- a/src/yaml_utils.cpp
-+++ b/src/yaml_utils.cpp
-@@ -199,8 +199,8 @@ void addNodeYaml(YAML::Node&        node,
-     if (node[key].Type() == YAML::NodeType::Scalar)
-     {
-         std::string value_str = node[key].as<std::string>();
--        if ((value_str.size() > 1 and value_str.substr(0, 2) == "./") or
--            (value_str.size() > 2 and value_str.substr(0, 3) == "../"))
-+        if ((value_str.size() > 1 && value_str.substr(0, 2) == "./") ||
-+            (value_str.size() > 2 && value_str.substr(0, 3) == "../"))
-         {
-             filesystem::path path_value = filesystem::path(parent_path) / filesystem::path(value.as<std::string>());
-             node[key]                   = path_value.string();
-@@ -212,11 +212,11 @@ std::string findFileRecursive(const std::string& name_with_extension, const std:
- {
-     for (auto folder : folders)
-     {
--        if (filesystem::exists(folder) and filesystem::is_directory(folder))
-+        if (filesystem::exists(folder) && filesystem::is_directory(folder))
-         {
-             for (auto const& entry : filesystem::recursive_directory_iterator(folder))
-             {
--                if (filesystem::is_regular_file(entry) and entry.path().filename().string() == name_with_extension)
-+                if (filesystem::is_regular_file(entry) && entry.path().filename().string() == name_with_extension)
-                 {
-                     return entry.path().string();
-                 }
-@@ -263,7 +263,7 @@ std::vector<std::string> getAllSchemas(const std::vector<std::string>& root_fold
-     std::vector<std::string> schemas_found;
-     for (auto root_folder : root_folders)
-         for (auto const& entry : filesystem::recursive_directory_iterator(root_folder))
--            if (filesystem::is_regular_file(entry) and entry.path().extension() == SCHEMA_EXTENSION)
-+            if (filesystem::is_regular_file(entry) && entry.path().extension() == SCHEMA_EXTENSION)
-                 schemas_found.push_back(entry.path().filename().string());
- 
-     return schemas_found;

--- a/ports/yaml-schema-cpp/fix-windows-build.patch
+++ b/ports/yaml-schema-cpp/fix-windows-build.patch
@@ -1,0 +1,245 @@
+diff --git a/include/yaml-schema-cpp/type_check.hpp b/include/yaml-schema-cpp/type_check.hpp
+index a73df4c..3c50cfb 100644
+--- a/include/yaml-schema-cpp/type_check.hpp
++++ b/include/yaml-schema-cpp/type_check.hpp
+@@ -18,12 +18,12 @@ namespace yaml_schema_cpp
+ #define CHECK_TYPE_CASE(TypeName) CHECK_STRING_TYPE_CASE(TypeName, TypeName);
+ 
+ #define CHECK_TYPE_EIGEN_CASE(size)                                                                                   \
+-    if (type == "Vector" #size "d" or type == "Eigen::Vector" #size "d")                                              \
++    if (type == "Vector" #size "d" || type == "Eigen::Vector" #size "d")                                              \
+     {                                                                                                                 \
+         node.as<Eigen::Matrix<double, size, 1> >();                                                                   \
+         return true;                                                                                                  \
+     }                                                                                                                 \
+-    if (type == "Matrix" #size "d" or type == "Eigen::Matrix" #size "d")                                              \
++    if (type == "Matrix" #size "d" || type == "Eigen::Matrix" #size "d")                                              \
+     {                                                                                                                 \
+         node.as<Eigen::Matrix<double, size, size> >();                                                                \
+         return true;                                                                                                  \
+@@ -108,7 +108,7 @@ bool isNonTrivialType(const std::string& type, const std::vector<std::string>& f
+ #define COMPARE_TYPE(TypeName) COMPARE_STRING_TYPE(TypeName, TypeName);
+ 
+ #define COMPARE_EIGEN(size)                                                                                           \
+-    if (type == "Vector" #size "d" or type == "Eigen::Vector" #size "d")                                              \
++    if (type == "Vector" #size "d" || type == "Eigen::Vector" #size "d")                                              \
+     {                                                                                                                 \
+         try                                                                                                           \
+         {                                                                                                             \
+@@ -121,7 +121,7 @@ bool isNonTrivialType(const std::string& type, const std::vector<std::string>& f
+             return false;                                                                                             \
+         }                                                                                                             \
+     }                                                                                                                 \
+-    if (type == "Matrix" #size "d" or type == "Eigen::Matrix" #size "d")                                              \
++    if (type == "Matrix" #size "d" || type == "Eigen::Matrix" #size "d")                                              \
+     {                                                                                                                 \
+         try                                                                                                           \
+         {                                                                                                             \
+@@ -138,10 +138,10 @@ bool isNonTrivialType(const std::string& type, const std::vector<std::string>& f
+ static bool compare(const YAML::Node& node1, const YAML::Node& node2, const std::string& type)
+ {
+     // sequence
+-    if (type.front() == '[' and type.back() == ']')
++    if (type.front() == '[' && type.back() == ']')
+     {
+         // both sequences
+-        if (not node1.IsSequence() or not node2.IsSequence()) return false;
++        if (not node1.IsSequence() || not node2.IsSequence()) return false;
+ 
+         // same size
+         if (node1.size() != node2.size()) return false;
+@@ -185,11 +185,11 @@ static bool compare(const YAML::Node& node1, const YAML::Node& node2, const std:
+ }
+ 
+ #define SETZERO_EIGEN(size)                                                                                           \
+-    if (type == "Vector" #size "d" or type == "Eigen::Vector" #size "d")                                              \
++    if (type == "Vector" #size "d" || type == "Eigen::Vector" #size "d")                                              \
+     {                                                                                                                 \
+         node = Eigen::Matrix<double, size, 1>::Zero();                                                                \
+     }                                                                                                                 \
+-    if (type == "Matrix" #size "d" or type == "Eigen::Matrix" #size "d")                                              \
++    if (type == "Matrix" #size "d" || type == "Eigen::Matrix" #size "d")                                              \
+     {                                                                                                                 \
+         node = Eigen::Matrix<double, size, size>::Zero();                                                             \
+     }
+@@ -197,12 +197,12 @@ static bool compare(const YAML::Node& node1, const YAML::Node& node2, const std:
+ static void setZero(YAML::Node& node, const std::string& type)
+ {
+     if (type == "bool") node = "false";
+-    if (type == "int" or type == "unsigned int" or type == "long int" or type == "long unsigned int") node = "0";
+-    if (type == "float" or type == "double") node = "0.0";
++    if (type == "int" || type == "unsigned int" || type == "long int" || type == "long unsigned int") node = "0";
++    if (type == "float" || type == "double") node = "0.0";
+     if (type == "char") node = "A";
+-    if (type == "string" or type == "std::string") node = "whatever";
+-    if (type == "VectorXd" or type == "Eigen::VectorXd") node = Eigen::VectorXd::Zero(3);
+-    if (type == "MatrixXd" or type == "Eigen::MatrixXd") node = Eigen::MatrixXd::Zero(3, 2);
++    if (type == "string" || type == "std::string") node = "whatever";
++    if (type == "VectorXd" || type == "Eigen::VectorXd") node = Eigen::VectorXd::Zero(3);
++    if (type == "MatrixXd" || type == "Eigen::MatrixXd") node = Eigen::MatrixXd::Zero(3, 2);
+ 
+     SETZERO_EIGEN(1)
+     SETZERO_EIGEN(2)
+@@ -219,16 +219,15 @@ static void setZero(YAML::Node& node, const std::string& type)
+ static std::string getZeroString(const std::string& type)
+ {
+     if (type == "bool") return "false";
+-    if (type == "int" or type == "unsigned int" or type == "long int" or type == "long unsigned int") return "0";
+-    if (type == "float" or type == "double") return "0.0";
++    if (type == "int" || type == "unsigned int" || type == "long int" || type == "long unsigned int") return "0";
++    if (type == "float" || type == "double") return "0.0";
+     if (type == "char") return "A";
+-    if (type == "string" or type == "std::string") return "whatever";
+-    if (type == "VectorXd" or type == "Eigen::VectorXd") return "[0.0, 0.0, 0.0]";
+-    if (type == "MatrixXd" or type == "Eigen::MatrixXd") return "[[3, 2], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]";
+-
++    if (type == "string" || type == "std::string") return "whatever";
++    if (type == "VectorXd" || type == "Eigen::VectorXd") return "[0.0, 0.0, 0.0]";
++    if (type == "MatrixXd" || type == "Eigen::MatrixXd") return "[[3, 2], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]";
+     for (auto i = 1; i <= 10; i++)
+     {
+-        if (type == "Vector" + std::to_string(i) + "d" or type == "Eigen::Vector" + std::to_string(i) + "d")
++        if (type == "Vector" + std::to_string(i) + "d" || type == "Eigen::Vector" + std::to_string(i) + "d")
+         {
+             std::string string_ret = "[0.0";
+             for (auto j = 2; j <= i; j++) string_ret += ", 0.0";
+@@ -237,7 +236,7 @@ static std::string getZeroString(const std::string& type)
+             return string_ret;
+         }
+ 
+-        if (type == "Matrix" + std::to_string(i) + "d" or type == "Eigen::Matrix" + std::to_string(i) + "d")
++        if (type == "Matrix" + std::to_string(i) + "d" || type == "Eigen::Matrix" + std::to_string(i) + "d")
+         {
+             std::string string_ret = "[0.0";
+             for (auto j = 2; j <= i * i; j++) string_ret += ", 0.0";
+diff --git a/include/yaml-schema-cpp/yaml_conversion.hpp b/include/yaml-schema-cpp/yaml_conversion.hpp
+index 81114e8..d660f8a 100644
+--- a/include/yaml-schema-cpp/yaml_conversion.hpp
++++ b/include/yaml-schema-cpp/yaml_conversion.hpp
+@@ -55,9 +55,9 @@ struct convert<Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols
+ 
+         // ==========================================================================================
+         // Special case empty vector/matrix
+-        if (node.IsSequence() and node.size() == 0)
++        if (node.IsSequence() && node.size() == 0)
+         {
+-            if (_Rows != Eigen::Dynamic and _Cols != Eigen::Dynamic)
++            if (_Rows != Eigen::Dynamic && _Cols != Eigen::Dynamic)
+             {
+                 std::cout << "Empty input sequence with not dynamic matrix" << std::endl;
+                 return false;
+diff --git a/src/expression.cpp b/src/expression.cpp
+index 1117b65..849d0bd 100644
+--- a/src/expression.cpp
++++ b/src/expression.cpp
+@@ -93,8 +93,8 @@ struct schema_USR : public parser_t::unknown_symbol_resolver
+             error_message = "checkExpression: The parameter '" + unknown_symbol + "' is not a basic type";
+         }
+         // mandatory (bool and true or with default
+-        else if (not(tryNodeAs(schema_[unknown_symbol][MANDATORY], "bool") and
+-                     (schema_[unknown_symbol][MANDATORY].as<bool>() or schema_[unknown_symbol][DEFAULT])))
++        else if (not(tryNodeAs(schema_[unknown_symbol][MANDATORY], "bool") &&
++                     (schema_[unknown_symbol][MANDATORY].as<bool>() || schema_[unknown_symbol][DEFAULT])))
+         {
+             error_message = "checkExpression: The parameter '" + unknown_symbol +
+                             "' is not mandatory (expressions with optional parameters not implemented yet)";
+diff --git a/src/yaml_schema.cpp b/src/yaml_schema.cpp
+index 0089c43..1e0d454 100644
+--- a/src/yaml_schema.cpp
++++ b/src/yaml_schema.cpp
+@@ -70,7 +70,7 @@ void checkSchema(const YAML::Node&               node_schema,
+                  const std::vector<std::string>& folders_schema)
+ {
+     // skip scalars and not defined (empty schemas)
+-    if (node_schema.IsScalar() or node_schema.IsNull()) return;
++    if (node_schema.IsScalar() || node_schema.IsNull()) return;
+ 
+     // Check that node_schema is map
+     if (not node_schema.IsMap())
+@@ -209,7 +209,7 @@ void checkSchema(const YAML::Node&               node_schema,
+ 
+             // if 'value', 'mandatory' should be false (no sense requiring user to define something already
+             // defined)
+-            if (isExpression(node_schema[MANDATORY]) or node_schema[MANDATORY].as<bool>())
++            if (isExpression(node_schema[MANDATORY]) || node_schema[MANDATORY].as<bool>())
+             {
+                 throw std::runtime_error("YAML schema: " + node_field + ", if " + VALUE + " defined, " + MANDATORY +
+                                          " should be false");
+@@ -624,7 +624,7 @@ bool applySchemaRecursive(YAML::Node&                     node_input,
+             // Check if it is mandatory
+             else
+             {
+-                assert(tryNodeAs(node_schema[MANDATORY], "bool") or isExpression(node_schema[MANDATORY]));
++                assert(tryNodeAs(node_schema[MANDATORY], "bool") || isExpression(node_schema[MANDATORY]));
+                 bool mandatory;
+                 if (isExpression(node_schema[MANDATORY]))
+                 {
+diff --git a/src/yaml_template_generator.cpp b/src/yaml_template_generator.cpp
+index 71182a3..c524f0d 100644
+--- a/src/yaml_template_generator.cpp
++++ b/src/yaml_template_generator.cpp
+@@ -27,7 +27,7 @@ int main(int argc, char* argv[])
+      */
+ 
+     // HELP
+-    if (argc == 2 and (std::string(argv[1]) == "-h" or std::string(argv[1]) == "--help"))
++    if (argc == 2 && (std::string(argv[1]) == "-h" || std::string(argv[1]) == "--help"))
+     {
+         cout << "--------- yaml_template_generator HELP ---------- \nCall it with:" << endl;
+         cout << "yaml_template_generator schema_name schema_folders output_file" << endl << endl;
+@@ -44,7 +44,7 @@ int main(int argc, char* argv[])
+         return 0;
+     }
+     // Call
+-    if (argc == 3 or argc == 4)
++    if (argc == 3 || argc == 4)
+     {
+         filesystem::path current_path(filesystem::current_path());
+ 
+@@ -54,7 +54,7 @@ int main(int argc, char* argv[])
+         // schema folders
+         std::string              schema_folders_input(argv[2]);
+         std::vector<std::string> schema_folders;
+-        if (schema_folders_input.front() == '[' and schema_folders_input.back() == ']')
++        if (schema_folders_input.front() == '[' && schema_folders_input.back() == ']')
+         {
+             // remove '[' and ']'
+             schema_folders_input.erase(0, 1);
+diff --git a/src/yaml_utils.cpp b/src/yaml_utils.cpp
+index ad14bd2..5047188 100644
+--- a/src/yaml_utils.cpp
++++ b/src/yaml_utils.cpp
+@@ -199,8 +199,8 @@ void addNodeYaml(YAML::Node&        node,
+     if (node[key].Type() == YAML::NodeType::Scalar)
+     {
+         std::string value_str = node[key].as<std::string>();
+-        if ((value_str.size() > 1 and value_str.substr(0, 2) == "./") or
+-            (value_str.size() > 2 and value_str.substr(0, 3) == "../"))
++        if ((value_str.size() > 1 && value_str.substr(0, 2) == "./") ||
++            (value_str.size() > 2 && value_str.substr(0, 3) == "../"))
+         {
+             filesystem::path path_value = filesystem::path(parent_path) / filesystem::path(value.as<std::string>());
+             node[key]                   = path_value.string();
+@@ -212,11 +212,11 @@ std::string findFileRecursive(const std::string& name_with_extension, const std:
+ {
+     for (auto folder : folders)
+     {
+-        if (filesystem::exists(folder) and filesystem::is_directory(folder))
++        if (filesystem::exists(folder) && filesystem::is_directory(folder))
+         {
+             for (auto const& entry : filesystem::recursive_directory_iterator(folder))
+             {
+-                if (filesystem::is_regular_file(entry) and entry.path().filename().string() == name_with_extension)
++                if (filesystem::is_regular_file(entry) && entry.path().filename().string() == name_with_extension)
+                 {
+                     return entry.path().string();
+                 }
+@@ -263,7 +263,7 @@ std::vector<std::string> getAllSchemas(const std::vector<std::string>& root_fold
+     std::vector<std::string> schemas_found;
+     for (auto root_folder : root_folders)
+         for (auto const& entry : filesystem::recursive_directory_iterator(root_folder))
+-            if (filesystem::is_regular_file(entry) and entry.path().extension() == SCHEMA_EXTENSION)
++            if (filesystem::is_regular_file(entry) && entry.path().extension() == SCHEMA_EXTENSION)
+                 schemas_found.push_back(entry.path().filename().string());
+ 
+     return schemas_found;

--- a/ports/yaml-schema-cpp/fix-windows-build.patch
+++ b/ports/yaml-schema-cpp/fix-windows-build.patch
@@ -153,3 +153,19 @@ index 81114e8..d660f8a 100644
              {
                  std::cout << "Empty input sequence with not dynamic matrix" << std::endl;
                  return false;
+diff --git a/src/yaml_generator.cpp b/src/yaml_generator.cpp
+index 8478e59..f45dc80 100644
+--- a/src/yaml_generator.cpp
++++ b/src/yaml_generator.cpp
+@@ -67,7 +67,11 @@ std::string generateTemplate(std::string                     filepath,
+     std::ofstream template_file;
+     template_file = std::ofstream(fp.c_str(), std::ofstream::out);  // open log file
+     if (not template_file.is_open())
++#ifdef _WIN32
++        throw std::runtime_error(std::string("Failed to open the template_file: ") + fp.string());
++#else
+         throw std::runtime_error(std::string("Failed to open the template_file: ") + fp.c_str());
++#endif
+     else
+         template_file << template_string;
+ 

--- a/ports/yaml-schema-cpp/fix-windows-build.patch
+++ b/ports/yaml-schema-cpp/fix-windows-build.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0399267..afd6ef7 100644
+index 0399267..bda2eb3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -37,6 +37,11 @@ SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/bin)
@@ -8,7 +8,7 @@ index 0399267..afd6ef7 100644
  
 +# support alternative tokens in MSVC
 +if(MSVC)
-+  add_compile_options(/permissive-)
++  add_compile_options(/permissive- /bigobj)
 +endif()
 +
  # ------ PROJECT OPTIONS ------

--- a/ports/yaml-schema-cpp/portfile.cmake
+++ b/ports/yaml-schema-cpp/portfile.cmake
@@ -6,12 +6,14 @@ vcpkg_from_github(
     REF 24623cc5c4a5acb63dea9581ebcd84601bac1da1
     SHA512 d7622401ebce65b107eb363af88868fef4725c50ce0aa659a4510223275a3bc6b9d1fc1c71946247ea0142f7bc460f39c02f91e3c6466fdadacb9ec2d4f7fe38
     HEAD_REF main
+    PATCHES
+        remove-root-dir-for-tests.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
-        -DBUILD_TESTS=OFF
+        -DBUILD_TESTS=OFFq
 )
 vcpkg_cmake_install()
 

--- a/ports/yaml-schema-cpp/portfile.cmake
+++ b/ports/yaml-schema-cpp/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DCMAKE_CXX_STANDARD=17
         -DBUILD_TESTS=OFF
 )
 vcpkg_cmake_install()

--- a/ports/yaml-schema-cpp/portfile.cmake
+++ b/ports/yaml-schema-cpp/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO joanvallve/yaml-schema-cpp
+    REF 24623cc5c4a5acb63dea9581ebcd84601bac1da1
+    SHA512 d7622401ebce65b107eb363af88868fef4725c50ce0aa659a4510223275a3bc6b9d1fc1c71946247ea0142f7bc460f39c02f91e3c6466fdadacb9ec2d4f7fe38
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBUILD_TESTS=OFF
+)
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH "lib/cmake/yaml-schema-cpp"
+    PACKAGE_NAME yaml-schema-cpp
+)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/yaml-schema-cpp/portfile.cmake
+++ b/ports/yaml-schema-cpp/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTS=OFF
 )
@@ -19,7 +19,6 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
     CONFIG_PATH "lib/cmake/yaml-schema-cpp"
-    PACKAGE_NAME yaml-schema-cpp
 )
 vcpkg_fixup_pkgconfig()
 

--- a/ports/yaml-schema-cpp/portfile.cmake
+++ b/ports/yaml-schema-cpp/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         remove-root-dir-for-tests.patch
+        fix-windows-build.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/yaml-schema-cpp/portfile.cmake
+++ b/ports/yaml-schema-cpp/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
-        -DBUILD_TESTS=OFFq
+        -DBUILD_TESTS=OFF
 )
 vcpkg_cmake_install()
 

--- a/ports/yaml-schema-cpp/remove-root-dir-for-tests.patch
+++ b/ports/yaml-schema-cpp/remove-root-dir-for-tests.patch
@@ -1,0 +1,11 @@
+diff --git a/internal/config.h.in b/internal/config.h.in
+index ebaf3dc..0c486a4 100644
+--- a/internal/config.h.in
++++ b/internal/config.h.in
+@@ -1,5 +1,3 @@
+ #pragma once
+ 
+-#define _YAML_SCHEMA_CPP_ROOT_DIR "${CMAKE_SOURCE_DIR}"
+-
+ #define _BOOST_FILESYSTEM_LIB ${BOOST_FILESYSTEM_LIB}
+\ No newline at end of file

--- a/ports/yaml-schema-cpp/vcpkg.json
+++ b/ports/yaml-schema-cpp/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "a C++ library for specification and validation of YAML files.",
   "homepage": "https://github.com/joanvallve/yaml-schema-cpp",
   "license": "MIT",
+  "supports": "!windows | mingw",
   "dependencies": [
     "boost-filesystem",
     "eigen3",

--- a/ports/yaml-schema-cpp/vcpkg.json
+++ b/ports/yaml-schema-cpp/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "a C++ library for specification and validation of YAML files.",
   "homepage": "https://github.com/joanvallve/yaml-schema-cpp",
   "license": "MIT",
-  "supports": "!windows | mingw",
   "dependencies": [
     "boost-filesystem",
     "eigen3",

--- a/ports/yaml-schema-cpp/vcpkg.json
+++ b/ports/yaml-schema-cpp/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "yaml-schema-cpp",
+  "version-date": "2025-11-10",
+  "description": "a C++ library for specification and validation of YAML files.",
+  "homepage": "https://github.com/joanvallve/yaml-schema-cpp",
+  "license": "MIT",
+  "dependencies": [
+    "boost-filesystem",
+    "eigen3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "yaml-cpp"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10732,6 +10732,10 @@
       "baseline": "0.8.0",
       "port-version": 3
     },
+    "yaml-schema-cpp": {
+      "baseline": "2025-11-10",
+      "port-version": 0
+    },
     "yandex-disk-cpp-client": {
       "baseline": "1.0.3",
       "port-version": 0

--- a/versions/y-/yaml-schema-cpp.json
+++ b/versions/y-/yaml-schema-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ada9411cacf70042b54d3f64021869c4af42aaba",
+      "version-date": "2025-11-10",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/y-/yaml-schema-cpp.json
+++ b/versions/y-/yaml-schema-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "65c9dda91bd369e3f88b3bc9fa6963fb6a4439fd",
+      "git-tree": "5b074d29ee61b2c7443a75d1177fccb38d299480",
       "version-date": "2025-11-10",
       "port-version": 0
     }

--- a/versions/y-/yaml-schema-cpp.json
+++ b/versions/y-/yaml-schema-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a8b9e44937968546338fc4b596785f0621efa5db",
+      "git-tree": "65c9dda91bd369e3f88b3bc9fa6963fb6a4439fd",
       "version-date": "2025-11-10",
       "port-version": 0
     }

--- a/versions/y-/yaml-schema-cpp.json
+++ b/versions/y-/yaml-schema-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d51034f05292f9fb3e357d393e399c5fe734d866",
+      "git-tree": "a8b9e44937968546338fc4b596785f0621efa5db",
       "version-date": "2025-11-10",
       "port-version": 0
     }

--- a/versions/y-/yaml-schema-cpp.json
+++ b/versions/y-/yaml-schema-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "23986c2eb400731d0b31ba03932ae08b047ab9fc",
+      "git-tree": "99effede8f5e08d7b41f0a69b3d041c0eb133e9d",
       "version-date": "2025-11-10",
       "port-version": 0
     }

--- a/versions/y-/yaml-schema-cpp.json
+++ b/versions/y-/yaml-schema-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5b074d29ee61b2c7443a75d1177fccb38d299480",
+      "git-tree": "23986c2eb400731d0b31ba03932ae08b047ab9fc",
       "version-date": "2025-11-10",
       "port-version": 0
     }

--- a/versions/y-/yaml-schema-cpp.json
+++ b/versions/y-/yaml-schema-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "99effede8f5e08d7b41f0a69b3d041c0eb133e9d",
+      "git-tree": "fc5d100ae6822b1a64609da25c8c3ba0ac6db5b9",
       "version-date": "2025-11-10",
       "port-version": 0
     }

--- a/versions/y-/yaml-schema-cpp.json
+++ b/versions/y-/yaml-schema-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bd3229a530c10f290d2dc6c300e6ae1af04e0272",
+      "git-tree": "90d135445430e29b8f65f89f729464ccb1a7c6a9",
       "version-date": "2025-11-10",
       "port-version": 0
     }

--- a/versions/y-/yaml-schema-cpp.json
+++ b/versions/y-/yaml-schema-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ada9411cacf70042b54d3f64021869c4af42aaba",
+      "git-tree": "d51034f05292f9fb3e357d393e399c5fe734d866",
       "version-date": "2025-11-10",
       "port-version": 0
     }

--- a/versions/y-/yaml-schema-cpp.json
+++ b/versions/y-/yaml-schema-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fc5d100ae6822b1a64609da25c8c3ba0ac6db5b9",
+      "git-tree": "bd3229a530c10f290d2dc6c300e6ae1af04e0272",
       "version-date": "2025-11-10",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/joanvallve/yaml-schema-cpp