### PR TITLE
[s2n] update to 1.6.1

### DIFF
--- a/ports/s2n/portfile.cmake
+++ b/ports/s2n/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aws/s2n-tls
     REF "v${VERSION}"
-    SHA512 bee235eb74559651140c3797a13011979764b7ccd879ce3abe3f2cc651aac24683af489037822bfbcc73a66277a939dcedd68a20f36b7e960942f7933a362343 
+    SHA512 95553ab7db986473f15981fd7631355113e90c6cc2fe4f5a801198a5cd5ed79370a4fde2d53fd89ed0c830dca11b79c7621d22c42c9fe1023e12278de660ca58 
     PATCHES
         fix-cmake-target-path.patch
         openssl.patch

--- a/ports/s2n/vcpkg.json
+++ b/ports/s2n/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "s2n",
-  "version": "1.5.27",
+  "version": "1.6.1",
   "description": "C99 implementation of the TLS/SSL protocols.",
   "homepage": "https://github.com/aws/s2n-tls",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8737,7 +8737,7 @@
       "port-version": 0
     },
     "s2n": {
-      "baseline": "1.5.27",
+      "baseline": "1.6.1",
       "port-version": 0
     },
     "safeint": {

--- a/versions/s-/s2n.json
+++ b/versions/s-/s2n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dee3f49a66b705a4665262c4b55e4d80dad2b077",
+      "version": "1.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ca684756840a914228bf3c2c983d5c71e7197a9c",
       "version": "1.5.27",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/aws/s2n-tls/releases/tag/v1.6.1
https://github.com/aws/s2n-tls/releases/tag/v1.6.0
