### PR TITLE
[amd-amf] Update to 1.5.0

### DIFF
--- a/ports/amd-amf/portfile.cmake
+++ b/ports/amd-amf/portfile.cmake
@@ -1,11 +1,22 @@
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO GPUOpen-LibrariesAndSDKs/AMF
-    REF "v${VERSION}"
-    SHA512 e19f8f98448412812ea1a4bf677ea501bebfc37871160e1cd0d0d2bf91af22f2115406949b594f405dab153952dcc3cbdc666ef2e6be1b768b803cdde7e23a7b
-    HEAD_REF master
+# Don't use vcpkg_from_github as the archive is much bigger than the headers only archive
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/GPUOpen-LibrariesAndSDKs/AMF/releases/download/v${VERSION}/AMF-headers-v${VERSION}.tar.gz"
+    FILENAME "AMF-headers-v${VERSION}.tar.gz"
+    SHA512 37d618c846bd2ba77ee282ac152fc5f807631007fca8156fca7e541ad1d1cb23786794aaad1ee3d3eb30b2011c4336bec9011031202c3238d91fe48d1e92f97b
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+)
+
+# Download license file
+vcpkg_download_distfile(LICENSE_FILE
+    URLS "https://raw.githubusercontent.com/GPUOpen-LibrariesAndSDKs/AMF/v${VERSION}/LICENSE.txt"
+    FILENAME "LICENSE.txt"
+    SHA512 6b3261e5f38179c0d96483e44b339933a8eb0d9324784953eed74dfe2658ab9d94a9afb09d85ac1138300c8272ac73fb5e1e1f56ea26312f572453fab86f228a
 )
 
 # Install the AMF headers to the default vcpkg location
-file(INSTALL "${SOURCE_PATH}/amf/public/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/AMF")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+file(INSTALL "${SOURCE_PATH}/AMF/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/AMF")
+vcpkg_install_copyright(FILE_LIST "${LICENSE_FILE}")

--- a/ports/amd-amf/vcpkg.json
+++ b/ports/amd-amf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "amd-amf",
-  "version": "1.4.36",
-  "port-version": 1,
+  "version": "1.5.0",
   "description": "AMD Advanced Media Framework headers",
   "homepage": "https://github.com/GPUOpen-LibrariesAndSDKs/AMF",
   "license": "MIT",

--- a/versions/a-/amd-amf.json
+++ b/versions/a-/amd-amf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "773d9ad1a04f02b47d3798dd7857e04c25fbbae6",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f2de56dcf603903f753764e5b3cfd413b58ed323",
       "version": "1.4.36",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -113,8 +113,8 @@
       "port-version": 0
     },
     "amd-amf": {
-      "baseline": "1.4.36",
-      "port-version": 1
+      "baseline": "1.5.0",
+      "port-version": 0
     },
     "ampl-asl": {
       "baseline": "1.0.1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Note: The normal release archive is 170MB bg, vs 81KB for just the header file archive.