### PR TITLE
[simpleamqpclient] new port

### DIFF
--- a/ports/simpleamqpclient/portfile.cmake
+++ b/ports/simpleamqpclient/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
         rabbitmqc-use-find-package-config.patch
 )
 
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES

--- a/ports/simpleamqpclient/portfile.cmake
+++ b/ports/simpleamqpclient/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO alanxz/SimpleAmqpClient
+    REF "v${VERSION}"
+    SHA512 f561a45774da55e7b846e6cab7fbcdabb0a6deb462450ca9e8a0e37acccb33957daeb29f31b24671934139f29f8c02c14ba53ce5fdf05b5349f7d6c041e4a6ab
+    HEAD_REF master
+    PATCHES
+        rabbitmqc-use-find-package-config.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        ssl ENABLE_SSL_SUPPORT
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIBS)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+        -DENABLE_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-MIT")

--- a/ports/simpleamqpclient/portfile.cmake
+++ b/ports/simpleamqpclient/portfile.cmake
@@ -8,18 +8,18 @@ vcpkg_from_github(
         rabbitmqc-use-find-package-config.patch
 )
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         ssl ENABLE_SSL_SUPPORT
 )
 
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIBS)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
-        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+        -DBUILD_SHARED_LIBS=ON
         -DENABLE_TESTING=OFF
 )
 

--- a/ports/simpleamqpclient/rabbitmqc-use-find-package-config.patch
+++ b/ports/simpleamqpclient/rabbitmqc-use-find-package-config.patch
@@ -1,0 +1,40 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index efefbfc..ae4b1fc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -52,11 +52,32 @@ find_package(Boost 1.47.0 COMPONENTS chrono system REQUIRED)
+ include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+ link_directories(${Boost_LIBRARY_DIRS})
+ 
+-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Modules)
+-find_package(Rabbitmqc REQUIRED)
+-INCLUDE_DIRECTORIES(SYSTEM ${Rabbitmqc_INCLUDE_DIRS})
++find_package(rabbitmq-c CONFIG REQUIRED)
++if (TARGET rabbitmq::rabbitmq)
++  set(Rabbitmqc_LIBRARY rabbitmq::rabbitmq)
++elseif (TARGET rabbitmq::rabbitmq-static)
++  set(Rabbitmqc_LIBRARY rabbitmq::rabbitmq-static)
++else()
++  message(FATAL_ERROR "Failed to find rabbitmq-c target")
++endif()
++get_target_property(Rabbitmqc_INCLUDE_DIRS ${Rabbitmqc_LIBRARY} INTERFACE_INCLUDE_DIRECTORIES)
++include_directories(SYSTEM ${Rabbitmqc_INCLUDE_DIRS})
++find_file(_Rabbitmqc_SSL_HEADER
++  NAMES amqp_ssl_socket.h
++  PATHS ${Rabbitmqc_INCLUDE_DIRS}
++  NO_DEFAULT_PATH
++)
++if (_Rabbitmqc_SSL_HEADER)
++  set(_ssl_enabled TRUE)
++else()
++  set(_ssl_enabled FALSE)
++endif()
++set(Rabbitmqc_SSL_ENABLED ${_ssl_enabled} CACHE BOOL "Rabbitmqc is SSL Enabled" FORCE)
+ 
+ option(ENABLE_SSL_SUPPORT "Enable SSL support." ${Rabbitmqc_SSL_ENABLED})
++if (ENABLE_SSL_SUPPORT AND NOT Rabbitmqc_SSL_ENABLED)
++  message(FATAL_ERROR "SSL support requested but rabbitmq-c was not built with SSL")
++endif()
+ 
+ if (ENABLE_SSL_SUPPORT)
+   add_definitions(-DSAC_SSL_SUPPORT_ENABLED)

--- a/ports/simpleamqpclient/vcpkg.json
+++ b/ports/simpleamqpclient/vcpkg.json
@@ -1,0 +1,42 @@
+{
+  "name": "simpleamqpclient",
+  "version": "2.5.1",
+  "description": "Simple C++ Interface to rabbitmq-c",
+  "homepage": "https://github.com/alanxz/SimpleAmqpClient",
+  "license": "MIT",
+  "dependencies": [
+    "boost-algorithm",
+    "boost-chrono",
+    "boost-foreach",
+    "boost-lexical-cast",
+    "boost-optional",
+    "boost-smart-ptr",
+    "boost-variant",
+    {
+      "name": "librabbitmq",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "ssl": {
+      "description": "Enable SSL support",
+      "dependencies": [
+        {
+          "name": "librabbitmq",
+          "default-features": false,
+          "features": [
+            "ssl"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/ports/simpleamqpclient/vcpkg.json
+++ b/ports/simpleamqpclient/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Simple C++ Interface to rabbitmq-c",
   "homepage": "https://github.com/alanxz/SimpleAmqpClient",
   "license": "MIT",
+  "supports": "!static",
   "dependencies": [
     "boost-algorithm",
     "boost-chrono",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9072,6 +9072,10 @@
       "baseline": "2020-06-14",
       "port-version": 2
     },
+    "simpleamqpclient": {
+      "baseline": "2.5.1",
+      "port-version": 0
+    },
     "simpleble": {
       "baseline": "0.8.1",
       "port-version": 1

--- a/versions/s-/simpleamqpclient.json
+++ b/versions/s-/simpleamqpclient.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e26b8deb24d0f971f5869b4ce7a60f6479fe9338",
+      "git-tree": "eec2726c36015d86217d317c58b35c9e6eaceb63",
       "version": "2.5.1",
       "port-version": 0
     }

--- a/versions/s-/simpleamqpclient.json
+++ b/versions/s-/simpleamqpclient.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eec2726c36015d86217d317c58b35c9e6eaceb63",
+      "git-tree": "9c25f58a60e5cbb2aa678a53587478a61a406398",
       "version": "2.5.1",
       "port-version": 0
     }

--- a/versions/s-/simpleamqpclient.json
+++ b/versions/s-/simpleamqpclient.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "46cb95498137f029345da1b6a5ef42d6ffb37dea",
+      "git-tree": "e26b8deb24d0f971f5869b4ce7a60f6479fe9338",
       "version": "2.5.1",
       "port-version": 0
     }

--- a/versions/s-/simpleamqpclient.json
+++ b/versions/s-/simpleamqpclient.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "46cb95498137f029345da1b6a5ef42d6ffb37dea",
+      "version": "2.5.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
