### PR TITLE
[pango] Update to 1.56.4

### DIFF
--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -1,11 +1,12 @@
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.gnome.org/
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO GNOME/pango
-    REF "${VERSION}"
-    SHA512 c980cfed2a4811c32ba473846d7d075e0b949a833089f4cafb436ce7442719307a60eb68956606c315dd6185cb8753df87d4bac140d752eaeaf0b67b17afbd79
-    HEAD_REF master
-) 
+string(REGEX MATCH "^([0-9]*[.][0-9]*)" VERSION_MAJOR_MINOR "${VERSION}")
+vcpkg_download_distfile(SOURCE_ARCHIVE
+    URLS "https://download.gnome.org/sources/pango/${VERSION_MAJOR_MINOR}/pango-${VERSION}.tar.xz"
+    FILENAME "pango-${VERSION}.tar.xz"
+    SHA512 19471618a66b68e19786c458387f2bc8027ecbda5aaf29efcc025a99b3a74402765c6c4c6ea2997d8f1219ef7f1bea817e6ca55e494dff24780f5d3f2a6242a2
+)
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${SOURCE_ARCHIVE}"
+)
 
 if("introspection" IN_LIST FEATURES)
     list(APPEND OPTIONS_RELEASE -Dintrospection=enabled)

--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_download_distfile(SOURCE_ARCHIVE
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${SOURCE_ARCHIVE}"
+    PATCHES
+        relax-gi-requirement.diff
 )
 
 if("introspection" IN_LIST FEATURES)
@@ -18,13 +20,16 @@ endif()
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -Ddocumentation=false
+        -Dman-pages=false
+        -Dbuild-testsuite=false
+        -Dbuild-examples=false
         -Dfontconfig=enabled # Build with FontConfig support.
         -Dsysprof=disabled # include tracing support for sysprof
         -Dlibthai=disabled # Build with libthai support
         -Dcairo=enabled # Build with cairo support
         -Dxft=disabled # Build with xft support
         -Dfreetype=enabled # Build with freetype support
-        -Dgtk_doc=false #Build API reference for Pango using GTK-Doc
         ${OPTIONS}
     OPTIONS_RELEASE
         ${OPTIONS_RELEASE}

--- a/ports/pango/relax-gi-requirement.diff
+++ b/ports/pango/relax-gi-requirement.diff
@@ -1,0 +1,25 @@
+diff --git a/meson.build b/meson.build
+index b8098c1..10033c8 100644
+--- a/meson.build
++++ b/meson.build
+@@ -209,7 +209,7 @@ glib_major_req = 2
+ glib_minor_req = 82
+ 
+ glib_req       = '>= @0@.@1@'.format(glib_major_req, glib_minor_req)
+-gi_req         = '>= 1.83.2'
++gi_req         = '>= 1.82.0'
+ fribidi_req    = '>= 1.0.6'
+ libthai_req    = '>= 0.1.9'
+ harfbuzz_req   = '>= 8.4.0'
+diff --git a/pango/meson.build b/pango/meson.build
+index f3c6d70..674b702 100644
+--- a/pango/meson.build
++++ b/pango/meson.build
+@@ -132,7 +132,6 @@ pango_dep_sources = [pango_enum_h]
+ if build_gir
+   gir_args = [
+     '--quiet',
+-    '--doc-format=gi-docgen',
+   ]
+   harfbuzz_gobject_dep = dependency('harfbuzz-gobject',
+                                     version: harfbuzz_req,

--- a/ports/pango/vcpkg.json
+++ b/ports/pango/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pango",
-  "version": "1.56.1",
-  "port-version": 2,
+  "version": "1.56.4",
   "description": "Text and font handling library.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7393,8 +7393,8 @@
       "port-version": 0
     },
     "pango": {
-      "baseline": "1.56.1",
-      "port-version": 2
+      "baseline": "1.56.4",
+      "port-version": 0
     },
     "pangolin": {
       "baseline": "0.9.4",

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "40d8186f155496d66abb0011a7691939823de111",
+      "git-tree": "89909ae6fb8f9a1a7c4ee8cc2fe80d5651e0e638",
       "version": "1.56.4",
       "port-version": 0
     },

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40d8186f155496d66abb0011a7691939823de111",
+      "version": "1.56.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "96a122d4e6ddef24f15a30ada70853135ad43217",
       "version": "1.56.1",
       "port-version": 2


### PR DESCRIPTION
Use tarball from official mirror service. Cf. https://github.com/microsoft/vcpkg/issues/48350#issue-3633768368.
Removing an unsued gir option which requires a troublesome gobject-introspection update. (Cf. #48155.)
Not updating to 1.57 which needs fontconfig 2.17 which is stuck in separate PRs.