### PR TITLE
[asmjit]: update to 2025-10-12

### DIFF
--- a/ports/asmjit/portfile.cmake
+++ b/ports/asmjit/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO asmjit/asmjit
-    REF e1b20711cc40c29ec4918b54e328ace96470f6e5 # commited on 2025-01-22
+    REF e1b20711cc40c29ec4918b54e328ace96470f6e5 # commited on 2025-10-12
     SHA512 5d40840ce203bcef86d81b3538be7a4443dbcba52735cf9c90bc9c974d3c7e1ab75ff0fd7e2c72533d73884cce93808e63aa2228c2b7c5376aee4437070714a2
     HEAD_REF master
 )

--- a/ports/asmjit/vcpkg.json
+++ b/ports/asmjit/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "asmjit",
-  "version-date": "2025-01-22",
+  "version-date": "2025-10-12",
   "description": "AsmJit is a lightweight library for machine code generation written in C++ language",
   "homepage": "https://asmjit.com/",
   "documentation": "https://asmjit.com/doc/",

--- a/scripts/test_ports/vcpkg-ci-asmjit/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-asmjit/portfile.cmake
@@ -1,0 +1,5 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-asmjit/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-asmjit/project/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.25.1)
+project(asmjit-test LANGUAGES CXX)
+find_package(asmjit CONFIG REQUIRED)
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE asmjit::asmjit)
+target_compile_features(main PRIVATE cxx_std_17)

--- a/scripts/test_ports/vcpkg-ci-asmjit/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-asmjit/project/main.cpp
@@ -1,0 +1,7 @@
+#include <asmjit/asmjit.h>
+int main()
+{
+   asmjit::Label label;
+   auto id = label.id();
+   return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-asmjit/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-asmjit/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-asmjit",
+  "version-string": "ci",
+  "description": "Validates asmjit",
+  "dependencies": [
+    "asmjit",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/asmjit.json
+++ b/versions/a-/asmjit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "73026ced267f3dc6bb1da26712476034cfa2a004",
+      "version-date": "2025-10-12",
+      "port-version": 0
+    },
+    {
       "git-tree": "7edf4fd2716465738a0d0eb8a199a828f0ba7aef",
       "version-date": "2025-01-22",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -309,7 +309,7 @@
       "port-version": 0
     },
     "asmjit": {
-      "baseline": "2025-01-22",
+      "baseline": "2025-10-12",
       "port-version": 0
     },
     "asmtk": {


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
