### PR TITLE
[neko-log] Add new port

### DIFF
--- a/ports/neko-log/portfile.cmake
+++ b/ports/neko-log/portfile.cmake
@@ -1,0 +1,26 @@
+﻿vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO moehoshio/NekoLog
+    REF v1.0.6
+    SHA512 acd86782fab0d3be5e1b4a4b54819b73018d9c14d2347a21d96e01fb2f7cf3641dc83b2363320d0564ad8cc77bb71ad6880dacc55aee8af77a04390d5f509d3c
+    HEAD_REF main
+)
+
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DNEKO_LOG_BUILD_TESTS=OFF
+        -DNEKO_LOG_AUTO_FETCH_DEPS=OFF
+        -DNEKO_LOG_ENABLE_MODULE=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/NekoLog PACKAGE_NAME nekolog)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/neko-log/usage
+++ b/ports/neko-log/usage
@@ -1,0 +1,4 @@
+NekoLog provides CMake targets:
+
+    find_package(NekoLog CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Neko::Log)

--- a/ports/neko-log/vcpkg.json
+++ b/ports/neko-log/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "neko-log",
+  "version": "1.0.6",
+  "description": "An easy-to-use, modern, lightweight, and efficient C++20 logging library",
+  "homepage": "https://github.com/moehoshio/NekoLog",
+  "license": "MIT OR Apache-2.0",
+  "supports": "!uwp",
+  "dependencies": [
+    "neko-schema",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6796,6 +6796,10 @@
       "baseline": "1.0.7",
       "port-version": 0
     },
+    "neko-log": {
+      "baseline": "1.0.6",
+      "port-version": 0
+    },
     "neko-schema": {
       "baseline": "1.0.4",
       "port-version": 0

--- a/versions/n-/neko-log.json
+++ b/versions/n-/neko-log.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "54d5d66ee783ba6aa5ca2d39d3bf55d2f7551597",
+      "version": "1.0.6",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Description

This PR adds **neko-log** to the vcpkg registry.

NekoLog is an easy-to-use, modern, lightweight, and efficient C++20 logging library featuring:
- Header-only design with no macro dependencies
- C++20 modules support (optional)
- Automatic source location capture
- Multiple appenders (Console, File, Custom)
- Asynchronous logging capabilities
- Thread-safe operations
- RAII-style scope logging

### Package Information

- **Package name**: `neko-log`
- **Version**: `1.0.6`
- **Homepage**: https://github.com/moehoshio/NekoLog
- **License**: MIT OR Apache-2.0
- **Dependencies**: `neko-schema`
- **Platform support**: Cross-platform (Linux, Windows, macOS)

## Testing

The package has been verified through automated CI workflows that:

1. **Build and install the package in overlay mode** across multiple platforms and triplets:
   - **Linux**: `x64-linux`, `x64-linux-dynamic`
   - **Windows**: `x64-windows`, `x64-windows-static`, `x86-windows`
   - **macOS**: `x64-osx`, `arm64-osx`

2. **Verify installation structure**, ensuring:
   - Header files are correctly placed in `include/neko/log/`
   - CMake config files are properly installed
   - Copyright and usage files are present
   - No unnecessary debug/lib directories (header-only library)

3. **Build and run a minimal integration test** that:
   - Links against the installed package using CMake's `find_package`
   - Includes the library headers
   - Compiles a simple test program
   - Executes successfully with basic logging functionality

All tests pass on all supported platforms and triplets, confirming the package is ready for distribution.

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

## Additional Notes

- This is a header-only library, so only headers and CMake config files are installed
- The package depends on `neko-schema`, which should be available in vcpkg
- C++20 compiler support is required
- Module support is optional and not enabled in the vcpkg port by default
