### PR TITLE
[usearch] update to 2.21.3

### DIFF
--- a/ports/usearch/portfile.cmake
+++ b/ports/usearch/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO unum-cloud/usearch
     REF "v${VERSION}"
-    SHA512 daea0cbdae65a5b1c09f7a85e1bbb4475d21c73fb427a287929c78b86528a2b01e787a7d4adb8a498f2251ade59996207f0f26cf062d34796032734f864340ae
+    SHA512 d4d48c7477c490aa89cfc5eaf3f98f64c3fec1174d21e14dd5e6cbf08b344a5483e2a851e41a4f6e0bdc933b945b7e8f3d116cc84822b235e404bca20d7951ea
     HEAD_REF main
     PATCHES
         use-vcpkg-ports.patch

--- a/ports/usearch/vcpkg.json
+++ b/ports/usearch/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "usearch",
-  "version": "2.21.0",
+  "version": "2.21.3",
   "description": "Fastest Search & Clustering engine × for Vectors & Strings",
   "homepage": "https://github.com/unum-cloud/usearch",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10037,7 +10037,7 @@
       "port-version": 0
     },
     "usearch": {
-      "baseline": "2.21.0",
+      "baseline": "2.21.3",
       "port-version": 0
     },
     "usockets": {

--- a/versions/u-/usearch.json
+++ b/versions/u-/usearch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fdfd47d2a85887339644c8800a038ae4e8c3da9a",
+      "version": "2.21.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "acfe663cbecc91d129bae8ffb2fee7f201225e72",
       "version": "2.21.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/unum-cloud/USearch/releases/tag/v2.21.3
https://github.com/unum-cloud/USearch/releases/tag/v2.21.2
https://github.com/unum-cloud/USearch/releases/tag/v2.21.1
