### PR TITLE
[ms-gdk] Update for April 2025 QFE 4 release

### DIFF
--- a/ports/ms-gdk/portfile.cmake
+++ b/ports/ms-gdk/portfile.cmake
@@ -1,4 +1,4 @@
-set(GDK_EDITION_NUMBER 250403)
+set(GDK_EDITION_NUMBER 250404)
 
 # The GDK contains a combination of static C++ libraries and DLL-based extension libraries.
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
@@ -6,7 +6,7 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.GDK.PC/${VERSION}"
     FILENAME "ms-gdk.${VERSION}.zip"
-    SHA512 a7ece6899aca25dba4c0c4bb8947502090c2576beef677a33b878cdf8babdc18925f6349161f5b6a518d7c1c7f5a7ac66f23983147672f67e9067acb2004e1c8
+    SHA512 143541167d34a6c685bef234ccc03b02e916f286e0d83f1b7dbdd269951b441e5709371270436128aad329a0ff3f4814afaf5d1ed3080989b8e2e0779da51123
 )
 
 vcpkg_extract_source_archive(

--- a/ports/ms-gdk/vcpkg.json
+++ b/ports/ms-gdk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-gdk",
-  "version": "2504.3.4084",
+  "version": "2504.4.4108",
   "description": "Microsoft Game Development Kit (GDK)",
   "homepage": "https://aka.ms/gdkx",
   "documentation": "https://aka.ms/gamedevdocs",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6561,7 +6561,7 @@
       "port-version": 1
     },
     "ms-gdk": {
-      "baseline": "2504.3.4084",
+      "baseline": "2504.4.4108",
       "port-version": 0
     },
     "ms-gdkx": {

--- a/versions/m-/ms-gdk.json
+++ b/versions/m-/ms-gdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c19c66eeffaeb113a1084f868d8b3a4bbb6437f7",
+      "version": "2504.4.4108",
+      "port-version": 0
+    },
+    {
       "git-tree": "b8ab3d66c9fc8a1589c82c6c88f786bf5094043b",
       "version": "2504.3.4084",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
