### PR TITLE
Sign the start SAS time.

### DIFF
--- a/scripts/azure-pipelines/android/azure-pipelines.yml
+++ b/scripts/azure-pipelines/android/azure-pipelines.yml
@@ -76,9 +76,10 @@ jobs:
       scriptType: bash
       scriptLocation: 'inlineScript'  # Be very very careful that the exit code from the last pwsh is reported correctly
       inlineScript: |
+        start=`date -u -d "-30 minutes" '+%Y-%m-%dT%H:%MZ'`
         end=`date -u -d "2 days" '+%Y-%m-%dT%H:%MZ'`
-        assetSas=`az storage container generate-sas --name cache --account-name vcpkgassetcachewus --as-user --auth-mode login --https-only --permissions rcl --expiry $end -o tsv`
-        binarySas=`az storage container generate-sas --name cache --account-name vcpkgbinarycachewus --as-user --auth-mode login --https-only --permissions rclw --expiry $end -o tsv`
+        assetSas=`az storage container generate-sas --name cache --account-name vcpkgassetcachewus --as-user --auth-mode login --https-only --permissions rcl --start $start --expiry $end -o tsv`
+        binarySas=`az storage container generate-sas --name cache --account-name vcpkgbinarycachewus --as-user --auth-mode login --https-only --permissions rclw --start $start --expiry $end -o tsv`
         echo Minting SAS tokens valid through $end
         echo "##vso[task.setvariable variable=BCACHE_SAS_TOKEN;issecret=true]$binarySas"
         USER=$(id --user)

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -73,9 +73,10 @@ jobs:
       scriptType: bash
       scriptLocation: 'inlineScript'  # Be very very careful that the exit code from the last pwsh is reported correctly
       inlineScript: |
+        start=`date -u -d "-30 minutes" '+%Y-%m-%dT%H:%MZ'`
         end=`date -u -d "2 days" '+%Y-%m-%dT%H:%MZ'`
-        assetSas=`az storage container generate-sas --name cache --account-name vcpkgassetcachewus --as-user --auth-mode login --https-only --permissions rcl --expiry $end -o tsv`
-        binarySas=`az storage container generate-sas --name cache --account-name vcpkgbinarycachewus --as-user --auth-mode login --https-only --permissions rclw --expiry $end -o tsv`
+        assetSas=`az storage container generate-sas --name cache --account-name vcpkgassetcachewus --as-user --auth-mode login --https-only --permissions rcl --start $start --expiry $end -o tsv`
+        binarySas=`az storage container generate-sas --name cache --account-name vcpkgbinarycachewus --as-user --auth-mode login --https-only --permissions rclw --start $start --expiry $end -o tsv`
         echo Minting SAS tokens valid through $end
         # Persist the binary SAS as a secret pipeline variable for the owners-db step
         echo "##vso[task.setvariable variable=BCACHE_SAS_TOKEN;issecret=true]$binarySas"

--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -49,11 +49,13 @@ jobs:
       scriptLocation: 'inlineScript'
       inlineScript: |
           $current = Get-Date -AsUtc
+          $startDate = $current.AddMinutes(-30)
           $endDate = $current.AddDays(2)
+          $start = Get-Date -Date $startDate -UFormat '+%Y-%m-%dT%H:%MZ'
           $end = Get-Date -Date $endDate -UFormat '+%Y-%m-%dT%H:%MZ'
-          $assetSas = az storage container generate-sas --name cache --account-name vcpkgassetcachewus --as-user --auth-mode login --https-only --permissions rcl --expiry $end -o tsv | Out-String
+          $assetSas = az storage container generate-sas --name cache --account-name vcpkgassetcachewus --as-user --auth-mode login --https-only --permissions rcl --start $start --expiry $end -o tsv | Out-String
           $assetSas = $assetSas.Trim()
-          $binarySas = az storage container generate-sas --name cache --account-name vcpkgbinarycachewus --as-user --auth-mode login --https-only --permissions rclw --expiry $end -o tsv | Out-String
+          $binarySas = az storage container generate-sas --name cache --account-name vcpkgbinarycachewus --as-user --auth-mode login --https-only --permissions rclw --start $start --expiry $end -o tsv | Out-String
           $binarySas = $binarySas.Trim()
           # Persist the binary SAS as a secret pipeline variable for the owners-db step
           Write-Host "##vso[task.setvariable variable=BCACHE_SAS_TOKEN;issecret=true]$binarySas"

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -57,24 +57,27 @@ jobs:
     inputs:
       targetPath: '$(DiffFile)'
       artifact: 'format.diff'
-  - task: AzureCLI@2
+  - task: AzurePowerShell@5
     displayName: '*** Test Modified Ports'
     inputs:
       azureSubscription: 'vcpkg-pr-fleet-wus'
-      scriptType: 'pscore'
-      scriptLocation: 'inlineScript'
-      inlineScript: |
+      ScriptType: 'InlineScript'
+      Inline: |
           $current = Get-Date -AsUtc
           $endDate = $current.AddDays(2)
