### PR TITLE
[ms-gdk] Rewrite port for new layout October 2025 packages

### DIFF
--- a/ports/ms-gdk/gdk-config.cmake.in
+++ b/ports/ms-gdk/gdk-config.cmake.in
@@ -1,0 +1,112 @@
+﻿get_filename_component(_msgdk_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(_msgdk_root "${_msgdk_root}" PATH)
+
+# GameRuntime Library
+add_library(Xbox::GameRuntime STATIC IMPORTED)
+set_target_properties(Xbox::GameRuntime PROPERTIES
+    IMPORTED_LOCATION "${_msgdk_root}/lib/xgameruntime.lib"
+    MAP_IMPORTED_CONFIG_MINSIZEREL ""
+    MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+    INTERFACE_INCLUDE_DIRECTORIES "${_msgdk_root}/include"
+    INTERFACE_COMPILE_FEATURES "cxx_std_11"
+    IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
+
+if (EXISTS "${_msgdk_root}/lib/XCurl.lib")
+    # XCurl
+    add_library(Xbox::XCurl SHARED IMPORTED)
+    set_target_properties(Xbox::XCurl PROPERTIES
+        IMPORTED_LOCATION "${_msgdk_root}/bin/XCurl.dll"
+        IMPORTED_IMPLIB "${_msgdk_root}/lib/XCurl.lib"
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_msgdk_root}/include")
+
+    # Xbox.Services.API.C (requires XCurl)
+    add_library(Xbox::XSAPI STATIC IMPORTED)
+    set_target_properties(Xbox::XSAPI PROPERTIES
+        IMPORTED_LOCATION_RELEASE "${_msgdk_root}/lib/Microsoft.Xbox.Services.@EXT_TOOLSET@.C.lib"
+        IMPORTED_LOCATION_DEBUG "${_msgdk_root}/debug/lib/Microsoft.Xbox.Services.@EXT_TOOLSET@.C.Debug.lib"
+        IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
+        MAP_IMPORTED_CONFIG_MINSIZEREL Release
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
+        INTERFACE_INCLUDE_DIRECTORIES "${_msgdk_root}/include"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
+
+    # Xbox::HTTPClient
+    add_library(Xbox::HTTPClient SHARED IMPORTED)
+    set_target_properties(Xbox::HTTPClient PROPERTIES
+        IMPORTED_LOCATION "${_msgdk_root}/bin/libHttpClient.dll"
+        IMPORTED_IMPLIB "${_msgdk_root}/lib/libHttpClient.lib"
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_msgdk_root}/include")
+
+    target_link_libraries(Xbox::XSAPI INTERFACE Xbox::HTTPClient Xbox::XCurl appnotify.lib winhttp.lib crypt32.lib)
+
+    # GameChat2
+    add_library(Xbox::GameChat2 SHARED IMPORTED)
+    set_target_properties(Xbox::GameChat2 PROPERTIES
+        IMPORTED_LOCATION "${_msgdk_root}/bin/GameChat2.dll"
+        IMPORTED_IMPLIB "${_msgdk_root}/lib/GameChat2.lib"
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_msgdk_root}/include")
+endif()
+
+if (@BUILD_PLAYFAB_SERVICES@ AND (EXISTS "${_msgdk_root}/lib/PlayFabCore.lib"))
+    # PlayFab Multiplayer (requires XCurl)
+    add_library(Xbox::PlayFabMultiplayer SHARED IMPORTED)
+    set_target_properties(Xbox::PlayFabMultiplayer PROPERTIES
+        IMPORTED_LOCATION "${_msgdk_root}/bin/PlayFabMultiplayer.dll"
+        IMPORTED_IMPLIB "${_msgdk_root}/lib/PlayFabMultiplayer.lib"
+        IMPORTED_LINK_DEPENDENT_LIBRARIES Xbox::XCurl
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_msgdk_root}/include")
+
+    target_link_libraries(Xbox::PlayFabMultiplayer INTERFACE Xbox::XCurl)
+
+    # PlayFab Services (requires XCurl)
+    add_library(Xbox::PlayFabServices SHARED IMPORTED)
+    set_target_properties(Xbox::PlayFabServices PROPERTIES
+        IMPORTED_LOCATION "${_msgdk_root}/bin/PlayFabServices.dll"
+        IMPORTED_IMPLIB "${_msgdk_root}/lib/PlayFabServices.lib"
+        IMPORTED_LINK_DEPENDENT_LIBRARIES Xbox::XCurl
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_msgdk_root}/include"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
+
+    add_library(Xbox::PlayFabCore SHARED IMPORTED)
+    set_target_properties(Xbox::PlayFabCore PROPERTIES
+        IMPORTED_LOCATION "${_msgdk_root}/bin/PlayFabCore.dll"
+        IMPORTED_IMPLIB "${_msgdk_root}/lib/PlayFabCore.lib"
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
+
+    target_link_libraries(Xbox::PlayFabServices INTERFACE Xbox::PlayFabCore Xbox::XCurl)
+
+    # PlayFab Party
+    add_library(Xbox::PlayFabParty SHARED IMPORTED)
+    set_target_properties(Xbox::PlayFabParty PROPERTIES
+        IMPORTED_LOCATION "${_msgdk_root}/bin/Party.dll"
+        IMPORTED_IMPLIB "${_msgdk_root}/lib/Party.lib"
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_msgdk_root}/include")
+
+    # PlayFab Party Xbox LIVE (requires PlayFab Party)
+    add_library(Xbox::PlayFabPartyLIVE SHARED IMPORTED)
+    set_target_properties(Xbox::PlayFabPartyLIVE PROPERTIES
+        IMPORTED_LOCATION "${_msgdk_root}/bin/PartyXboxLive.dll"
+        IMPORTED_IMPLIB "${_msgdk_root}/lib/PartyXboxLive.lib"
+        IMPORTED_LINK_DEPENDENT_LIBRARIES Xbox::PlayFabParty
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_msgdk_root}/include")
+
+    target_link_libraries(Xbox::PlayFabPartyLIVE INTERFACE Xbox::PlayFabParty)
+endif()
+
+unset(_msgdk_root)

--- a/ports/ms-gdk/pfusage
+++ b/ports/ms-gdk/pfusage
@@ -1,12 +1,6 @@
 
-  find_package(playfab.services.c CONFIG REQUIRED)
+  find_package(ms-gdk CONFIG REQUIRED)
   target_link_libraries(main PRIVATE Xbox::PlayFabServices)
-
-  find_package(playfab.multiplayer.cpp CONFIG REQUIRED)
   target_link_libraries(main PRIVATE Xbox::PlayFabMultiplayer)
-
-  find_package(playfab.party.cpp CONFIG REQUIRED)
   target_link_libraries(main PRIVATE Xbox::PlayFabParty)
-
-  find_package(playfab.partyxboxlive.cpp CONFIG REQUIRED)
   target_link_libraries(main PRIVATE Xbox::PlayFabPartyLIVE)

--- a/ports/ms-gdk/pfusage
+++ b/ports/ms-gdk/pfusage
@@ -1,5 +1,3 @@
-
-  find_package(ms-gdk CONFIG REQUIRED)
   target_link_libraries(main PRIVATE Xbox::PlayFabServices)
   target_link_libraries(main PRIVATE Xbox::PlayFabMultiplayer)
   target_link_libraries(main PRIVATE Xbox::PlayFabParty)

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -34,8 +34,10 @@ vcpkg_check_features(
 )
 
 # Install core tools
-file(INSTALL "${PACKAGE_PATH_CORE}/native/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
-file(INSTALL "${PACKAGE_PATH_CORE}/native/bin/GameConfigEditorDependencies" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    file(INSTALL "${PACKAGE_PATH_CORE}/native/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+    file(INSTALL "${PACKAGE_PATH_CORE}/native/bin/GameConfigEditorDependencies" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+endif()
 
 set(WINDOWS_PATH "${PACKAGE_PATH}/native/${GDK_EDITION_NUMBER}/windows")
 
@@ -49,10 +51,8 @@ file(REMOVE_RECURSE "${WINDOWS_PATH}/include/cpprest")
 file(REMOVE_RECURSE "${WINDOWS_PATH}/include/pplx")
 
 # Install core content
-
 set(CORE_BINS xgameruntime.dll xgameruntime.pdb)
 set(CORE_INCLUDES grdk.h)
-
 set(CORE_LIBS xgameruntime.lib)
 
 file(GLOB HEADERS "${WINDOWS_PATH}/include/X*.*")

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -154,4 +154,4 @@ configure_file("${CMAKE_CURRENT_LIST_DIR}/gdk-config.cmake.in"
 
 vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})
 
-message(STATUS "BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS: https://www.nuget.org/packages/Microsoft.GDK.PC/${VERSION}/License")
+message(STATUS "BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS: https://www.nuget.org/packages/Microsoft.GDK.Windows/${VERSION}/License")

--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -1,12 +1,24 @@
-set(GDK_EDITION_NUMBER 250404)
+set(GDK_EDITION_NUMBER 251000)
 
 # The GDK contains a combination of static C++ libraries and DLL-based extension libraries.
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
+vcpkg_download_distfile(ARCHIVE_CORE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.Core/${VERSION}"
+    FILENAME "ms-gdk-core.${VERSION}.zip"
+    SHA512 447a9807a746a7922230d185ee60cbeac21caa923662f1994f07df6f08286470aea3ca2ce72c10ef3487e680b7c98651f3612f06481c9606dc0369d5e14bc736
+)
+
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"
-    FILENAME "ms-gdk.${VERSION}.zip"
-    SHA512 143541167d34a6c685bef234ccc03b02e916f286e0d83f1b7dbdd269951b441e5709371270436128aad329a0ff3f4814afaf5d1ed3080989b8e2e0779da51123
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.Windows/${VERSION}"
+    FILENAME "ms-gdk-windows.${VERSION}.zip"
+    SHA512 4520e870070b7b219a9bca80d2a9d8eab2c833efa4be075aca4da5aefef1cba58e59bf3aef107ae5126e0ad680253cf25d39d4700df86afcdc82f9502f43fd77
+)
+
+vcpkg_extract_source_archive(
+    PACKAGE_PATH_CORE
+    ARCHIVE "${ARCHIVE_CORE}"
+    NO_REMOVE_ONE_LEVEL
 )
 
 vcpkg_extract_source_archive(
@@ -21,63 +33,124 @@ vcpkg_check_features(
         playfab BUILD_PLAYFAB_SERVICES
 )
 
-set(GRDK_PATH "${PACKAGE_PATH}/native/${GDK_EDITION_NUMBER}/GRDK")
+# Install core tools
+file(INSTALL "${PACKAGE_PATH_CORE}/native/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+file(INSTALL "${PACKAGE_PATH_CORE}/native/bin/GameConfigEditorDependencies" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+
+set(WINDOWS_PATH "${PACKAGE_PATH}/native/${GDK_EDITION_NUMBER}/windows")
 
 # We use the gameinput port instead
-file(REMOVE "${GRDK_PATH}/GameKit/Include/GameInput.h")
-file(REMOVE "${GRDK_PATH}/GameKit/Lib/amd64/GameInput.lib")
+file(REMOVE "${WINDOWS_PATH}/include/GameInput.h")
+file(REMOVE "${WINDOWS_PATH}/lib/arm64/GameInput.lib")
+file(REMOVE "${WINDOWS_PATH}/lib/x64/GameInput.lib")
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${GRDK_PATH}"
-    OPTIONS ${FEATURE_OPTIONS}
-)
+# We use the cpprestsdk port instead
+file(REMOVE_RECURSE "${WINDOWS_PATH}/include/cpprest")
+file(REMOVE_RECURSE "${WINDOWS_PATH}/include/pplx")
 
-vcpkg_cmake_install()
+# Install core content
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.gameruntime)
-vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.game.chat.2.cpp.api)
-vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.libhttpclient)
-vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.services.api.c)
-vcpkg_cmake_config_fixup(PACKAGE_NAME xbox.xcurl.api)
+set(CORE_BINS xgameruntime.dll xgameruntime.pdb)
+set(CORE_INCLUDES grdk.h)
 
+set(CORE_LIBS xgameruntime.lib)
+
+file(GLOB HEADERS "${WINDOWS_PATH}/include/X*.*")
+foreach(t IN LISTS HEADERS)
+    get_filename_component(h ${t} NAME)
+    list(APPEND CORE_INCLUDES ${h})
+endforeach()
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    list(APPEND CORE_BINS xgameruntime.thunks.dll GameChat2.dll GameChat2.pdb libHttpClient.dll libHttpClient.pdb XCurl.dll XCurl.pdb)
+    list(APPEND CORE_LIBS GameChat2.lib libHttpClient.lib XCurl.lib xgameruntime.thunks.lib)
+
+    file(INSTALL "${WINDOWS_PATH}/bin/x64/Microsoft.Xbox.Services.C.Thunks.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(INSTALL "${WINDOWS_PATH}/bin/x64/Microsoft.Xbox.Services.C.Thunks.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(INSTALL "${WINDOWS_PATH}/lib/x64/Microsoft.Xbox.Services.C.Thunks.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(INSTALL "${WINDOWS_PATH}/lib/x64/Microsoft.Xbox.Services.142.C.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(INSTALL "${WINDOWS_PATH}/lib/x64/Microsoft.Xbox.Services.142.C.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+
+    file(INSTALL "${WINDOWS_PATH}/bin/x64/Microsoft.Xbox.Services.C.Thunks.Debug.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(INSTALL "${WINDOWS_PATH}/bin/x64/Microsoft.Xbox.Services.C.Thunks.Debug.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(INSTALL "${WINDOWS_PATH}/lib/x64/Microsoft.Xbox.Services.C.Thunks.Debug.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+    file(INSTALL "${WINDOWS_PATH}/lib/x64/Microsoft.Xbox.Services.142.C.Debug.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+    file(INSTALL "${WINDOWS_PATH}/lib/x64/Microsoft.Xbox.Services.142.C.Debug.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+
+    list(APPEND CORE_INCLUDES cpprestsdk_impl.h XCurl.h GameChat2.h GameChat2Impl.h GameChat2_c.h)
+
+    set(INCLUDE_DIRS httpClient Xal xsapi-c xsapi-cpp)
+endif()
+
+foreach(t IN LISTS CORE_BINS)
+    file(INSTALL "${WINDOWS_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/${t}" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(INSTALL "${WINDOWS_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/${t}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+endforeach()
+
+foreach(t IN LISTS CORE_INCLUDES)
+    file(INSTALL "${WINDOWS_PATH}/include/${t}" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+endforeach()
+
+foreach(t IN LISTS INCLUDE_DIRS)
+    file(INSTALL "${WINDOWS_PATH}/include/${t}" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+endforeach()
+
+foreach(t IN LISTS CORE_LIBS)
+    file(INSTALL "${WINDOWS_PATH}/lib/${VCPKG_TARGET_ARCHITECTURE}/${t}" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(INSTALL "${WINDOWS_PATH}/lib/${VCPKG_TARGET_ARCHITECTURE}/${t}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+endforeach()
+
+# Build license file.
 set(LICENSE_FILES "${PACKAGE_PATH}/LICENSE.md")
 
 list(APPEND LICENSE_FILES
-    "${GRDK_PATH}/ExtensionLibraries/Xbox.LibHttpClient/Include/httpClient/ThirdPartyNotices.txt"
-    "${GRDK_PATH}/ExtensionLibraries/Xbox.XCurl.API/Include/ThirdPartyNotices.txt"
-    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/cpprest/ThirdPartyNotices.txt"
-    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/pplx/ThirdPartyNotices.txt"
-    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-c/ThirdPartyNotices.txt"
-    "${GRDK_PATH}/ExtensionLibraries/Xbox.Services.API.C/Include/xsapi-cpp/ThirdPartyNotices.txt"
+    "${WINDOWS_PATH}/include/httpClient/ThirdPartyNotices.txt"
+    "${WINDOWS_PATH}/include/ThirdPartyNotices.txt"
+    "${WINDOWS_PATH}/include/xsapi-c/ThirdPartyNotices.txt"
+    "${WINDOWS_PATH}/include/xsapi-cpp/ThirdPartyNotices.txt"
 )
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
+# Optional PlayFab components
 if("playfab" IN_LIST FEATURES)
-    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.multiplayer.cpp)
-    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.party.cpp)
-    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.partyxboxlive.cpp)
-    vcpkg_cmake_config_fixup(PACKAGE_NAME playfab.services.c)
 
-    list(APPEND LICENSE_FILES
-        "${GRDK_PATH}/ExtensionLibraries/PlayFab.Multiplayer.Cpp/Include/NOTICE.txt"
-        "${GRDK_PATH}/ExtensionLibraries/PlayFab.Party.Cpp/Include/NOTICE.txt"
-        "${GRDK_PATH}/ExtensionLibraries/PlayFab.PartyXboxLive.Cpp/Include/NOTICE.txt"
-    )
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        set(PF_BINS
+            PlayFabCore.dll PlayFabCore.pdb PlayFabServices.dll PlayFabServices.pdb PlayFabMultiplayer.dll PlayFabMultiplayer.pdb
+            Party.dll Party.pdb PartyXboxLive.dll PartyXboxLive.pdb PlayFabGameSave.dll PlayFabGameSave.pdb)
+
+        set(PF_LIBS
+            PlayFabCore.lib PlayFabServices.lib PlayFabMultiplayer.lib
+            Party.lib PartyXboxLive.lib PlayFabGameSave.lib)
+
+        file(INSTALL "${WINDOWS_PATH}/include/playfab" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+        file(INSTALL "${WINDOWS_PATH}/include/PFXGameSave.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    endif()
+
+    foreach(t IN LISTS PF_BINS)
+        file(INSTALL "${WINDOWS_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/${t}" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+        file(INSTALL "${WINDOWS_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/${t}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    endforeach()
+
+    foreach(t IN LISTS PF_LIBS)
+        file(INSTALL "${WINDOWS_PATH}/lib/${VCPKG_TARGET_ARCHITECTURE}/${t}" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+        file(INSTALL "${WINDOWS_PATH}/lib/${VCPKG_TARGET_ARCHITECTURE}/${t}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+    endforeach()
+
+    list(APPEND LICENSE_FILES "${WINDOWS_PATH}/include/playfab/multiplayer/NOTICE.txt")
 
     file(READ "${CMAKE_CURRENT_LIST_DIR}/pfusage" USAGE_CONTENT)
     file(APPEND "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" ${USAGE_CONTENT})
-else()
+
 endif()
 
-file(INSTALL "${PACKAGE_PATH}/native/bin/" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
-file(INSTALL "${PACKAGE_PATH}/native/bin/GameConfigEditorDependencies" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+set(EXT_TOOLSET 142)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/gdk-config.cmake.in"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake"
+    @ONLY)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-# Uses the cpprestsdk port instead
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/cpprest")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/pplx")
+#file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})
 

--- a/ports/ms-gdk/usage
+++ b/ports/ms-gdk/usage
@@ -1,16 +1,8 @@
 The Microsoft GDK package provides CMake targets:
 
-  find_package(xbox.gameruntime CONFIG REQUIRED)
+  find_package(ms-gdk CONFIG REQUIRED)
   target_link_libraries(main PRIVATE Xbox::GameRuntime)
-
-  find_package(xbox.libhttpclient CONFIG REQUIRED)
   target_link_libraries(main PRIVATE Xbox::HTTPClient)
-
-  find_package(xbox.xcurl.api CONFIG REQUIRED)
   target_link_libraries(main PRIVATE Xbox::XCurl)
-
-  find_package(xbox.services.api.c CONFIG REQUIRED)
   target_link_libraries(main PRIVATE Xbox::XSAPI)
-
-  find_package(xbox.game.chat.2.cpp.api CONFIG REQUIRED)
   target_link_libraries(main PRIVATE Xbox::GameChat2)

--- a/ports/ms-gdk/vcpkg.json
+++ b/ports/ms-gdk/vcpkg.json
@@ -10,14 +10,6 @@
     {
       "name": "cpprestsdk",
       "default-features": false
-    },
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ],
   "features": {

--- a/ports/ms-gdk/vcpkg.json
+++ b/ports/ms-gdk/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "ms-gdk",
-  "version": "2504.4.4108",
+  "version": "2510.0.6194",
   "description": "Microsoft Game Development Kit (GDK)",
   "homepage": "https://aka.ms/gdkx",
   "documentation": "https://aka.ms/gamedevdocs",
   "license": null,
-  "supports": "windows & x64 & !uwp & !xbox & !staticcrt",
+  "supports": "windows & (x64 | arm64) & !uwp & !xbox & !staticcrt",
   "dependencies": [
     {
       "name": "cpprestsdk",
@@ -22,7 +22,8 @@
   ],
   "features": {
     "playfab": {
-      "description": "Include PlayFab Extension Libraries"
+      "description": "Include PlayFab Extension Libraries",
+      "supports": "windows & x64 & !uwp & !xbox & !staticcrt"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6561,7 +6561,7 @@
       "port-version": 1
     },
     "ms-gdk": {
-      "baseline": "2504.4.4108",
+      "baseline": "2510.0.6194",
       "port-version": 0
     },
     "ms-gdkx": {

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d6371fc5606672b95a959307da335689f628293",
+      "version": "2510.0.6194",
+      "port-version": 0
+    },
+    {
       "git-tree": "c19c66eeffaeb113a1084f868d8b3a4bbb6437f7",
       "version": "2504.4.4108",
       "port-version": 0

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6d6371fc5606672b95a959307da335689f628293",
+      "git-tree": "87213a136c388c973362a7a9b9fcdd69cde72709",
       "version": "2510.0.6194",
       "port-version": 0
     },


### PR DESCRIPTION
For the October 2025 GDK, we have a new directory layout and a new set of NuGet packages to match. This converts the exiting **ms-gdk** port to use the new layout for 2510.

The new October 2025 GDK has (minimal) ARM64 support so that's included. Over time we expect this support to grow.

The one change here is that for the new layouts, I unified the `find_package` to just `ms-gdk` instead of having eight different names. The target names are the same.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

> I had originally thought having the CMake files embedded in the NuGet to make it 'self-describing' would be easier to maintain over time, but it's too inflexible and is really only used by VCPKG anyhow.
