### PR TITLE
[libmicrohttpd] Update to 1.0.2

### DIFF
--- a/ports/libmicrohttpd/portfile.cmake
+++ b/ports/libmicrohttpd/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_download_distfile(ARCHIVE
     URLS
-        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${VERSION}.tar.gz"
+        "https://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-${VERSION}.tar.gz"
         "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${VERSION}.tar.gz"
     FILENAME "libmicrohttpd-${VERSION}.tar.gz"
-    SHA512 c99b8b93cae5feee8debcc5667ee3ff043412a84b30696fe852e6c138f3c890bb43c8fcd7199f1d2f809d522fef159e83b607c743d6cf3401a57050fbdf9b5c1
+    SHA512 7092f307a00ba04b539be79a7c94ddf9b4b6e43343a66da49c6602fa860f77cf7f9017d7e40f9b7400d85a828a503248eb12dd121413aad68133003a20bb2c4a
 )
 
 vcpkg_extract_source_archive(
@@ -39,19 +39,20 @@ else()
         vcpkg_list(APPEND config_args "--disable-https")
     endif()
 
-    vcpkg_configure_make(
+    vcpkg_make_configure(
         SOURCE_PATH "${SOURCE_PATH}"
+        AUTORECONF
         OPTIONS
             --disable-doc
-            --disable-nls
             --disable-examples
             --disable-curl
+            --disable-tools
             ${config_args}
         OPTIONS_DEBUG --enable-asserts
         OPTIONS_RELEASE --disable-asserts
     )
 
-    vcpkg_install_make()
+    vcpkg_make_install()
     vcpkg_fixup_pkgconfig()
     
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libmicrohttpd/vcpkg.json
+++ b/ports/libmicrohttpd/vcpkg.json
@@ -1,15 +1,15 @@
 {
   "name": "libmicrohttpd",
-  "version": "1.0.1",
-  "port-version": 2,
+  "version": "1.0.2",
   "description": "GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application",
   "homepage": "https://www.gnu.org/software/libmicrohttpd/",
   "license": "LGPL-2.1-or-later",
-  "supports": "!((arm & windows) | uwp)",
+  "supports": "!(arm & windows) & !uwp",
   "dependencies": [
     {
-      "name": "gettext",
-      "platform": "!windows"
+      "name": "vcpkg-make",
+      "host": true,
+      "platform": "!windows | mingw"
     },
     {
       "name": "vcpkg-msbuild",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5137,8 +5137,8 @@
       "port-version": 2
     },
     "libmicrohttpd": {
-      "baseline": "1.0.1",
-      "port-version": 2
+      "baseline": "1.0.2",
+      "port-version": 0
     },
     "libmidi2": {
       "baseline": "0.15",

--- a/versions/l-/libmicrohttpd.json
+++ b/versions/l-/libmicrohttpd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1120196d94b48ba49938214ec518db800ae6bd5",
+      "version": "1.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "4e531f6d4e0db3536d1af649eea99e332978b12e",
       "version": "1.0.1",
       "port-version": 2


### PR DESCRIPTION
Upstream moved gettext/nls/po dependency stuff to a separate maintainer-only directory already in 2022 (259cbd83). Noticed due to "unknown option --disable-nls" warning.