-          $end = Get-Date -Date $endDate -UFormat '+%Y-%m-%dT%H:%MZ'
-          $assetSas = az storage container generate-sas --name cache --account-name vcpkgassetcachewus --as-user --auth-mode login --https-only --permissions rcl --expiry $end -o tsv | Out-String
-          $assetSas = $assetSas.Trim()
-          $binarySas = az storage container generate-sas --name cache --account-name vcpkgbinarycachewus --as-user --auth-mode login --https-only --permissions rclw --expiry $end -o tsv | Out-String
-          $binarySas = $binarySas.Trim()
+          $assetContext = New-AzStorageContext -StorageAccountName 'vcpkgassetcachewus' -UseConnectedAccount
+          $startDate = $current.AddMinutes(-30)
+          $assetSas = New-AzStorageContainerSASToken -Name 'cache' -Context $assetContext -Permission 'rcl' -StartTime $startDate -ExpiryTime $endDate -Protocol HttpsOnly -AsUser
+          $assetSas = $assetSas.Trim().TrimStart('?')
+          $binaryContext = New-AzStorageContext -StorageAccountName 'vcpkgbinarycachewus' -UseConnectedAccount
+          $binarySas = New-AzStorageContainerSASToken -Name 'cache' -Context $binaryContext -Permission 'rclw' -StartTime $startDate -ExpiryTime $endDate -Protocol HttpsOnly -AsUser
+          $binarySas = $binarySas.Trim().TrimStart('?')
           # Persist the binary SAS as a secret pipeline variable for the owners-db step
           Write-Host "##vso[task.setvariable variable=BCACHE_SAS_TOKEN;issecret=true]$binarySas"
           $env:X_VCPKG_ASSET_SOURCES = "x-azurl,https://vcpkgassetcachewus.blob.core.windows.net/cache,$assetSas,readwrite"
           & scripts/azure-pipelines/test-modified-ports.ps1 -Triplet ${{ replace(parameters.jobName, '_', '-') }} -BuildReason $(Build.Reason) -BinarySourceStub "x-azcopy-sas,https://vcpkgbinarycachewus.blob.core.windows.net/cache,$binarySas" -WorkingRoot $env:WORKING_ROOT -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)
+      azurePowerShellVersion: LatestVersion
+      pwsh: true
   - task: PowerShell@2
     displayName: 'Validate version files'
     condition: eq('${{ replace(parameters.jobName, '_', '-') }}', '${{ variables.ExtraChecksTriplet }}')

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -57,27 +57,26 @@ jobs:
     inputs:
       targetPath: '$(DiffFile)'
       artifact: 'format.diff'
-  - task: AzurePowerShell@5
+  - task: AzureCLI@2
     displayName: '*** Test Modified Ports'
     inputs:
       azureSubscription: 'vcpkg-pr-fleet-wus'
-      ScriptType: 'InlineScript'
-      Inline: |
+      scriptType: 'pscore'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
           $current = Get-Date -AsUtc
           $endDate = $current.AddDays(2)
-          $assetContext = New-AzStorageContext -StorageAccountName 'vcpkgassetcachewus' -UseConnectedAccount
           $startDate = $current.AddMinutes(-30)
-          $assetSas = New-AzStorageContainerSASToken -Name 'cache' -Context $assetContext -Permission 'rcl' -StartTime $startDate -ExpiryTime $endDate -Protocol HttpsOnly -AsUser
-          $assetSas = $assetSas.Trim().TrimStart('?')
-          $binaryContext = New-AzStorageContext -StorageAccountName 'vcpkgbinarycachewus' -UseConnectedAccount
-          $binarySas = New-AzStorageContainerSASToken -Name 'cache' -Context $binaryContext -Permission 'rclw' -StartTime $startDate -ExpiryTime $endDate -Protocol HttpsOnly -AsUser
-          $binarySas = $binarySas.Trim().TrimStart('?')
+          $end = Get-Date -Date $endDate -UFormat '+%Y-%m-%dT%H:%MZ'
+          $start = Get-Date -Date $startDate -UFormat '+%Y-%m-%dT%H:%MZ'
+          $assetSas = az storage container generate-sas --name cache --account-name vcpkgassetcachewus --as-user --auth-mode login --https-only --permissions rcl --start $start --expiry $end -o tsv | Out-String
+          $assetSas = $assetSas.Trim()
+          $binarySas = az storage container generate-sas --name cache --account-name vcpkgbinarycachewus --as-user --auth-mode login --https-only --permissions rclw --start $start --expiry $end -o tsv | Out-String
+          $binarySas = $binarySas.Trim()
           # Persist the binary SAS as a secret pipeline variable for the owners-db step
           Write-Host "##vso[task.setvariable variable=BCACHE_SAS_TOKEN;issecret=true]$binarySas"
           $env:X_VCPKG_ASSET_SOURCES = "x-azurl,https://vcpkgassetcachewus.blob.core.windows.net/cache,$assetSas,readwrite"
           & scripts/azure-pipelines/test-modified-ports.ps1 -Triplet ${{ replace(parameters.jobName, '_', '-') }} -BuildReason $(Build.Reason) -BinarySourceStub "x-azcopy-sas,https://vcpkgbinarycachewus.blob.core.windows.net/cache,$binarySas" -WorkingRoot $env:WORKING_ROOT -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)
-      azurePowerShellVersion: LatestVersion
-      pwsh: true
   - task: PowerShell@2
     displayName: 'Validate version files'
     condition: eq('${{ replace(parameters.jobName, '_', '-') }}', '${{ variables.ExtraChecksTriplet }}')


### PR DESCRIPTION
We got asked to block SAS tokens with a long validity period and turning that on without a start time in the SAS token causes the tokens to be rejected.