### PR TITLE
[caf] Update to 1.1.0

### DIFF
--- a/ports/caf/portfile.cmake
+++ b/ports/caf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO actor-framework/actor-framework
     REF "${VERSION}"
-    SHA512 496bca714b3d84dafe155f775229e1b6190aae092ab82f8c098af4b0268cd565b980624e93436f5ccba34bac350c62a03ff46b9bddaa1c9bc646d78a2338c53a
+    SHA512 64e504513694b351eec954baae4c243dc3d273cc893094548be31131abfc5bd4eb3968ab6326b26d1b9de8454c1511104a46a4e81c9ff73f54028592abc9f410
     HEAD_REF main
     PATCHES
         fix_dependency.patch

--- a/ports/caf/vcpkg.json
+++ b/ports/caf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "caf",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "an open source implementation of the actor model for C++ featuring lightweight & fast actor implementations, pattern matching for messages, network transparent messaging, and more.",
   "homepage": "https://github.com/actor-framework/actor-framework",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1557,7 +1557,7 @@
       "port-version": 0
     },
     "caf": {
-      "baseline": "1.0.2",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "cairo": {

--- a/versions/c-/caf.json
+++ b/versions/c-/caf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51a8e4c9f38d423f3d79fd7cd9888f30f7b91e5c",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "86e73f510944cefac001f43a61cb7196365c713c",
       "version": "1.0.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.