### PR TITLE
[if97] Update to 2.2.1

### DIFF
--- a/ports/if97/portfile.cmake
+++ b/ports/if97/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CoolProp/IF97
-    REF v2.1.3
-    SHA512 b29a74f134d69b72ba4bb825b25f0631f2fb335500da5d9016c4e6e417d8c93a5b309e95770eb6a7b723948dd82a7b46d873a1fe4e3f3047a881603442d73eff
+    REF "v${VERSION}"
+    SHA512 c8aef492445a167d76f92174edadfd37d9918a3f9ca718d63d26dc4692ade5539cbce362a92e4a5b78f3d95766baf5da36a6783cc6001bd9fad204ebe2cad44f
     HEAD_REF master
     PATCHES
         relax-encoding.diff

--- a/ports/if97/relax-encoding.diff
+++ b/ports/if97/relax-encoding.diff
@@ -1,8 +1,8 @@
 diff --git a/IF97.h b/IF97.h
-index 864f3a0..4e6cab5 100644
+index 6de27ce..b796d86 100644
 --- a/IF97.h
 +++ b/IF97.h
-@@ -52,7 +52,7 @@ namespace IF97
+@@ -75,7 +75,7 @@ namespace IF97
      // IF97 Constants
      const double Tcrit   = 647.096;             // K
      const double Pcrit   = 22.064*p_fact;       // MPa*
@@ -10,8 +10,8 @@ index 864f3a0..4e6cab5 100644
 +    const double Rhocrit = 322.0;               // kg/m^3
      const double Scrit   = 4.41202148223476*R_fact; // kJ*/kg-K (needed for backward eqn. in Region 3(a)(b)
      const double Ttrip   = 273.16;              // K
-     const double Ptrip   = 0.000611656*p_fact;  // MPa*
-@@ -2394,7 +2394,7 @@ namespace IF97
+     const double Ptrip   = 0.000611657*p_fact;  // MPa*   [Change per IAPWS R7-97(2012), p. 7, Eq. 9]
+@@ -2418,7 +2418,7 @@ namespace IF97
          //    The equation is rearranged to solve for rho and turned
          //    into functions f(T,P,rho0) and f'(T,P,rho0) for the
          //    Newton-Raphson technique.  Functions for
@@ -20,16 +20,16 @@ index 864f3a0..4e6cab5 100644
          //    additional Taylor functions are defined above.
          //
          double f(double T, double p, double rho0) const{
-@@ -4172,7 +4172,7 @@ namespace IF97
-             return RegionOutput( IF97_HMASS,RegionOutputBackward(Pmax,s,IF97_SMASS),Pmax, NONE);
+@@ -4401,7 +4401,7 @@ namespace IF97
+             return RegionOutput( IF97_HMASS,RegionOutputBackward(Pmax,s,IF97_SMASS,false,NONE),Pmax, NONE);
          else { 
          // Determining H(s) along Tmax is difficult because there is no direct p(T,s) formulation.
 -        // This linear combination fit h(s)=a*ln(s)+b/s+c/s²+d is not perfect, but it's close
 +        // This linear combination fit h(s)=a*ln(s)+b/s+c/s^2+d is not perfect, but it's close
          // and can serve as a limit along that Tmax boundary. Coefficients in HTmaxdata above.
          // There is a better way to do this using Newton-Raphson on Tmax = T(p,s), but it is iterative and slow.
-             double ETA = Hmax_n[0]*log(sigma) + Hmax_n[1]/sigma + Hmax_n[2]/pow(sigma,2) +Hmax_n[3];
-@@ -4323,14 +4323,14 @@ namespace IF97
+             double ETA = Hmax_n[0]*log(sigma) + Hmax_n[1]/sigma + Hmax_n[2]/powi(sigma,2) +Hmax_n[3];
+@@ -4556,14 +4556,14 @@ namespace IF97
      inline double cvmass_Tp(double T, double p){ return RegionOutput( IF97_CVMASS, T, p, NONE); };
      /// Get the speed of sound [m/s] as a function of T [K] and p [Pa]
      inline double speed_sound_Tp(double T, double p){ return RegionOutput( IF97_W, T, p, NONE); };
@@ -43,6 +43,15 @@ index 864f3a0..4e6cab5 100644
  
 -    /// Get the viscosity [Pa-s] as a function of T [K] and Rho [kg/m³]
 +    /// Get the viscosity [Pa-s] as a function of T [K] and Rho [kg/m^3]
+     /// Used for function verification only
      inline double visc_TRho(double T, double rho) {	
          // Since we have density, we don't need to determine the region for viscosity.
-         static Region1 R1;  // All regions use base region equations for visc(T,rho).
+@@ -4573,7 +4573,7 @@ namespace IF97
+     /// Get the viscosity [Pa-s] as a function of T [K] and p [Pa]
+     inline double visc_Tp(double T, double p) { return RegionOutput(IF97_MU, T, p, NONE); };
+ 
+-    /// Get the thermal conductivity [W/m-K] as a function of T [K], p [Pa], and Rho [kg/m³]
++    /// Get the thermal conductivity [W/m-K] as a function of T [K], p [Pa], and Rho [kg/m^3]
+     /// Used for function verification only
+     inline double tcond_TpRho(double T, double p, double rho) {
+         // Since we have density, we don't need to determine the region for viscosity.

--- a/ports/if97/vcpkg.json
+++ b/ports/if97/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "if97",
-  "version": "2.1.3",
-  "port-version": 1,
+  "version": "2.2.1",
   "description": "This repository implements the IF97 formulation for the properties of pure water substance.",
   "homepage": "https://github.com/CoolProp/IF97",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3877,8 +3877,8 @@
       "port-version": 0
     },
     "if97": {
-      "baseline": "2.1.3",
-      "port-version": 1
+      "baseline": "2.2.1",
+      "port-version": 0
     },
     "igloo": {
       "baseline": "1.1.1",

--- a/versions/i-/if97.json
+++ b/versions/i-/if97.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d43a90419be9fd2635919078854c294d5326d28",
+      "version": "2.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2177f39e3ea1add06da2e665c0e34d2f620ec9a5",
       "version": "2.1.3",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
