### PR TITLE
[blickfeld-qb2] Update to 2.13

### DIFF
--- a/ports/blickfeld-qb2/portfile.cmake
+++ b/ports/blickfeld-qb2/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Blickfeld/blickfeld-qb2
     REF "v${VERSION}"
-    SHA512 03711c34b2d36a4b0d6a15c0bcdf725ffbfe8b319f10dab4909550f3adae4a7990fc468956fbf7e2c5dd5cc65964b622ebd988c81641d3e78688e6f9f86beadb
+    SHA512 d1bbec6fdb0cc407f5ec08042bb291c459cebdb5e713daa70be8136bd34a95737dcb9961e7c134d3f325f4219e32c7099e94b17691b69cffdfca845fc4387456
     HEAD_REF main
 )
 

--- a/ports/blickfeld-qb2/vcpkg.json
+++ b/ports/blickfeld-qb2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "blickfeld-qb2",
-  "version": "2.8.3",
+  "version": "2.13",
   "description": "Client library to communicate securely with Qb2 LiDAR devices of Blickfeld GmbH.",
   "homepage": "https://github.com/Blickfeld/blickfeld-qb2",
   "license": "BSD-3-Clause",

--- a/versions/b-/blickfeld-qb2.json
+++ b/versions/b-/blickfeld-qb2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef0cbb924625815fd8180f8d534f27c2fb079983",
+      "version": "2.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "81294fe8a9c1afd9ae86e02c8b91728664c43e0e",
       "version": "2.8.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -753,7 +753,7 @@
       "port-version": 1
     },
     "blickfeld-qb2": {
-      "baseline": "2.8.3",
+      "baseline": "2.13",
       "port-version": 0
     },
     "blingfire": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.