### PR TITLE
[supernovas] Patch for upstream issue #272.

### DIFF
--- a/ports/supernovas/cmake.patch
+++ b/ports/supernovas/cmake.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d340fb28..7a4ad3ea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -168,9 +168,6 @@ set_target_properties(core PROPERTIES
+     VERSION ${PROJECT_VERSION}
+     SOVERSION ${PROJECT_VERSION_MAJOR}
+     POSITION_INDEPENDENT_CODE ON
+-    EXPORT_NAME supernovas
+-    OUTPUT_NAME supernovas
+-    CLEAN_DIRECT_OUTPUT ON
+ )
+ 
+ target_include_directories(core PUBLIC

--- a/ports/supernovas/portfile.cmake
+++ b/ports/supernovas/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 b78e5b3e9792fbebd47064c747be675022f2758c30ac2cd69ade5601d9693b8eb8786c46c56df76f04feef963310838042833b7a91e2cc6c9317a5c34717ade8
     HEAD_REF main
+    PATCHES
+    	cmake.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/supernovas/vcpkg.json
+++ b/ports/supernovas/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "supernovas",
   "version": "1.5.0",
+  "port-version": 1,
   "description": "SuperNOVAS C/C++ high-precision astrometry library",
   "homepage": "https://smithsonian.github.io/SuperNOVAS/",
   "documentation": "https://smithsonian.github.io/SuperNOVAS/doc/html/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9510,7 +9510,7 @@
     },
     "supernovas": {
       "baseline": "1.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "sushant-wayal-stringhash": {
       "baseline": "1.1.0",

--- a/versions/s-/supernovas.json
+++ b/versions/s-/supernovas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e68d91b07bbfb40406e0fae9c568de50601eba8d",
+      "version": "1.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "23a370449299e68985392d80988e4fbc7b675245",
       "version": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
The upstream `CMakeLists.txt` exported the main library target with a different name than what `supernovasConfig.cmake` was expecting (see upstream Issue [#272](https://github.com/Smithsonian/SuperNOVAS/issues/272)). A patch to `CMakeLists.txt` should fix this issue, until the same fix is released upstream in a couple of months...

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

