### PR TITLE
[qcbor] update to 1.6

### DIFF
--- a/ports/qcbor/portfile.cmake
+++ b/ports/qcbor/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO laurencelundblade/QCBOR
     REF v${VERSION}
-    SHA512 3961cbcde2dde3565b68f92b53e92db31b649b71bc683a8439bada3aa6c44f4727747ca7b4ad35c4ca6f5bd0594abc2bf36a6ce0c7452eb412e8dcd55e946585
+    SHA512 cae2f9ed6554744733bed03e751179eee36988918b1f3fd42fe833650613b4ec06e260bb4a9e9663c8498b7b6dbb1369e7d5fd0c900c4767070ea3d94d4ddab7
     HEAD_REF master
     PATCHES
         install.patch
@@ -21,7 +21,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(REMOVE_RECURSE 
+file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )

--- a/ports/qcbor/vcpkg.json
+++ b/ports/qcbor/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qcbor",
-  "version": "1.5.3",
+  "version": "1.6",
   "description": "Comprehensive, powerful, commercial-quality CBOR encoder/ decoder that is still suited for small devices.",
   "homepage": "https://github.com/laurencelundblade/QCBOR",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7841,7 +7841,7 @@
       "port-version": 4
     },
     "qcbor": {
-      "baseline": "1.5.3",
+      "baseline": "1.6",
       "port-version": 0
     },
     "qcoro": {

--- a/versions/q-/qcbor.json
+++ b/versions/q-/qcbor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d83f385a35e1ecc084951ed10ad0cd72dbdb3278",
+      "version": "1.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "78d55821d9252e9e85bcfd345659d63ea4ba4efa",
       "version": "1.5.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/laurencelundblade/QCBOR/releases/tag/v1.6
