### PR TITLE
[aws-c-cal] update to 0.9.13

### DIFF
--- a/ports/aws-c-cal/portfile.cmake
+++ b/ports/aws-c-cal/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-cal
     REF "v${VERSION}"
-    SHA512 918b0afd2b955c32b34c92e1cf253c5dcf74db16eeb30bdda011fca4901b270b3d788fb3daf7051f2197918501dbc104a900f12582dbff1f0d6a8ed29f44df82
+    SHA512 62b84c3bbe9deb1618c66e29f2211c4462fdd85a1a71d63cc815f57cdbde653e659435630471c067688bf0975825717ee1148ab4e1c25e764e37917fb59dff11
     HEAD_REF master
     PATCHES remove-libcrypto-messages.patch
 )

--- a/ports/aws-c-cal/vcpkg.json
+++ b/ports/aws-c-cal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-cal",
-  "version": "0.9.11",
+  "version": "0.9.13",
   "description": "C99 wrapper for cryptography primitives.",
   "homepage": "https://github.com/awslabs/aws-c-cal",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-cal.json
+++ b/versions/a-/aws-c-cal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f5b466fcf369984cbffde978f0cf7f93b93b724b",
+      "version": "0.9.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "5597ec566326b0c28a4f2900ec25c1d216e104bb",
       "version": "0.9.11",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -441,7 +441,7 @@
       "port-version": 0
     },
     "aws-c-cal": {
-      "baseline": "0.9.11",
+      "baseline": "0.9.13",
       "port-version": 0
     },
     "aws-c-common": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/awslabs/aws-c-cal/releases/tag/v0.9.13
https://github.com/awslabs/aws-c-cal/releases/tag/v0.9.12
