### PR TITLE
[luau] update to 0.699

### DIFF
--- a/ports/luau/cmake-config-export.patch
+++ b/ports/luau/cmake-config-export.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4fb21c3..5ce6814 100644
+index 0ca0bdb..36402d7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -66,41 +66,41 @@ add_library(Luau.VM.Internals INTERFACE)
- 
+@@ -67,45 +67,45 @@ add_library(Luau.VM.Internals INTERFACE)
  include(Sources.cmake)
  
--target_include_directories(Luau.Common INTERFACE Common/include)
-+target_include_directories(Luau.Common INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Common/include> $<INSTALL_INTERFACE:include/luau>)
+ target_compile_features(Luau.Common PUBLIC cxx_std_17)
+-target_include_directories(Luau.Common PUBLIC Common/include)
++target_include_directories(Luau.Common PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Common/include> $<INSTALL_INTERFACE:include/luau>)
  
  target_compile_features(Luau.CLI.lib PUBLIC cxx_std_17)
 -target_include_directories(Luau.CLI.lib PUBLIC CLI/include)
@@ -53,7 +53,12 @@ index 4fb21c3..5ce6814 100644
  target_link_libraries(Luau.VM PUBLIC Luau.Common)
  
  target_compile_features(Luau.Require PUBLIC cxx_std_17)
-@@ -189,22 +189,6 @@ if(MSVC AND LUAU_BUILD_CLI)
+-target_include_directories(Luau.Require PUBLIC Require/include)
++target_include_directories(Luau.Require PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Require/include> $<INSTALL_INTERFACE:include/luau>)
+ target_link_libraries(Luau.Require PUBLIC Luau.Config Luau.VM)
+ 
+ target_include_directories(isocline PUBLIC extern/isocline/include)
+@@ -190,22 +190,6 @@ if(MSVC AND LUAU_BUILD_CLI)
      set_target_properties(Luau.Repl.CLI PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
  endif()
  
@@ -76,7 +81,7 @@ index 4fb21c3..5ce6814 100644
  # On Windows and Android threads are provided, on Linux/Mac/iOS we use pthreads
  add_library(osthreads INTERFACE)
  if(CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin|iOS")
-@@ -297,3 +281,54 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.EqSat Luau.Cod
+@@ -298,3 +282,54 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.EqSat Luau.Cod
          endif()
      endif()
  endforeach()
@@ -133,8 +138,9 @@ index 4fb21c3..5ce6814 100644
 +)
 diff --git b/cmake/unofficial-luau-config.cmake b/cmake/unofficial-luau-config.cmake
 new file mode 100644
-index 0000000..13fd463
+index 0000000..2680ef3
 --- /dev/null
 +++ b/cmake/unofficial-luau-config.cmake
 @@ -0,0 +1 @@
 +include(${CMAKE_CURRENT_LIST_DIR}/unofficial-luau-targets.cmake)
+\ No newline at end of file

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 74e4ffc8dbd3f05bcd92fa0e0e75a96b393dc738ec3ccacacf3de58738ba2fa65c5aeaa4da7e317c06ce43deb66635dce34d777a91d4e41f4ac9a13186168c69
+    SHA512 c3b73c9d7acc308f2ab1cb659e183b2e47cb023c25040b198f0c69722a7fce2b7d353b884a488e38942ad3e842318f0ca2fd6031411b702c9bf58bdac6968571
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.698",
+  "version": "0.699",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6073,7 +6073,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.698",
+      "baseline": "0.699",
       "port-version": 0
     },
     "luminoengine": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49e2cfcba9d457b161a3d120234f56c011779895",
+      "version": "0.699",
+      "port-version": 0
+    },
+    {
       "git-tree": "5875c935febb8f8d7b18f91e1c518e51aabb6762",
       "version": "0.698",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/luau-lang/luau/releases/tag/0.699
