### PR TITLE
[openblas] Add OpenMP feature

### DIFF
--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
 vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
     FEATURES
         threads        USE_THREAD
+        openmp         USE_OPENMP
         simplethread   USE_SIMPLE_THREADED_LEVEL3
         dynamic-arch   DYNAMIC_ARCH
 )

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -21,7 +21,7 @@
   "features": {
     "dynamic-arch": {
       "description": "Support for multiple targets in a single library",
-      "supports": "!windows | mingw",
+      "supports": "!windows | mingw"
     },
     "openmp": {
       "description": "Build blas to play nice with openmp. Can prevent threading issues when using openmp. Requires linking to openmp."

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -21,7 +21,10 @@
   "features": {
     "dynamic-arch": {
       "description": "Support for multiple targets in a single library",
-      "supports": "!windows | mingw"
+      "supports": "!windows | mingw",
+    },
+    "openmp": {
+      "description": "Build blas to play nice with openmp. Can prevent threading issues when using openmp. Requires linking to openmp."
     },
     "simplethread": {
       "description": [

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -191,6 +191,7 @@ ode:arm64-windows=fail
 offscale-libetcd-cpp(uwp)=fail
 ogre-next(android)=fail
 ois:x64-android=fail
+openblas[openmp](osx) = feature-fails # No openmp on default osx toolchain
 opencc:arm64-windows=fail # opencc/deps/rapidjson-1.1.0/rapidjson.h: Unknown machine endianess detected
 opencc:x64-android=fail
 opencc(uwp)=fail # opencc/deps/marisa-0.2.5/lib/marisa/grimoire/io/mapper.cc currently doesn't support UWP.

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3d3d198cfb372ccd328a36248c4c12fb7c6b3bb6",
+      "git-tree": "b149e956977d7e1a07201f9095427a70a7961c60",
       "version": "0.3.29",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
