### PR TITLE
[openexr] update to 3.4.4

### DIFF
--- a/ports/openexr/portfile.cmake
+++ b/ports/openexr/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/openexr
     REF "v${VERSION}"
-    SHA512 74675b981cc82b6b3144d9dd56df611031dcb2f3da91aeb46b41fc97ec94b9ea45cad10142e3f2d1cd29022b42351d057e1540bde519f4381e206076dc3a5dbb
+    SHA512 5543063d7941f08b4c85ab9428c104ba9ad38f33a043862d5dfd3243450cc0a3cdb2f3818c11db9fa15f5a0fa6847af8a756a6a96d7d5f7c9aa5b7fdccd817a6
     HEAD_REF main
 )
 

--- a/ports/openexr/vcpkg.json
+++ b/ports/openexr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openexr",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications",
   "homepage": "https://www.openexr.com/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7165,7 +7165,7 @@
       "port-version": 1
     },
     "openexr": {
-      "baseline": "3.4.3",
+      "baseline": "3.4.4",
       "port-version": 0
     },
     "openfbx": {

--- a/versions/o-/openexr.json
+++ b/versions/o-/openexr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b80602a27efa650b45541423bb10c1fcc34889b7",
+      "version": "3.4.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "76d89db63a18031e0d212bf12c00d54917d5bfc4",
       "version": "3.4.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.4.4
