### PR TITLE
[portaudio] Fix linker errors due to duplicate GUID symbols

### DIFF
--- a/ports/portaudio/fix-guid-linker-errors.patch
+++ b/ports/portaudio/fix-guid-linker-errors.patch
@@ -1,0 +1,65 @@
+From bf5d562f6e35d2aa2d264e92f90666484212a88e Mon Sep 17 00:00:00 2001
+From: invertego <invertego@users.noreply.github.com>
+Date: Mon, 2 Oct 2023 16:44:48 -0700
+Subject: [PATCH 1/2] wdmks: declare GUIDs with selectany attribute
+
+Match the behavior of guiddef.h in both mingw and the Windows SDK
+headers. This prevents linking errors caused by multiply defined symbols
+when linking against certain Windows SDK libs (like dxguid.lib).
+---
+ src/hostapi/wdmks/pa_win_wdmks.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/hostapi/wdmks/pa_win_wdmks.c b/src/hostapi/wdmks/pa_win_wdmks.c
+index bafc970d3..5d2a98743 100644
+--- a/src/hostapi/wdmks/pa_win_wdmks.c
++++ b/src/hostapi/wdmks/pa_win_wdmks.c
+@@ -165,11 +165,11 @@ Default is to use the pin category.
+ #define _NTRTL_ /* Turn off default definition of DEFINE_GUIDEX */
+ #undef DEFINE_GUID
+ #if defined(__clang__) || (defined(_MSVC_TRADITIONAL) && !_MSVC_TRADITIONAL) /* clang-cl and new msvc preprocessor: avoid too many arguments error */
+-    #define DEFINE_GUID(n, ...) EXTERN_C const GUID n = {__VA_ARGS__}
++    #define DEFINE_GUID(n, ...) EXTERN_C const GUID DECLSPEC_SELECTANY n = {__VA_ARGS__}
+     #define DEFINE_GUID_THUNK(n, ...) DEFINE_GUID(n, __VA_ARGS__)
+     #define DEFINE_GUIDEX(n) DEFINE_GUID_THUNK(n, STATIC_##n)
+ #else
+-    #define DEFINE_GUID(n, data) EXTERN_C const GUID n = {data}
++    #define DEFINE_GUID(n, data) EXTERN_C const GUID DECLSPEC_SELECTANY n = {data}
+     #define DEFINE_GUID_THUNK(n, data) DEFINE_GUID(n, data)
+     #define DEFINE_GUIDEX(n) DEFINE_GUID_THUNK(n, STATIC_##n)
+ #endif /* __clang__, !_MSVC_TRADITIONAL */
+
+From 63c6e189cafd6f184797776077a141809ef8cf0e Mon Sep 17 00:00:00 2001
+From: Ross Bencina <rossb@audiomulch.com>
+Date: Sat, 7 Oct 2023 09:49:19 +1100
+Subject: [PATCH 2/2] Make sure this works even if DECLSPEC_SELECTANY is not
+ defined
+
+---
+ src/hostapi/wdmks/pa_win_wdmks.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/src/hostapi/wdmks/pa_win_wdmks.c b/src/hostapi/wdmks/pa_win_wdmks.c
+index 5d2a98743..36cb396a8 100644
+--- a/src/hostapi/wdmks/pa_win_wdmks.c
++++ b/src/hostapi/wdmks/pa_win_wdmks.c
+@@ -164,12 +164,17 @@ Default is to use the pin category.
+ #define DYNAMIC_GUID(data) {data}
+ #define _NTRTL_ /* Turn off default definition of DEFINE_GUIDEX */
+ #undef DEFINE_GUID
++#ifdef DECLSPEC_SELECTANY
++#define PA_DECLSPEC_SELECTANY DECLSPEC_SELECTANY
++#else
++#define PA_DECLSPEC_SELECTANY
++#endif
+ #if defined(__clang__) || (defined(_MSVC_TRADITIONAL) && !_MSVC_TRADITIONAL) /* clang-cl and new msvc preprocessor: avoid too many arguments error */
+-    #define DEFINE_GUID(n, ...) EXTERN_C const GUID DECLSPEC_SELECTANY n = {__VA_ARGS__}
++    #define DEFINE_GUID(n, ...) EXTERN_C const GUID PA_DECLSPEC_SELECTANY n = {__VA_ARGS__}
+     #define DEFINE_GUID_THUNK(n, ...) DEFINE_GUID(n, __VA_ARGS__)
+     #define DEFINE_GUIDEX(n) DEFINE_GUID_THUNK(n, STATIC_##n)
+ #else
+-    #define DEFINE_GUID(n, data) EXTERN_C const GUID DECLSPEC_SELECTANY n = {data}
++    #define DEFINE_GUID(n, data) EXTERN_C const GUID PA_DECLSPEC_SELECTANY n = {data}
+     #define DEFINE_GUID_THUNK(n, data) DEFINE_GUID(n, data)
+     #define DEFINE_GUIDEX(n) DEFINE_GUID_THUNK(n, STATIC_##n)
+ #endif /* __clang__, !_MSVC_TRADITIONAL */

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 0f56e5f5b004f51915f29771b8fc1fe886f1fef5d65ab5ea1db43f43c49917476b9eec14b36aa54d3e9fb4d8bdf61e68c79624d00b7e548d4c493395a758233a
     PATCHES
         jack.diff
