### PR TITLE
[bddisasm] Update to 3.0.0

### DIFF
--- a/ports/bddisasm/portfile.cmake
+++ b/ports/bddisasm/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bitdefender/bddisasm
     REF "v${VERSION}"
-    SHA512 5c1b8b8b9a29db76ce6197674e662fdc526e89372a84f7fac8e74cf4cc53bfab8d55c096cdb3f344fcfaa6a4d54a5bef79e8f1cf9131e497636072523b2cf3ec
+    SHA512 584e7640ee1964c6ddca9c8653eeb07836adaa48b99ec1bf62b7fc7e8f094ec75f14f82ac1cb227e1b48352add24841fb2b7f6c53f975d7421e4fd9bdf99cb7c
     HEAD_REF master
 )
 

--- a/ports/bddisasm/vcpkg.json
+++ b/ports/bddisasm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bddisasm",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "maintainers": "Cristi Anichitei <ianichitei@bitdefender.com>",
   "description": "bddisasm is a fast, lightweight, x86/x64 instruction decoder and emulator.",
   "homepage": "https://github.com/bitdefender/bddisasm",

--- a/versions/b-/bddisasm.json
+++ b/versions/b-/bddisasm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8462a1ae4b00ccf36adf0a7532221b306a56ecd9",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "67bc59a4afc477abcc19ae1d0dcc5c4e4884aea6",
       "version": "2.2.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -637,7 +637,7 @@
       "port-version": 4
     },
     "bddisasm": {
-      "baseline": "2.2.0",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "bde": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
