### PR TITLE
[alpaka] Update to 2.0.0

### DIFF
--- a/ports/alpaka/portfile.cmake
+++ b/ports/alpaka/portfile.cmake
@@ -2,14 +2,15 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alpaka-group/alpaka
     REF ${VERSION}
-    SHA512 ef161c43cafaa4e6cfa8944855dbdafe260d97b23e9275716608301ffffc0f088a3f8bf2f01dc34c38639cf40fe4266e4f48126684ba824a6db6ef3c13fd873f
+    SHA512 b7b21aee985ab37e2130027b789fc4769ebe48073330bbe8c95c2125b7640c39d5ab2fa646a10ce7ea5cbe15d7ab0e3aa4b3fa3e4a8e3f17e00a5b1fcb027023
     HEAD_REF develop
 )
 set(VCPKG_BUILD_TYPE release)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}")
-    
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/alpaka")

--- a/ports/alpaka/vcpkg.json
+++ b/ports/alpaka/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "alpaka",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "The alpaka library is a header-only abstraction library for accelerator development",
   "homepage": "https://github.com/alpaka-group/alpaka",
   "license": "MPL-2.0",

--- a/versions/a-/alpaka.json
+++ b/versions/a-/alpaka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "905ab80fdc77913d16ef196b3ef41d73e250edc8",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cd185626a62396b8160dae226d4f8aa89c8b4822",
       "version": "1.2.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -101,7 +101,7 @@
       "port-version": 0
     },
     "alpaka": {
-      "baseline": "1.2.0",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "alsa": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.