### PR TITLE
[openxr-loader] Update to 1.1.53

### DIFF
--- a/ports/openxr-loader/portfile.cmake
+++ b/ports/openxr-loader/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/OpenXR-SDK-Source
     REF "release-${VERSION}"
-    SHA512 9d7548e6d992cde412e331fc6253960d37897cc4b55cafdc07f7d0a14a70d5ec8534b33f3bb537c797306035cb80aa1b3abf2656ed9d4a6e43e375f5f6e1e2a4
+    SHA512 8e933f6d3cc4e539eea4faa6208dca9037ee844d6f3abd3acf23d18d725ffee75bb61521ebf2bfd3199611c703ba098379aeca53a6bb867f40887fa7a83a4107
     HEAD_REF master
     PATCHES
         fix-openxr-sdk-jsoncpp.patch

--- a/ports/openxr-loader/vcpkg.json
+++ b/ports/openxr-loader/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openxr-loader",
-  "version": "1.1.45",
-  "port-version": 1,
+  "version": "1.1.53",
   "description": "A royalty-free, open standard that provides high-performance access to Augmented Reality (AR) and Virtual Reality (VR)—collectively known as XR—platforms and devices",
   "homepage": "https://github.com/KhronosGroup/OpenXR-SDK",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7321,8 +7321,8 @@
       "port-version": 0
     },
     "openxr-loader": {
-      "baseline": "1.1.45",
-      "port-version": 1
+      "baseline": "1.1.53",
+      "port-version": 0
     },
     "openzl": {
       "baseline": "0.1.0",

--- a/versions/o-/openxr-loader.json
+++ b/versions/o-/openxr-loader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "458a71e49cf48193d632a4eaed61ec729e293094",
+      "version": "1.1.53",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b47fb6babbac5b293d473f955337cc170e3e8a1",
       "version": "1.1.45",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.