### PR TITLE
[lockpp] Update to 3.2.0

### DIFF
--- a/ports/lockpp/portfile.cmake
+++ b/ports/lockpp/portfile.cmake
@@ -2,12 +2,27 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Curve/lockpp
     REF "v${VERSION}"
-    SHA512 ce2572ff53096a53cda722e47bbd23e4c3a8b3856de9dfe775b7468cd5f7fcbc86412457af091b8977dd0b41d161c103b679c7a98016f6e9d3ab70aaa360648f
+    SHA512 0581718dc2451d3cc62f2d0443f52a1adc95fe7a8ee859bd9cca78d68aa029ce7bc9e5387eca24f1b5fe44fc4af3ec662426c471b16e5ad0f29aa83ae0d2c4c1
     HEAD_REF master
+    PATCHES
+        remove-cpm.patch
 )
 
-vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+# Replace CPM and download PackageProject directly to avoid issues with FETCHCONTENT_FULLY_DISCONNECTED
+vcpkg_from_github(
+    OUT_SOURCE_PATH PACKAGE_PROJECT_PATH
+    REPO TheLartians/PackageProject.cmake
+    REF "v1.13.0"
+    SHA512 3cf0523bddc213f206ed0ca57803550cb7db9e293392d3741138be47f49d9027ef517e1656235a349a62b492d35c3fc677714dc00afe59e2d36144a9689cfa8f
+    HEAD_REF master
+)
+file(RENAME "${PACKAGE_PROJECT_PATH}" "${SOURCE_PATH}/cmake/packageproject.cmake")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/cmake/lockpp-${VERSION}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/lockpp/remove-cpm.patch
+++ b/ports/lockpp/remove-cpm.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d811dda..dc28e2f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,13 +39,7 @@ endif()
+ # Install Targets
+ # --------------------------------------------------------------------------------------------------------
+ 
+-include("cmake/cpm.cmake")
+-
+-CPMFindPackage(
+-  NAME           PackageProject
+-  VERSION        1.13.0
+-  GIT_REPOSITORY "https://github.com/TheLartians/PackageProject.cmake"
+-)
++add_subdirectory(cmake/packageproject.cmake)
+ 
+ packageProject(
+   NAMESPACE cr

--- a/ports/lockpp/vcpkg.json
+++ b/ports/lockpp/vcpkg.json
@@ -1,13 +1,16 @@
 {
   "name": "lockpp",
-  "version": "3.0",
-  "port-version": 1,
+  "version": "3.2.0",
   "description": "A C++17 Library that provides mutex protected objects",
   "homepage": "https://github.com/Curve/lockpp",
   "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/ports/saucer/0001-use-local-packages.patch
+++ b/ports/saucer/0001-use-local-packages.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 32fdea7..2698429 100644
+index 32fdea7..cc311e0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -286,62 +286,28 @@ endif()
+@@ -286,62 +286,26 @@ endif()
  include("cmake/nuget.cmake")
  include("cmake/module.cmake")
  
@@ -62,9 +62,6 @@ index 32fdea7..2698429 100644
 -
 -target_link_libraries(${PROJECT_NAME} ${saucer_linkage} boost_preprocessor cr::lockpp cr::flagpp)
 -target_link_libraries(${PROJECT_NAME} PUBLIC            boost_callable_traits cr::ereignis fmt::fmt cr::rebind cr::poolparty cr::eraser)
-+find_path(LOCKPP_INCLUDE_DIRS "lockpp")
-+add_library(cr::lockpp INTERFACE IMPORTED)
-+target_include_directories(cr::lockpp INTERFACE ${LOCKPP_INCLUDE_DIRS})
 +find_path(FLAGPP_INCLUDE_DIRS "flagpp")
 +add_library(cr::flagpp INTERFACE IMPORTED)
 +target_include_directories(cr::flagpp INTERFACE ${FLAGPP_INCLUDE_DIRS})
@@ -78,8 +75,9 @@ index 32fdea7..2698429 100644
 +add_library(cr::poolparty INTERFACE IMPORTED)
 +target_include_directories(cr::poolparty INTERFACE ${POOLPARTY_INCLUDE_DIRS})
 +
-+find_package(eraser REQUIRED)
 +find_package(fmt CONFIG REQUIRED)
++find_package(eraser REQUIRED)
++find_package(lockpp REQUIRED)
 +find_package(Boost REQUIRED COMPONENTS callable_traits preprocessor)
 +
 +target_link_libraries(${PROJECT_NAME} ${saucer_linkage} Boost::preprocessor cr::lockpp cr::flagpp)
@@ -87,7 +85,7 @@ index 32fdea7..2698429 100644
  
  # --------------------------------------------------------------------------------------------------------
  # Setup Backends
-@@ -405,7 +371,7 @@ if (saucer_backend STREQUAL "WebView2")
+@@ -405,7 +369,7 @@ if (saucer_backend STREQUAL "WebView2")
    target_compile_definitions(${PROJECT_NAME} PRIVATE UNICODE=1 _UNICODE=1 NOMINMAX=1)
  
    include("cmake/webview2.cmake")
@@ -96,7 +94,7 @@ index 32fdea7..2698429 100644
  endif()
  
  # --------------------------------------------------------------------------------------------------------
-@@ -418,12 +384,8 @@ if (saucer_serializer STREQUAL "Glaze")
+@@ -418,12 +382,8 @@ if (saucer_serializer STREQUAL "Glaze")
    )
  
    target_sources(${PROJECT_NAME} PRIVATE ${glaze_sources})

--- a/ports/saucer/vcpkg.json
+++ b/ports/saucer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "saucer",
   "version": "6.0.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Next-gen desktop apps with web-frontend in C++",
   "homepage": "https://saucer.github.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8814,7 +8814,7 @@
     },
     "saucer": {
       "baseline": "6.0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "sbgecom": {
       "baseline": "5.3.2276",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6005,8 +6005,8 @@
       "port-version": 0
     },
     "lockpp": {
-      "baseline": "3.0",
-      "port-version": 1
+      "baseline": "3.2.0",
+      "port-version": 0
     },
     "lodepng": {
       "baseline": "2021-12-04",

--- a/versions/l-/lockpp.json
+++ b/versions/l-/lockpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ccbb14a09d88dce4f41ed2f1788b1f9481709256",
+      "version": "3.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "17e2f663311b1a32f97d897cf7da3024e1b6c659",
       "version": "3.0",
       "port-version": 1

--- a/versions/s-/saucer.json
+++ b/versions/s-/saucer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b99624fc80699236806ad50e5793fb8dbac38ed8",
+      "version": "6.0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "bde24b1179cf6523218a78b6f75abe16e2bc9172",
       "version": "6.0.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Requires #48250 as the used CPM version (0.40.8) [checks for CMake 3.30.3](https://github.com/cpm-cmake/CPM.cmake/blob/d9364ce284d92f4e18a96a7ca27e2c5deecf6700/cmake/CPM.cmake#L967). As #48250 is ready to merge I don't see any reason to add a patch to this port here to set CMP0169 temporary to the old behavior.

Closes #47157