### PR TITLE
[blake3] Update to 1.8.2

### DIFF
--- a/ports/blake3/portfile.cmake
+++ b/ports/blake3/portfile.cmake
@@ -1,11 +1,18 @@
+vcpkg_download_distfile(PATCH_BLAKE3_PR_482
+    URLS https://github.com/BLAKE3-team/BLAKE3/commit/cd6e3e4dd9a9518be45ef742606462ddfb0f3cfd.patch
+    SHA512 a2e6179f577d4b4b3aa83d2f44e2d2a346808fc130f262047e749ee50126970fae1b1d5edf910dae664b65871fadf05cdc2b80c0a8e520807340cf404756ffc5
+    FILENAME cd6e3e4dd9a9518be45ef742606462ddfb0f3cfd.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BLAKE3-team/BLAKE3
     REF "${VERSION}"
-    SHA512 a47ab31ae96d54884f8377e831028e3b503009bf89ac5a4383b83d3fe1cca5c99eefb7486fba9c7f459a7dbbad15754d1354f4e20e7bb0bb63a9e06ee8ce3507
+    SHA512 5832d15373a0ec224e3c8dc86e1540e9246efbdf8db88fc2cce8924552f632532d9b74eeb15e1d31e3f13676656b5230d009151b4c57eb9d84224a9e385ba839
     HEAD_REF main
     PATCHES
         fix-windows-arm-build-error.patch
+        "${PATCH_BLAKE3_PR_482}"
 )
 
 vcpkg_check_features(

--- a/ports/blake3/vcpkg.json
+++ b/ports/blake3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "blake3",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "BLAKE3 cryptographic hash function.",
   "homepage": "https://github.com/BLAKE3-team/BLAKE3",
   "license": "CC0-1.0 OR Apache-2.0",

--- a/versions/b-/blake3.json
+++ b/versions/b-/blake3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2138f2b369e465fced0fbff6bac08d01d9de95f5",
+      "version": "1.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ffbeed13f05feae7a0d28ed51efe781c9a84c0fd",
       "version": "1.8.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -737,7 +737,7 @@
       "port-version": 0
     },
     "blake3": {
-      "baseline": "1.8.1",
+      "baseline": "1.8.2",
       "port-version": 0
     },
     "blas": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
