### PR TITLE
[utf8proc] update to 2.11.1

### DIFF
--- a/ports/utf8proc/portfile.cmake
+++ b/ports/utf8proc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO JuliaLang/utf8proc
     REF v${VERSION}
-    SHA512 bf9bfb20036e8b709449ee4a11592becf99e61f4c82d03519ab9de1a93ca47d6f8ed4b0bb471f7ca3ae06293275a391a9102ae810a9e07e914789d05ddbd25ab
+    SHA512 01796ffd1b253c4943af8c084f60b3fed3ef469a25f017fdb5cdb430fff901741dd06186c938c4559e9f03bbc376d3e90fcf36eba93f9c6febff3be9cc38fdae
 )
 
 vcpkg_cmake_configure(

--- a/ports/utf8proc/vcpkg.json
+++ b/ports/utf8proc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "utf8proc",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Clean C library for processing UTF-8 Unicode data.",
   "homepage": "https://github.com/JuliaLang/utf8proc",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10057,7 +10057,7 @@
       "port-version": 1
     },
     "utf8proc": {
-      "baseline": "2.11.0",
+      "baseline": "2.11.1",
       "port-version": 0
     },
     "utfcpp": {

--- a/versions/u-/utf8proc.json
+++ b/versions/u-/utf8proc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d1c1493e2d069882d9c0b412dc2e7c8355283fd4",
+      "version": "2.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8f63969b6709cad0d4618ba521d6762ab5844026",
       "version": "2.11.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/JuliaStrings/utf8proc/releases/tag/v2.11.1
