### PR TITLE
[openvr] Update to 2.12.14

### DIFF
--- a/ports/openvr/portfile.cmake
+++ b/ports/openvr/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ValveSoftware/openvr
-    REF v2.5.1
-    SHA512 e224737e75f21ec074ca8450a1f1d81764aafeec924cc92a3f5571efc466d74280cb59b0ddfcd251431165ffbfae8aa0c8afe94144fe1c9106a3aa4c2761f3dc
+    REF "v${VERSION}"
+    SHA512 95e7263e4a03a58c9f6b7efc586a963578fd6c468ce9cd73d2e4caa9fff3a0f63f94e6e69234bc220a49e8a9341c19b8144449116466f9476e0e9cc1ca36e403
     HEAD_REF master
 )
 

--- a/ports/openvr/vcpkg.json
+++ b/ports/openvr/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openvr",
-  "version": "2.5.1",
-  "port-version": 1,
+  "version": "2.12.14",
   "description": "An API and runtime that allows access to VR hardware from multiple vendors without requiring that applications have specific knowledge of the hardware they are targeting.",
   "homepage": "https://github.com/ValveSoftware/openvr",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7313,8 +7313,8 @@
       "port-version": 1
     },
     "openvr": {
-      "baseline": "2.5.1",
-      "port-version": 1
+      "baseline": "2.12.14",
+      "port-version": 0
     },
     "openxlsx": {
       "baseline": "2025-07-14",

--- a/versions/o-/openvr.json
+++ b/versions/o-/openvr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b87f87eae0bd7297ec88e86e2a6fb14e9802e7a4",
+      "version": "2.12.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "c77779dc51d757b6652b90cec18fb264c3f9273f",
       "version": "2.5.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.