### PR TITLE
[atl, atlmfc, wtl] ATL/MFC are not supported for xbox platform

### DIFF
--- a/ports/atl/vcpkg.json
+++ b/ports/atl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "atl",
   "version": "0",
+  "port-version": 1,
   "description": "A stub package that ensures Visual Studio has Active Template Library (ATL) installed.",
-  "supports": "windows"
+  "supports": "windows & !xbox"
 }

--- a/ports/atlmfc/vcpkg.json
+++ b/ports/atlmfc/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "atlmfc",
   "version": "0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A stub package that ensures Visual Studio has ATL/MFC installed.",
-  "supports": "windows",
+  "supports": "windows & !xbox",
   "dependencies": [
     "atl"
   ]

--- a/ports/wtl/vcpkg.json
+++ b/ports/wtl/vcpkg.json
@@ -1,8 +1,12 @@
 {
   "name": "wtl",
   "version": "10.0.10320",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Windows Template Library (WTL) is a C++ library for developing Windows applications and UI components.",
   "homepage": "https://sourceforge.net/projects/wtl/",
-  "license": "MS-PL"
+  "license": "MS-PL",
+  "supports": "windows & !xbox",
+  "dependencies": [
+    "atl"
+  ]
 }

--- a/versions/a-/atl.json
+++ b/versions/a-/atl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8377a72c91d9c135f3cb8524c3d43571de2e3d20",
+      "version": "0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0cf33fe03c09b26209c1162fee2bb2c5538f8b0f",
       "version": "0",
       "port-version": 0

--- a/versions/a-/atlmfc.json
+++ b/versions/a-/atlmfc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cde2247ecf111c629f61c1975275e9433fad9756",
+      "version": "0",
+      "port-version": 4
+    },
+    {
       "git-tree": "1a6d710d7d3ffd42089aa001571c625805f59918",
       "version": "0",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -362,7 +362,7 @@
     },
     "atl": {
       "baseline": "0",
-      "port-version": 0
+      "port-version": 1
     },
     "atliac-minitest": {
       "baseline": "1.0.0",
@@ -370,7 +370,7 @@
     },
     "atlmfc": {
       "baseline": "0",
-      "port-version": 3
+      "port-version": 4
     },
     "atomic-queue": {
       "baseline": "1.7.1",
@@ -9072,16 +9072,16 @@
       "baseline": "2025-02-08",
       "port-version": 0
     },
-    "slick-queue": {
-      "baseline": "1.1.2",
+    "slick-logger": {
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "slick-object-pool": {
       "baseline": "0.1.2",
       "port-version": 0
     },
-    "slick-logger": {
-      "baseline": "1.0.1",
+    "slick-queue": {
+      "baseline": "1.1.2",
       "port-version": 0
     },
     "slikenet": {
@@ -10578,7 +10578,7 @@
     },
     "wtl": {
       "baseline": "10.0.10320",
-      "port-version": 4
+      "port-version": 5
     },
     "wxchartdir": {
       "baseline": "2.0.0",

--- a/versions/w-/wtl.json
+++ b/versions/w-/wtl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a688618c746f50c4ee4084a70c8a472a38c5a61",
+      "version": "10.0.10320",
+      "port-version": 5
+    },
+    {
       "git-tree": "c76ddf631b62e5d0b433859f7798c7ab06050f47",
       "version": "10.0.10320",
       "port-version": 4


### PR DESCRIPTION
When testing the xbox triplets, I noticed that some ports were using *atl* or *atlmfc*. Neither of these are supported for the xbox platform.

The wtl library requires atl, so I added that as a dependency.

> Note that most of WRL does work for Xbox, although not all of it.