### PR TITLE
[directx12-agility] Update for 1.618.3 release

### DIFF
--- a/ports/directx12-agility/portfile.cmake
+++ b/ports/directx12-agility/portfile.cmake
@@ -6,7 +6,7 @@ set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled) # DX12 SDK Debug Layer i
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/${VERSION}"
     FILENAME "Microsoft.Direct3D.D3D12.${VERSION}.zip"
-    SHA512 16f56830483c3e973b780dbac87d4d52ddbd14e3fdfae8c6241d7c0a275ab8f7b31b5663b0ee0b1c4ead8876146189acf49646486892f20fd8c8149afa797e65
+    SHA512 0e76fe8d4e756dfdda86e458f0f05425741344c87d7dabb43eddb4d11ec5c2ab27cb5377d0cf490414a2961150000bd7c546ef2748af71832d6b800bfe8778b1
 )
 
 vcpkg_extract_source_archive(

--- a/ports/directx12-agility/vcpkg.json
+++ b/ports/directx12-agility/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directx12-agility",
-  "version": "1.618.2",
+  "version": "1.618.3",
   "description": "DirectX 12 Agility SDK",
   "homepage": "https://aka.ms/directx12agility",
   "documentation": "https://devblogs.microsoft.com/directx/gettingstarted-dx12agility/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2437,7 +2437,7 @@
       "port-version": 0
     },
     "directx12-agility": {
-      "baseline": "1.618.2",
+      "baseline": "1.618.3",
       "port-version": 0
     },
     "directxmath": {

--- a/versions/d-/directx12-agility.json
+++ b/versions/d-/directx12-agility.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0fda62be20c9972fd77a2a2d848598a0d790c68d",
+      "version": "1.618.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "014a035fd7b769b23ffaa2996001b034e847cab3",
       "version": "1.618.2",
       "port-version": 0


### PR DESCRIPTION
Servicing update for 1.618. No changes to **directx-headers**.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
