### PR TITLE
[libhat]: update to 0.9.0

### DIFF
--- a/ports/libhat/0002-fix-gcc.patch
+++ b/ports/libhat/0002-fix-gcc.patch
@@ -1,9 +1,9 @@
 diff --git a/include/libhat/compressed_pair.hpp b/include/libhat/compressed_pair.hpp
-index 7bf839a..1b2be6c 100644
+index 39cb8ea..341f9e3 100644
 --- a/include/libhat/compressed_pair.hpp
 +++ b/include/libhat/compressed_pair.hpp
-@@ -4,6 +4,7 @@
-     #include <tuple>
+@@ -5,6 +5,7 @@
+     #include <utility>
  #endif
  
 +#include <cstddef>
@@ -11,10 +11,15 @@ index 7bf839a..1b2be6c 100644
  #include "type_traits.hpp"
  
 diff --git a/include/libhat/strconv.hpp b/include/libhat/strconv.hpp
-index f23d096..ad527fb 100644
+index bbd786f..ad527fb 100644
 --- a/include/libhat/strconv.hpp
 +++ b/include/libhat/strconv.hpp
-@@ -5,6 +5,7 @@
+@@ -1,11 +1,11 @@
+ #pragma once
+ 
+ #ifndef LIBHAT_MODULE
+-    #include <cstdint>
+     #include <string_view>
      #include <type_traits>
  #endif
  

--- a/ports/libhat/portfile.cmake
+++ b/ports/libhat/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BasedInc/libhat
     REF "v${VERSION}"
-    SHA512 07bdca0a84fc48d6c3d941136459d73e7c4f09c398c5a787e307dd01ee0124fc56d2ba827e49b342611b754816408d21109c6f17bede62dcc231a1a2e3c1d225
+    SHA512 68ce4d66f92553eb0f3e0f26c0274bc048d735936a68abf2fcb2ce7766dcdab73fb5dc0d8bbf249e5b36bd7a2eb2db06878eaffcd16d4bcac839953506704c8d
     HEAD_REF master
     PATCHES
         0001-CMakeLists.patch

--- a/ports/libhat/vcpkg.json
+++ b/ports/libhat/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libhat",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A high-performance, modern, C++20 library designed around game hacking.",
   "homepage": "https://github.com/BasedInc/libhat",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4953,7 +4953,7 @@
       "port-version": 1
     },
     "libhat": {
-      "baseline": "0.8.0",
+      "baseline": "0.9.0",
       "port-version": 0
     },
     "libhdfs3": {

--- a/versions/l-/libhat.json
+++ b/versions/l-/libhat.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ac4723a64c63a515213456a0a42b0a46f6819df4",
+      "git-tree": "a23e41e2d3791f243c9b83d024c704e74a058f4a",
       "version": "0.9.0",
       "port-version": 0
     },

--- a/versions/l-/libhat.json
+++ b/versions/l-/libhat.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac4723a64c63a515213456a0a42b0a46f6819df4",
+      "version": "0.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "03bfd77c34d0e6da9a00175d46e419a308155b06",
       "version": "0.8.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
