### PR TITLE
[libzim] Remove SORTPP_PASS to fix modern Windows SDKs.

### DIFF
--- a/ports/libzim/portfile.cmake
+++ b/ports/libzim/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         cross-builds.diff
         dllexport.diff
         subdirs.diff
+        remove-sortpp-pass.diff # https://github.com/openzim/libzim/pull/1017
 )
 
 set(EXTRA_OPTIONS "")

--- a/ports/libzim/remove-sortpp-pass.diff
+++ b/ports/libzim/remove-sortpp-pass.diff
@@ -1,0 +1,12 @@
+diff --git a/meson.build b/meson.build
+index adca804..1b2970b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -61,7 +61,6 @@ public_conf.set('LIBZIM_WITH_XAPIAN', xapian_dep.found())
+ 
+ if build_machine.system() == 'windows'
+     win_deps = declare_dependency(
+-        compile_args: ['-DSORTPP_PASS'],
+         link_args: ['-lRpcrt4', '-lWs2_32', '-lwinmm', '-lshlwapi']
+     )
+ else

--- a/ports/libzim/vcpkg.json
+++ b/ports/libzim/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libzim",
   "version": "9.4.0",
+  "port-version": 1,
   "description": "The Libzim is the reference implementation for the ZIM file format. It's a software library to read and write ZIM files on many systems and architectures. More information about the ZIM format and the openZIM project at https://openzim.org/.",
   "homepage": "https://github.com/openzim/libzim",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5886,7 +5886,7 @@
     },
     "libzim": {
       "baseline": "9.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libzip": {
       "baseline": "1.11.4",

--- a/versions/l-/libzim.json
+++ b/versions/l-/libzim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d335c691779ee94ea8c9e7e145a4eb4439304c16",
+      "version": "9.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c327e69f6f675cfa31d833aa26ae0c96366366b3",
       "version": "9.4.0",
       "port-version": 0


### PR DESCRIPTION
Related: https://github.com/openzim/libzim/pull/1017
Related: https://github.com/microsoft/vcpkg/pull/48366

Repeats https://github.com/microsoft/vcpkg/pull/48385 but we couldn't actually push merge on that because both maintainers were locked out due to being the author and last pusher.
