### PR TITLE
[usearch] update to 2.21.4

### DIFF
--- a/ports/usearch/portfile.cmake
+++ b/ports/usearch/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO unum-cloud/usearch
     REF "v${VERSION}"
-    SHA512 d4d48c7477c490aa89cfc5eaf3f98f64c3fec1174d21e14dd5e6cbf08b344a5483e2a851e41a4f6e0bdc933b945b7e8f3d116cc84822b235e404bca20d7951ea
+    SHA512 c2b120632b1e6bfccc717ef51bc877ee2a8230c20830942613807b47903ae00fb44cd5a7f40b60844ab066d65edfd5ba531a8722043a1faf92c5557471e68b3f
     HEAD_REF main
     PATCHES
         use-vcpkg-ports.patch

--- a/ports/usearch/vcpkg.json
+++ b/ports/usearch/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "usearch",
-  "version": "2.21.3",
+  "version": "2.21.4",
   "description": "Fastest Search & Clustering engine × for Vectors & Strings",
   "homepage": "https://github.com/unum-cloud/usearch",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10101,7 +10101,7 @@
       "port-version": 0
     },
     "usearch": {
-      "baseline": "2.21.3",
+      "baseline": "2.21.4",
       "port-version": 0
     },
     "usockets": {

--- a/versions/u-/usearch.json
+++ b/versions/u-/usearch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "31f2bdb57497bbb325d06d3add8c35a64981d706",
+      "version": "2.21.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "fdfd47d2a85887339644c8800a038ae4e8c3da9a",
       "version": "2.21.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/unum-cloud/USearch/releases/tag/v2.21.4
