### PR TITLE
[libwebsockets] update to 4.5.0

### DIFF
--- a/ports/libwebsockets/export-include-path.patch
+++ b/ports/libwebsockets/export-include-path.patch
@@ -1,7 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
---- a/CMakeLists.txt	(revision b0a749c8e7a8294b68581ce4feac0e55045eb00b)
-+++ b/CMakeLists.txt	(date 1669850632899)
-@@ -1071,8 +1071,8 @@
+index e067e99..35dbddd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1230,8 +1230,8 @@ file(RELATIVE_PATH
      "${LWS_ABSOLUTE_INSTALL_CMAKE_DIR}"
      "${LWS_ABSOLUTE_INSTALL_INCLUDE_DIR}") # Calculate the relative directory from the cmake dir.
  
@@ -12,24 +13,3 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
  endif()
  if (DEFINED OPENSSL_INCLUDE_DIRS)
  	set(LWS__INCLUDE_DIRS "${LWS__INCLUDE_DIRS};${OPENSSL_INCLUDE_DIRS}")
-diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
---- a/lib/CMakeLists.txt	(revision b0a749c8e7a8294b68581ce4feac0e55045eb00b)
-+++ b/lib/CMakeLists.txt	(date 1669850782017)
-@@ -174,7 +174,7 @@
- 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
- 		$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>
- 	)
--	target_include_directories(websockets PRIVATE ${LWS_LIB_BUILD_INC_PATHS})
-+	target_include_directories(websockets PRIVATE $<BUILD_INTERFACE:${LWS_LIB_BUILD_INC_PATHS}> PUBLIC $<INSTALL_INTERFACE:include>)
- 	target_compile_definitions(websockets PRIVATE LWS_BUILDING_STATIC)
- 	target_include_directories(websockets PUBLIC ${LWS_PUBLIC_INCLUDES})
- 	set(LWS_PUBLIC_INCLUDES ${LWS_PUBLIC_INCLUDES} PARENT_SCOPE)
-@@ -202,7 +202,7 @@
- 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
- 		$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>
- 	)
--	target_include_directories(websockets_shared PRIVATE ${LWS_LIB_BUILD_INC_PATHS})
-+	target_include_directories(websockets_shared PRIVATE $<BUILD_INTERFACE:${LWS_LIB_BUILD_INC_PATHS}> PUBLIC $<INSTALL_INTERFACE:include>)
- 	target_compile_definitions(websockets_shared PRIVATE LWS_BUILDING_SHARED)
- 	target_include_directories(websockets_shared PUBLIC ${LWS_PUBLIC_INCLUDES})
- 	set(LWS_PUBLIC_INCLUDES ${LWS_PUBLIC_INCLUDES} PARENT_SCOPE)

--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO warmcat/libwebsockets
     REF "v${VERSION}"
-    SHA512 86f85066ce0e9f7f29af5b7c7be803bd19f1a7e6afd8bcdd7c3afc1a66735324317852d7b19bbe9a5af69e759ec532dd28bebffa256f3e1c30ade7ead41a4275
+    SHA512 25fc588088a712c4906b8a4c83524705bbed3b31494a70cc8455ddd10751d0978d942b21bf218400de1fee8e93dab6a4e0c942044bb36c31465567d5db7e5104
     HEAD_REF master
     PATCHES
         fix-dependency-libuv.patch

--- a/ports/libwebsockets/vcpkg.json
+++ b/ports/libwebsockets/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libwebsockets",
-  "version-semver": "4.4.1",
+  "version-semver": "4.5.0",
   "description": "Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.",
   "homepage": "https://libwebsockets.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5737,7 +5737,7 @@
       "port-version": 2
     },
     "libwebsockets": {
-      "baseline": "4.4.1",
+      "baseline": "4.5.0",
       "port-version": 0
     },
     "libx11": {

--- a/versions/l-/libwebsockets.json
+++ b/versions/l-/libwebsockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1115704d2ab44a991d58f33bcb01e60a98475ce3",
+      "version-semver": "4.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fa06af046274542c8e89ef49d93ad79a773e58aa",
       "version-semver": "4.4.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/warmcat/libwebsockets/releases/tag/v4.5.0
