### PR TITLE
[libwebp] Remove NDK-bundled cpu-features source files

### DIFF
--- a/ports/libwebp/0009-cpufeatures-android.patch
+++ b/ports/libwebp/0009-cpufeatures-android.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 39d3d8f6..6169be39 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -185,24 +185,8 @@ if(WEBP_ENABLE_WUNUSED_RESULT)
+ endif()
+ 
+ # ##############################################################################
+-# Android only.
+-if(ANDROID)
+-  include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
+-  add_library(cpufeatures-webp STATIC
+-              ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
+-  list(APPEND INSTALLED_LIBRARIES cpufeatures-webp)
+-  target_link_libraries(cpufeatures-webp dl)
+-  set(SHARPYUV_DEP_LIBRARIES ${SHARPYUV_DEP_LIBRARIES} cpufeatures-webp)
+-  set(WEBP_DEP_LIBRARIES ${WEBP_DEP_LIBRARIES} cpufeatures-webp)
+-  set(cpufeatures_include_dir ${ANDROID_NDK}/sources/android/cpufeatures)
+-  set(SHARPYUV_DEP_INCLUDE_DIRS ${SHARPYUV_DEP_INCLUDE_DIRS}
+-                                ${cpufeatures_include_dir})
+-  set(WEBP_DEP_INCLUDE_DIRS ${WEBP_DEP_INCLUDE_DIRS} ${cpufeatures_include_dir})
+-  add_definitions(-DHAVE_CPU_FEATURES_H=1)
+-  set(HAVE_CPU_FEATURES_H 1)
+-else()
+-  set(HAVE_CPU_FEATURES_H 0)
+-endif()
++# To streamline dependency management, remove usage of the NDK-bundled cpufeatures.
++set(HAVE_CPU_FEATURES_H 0)
+ 
+ function(configure_pkg_config FILE)
+   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/${FILE}.in"

--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         0002-cmake-config.patch
         0003-simd.patch
         0008-sdl.patch
+        0009-cpufeatures-android.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libwebp/vcpkg.json
+++ b/ports/libwebp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libwebp",
   "version": "1.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "WebP codec: library to encode and decode images in WebP format",
   "homepage": "https://github.com/webmproject/libwebp",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5722,7 +5722,7 @@
     },
     "libwebp": {
       "baseline": "1.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libwebsockets": {
       "baseline": "4.4.1",

--- a/versions/l-/libwebp.json
+++ b/versions/l-/libwebp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5366c6ab4c6a5ece31ab06309b9729d29a5d4da1",
+      "version": "1.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "c0a4a598eacd380393ff3a92be045f4474643649",
       "version": "1.6.0",
       "port-version": 1


### PR DESCRIPTION
libwebp previously built and linked the Android NDK’s bundled `cpu-features` sources. These sources have been deprecated for a long time, and including them directly causes symbol and linkage conflicts when vcpkg's `cpu-features` port (or other libraries using `cpu-features`) are present.

Given that non-NEON ARMv7 devices are virtually obsolete and the `arm-android` triplet is community-supported only, this patch removes the bundled `cpu-features` to simplify dependency management and avoid conflicts. Support for non-NEON ARMv7 can be reconsidered if requested by the community.

Related: #48265

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.