### PR TITLE
freerdp: update to 3.18.0

### DIFF
--- a/ports/freerdp/portfile.cmake
+++ b/ports/freerdp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FreeRDP/FreeRDP
     REF "${VERSION}"
-    SHA512 644a22f011fd31f2d91e73e26f0b4cfc1e9f8cf862440b08a9a81a5a94e921aeeb1dde2be24d6a9395e355d0ccbe89fd369b0cf7bb45582c2eb6f741036da775
+    SHA512 3d33a7b9be130cf5427a2760cb190fee2abf7b1cb9bdd7aa61b3a82e27e36792db8b2bbae940bd1a14a3a122a71685281229646e7e8eb779c1200be5fec2d2f2
     HEAD_REF master
     PATCHES
         dependencies.patch

--- a/ports/freerdp/vcpkg.json
+++ b/ports/freerdp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "freerdp",
-  "version": "3.17.2",
+  "version": "3.18.0",
   "description": "A free implementation of the Remote Desktop Protocol (RDP)",
   "homepage": "https://github.com/FreeRDP/FreeRDP",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3101,7 +3101,7 @@
       "port-version": 9
     },
     "freerdp": {
-      "baseline": "3.17.2",
+      "baseline": "3.18.0",
       "port-version": 0
     },
     "freetds": {

--- a/versions/f-/freerdp.json
+++ b/versions/f-/freerdp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "",
+      "version": "3.18.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5a9d72b56a771354cf51d90840f64221861bea3a",
       "version": "3.17.2",
       "port-version": 0

--- a/versions/f-/freerdp.json
+++ b/versions/f-/freerdp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "",
+      "git-tree": "ac90a1b782b1b28ff90e82994ab3b0b49322857d",
       "version": "3.18.0",
       "port-version": 0
     },


### PR DESCRIPTION
This PR updates FreeRDP to version 3.18.0.

Changes made:
- Updated the version field in ports/freerdp/vcpkg.json
- Updated the SHA512 hash in ports/freerdp/portfile.cmake
- Added a new entry for version 3.18.0 in versions/f-/freerdp.json

No additional changes were required since the REF in the portfile already uses ${VERSION}.