+        fix-guid-linker-errors.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" PA_DLL_LINK_WITH_STATIC_RUNTIME)

--- a/ports/portaudio/vcpkg.json
+++ b/ports/portaudio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "portaudio",
   "version": "19.7",
-  "port-version": 7,
+  "port-version": 8,
   "description": "PortAudio Portable Cross-platform Audio I/O API PortAudio is a free, cross-platform, open-source, audio I/O library.  It lets you write simple audio programs in 'C' or C++ that will compile and run on many platforms including Windows, Macintosh OS X, and Unix (OSS/ALSA). It is intended to promote the exchange of audio software between developers on different platforms. Many applications use PortAudio for Audio I/O.",
   "homepage": "https://www.portaudio.com",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7702,7 +7702,7 @@
     },
     "portaudio": {
       "baseline": "19.7",
-      "port-version": 7
+      "port-version": 8
     },
     "portmidi": {
       "baseline": "2.0.6",

--- a/versions/p-/portaudio.json
+++ b/versions/p-/portaudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47dce0abd35ae2790f4fa16d09279a80f601db93",
+      "version": "19.7",
+      "port-version": 8
+    },
+    {
       "git-tree": "a0dea3aa03b2c63b924f0c068cd21b6a30a6ada5",
       "version": "19.7",
       "port-version": 7


### PR DESCRIPTION
This applies an upstream patch to portaudio, which fixes the following linker errors due to strong definitions of those GUID symbols in both, portaudio and some libs of the WinSDK:

```
strmiids.lib(strmiids.obj) : error LNK2005: ENCAPIPARAM_BITRATE already defined in portaudio.lib(pa_win_wdmks.c.obj)
strmiids.lib(strmiids.obj) : error LNK2005: ENCAPIPARAM_PEAK_BITRATE already defined in portaudio.lib(pa_win_wdmks.c.obj)
strmiids.lib(strmiids.obj) : error LNK2005: ENCAPIPARAM_BITRATE_MODE already defined in portaudio.lib(pa_win_wdmks.c.obj)
strmiids.lib(strmiids.obj) : error LNK2005: CODECAPI_CHANGELISTS already defined in portaudio.lib(pa_win_wdmks.c.obj)
strmiids.lib(strmiids.obj) : error LNK2005: CODECAPI_VIDEO_ENCODER already defined in portaudio.lib(pa_win_wdmks.c.obj)
strmiids.lib(strmiids.obj) : error LNK2005: CODECAPI_AUDIO_ENCODER already defined in portaudio.lib(pa_win_wdmks.c.obj)
strmiids.lib(strmiids.obj) : error LNK2005: CODECAPI_SETALLDEFAULTS already defined in portaudio.lib(pa_win_wdmks.c.obj)
strmiids.lib(strmiids.obj) : error LNK2005: CODECAPI_ALLSETTINGS already defined in portaudio.lib(pa_win_wdmks.c.obj)
strmiids.lib(strmiids.obj) : error LNK2005: CODECAPI_SUPPORTSEVENTS already defined in portaudio.lib(pa_win_wdmks.c.obj)
strmiids.lib(strmiids.obj) : error LNK2005: CODECAPI_CURRENTCHANGELIST already defined in portaudio.lib(pa_win_wdmks.c.obj)
```


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
