### PR TITLE
[nonstd-bit-lite] Update to 2.0.0

### DIFF
--- a/ports/nonstd-bit-lite/portfile.cmake
+++ b/ports/nonstd-bit-lite/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nonstd-lite/bit-lite
     REF "v${VERSION}"
-    SHA512 96706a536891cdeaa7a3c2285a610b0fcf0a7096fe89aca8eef6d8c8db89c71263d3eaa2fc97cdd80992a0ce196a0e3aaa979b48e452820302fd7db891c7b761
+    SHA512 a0b9f5786e72ffa1dcd77f7bd62ad08160a845c4fb05ff0b6fe7233c80aed89b7df6e698eed9ff633dd9e7ffaf19fa866d93d5d541d0a5af0d79afd5f76425e3
     HEAD_REF master
 )
 

--- a/ports/nonstd-bit-lite/vcpkg.json
+++ b/ports/nonstd-bit-lite/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nonstd-bit-lite",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "C++20/C++23 bit operations for C++98 and later in a single-file header-only library",
   "homepage": "https://github.com/nonstd-lite/bit-lite",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6901,7 +6901,7 @@
       "port-version": 4
     },
     "nonstd-bit-lite": {
-      "baseline": "1.2.0",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "nonstd-scope-lite": {

--- a/versions/n-/nonstd-bit-lite.json
+++ b/versions/n-/nonstd-bit-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53179a2569d2122b34cbafb3c890ad874cf6205a",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fcca7a564ac54c346228c5a91b2c34b6d1d9eee1",
       "version": "1.2.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
