### PR TITLE
[glslang] Update to 16.1.0

### DIFF
--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/glslang
     REF "${VERSION}"
-    SHA512 8ba7e5f73746b221ff39387282e2d929d1142c60d1c79019f4c21c84b105fb59253e88f2f649a25e9bb7ab01094e455f002c7412aeea882548fac4a426eee809
+    SHA512 bcd0604f0a4a1a17ae207b90daeb9031d5c473968d331baf487acbc0f38871a0a82d2b20d274389f9988735e8dcd3fe4d2c2bd1513c77d031c8253c66424dbc4
     HEAD_REF master
 )
 
@@ -46,7 +46,7 @@ endif()
 vcpkg_copy_pdbs()
 
 if(ENABLE_GLSLANG_BINARIES)
-    vcpkg_copy_tools(TOOL_NAMES glslang glslangValidator spirv-remap AUTO_CLEAN)
+    vcpkg_copy_tools(TOOL_NAMES glslang glslangValidator AUTO_CLEAN)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/glslang/vcpkg.json
+++ b/ports/glslang/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glslang",
-  "version": "15.1.0",
+  "version": "16.1.0",
   "description": "Khronos-reference front end for GLSL/ESSL, partial front end for HLSL, and a SPIR-V generator.",
   "homepage": "https://github.com/KhronosGroup/glslang",
   "license": "Apache-2.0 AND BSD-3-Clause AND MIT AND GPL-3.0-or-later",
@@ -25,8 +25,8 @@
       "description": "Build with dynamic typeinfo"
     },
     "tools": {
-      "description": "Build the glslangValidator and spirv-remap binaries",
-      "supports": "!ios"
+      "description": "Build the glslang binaries",
+      "supports": "!android & !ios"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3385,7 +3385,7 @@
       "port-version": 3
     },
     "glslang": {
-      "baseline": "15.1.0",
+      "baseline": "16.1.0",
       "port-version": 0
     },
     "glui": {

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "979a04a1f3893a86dde72b1bdf9efa1d79f1c1db",
+      "version": "16.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "218e34707c9d9c77a6c853ac61f9df9fb91e2555",
       "version": "15.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.