### PR TITLE
[sqlite-flux] New port version 1.0.0

### DIFF
--- a/ports/sqlite-flux/portfile.cmake
+++ b/ports/sqlite-flux/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO a-alomran/sqlite_flux
+    REF v1.0.0
+    SHA512 7c1486e0b89a719230368f9202049a823420b0305999bef0c4b15567b5fe97aec47862fbffd65e8986423d56a9cdf9d10abace4385e08825ad20a324ec729347
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME sqlite_flux
+    CONFIG_PATH lib/cmake/sqlite_flux
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sqlite-flux/vcpkg.json
+++ b/ports/sqlite-flux/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "sqlite-flux",
+  "version": "1.0.0",
+  "description": "Modern C++20 type-safe, thread-safe SQLite query builder with fluent API and compile-time validation",
+  "homepage": "https://github.com/a-alomran/sqlite-flux",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    "sqlite3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9264,6 +9264,10 @@
       "baseline": "0.3.0",
       "port-version": 0
     },
+    "sqlite-flux": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "sqlite-modern-cpp": {
       "baseline": "2023-12-03",
       "port-version": 0

--- a/versions/s-/sqlite-flux.json
+++ b/versions/s-/sqlite-flux.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "27f146a38571fe02442194a822d8fc9bd9684cfb",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
