### PR TITLE
[firebird] new port

### DIFF
--- a/ports/firebird/firebird-config.cmake
+++ b/ports/firebird/firebird-config.cmake
@@ -1,0 +1,138 @@
+if(TARGET firebird)
+    return()
+endif()
+
+include(CMakeFindDependencyMacro)
+
+set(_FIREBIRD_ROOT "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}")
+set(_FIREBIRD_ROOT_DEBUG "${_FIREBIRD_ROOT}/debug")
+set(_FIREBIRD_LIB_DIR "${_FIREBIRD_ROOT}/lib")
+set(_FIREBIRD_LIB_DIR_DEBUG "${_FIREBIRD_ROOT_DEBUG}/lib")
+set(_FIREBIRD_BIN_DIR "${_FIREBIRD_ROOT}/bin")
+set(_FIREBIRD_BIN_DIR_DEBUG "${_FIREBIRD_ROOT_DEBUG}/bin")
+
+set(_FIREBIRD_SELECTED_LINKAGE "")
+set(_FIREBIRD_SHARED_FILENAME "")
+
+if(WIN32)
+    if(EXISTS "${_FIREBIRD_LIB_DIR}/fbclient_ms.lib")
+        set(_FIREBIRD_SELECTED_LINKAGE "shared")
+    elseif(EXISTS "${_FIREBIRD_LIB_DIR}/fbclient_static_ms.lib")
+        set(_FIREBIRD_SELECTED_LINKAGE "static")
+    endif()
+else()
+    foreach(_FIREBIRD_SHARED_CANDIDATE libfbclient.so libfbclient.dylib)
+        if(EXISTS "${_FIREBIRD_LIB_DIR}/${_FIREBIRD_SHARED_CANDIDATE}")
+            set(_FIREBIRD_SELECTED_LINKAGE "shared")
+            set(_FIREBIRD_SHARED_FILENAME "${_FIREBIRD_SHARED_CANDIDATE}")
+            break()
+        endif()
+    endforeach()
+    if(NOT _FIREBIRD_SELECTED_LINKAGE AND EXISTS "${_FIREBIRD_LIB_DIR}/libfbclient_static.a")
+        set(_FIREBIRD_SELECTED_LINKAGE "static")
+    endif()
+endif()
+
+if(NOT _FIREBIRD_SELECTED_LINKAGE)
+    message(FATAL_ERROR "Firebird client libraries were not found under ${_FIREBIRD_ROOT}.")
+endif()
+
+if(_FIREBIRD_SELECTED_LINKAGE STREQUAL "shared")
+    add_library(firebird SHARED IMPORTED)
+else()
+    add_library(firebird STATIC IMPORTED)
+endif()
+
+if(_FIREBIRD_SELECTED_LINKAGE STREQUAL "static")
+    find_dependency(libtommath CONFIG REQUIRED)
+    set(_FIREBIRD_TOMMATH_TARGET "libtommath")
+    if(TARGET libtommath::libtommath)
+        set(_FIREBIRD_TOMMATH_TARGET "libtommath::libtommath")
+    endif()
+    # LINK_ONLY keeps CMake from validating libtommath's include directories here.
+    set_property(TARGET firebird APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:${_FIREBIRD_TOMMATH_TARGET}>"
+    )
+endif()
+
+set_target_properties(firebird PROPERTIES
+    IMPORTED_CONFIGURATIONS "DEBUG;RELEASE"
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/../../include/"
+)
+
+if(WIN32)
+    if(_FIREBIRD_SELECTED_LINKAGE STREQUAL "shared")
+        set(_FIREBIRD_IMPLIB_RELEASE "${_FIREBIRD_LIB_DIR}/fbclient_ms.lib")
+        set(_FIREBIRD_IMPLIB_DEBUG "${_FIREBIRD_LIB_DIR_DEBUG}/fbclient_ms.lib")
+        if(NOT EXISTS "${_FIREBIRD_IMPLIB_DEBUG}")
+            set(_FIREBIRD_IMPLIB_DEBUG "${_FIREBIRD_IMPLIB_RELEASE}")
+        endif()
+
+        set(_FIREBIRD_DLL_RELEASE "${_FIREBIRD_BIN_DIR}/fbclient.dll")
+        set(_FIREBIRD_DLL_DEBUG "${_FIREBIRD_BIN_DIR_DEBUG}/fbclient.dll")
+        if(NOT EXISTS "${_FIREBIRD_DLL_DEBUG}")
+            set(_FIREBIRD_DLL_DEBUG "${_FIREBIRD_DLL_RELEASE}")
+        endif()
+
+        set_target_properties(firebird PROPERTIES
+            IMPORTED_IMPLIB_RELEASE "${_FIREBIRD_IMPLIB_RELEASE}"
+            IMPORTED_IMPLIB_DEBUG "${_FIREBIRD_IMPLIB_DEBUG}"
+            IMPORTED_LOCATION_RELEASE "${_FIREBIRD_DLL_RELEASE}"
+            IMPORTED_LOCATION_DEBUG "${_FIREBIRD_DLL_DEBUG}"
+        )
+    else()
+        set(_FIREBIRD_STATIC_RELEASE "${_FIREBIRD_LIB_DIR}/fbclient_static_ms.lib")
+        set(_FIREBIRD_STATIC_DEBUG "${_FIREBIRD_LIB_DIR_DEBUG}/fbclient_static_ms.lib")
+        if(NOT EXISTS "${_FIREBIRD_STATIC_DEBUG}")
+            set(_FIREBIRD_STATIC_DEBUG "${_FIREBIRD_STATIC_RELEASE}")
+        endif()
+
+        set_target_properties(firebird PROPERTIES
+            IMPORTED_LOCATION_RELEASE "${_FIREBIRD_STATIC_RELEASE}"
+            IMPORTED_LOCATION_DEBUG "${_FIREBIRD_STATIC_DEBUG}"
+        )
+    endif()
+else()
+    if(_FIREBIRD_SELECTED_LINKAGE STREQUAL "shared")
+        set(_FIREBIRD_SHARED_RELEASE "${_FIREBIRD_LIB_DIR}/${_FIREBIRD_SHARED_FILENAME}")
+        set(_FIREBIRD_SHARED_DEBUG "${_FIREBIRD_LIB_DIR_DEBUG}/${_FIREBIRD_SHARED_FILENAME}")
+        if(NOT EXISTS "${_FIREBIRD_SHARED_DEBUG}")
+            set(_FIREBIRD_SHARED_DEBUG "${_FIREBIRD_SHARED_RELEASE}")
+        endif()
+
+        set_target_properties(firebird PROPERTIES
+            IMPORTED_LOCATION_RELEASE "${_FIREBIRD_SHARED_RELEASE}"
+            IMPORTED_LOCATION_DEBUG "${_FIREBIRD_SHARED_DEBUG}"
+        )
+    else()
+        set(_FIREBIRD_STATIC_RELEASE "${_FIREBIRD_LIB_DIR}/libfbclient_static.a")
+        set(_FIREBIRD_STATIC_DEBUG "${_FIREBIRD_LIB_DIR_DEBUG}/libfbclient_static.a")
+        if(NOT EXISTS "${_FIREBIRD_STATIC_DEBUG}")
+            set(_FIREBIRD_STATIC_DEBUG "${_FIREBIRD_STATIC_RELEASE}")
+        endif()
+
+        set_target_properties(firebird PROPERTIES
+            IMPORTED_LOCATION_RELEASE "${_FIREBIRD_STATIC_RELEASE}"
+            IMPORTED_LOCATION_DEBUG "${_FIREBIRD_STATIC_DEBUG}"
+        )
+    endif()
+endif()
+
+unset(_FIREBIRD_ROOT)
+unset(_FIREBIRD_ROOT_DEBUG)
+unset(_FIREBIRD_LIB_DIR)
+unset(_FIREBIRD_LIB_DIR_DEBUG)
+unset(_FIREBIRD_BIN_DIR)
+unset(_FIREBIRD_BIN_DIR_DEBUG)
+unset(_FIREBIRD_SELECTED_LINKAGE)
+unset(_FIREBIRD_SHARED_FILENAME)
+unset(_FIREBIRD_SHARED_CANDIDATE)
+unset(_FIREBIRD_SHARED_RELEASE)
+unset(_FIREBIRD_SHARED_DEBUG)
+unset(_FIREBIRD_IMPLIB_RELEASE)
+unset(_FIREBIRD_IMPLIB_DEBUG)
+unset(_FIREBIRD_DLL_RELEASE)
+unset(_FIREBIRD_DLL_DEBUG)
+unset(_FIREBIRD_STATIC_RELEASE)
+unset(_FIREBIRD_STATIC_DEBUG)
+unset(_FIREBIRD_TOMMATH_TARGET)

