### PR TITLE
[vtk] Fix exported MPI C dependency

### DIFF
--- a/ports/vtk/mpi-language.diff
+++ b/ports/vtk/mpi-language.diff
@@ -1,0 +1,14 @@
+diff --git a/CMake/vtkModule.cmake b/CMake/vtkModule.cmake
+index 28d09e98..654c93f6 100644
+--- a/CMake/vtkModule.cmake
++++ b/CMake/vtkModule.cmake
+@@ -5424,6 +5424,9 @@ if (_vtk_module_find_package_enabled)
+       \"Failed to find the ${_vtk_export_package} package.\")
+   endif ()\n")
+ 
++      if(_vtk_export_package STREQUAL "MPI")
++        string(PREPEND _vtk_export_module_content "  enable_language(C)\n  enable_language(CXX)\n")
++      endif()
+       string(APPEND _vtk_export_module_build_content "${_vtk_export_module_content}")
+       # Private usages should be guarded by `$<BUILD_INTERFACE>` and can be
+       # skipped for the install tree regardless of the build mode.

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -46,6 +46,7 @@ vcpkg_from_github(
         backport-bda8324.diff # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12418
         use-compile-tools.diff
         zspace.diff # https://gitlab.kitware.com/vtk/vtk/-/commit/01a8bd7a917d33892f67a8d76ce7fc4b524d56b4
+        mpi-language.diff
 )
 
 # =============================================================================

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.3.0-pv5.12.1",
-  "port-version": 12,
+  "port-version": 13,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10374,7 +10374,7 @@
     },
     "vtk": {
       "baseline": "9.3.0-pv5.12.1",
-      "port-version": 12
+      "port-version": 13
     },
     "vtk-compile-tools": {
       "baseline": "9.3.0-pv5.12.1",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ff6c94473bcb9575780025c9483582dd9148351",
+      "version-semver": "9.3.0-pv5.12.1",
+      "port-version": 13
+    },
+    {
       "git-tree": "6d758a06fe8b227f7a811d5302ba0e2d103597af",
       "version-semver": "9.3.0-pv5.12.1",
       "port-version": 12


### PR DESCRIPTION
Cherry-picked from #48492: Fixes build of CXX projects like port dbow2.