### PR TITLE
[slick-logger] new port

### DIFF
--- a/ports/slick-logger/portfile.cmake
+++ b/ports/slick-logger/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY HEADER_ONLY_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick_logger

--- a/ports/slick-logger/portfile.cmake
+++ b/ports/slick-logger/portfile.cmake
@@ -1,4 +1,4 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY HEADER_ONLY_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/slick-logger/portfile.cmake
+++ b/ports/slick-logger/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO SlickQuant/slick_logger
+    REF "v${VERSION}"
+    SHA512 5b5a39ec7d56847906eccce951e7fd656217fe66d26671141edd44e8966108fb5d1185449ea553b3aa843b51898a68ab553e5ad52e1433bc43e9069dc6773f1c
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SLICK_LOGGER_TESTING=OFF
+        -DBUILD_SLICK_LOGGER_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME slick_logger
+    CONFIG_PATH lib/cmake/slick_logger
+)
+
+# Header-only library - remove lib directory
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+
+# Install license
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/slick-logger/vcpkg.json
+++ b/ports/slick-logger/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-logger",
-  "version-semver": "1.0.1",
+  "version": "1.0.1",
   "description": "A high-performance, cross-platform header-only logging library for C++20 using a multi-producer, multi-consumer ring buffer with multi-sink support and log rotation capabilities",
   "homepage": "https://github.com/SlickQuant/slick_logger",
   "license": "MIT",

--- a/ports/slick-logger/vcpkg.json
+++ b/ports/slick-logger/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "slick-logger",
+  "version-string": "1.0.1",
+  "description": "A high-performance, cross-platform header-only logging library for C++20 using a multi-producer, multi-consumer ring buffer with multi-sink support and log rotation capabilities",
+  "homepage": "https://github.com/SlickQuant/slick_logger",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/slick-logger/vcpkg.json
+++ b/ports/slick-logger/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-logger",
-  "version-string": "1.0.1",
+  "version-semver": "1.0.1",
   "description": "A high-performance, cross-platform header-only logging library for C++20 using a multi-producer, multi-consumer ring buffer with multi-sink support and log rotation capabilities",
   "homepage": "https://github.com/SlickQuant/slick_logger",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9060,6 +9060,10 @@
       "baseline": "2025-02-08",
       "port-version": 0
     },
+    "slick-logger": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "slikenet": {
       "baseline": "2021-06-07",
       "port-version": 3

--- a/versions/s-/slick-logger.json
+++ b/versions/s-/slick-logger.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "d503e4917c8aa72ef82241bb24a7e9f34a39f902",
-      "version-string": "1.0.1",
+      "version": "1.0.1",
       "port-version": 0
     }
   ]

--- a/versions/s-/slick-logger.json
+++ b/versions/s-/slick-logger.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d503e4917c8aa72ef82241bb24a7e9f34a39f902",
+      "git-tree": "f2880036a05c4114a7fc995c5d1323e1a7a2b2a7",
       "version": "1.0.1",
       "port-version": 0
     }

--- a/versions/s-/slick-logger.json
+++ b/versions/s-/slick-logger.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d503e4917c8aa72ef82241bb24a7e9f34a39f902",
+      "version-string": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

**Description:**
Add new port for slick_logger, A high-performance, cross-platform header-only C++ logging library.

Features:
- High Performance: Asynchronous logging using slick_queue ring buffer for minimal latency
- Modern Formatting: Uses C++20 std::format for type-safe, efficient string formatting
- Multi-Sink Architecture: Log to multiple destinations simultaneously (console, files, custom sinks)
- Log Rotation: Size-based and time-based rotation with configurable retention
- Colored Console Output: ANSI color support with configurable error routing
- Header-Only: No linking required - just include and use
- Cross-Platform: Supports Windows, Linux, and macOS
- Multi-Threaded: Safe for concurrent logging from multiple threads
- C++20: Utilizes modern C++ features
- Easy to Use: Simple macros for logging at different levels

**Homepage:** https://github.com/SlickQuant/slick_logger
**License:** MIT