### PR TITLE
[camport3] Update to 1.6.75

### DIFF
--- a/ports/camport3/portfile.cmake
+++ b/ports/camport3/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO percipioxyz/camport3
-    REF v1.6.2
-    SHA512 e3b1fadb13b826e86aa174215430f5e4175aafd9a967f2401beb3768dcc489a8ce5a74c151d615bd3e34b837c81e201db55b290ef258612381141b0b94212fd1
+    REF "v${VERSION}"
+    SHA512 9d2ab3fdf4c46ca92afbf3c2ebc171df0a29415956e3a4325a4e5146d128e886c09f3b992fbad4c759cadcf22c08d149bb6c37fe33a27accacc66dc71b2b1dfa
     HEAD_REF master
 )
 
@@ -10,8 +10,10 @@ file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/include")
 file(COPY
     "${SOURCE_PATH}/include/TYApi.h"
     "${SOURCE_PATH}/include/TYCoordinateMapper.h"
+    "${SOURCE_PATH}/include/TYDefs.h"
     "${SOURCE_PATH}/include/TYImageProc.h"
     "${SOURCE_PATH}/include/TyIsp.h"
+    "${SOURCE_PATH}/include/TYVer.h"
     DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/camport3/vcpkg.json
+++ b/ports/camport3/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "name": "camport3",
-  "version": "1.6.2",
+  "version": "1.6.75",
   "description": "percipio.xyz cameras SDK",
   "homepage": "https://github.com/percipioxyz/camport3",
+  "license": "LicenseRef-PERCIPIO",
   "supports": "((windows & !uwp & !arm & !arm64 & !static) | linux) & !wasm32"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1573,7 +1573,7 @@
       "port-version": 1
     },
     "camport3": {
-      "baseline": "1.6.2",
+      "baseline": "1.6.75",
       "port-version": 0
     },
     "canvas-ity": {

--- a/versions/c-/camport3.json
+++ b/versions/c-/camport3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f043e6106e14d5944184d28ea29ebd0b46c50029",
+      "version": "1.6.75",
+      "port-version": 0
+    },
+    {
       "git-tree": "f8fd1afea0703ffb17838422fd2aef895ab8c828",
       "version": "1.6.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
