### PR TITLE
[simdutf] update to 7.7.0

### DIFF
--- a/ports/simdutf/portfile.cmake
+++ b/ports/simdutf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO simdutf/simdutf
     REF "v${VERSION}"
-    SHA512 0d1d15f0030b002a6cb865b8876f252d9ad1657b7396248902f3adbe23023ac705a40c57e3f1895c3f66fbab6d490c69b545baecdd6ea7a085b0e5c694e38a42
+    SHA512 9af2121d235e5b13589f64a9a9e2a2c83d287fbb1ebe1d5dee500bb229bf856efbb80ac2af1d8b764ca1f9d822a3c1b5b3aac0da958d661b1c84fc0f9a757a5b
     HEAD_REF master
 )
 

--- a/ports/simdutf/vcpkg.json
+++ b/ports/simdutf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdutf",
-  "version-semver": "7.6.0",
+  "version-semver": "7.7.0",
   "description": "Unicode validation and transcoding at billions of characters per second",
   "homepage": "https://github.com/simdutf/simdutf",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9049,7 +9049,7 @@
       "port-version": 0
     },
     "simdutf": {
-      "baseline": "7.6.0",
+      "baseline": "7.7.0",
       "port-version": 0
     },
     "simonbrunel-qtpromise": {

--- a/versions/s-/simdutf.json
+++ b/versions/s-/simdutf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "378e2ed17280950bcb9b740fa36ba394ed1e199f",
+      "version-semver": "7.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6ac8568d11d118dd6d417ad2bcba67230b424b65",
       "version-semver": "7.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/simdutf/simdutf/releases/tag/v7.7.0
