### PR TITLE
[directfb2] add port

### DIFF
--- a/ports/directfb2/portfile.cmake
+++ b/ports/directfb2/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO directfb2/DirectFB2
+    REF "7d4682d0cc092ed2f28c903175d1a0c104e9e9a8" # no release tag available yet in upstream: https://github.com/directfb2/DirectFB2/issues/162
+    SHA512 b57c43559992fc7594ca2806dd07c547c13260e7286791eadf64ec75631cb7d61d049d17644e714702919aaee82850387d08fc92b97b8a8a595981faf0c8f4a5
+    HEAD_REF master
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_install_meson(ADD_BIN_TO_PATH)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_clean_executables_in_bin(FILE_NAMES dfb-update-pkgconfig)

--- a/ports/directfb2/vcpkg.json
+++ b/ports/directfb2/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "directfb2",
+  "version-date": "2025-11-25",
+  "description": "A graphics library designed with embedded systems in mind. Clean and drop-in successor to DirectFB",
+  "homepage": "https://github.com/directfb2/DirectFB2",
+  "supports": "linux & !android",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/ports/vulkan-loader/vcpkg.json
+++ b/ports/vulkan-loader/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vulkan-loader",
   "version": "1.4.309.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Vulkan Development Tools",
   "homepage": "https://github.com/KhronosGroup/Vulkan-Loader",
   "license": null,
@@ -19,7 +19,10 @@
   ],
   "features": {
     "directfb": {
-      "description": "Build DirectFB WSI support"
+      "description": "Build DirectFB WSI support",
+      "dependencies": [
+        "directfb2"
+      ]
     },
     "wayland": {
       "description": "Build Wayland WSI support"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10398,7 +10398,7 @@
     },
     "vulkan-loader": {
       "baseline": "1.4.309.0",
-      "port-version": 2
+      "port-version": 3
     },
     "vulkan-memory-allocator": {
       "baseline": "3.3.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2436,6 +2436,10 @@
       "baseline": "0.1.0",
       "port-version": 0
     },
+    "directfb2": {
+      "baseline": "2025-11-25",
+      "port-version": 0
+    },
     "directx-dxc": {
       "baseline": "2025-10-10",
       "port-version": 0

--- a/versions/d-/directfb2.json
+++ b/versions/d-/directfb2.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5b057a7ed942a0266a02241988361a2fb806cd2f",
+      "version-date": "2025-11-25",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/v-/vulkan-loader.json
+++ b/versions/v-/vulkan-loader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1fdf24f832033f1e6a1179ecbff1ac5aa2126d6e",
+      "version": "1.4.309.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "50476d8ba9c81c18f41a401eeb57d830e9719415",
       "version": "1.4.309.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.