### PR TITLE
[serd] Fix build for wasm32-emscripten targets

### DIFF
--- a/ports/serd/portfile.cmake
+++ b/ports/serd/portfile.cmake
@@ -7,14 +7,24 @@ vcpkg_from_gitlab(
     HEAD_REF main
 )
 
+if("tools" IN_LIST FEATURES)
+    set(tools_option -Dtools=enabled)
+else()
+    set(tools_option -Dtools=disabled)
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${tools_option}
 )
 
 vcpkg_install_meson()
 
 vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-vcpkg_copy_tools(TOOL_NAMES serdi AUTO_CLEAN)
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES serdi AUTO_CLEAN)
+endif()
 vcpkg_fixup_pkgconfig()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/serd/vcpkg.json
+++ b/ports/serd/vcpkg.json
@@ -9,5 +9,11 @@
       "name": "vcpkg-tool-meson",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build the serdi command-line tool",
+      "supports": "!emscripten"
+    }
+  }
 }

--- a/ports/serd/vcpkg.json
+++ b/ports/serd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "serd",
   "version": "0.32.6",
+  "port-version": 1,
   "description": "Serd is a lightweight C library for RDF syntax which supports reading and writing Turtle, TRiG, NTriples, and NQuads.",
   "homepage": "https://drobilla.net/software/serd",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8942,7 +8942,7 @@
     },
     "serd": {
       "baseline": "0.32.6",
-      "port-version": 0
+      "port-version": 1
     },
     "serdepp": {
       "baseline": "0.1.4.1",

--- a/versions/s-/serd.json
+++ b/versions/s-/serd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3d0bdc9349a753cf4f10743f81bad487de59025",
+      "version": "0.32.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "52a4af11144b1af1cf5ad7de867a19373966235b",
       "version": "0.32.6",
       "port-version": 0


### PR DESCRIPTION
## Summary
- Disable tools build when targeting Emscripten/WASM by passing `-Dtools=disabled` to meson
- Skip `vcpkg_copy_tools` for WASM targets since CLI executables cannot be built

## Issue
Building serd for `wasm32-emscripten` fails with:

```
CMake Error at scripts/cmake/vcpkg_copy_tools.cmake:36 (message):
Couldn't find tool "serdi"
```

The `serdi` CLI tool cannot be built for WASM targets as executables don't make sense for WASM.

## Test plan
- [ ] Build serd for wasm32-emscripten triplet
- [ ] Verify native builds still include serdi tool