### PR TITLE
[sdl3] Add emscripten-pthreads feature

### DIFF
--- a/ports/sdl3/portfile.cmake
+++ b/ports/sdl3/portfile.cmake
@@ -21,6 +21,14 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         x11      SDL_X11
 )
 
+if (VCPKG_TARGET_IS_EMSCRIPTEN)
+    vcpkg_check_features(OUT_FEATURE_OPTIONS EMSCRIPTEN_FEATURE_OPTIONS
+        FEATURES
+            emscripten-pthreads     SDL_PTHREADS
+    )
+    vcpkg_list(APPEND FEATURE_OPTIONS "${EMSCRIPTEN_FEATURE_OPTIONS}")
+endif()
+
 if ("x11" IN_LIST FEATURES)
     message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxft-dev libxext-dev\n")
 endif()

--- a/ports/sdl3/vcpkg.json
+++ b/ports/sdl3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl3",
   "version": "3.2.26",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
   "license": "Zlib AND MIT AND Apache-2.0",
@@ -43,6 +44,10 @@
           "platform": "linux"
         }
       ]
+    },
+    "emscripten-pthreads": {
+      "description": "Build Emscripten pthreads support",
+      "supports": "emscripten"
     },
     "ibus": {
       "description": "Build with ibus IME support",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8850,7 +8850,7 @@
     },
     "sdl3": {
       "baseline": "3.2.26",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl3-image": {
       "baseline": "3.2.4",

--- a/versions/s-/sdl3.json
+++ b/versions/s-/sdl3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e3b711cecef4a6c16644131eb29a4ea698865e4",
+      "version": "3.2.26",
+      "port-version": 1
+    },
+    {
       "git-tree": "f0a79b5c053822d02dc17b2ba42adf9b3f9c91bc",
       "version": "3.2.26",
       "port-version": 0


### PR DESCRIPTION
SDL3 and Emscripten support compiling with pthreads enabled or disabled.

SDL3 offers an option to control this, which (currently) defaults to off for Emscripten builds.

This PR exposes the option to compile sdl3 with pthreads support on Emscripten with a new `emscripten-pthreads` feature.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
