### PR TITLE
[outcome] Update to 2.2.13

### DIFF
--- a/ports/outcome/portfile.cmake
+++ b/ports/outcome/portfile.cmake
@@ -15,12 +15,6 @@
 # the exact copy of those third party libraries known to
 # have passed Outcome's CI process.
 
-vcpkg_download_distfile(MISSING_HEADER_FIX
-    URLS https://github.com/ned14/outcome/commit/d4d38266a0c889be00069600bdbc339456f8f5bd.patch?full_index=1
-    FILENAME outcome-missing-swap-d4d38266a0c889be00069600bdbc339456f8f5bd.patch
-    SHA512 bcc6c050001776b998ff8146b7937ab86811288a0e611b911fad5031b654b0839c41a57196f70ec314c322124e1cb6473a7c5e91472e18b5bb6d35780eaf65f8
-)
-
 if ("polyfill-cxx20" IN_LIST FEATURES)
     message(WARNING [=[
     Outcome depends on QuickCppLib which uses the vcpkg versions of gsl-lite and byte-lite, rather than the versions tested by QuickCppLib's and Outcome's CI. It is not guaranteed to work with other versions, with failures experienced in the past up-to-and-including runtime crashes. See the warning message from QuickCppLib for how you can pin the versions of those dependencies in your manifest file to those with which QuickCppLib was tested. Do not report issues to upstream without first pinning the versions as QuickCppLib was tested against.
@@ -31,11 +25,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ned14/outcome
     REF v${VERSION}
-    SHA512 faa92dbee1f5c74389bc181721e12cd87ad616bdcd2e5845b19233f63cd366270eb806b88ac057ea9a3147e3df49210b7219e9b98a0a0299f00c98eaf2ab8903
+    SHA512 01a7c05d287a2284d5a1a7208f4fd212297217065e77c25cb6efb042877939c34735f3523a8c3eaf8d9f7032f303d3f5fcd1f903dbd64469501cf80634c598ab
     HEAD_REF develop
     PATCHES
         fix-status-code-path.patch
-        "${MISSING_HEADER_FIX}"
         files-do-not-exist.patch
 )
 

--- a/ports/outcome/vcpkg.json
+++ b/ports/outcome/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "outcome",
-  "version": "2.2.12",
-  "port-version": 2,
+  "version": "2.2.13",
   "maintainers": [
     "Niall Douglas <s_github@nedprod.com>",
     "Henrik Gaßmann <henrik@gassmann.onl>"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7385,8 +7385,8 @@
       "port-version": 0
     },
     "outcome": {
-      "baseline": "2.2.12",
-      "port-version": 2
+      "baseline": "2.2.13",
+      "port-version": 0
     },
     "p-ranav-csv": {
       "baseline": "2019-07-11",

--- a/versions/o-/outcome.json
+++ b/versions/o-/outcome.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "864dc027cc9bb08ff96b64cd75eaa10456217a7f",
+      "version": "2.2.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "5e0e997c8d5bdb238cc944b38faf39069a77d322",
       "version": "2.2.12",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
