### PR TITLE
[orange-math]: update to 4.3.0

### DIFF
--- a/ports/orange-math/portfile.cmake
+++ b/ports/orange-math/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO orange-cpp/omath
     REF "v${VERSION}"
-    SHA512 45d78e35d6bf9d7bbf511f27b77a0d2300033faf581f3c67f7c97f6e529842f520bec844fdee12000d53b5abd2c1e3acd04393429edf639b199501e53d333c1b
+    SHA512 7a234bab6511d64cd7ad8cbc69bdee9c2259be4acc5bcd06ef55bf209c2513778d1abf6d30a34f24c9244bceea605566a227065436fc1fa56845faa3092b0cdb
     HEAD_REF master
 )
 

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "orange-math",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "General purpose math library",
   "homepage": "https://github.com/orange-cpp/omath",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7301,7 +7301,7 @@
       "port-version": 1
     },
     "orange-math": {
-      "baseline": "4.2.0",
+      "baseline": "4.3.0",
       "port-version": 0
     },
     "orc": {

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c236701bef338f8cc77221fca1319e132986702e",
+      "git-tree": "32f1fb75d3932d0aaaaf4a086790a3033c6968f6",
       "version": "4.3.0",
       "port-version": 0
     },

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c236701bef338f8cc77221fca1319e132986702e",
+      "version": "4.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7d0411b41fa0520e8c349c43c3d358e0f862976b",
       "version": "4.2.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
