### PR TITLE
[gklib] remove potential libm dependency on windows

### DIFF
--- a/ports/gklib/build-fixes.patch
+++ b/ports/gklib/build-fixes.patch
@@ -1,7 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6a9a694..fd3705e 100644
+index 6a9a694..82c3d01 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -73,7 +73,7 @@ target_include_directories(${PROJECT_NAME}
+          $<INSTALL_INTERFACE:include>)
+ 
+ target_link_libraries(${PROJECT_NAME}
+-  PUBLIC $<$<NOT:$<C_COMPILER_ID:MSVC>>:m>)
++  PUBLIC $<$<NOT:$<PLATFORM_ID:Windows>>:m>)
+ 
+ set_target_properties(${PROJECT_NAME} PROPERTIES
+   SOVERSION ${PROJECT_VERSION_MAJOR}
 @@ -163,11 +163,6 @@ target_compile_definitions(${PROJECT_NAME}
  target_compile_options(${PROJECT_NAME}
    PUBLIC $<$<AND:$<BOOL:${GPROF}>,$<BOOL:${HAVE_GPROF_SUPPORT}>>:-pg>)

--- a/ports/gklib/vcpkg.json
+++ b/ports/gklib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gklib",
   "version-date": "2025-07-06",
+  "port-version": 1,
   "description": "General helper libraries for KarypisLab.",
   "homepage": "https://github.com/KarypisLab/GKlib/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3318,7 +3318,7 @@
     },
     "gklib": {
       "baseline": "2025-07-06",
-      "port-version": 0
+      "port-version": 1
     },
     "gl2ps": {
       "baseline": "1.4.2",

--- a/versions/g-/gklib.json
+++ b/versions/g-/gklib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f49528fc119152dfcf0112a49b394228b3c7b6bd",
+      "version-date": "2025-11-27",
+      "port-version": 1
+    },
+    {
       "git-tree": "c3b9e3dbc3c508699816a7723c720428a478b364",
       "version-date": "2025-07-06",
       "port-version": 0

--- a/versions/g-/gklib.json
+++ b/versions/g-/gklib.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "f49528fc119152dfcf0112a49b394228b3c7b6bd",
-      "version-date": "2025-11-27",
+      "git-tree": "931c9baeaa3d783571dabcf49015bd60d0812b28",
+      "version-date": "2025-07-06",
       "port-version": 1
     },
     {


### PR DESCRIPTION
GKLib optionally links to libm using the generator expression `C_COMPILER_ID:MSVC`: this doesn't work in all cases, e.g. if the project is build using a CXX compiler, or if clang or clang-cl is used.
This patch changes the generator expression to `PLATFORM_ID:Windows`, which should be more reliable.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] n.a.  SHA512s are updated for each updated download.
- [ ] n.a. The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x]  Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
