### PR TITLE
[libcgroup] Update to 3.2.0

### DIFF
--- a/ports/libcgroup/portfile.cmake
+++ b/ports/libcgroup/portfile.cmake
@@ -1,17 +1,9 @@
-vcpkg_download_distfile(PATCH_FIX_SYSTEMD_HEADER_INSTALLATION
-    URLS https://github.com/t43rr7/libcgroup/commit/592dcdcf243576bd2517d3da9bc18990de08e37e.patch?full_index=1
-    SHA512 0977e0b32119d1938ce2af6687ff31f6349aa6189307041d1249967e688ed9d84bc133ef270eb3d474a81644dd2152213c8605c6bd9a585c880fef0e026170fa
-    FILENAME 0000-fix-systemd-header-installation.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libcgroup/libcgroup
-    SHA512 29fb7f5c795080cafc27ab99f2f3d7683933515840226564e047605e41a76f7ca31b48c8c9e8e1963eb808e3fc82206ea6ad550c80dcfb745b5cb7425e2875a9
+    SHA512 53a1362de915a4d57573342234d72d8fe2d91a5df9e06835594235bca29027c10a1f0b232449aa75e1ee77bfd426e9bb11ea38ef001e1f541379d3eb07f94771
     REF "v${VERSION}"
     HEAD_REF master
-    PATCHES
-        "${PATCH_FIX_SYSTEMD_HEADER_INSTALLATION}"
 )
 
 message(STATUS "${PORT} currently requires the following libraries from the system package manager:\n"

--- a/ports/libcgroup/vcpkg.json
+++ b/ports/libcgroup/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcgroup",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Library for working with cgroup",
   "homepage": "https://github.com/libcgroup/libcgroup",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4673,7 +4673,7 @@
       "port-version": 0
     },
     "libcgroup": {
-      "baseline": "3.1.0",
+      "baseline": "3.2.0",
       "port-version": 0
     },
     "libcoap": {

--- a/versions/l-/libcgroup.json
+++ b/versions/l-/libcgroup.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e7f8cec706b2f9141cc953d1185d285c7b76705",
+      "version": "3.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c729cc038b705fdf523ff0ee17ae6d3cc9f08805",
       "version": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
