### PR TITLE
[proj] Update to 9.7.1

### DIFF
--- a/ports/proj/portfile.cmake
+++ b/ports/proj/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/PROJ
     REF "${VERSION}"
-    SHA512 0899fbf37e9a51abd9a4ded90b5fc0500432b497e27e05b21c524935621098399120cf3151e8ee4637b79943bd7ee31cda75f064a7f9ef47de5199d96ca92aa4
+    SHA512 c5ca62e34612a764cf5cef15e7313ac9e3dccf698e045ac09f8d24e4c109ebf9ee207bcd9d5d698b3f6ecb35d98ec621672f58d130e0eefce74705c3152f374c
     HEAD_REF master
     PATCHES
         fix-proj4-targets-cmake.patch

--- a/ports/proj/vcpkg.json
+++ b/ports/proj/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "proj",
-  "version": "9.7.0",
+  "version": "9.7.1",
   "description": "PROJ library for cartographic projections",
   "homepage": "https://proj.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7769,7 +7769,7 @@
       "port-version": 0
     },
     "proj": {
-      "baseline": "9.7.0",
+      "baseline": "9.7.1",
       "port-version": 0
     },
     "projectm": {

--- a/versions/p-/proj.json
+++ b/versions/p-/proj.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efcf327291c6be6908a96814445f995a7f3ba8e2",
+      "version": "9.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "817f5ae47fb30ba2f01276c4809d4e85583b7fda",
       "version": "9.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.