### PR TITLE
[orange-math]: try osx support

### DIFF
--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "General purpose math library",
   "homepage": "https://github.com/orange-cpp/omath",
   "license": "Zlib",
-  "supports": "windows | linux",
+  "supports": "windows | linux | osx",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "orange-math",
   "version": "4.4.0",
+  "port-version": 1,
   "description": "General purpose math library",
   "homepage": "https://github.com/orange-cpp/omath",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7346,7 +7346,7 @@
     },
     "orange-math": {
       "baseline": "4.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "orc": {
       "baseline": "2.1.0",

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -6,7 +6,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "2213a59d982b95fdca9d8ebda0c4f1a81145882c",
+      "git-tree": "43ff3f1e99f32af0098b0fbbd380f9815e68ebae",
       "version": "4.4.0",
       "port-version": 0
     },

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "43ff3f1e99f32af0098b0fbbd380f9815e68ebae",
+      "git-tree": "2213a59d982b95fdca9d8ebda0c4f1a81145882c",
       "version": "4.4.0",
       "port-version": 0
     },

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa7f32d8eb2f05696ff63ac32fb840dfa38a39c9",
+      "version": "4.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2213a59d982b95fdca9d8ebda0c4f1a81145882c",
       "version": "4.4.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
