### PR TITLE
[anari] Update to anari 0.15.0

### DIFF
--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -28,8 +28,10 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+file(GLOB ANARI_CMAKE_CONFIG_FILE RELATIVE ${CURRENT_PACKAGES_DIR} "${CURRENT_PACKAGES_DIR}/lib/cmake/*/anariConfig.cmake")
+cmake_path(GET ANARI_CMAKE_CONFIG_FILE PARENT_PATH ANARI_CMAKE_CONFIG_DIR)
 vcpkg_cmake_config_fixup(
-  CONFIG_PATH "lib/cmake/${PORT}-${VERSION}"
+  CONFIG_PATH ${ANARI_CMAKE_CONFIG_DIR}
 )
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()

--- a/ports/anari/portfile.cmake
+++ b/ports/anari/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KhronosGroup/ANARI-SDK
   REF "v${VERSION}"
-  SHA512 02db5cdf5f84df213b4d14f93363b7949d6c1a51c9cda616ef3612cb072f6b30bc942c5a6b0b9e89ea8b76b048fabd6bafcabde3c55380c3d90837116fa8b237
+  SHA512 504be3b6e8b33def5c43e0c59927da0fccd8c9356f384ceab20740e49a26f6e2e62b142893afec028ce61207741de9e72d9a496b7981109f290bb580552a0965
   HEAD_REF next_release
   PATCHES anari-lib-maybe-static-lib.patch
 )

--- a/ports/anari/vcpkg.json
+++ b/ports/anari/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "anari",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Cross-Platform 3D Rendering Engine API.",
   "homepage": "https://www.khronos.org/anari",
   "license": "Apache-2.0",

--- a/versions/a-/anari.json
+++ b/versions/a-/anari.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f8711e4f387cebff0f79132b29c4ddb09a63f77e",
+      "version": "0.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a988fe0e6db993e29d2628acf456fc8b99e5ea31",
       "version": "0.14.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -129,7 +129,7 @@
       "port-version": 0
     },
     "anari": {
-      "baseline": "0.14.1",
+      "baseline": "0.15.0",
       "port-version": 0
     },
     "anax": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This PR also updates the logic to fix running `vcpkg install --head anari`