### PR TITLE
[aliyun-oss-cpp-sdk] Update to 1.10.1

### DIFF
--- a/ports/aliyun-oss-cpp-sdk/portfile.cmake
+++ b/ports/aliyun-oss-cpp-sdk/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aliyun/aliyun-oss-cpp-sdk
     REF "${VERSION}"
-    SHA512 7773961ad380d28cda96e16ae6491a76e03f0cb5f0c5135b660179dd449d730e1dfffb916489ed60e13815f53566c24cd9cfd8985c468438369341358eeed3bd
+    SHA512 4bcc1f609e77ea514a1f5ba76e63b51acc322d034e2889e3be545c3eb8d5e783ec9eee30745d536c6ad35474029eb921e31ceaa18f03d4678fccddf66d6604fe
     HEAD_REF master
     PATCHES
         0001-dependency-and-targets.patch

--- a/ports/aliyun-oss-cpp-sdk/vcpkg.json
+++ b/ports/aliyun-oss-cpp-sdk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "aliyun-oss-cpp-sdk",
-  "version": "1.10.0",
-  "port-version": 4,
+  "version": "1.10.1",
   "description": "Alibaba Cloud Object Storage Service (OSS) is a cloud storage service provided by Alibaba Cloud, featuring massive capacity, security, a low cost, and high reliability.",
   "homepage": "https://github.com/aliyun/aliyun-oss-cpp-sdk",
   "license": "Apache-2.0",

--- a/versions/a-/aliyun-oss-cpp-sdk.json
+++ b/versions/a-/aliyun-oss-cpp-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f7e00a365ffd5a3b9a805418314faae13794fed",
+      "version": "1.10.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0a3a24c8c70b6a27060c31a2be0a748bff22ef52",
       "version": "1.10.0",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -89,8 +89,8 @@
       "port-version": 0
     },
     "aliyun-oss-cpp-sdk": {
-      "baseline": "1.10.0",
-      "port-version": 4
+      "baseline": "1.10.1",
+      "port-version": 0
     },
     "allegro5": {
       "baseline": "5.2.10.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.