### PR TITLE
[gameinput] Update for GameInput 2.2 release

### DIFF
--- a/ports/gameinput/portfile.cmake
+++ b/ports/gameinput/portfile.cmake
@@ -43,7 +43,7 @@ else()
     vcpkg_download_distfile(ARCHIVE
         URLS "https://www.nuget.org/api/v2/package/Microsoft.GameInput/${VERSION}"
         FILENAME "gameinput.${VERSION}.zip"
-        SHA512 f130304cadf223204e234ae782127458082dfd9c92320fe6a75da14b25195379666ea1021ae75a1a9b3ebb46384b64ee7c0169c00d1eb5ec3b86083e2a7f720c
+        SHA512 144cff0bfe9ba9e66d3641bdaed5cf8445bcfe52e83c7c160c111b983545f5346304821200acefe3aed0913ab14f3a9a17f7da1f67b6f75e36bad259f1b312c5
     )
 
     vcpkg_extract_source_archive(

--- a/ports/gameinput/vcpkg.json
+++ b/ports/gameinput/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gameinput",
-  "version": "2.0.26100.5334",
+  "version": "2.2.26100.6114",
   "description": "GameInput",
   "homepage": "https://aka.ms/gameinput",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3181,7 +3181,7 @@
       "port-version": 0
     },
     "gameinput": {
-      "baseline": "2.0.26100.5334",
+      "baseline": "2.2.26100.6114",
       "port-version": 0
     },
     "gamenetworkingsockets": {

--- a/versions/g-/gameinput.json
+++ b/versions/g-/gameinput.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d4a382441b215a535cf212671e87daa224782bb",
+      "version": "2.2.26100.6114",
+      "port-version": 0
+    },
+    {
       "git-tree": "1a43840ce4379983cc8af3cfb39ce486b7d6500c",
       "version": "2.0.26100.5334",
       "port-version": 0


### PR DESCRIPTION
Fixes critical bugs and perf regressions in GameInput v2. Adds SteamDeck compat.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
