### PR TITLE
[gameinput] Servicing fix for GameInput v2

### DIFF
--- a/ports/gameinput/portfile.cmake
+++ b/ports/gameinput/portfile.cmake
@@ -43,7 +43,7 @@ else()
     vcpkg_download_distfile(ARCHIVE
         URLS "https://www.nuget.org/api/v2/package/Microsoft.GameInput/${VERSION}"
         FILENAME "gameinput.${VERSION}.zip"
-        SHA512 80baba86f3f89aca72b4d4fdaf0091f3b24a3a671476a0973dce23ba5b8e11d625c9647b1aceed8b2eb6ecb95ff4fb7c1845e38683cf2e757bdea7210f946955
+        SHA512 f130304cadf223204e234ae782127458082dfd9c92320fe6a75da14b25195379666ea1021ae75a1a9b3ebb46384b64ee7c0169c00d1eb5ec3b86083e2a7f720c
     )
 
     vcpkg_extract_source_archive(

--- a/ports/gameinput/vcpkg.json
+++ b/ports/gameinput/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gameinput",
-  "version": "2.0.26100.5312",
+  "version": "2.0.26100.5334",
   "description": "GameInput",
   "homepage": "https://aka.ms/gameinput",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3181,7 +3181,7 @@
       "port-version": 0
     },
     "gameinput": {
-      "baseline": "2.0.26100.5312",
+      "baseline": "2.0.26100.5334",
       "port-version": 0
     },
     "gamenetworkingsockets": {

--- a/versions/g-/gameinput.json
+++ b/versions/g-/gameinput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a43840ce4379983cc8af3cfb39ce486b7d6500c",
+      "version": "2.0.26100.5334",
+      "port-version": 0
+    },
+    {
       "git-tree": "79e96edfb7080c333ea382f2b813d2ccf4469bc8",
       "version": "2.0.26100.5312",
       "port-version": 0


### PR DESCRIPTION
Fixes regression in previous release.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
