### PR TITLE
[cuda-api-wrappers] Update to 0.8.1

### DIFF
--- a/ports/cuda-api-wrappers/portfile.cmake
+++ b/ports/cuda-api-wrappers/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eyalroz/cuda-api-wrappers
     REF "v${VERSION}"
-    SHA512 14df77c3d613500e57f223fb692b04ea89c6b6b4ba9ecc1b58059e1b2970acaa8986cb55f3f090d305a3fe6136a83d2a8cf0bb88e02be691456fcef1b1867ef9
+    SHA512 5d42cebdc1361e525fc93ea71df6b126f9ce79b2aad3af60e1e59caa8185e3e06997452c588505a294200917c84840f33324bcea8c11ee911b5fd5b11a6b1f9d
     HEAD_REF master
 )
 

--- a/ports/cuda-api-wrappers/vcpkg.json
+++ b/ports/cuda-api-wrappers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cuda-api-wrappers",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Header-only library of integrated wrappers around the core parts of NVIDIA's CUDA execution ecosystem",
   "homepage": "https://github.com/eyalroz/cuda-api-wrappers",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2237,7 +2237,7 @@
       "port-version": 13
     },
     "cuda-api-wrappers": {
-      "baseline": "0.8.0",
+      "baseline": "0.8.1",
       "port-version": 0
     },
     "cudnn": {

--- a/versions/c-/cuda-api-wrappers.json
+++ b/versions/c-/cuda-api-wrappers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39a8d3534f1bf09d31f2549c086d30338466dc9a",
+      "version": "0.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "11274aecf51310841c0165bc3d3b6c77525dd38e",
       "version": "0.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
