### PR TITLE
[projectm] Update projectm port to version 4.1.6

### DIFF
--- a/ports/projectm/portfile.cmake
+++ b/ports/projectm/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO projectM-visualizer/projectm
     REF "v${VERSION}"
-    SHA512 "c59885d1b6c96372f451b436a47a10e72f94e114b0dad913aa91b3ee5b48ce77f8423c011f60786cb2a2577d3875cba8e58f2e70e60116672cbc49b2de695ad4"
+    SHA512 "9102e5136653abb81da2f36f4b08446ef553fe2d49879d8e906bd4cd30728f97ca87075e6561605cf05e0f4ecf8cbd3d95f372a99b2af893058f5c522864ea69"
     HEAD_REF master
     PATCHES
         macos-pkgconfig.patch

--- a/ports/projectm/vcpkg.json
+++ b/ports/projectm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "projectm",
-  "version": "4.1.4",
+  "version": "4.1.6",
   "description": "The projectM Music Visualizer. A cross-platform, OpenGL-based reimplementation of Milkdrop as a reusable library.",
   "homepage": "https://github.com/projectM-visualizer/projectm",
   "license": "LGPL-2.1-only AND MIT AND MIT-0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7761,7 +7761,7 @@
       "port-version": 0
     },
     "projectm": {
-      "baseline": "4.1.4",
+      "baseline": "4.1.6",
       "port-version": 0
     },
     "projectm-eval": {

--- a/versions/p-/projectm.json
+++ b/versions/p-/projectm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6dac9b7f7940cf8a2b902b6d76f7750492bf5a01",
+      "version": "4.1.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "2232688923256f7411cc89a6331fbdd9e1da3425",
       "version": "4.1.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Updating the projectm port to the newly released version 4.1.6, fixing a build issue introduced in the previous 4.1.5 release.