### PR TITLE
[nuraft] Add new port (#28286)

### DIFF
--- a/ports/nuraft/fix-build-compatibility-issues.patch
+++ b/ports/nuraft/fix-build-compatibility-issues.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0e5ac72..ef6d42c 100644
+index 0e5ac72..0fb7c75 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -177,9 +177,7 @@ endif(WITH_CONAN)
@@ -13,15 +13,6 @@ index 0e5ac72..ef6d42c 100644
  
  # === Compiler flags ===
  option(USE_PTHREAD_EXIT "Call pthread_exit on server threads" OFF)
-@@ -208,7 +206,7 @@ if(NOT WIN32)
-     endif()
- 
- else()
--    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd5045 /wd4571 /wd4774 /wd4820 /wd5039 /wd4626 /wd4625 /wd5026 /wd5027 /wd4623 /wd4996 /wd4530 /wd4267 /wd4244 /W3")
-+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd5045 /wd4571 /wd4774 /wd4820 /wd5039 /wd4626 /wd4625 /wd5026 /wd5027 /wd4623 /wd4996 /wd4530 /wd4267 /wd4244 /W3 /permissive-")
-     message(STATUS "---- WIN32 ----")
- 
-     if(USE_PTHREAD_EXIT)
 @@ -335,10 +333,6 @@ add_library(static_lib ${STATIC_LIB_SRC})
  add_library(NuRaft::static_lib ALIAS static_lib)
  set_target_properties(static_lib PROPERTIES OUTPUT_NAME ${LIBRARY_NAME} CLEAN_DIRECT_OUTPUT 1)
@@ -75,3 +66,16 @@ index 0e5ac72..ef6d42c 100644
      EXPORT nuraft-targets
      LIBRARY DESTINATION lib
      ARCHIVE DESTINATION lib
+diff --git a/src/tracer.hxx b/src/tracer.hxx
+index ac5f100..e10b30a 100644
+--- a/src/tracer.hxx
++++ b/src/tracer.hxx
+@@ -53,7 +53,7 @@ static inline std::string msg_if_given(const char* format, ...) {
+     }
+ 
+     // Get rid of newline at the end.
+-    if ((not msg.empty()) && (msg.back() == '\n')) {
++    if ((!msg.empty()) && (msg.back() == '\n')) {
+         msg.pop_back();
+     }
+     return msg;

--- a/ports/nuraft/fix-build-compatibility-issues.patch
+++ b/ports/nuraft/fix-build-compatibility-issues.patch
@@ -1,0 +1,40 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0e5ac72..e165be8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -335,10 +335,6 @@ add_library(static_lib ${STATIC_LIB_SRC})
+ add_library(NuRaft::static_lib ALIAS static_lib)
+ set_target_properties(static_lib PROPERTIES OUTPUT_NAME ${LIBRARY_NAME} CLEAN_DIRECT_OUTPUT 1)
+ 
+-add_library(shared_lib SHARED ${STATIC_LIB_SRC})
+-add_library(NuRaft::shared_lib ALIAS shared_lib)
+-set_target_properties(shared_lib PROPERTIES OUTPUT_NAME ${LIBRARY_NAME} CLEAN_DIRECT_OUTPUT 1)
+-
+ # Include directories are necessary for dependents to use the targets.
+ target_include_directories(static_lib
+     PUBLIC
+@@ -346,15 +342,8 @@ target_include_directories(static_lib
+     $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
+ )
+ 
+-target_include_directories(shared_lib
+-    PUBLIC
+-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
+-)
+-
+ # if (APPLE)
+ # There is no harm in adding libraries; this is required when building with Conan
+-target_link_libraries(shared_lib ${LIBRARIES})
+ target_link_libraries(static_lib ${LIBRARIES})
+ 
+ # endif ()
+@@ -404,7 +393,7 @@ if(CODE_COVERAGE GREATER 0)
+ endif()
+ 
+ # === Install Targets ===
+-install(TARGETS shared_lib static_lib
++install(TARGETS static_lib
+     EXPORT nuraft-targets
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib

--- a/ports/nuraft/fix-build-compatibility-issues.patch
+++ b/ports/nuraft/fix-build-compatibility-issues.patch
@@ -1,8 +1,31 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0e5ac72..e165be8 100644
+index 0e5ac72..59a0032 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -335,10 +335,6 @@ add_library(static_lib ${STATIC_LIB_SRC})
+@@ -170,7 +170,12 @@ else()
+     # === Other shared libraries ===
+     if(NOT WIN32)
+         set(LIBDL dl)
+-        set(LIBZ z)
++        find_package(ZLIB QUIET)
++        if(ZLIB_FOUND)
++            set(LIBZ ZLIB::ZLIB)
++        else()
++            set(LIBZ z)
++        endif()
+     endif()
+ endif(WITH_CONAN)
+ 
+@@ -208,7 +213,7 @@ if(NOT WIN32)
+     endif()
+ 
+ else()
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd5045 /wd4571 /wd4774 /wd4820 /wd5039 /wd4626 /wd4625 /wd5026 /wd5027 /wd4623 /wd4996 /wd4530 /wd4267 /wd4244 /W3")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd5045 /wd4571 /wd4774 /wd4820 /wd5039 /wd4626 /wd4625 /wd5026 /wd5027 /wd4623 /wd4996 /wd4530 /wd4267 /wd4244 /W3 /permissive-")
+     message(STATUS "---- WIN32 ----")
+ 
+     if(USE_PTHREAD_EXIT)
+@@ -335,10 +340,6 @@ add_library(static_lib ${STATIC_LIB_SRC})
  add_library(NuRaft::static_lib ALIAS static_lib)
  set_target_properties(static_lib PROPERTIES OUTPUT_NAME ${LIBRARY_NAME} CLEAN_DIRECT_OUTPUT 1)
  
@@ -13,7 +36,7 @@ index 0e5ac72..e165be8 100644
  # Include directories are necessary for dependents to use the targets.
  target_include_directories(static_lib
      PUBLIC
-@@ -346,15 +342,8 @@ target_include_directories(static_lib
+@@ -346,17 +347,25 @@ target_include_directories(static_lib
      $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
  )
  
@@ -28,13 +51,30 @@ index 0e5ac72..e165be8 100644
 -target_link_libraries(shared_lib ${LIBRARIES})
  target_link_libraries(static_lib ${LIBRARIES})
  
++if(NOT WIN32)
++    set(TARGET_LIST "shared_lib;static_lib")
++    add_library(shared_lib SHARED ${STATIC_LIB_SRC})
++    add_library(NuRaft::shared_lib ALIAS shared_lib)
++    set_target_properties(shared_lib PROPERTIES OUTPUT_NAME ${LIBRARY_NAME} CLEAN_DIRECT_OUTPUT 1)
++    target_include_directories(shared_lib
++        PUBLIC
++        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
++        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
++    )
++    target_link_libraries(shared_lib ${LIBRARIES})
++else()
++    set(TARGET_LIST "static_lib")
++endif()
++
  # endif ()
-@@ -404,7 +393,7 @@ if(CODE_COVERAGE GREATER 0)
+ if(WIN32)
+     set(LIBRARY_OUTPUT_NAME "${LIBRARY_NAME}.lib")
+@@ -404,7 +413,7 @@ if(CODE_COVERAGE GREATER 0)
  endif()
  
  # === Install Targets ===
 -install(TARGETS shared_lib static_lib
-+install(TARGETS static_lib
++install(TARGETS ${TARGET_LIST}
      EXPORT nuraft-targets
      LIBRARY DESTINATION lib
      ARCHIVE DESTINATION lib

--- a/ports/nuraft/fix-build-compatibility-issues.patch
+++ b/ports/nuraft/fix-build-compatibility-issues.patch
@@ -1,22 +1,19 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0e5ac72..59a0032 100644
+index 0e5ac72..ef6d42c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -170,7 +170,12 @@ else()
-     # === Other shared libraries ===
-     if(NOT WIN32)
-         set(LIBDL dl)
--        set(LIBZ z)
-+        find_package(ZLIB QUIET)
-+        if(ZLIB_FOUND)
-+            set(LIBZ ZLIB::ZLIB)
-+        else()
-+            set(LIBZ z)
-+        endif()
-     endif()
- endif(WITH_CONAN)
+@@ -177,9 +177,7 @@ endif(WITH_CONAN)
+ set(LIBRARIES
+     ${LIBSSL}
+     ${LIBCRYPTO}
+-    ${LIBBOOST_SYSTEM}
+-    ${LIBDL}
+-    ${LIBZ})
++    ${LIBBOOST_SYSTEM})
  
-@@ -208,7 +213,7 @@ if(NOT WIN32)
+ # === Compiler flags ===
+ option(USE_PTHREAD_EXIT "Call pthread_exit on server threads" OFF)
+@@ -208,7 +206,7 @@ if(NOT WIN32)
      endif()
  
  else()
@@ -25,7 +22,7 @@ index 0e5ac72..59a0032 100644
      message(STATUS "---- WIN32 ----")
  
      if(USE_PTHREAD_EXIT)
-@@ -335,10 +340,6 @@ add_library(static_lib ${STATIC_LIB_SRC})
+@@ -335,10 +333,6 @@ add_library(static_lib ${STATIC_LIB_SRC})
  add_library(NuRaft::static_lib ALIAS static_lib)
  set_target_properties(static_lib PROPERTIES OUTPUT_NAME ${LIBRARY_NAME} CLEAN_DIRECT_OUTPUT 1)
  
@@ -36,7 +33,7 @@ index 0e5ac72..59a0032 100644
  # Include directories are necessary for dependents to use the targets.
  target_include_directories(static_lib
      PUBLIC
-@@ -346,17 +347,25 @@ target_include_directories(static_lib
+@@ -346,17 +340,25 @@ target_include_directories(static_lib
      $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
  )
  
@@ -69,7 +66,7 @@ index 0e5ac72..59a0032 100644
  # endif ()
  if(WIN32)
      set(LIBRARY_OUTPUT_NAME "${LIBRARY_NAME}.lib")
-@@ -404,7 +413,7 @@ if(CODE_COVERAGE GREATER 0)
+@@ -404,7 +406,7 @@ if(CODE_COVERAGE GREATER 0)
  endif()
  
  # === Install Targets ===

--- a/ports/nuraft/portfile.cmake
+++ b/ports/nuraft/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO eBay/NuRaft
+    REF "v${VERSION}"
+    SHA512 16baaa9921228c48bfee2aa795b0c644228ceeae32430d2782593dd8087978359edcf47e17e551fbf475df22b127097d8d149fc0996c9ade7b5ae7bafd183f62
+    HEAD_REF master
+)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+    set(msvc_options "-DCMAKE_CXX_FLAGS=\"/std:c++latest\"")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    WINDOWS_USE_MSBUILD
+    OPTIONS
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_TESTING=OFF
+        ${msvc_options}
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/NuRaft)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/nuraft/portfile.cmake
+++ b/ports/nuraft/portfile.cmake
@@ -1,19 +1,20 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+    set(msvc_options "-DCMAKE_CXX_FLAGS=\"/permissive-\"")
+    set(msvc_patches "fix-build-compatibility-issues.patch")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eBay/NuRaft
     REF "v${VERSION}"
     SHA512 16baaa9921228c48bfee2aa795b0c644228ceeae32430d2782593dd8087978359edcf47e17e551fbf475df22b127097d8d149fc0996c9ade7b5ae7bafd183f62
     HEAD_REF master
+    PATCHES ${msvc_patches}
 )
-
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-    set(msvc_options "-DCMAKE_CXX_FLAGS=\"/std:c++latest\"")
-endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    WINDOWS_USE_MSBUILD
     OPTIONS
         -DBUILD_EXAMPLES=OFF
         -DBUILD_TESTING=OFF

--- a/ports/nuraft/portfile.cmake
+++ b/ports/nuraft/portfile.cmake
@@ -1,7 +1,5 @@
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-    set(msvc_options "-DCMAKE_CXX_FLAGS=\"/permissive-\"")
-    set(msvc_patches "fix-build-compatibility-issues.patch")
 endif()
 
 vcpkg_from_github(
@@ -10,7 +8,7 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 16baaa9921228c48bfee2aa795b0c644228ceeae32430d2782593dd8087978359edcf47e17e551fbf475df22b127097d8d149fc0996c9ade7b5ae7bafd183f62
     HEAD_REF master
-    PATCHES ${msvc_patches}
+    PATCHES fix-build-compatibility-issues.patch
 )
 
 vcpkg_cmake_configure(
@@ -18,7 +16,6 @@ vcpkg_cmake_configure(
     OPTIONS
         -DBUILD_EXAMPLES=OFF
         -DBUILD_TESTING=OFF
-        ${msvc_options}
 )
 
 vcpkg_cmake_install()

--- a/ports/nuraft/usage
+++ b/ports/nuraft/usage
@@ -1,0 +1,4 @@
+nuraft provides CMake targets:
+
+  find_package(NuRaft CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE NuRaft::shared_lib NuRaft::static_lib)

--- a/ports/nuraft/usage
+++ b/ports/nuraft/usage
@@ -1,4 +1,4 @@
 nuraft provides CMake targets:
 
   find_package(NuRaft CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE NuRaft::shared_lib NuRaft::static_lib)
+  target_link_libraries(main PRIVATE NuRaft::static_lib)

--- a/ports/nuraft/vcpkg.json
+++ b/ports/nuraft/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "C++ implementation of Raft core logic as a replication library.",
   "homepage": "https://github.com/eBay/NuRaft",
   "license": "Apache-2.0",
-  "supports": "windows | linux | osx",
+  "supports": "!(arm & windows) & !uwp",
   "dependencies": [
     "asio",
     {

--- a/ports/nuraft/vcpkg.json
+++ b/ports/nuraft/vcpkg.json
@@ -18,6 +18,10 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    },
+    {
+      "name": "zlib",
+      "platform": "!windows"
     }
   ]
 }

--- a/ports/nuraft/vcpkg.json
+++ b/ports/nuraft/vcpkg.json
@@ -18,10 +18,6 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "zlib",
-      "platform": "!windows"
     }
   ]
 }

--- a/ports/nuraft/vcpkg.json
+++ b/ports/nuraft/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "C++ implementation of Raft core logic as a replication library.",
   "homepage": "https://github.com/eBay/NuRaft",
   "license": "Apache-2.0",
-  "supports": "!(arm & windows) & !uwp",
+  "supports": "!uwp",
   "dependencies": [
     "asio",
     {

--- a/ports/nuraft/vcpkg.json
+++ b/ports/nuraft/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "nuraft",
+  "version": "3.0.0",
+  "description": "C++ implementation of Raft core logic as a replication library.",
+  "homepage": "https://github.com/eBay/NuRaft",
+  "license": "Apache-2.0",
+  "supports": "windows | linux | osx",
+  "dependencies": [
+    "asio",
+    {
+      "name": "openssl",
+      "platform": "!windows"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6980,6 +6980,10 @@
       "baseline": "2.14.2",
       "port-version": 0
     },
+    "nuraft": {
+      "baseline": "3.0.0",
+      "port-version": 0
+    },
     "nuspell": {
       "baseline": "5.1.6",
       "port-version": 0

--- a/versions/n-/nuraft.json
+++ b/versions/n-/nuraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dd8e3f0cc6a40f9092d70d50f3c85ed27b4de825",
+      "git-tree": "c951fae11b7cc7bca82814f02a6b2c18a442ab4c",
       "version": "3.0.0",
       "port-version": 0
     }

--- a/versions/n-/nuraft.json
+++ b/versions/n-/nuraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "504c98856ab92c05310015861fac54cd63698bdc",
+      "git-tree": "b5972b31d8c1d4dbb52a5f831d8ac10534c44168",
       "version": "3.0.0",
       "port-version": 0
     }

--- a/versions/n-/nuraft.json
+++ b/versions/n-/nuraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "99f9966a3b700dddb9e40afa9c5af8d285c5fc8c",
+      "git-tree": "dd8e3f0cc6a40f9092d70d50f3c85ed27b4de825",
       "version": "3.0.0",
       "port-version": 0
     }

--- a/versions/n-/nuraft.json
+++ b/versions/n-/nuraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a224f30614eab0b6c2b0777973491f22db08e0c8",
+      "git-tree": "504c98856ab92c05310015861fac54cd63698bdc",
       "version": "3.0.0",
       "port-version": 0
     }

--- a/versions/n-/nuraft.json
+++ b/versions/n-/nuraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b5972b31d8c1d4dbb52a5f831d8ac10534c44168",
+      "git-tree": "99f9966a3b700dddb9e40afa9c5af8d285c5fc8c",
       "version": "3.0.0",
       "port-version": 0
     }

--- a/versions/n-/nuraft.json
+++ b/versions/n-/nuraft.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a224f30614eab0b6c2b0777973491f22db08e0c8",
+      "version": "3.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
# Add new port: nuraft

## Description

This PR adds `nuraft`, a C++ replication library implementing the Raft consensus algorithm.

## Package Information

- **Package name:** nuraft
- **Version:** 3.0.0
- **Homepage:** https://github.com/eBay/NuRaft
- **License:** Apache-2.0
- **Supports:** Windows, Linux, macOS

## Dependencies

- `asio` (required)
- `openssl` (required on !windows)

## Testing

✅ This port has been tested and verified:

- **Test Coverage:** Builds and runs integration tests on multiple platforms and triplets:
  - Windows: `x64-windows-static`
  - Linux: `x64-linux`, `x64-linux-dynamic`
  - macOS: `x64-osx`, `arm64-osx`

- **Integration Test:** A test application is compiled and executed to verify:
  - Successful package installation
  - Header file accessibility
  - Library linkage
  - CMake config file correctness
  - Core functionality

- **Build Verification:** All triplets build successfully with proper runtime library handling.

## Build Status

The port successfully builds on:

- ✅ Windows 11 Enterprise (MSVC 2022)
- ✅ Gentoo (latest)
- ✅ macOS 12

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.