### PR TITLE
[fxaudio] Update to 1.0.1

### DIFF
--- a/ports/fxaudio/portfile.cmake
+++ b/ports/fxaudio/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO EnzoMassyle/AudioFX
     REF ${VERSION}
-    SHA512 406f346e580a8c0df6a0aa2f38b99b0e58920b05bea97b5dd625b077ef8cc48bbbadeeee1f76cc986dedbbe5eca07e20ba6ade61f6e0a880e071f0fae7afd020
+    SHA512 fca56da7b4579dafd02138817e1b1d6cceb1f6d210f414afb042d8d720e9d611f7a4c110b7edb36b07e6ef0e7b1f412888c0c8e42c35f66db09cde23882aeb6b
     HEAD_REF main
 )
 

--- a/ports/fxaudio/vcpkg.json
+++ b/ports/fxaudio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fxaudio",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An easy to use audio processing library",
   "homepage": "https://github.com/EnzoMassyle/AudioFX",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3165,7 +3165,7 @@
       "port-version": 6
     },
     "fxaudio": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "fxdiv": {

--- a/versions/f-/fxaudio.json
+++ b/versions/f-/fxaudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ded8580ea18ee60c9704f8d905595a1da69fccf2",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c1c1780f32ff86c05cbb4662df79f2f9f91deb37",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.