### PR TITLE
[tsl-hat-trie] update to 0.7.1

### DIFF
--- a/ports/tsl-hat-trie/portfile.cmake
+++ b/ports/tsl-hat-trie/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Tessil/hat-trie
     REF "v${VERSION}"
-    SHA512 24b7f2fd83f03ff30cfa186cd68b8110ee7ed40c378861de750c1c0957e3a9870dc434ee3ae184d8ce4b07687cb0ffa83e8c7ddadccd57d8e87c97ae7b066115
+    SHA512 0775b95d10535e1596f6dc79feadecdd98d63e99d4ca492bc64fa8c5bcfe6bdb864b52ee55cba26cdad00e64c2ee857f70663d3e4ed03c33af8055fc17e8c38e
     HEAD_REF master
 )
 

--- a/ports/tsl-hat-trie/vcpkg.json
+++ b/ports/tsl-hat-trie/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tsl-hat-trie",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "C++ implementation of a fast and memory efficient HAT-trie",
   "homepage": "https://github.com/Tessil/hat-trie",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9905,7 +9905,7 @@
       "port-version": 0
     },
     "tsl-hat-trie": {
-      "baseline": "0.7.0",
+      "baseline": "0.7.1",
       "port-version": 0
     },
     "tsl-hopscotch-map": {

--- a/versions/t-/tsl-hat-trie.json
+++ b/versions/t-/tsl-hat-trie.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "38f09531dd8dd0964b2b354d8dae0e27d117caa1",
+      "version": "0.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ab3aec7490ecf90ca2f5da33686997d2defb93c2",
       "version": "0.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Tessil/hat-trie/releases/tag/v0.7.1
