### PR TITLE
[libatomic-ops] update to 7.10.0

### DIFF
--- a/ports/libatomic-ops/portfile.cmake
+++ b/ports/libatomic-ops/portfile.cmake
@@ -1,14 +1,15 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO ivmai/libatomic_ops
+    REPO bdwgc/libatomic_ops
     REF "v${VERSION}"
-    SHA512 09ea0934e223898b6d6d615813a42e25237ecc9c728b454cabe25a031a72383fb3eccecf36157b9625ca8407363157815b14b8098541453a4d799175d82a710c
+    SHA512 3980e52faaef12fe5794389a88c985124b408e7c2051aae5966939ee1577cd0b7a9e807a373791086f38fb82a7dc2bd062ebbe8efc1124383060f78625fb99cc
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DBUILD_TESTING=OFF
         -Denable_docs=OFF
     OPTIONS_DEBUG
         -Dinstall_headers=OFF

--- a/ports/libatomic-ops/vcpkg.json
+++ b/ports/libatomic-ops/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "libatomic-ops",
-  "version": "7.8.4",
+  "version": "7.10.0",
   "description": "The atomic_ops project (Atomic memory update operations portable implementation)",
-  "homepage": "https://github.com/ivmai/libatomic_ops",
+  "homepage": "https://github.com/bdwgc/libatomic_ops",
   "license": "MIT OR GPL-2.0-or-later",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4621,7 +4621,7 @@
       "port-version": 0
     },
     "libatomic-ops": {
-      "baseline": "7.8.4",
+      "baseline": "7.10.0",
       "port-version": 0
     },
     "libavif": {

--- a/versions/l-/libatomic-ops.json
+++ b/versions/l-/libatomic-ops.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ddbd3cb9af07c73a4d859b488675916af0b3ce6a",
+      "version": "7.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "39768f50d6e4ab0002e76282a3dddf0a8bc95a5e",
       "version": "7.8.4",
       "port-version": 0


### PR DESCRIPTION
Update to the latest upstream.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
