### PR TITLE
[lapack] Fix lapack for mingw

### DIFF
--- a/ports/lapack-reference/portfile.cmake
+++ b/ports/lapack-reference/portfile.cmake
@@ -87,7 +87,10 @@ if(EXISTS "${pcfile}")
     file(WRITE "${pcfile}" "prefix=${CURRENT_INSTALLED_DIR}/debug\n${_contents}")
 endif()
 
-if(NOT USE_OPTIMIZED_BLAS AND NOT (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static"))
+if(NOT USE_OPTIMIZED_BLAS AND NOT (
+		VCPKG_TARGET_IS_WINDOWS AND
+		VCPKG_LIBRARY_LINKAGE STREQUAL "static" AND
+		NOT VCPKG_TARGET_IS_MINGW ))
     set(pcfile "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/blas.pc")
     if(EXISTS "${pcfile}")
         file(READ "${pcfile}" _contents)

--- a/ports/lapack-reference/vcpkg.json
+++ b/ports/lapack-reference/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lapack-reference",
   "version": "3.12.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "LAPACK - Linear Algebra PACKage",
   "homepage": "https://netlib.org/lapack/",
   "license": "BSD-3-Clause-Open-MPI",
@@ -41,7 +41,7 @@
     },
     "noblas": {
       "description": "Use external optimized BLAS",
-      "supports": "!windows | !static",
+      "supports": "!windows | !static | mingw",
       "dependencies": [
         "blas"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4474,7 +4474,7 @@
     },
     "lapack-reference": {
       "baseline": "3.12.1",
-      "port-version": 1
+      "port-version": 2
     },
     "lastools": {
       "baseline": "2.0.4",

--- a/versions/l-/lapack-reference.json
+++ b/versions/l-/lapack-reference.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f50927961bf58450be5c919b3f2e66584cd6585c",
+      "version": "3.12.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "2cb3ab92f81e3a04378f80e0efb1c1fac10a6164",
       "version": "3.12.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.