### PR TITLE
[libmysofa] Update to 1.3.3

### DIFF
--- a/ports/libmysofa/portfile.cmake
+++ b/ports/libmysofa/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hoene/libmysofa
-    REF "1f9c8df42dfd6765e390ed8840341f15e1ab997b"
-    SHA512 67ce39d78981dc95cf190b1be4addceec4ecc7c2b14660da53a856be8fcff97a2f238343fccac2d042212e5a101eaf26fd12b78c86d0f6ce022bb79aa9815c67
-    HEAD_REF "v${VERSION}"
+    REF "v${VERSION}"
+    SHA512 83800ce29ae5c98f302ca574fd9a28de4ec0f85f5bc217c5497b690f12abdf72809e60e36412d6457181303ba7d082cb050050cd1164e7cfc9446e8e0783dda0
+    HEAD_REF main
     PATCHES
       use-vcpkg-zlib.patch
 )

--- a/ports/libmysofa/vcpkg.json
+++ b/ports/libmysofa/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmysofa",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Reader for AES SOFA files to get better HRTFs (Head-Relative Transfer Functions)",
   "homepage": "https://github.com/hoene/libmysofa",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5209,7 +5209,7 @@
       "port-version": 1
     },
     "libmysofa": {
-      "baseline": "1.3.2",
+      "baseline": "1.3.3",
       "port-version": 0
     },
     "libmysql": {

--- a/versions/l-/libmysofa.json
+++ b/versions/l-/libmysofa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e0c19c902473a0c3b91cecf038a5f499ab1b2326",
+      "version": "1.3.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "7af8df14c5cacf2ba9f4798281ec863159c387ec",
       "version": "1.3.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
