### PR TITLE
[bext-ut] Update to 2.3.1

### DIFF
--- a/ports/bext-ut/portfile.cmake
+++ b/ports/bext-ut/portfile.cmake
@@ -2,14 +2,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO boost-ext/ut
     REF "v${VERSION}"
-    SHA512 6894767ddae9d3ddd7aac2f77565f653e5051d213d39129a149405c6441a5f20a2878a5f548ad8d4ca37f70e44c6360c447f12df9c870149f9ed57a281214c24
+    SHA512 f95bdc9ba483f309bdcbe57d2fef92a0b4301bdb1c83700e711ac152c72a76b1d502a16462cca48074db024c0eb97920ffca7b3236f04c3bb40080c672c80f50
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBOOST_UT_ALLOW_CPM_USE=OFF
         -DBOOST_UT_BUILD_BENCHMARKS=OFF
         -DBOOST_UT_BUILD_EXAMPLES=OFF
         -DBOOST_UT_BUILD_TESTS=OFF
@@ -18,7 +17,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(PACKAGE_NAME ut CONFIG_PATH lib/cmake/ut-${VERSION})
+vcpkg_cmake_config_fixup(PACKAGE_NAME ut CONFIG_PATH lib/cmake/ut)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug"
                     "${CURRENT_PACKAGES_DIR}/lib"

--- a/ports/bext-ut/vcpkg.json
+++ b/ports/bext-ut/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bext-ut",
-  "version": "2.0.1",
+  "version": "2.3.1",
   "description": "C++ single header/single module, macro-free μ(micro)/Unit Testing Framework.",
   "homepage": "https://github.com/boost-ext/ut",
   "license": "BSL-1.0",

--- a/versions/b-/bext-ut.json
+++ b/versions/b-/bext-ut.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ee79d45a5fe130351def4bc8185531284ad92950",
+      "version": "2.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "005d8801fa1f5a1ebb1e7927e9ab55816fe171c0",
       "version": "2.0.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -693,7 +693,7 @@
       "port-version": 0
     },
     "bext-ut": {
-      "baseline": "2.0.1",
+      "baseline": "2.3.1",
       "port-version": 0
     },
     "bext-wintls": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