--- a/ports/firebird/osx-unvcpkg.patch
+++ b/ports/firebird/osx-unvcpkg.patch
@@ -1,0 +1,66 @@
+diff --git a/configure.ac b/configure.ac
+index 7f575754e2..0407bc1aee 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -77,27 +77,6 @@ AC_CANONICAL_BUILD
+ CPU_TYPE=$build_cpu
+ AC_SUBST(CPU_TYPE)
+ 
+-case "$build" in
+-  aarch64-*-darwin*)
+-    VCPKG_TRIPLET=fb-arm64-osx
+-    ;;
+-
+-  x*64-*-darwin*)
+-    VCPKG_TRIPLET=fb-x64-osx
+-    ;;
+-esac
+-
+-if test "x$VCPKG_TRIPLET" != "x" ; then
+-  if ! test -f ./vcpkg/vcpkg; then
+-    ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+-  fi
+-
+-  ./vcpkg/vcpkg install --triplet=$VCPKG_TRIPLET
+-
+-  VCPKG_INSTALLED=`pwd`/vcpkg_installed/$VCPKG_TRIPLET
+-  AC_SUBST(VCPKG_INSTALLED)
+-fi
+-
+ dnl EKU: set appropiate defaults for each platform
+ dnl      EDITLINE_FLG     : support fancy command line editing in isql
+ dnl      SHRLIB_EXT       : suffix of shared library files
+@@ -711,14 +690,6 @@ CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+ CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
+ LIBS="$LIBS $PTHREAD_LIBS"
+ 
+-case "$build" in
+-  *-*-darwin*)
+-    CFLAGS="$CFLAGS -I${VCPKG_INSTALLED}/include"
+-    CXXFLAGS="$CXXFLAGS -nostdinc++ -isystem ${VCPKG_INSTALLED}/include/c++/v1 -I${VCPKG_INSTALLED}/include"
+-    LDFLAGS="$LDFLAGS -nostdlib++ -stdlib=libc++ -L${VCPKG_INSTALLED}/lib -lc++"
+-    ;;
+-esac
+-
+ AC_ARG_ENABLE(raw-devices,
+   [  --enable-raw-devices    enable databases on raw devices (default on POSIX)],
+   [case "$enableval" in
+@@ -1447,18 +1418,6 @@ dnl # output
+ 		fi
+ 	fi
+ 
+-  case "$build" in
+-    *-*-darwin*)
+-      cp -a $VCPKG_INSTALLED/lib/libicu* gen/\$fb_tgt/firebird/lib/
+-      install_name_tool -id @rpath/lib/libicuuc.dylib gen/\$fb_tgt/firebird/lib/libicuuc.dylib
+-      install_name_tool -id @rpath/lib/libicui18n.dylib gen/\$fb_tgt/firebird/lib/libicui18n.dylib
+-      install_name_tool -id @rpath/lib/libicudata.dylib gen/\$fb_tgt/firebird/lib/libicudata.dylib
+-      install_name_tool -change @rpath/libicudata.71.dylib @loader_path/libicudata.71.dylib gen/\$fb_tgt/firebird/lib/libicuuc.71.dylib
+-      install_name_tool -change @rpath/libicudata.71.dylib @loader_path/libicudata.71.dylib gen/\$fb_tgt/firebird/lib/libicui18n.71.dylib
+-      install_name_tool -change @rpath/libicuuc.71.dylib @loader_path/libicuuc.71.dylib gen/\$fb_tgt/firebird/lib/libicui18n.71.dylib
+-      ;;
+-  esac
+-
+ dnl ### TEMP ### directories for generated .cpp, .o and .d by module name
+ 	for src_dir in `cd src; ls -R -1 * | grep : | tr -d : | tr "\n" " "; cd ..`; do
+     	mkdir -p temp/\$fb_tgt/\$src_dir

--- a/ports/firebird/portfile.cmake
+++ b/ports/firebird/portfile.cmake
@@ -1,0 +1,39 @@
+set(VCPKG_POLICY_ALLOW_DEBUG_SHARE enabled)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO FirebirdSQL/firebird
+    REF v5.0.3
+    SHA512 73bbc54342cff68adad66c3b7b9a22b4392ee390b745bda76b03f71a681a6a04337f3f904f2ed4504665bd1a037d68351124fa7c20bed07e22304f14dd54e69f
+    HEAD_REF master
+    PATCHES
+        windows-paths.diff
+        posix-support-for-static-fbclient.patch
+        windows-support-for-static-fbclient.patch
+        osx-unvcpkg.patch
+        windows-timeout.patch
+)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    include("${CMAKE_CURRENT_LIST_DIR}/windows/portfile.cmake")
+else()
+    include("${CMAKE_CURRENT_LIST_DIR}/posix/portfile.cmake")
+endif()
+
+# Copy common files
+
+file(
+    INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/builds/install/misc/IPLicense.txt"
+        "${SOURCE_PATH}/builds/install/misc/IDPLicense.txt"
+)
+
+file(
+    INSTALL "${CMAKE_CURRENT_LIST_DIR}/${PORT}-config.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)

--- a/ports/firebird/posix-support-for-static-fbclient.patch
+++ b/ports/firebird/posix-support-for-static-fbclient.patch
@@ -1,0 +1,184 @@
+diff --git a/builds/install/arch-specific/freebsd/install.sh.in b/builds/install/arch-specific/freebsd/install.sh.in
+index 20d848357a..f4adb96e33 100755
+--- a/builds/install/arch-specific/freebsd/install.sh.in
++++ b/builds/install/arch-specific/freebsd/install.sh.in
+@@ -43,6 +43,7 @@ TargetDir=             # Install in real FS
+ SecurityDatabase=security2.fdb
+ RunUser=firebird
+ RunGroup=firebird
++FBCLIENT_STATIC_FLG=@FBCLIENT_STATIC_FLG@
+ 
+ 
+ #------------------------------------------------------------------------
+@@ -236,6 +237,10 @@ copyFiles() {
+ 	#lib
+     copyIfExists $BuiltFBDir/lib/libfbembed.so* ${TargetDir}@FB_LIBDIR@
+     cp -f $BuiltFBDir/lib/libfbclient.so* ${TargetDir}@FB_LIBDIR@
++	if [ "$FBCLIENT_STATIC_FLG" = "Y" ] && [ -f $BuiltFBDir/lib/libfbclient_static.a ]; then
++		cp -f $BuiltFBDir/lib/libfbclient_static.a ${TargetDir}@FB_LIBDIR@/libfbclient_static.a
++		chmod 0644 ${TargetDir}@FB_LIBDIR@/libfbclient_static.a
++	fi
+     cp -f $BuiltFBDir/lib/libib_util.so ${TargetDir}@FB_LIBDIR@/libib_util.so
+     copyIfExists $BuiltFBDir/lib/libicu*.so* ${TargetDir}@FB_LIBDIR@
+ 
+diff --git a/builds/install/arch-specific/hpux/super/makeinstallImage.sh.in b/builds/install/arch-specific/hpux/super/makeinstallImage.sh.in
+index 07d86c00a6..b4ec0d8224 100644
+--- a/builds/install/arch-specific/hpux/super/makeinstallImage.sh.in
++++ b/builds/install/arch-specific/hpux/super/makeinstallImage.sh.in
+@@ -48,6 +48,7 @@ TargetDir=buildroot    # Where we want to build the install image
+ RealRootDir=/usr/local/firebird   # Where it will be installed on new machine
+ FBRootDir=${RealRootDir#/}   # strip off leading /
+ DestDir=$TargetDir/$FBRootDir
++FBCLIENT_STATIC_FLG=@FBCLIENT_STATIC_FLG@
+ 
+ 
+ #------------------------------------------------------------------------
+@@ -142,6 +143,10 @@ copyFiles() {
+ 
+ 
+     cp -f $BuiltFBDir/lib/libfbclient.sl* $DestDir/lib
++    if [ "$FBCLIENT_STATIC_FLG" = "Y" ] && [ -f $BuiltFBDir/lib/libfbclient_static.a ]; then
++        cp -f $BuiltFBDir/lib/libfbclient_static.a $DestDir/lib/libfbclient_static.a
++        chmod 0644 $DestDir/lib/libfbclient_static.a
++    fi
+ 
+     cp -f $BuiltFBDir/lib/libib_util.sl $DestDir/lib/libib_util.sl
+ 
+diff --git a/builds/install/arch-specific/linux/makeInstallImage.sh.in b/builds/install/arch-specific/linux/makeInstallImage.sh.in
+index 98c56abc0e..25caba22e9 100644
+--- a/builds/install/arch-specific/linux/makeInstallImage.sh.in
++++ b/builds/install/arch-specific/linux/makeInstallImage.sh.in
+@@ -40,6 +40,7 @@ TomCryptBuild="@TOMCRYPT_BUILD@"
+ OBJDUMP=@OBJDUMP@
+ CLIENT_ONLY_FLG=@CLIENT_ONLY_FLG@
+ WITH_TOMCRYPT=@WITH_TOMCRYPT@
++FBCLIENT_STATIC_FLG=@FBCLIENT_STATIC_FLG@
+ 
+ #------------------------------------------------------------------------
+ #  addLibs
+@@ -258,6 +259,10 @@ copyFiles() {
+ 
+ 	#lib
+ 	cp -df $BuiltFBDir/lib/libfbclient.so* ${TargetDir}@FB_LIBDIR@
++	if [ "$FBCLIENT_STATIC_FLG" = "Y" ] && [ -f $BuiltFBDir/lib/libfbclient_static.a ]; then
++		cp -f $BuiltFBDir/lib/libfbclient_static.a ${TargetDir}@FB_LIBDIR@/libfbclient_static.a
++		chmod 0644 ${TargetDir}@FB_LIBDIR@/libfbclient_static.a
++	fi
+ 	if [ "$CLIENT_ONLY_FLG" = "N" ]; then
+ 		cp -f $BuiltFBDir/lib/libib_util.so ${TargetDir}@FB_LIBDIR@/libib_util.so
+ 	fi
+diff --git a/builds/install/arch-specific/netbsd/install.sh.in b/builds/install/arch-specific/netbsd/install.sh.in
+index c234ee8cea..51c994cb00 100644
+--- a/builds/install/arch-specific/netbsd/install.sh.in
++++ b/builds/install/arch-specific/netbsd/install.sh.in
+@@ -51,6 +51,7 @@ copyIfExists() {
+ 
+ }
+ 
++FBCLIENT_STATIC_FLG=@FBCLIENT_STATIC_FLG@
+ InstallFirebirdPrefix=@prefix@
+ InstallPrefix=${InstallFirebirdPrefix%/firebird}
+ unset InstallFirebirdPrefix
+@@ -171,6 +172,10 @@ cp $BuiltFBDir/include/*.h $DestDir/include || exit
+ 
+ cp -Rf $BuiltFBDir/lib/libfbembed.so* $DestDir/lib || exit
+ cp -Rf $BuiltFBDir/lib/libfbclient.so* $DestDir/lib || exit
++if [ "$FBCLIENT_STATIC_FLG" = "Y" ] && [ -f $BuiltFBDir/lib/libfbclient_static.a ]; then
++	cp -f $BuiltFBDir/lib/libfbclient_static.a $DestDir/lib/libfbclient_static.a || exit
++	chmod 0644 $DestDir/lib/libfbclient_static.a || exit
++fi
+ 
+ cp -f $BuiltFBDir/lib/libib_util.so $DestDir/lib/libib_util.so  || exit
+ 
+diff --git a/builds/posix/Makefile.in b/builds/posix/Makefile.in
+index 063d2abedc..0e7b458f58 100644
+--- a/builds/posix/Makefile.in
++++ b/builds/posix/Makefile.in
+@@ -448,7 +448,14 @@ $(GPRE_BOOT):	$(GPRE_Boot_Objects) $(COMMON_LIB)
+ # yValve
+ #
+ 
++ifeq ($(FBCLIENT_STATIC_FLG),Y)
++DEC_FLOAT_LIB := $(STATIC_LIB)/libdecFloat$(CROSS).a
++endif
++
+ yvalve: $(LIBFIREBIRD_BASENAME)
++ifeq ($(FBCLIENT_STATIC_FLG),Y)
++yvalve: $(LIBFIREBIRD_STATIC)
++endif
+ 
+ ifneq ($(LibraryBaseName),$(LibrarySoName))
+ $(LIBFIREBIRD_BASENAME):	$(LIBFIREBIRD_SONAME)
+@@ -464,6 +471,23 @@ endif
+ $(LIBFIREBIRD_FULLNAME):	$(YValve_Objects) $(Remote_Client_Objects) $(COMMON_LIB)
+ 	$(LINK_FIREBIRD) -o $@ $^ $(LINK_FIREBIRD_LIBS) $(call LIB_LINK_DARWIN_INSTALL_NAME,lib/libfbclient.$(SHRLIB_EXT))
+ 
++ifeq ($(FBCLIENT_STATIC_FLG),Y)
++$(LIBFIREBIRD_STATIC):	$(YValve_Objects) $(Remote_Client_Objects) $(Common_Objects) $(DEC_FLOAT_LIB)
++	-$(RM) $@
++	$(STATICLIB_LINK) $@ $^
++
++	DEC_TMP="$(TMP_ROOT)/decFloat-extract"; \
++	rm -rf "$$DEC_TMP"; \
++	mkdir -p "$$DEC_TMP"; \
++	cd "$$DEC_TMP" && $(AR) x "$(DEC_FLOAT_LIB)"; \
++	if ls "$$DEC_TMP"/*.o >/dev/null 2>&1; then \
++		$(AR) q $@ "$$DEC_TMP"/*.o; \
++	fi; \
++	rm -rf "$$DEC_TMP"
++
++	$(RANLIB) $@
++endif
++
+ 
+ #___________________________________________________________________________
+ # core part - jrd's engine
+diff --git a/builds/posix/make.defaults b/builds/posix/make.defaults
+index 2bbf905236..e454d53caf 100755
+--- a/builds/posix/make.defaults
++++ b/builds/posix/make.defaults
+@@ -117,6 +117,7 @@ PLUSPLUS_FLAGS:= -fno-rtti -std=c++17
+ IsDeveloper = @DEVEL_FLG@
+ CLIENT_ONLY_FLG=@CLIENT_ONLY_FLG@
+ WITH_TOMCRYPT=@WITH_TOMCRYPT@
++FBCLIENT_STATIC_FLG=@FBCLIENT_STATIC_FLG@
+ 
+ CpuType=@CPU_TYPE@
+ PLATFORM=@PLATFORM@
+@@ -260,6 +261,7 @@ LibraryBaseName=$(LibraryFileName).${SHRLIB_EXT}
+ LIBFIREBIRD_FULLNAME = $(LIB)/$(LibraryFullName)
+ LIBFIREBIRD_SONAME = $(LIB)/$(LibraryBaseName)
+ LIBFIREBIRD_BASENAME = $(LIB)/$(LibrarySoName)
++LIBFIREBIRD_STATIC = $(LIB)/$(LibraryFileName)_static.a
+ 
+ # The firebird engine library name
+ 
+@@ -446,4 +448,3 @@ FIREBIRD_MSG    = $(FIREBIRD)/firebird.msg
+ # For want of a better suggestion we may as well default to posix
+ PLATFORM_PATH	=	os/posix
+ TRACE_OS_Sources	=
+-
+diff --git a/configure.ac b/configure.ac
+index 7f575754e2..4cb5eafbe6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -637,6 +637,16 @@ AC_ARG_ENABLE(client-only,
+    esac])
+ AC_SUBST(CLIENT_ONLY_FLG)
+ 
++FBCLIENT_STATIC_FLG=N
++AC_ARG_ENABLE(fbclient-static,
++  [  --enable-fbclient-static build libfbclient_static.a together with the shared client (default=no)],
++  [case "$enableval" in
++     yes) FBCLIENT_STATIC_FLG=Y;;
++     no)  FBCLIENT_STATIC_FLG=N;;
++     *)   AC_MSG_ERROR(bad value '${enableval}' for --enable-fbclient-static);;
++   esac])
++AC_SUBST(FBCLIENT_STATIC_FLG)
++
+ CROSS=
+ IS_CROSS=N
+ AC_ARG_WITH(cross-build,
+-- 
+2.51.0
+

--- a/ports/firebird/posix/portfile.cmake
+++ b/ports/firebird/posix/portfile.cmake
@@ -1,0 +1,140 @@
+# In Linux, we adjust rpaths to be more precise than what vcpkg does by default.
+set(VCPKG_FIXUP_ELF_RPATH OFF)
+#set(VCPKG_FIXUP_MACHO_RPATH OFF)
+
+if(NOT VCPKG_TARGET_IS_OSX)
+vcpkg_find_acquire_program(PATCHELF)
+endif()
+
+set(FIREBIRD_CONFIGURE_OPTIONS
+    --enable-client-only
+    --enable-binreloc
+    --with-plugins=plugins/${PORT}
+    --with-fbmsg=share/${PORT}
+    --with-tzdata=share/${PORT}/tzdata
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND FIREBIRD_CONFIGURE_OPTIONS
+        --enable-fbclient-static
+    )
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    COPY_SOURCE
+    AUTOCONFIG
+    OPTIONS
+        ${FIREBIRD_CONFIGURE_OPTIONS}
+    OPTIONS_DEBUG
+        --enable-developer
+)
+
+vcpkg_build_make()
+
+
+# Release build
+
+set(SOURCE_COPY_REL_PATH "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel")
+
+file(
+    INSTALL "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/include"
+    DESTINATION "${CURRENT_PACKAGES_DIR}"
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(GLOB FIREBIRD_RELEASE_LIBS
+        "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/lib/*"
+    )
+else()
+    file(GLOB FIREBIRD_RELEASE_LIBS
+        "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/lib/*.a"
+    )
+endif()
+
+file(
+    INSTALL ${FIREBIRD_RELEASE_LIBS}
+    DESTINATION "${CURRENT_PACKAGES_DIR}/lib"
+    USE_SOURCE_PERMISSIONS
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(GLOB PLUGINS_FILES_RELEASE
+        "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/plugins/*"
+    )
+
+    if(NOT VCPKG_TARGET_IS_OSX)
+        foreach(plugin ${PLUGINS_FILES_RELEASE})
+            execute_process(
+                COMMAND "${PATCHELF}" --set-rpath "$ORIGIN/../../lib" ${plugin}
+            )
+        endforeach()
+    endif()
+
+    file(
+        INSTALL ${PLUGINS_FILES_RELEASE}
+        DESTINATION "${CURRENT_PACKAGES_DIR}/plugins/${PORT}"
+        USE_SOURCE_PERMISSIONS
+    )
+endif()
+
+file(
+    INSTALL "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/firebird.msg"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_COPY_REL_PATH}/gen/Release/firebird/tzdata"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+
+# Debug build
+
+set(SOURCE_COPY_DBG_PATH "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(GLOB FIREBIRD_DEBUG_LIBS
+        "${SOURCE_COPY_DBG_PATH}/gen/Debug/firebird/lib/*"
+    )
+else()
+    file(GLOB FIREBIRD_DEBUG_LIBS
+        "${SOURCE_COPY_DBG_PATH}/gen/Debug/firebird/lib/*.a"
+    )
+endif()
+
+file(
+    INSTALL ${FIREBIRD_DEBUG_LIBS}
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib"
+    USE_SOURCE_PERMISSIONS
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(GLOB PLUGINS_FILES_DEBUG
+        "${SOURCE_COPY_DBG_PATH}/gen/Debug/firebird/plugins/*"
+    )
+
+    if(NOT VCPKG_TARGET_IS_OSX)
+        foreach(plugin ${PLUGINS_FILES_DEBUG})
+            execute_process(
+                COMMAND "${PATCHELF}" --set-rpath "$ORIGIN/../../lib" ${plugin}
+            )
+        endforeach()
+    endif()
+
+    file(
+        INSTALL ${PLUGINS_FILES_DEBUG}
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/plugins/${PORT}"
+        USE_SOURCE_PERMISSIONS
+    )
+endif()
+
+file(
+    INSTALL "${SOURCE_COPY_DBG_PATH}/gen/Debug/firebird/firebird.msg"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_COPY_DBG_PATH}/gen/Debug/firebird/tzdata"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
+)

--- a/ports/firebird/usage
+++ b/ports/firebird/usage
@@ -1,0 +1,3 @@
+firebird provides CMake targets:
+    find_package(firebird CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE firebird)

--- a/ports/firebird/vcpkg.json
+++ b/ports/firebird/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "firebird",
+  "version-semver": "5.0.3",
+  "description": "Firebird SQL DBMS client library",
+  "homepage": "https://firebirdsql.org/",
+  "license": "LicenseRef-IDPL",
+  "supports": "(windows & !uwp & (x86 | x64) & !staticcrt) | linux | osx",
+  "dependencies": [
+    {
+      "name": "icu",
+      "platform": "!windows"
+    },
+    "libtomcrypt",
+    "libtommath",
+    {
+      "name": "ncurses",
+      "platform": "!windows"
+    },
+    {
+      "name": "zlib",
+      "platform": "linux"
+    }
+  ]
+}

--- a/ports/firebird/windows-paths.diff
+++ b/ports/firebird/windows-paths.diff
@@ -1,0 +1,95 @@
+diff --git a/src/common/unicode_util.cpp b/src/common/unicode_util.cpp
+index 40871dcfdb..45c1bce046 100644
+--- a/src/common/unicode_util.cpp
++++ b/src/common/unicode_util.cpp
+@@ -239,6 +239,12 @@ void BaseICU::initialize(ModuleLoader::Module* module)
+ 
+ 		pathsToTry.add(Config::getRootDirectory());
+ 
++#ifdef FB_SHAREDIR
++		PathName sharePath;
++		PathUtils::concatPath(sharePath, Config::getRootDirectory(), FB_SHAREDIR);
++		pathsToTry.add(sharePath);
++#endif
++
+ 		file.printf("icudt%u%c.dat", majorVersion,
+ #ifdef WORDS_BIGENDIAN
+ 			'b'
+diff --git a/src/include/gen/autoconfig_msvc.h b/src/include/gen/autoconfig_msvc.h
+index 1e25478c64..7cf81bd668 100644
+--- a/src/include/gen/autoconfig_msvc.h
++++ b/src/include/gen/autoconfig_msvc.h
+@@ -318,6 +318,7 @@
+ 
+ #define FB_PREFIX "c:\\Program Files\\Firebird\\"
+ 
++#define FB_SHAREDIR "share/firebird"
+ #define FB_BINDIR ""
+ #define FB_CONFDIR ""
+ #define FB_DOCDIR ""
+@@ -327,13 +328,13 @@
+ #define FB_LIBDIR ""
+ #define FB_LOGDIR ""
+ #define FB_MISCDIR ""
+-#define FB_MSGDIR ""
+-#define FB_PLUGDIR ""
++#define FB_MSGDIR FB_SHAREDIR
++#define FB_PLUGDIR "plugins/firebird"
+ #define FB_SAMPLEDBDIR ""
+ #define FB_SAMPLEDIR ""
+ #define FB_SBINDIR ""
+ #define FB_SECDBDIR ""
+-#define FB_TZDATADIR ""
++#define FB_TZDATADIR (FB_SHAREDIR "/tzdata")
+ 
+ #define FB_LOGFILENAME "firebird.log"
+ 
+diff --git a/src/yvalve/config/os/win32/config_root.cpp b/src/yvalve/config/os/win32/config_root.cpp
+index 3658ee3d89..bcd6d5b3a0 100644
+--- a/src/yvalve/config/os/win32/config_root.cpp
++++ b/src/yvalve/config/os/win32/config_root.cpp
+@@ -68,40 +68,20 @@ void ConfigRoot::osConfigInstallDir()
+ 	// get the pathname of the running dll / executable
+ 	PathName module_path;
+ 	if (!getPathFromHInstance(module_path))
+-	{
+ 		module_path = fb_utils::get_process_name();
+-	}
+ 
+ 	if (module_path.hasData())
+ 	{
+ 		// get rid of the filename
+-		PathName bin_dir, file_name;
++		PathName bin_dir, file_name, parent_dir;
+ 		PathUtils::splitLastComponent(bin_dir, file_name, module_path);
++		PathUtils::splitLastComponent(parent_dir, file_name, bin_dir);
+ 
+-		// search for the configuration file in the bin directory
+-		PathUtils::concatPath(file_name, bin_dir, Firebird::CONFIG_FILE);
+-		DWORD attributes = GetFileAttributes(file_name.c_str());
+-		if (attributes == INVALID_FILE_ATTRIBUTES || attributes == FILE_ATTRIBUTE_DIRECTORY)
+-		{
+-			// search for the configuration file in the parent directory
+-			PathName parent_dir;
+-			PathUtils::splitLastComponent(parent_dir, file_name, bin_dir);
+-
+-			if (parent_dir.hasData())
+-			{
+-				PathUtils::concatPath(file_name, parent_dir, Firebird::CONFIG_FILE);
+-				attributes = GetFileAttributes(file_name.c_str());
+-				if (attributes != INVALID_FILE_ATTRIBUTES && attributes != FILE_ATTRIBUTE_DIRECTORY)
+-				{
+-					install_dir = parent_dir;
+-				}
+-			}
+-		}
++		if (parent_dir.hasData())
++			install_dir = parent_dir;
+ 
+ 		if (install_dir.isEmpty())
+-		{
+ 			install_dir = bin_dir;
+-		}
+ 	}
+ 
+ 	if (install_dir.isEmpty())

--- a/ports/firebird/windows-support-for-static-fbclient.patch
+++ b/ports/firebird/windows-support-for-static-fbclient.patch
@@ -1,0 +1,1157 @@
+diff --git a/builds/win32/compile_static.bat b/builds/win32/compile_static.bat
+new file mode 100644
+index 0000000000..e09d2cc6b8
+--- /dev/null
++++ b/builds/win32/compile_static.bat
+@@ -0,0 +1,40 @@
++@echo off
++::==============
++:: compile.bat solution, output, [projects...]
++::
++::   Note: Our projects create object files in temp/$platform/$config
++::     but we call devenv with $config|$platform (note variable in reverse order
++::     and odd syntax).
++
++setlocal
++set solution=%1
++set output_path=%~dp2
++set output=%2
++set projects=
++
++@if "%FB_DBG%"=="" (
++	set config=releaseStatic
++) else (
++	set config=debugStatic
++)
++
++shift
++shift
++
++:loop_start
++
++if "%1" == "" goto loop_end
++
++set projects=%projects% /target:%1%FB_CLEAN%
++
++shift
++goto loop_start
++
++:loop_end
++
++if not exist "%output_path%" mkdir "%output_path%"
++msbuild "%FB_LONG_ROOT_PATH%\%solution%.sln" /maxcpucount /p:Configuration=%config% /p:Platform=%FB_TARGET_PLATFORM% %projects% /fileLoggerParameters:LogFile=%output%
++
++endlocal
++
++goto :EOF
+diff --git a/builds/win32/make_all.bat b/builds/win32/make_all.bat
+index ebeb3910dd..a370d3aec5 100644
+--- a/builds/win32/make_all.bat
++++ b/builds/win32/make_all.bat
+@@ -23,6 +23,11 @@ set ERRLEV=0
+ )
+ if errorlevel 1 call :ERROR build failed - see make_all_%FB_TARGET_PLATFORM%.log for details
+ 
++@if "%FB_ENABLE_FBCLIENT_STATIC%"=="TRUE" (
++	call compile_static.bat builds\win32\%VS_VER%\Firebird make_all_%FB_TARGET_PLATFORM%_static.log DLLs\yvalve
++	if errorlevel 1 call :ERROR build failed - see make_all_%FB_TARGET_PLATFORM%_static.log for details
++)
++
+ @if "%ERRLEV%"=="1" (
+   @goto :EOF
+ ) else (
+@@ -60,6 +65,10 @@ if errorlevel 1 call :ERROR build failed - see make_all_%FB_TARGET_PLATFORM%.log
+ @copy %FB_ROOT_PATH%\temp\%FB_OBJ_DIR%\firebird\plugins\*.dll %FB_OUTPUT_DIR%\plugins >nul
+ @copy %FB_ROOT_PATH%\temp\%FB_OBJ_DIR%\yvalve\fbclient.lib %FB_OUTPUT_DIR%\lib\fbclient_ms.lib >nul
+ 
++@if "%FB_ENABLE_FBCLIENT_STATIC%"=="TRUE" (
++	@copy %FB_ROOT_PATH%\temp\%FB_STATIC_OBJ_DIR%\yvalve\fbclient_static.lib %FB_OUTPUT_DIR%\lib\fbclient_static_ms.lib >nul
++)
++
+ @if "%FB_CLIENT_ONLY%"=="" (
+ 	copy %FB_ROOT_PATH%\temp\%FB_OBJ_DIR%\firebird\intl\* %FB_OUTPUT_DIR%\intl >nul
+ 	copy %FB_ROOT_PATH%\temp\%FB_OBJ_DIR%\firebird\plugins\udr\*.dll %FB_OUTPUT_DIR%\plugins\udr >nul
+diff --git a/builds/win32/msvc15/Firebird.sln b/builds/win32/msvc15/Firebird.sln
+index 4293fbe7bd..ddf87353b3 100644
+--- a/builds/win32/msvc15/Firebird.sln
++++ b/builds/win32/msvc15/Firebird.sln
+@@ -1,6 +1,6 @@
+ Microsoft Visual Studio Solution File, Format Version 12.00
+-# Visual Studio 15
+-VisualStudioVersion = 15.0.27703.2047
++# Visual Studio Version 17
++VisualStudioVersion = 17.14.36408.4 d17.14
+ MinimumVisualStudioVersion = 10.0.40219.1
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "alice", "alice.vcxproj", "{0D616380-1A5A-4230-A80B-021360E4E669}"
+ EndProject
+@@ -102,304 +102,464 @@ Global
+ 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+ 		Debug|Win32 = Debug|Win32
+ 		Debug|x64 = Debug|x64
++		DebugStatic|Win32 = DebugStatic|Win32
++		DebugStatic|x64 = DebugStatic|x64
+ 		Release|Win32 = Release|Win32
+ 		Release|x64 = Release|x64
++		ReleaseStatic|Win32 = ReleaseStatic|Win32
++		ReleaseStatic|x64 = ReleaseStatic|x64
+ 	EndGlobalSection
+ 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+ 		{0D616380-1A5A-4230-A80B-021360E4E669}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{0D616380-1A5A-4230-A80B-021360E4E669}.Debug|Win32.Build.0 = Debug|Win32
+ 		{0D616380-1A5A-4230-A80B-021360E4E669}.Debug|x64.ActiveCfg = Debug|x64
+ 		{0D616380-1A5A-4230-A80B-021360E4E669}.Debug|x64.Build.0 = Debug|x64
++		{0D616380-1A5A-4230-A80B-021360E4E669}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{0D616380-1A5A-4230-A80B-021360E4E669}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{0D616380-1A5A-4230-A80B-021360E4E669}.Release|Win32.ActiveCfg = Release|Win32
+ 		{0D616380-1A5A-4230-A80B-021360E4E669}.Release|Win32.Build.0 = Release|Win32
+ 		{0D616380-1A5A-4230-A80B-021360E4E669}.Release|x64.ActiveCfg = Release|x64
+ 		{0D616380-1A5A-4230-A80B-021360E4E669}.Release|x64.Build.0 = Release|x64
++		{0D616380-1A5A-4230-A80B-021360E4E669}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{0D616380-1A5A-4230-A80B-021360E4E669}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{D1507562-A363-4685-96AF-B036F5E5E47F}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{D1507562-A363-4685-96AF-B036F5E5E47F}.Debug|Win32.Build.0 = Debug|Win32
+ 		{D1507562-A363-4685-96AF-B036F5E5E47F}.Debug|x64.ActiveCfg = Debug|x64
+ 		{D1507562-A363-4685-96AF-B036F5E5E47F}.Debug|x64.Build.0 = Debug|x64
++		{D1507562-A363-4685-96AF-B036F5E5E47F}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{D1507562-A363-4685-96AF-B036F5E5E47F}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{D1507562-A363-4685-96AF-B036F5E5E47F}.Release|Win32.ActiveCfg = Release|Win32
+ 		{D1507562-A363-4685-96AF-B036F5E5E47F}.Release|Win32.Build.0 = Release|Win32
+ 		{D1507562-A363-4685-96AF-B036F5E5E47F}.Release|x64.ActiveCfg = Release|x64
+ 		{D1507562-A363-4685-96AF-B036F5E5E47F}.Release|x64.Build.0 = Release|x64
++		{D1507562-A363-4685-96AF-B036F5E5E47F}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{D1507562-A363-4685-96AF-B036F5E5E47F}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{15605F44-BFFD-444F-AD4C-55DC9D704465}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{15605F44-BFFD-444F-AD4C-55DC9D704465}.Debug|Win32.Build.0 = Debug|Win32
+ 		{15605F44-BFFD-444F-AD4C-55DC9D704465}.Debug|x64.ActiveCfg = Debug|x64
+ 		{15605F44-BFFD-444F-AD4C-55DC9D704465}.Debug|x64.Build.0 = Debug|x64
++		{15605F44-BFFD-444F-AD4C-55DC9D704465}.DebugStatic|Win32.ActiveCfg = DebugStatic|Win32
++		{15605F44-BFFD-444F-AD4C-55DC9D704465}.DebugStatic|Win32.Build.0 = DebugStatic|Win32
++		{15605F44-BFFD-444F-AD4C-55DC9D704465}.DebugStatic|x64.ActiveCfg = DebugStatic|x64
++		{15605F44-BFFD-444F-AD4C-55DC9D704465}.DebugStatic|x64.Build.0 = DebugStatic|x64
+ 		{15605F44-BFFD-444F-AD4C-55DC9D704465}.Release|Win32.ActiveCfg = Release|Win32
+ 		{15605F44-BFFD-444F-AD4C-55DC9D704465}.Release|Win32.Build.0 = Release|Win32
+ 		{15605F44-BFFD-444F-AD4C-55DC9D704465}.Release|x64.ActiveCfg = Release|x64
+ 		{15605F44-BFFD-444F-AD4C-55DC9D704465}.Release|x64.Build.0 = Release|x64
++		{15605F44-BFFD-444F-AD4C-55DC9D704465}.ReleaseStatic|Win32.ActiveCfg = ReleaseStatic|Win32
++		{15605F44-BFFD-444F-AD4C-55DC9D704465}.ReleaseStatic|Win32.Build.0 = ReleaseStatic|Win32
++		{15605F44-BFFD-444F-AD4C-55DC9D704465}.ReleaseStatic|x64.ActiveCfg = ReleaseStatic|x64
++		{15605F44-BFFD-444F-AD4C-55DC9D704465}.ReleaseStatic|x64.Build.0 = ReleaseStatic|x64
+ 		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.Debug|Win32.Build.0 = Debug|Win32
+ 		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.Debug|x64.ActiveCfg = Debug|x64
+ 		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.Debug|x64.Build.0 = Debug|x64
++		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.Release|Win32.ActiveCfg = Release|Win32
+ 		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.Release|Win32.Build.0 = Release|Win32
+ 		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.Release|x64.ActiveCfg = Release|x64
+ 		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.Release|x64.Build.0 = Release|x64
++		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{F8798A49-9D20-451E-A7BD-FEB5237103B5}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{E8397148-0E9C-449B-9F45-7FB377A08242}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{E8397148-0E9C-449B-9F45-7FB377A08242}.Debug|Win32.Build.0 = Debug|Win32
+ 		{E8397148-0E9C-449B-9F45-7FB377A08242}.Debug|x64.ActiveCfg = Debug|x64
+ 		{E8397148-0E9C-449B-9F45-7FB377A08242}.Debug|x64.Build.0 = Debug|x64
++		{E8397148-0E9C-449B-9F45-7FB377A08242}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{E8397148-0E9C-449B-9F45-7FB377A08242}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{E8397148-0E9C-449B-9F45-7FB377A08242}.Release|Win32.ActiveCfg = Release|Win32
+ 		{E8397148-0E9C-449B-9F45-7FB377A08242}.Release|Win32.Build.0 = Release|Win32
+ 		{E8397148-0E9C-449B-9F45-7FB377A08242}.Release|x64.ActiveCfg = Release|x64
+ 		{E8397148-0E9C-449B-9F45-7FB377A08242}.Release|x64.Build.0 = Release|x64
++		{E8397148-0E9C-449B-9F45-7FB377A08242}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{E8397148-0E9C-449B-9F45-7FB377A08242}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.Debug|Win32.Build.0 = Debug|Win32
+ 		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.Debug|x64.ActiveCfg = Debug|x64
+ 		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.Debug|x64.Build.0 = Debug|x64
++		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.Release|Win32.ActiveCfg = Release|Win32
+ 		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.Release|Win32.Build.0 = Release|Win32
+ 		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.Release|x64.ActiveCfg = Release|x64
+ 		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.Release|x64.Build.0 = Release|x64
++		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{BBD83ED3-8A48-4FE8-B4B7-CB27730986B2}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.Debug|Win32.Build.0 = Debug|Win32
+ 		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.Debug|x64.ActiveCfg = Debug|x64
+ 		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.Debug|x64.Build.0 = Debug|x64
++		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.Release|Win32.ActiveCfg = Release|Win32
+ 		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.Release|Win32.Build.0 = Release|Win32
+ 		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.Release|x64.ActiveCfg = Release|x64
+ 		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.Release|x64.Build.0 = Release|x64
++		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{23EC8DAA-6718-4EF3-979F-89F611C7D504}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.Debug|Win32.Build.0 = Debug|Win32
+ 		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.Debug|x64.ActiveCfg = Debug|x64
+ 		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.Debug|x64.Build.0 = Debug|x64
++		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.Release|Win32.ActiveCfg = Release|Win32
+ 		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.Release|Win32.Build.0 = Release|Win32
+ 		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.Release|x64.ActiveCfg = Release|x64
+ 		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.Release|x64.Build.0 = Release|x64
++		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{B732F5D2-B5D9-417F-B156-D790F466CB8E}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{44A9E4AD-B932-4620-B319-431A153BB341}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{44A9E4AD-B932-4620-B319-431A153BB341}.Debug|Win32.Build.0 = Debug|Win32
+ 		{44A9E4AD-B932-4620-B319-431A153BB341}.Debug|x64.ActiveCfg = Debug|x64
+ 		{44A9E4AD-B932-4620-B319-431A153BB341}.Debug|x64.Build.0 = Debug|x64
++		{44A9E4AD-B932-4620-B319-431A153BB341}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{44A9E4AD-B932-4620-B319-431A153BB341}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{44A9E4AD-B932-4620-B319-431A153BB341}.Release|Win32.ActiveCfg = Release|Win32
+ 		{44A9E4AD-B932-4620-B319-431A153BB341}.Release|Win32.Build.0 = Release|Win32
+ 		{44A9E4AD-B932-4620-B319-431A153BB341}.Release|x64.ActiveCfg = Release|x64
+ 		{44A9E4AD-B932-4620-B319-431A153BB341}.Release|x64.Build.0 = Release|x64
++		{44A9E4AD-B932-4620-B319-431A153BB341}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{44A9E4AD-B932-4620-B319-431A153BB341}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.Debug|Win32.Build.0 = Debug|Win32
+ 		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.Debug|x64.ActiveCfg = Debug|x64
+ 		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.Debug|x64.Build.0 = Debug|x64
++		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.Release|Win32.ActiveCfg = Release|Win32
+ 		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.Release|Win32.Build.0 = Release|Win32
+ 		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.Release|x64.ActiveCfg = Release|x64
+ 		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.Release|x64.Build.0 = Release|x64
++		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{D84F0839-28A4-40B2-B5F4-F5E1E7F48FD0}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.Debug|Win32.Build.0 = Debug|Win32
+ 		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.Debug|x64.ActiveCfg = Debug|x64
+ 		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.Debug|x64.Build.0 = Debug|x64
++		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.Release|Win32.ActiveCfg = Release|Win32
+ 		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.Release|Win32.Build.0 = Release|Win32
+ 		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.Release|x64.ActiveCfg = Release|x64
+ 		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.Release|x64.Build.0 = Release|x64
++		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{7043CC61-DEC1-4C6B-86B9-0E911D1094C9}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.Debug|Win32.Build.0 = Debug|Win32
+ 		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.Debug|x64.ActiveCfg = Debug|x64
+ 		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.Debug|x64.Build.0 = Debug|x64
++		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.Release|Win32.ActiveCfg = Release|Win32
+ 		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.Release|Win32.Build.0 = Release|Win32
+ 		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.Release|x64.ActiveCfg = Release|x64
+ 		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.Release|x64.Build.0 = Release|x64
++		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{B7F22B7F-9937-4874-9A8B-6AB4E36E74A5}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{7E862973-37C4-4202-80E7-490ED4DEDA14}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{7E862973-37C4-4202-80E7-490ED4DEDA14}.Debug|Win32.Build.0 = Debug|Win32
+ 		{7E862973-37C4-4202-80E7-490ED4DEDA14}.Debug|x64.ActiveCfg = Debug|x64
+ 		{7E862973-37C4-4202-80E7-490ED4DEDA14}.Debug|x64.Build.0 = Debug|x64
++		{7E862973-37C4-4202-80E7-490ED4DEDA14}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{7E862973-37C4-4202-80E7-490ED4DEDA14}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{7E862973-37C4-4202-80E7-490ED4DEDA14}.Release|Win32.ActiveCfg = Release|Win32
+ 		{7E862973-37C4-4202-80E7-490ED4DEDA14}.Release|Win32.Build.0 = Release|Win32
+ 		{7E862973-37C4-4202-80E7-490ED4DEDA14}.Release|x64.ActiveCfg = Release|x64
+ 		{7E862973-37C4-4202-80E7-490ED4DEDA14}.Release|x64.Build.0 = Release|x64
++		{7E862973-37C4-4202-80E7-490ED4DEDA14}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{7E862973-37C4-4202-80E7-490ED4DEDA14}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.Debug|Win32.Build.0 = Debug|Win32
+ 		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.Debug|x64.ActiveCfg = Debug|x64
+ 		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.Debug|x64.Build.0 = Debug|x64
++		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.Release|Win32.ActiveCfg = Release|Win32
+ 		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.Release|Win32.Build.0 = Release|Win32
+ 		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.Release|x64.ActiveCfg = Release|x64
+ 		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.Release|x64.Build.0 = Release|x64
++		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{EABA0FF3-1C4D-4FAB-8418-31C9061F3F0D}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.Debug|Win32.Build.0 = Debug|Win32
+ 		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.Debug|x64.ActiveCfg = Debug|x64
+ 		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.Debug|x64.Build.0 = Debug|x64
++		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.Release|Win32.ActiveCfg = Release|Win32
+ 		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.Release|Win32.Build.0 = Release|Win32
+ 		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.Release|x64.ActiveCfg = Release|x64
+ 		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.Release|x64.Build.0 = Release|x64
++		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{19470DE6-1975-4F9B-B1BE-E87A83240B15}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{72894398-38CA-47A6-95FE-9647DE2BE968}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{72894398-38CA-47A6-95FE-9647DE2BE968}.Debug|Win32.Build.0 = Debug|Win32
+ 		{72894398-38CA-47A6-95FE-9647DE2BE968}.Debug|x64.ActiveCfg = Debug|x64
+ 		{72894398-38CA-47A6-95FE-9647DE2BE968}.Debug|x64.Build.0 = Debug|x64
++		{72894398-38CA-47A6-95FE-9647DE2BE968}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{72894398-38CA-47A6-95FE-9647DE2BE968}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{72894398-38CA-47A6-95FE-9647DE2BE968}.Release|Win32.ActiveCfg = Release|Win32
+ 		{72894398-38CA-47A6-95FE-9647DE2BE968}.Release|Win32.Build.0 = Release|Win32
+ 		{72894398-38CA-47A6-95FE-9647DE2BE968}.Release|x64.ActiveCfg = Release|x64
+ 		{72894398-38CA-47A6-95FE-9647DE2BE968}.Release|x64.Build.0 = Release|x64
++		{72894398-38CA-47A6-95FE-9647DE2BE968}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{72894398-38CA-47A6-95FE-9647DE2BE968}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.Debug|Win32.Build.0 = Debug|Win32
+ 		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.Debug|x64.ActiveCfg = Debug|x64
+ 		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.Debug|x64.Build.0 = Debug|x64
++		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.Release|Win32.ActiveCfg = Release|Win32
+ 		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.Release|Win32.Build.0 = Release|Win32
+ 		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.Release|x64.ActiveCfg = Release|x64
+ 		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.Release|x64.Build.0 = Release|x64
++		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{DFFA2117-E6A8-4806-BB69-94DAC8F8F42A}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.Debug|Win32.Build.0 = Debug|Win32
+ 		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.Debug|x64.ActiveCfg = Debug|x64
+ 		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.Debug|x64.Build.0 = Debug|x64
++		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.Release|Win32.ActiveCfg = Release|Win32
+ 		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.Release|Win32.Build.0 = Release|Win32
+ 		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.Release|x64.ActiveCfg = Release|x64
+ 		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.Release|x64.Build.0 = Release|x64
++		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{DEE75AD5-F165-40E1-80B2-400E27725D5C}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{4BCC693D-1745-45ED-8302-E5E2F979549A}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{4BCC693D-1745-45ED-8302-E5E2F979549A}.Debug|Win32.Build.0 = Debug|Win32
+ 		{4BCC693D-1745-45ED-8302-E5E2F979549A}.Debug|x64.ActiveCfg = Debug|x64
+ 		{4BCC693D-1745-45ED-8302-E5E2F979549A}.Debug|x64.Build.0 = Debug|x64
++		{4BCC693D-1745-45ED-8302-E5E2F979549A}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{4BCC693D-1745-45ED-8302-E5E2F979549A}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{4BCC693D-1745-45ED-8302-E5E2F979549A}.Release|Win32.ActiveCfg = Release|Win32
+ 		{4BCC693D-1745-45ED-8302-E5E2F979549A}.Release|Win32.Build.0 = Release|Win32
+ 		{4BCC693D-1745-45ED-8302-E5E2F979549A}.Release|x64.ActiveCfg = Release|x64
+ 		{4BCC693D-1745-45ED-8302-E5E2F979549A}.Release|x64.Build.0 = Release|x64
++		{4BCC693D-1745-45ED-8302-E5E2F979549A}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{4BCC693D-1745-45ED-8302-E5E2F979549A}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.Debug|Win32.Build.0 = Debug|Win32
+ 		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.Debug|x64.ActiveCfg = Debug|x64
+ 		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.Debug|x64.Build.0 = Debug|x64
++		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.Release|Win32.ActiveCfg = Release|Win32
+ 		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.Release|Win32.Build.0 = Release|Win32
+ 		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.Release|x64.ActiveCfg = Release|x64
+ 		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.Release|x64.Build.0 = Release|x64
++		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{01A41DFA-8908-4576-A1F1-C8BC7EAE39A1}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{C6A31374-178C-4680-A404-76BE24D0229B}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{C6A31374-178C-4680-A404-76BE24D0229B}.Debug|Win32.Build.0 = Debug|Win32
+ 		{C6A31374-178C-4680-A404-76BE24D0229B}.Debug|x64.ActiveCfg = Debug|x64
+ 		{C6A31374-178C-4680-A404-76BE24D0229B}.Debug|x64.Build.0 = Debug|x64
++		{C6A31374-178C-4680-A404-76BE24D0229B}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{C6A31374-178C-4680-A404-76BE24D0229B}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{C6A31374-178C-4680-A404-76BE24D0229B}.Release|Win32.ActiveCfg = Release|Win32
+ 		{C6A31374-178C-4680-A404-76BE24D0229B}.Release|Win32.Build.0 = Release|Win32
+ 		{C6A31374-178C-4680-A404-76BE24D0229B}.Release|x64.ActiveCfg = Release|x64
+ 		{C6A31374-178C-4680-A404-76BE24D0229B}.Release|x64.Build.0 = Release|x64
++		{C6A31374-178C-4680-A404-76BE24D0229B}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{C6A31374-178C-4680-A404-76BE24D0229B}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{FAF9AD25-8238-49E9-9AC9-8C56E190440A}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{FAF9AD25-8238-49E9-9AC9-8C56E190440A}.Debug|Win32.Build.0 = Debug|Win32
+ 		{FAF9AD25-8238-49E9-9AC9-8C56E190440A}.Debug|x64.ActiveCfg = Debug|Win32
++		{FAF9AD25-8238-49E9-9AC9-8C56E190440A}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{FAF9AD25-8238-49E9-9AC9-8C56E190440A}.DebugStatic|x64.ActiveCfg = Debug|Win32
+ 		{FAF9AD25-8238-49E9-9AC9-8C56E190440A}.Release|Win32.ActiveCfg = Release|Win32
+ 		{FAF9AD25-8238-49E9-9AC9-8C56E190440A}.Release|Win32.Build.0 = Release|Win32
+ 		{FAF9AD25-8238-49E9-9AC9-8C56E190440A}.Release|x64.ActiveCfg = Release|Win32
++		{FAF9AD25-8238-49E9-9AC9-8C56E190440A}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{FAF9AD25-8238-49E9-9AC9-8C56E190440A}.ReleaseStatic|x64.ActiveCfg = Release|Win32
+ 		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.Debug|Win32.Build.0 = Debug|Win32
+ 		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.Debug|x64.ActiveCfg = Debug|x64
+ 		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.Debug|x64.Build.0 = Debug|x64
++		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.Release|Win32.ActiveCfg = Release|Win32
+ 		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.Release|Win32.Build.0 = Release|Win32
+ 		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.Release|x64.ActiveCfg = Release|x64
+ 		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.Release|x64.Build.0 = Release|x64
++		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{EFB07DBC-36E3-4C54-B941-3CDAFAACF47B}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.Debug|Win32.Build.0 = Debug|Win32
+ 		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.Debug|x64.ActiveCfg = Debug|x64
+ 		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.Debug|x64.Build.0 = Debug|x64
++		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.Release|Win32.ActiveCfg = Release|Win32
+ 		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.Release|Win32.Build.0 = Release|Win32
+ 		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.Release|x64.ActiveCfg = Release|x64
+ 		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.Release|x64.Build.0 = Release|x64
++		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{53F75437-15B8-4A5C-86BF-E238CC68FCBC}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{58C7E370-0EDD-4F5E-8617-3F5071170205}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{58C7E370-0EDD-4F5E-8617-3F5071170205}.Debug|Win32.Build.0 = Debug|Win32
+ 		{58C7E370-0EDD-4F5E-8617-3F5071170205}.Debug|x64.ActiveCfg = Debug|x64
+ 		{58C7E370-0EDD-4F5E-8617-3F5071170205}.Debug|x64.Build.0 = Debug|x64
++		{58C7E370-0EDD-4F5E-8617-3F5071170205}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{58C7E370-0EDD-4F5E-8617-3F5071170205}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{58C7E370-0EDD-4F5E-8617-3F5071170205}.Release|Win32.ActiveCfg = Release|Win32
+ 		{58C7E370-0EDD-4F5E-8617-3F5071170205}.Release|Win32.Build.0 = Release|Win32
+ 		{58C7E370-0EDD-4F5E-8617-3F5071170205}.Release|x64.ActiveCfg = Release|x64
+ 		{58C7E370-0EDD-4F5E-8617-3F5071170205}.Release|x64.Build.0 = Release|x64
++		{58C7E370-0EDD-4F5E-8617-3F5071170205}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{58C7E370-0EDD-4F5E-8617-3F5071170205}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.Debug|Win32.Build.0 = Debug|Win32
+ 		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.Debug|x64.ActiveCfg = Debug|x64
+ 		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.Debug|x64.Build.0 = Debug|x64
++		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.Release|Win32.ActiveCfg = Release|Win32
+ 		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.Release|Win32.Build.0 = Release|Win32
+ 		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.Release|x64.ActiveCfg = Release|x64
+ 		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.Release|x64.Build.0 = Release|x64
++		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{20DEBF08-EF0A-4C94-ADEB-FE9BBA14588B}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{2925B855-5975-44AE-BB00-1217A2A4E511}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{2925B855-5975-44AE-BB00-1217A2A4E511}.Debug|Win32.Build.0 = Debug|Win32
+ 		{2925B855-5975-44AE-BB00-1217A2A4E511}.Debug|x64.ActiveCfg = Debug|x64
+ 		{2925B855-5975-44AE-BB00-1217A2A4E511}.Debug|x64.Build.0 = Debug|x64
++		{2925B855-5975-44AE-BB00-1217A2A4E511}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{2925B855-5975-44AE-BB00-1217A2A4E511}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{2925B855-5975-44AE-BB00-1217A2A4E511}.Release|Win32.ActiveCfg = Release|Win32
+ 		{2925B855-5975-44AE-BB00-1217A2A4E511}.Release|Win32.Build.0 = Release|Win32
+ 		{2925B855-5975-44AE-BB00-1217A2A4E511}.Release|x64.ActiveCfg = Release|x64
+ 		{2925B855-5975-44AE-BB00-1217A2A4E511}.Release|x64.Build.0 = Release|x64
++		{2925B855-5975-44AE-BB00-1217A2A4E511}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{2925B855-5975-44AE-BB00-1217A2A4E511}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{4FE03933-98CD-4879-A135-FD9430087A6B}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{4FE03933-98CD-4879-A135-FD9430087A6B}.Debug|Win32.Build.0 = Debug|Win32
+ 		{4FE03933-98CD-4879-A135-FD9430087A6B}.Debug|x64.ActiveCfg = Debug|x64
+ 		{4FE03933-98CD-4879-A135-FD9430087A6B}.Debug|x64.Build.0 = Debug|x64
++		{4FE03933-98CD-4879-A135-FD9430087A6B}.DebugStatic|Win32.ActiveCfg = DebugStatic|Win32
++		{4FE03933-98CD-4879-A135-FD9430087A6B}.DebugStatic|Win32.Build.0 = DebugStatic|Win32
++		{4FE03933-98CD-4879-A135-FD9430087A6B}.DebugStatic|x64.ActiveCfg = DebugStatic|x64
++		{4FE03933-98CD-4879-A135-FD9430087A6B}.DebugStatic|x64.Build.0 = DebugStatic|x64
+ 		{4FE03933-98CD-4879-A135-FD9430087A6B}.Release|Win32.ActiveCfg = Release|Win32
+ 		{4FE03933-98CD-4879-A135-FD9430087A6B}.Release|Win32.Build.0 = Release|Win32
+ 		{4FE03933-98CD-4879-A135-FD9430087A6B}.Release|x64.ActiveCfg = Release|x64
+ 		{4FE03933-98CD-4879-A135-FD9430087A6B}.Release|x64.Build.0 = Release|x64
++		{4FE03933-98CD-4879-A135-FD9430087A6B}.ReleaseStatic|Win32.ActiveCfg = ReleaseStatic|Win32
++		{4FE03933-98CD-4879-A135-FD9430087A6B}.ReleaseStatic|Win32.Build.0 = ReleaseStatic|Win32
++		{4FE03933-98CD-4879-A135-FD9430087A6B}.ReleaseStatic|x64.ActiveCfg = ReleaseStatic|x64
++		{4FE03933-98CD-4879-A135-FD9430087A6B}.ReleaseStatic|x64.Build.0 = ReleaseStatic|x64
+ 		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.Debug|Win32.Build.0 = Debug|Win32
+ 		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.Debug|x64.ActiveCfg = Debug|x64
+ 		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.Debug|x64.Build.0 = Debug|x64
++		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.Release|Win32.ActiveCfg = Release|Win32
+ 		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.Release|Win32.Build.0 = Release|Win32
+ 		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.Release|x64.ActiveCfg = Release|x64
+ 		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.Release|x64.Build.0 = Release|x64
++		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{D836FBF5-071E-4E04-8D63-C7EB6701B296}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.Debug|Win32.Build.0 = Debug|Win32
+ 		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.Debug|x64.ActiveCfg = Debug|x64
+ 		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.Debug|x64.Build.0 = Debug|x64
++		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.Release|Win32.ActiveCfg = Release|Win32
+ 		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.Release|Win32.Build.0 = Release|Win32
+ 		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.Release|x64.ActiveCfg = Release|x64
+ 		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.Release|x64.Build.0 = Release|x64
++		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{BD00D28E-6667-414E-A4B1-6BEFC07ADB42}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{062BD3C7-2D01-44F6-8D79-070F688C559F}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{062BD3C7-2D01-44F6-8D79-070F688C559F}.Debug|Win32.Build.0 = Debug|Win32
+ 		{062BD3C7-2D01-44F6-8D79-070F688C559F}.Debug|x64.ActiveCfg = Debug|x64
+ 		{062BD3C7-2D01-44F6-8D79-070F688C559F}.Debug|x64.Build.0 = Debug|x64
++		{062BD3C7-2D01-44F6-8D79-070F688C559F}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{062BD3C7-2D01-44F6-8D79-070F688C559F}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{062BD3C7-2D01-44F6-8D79-070F688C559F}.Release|Win32.ActiveCfg = Release|Win32
+ 		{062BD3C7-2D01-44F6-8D79-070F688C559F}.Release|Win32.Build.0 = Release|Win32
+ 		{062BD3C7-2D01-44F6-8D79-070F688C559F}.Release|x64.ActiveCfg = Release|x64
+ 		{062BD3C7-2D01-44F6-8D79-070F688C559F}.Release|x64.Build.0 = Release|x64
++		{062BD3C7-2D01-44F6-8D79-070F688C559F}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{062BD3C7-2D01-44F6-8D79-070F688C559F}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.Debug|Win32.Build.0 = Debug|Win32
+ 		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.Debug|x64.ActiveCfg = Debug|x64
+ 		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.Debug|x64.Build.0 = Debug|x64
++		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.Release|Win32.ActiveCfg = Release|Win32
+ 		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.Release|Win32.Build.0 = Release|Win32
+ 		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.Release|x64.ActiveCfg = Release|x64
+ 		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.Release|x64.Build.0 = Release|x64
++		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{6794EB8C-6425-422D-A3B0-14EED54C0E98}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.Debug|Win32.Build.0 = Debug|Win32
+ 		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.Debug|x64.ActiveCfg = Debug|x64
+ 		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.Debug|x64.Build.0 = Debug|x64
++		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.Release|Win32.ActiveCfg = Release|Win32
+ 		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.Release|Win32.Build.0 = Release|Win32
+ 		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.Release|x64.ActiveCfg = Release|x64
+ 		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.Release|x64.Build.0 = Release|x64
++		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{F2E1A852-5A4B-4162-9DA8-0363805FCFD0}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{B32D1B09-8161-451E-8D20-D30F26094EC0}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{B32D1B09-8161-451E-8D20-D30F26094EC0}.Debug|Win32.Build.0 = Debug|Win32
+ 		{B32D1B09-8161-451E-8D20-D30F26094EC0}.Debug|x64.ActiveCfg = Debug|x64
+ 		{B32D1B09-8161-451E-8D20-D30F26094EC0}.Debug|x64.Build.0 = Debug|x64
++		{B32D1B09-8161-451E-8D20-D30F26094EC0}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{B32D1B09-8161-451E-8D20-D30F26094EC0}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{B32D1B09-8161-451E-8D20-D30F26094EC0}.Release|Win32.ActiveCfg = Release|Win32
+ 		{B32D1B09-8161-451E-8D20-D30F26094EC0}.Release|Win32.Build.0 = Release|Win32
+ 		{B32D1B09-8161-451E-8D20-D30F26094EC0}.Release|x64.ActiveCfg = Release|x64
+ 		{B32D1B09-8161-451E-8D20-D30F26094EC0}.Release|x64.Build.0 = Release|x64
++		{B32D1B09-8161-451E-8D20-D30F26094EC0}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{B32D1B09-8161-451E-8D20-D30F26094EC0}.ReleaseStatic|x64.ActiveCfg = Release|x64
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Debug|Win32.ActiveCfg = Debug|Win32
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Debug|Win32.Build.0 = Debug|Win32
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Debug|x64.ActiveCfg = Debug|x64
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Debug|x64.Build.0 = Debug|x64
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.DebugStatic|x64.ActiveCfg = Debug|x64
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Release|Win32.ActiveCfg = Release|Win32
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Release|Win32.Build.0 = Release|Win32
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Release|x64.ActiveCfg = Release|x64
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Release|x64.Build.0 = Release|x64
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{035D26F9-B406-4D60-A8B7-172098479254}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{035D26F9-B406-4D60-A8B7-172098479254}.Debug|Win32.Build.0 = Debug|Win32
+ 		{035D26F9-B406-4D60-A8B7-172098479254}.Debug|x64.ActiveCfg = Debug|x64
+ 		{035D26F9-B406-4D60-A8B7-172098479254}.Debug|x64.Build.0 = Debug|x64
++		{035D26F9-B406-4D60-A8B7-172098479254}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{035D26F9-B406-4D60-A8B7-172098479254}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{035D26F9-B406-4D60-A8B7-172098479254}.Release|Win32.ActiveCfg = Release|Win32
+ 		{035D26F9-B406-4D60-A8B7-172098479254}.Release|Win32.Build.0 = Release|Win32
+ 		{035D26F9-B406-4D60-A8B7-172098479254}.Release|x64.ActiveCfg = Release|x64
+ 		{035D26F9-B406-4D60-A8B7-172098479254}.Release|x64.Build.0 = Release|x64
++		{035D26F9-B406-4D60-A8B7-172098479254}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{035D26F9-B406-4D60-A8B7-172098479254}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.Debug|Win32.Build.0 = Debug|Win32
+ 		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.Debug|x64.ActiveCfg = Debug|x64
+ 		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.Debug|x64.Build.0 = Debug|x64
++		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.DebugStatic|Win32.ActiveCfg = Debug|Win32
++		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.DebugStatic|x64.ActiveCfg = Debug|x64
+ 		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.Release|Win32.ActiveCfg = Release|Win32
+ 		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.Release|Win32.Build.0 = Release|Win32
+ 		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.Release|x64.ActiveCfg = Release|x64
+ 		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.Release|x64.Build.0 = Release|x64
+-		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Debug|Win32.ActiveCfg = Debug|Win32
+-		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Debug|Win32.Build.0 = Debug|Win32
+-		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Debug|x64.ActiveCfg = Debug|x64
+-		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Debug|x64.Build.0 = Debug|x64
+-		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Release|Win32.ActiveCfg = Release|Win32
+-		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Release|Win32.Build.0 = Release|Win32
+-		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Release|x64.ActiveCfg = Release|x64
+-		{9821F2C0-4EC1-4ACB-BF32-DEB4C21032DE}.Release|x64.Build.0 = Release|x64
++		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.ReleaseStatic|Win32.ActiveCfg = Release|Win32
++		{3314D6AD-554F-4AE1-B297-6D2D6207DD7C}.ReleaseStatic|x64.ActiveCfg = Release|x64
+ 	EndGlobalSection
+ 	GlobalSection(SolutionProperties) = preSolution
+ 		HideSolutionNode = FALSE
+diff --git a/builds/win32/msvc15/common.vcxproj b/builds/win32/msvc15/common.vcxproj
+index 3d3a267fdf..aad9fba5c6 100644
+--- a/builds/win32/msvc15/common.vcxproj
++++ b/builds/win32/msvc15/common.vcxproj
+@@ -5,18 +5,34 @@
+       <Configuration>Debug</Configuration>
+       <Platform>Win32</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="DebugStatic|Win32">
++      <Configuration>DebugStatic</Configuration>
++      <Platform>Win32</Platform>
++    </ProjectConfiguration>
+     <ProjectConfiguration Include="Debug|x64">
+       <Configuration>Debug</Configuration>
+       <Platform>x64</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="DebugStatic|x64">
++      <Configuration>DebugStatic</Configuration>
++      <Platform>x64</Platform>
++    </ProjectConfiguration>
+     <ProjectConfiguration Include="Release|Win32">
+       <Configuration>Release</Configuration>
+       <Platform>Win32</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="ReleaseStatic|Win32">
++      <Configuration>ReleaseStatic</Configuration>
++      <Platform>Win32</Platform>
++    </ProjectConfiguration>
+     <ProjectConfiguration Include="Release|x64">
+       <Configuration>Release</Configuration>
+       <Platform>x64</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="ReleaseStatic|x64">
++      <Configuration>ReleaseStatic</Configuration>
++      <Platform>x64</Platform>
++    </ProjectConfiguration>
+   </ItemGroup>
+   <ItemGroup>
+     <ClCompile Include="..\..\..\src\common\Auth.cpp" />
+@@ -241,6 +257,14 @@
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0'">v141</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>StaticLibrary</ConfigurationType>
+     <UseOfMfc>false</UseOfMfc>
+@@ -249,6 +273,14 @@
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0'">v141</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>StaticLibrary</ConfigurationType>
+     <UseOfMfc>false</UseOfMfc>
+@@ -257,6 +289,14 @@
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0'">v141</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>StaticLibrary</ConfigurationType>
+     <UseOfMfc>false</UseOfMfc>
+@@ -265,6 +305,14 @@
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0'">v141</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
++  </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+   </ImportGroup>
+@@ -274,39 +322,75 @@
+     <Import Project="FirebirdCommon.props" />
+     <Import Project="FirebirdDebug.props" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
++    <Import Project="FirebirdCommon.props" />
++    <Import Project="FirebirdDebug.props" />
++  </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+     <Import Project="FirebirdCommon.props" />
+     <Import Project="FirebirdRelease.props" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
++    <Import Project="FirebirdCommon.props" />
++    <Import Project="FirebirdRelease.props" />
++  </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+     <Import Project="FirebirdCommon.props" />
+     <Import Project="FirebirdDebug.props" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
++    <Import Project="FirebirdCommon.props" />
++    <Import Project="FirebirdDebug.props" />
++  </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+     <Import Project="FirebirdCommon.props" />
+     <Import Project="FirebirdRelease.props" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
++    <Import Project="FirebirdCommon.props" />
++    <Import Project="FirebirdRelease.props" />
++  </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
++    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
++    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'" />
++    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'" />
+     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
+     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
++    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
++    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'" />
++    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'" />
+     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
++    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
++    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'" />
++    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'" />
+     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
+     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
++    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
++    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'" />
++    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'" />
+   </PropertyGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+     <ClCompile>
+@@ -353,6 +437,51 @@
+       <AdditionalDependencies>ws2_32.lib;../../../extern/libtommath/lib/$(PlatformName)\$(Configuration)\tommath.lib;../../../extern/libtomcrypt/lib/$(PlatformName)\$(Configuration)\tomcrypt.lib;../../../extern/decNumber/lib/$(PlatformName)\$(Configuration)\decnumber.lib;../../../extern/ttmath\$(Configuration)\ttmathuint_x86_64_msvc.obj;%(AdditionalDependencies)</AdditionalDependencies>
+     </Lib>
+   </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'">
++    <ClCompile>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;SUPERSERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++    </ClCompile>
++    <Lib>
++      <AdditionalDependencies>ws2_32.lib;../../../extern/libtommath/lib/$(PlatformName)\Release\tommath.lib;../../../extern/libtomcrypt/lib/$(PlatformName)\Release\tomcrypt.lib;../../../extern/decNumber/lib/$(PlatformName)\Release\decnumber.lib;%(AdditionalDependencies)</AdditionalDependencies>
++    </Lib>
++  </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'">
++    <ClCompile>
++      <Optimization>Disabled</Optimization>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;DEV_BUILD;SUPERSERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
++    </ClCompile>
++    <Lib>
++      <AdditionalDependencies>ws2_32.lib;../../../extern/libtommath/lib/$(PlatformName)\Debug\tommath.lib;../../../extern/libtomcrypt/lib/$(PlatformName)\Debug\tomcrypt.lib;../../../extern/decNumber/lib/$(PlatformName)\Debug\decnumber.lib;%(AdditionalDependencies)</AdditionalDependencies>
++    </Lib>
++  </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">
++    <Midl>
++      <TargetEnvironment>X64</TargetEnvironment>
++    </Midl>
++    <ClCompile>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;SUPERSERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++    </ClCompile>
++    <Lib>
++      <AdditionalDependencies>ws2_32.lib;../../../extern/decNumber/lib/$(PlatformName)\Release\decnumber.lib;../../../extern/ttmath\Release\ttmathuint_x86_64_msvc.obj;%(AdditionalDependencies)</AdditionalDependencies>
++    </Lib>
++  </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'">
++    <Midl>
++      <TargetEnvironment>X64</TargetEnvironment>
++    </Midl>
++    <ClCompile>
++      <Optimization>Disabled</Optimization>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;DEV_BUILD;SUPERSERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++    </ClCompile>
++    <Lib>
++      <AdditionalDependencies>ws2_32.lib;../../../extern/decNumber/lib/$(PlatformName)\Debug\decnumber.lib;../../../extern/ttmath\Debug\ttmathuint_x86_64_msvc.obj;%(AdditionalDependencies)</AdditionalDependencies>
++    </Lib>
++  </ItemDefinitionGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+   <ImportGroup Label="ExtensionTargets">
+   </ImportGroup>
+diff --git a/builds/win32/msvc15/yvalve.vcxproj b/builds/win32/msvc15/yvalve.vcxproj
+index 5772b98011..86616a4dc3 100644
+--- a/builds/win32/msvc15/yvalve.vcxproj
++++ b/builds/win32/msvc15/yvalve.vcxproj
+@@ -5,23 +5,38 @@
+       <Configuration>Debug</Configuration>
+       <Platform>Win32</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="DebugStatic|Win32">
++      <Configuration>DebugStatic</Configuration>
++      <Platform>Win32</Platform>
++    </ProjectConfiguration>
+     <ProjectConfiguration Include="Debug|x64">
+       <Configuration>Debug</Configuration>
+       <Platform>x64</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="DebugStatic|x64">
++      <Configuration>DebugStatic</Configuration>
++      <Platform>x64</Platform>
++    </ProjectConfiguration>
+     <ProjectConfiguration Include="Release|Win32">
+       <Configuration>Release</Configuration>
+       <Platform>Win32</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="ReleaseStatic|Win32">
++      <Configuration>ReleaseStatic</Configuration>
++      <Platform>Win32</Platform>
++    </ProjectConfiguration>
+     <ProjectConfiguration Include="Release|x64">
+       <Configuration>Release</Configuration>
+       <Platform>x64</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="ReleaseStatic|x64">
++      <Configuration>ReleaseStatic</Configuration>
++      <Platform>x64</Platform>
++    </ProjectConfiguration>
+   </ItemGroup>
+   <ItemGroup>
+     <ClCompile Include="..\..\..\src\auth\SecureRemotePassword\client\SrpClient.cpp" />
+     <ClCompile Include="..\..\..\src\auth\SecurityDatabase\LegacyClient.cpp" />
+-    <ClCompile Include="..\..\..\src\jrd\os\win32\ibinitdll.cpp" />
+     <ClCompile Include="..\..\..\src\plugins\crypt\arc4\Arc4.cpp" />
+     <ClCompile Include="..\..\..\src\remote\client\BlrFromMessage.cpp" />
+     <ClCompile Include="..\..\..\src\remote\client\interface.cpp" />
+@@ -39,6 +54,10 @@
+     <ClCompile Include="..\..\..\src\yvalve\user_dsql.cpp" />
+     <ClCompile Include="..\..\..\src\yvalve\utl.cpp" />
+     <ClCompile Include="..\..\..\src\yvalve\why.cpp" />
++    <ClCompile Include="..\..\..\src\jrd\os\win32\ibinitdll.cpp">
++      <ExcludedFromBuild Condition="'$(Configuration)'=='DebugStatic'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)'=='ReleaseStatic'">true</ExcludedFromBuild>
++    </ClCompile>
+   </ItemGroup>
+   <ItemGroup>
+     <ClInclude Include="..\..\..\src\auth\SecureRemotePassword\client\SrpClient.h" />
+@@ -78,7 +97,10 @@
+     </ProjectReference>
+   </ItemGroup>
+   <ItemGroup>
+-    <ResourceCompile Include="..\..\..\src\jrd\version.rc" />
++    <ResourceCompile Include="..\..\..\src\jrd\version.rc">
++      <ExcludedFromBuild Condition="'$(Configuration)'=='DebugStatic'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)'=='ReleaseStatic'">true</ExcludedFromBuild>
++    </ResourceCompile>
+   </ItemGroup>
+   <ItemGroup>
+     <None Include="..\defs\firebird.def" />
+@@ -99,6 +121,14 @@
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0'">v141</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+     <UseOfMfc>false</UseOfMfc>
+@@ -107,6 +137,14 @@
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0'">v141</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+     <UseOfMfc>false</UseOfMfc>
+@@ -115,6 +153,14 @@
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0'">v141</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+     <UseOfMfc>false</UseOfMfc>
+@@ -123,6 +169,14 @@
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0'">v141</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='16.0'">v142</PlatformToolset>
++    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17.0'">v143</PlatformToolset>
++  </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+   </ImportGroup>
+@@ -132,43 +186,83 @@
+     <Import Project="FirebirdCommon.props" />
+     <Import Project="FirebirdDebug.props" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
++    <Import Project="FirebirdCommon.props" />
++    <Import Project="FirebirdDebug.props" />
++  </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+     <Import Project="FirebirdCommon.props" />
+     <Import Project="FirebirdRelease.props" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
++    <Import Project="FirebirdCommon.props" />
++    <Import Project="FirebirdRelease.props" />
++  </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+     <Import Project="FirebirdCommon.props" />
+     <Import Project="FirebirdDebug.props" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
++    <Import Project="FirebirdCommon.props" />
++    <Import Project="FirebirdDebug.props" />
++  </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+     <Import Project="FirebirdCommon.props" />
+     <Import Project="FirebirdRelease.props" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
++    <Import Project="FirebirdCommon.props" />
++    <Import Project="FirebirdRelease.props" />
++  </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
++    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
++    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'" />
++    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'" />
+     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
+     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
++    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
++    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'" />
++    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'" />
+     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
++    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
++    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'" />
++    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'" />
+     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
+     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
++    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
++    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'" />
++    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'" />
+     <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">fbclient</TargetName>
++    <TargetName Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'">fbclient_static</TargetName>
+     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">fbclient</TargetName>
++    <TargetName Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'">fbclient_static</TargetName>
+     <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">fbclient</TargetName>
++    <TargetName Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'">fbclient_static</TargetName>
+     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">fbclient</TargetName>
++    <TargetName Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">fbclient_static</TargetName>
+     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\..\temp\$(PlatformName)\$(Configuration)\firebird\</OutDir>
+     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\..\temp\$(PlatformName)\$(Configuration)\firebird\</OutDir>
+     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\..\..\temp\$(PlatformName)\$(Configuration)\firebird\</OutDir>
+@@ -228,7 +322,40 @@
+       <SubSystem>Windows</SubSystem>
+     </Link>
+   </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|Win32'">
++    <ClCompile>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;SUPERSERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++    </ClCompile>
++  </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|Win32'">
++    <ClCompile>
++      <Optimization>Disabled</Optimization>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;DEV_BUILD;SUPERSERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
++    </ClCompile>
++  </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">
++    <Midl>
++      <TargetEnvironment>X64</TargetEnvironment>
++    </Midl>
++    <ClCompile>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;SUPERSERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++    </ClCompile>
++  </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugStatic|x64'">
++    <Midl>
++      <TargetEnvironment>X64</TargetEnvironment>
++    </Midl>
++    <ClCompile>
++      <Optimization>Disabled</Optimization>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;DEV_BUILD;SUPERSERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++    </ClCompile>
++  </ItemDefinitionGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+   <ImportGroup Label="ExtensionTargets">
+   </ImportGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/builds/win32/msvc15/yvalve.vcxproj.filters b/builds/win32/msvc15/yvalve.vcxproj.filters
+index 09ca441a43..75a6132836 100644
+--- a/builds/win32/msvc15/yvalve.vcxproj.filters
++++ b/builds/win32/msvc15/yvalve.vcxproj.filters
+@@ -1,15 +1,15 @@
+ ﻿<?xml version="1.0" encoding="utf-8"?>
+ <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+   <ItemGroup>
+-    <Filter Include="headers">
+-      <UniqueIdentifier>{e851796a-334f-465a-87d4-3a8493cde72c}</UniqueIdentifier>
+-    </Filter>
+     <Filter Include="source">
+       <UniqueIdentifier>{c8501fd3-5859-4685-baad-969e1b6e2e1c}</UniqueIdentifier>
+     </Filter>
+     <Filter Include="Resource files">
+       <UniqueIdentifier>{a06a0231-22bb-432f-95c2-ee97b9a1cee8}</UniqueIdentifier>
+     </Filter>
++    <Filter Include="headers">
++      <UniqueIdentifier>{e851796a-334f-465a-87d4-3a8493cde72c}</UniqueIdentifier>
++    </Filter>
+     <Filter Include="GPRE files">
+       <UniqueIdentifier>{754afcc7-5b6d-4620-abe9-78b4653e08b0}</UniqueIdentifier>
+     </Filter>
+@@ -60,9 +60,6 @@
+     <ClCompile Include="..\..\..\src\auth\SecurityDatabase\LegacyClient.cpp">
+       <Filter>Auth</Filter>
+     </ClCompile>
+-    <ClCompile Include="..\..\..\src\jrd\os\win32\ibinitdll.cpp">
+-      <Filter>source</Filter>
+-    </ClCompile>
+     <ClCompile Include="..\..\..\src\remote\client\interface.cpp">
+       <Filter>Remote client</Filter>
+     </ClCompile>
+@@ -84,6 +81,17 @@
+     <ClCompile Include="..\..\..\src\yvalve\config\os\win32\config_root.cpp">
+       <Filter>source</Filter>
+     </ClCompile>
++    <ClCompile Include="..\..\..\src\jrd\os\win32\ibinitdll.cpp">
++      <Filter>source</Filter>
++    </ClCompile>
++  </ItemGroup>
++  <ItemGroup>
++    <ResourceCompile Include="..\..\..\src\jrd\version.rc">
++      <Filter>Resource files</Filter>
++    </ResourceCompile>
++  </ItemGroup>
++  <ItemGroup>
++    <None Include="..\defs\firebird.def" />
+   </ItemGroup>
+   <ItemGroup>
+     <ClInclude Include="..\..\..\src\yvalve\why_proto.h">
+@@ -138,12 +146,4 @@
+       <Filter>headers</Filter>
+     </ClInclude>
+   </ItemGroup>
+-  <ItemGroup>
+-    <ResourceCompile Include="..\..\..\src\jrd\version.rc">
+-      <Filter>Resource files</Filter>
+-    </ResourceCompile>
+-  </ItemGroup>
+-  <ItemGroup>
+-    <None Include="..\defs\firebird.def" />
+-  </ItemGroup>
+ </Project>
+diff --git a/builds/win32/setenvvar.bat b/builds/win32/setenvvar.bat
+index 332f67ad1b..6167c0336e 100644
+--- a/builds/win32/setenvvar.bat
++++ b/builds/win32/setenvvar.bat
+@@ -17,6 +17,7 @@ for %%v in ( %* )  do (
+   ( if /I "%%v"=="RELEASE" ( (set FB_DBG=) && (set FB_CONFIG=release) ) )
+   ( if /I "%%v"=="CLIENT_ONLY" (set FB_CLIENT_ONLY=TRUE) )
+   ( if /I "%%v"=="CLIENT_ONLY=FALSE" (set FB_CLIENT_ONLY=) )
++  ( if /I "%%v"=="ENABLE_FBCLIENT_STATIC" (set FB_ENABLE_FBCLIENT_STATIC=TRUE) )
+ )
+ 
+ @if not defined FB_CONFIG (
+@@ -123,10 +124,10 @@ rem NOTE 2 This code is likely to break again in the future !!!!
+   @setlocal EnableDelayedExpansion
+ 
+   if not exist "!VCToolsRedistDir!!VSCMD_ARG_TGT_ARCH!\Microsoft.VC!MSVC_RUNTIME_MAJOR_VERSION!!MSVC_RUNTIME_MINOR_VERSION!.CRT" (
+-    @endlocal  
++    @endlocal
+     set MSVC_RUNTIME_MINOR_VERSION=3
+   ) else (
+-    @endlocal  
++    @endlocal
+   )
+   set MSVC_RUNTIME_LIBRARY_VERSION=%MSVC_RUNTIME_MAJOR_VERSION%%MSVC_RUNTIME_MINOR_VERSION%
+ 
+@@ -160,6 +161,17 @@ rem NOTE 2 This code is likely to break again in the future !!!!
+ @set FIREBIRD_BOOT_BUILD=1
+ 
+ @set FB_OBJ_DIR=%FB_TARGET_PLATFORM%\%FB_CONFIG%
++@if /I "%FB_ENABLE_FBCLIENT_STATIC%"=="TRUE" (
++  @if /I "%FB_DBG%"=="TRUE" (
++    @set FB_STATIC_CONFIG=DebugStatic
++  ) else (
++    @set FB_STATIC_CONFIG=ReleaseStatic
++  )
++  @set FB_STATIC_OBJ_DIR=%FB_TARGET_PLATFORM%\%FB_STATIC_CONFIG%
++) else (
++  @set FB_STATIC_CONFIG=
++  @set FB_STATIC_OBJ_DIR=
++)
+ @set FB_BIN_DIR=%FB_ROOT_PATH%\temp\%FB_OBJ_DIR%\firebird
+ 
+ 
+@@ -195,6 +207,9 @@ goto :END
+ @echo    vs_ver=%VS_VER%
+ @echo    FB_VSCOMNTOOLS=%FB_VSCOMNTOOLS%
+ @echo    platform=%FB_TARGET_PLATFORM%
++@if /I "%FB_ENABLE_FBCLIENT_STATIC%"=="TRUE" (
++  @echo    fbclient_static_config=%FB_STATIC_CONFIG%
++)
+ @echo    msvc_version=%MSVC_VERSION%
+ @echo    db_path=%FB_DB_PATH%
+ @echo    root_path=%FB_ROOT_PATH%

--- a/ports/firebird/windows-timeout.patch
+++ b/ports/firebird/windows-timeout.patch
@@ -1,0 +1,13 @@
+diff --git a/builds/win32/make_all.bat b/builds/win32/make_all.bat
+index ddea45b1c3..04f3271c55 100644
+--- a/builds/win32/make_all.bat
++++ b/builds/win32/make_all.bat
+@@ -36,7 +36,7 @@ if errorlevel 1 call :ERROR build failed - see make_all_%FB_TARGET_PLATFORM%.log
+ @rmdir /S /Q "%FB_OUTPUT_DIR%" 2>nul
+ 
+ :: short delay to let OS complete actions by rmdir above
+-@timeout 1 >nul
++@%SystemRoot%\System32\timeout /t 1 /nobreak >nul
+ 
+ @mkdir %FB_OUTPUT_DIR% 2>nul
+ @mkdir %FB_OUTPUT_DIR%\tzdata 2>nul

--- a/ports/firebird/windows/portfile.cmake
+++ b/ports/firebird/windows/portfile.cmake
@@ -1,0 +1,122 @@
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(FB_ARCH_OUT "Win32")
+    set(FB_PROCESSOR_ARCHITECTURE "x86")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(FB_ARCH_OUT "x64")
+    set(FB_PROCESSOR_ARCHITECTURE "AMD64")
+endif()
+
+
+# Release build
+
+vcpkg_execute_build_process(
+    COMMAND ${CMAKE_COMMAND} -E env
+        "FB_PROCESSOR_ARCHITECTURE=${FB_PROCESSOR_ARCHITECTURE}"
+        run_all.bat
+        JUSTBUILD
+        RELEASE
+        CLIENT_ONLY
+        ENABLE_FBCLIENT_STATIC=TRUE
+    WORKING_DIRECTORY "${SOURCE_PATH}/builds/win32"
+    LOGNAME configure-${TARGET_TRIPLET}-rel
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH_OUT}_release/include"
+    DESTINATION "${CURRENT_PACKAGES_DIR}"
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(
+        INSTALL "${SOURCE_PATH}/output_${FB_ARCH_OUT}_release/lib/fbclient_ms.lib"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/lib"
+    )
+
+    file(
+        INSTALL "${SOURCE_PATH}/output_${FB_ARCH_OUT}_release/fbclient.dll"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/bin"
+    )
+
+    file(
+        INSTALL "${SOURCE_PATH}/temp/${FB_ARCH_OUT}/release/yvalve/fbclient.pdb"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/bin"
+    )
+
+    file(GLOB PLUGINS_FILES_RELEASE
+        "${SOURCE_PATH}/output_${FB_ARCH_OUT}_release/plugins/*"
+    )
+    file(
+        INSTALL ${PLUGINS_FILES_RELEASE}
+        DESTINATION "${CURRENT_PACKAGES_DIR}/plugins/${PORT}"
+    )
+else()
+    file(
+        INSTALL "${SOURCE_PATH}/output_${FB_ARCH_OUT}_release/lib/fbclient_static_ms.lib"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/lib"
+    )
+endif()
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH_OUT}_release/firebird.msg"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH_OUT}_release/tzdata"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+
+# Debug build
+
+vcpkg_execute_build_process(
+    COMMAND ${CMAKE_COMMAND} -E env
+        "FB_PROCESSOR_ARCHITECTURE=${FB_PROCESSOR_ARCHITECTURE}"
+        run_all.bat
+        JUSTBUILD
+        DEBUG
+        CLIENT_ONLY
+        ENABLE_FBCLIENT_STATIC=TRUE
+    WORKING_DIRECTORY "${SOURCE_PATH}/builds/win32"
+    LOGNAME configure-${TARGET_TRIPLET}-dbg
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(
+        INSTALL "${SOURCE_PATH}/output_${FB_ARCH_OUT}_debug/lib/fbclient_ms.lib"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib"
+    )
+
+    file(
+        INSTALL "${SOURCE_PATH}/output_${FB_ARCH_OUT}_debug/fbclient.dll"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
+
+    file(
+        INSTALL "${SOURCE_PATH}/temp/${FB_ARCH_OUT}/debug/yvalve/fbclient.pdb"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
+
+    file(GLOB PLUGINS_FILES_DEBUG
+        "${SOURCE_PATH}/output_${FB_ARCH_OUT}_debug/plugins/*"
+    )
+    file(
+        INSTALL ${PLUGINS_FILES_DEBUG}
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/plugins/${PORT}"
+    )
+else()
+    file(
+        INSTALL "${SOURCE_PATH}/output_${FB_ARCH_OUT}_debug/lib/fbclient_static_ms.lib"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib"
+    )
+endif()
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH_OUT}_debug/firebird.msg"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
+)
+
+file(
+    INSTALL "${SOURCE_PATH}/output_${FB_ARCH_OUT}_debug/tzdata"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}"
+)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2936,6 +2936,10 @@
       "baseline": "2023-07-31",
       "port-version": 0
     },
+    "firebird": {
+      "baseline": "5.0.3",
+      "port-version": 0
+    },
     "fixed-containers": {
       "baseline": "2024-09-19",
       "port-version": 0

--- a/versions/f-/firebird.json
+++ b/versions/f-/firebird.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4996a21a823739eec947cfc7d0675ad303e77387",
+      "version-semver": "5.0.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.