### PR TITLE
[commata] update to 1.1.2

### DIFF
--- a/ports/commata/portfile.cmake
+++ b/ports/commata/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO furfurylic/commata
   REF "v${VERSION}"
-  SHA512 1c4ca9f37ea629289b6067a2fd6ac4ce61205c03fc1a2e9460cac1c139e46b14fa11a772bff217302ed847cf2043ad2f1af4ebc8962811dc57360e20cbd708ce
+  SHA512 aaf2343c81db642ec17f35a3a33d637f300ade7f7aab14a7f0c1b87ec66aec9bc4bad845c67ade7931e81427510fde6f1af66ddbef9bc700dd8b01015debc3a0
   HEAD_REF master
 )
 

--- a/ports/commata/vcpkg.json
+++ b/ports/commata/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "commata",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Just another header-only C++17 CSV parser.",
   "homepage": "https://github.com/furfurylic/commata",
   "license": "Unlicense"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1901,7 +1901,7 @@
       "port-version": 0
     },
     "commata": {
-      "baseline": "1.1.1",
+      "baseline": "1.1.2",
       "port-version": 0
     },
     "comms": {

--- a/versions/c-/commata.json
+++ b/versions/c-/commata.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d91b91f16014698c5d15d2feb27e33f06c758d0",
+      "version": "1.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "4054c21f12ceefa50efff9554afe43d450fc56de",
       "version": "1.1.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/furfurylic/commata/releases/tag/v1.1.2
