### PR TITLE
[duckdb] update to 1.4.2

### DIFF
--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO duckdb/duckdb
         REF v${VERSION}
-        SHA512 4965071888bfd791ddc81ed9eb53cedcd0248b159e6db3492bf5d17557b0f7516aed0840408ff46a06e9a0989a42d7b2a7452fdaf619c8ca44de43e5d1c338b8
+        SHA512 28eabd8ee84c8b859c475f0fce5c4ee3df53143807fef2b0892caeb39abb006ff27c0c9549f1502ad4afa0aab715a5c751a592af86ce4ad1e3abb1a3b7c63c03
         HEAD_REF main
     PATCHES
         library-linkage.diff
@@ -41,8 +41,8 @@ if("httpfs" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH DUCKDB_HTTPFS_SOURCE_PATH
         REPO duckdb/duckdb_httpfs
-        REF 0989823e43554e8a00b31959a853e29ab9bd07f9
-        SHA512 71461d522aa5338df81931f937ed538b453b274d22e91ad7e0f1a92e4437a29cc869a0f5be3bd5a9abf0045dfd4681a787923ee32374be471483909c0a60a21f
+        REF 39ebaf77e93a55b2bb839b621794eba49b2e359b
+        SHA512 865bb9f686174043a6ddb7b804160cfb1859ed32a0d430a1a70de0437f8e5e0e80200863f3c1fa0be6512707834c012d00c18cf4a6fadb41969eefa1dc9db64e
         HEAD_REF main
         PATCHES
             library-linkage-httpfs.diff
@@ -51,7 +51,7 @@ if("httpfs" IN_LIST FEATURES)
     file(WRITE "${SOURCE_PATH}/.github/config/extensions/httpfs.cmake" "
 duckdb_extension_load(httpfs
     SOURCE_DIR \"${DUCKDB_HTTPFS_SOURCE_PATH}\"
-    INCLUDE_DIR \"${DUCKDB_HTTPFS_SOURCE_PATH}/extension/httpfs/include\"
+    INCLUDE_DIR \"${DUCKDB_HTTPFS_SOURCE_PATH}/src/include\"
 )
 ")
 endif()

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "duckdb",
-  "version": "1.4.1",
-  "port-version": 2,
+  "version": "1.4.2",
   "description": "High-performance in-process analytical database system",
   "homepage": "https://duckdb.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2557,8 +2557,8 @@
       "port-version": 0
     },
     "duckdb": {
-      "baseline": "1.4.1",
-      "port-version": 2
+      "baseline": "1.4.2",
+      "port-version": 0
     },
     "duckx": {
       "baseline": "1.2.2",

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8db2ab542f144becf9a849a9ace9192ab7ef31d",
+      "version": "1.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "63e94070c47a5b3f43add53f637fba319c27d6f3",
       "version": "1.4.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/duckdb/duckdb/releases/tag/v1.4.2
