### PR TITLE
[node-api-headers] Fix CMakeLists.txt for Windows with CMake 4.0+

### DIFF
--- a/ports/node-api-headers/CMakeLists.txt
+++ b/ports/node-api-headers/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.0)
+
 project(nodelib C)
 
 if (MINGW)

--- a/ports/node-api-headers/vcpkg.json
+++ b/ports/node-api-headers/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "node-api-headers",
   "version": "1.5.0",
+  "port-version": 1,
   "description": "NodeJS API for writing modules in C++",
   "homepage": "https://nodejs.org/api/addons.html",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6906,7 +6906,7 @@
     },
     "node-api-headers": {
       "baseline": "1.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nodesoup": {
       "baseline": "2023-06-12",

--- a/versions/n-/node-api-headers.json
+++ b/versions/n-/node-api-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "946b36ec0b807a2ad6c9da820a216ec6f9e2679e",
+      "version": "1.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0dd99f007a3d9873fda33d17b0dd824b924adb7d",
       "version": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
Add a CMake minimum required version of 3.0 to the node-api-headers port in order to fix builds on CMake >= 4.0 on Windows.

When compiled on Windows, this port installs CMakeLists.txt to the root of the node-api-headers repository before building the port. Up until now, the CMakeLists.txt file neglected to declare a minimum CMake version even though it is required (Refer to CMake policy [CMP0000](https://cmake.org/cmake/help/latest/policy/CMP0000.html)).

The OLD behavior of CMP0000, which was to silently ignore the missing invocation of cmake_minimum_required, was removed in CMake version 4.0. CMake 4.0+ will fail to configure and build projects which do not specify a minimum CMake version.

Bump port-version.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
