### PR TITLE
[cppad] Update to 20250000.2

### DIFF
--- a/ports/cppad/portfile.cmake
+++ b/ports/cppad/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO coin-or/CppAD
     REF "${VERSION}"
-    SHA512 a2e9b90246a78319d2a50347e03ee7a4e807e059200d834290981b5fc4ff99e1964c420f606a36b6cacb21d5b254f34edbafa660242b260a828e2259686f40cd
+    SHA512 c94637d1859a8f3ac2ac3064d8f9f0baefefe8da6d4534bfa6a1602d610844bb3838bd9a2fcaf8ae1cce5dc2a2adb5e7eacaeccf006d746552eb2ff3ca75494a
     HEAD_REF master
 )
 
@@ -19,7 +19,12 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+    # Remove empty dirs
+    "${CURRENT_PACKAGES_DIR}/include/cppad/local/sweep/template"
+    "${CURRENT_PACKAGES_DIR}/include/cppad/local/var_op/template"
+)
 
 # Add the copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/cppad/vcpkg.json
+++ b/ports/cppad/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "$comment": "See related issue for compilation failure on UWP and ARM: https://github.com/microsoft/vcpkg/pull/12560#issuecomment-668412073",
   "name": "cppad",
-  "version": "20240000.7",
+  "version": "20250000.2",
   "description": "CppAD: A Package for Differentiation of C++ Algorithms",
   "homepage": "https://github.com/coin-or/CppAD",
   "license": "EPL-2.0",
   "supports": "!(arm | uwp)",
   "dependencies": [
+    "pkgconf",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2045,7 +2045,7 @@
       "port-version": 0
     },
     "cppad": {
-      "baseline": "20240000.7",
+      "baseline": "20250000.2",
       "port-version": 0
     },
     "cppcms": {

--- a/versions/c-/cppad.json
+++ b/versions/c-/cppad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ae82a3ae42d62a6db772e387dae2f45150b27c6",
+      "version": "20250000.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d69e902bac2437d6ccb8828d183d1d00d5ff8a4b",
       "version": "20240000.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
