### PR TITLE
Update EnTT to v3.16.0

### DIFF
--- a/ports/entt/portfile.cmake
+++ b/ports/entt/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DENTT_BUILD_TESTING=OFF
+        -DENTT_BUILD_TESTBED=OFF
         -DENTT_BUILD_DOCS=OFF
         -DENTT_INSTALL=ON
 )
@@ -22,7 +23,7 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/EnTT/cmake)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 # Install natvis files
-file(INSTALL "${SOURCE_PATH}/natvis/entt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/natvis")
+file(INSTALL "${SOURCE_PATH}/src/entt/natvis" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/natvis")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/entt/portfile.cmake
+++ b/ports/entt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO skypjack/entt
     REF "v${VERSION}"
-    SHA512 ab9ea213fdfedb7b51554b4adfdb07ec363482728f4e758ec002ea3cdbb2ff45bbfbd06f46db17a50d8ce14c6537ff7683efdb3102212f0c4ab674d18a5517a3
+    SHA512 69350434d62942fff78128408759c1763cdcc5ddf8c1d2d7ffdc2ac3813786e04535f8e9e58a5c727f37b9c88cf2d444aaca1a3b2559d234cca89a79bd9ac1bf
     HEAD_REF master
 )
 

--- a/ports/entt/vcpkg.json
+++ b/ports/entt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "entt",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Gaming meets modern C++ - a fast and reliable entity-component system and much more",
   "homepage": "https://github.com/skypjack/entt",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2741,7 +2741,7 @@
       "port-version": 6
     },
     "entt": {
-      "baseline": "3.15.0",
+      "baseline": "3.16.0",
       "port-version": 0
     },
     "epoll-shim": {

--- a/versions/e-/entt.json
+++ b/versions/e-/entt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43e44f7b04f51e9a7923e3858bbea904d3f80373",
+      "version": "3.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b27478e44a27785f939170cfb8c910d87194b289",
       "version": "3.15.0",
       "port-version": 0

--- a/versions/e-/entt.json
+++ b/versions/e-/entt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "43e44f7b04f51e9a7923e3858bbea904d3f80373",
+      "git-tree": "bcf1a8bfc124718151698b46475c5273194e379c",
       "version": "3.16.0",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
