### PR TITLE
[kubernetes] update to 0.14.0

### DIFF
--- a/ports/kubernetes/portfile.cmake
+++ b/ports/kubernetes/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kubernetes-client/c
     REF "v${VERSION}"
-    SHA512 4cee597f81a0181ba9a3dee9c7f01b7e55cba939fc3367d1d314aeb6a39044701886fe4b7f8eb72e890aafed653afa0f2f36cbd3aaa91ee85cf581f1b1eaec85
+    SHA512 8324049f030201e9a031556a799defcbc90fe41bc7b40e2997ed0c706f97660af39b84d679065e83adce85b66c832d406468a9c543367b64c5b702fc5896ee07
     HEAD_REF master
     PATCHES
         001-fix-destination.patch

--- a/ports/kubernetes/vcpkg.json
+++ b/ports/kubernetes/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kubernetes",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Kubernetes C client",
   "homepage": "https://github.com/kubernetes-client/c/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4441,7 +4441,7 @@
       "port-version": 0
     },
     "kubernetes": {
-      "baseline": "0.13.0",
+      "baseline": "0.14.0",
       "port-version": 0
     },
     "kuku": {

--- a/versions/k-/kubernetes.json
+++ b/versions/k-/kubernetes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e25593431c9c23fffbf82fff82d08a784adbd3ed",
+      "version": "0.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff1313dbaf8188681431a2cf974307399520cc5a",
       "version": "0.13.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/kubernetes-client/c/releases/tag/v0.14.0
