### PR TITLE
[libatomic-ops] update repo/homepage URL, turn off tests compilation

### DIFF
--- a/ports/libatomic-ops/portfile.cmake
+++ b/ports/libatomic-ops/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO ivmai/libatomic_ops
+    REPO bdwgc/libatomic_ops
     REF "v${VERSION}"
     SHA512 3980e52faaef12fe5794389a88c985124b408e7c2051aae5966939ee1577cd0b7a9e807a373791086f38fb82a7dc2bd062ebbe8efc1124383060f78625fb99cc
     HEAD_REF master
@@ -9,6 +9,7 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DBUILD_TESTING=OFF
         -Denable_docs=OFF
     OPTIONS_DEBUG
         -Dinstall_headers=OFF

--- a/ports/libatomic-ops/vcpkg.json
+++ b/ports/libatomic-ops/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "libatomic-ops",
   "version": "7.10.0",
+  "port-version": 1,
   "description": "The atomic_ops project (Atomic memory update operations portable implementation)",
-  "homepage": "https://github.com/ivmai/libatomic_ops",
+  "homepage": "https://github.com/bdwgc/libatomic_ops",
   "license": "MIT OR GPL-2.0-or-later",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4622,7 +4622,7 @@
     },
     "libatomic-ops": {
       "baseline": "7.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libavif": {
       "baseline": "1.3.0",

--- a/versions/l-/libatomic-ops.json
+++ b/versions/l-/libatomic-ops.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39c3630fd2bc1b0e4a8753c214a28fc3e50976ea",
+      "version": "7.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7de96f122092175f9e2f327a0d65921a86c068fe",
       "version": "7.10.0",
       "port-version": 0


### PR DESCRIPTION
Update upstream URL base: github.com/ivmai -> github.com/bdwgc
Turn off compilation of tests (as was previously turned off before [update](https://github.com/microsoft/vcpkg/pull/48587) to v7.10.0)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.