### PR TITLE
[libupnp] Add new port for libupnp (pupnp)

### DIFF
--- a/ports/libupnp/fix-pthreads4w-targets.patch
+++ b/ports/libupnp/fix-pthreads4w-targets.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 45c13c195d..7eb05f7277 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -226,6 +226,8 @@ if(NOT MSVC)
+ 	endif()
+ else()
+ 	find_package(PTHREADS4W CONFIG REQUIRED)
++	add_library(Threads::Shared ALIAS PThreads4W::PThreads4W)
++	add_library(Threads::Static ALIAS PThreads4W::PThreads4W)
+ endif()
+
+ #

--- a/ports/libupnp/usage
+++ b/ports/libupnp/usage
@@ -1,0 +1,18 @@
+libupnp provides pkg-config modules:
+
+  # Linux SDK for UPnP Devices
+  libupnp
+
+libupnp provides CMake targets:
+
+  find_package(UPNP CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE UPNP::Shared)
+  -- or --
+  target_link_libraries(main PRIVATE UPNP::Static)
+
+libixml provides CMake targets:
+
+  find_package(IXML CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE IXML::Shared)
+  -- or --
+  target_link_libraries(main PRIVATE IXML::Static)

--- a/ports/libupnp/vcpkg.json
+++ b/ports/libupnp/vcpkg.json
@@ -1,0 +1,37 @@
+{
+  "name": "libupnp",
+  "version": "1.14.25",
+  "description": "libupnp: Build UPnP-compliant control points, devices, and bridges on several operating systems.",
+  "homepage": "https://github.com/pupnp/pupnp/",
+  "documentation": "https://github.com/pupnp/pupnp/",
+  "license": "BSD-3-Clause",
+  "supports": "!uwp",
+  "dependencies": [
+    "pthreads",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "client-api": {
+      "description": "Enable control point code (client)"
+    },
+    "ipv6": {
+      "description": "Enable IPv6 support"
+    },
+    "ssl": {
+      "description": "OpenSSL support for encrypted connections",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "webserver": {
+      "description": "Enable integrated webserver"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5648,6 +5648,10 @@
       "baseline": "1.8.3",
       "port-version": 0
     },
+    "libupnp": {
+      "baseline": "1.14.25",
+      "port-version": 0
+    },
     "liburcu": {
       "baseline": "0.15.2",
       "port-version": 0

--- a/versions/l-/libupnp.json
+++ b/versions/l-/libupnp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "49cc2e5824590583f7277390e1e74512cfa56889",
+      "version": "1.14.25",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

New port for Intel's libupnp, a library to build UPnP-compliant control points, devices, and bridges on several operating systems.

The `ssl` feature will add a single API function, wrapped in an `#if UPNP_ENABLE_OPEN_SSL` block, and sets this define to 1 when enabled so applications can use it during compilation to enable/disable use of this function accordingly. If this is definitely not wanted (since the maintainer guide says this is generally prohibited), I can remove the `ssl` feature and add OpenSSL as a hard dependency.

All other build settings enabling additional API endpoints (e.g. in IXML) are forcibly enabled according to the maintainer guide. The features "device-api" and "client-api" enable support for internal APIs for _talking_ to UPnP devices and the internal webserver, not external libupnp C APIs.