### PR TITLE
[trianglemeshdistance, mujoco] add trianglemeshdistance new port. update mujoco to v3.3.7.

### DIFF
--- a/ports/mujoco/fix_dependencies.patch
+++ b/ports/mujoco/fix_dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index aaac4e38..58bafedb 100644
+index 83b9fdcb..4ad77a3c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -95,7 +95,7 @@ add_subdirectory(src/render)
+@@ -116,7 +116,7 @@ add_subdirectory(src/render)
  add_subdirectory(src/thread)
  add_subdirectory(src/ui)
  
@@ -11,7 +11,7 @@ index aaac4e38..58bafedb 100644
  if(MUJOCO_ENABLE_AVX_INTRINSICS)
    target_compile_definitions(mujoco PUBLIC mjUSEPLATFORMSIMD)
  endif()
-@@ -118,9 +118,9 @@ target_link_libraries(
+@@ -139,9 +139,9 @@ target_link_libraries(
    mujoco
    PRIVATE ccd
            lodepng
@@ -25,7 +25,7 @@ index aaac4e38..58bafedb 100644
  
  set_target_properties(
 diff --git a/cmake/MujocoDependencies.cmake b/cmake/MujocoDependencies.cmake
-index 23e4e71e..e4cfad28 100644
+index ca935cbc..ba3bb48c 100644
 --- a/cmake/MujocoDependencies.cmake
 +++ b/cmake/MujocoDependencies.cmake
 @@ -90,7 +90,7 @@ set(BUILD_SHARED_LIBS
@@ -45,7 +45,7 @@ index 23e4e71e..e4cfad28 100644
  if(NOT TARGET marchingcubecpp)
    FetchContent_Declare(
      marchingcubecpp
-@@ -123,36 +124,60 @@ if(NOT TARGET marchingcubecpp)
+@@ -123,36 +124,61 @@ if(NOT TARGET marchingcubecpp)
      include_directories(${marchingcubecpp_SOURCE_DIR})
    endif()
  endif()
@@ -99,6 +99,7 @@ index 23e4e71e..e4cfad28 100644
 +endif()
 +
 +include_directories(
++  ${Qhull_DIR}/../../include
 +  ${Qhull_DIR}/../../include/libqhull_r
 +  ${Qhull_DIR}/../../include/marchingcubecpp
 +)
@@ -111,7 +112,7 @@ index 23e4e71e..e4cfad28 100644
    PACKAGE_NAME
    tinyxml2
    LIBRARY_NAME
-@@ -165,12 +190,14 @@ findorfetch(
+@@ -165,8 +191,10 @@ findorfetch(
    tinyxml2
    EXCLUDE_FROM_ALL
  )
@@ -120,6 +121,10 @@ index 23e4e71e..e4cfad28 100644
  target_link_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
 +endif()
  
+ # update cmake_minimum_required version for compatibility with newer version of cmake
+ if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+@@ -175,7 +203,7 @@ if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+ endif()
  findorfetch(
    USE_SYSTEM_PACKAGE
 -  OFF
@@ -127,32 +132,36 @@ index 23e4e71e..e4cfad28 100644
    PACKAGE_NAME
    tinyobjloader
    LIBRARY_NAME
-@@ -189,9 +216,9 @@ option(SDFLIB_USE_OPENMP OFF)
- option(SDFLIB_USE_ENOKI OFF)
- findorfetch(
-   USE_SYSTEM_PACKAGE
--  OFF
-+  ON
-   PACKAGE_NAME
--  sdflib
-+  SdfLib
-   LIBRARY_NAME
-   sdflib
-   GIT_REPO
-@@ -202,14 +229,19 @@ findorfetch(
-   SdfLib
-   EXCLUDE_FROM_ALL
- )
-+
-+add_library(SdfLib ALIAS SdfLib::SdfLib)
-+
-+if(0)
- target_compile_options(SdfLib PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
- target_link_options(SdfLib PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
-+endif()
+@@ -193,7 +221,7 @@ if(CMAKE_POLICY_VERSION_MINIMUM_LOCALLY_DEFINED)
+   unset(CMAKE_POLICY_VERSION_MINIMUM_LOCALLY_DEFINED)
+ endif()
  
+-if(NOT TARGET trianglemeshdistance)
++if(0)
+   FetchContent_Declare(
+     trianglemeshdistance
+     GIT_REPOSITORY https://github.com/InteractiveComputerGraphics/TriangleMeshDistance.git
+@@ -217,6 +245,18 @@ if(NOT TARGET trianglemeshdistance)
+   endif()
+ endif()
+ 
++findorfetch(
++  USE_SYSTEM_PACKAGE
++  ON
++  PACKAGE_NAME
++  unofficial-trianglemeshdistance
++  LIBRARY_NAME
++  trianglemeshdistance
++  TARGETS
++  trianglemeshdistance
++  EXCLUDE_FROM_ALL
++)
++
  set(ENABLE_DOUBLE_PRECISION ON)
  set(CCD_HIDE_ALL_SYMBOLS ON)
+ # update cmake_minimum_required version for compatibility with newer version of cmake
+@@ -226,7 +270,7 @@ if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+ endif()
  findorfetch(
    USE_SYSTEM_PACKAGE
 -  OFF
@@ -160,10 +169,10 @@ index 23e4e71e..e4cfad28 100644
    PACKAGE_NAME
    ccd
    LIBRARY_NAME
-@@ -222,11 +254,14 @@ findorfetch(
-   ccd
-   EXCLUDE_FROM_ALL
- )
+@@ -243,11 +287,14 @@ if(CMAKE_POLICY_VERSION_MINIMUM_LOCALLY_DEFINED)
+   unset(CMAKE_POLICY_VERSION_MINIMUM)
+   unset(CMAKE_POLICY_VERSION_MINIMUM_LOCALLY_DEFINED)
+ endif()
 +if(0)
  target_compile_options(ccd PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
  target_link_options(ccd PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
@@ -175,7 +184,7 @@ index 23e4e71e..e4cfad28 100644
  if(WIN32)
    if(MSVC)
      # C4005 is the MSVC equivalent of -Wmacro-redefined.
-@@ -235,6 +270,7 @@ if(WIN32)
+@@ -256,6 +303,7 @@ if(WIN32)
      target_compile_options(ccd PRIVATE -Wno-macro-redefined)
    endif()
  endif()
@@ -184,7 +193,7 @@ index 23e4e71e..e4cfad28 100644
  if(MUJOCO_BUILD_TESTS)
    set(ABSL_PROPAGATE_CXX_STD ON)
 diff --git a/simulate/cmake/SimulateDependencies.cmake b/simulate/cmake/SimulateDependencies.cmake
-index 5141406c..41f399b7 100644
+index 7885f5f9..01db1dbc 100644
 --- a/simulate/cmake/SimulateDependencies.cmake
 +++ b/simulate/cmake/SimulateDependencies.cmake
 @@ -86,7 +86,7 @@ findorfetch(
@@ -200,8 +209,22 @@ index 5141406c..41f399b7 100644
    unset(BUILD_SHARED_LIBS_OLD)
  endif()
  
--if(NOT SIMULATE_STANDALONE)
+-if(NOT SIMULATE_STANDALONE AND NOT MUJOCO_SIMULATE_USE_SYSTEM_GLFW)
 +if(0)
    target_compile_options(glfw PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
    target_link_options(glfw PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
  endif()
+diff --git a/src/user/user_mesh.cc b/src/user/user_mesh.cc
+--- a/src/user/user_mesh.cc
++++ b/src/user/user_mesh.cc
+@@ -33,9 +33,9 @@
+ #include <vector>
+ 
+ #include <mujoco/mjspec.h>
+ #include "user/user_api.h"
+-#include <TriangleMeshDistance/include/tmd/TriangleMeshDistance.h>
++#include <tmd/TriangleMeshDistance.h>
+ 
+ #ifdef MUJOCO_TINYOBJLOADER_IMPL
+ #define TINYOBJLOADER_IMPLEMENTATION
+ #endif

--- a/ports/mujoco/portfile.cmake
+++ b/ports/mujoco/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO deepmind/mujoco
     REF ${VERSION}
-    SHA512 b9862c266c867771a6fbbffbb595684ebaf2c6ae1502718ee2a656e774900094f5e341b212fe8f92646a98da3e431ae4209d8130aee6c41ddc0e33259b8f63ca
+    SHA512 08ae4c638df552112715d08532087430b9457db67b26f5fd8e0e0ec72d5f195694e19749acbf2553285a57a35a9f1aaa3d19194f3ef125014345d0b7a1372f9c
     PATCHES
         fix_dependencies.patch
         disable-werror.patch

--- a/ports/mujoco/vcpkg.json
+++ b/ports/mujoco/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mujoco",
-  "version": "3.3.0",
+  "version": "3.3.7",
   "description": "Multi-Joint dynamics with Contact.",
   "homepage": "https://mujoco.org",
   "license": "Apache-2.0",
@@ -16,9 +16,9 @@
     "lodepng",
     "marchingcubecpp",
     "qhull",
-    "sdflib",
     "tinyobjloader",
     "tinyxml2",
+    "trianglemeshdistance",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/trianglemeshdistance/cmake-export.patch
+++ b/ports/trianglemeshdistance/cmake-export.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,31 @@
+ cmake_minimum_required(VERSION 3.1)
+ project(TriangleMeshDistance)
+ set(CMAKE_CXX_STANDARD 11)
+ 
+-add_subdirectory(tests)
++if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
++    SET(CMAKE_INSTALL_INCLUDEDIR include CACHE
++        PATH "Output directory for header files")
++endif()
++
++add_library(trianglemeshdistance INTERFACE)
++
++target_include_directories(trianglemeshdistance
++    INTERFACE
++        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/TriangleMeshDistance/include>
++        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++)
++
++install(
++    DIRECTORY TriangleMeshDistance/include/
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++)
++
++install(
++    TARGETS trianglemeshdistance
++    EXPORT TriangleMeshDistanceTargets
++)
++
++install(EXPORT TriangleMeshDistanceTargets
++    FILE unofficial-trianglemeshdistance-config.cmake
++    NAMESPACE unofficial::trianglemeshdistance::
++    DESTINATION share/unofficial-trianglemeshdistance)

--- a/ports/trianglemeshdistance/portfile.cmake
+++ b/ports/trianglemeshdistance/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO InteractiveComputerGraphics/TriangleMeshDistance
+    REF 2cb643de1436e1ba8e2be49b07ec5491ac604457 # 2024-08-17
+    SHA512 92a9e7c6e09c9184a3762ae7bb89ffae1ebe0ceead8fe5853cb809ec19c516ce4b3c2fcb3ecc5c2927e3578ebd548b571085527209ea0d58934440f932b554b0
+    PATCHES
+        cmake-export.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+   
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/trianglemeshdistance/vcpkg.json
+++ b/ports/trianglemeshdistance/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "trianglemeshdistance",
+  "version-date": "2024-08-17",
+  "description": "Header only library to compute the signed distance function (SDF) to a triangle mesh.",
+  "homepage": "https://github.com/InteractiveComputerGraphics/TriangleMeshDistance",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6641,7 +6641,7 @@
       "port-version": 0
     },
     "mujoco": {
-      "baseline": "3.3.0",
+      "baseline": "3.3.7",
       "port-version": 0
     },
     "mujs": {
@@ -9943,6 +9943,10 @@
     "triangle": {
       "baseline": "1.6",
       "port-version": 4
+    },
+    "trianglemeshdistance": {
+      "baseline": "2024-08-17",
+      "port-version": 0
     },
     "triton": {
       "baseline": "2025-02-15",

--- a/versions/m-/mujoco.json
+++ b/versions/m-/mujoco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47bb038c84c8f73f905fb67bf9dc0e345fcda81e",
+      "version": "3.3.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "cf24c25916cdfba636fd2b4a4d2a172cdaf9bbf4",
       "version": "3.3.0",
       "port-version": 0

--- a/versions/t-/trianglemeshdistance.json
+++ b/versions/t-/trianglemeshdistance.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4f3f6aff20eeeb11c6e24384e64c72520efcb2b2",
+      "version-date": "2024-08-17",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

