### PR TITLE
[qtwebengine] allow building with MSVC 14.5 / Visual Studio 2026

### DIFF
--- a/ports/qtwebengine/allow-msvc-145.diff
+++ b/ports/qtwebengine/allow-msvc-145.diff
@@ -1,0 +1,13 @@
+diff --git a/configure.cmake b/configure.cmake
+index 6b3b5f770..70a867bdb 100644
+--- a/configure.cmake
++++ b/configure.cmake
+@@ -473,7 +473,7 @@ qt_webengine_configure_check("compiler"
+ )
+ qt_webengine_configure_check("visual-studio"
+     MODULES QtWebEngine QtPdf
+-    CONDITION NOT WIN32 OR NOT MSVC OR MSVC_TOOLSET_VERSION EQUAL 142 OR MSVC_TOOLSET_VERSION EQUAL 143
++    CONDITION NOT WIN32 OR NOT MSVC OR MSVC_TOOLSET_VERSION EQUAL 142 OR MSVC_TOOLSET_VERSION EQUAL 143 OR MSVC_TOOLSET_VERSION EQUAL 145
+     MESSAGE "Build requires Visual Studio 2019 or higher."
+     DOCUMENTATION "Visual Studio 2019 or higher."
+     TAGS WINDOWS_PLATFORM

--- a/ports/qtwebengine/portfile.cmake
+++ b/ports/qtwebengine/portfile.cmake
@@ -12,6 +12,7 @@ set(${PORT}_PATCHES
       "pkg-config.diff"
       "rpath.diff"
       "include-dir-order.diff"
+      "allow-msvc-145.diff"
 )
 
 set(qtwebengine_target "${VCPKG_TARGET_TRIPLET}-${VCPKG_CMAKE_SYSTEM_NAME}")

--- a/ports/qtwebengine/vcpkg.json
+++ b/ports/qtwebengine/vcpkg.json
@@ -2,6 +2,7 @@
   "$comment": "x86-windows is not within the upstream support matrix of Qt6",
   "name": "qtwebengine",
   "version": "6.9.3",
+  "port-version": 1,
   "description": "Qt modules for rendering web and PDF content.",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8306,7 +8306,7 @@
     },
     "qtwebengine": {
       "baseline": "6.9.3",
-      "port-version": 0
+      "port-version": 1
     },
     "qtwebsockets": {
       "baseline": "6.9.3",

--- a/versions/q-/qtwebengine.json
+++ b/versions/q-/qtwebengine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66da6c7157c61ce4a7d775d64b4d38c28a27989b",
+      "version": "6.9.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "a586f13b83645b55a6c47b32354abc3b0031826c",
       "version": "6.9.3",
       "port-version": 0


### PR DESCRIPTION
Trying to build QtWebEngine with MSVC Toolset 14.5 / Visual Studio 2026 currently fails with "Build requires Visual Studio 2019 or higher." due to explicit check for toolset versions 14.2 and 14.3. Extending the check for 14.5 fixes the problem.

Upstream bug: https://qt-project.atlassian.net/browse/QTBUG-142323

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.