### PR TITLE
[utf8proc] update to 2.11.2

### DIFF
--- a/ports/utf8proc/portfile.cmake
+++ b/ports/utf8proc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO JuliaLang/utf8proc
     REF v${VERSION}
-    SHA512 01796ffd1b253c4943af8c084f60b3fed3ef469a25f017fdb5cdb430fff901741dd06186c938c4559e9f03bbc376d3e90fcf36eba93f9c6febff3be9cc38fdae
+    SHA512 59109d6e4e4f34e23ee9c112199f6eb781f4f58300749dabe418ac5fc1a914e5d522129b86e35f59c224e1bb099a091307206d0cf8012f82c42b92127c1b1aba
 )
 
 vcpkg_cmake_configure(

--- a/ports/utf8proc/vcpkg.json
+++ b/ports/utf8proc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "utf8proc",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Clean C library for processing UTF-8 Unicode data.",
   "homepage": "https://github.com/JuliaLang/utf8proc",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10109,7 +10109,7 @@
       "port-version": 1
     },
     "utf8proc": {
-      "baseline": "2.11.1",
+      "baseline": "2.11.2",
       "port-version": 0
     },
     "utfcpp": {

--- a/versions/u-/utf8proc.json
+++ b/versions/u-/utf8proc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35807db3f400becadade26e3a088236741d18483",
+      "version": "2.11.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d1c1493e2d069882d9c0b412dc2e7c8355283fd4",
       "version": "2.11.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/JuliaStrings/utf8proc/releases/tag/v2.11.2
