### PR TITLE
[vcpkg script] Update ninja to 1.13.2

### DIFF
--- a/scripts/vcpkg-tools.json
+++ b/scripts/vcpkg-tools.json
@@ -249,50 +249,50 @@
       "name": "ninja",
       "os": "windows",
       "arch": "arm64",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "executable": "ninja.exe",
-      "url": "https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-winarm64.zip",
-      "sha512": "6a3873522b3397a4d68c6a6c3e389085b81ba5ff20d4f5c289b3974c8bf7169de9cf2c8d9482c2b06846783492620008f486db44c2c651f007b3c335022a472d",
-      "archive": "ninja-winarm64-1.13.1.zip"
+      "url": "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-winarm64.zip",
+      "sha512": "11541733eede64fe928ad645cd6e5c06cfc2fb7d8c2225aea270a6ed91ffd17c3a13332a348af236e6732cb9f1972fca088cab186439907ca2455b79709d70f6",
+      "archive": "ninja-winarm64-1.13.2.zip"
     },
     {
       "name": "ninja",
       "os": "windows",
       "arch": "x64",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "executable": "ninja.exe",
-      "url": "https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-win.zip",
-      "sha512": "44955ef9e0053036dc316de3693523ce280338c816b445c27fcbe7dd219543b815812662c9082c409b17d823284506faa5b5c3c5f6d3721242dfc73e56d4ec34",
-      "archive": "ninja-win-1.13.1.zip"
+      "url": "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-win.zip",
+      "sha512": "55d3d891e8fc6c8ad7f92e172125319896761e57c5125944613d9bbfa5b9374387e9fc1468ad5bcb31464f43fb1c455ea251343942595f42955dc67090aa12ee",
+      "archive": "ninja-win-1.13.2.zip"
     },
     {
       "name": "ninja",
       "os": "linux",
       "arch": "arm64",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "executable": "ninja",
-      "url": "https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-linux-aarch64.zip",
-      "sha512": "7cd841409fd2a4f35566ab2f0add75d89d94cfaa5952bc550cf263878469ab8109e36553b66e6422018012a4e9af4c7eaf79c84af1733d061231ce3511e3c98e",
-      "archive": "ninja-linux-aarch64-1.13.1.zip"
+      "url": "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-linux-aarch64.zip",
+      "sha512": "318714ef0f7cb81fe5aab99032d19cfec07035e784ec9a1de63825ce8bed70f9ad6c5801b84bb7130a0b7acb6d5ed960b2953b27256ff51e18dfd720840faa39",
+      "archive": "ninja-linux-aarch64-1.13.2.zip"
     },
     {
       "name": "ninja",
       "os": "linux",
       "arch": "x64",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "executable": "ninja",
-      "url": "https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-linux.zip",
-      "sha512": "ca4e424c46c12f4e120ab2030edcff8e34cf5db9d05b4364f2d4be10f46e1a29eef64f7b4bf65fb33cd629b3bc3bcb9292341f92953968ef226f44b52959d916",
-      "archive": "ninja-linux-1.13.1.zip"
+      "url": "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-linux.zip",
+      "sha512": "714b900cf10b7ecb1b641c91f4ef696250c64984e5955a8088e4a538d6e8077f43e55f6da47efcedbe316c68d51a9e98feff51734eb0eac1b17aa85af5698753",
+      "archive": "ninja-linux-1.13.2.zip"
     },
     {
       "name": "ninja",
       "os": "osx",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "executable": "ninja",
-      "url": "https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-mac.zip",
-      "sha512": "72ce74b57d21bcd50c1d457a304a3f4f88d960631a945f754180153a7e747950bc2e34195d0490d2c298bba2c02f96d5a5925b4096ddb7c86b67d35f7579641f",
-      "archive": "ninja-mac-1.13.1.zip"
+      "url": "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-mac.zip",
+      "sha512": "bf71f820791bb2ef97da6e7f8376aaa1c51f3860884df1acde692d2df4c0747a2e167d843dcd5537813da2e5d14457d6ee3f48df13cdd678cea87e68fe73e9f0",
+      "archive": "ninja-mac-1.13.2.zip"
     },
     {
       "name": "powershell-core",


### PR DESCRIPTION
Contains just a [single fix](https://github.com/ninja-build/ninja/releases/tag/v1.13.2), but this could be relevant:
> Fix Ninja exit code when interrupted

I'm not sure, but I think vcpkg could think a build was succeeded, even it was aborted, and therefore cache broken results.