### PR TITLE
[audit] Update to 4.1.2

### DIFF
--- a/ports/audit/portfile.cmake
+++ b/ports/audit/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO linux-audit/audit-userspace
-    SHA512 14fa19922cf6436284e1448d5a0e069ce5066d2d49d28679fe3ad019be60c133aee6e345b36e0f482ea1fdeadad7d78676f931aab1c25b91a2d0b445dce3eedf
+    SHA512 a47fec1041e11a76ad57b57bcf6e9b454188d95ec26cabf15e92e114d46c7c8f09ddb251d5aebef8bc7faacc6ccffe44c73543d8234af237548b4ad89a408fc3
     REF "v${VERSION}"
     HEAD_REF master
 )

--- a/ports/audit/vcpkg.json
+++ b/ports/audit/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "audit",
-  "version": "4.0.5",
+  "version": "4.1.2",
   "description": "Library for working with audit subsystem",
   "homepage": "https://github.com/linux-audit/audit-userspace",
   "license": "GPL-2.0-or-later OR LGPL-2.1-or-later",

--- a/versions/a-/audit.json
+++ b/versions/a-/audit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e893a1ee6fc7d03944fbbd2cbc10609fa701e56c",
+      "version": "4.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e72e8d1b72bb7e97d7312821e7ae6a4c19f5b905",
       "version": "4.0.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -393,7 +393,7 @@
       "port-version": 0
     },
     "audit": {
-      "baseline": "4.0.5",
+      "baseline": "4.1.2",
       "port-version": 0
     },
     "aurora": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
