### PR TITLE
[json-schema-validator] Update to 2.4.0

### DIFF
--- a/ports/json-schema-validator/portfile.cmake
+++ b/ports/json-schema-validator/portfile.cmake
@@ -1,17 +1,9 @@
-vcpkg_download_distfile(PATCH_JSON_SCHEMA_VALIDATOR_PR_315
-    URLS https://github.com/pboettch/json-schema-validator/commit/0034c113477f83c28d4380de1ee189c25b1168e6.patch
-    SHA512 5c165b50813b0d9937ff0eb4d4a81e2d1e77718ac3b0d02b93931c8eddb4e06e4fae1822c5cc97a5b01c995916a29d0af03fcbcd8f059cb29cfeb0e2371b15e3
-    FILENAME 0034c113477f83c28d4380de1ee189c25b1168e6.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pboettch/json-schema-validator
     REF "${VERSION}"
-    SHA512 6d207031acdb94c44f96ff6346dccaf98f2c9d3619d71e419ddabff548ea34d50e8eb103622c99ae28ecb7fddedd687b297e5ad934aa0106c58ac59fc4d65ea9
+    SHA512 67d7ffbee7fe0761171d021d66955c760ee02161a1fb3a3eb89e15cb3f320cb4646f5ae7f9c15ddf50b9ad4312dd03af4eb5c88f7427da9426f0ce4afb67ee59
     HEAD_REF master
-    PATCHES
-        "${PATCH_JSON_SCHEMA_VALIDATOR_PR_315}"
 )
 
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" BUILD_SHARED_LIBS)

--- a/ports/json-schema-validator/vcpkg.json
+++ b/ports/json-schema-validator/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "json-schema-validator",
-  "version": "2.3.0",
-  "port-version": 2,
+  "version": "2.4.0",
   "description": "C++ library for validating JSON documents based on a JSON Schema. This validator is based on the nlohmann-json library.",
   "homepage": "https://github.com/pboettch/json-schema-validator",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4121,8 +4121,8 @@
       "port-version": 0
     },
     "json-schema-validator": {
-      "baseline": "2.3.0",
-      "port-version": 2
+      "baseline": "2.4.0",
+      "port-version": 0
     },
     "json-spirit": {
       "baseline": "4.1.0",

--- a/versions/j-/json-schema-validator.json
+++ b/versions/j-/json-schema-validator.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d2be4a7db1bc34201fe849151869e69ea7ce6a97",
+      "version": "2.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8982b7778711884f44358d66f92ddb1f0ad4b99d",
       "version": "2.3.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
