### PR TITLE
[libsystemd] fix found python3-jinja2

### DIFF
--- a/ports/libsystemd/portfile.cmake
+++ b/ports/libsystemd/portfile.cmake
@@ -14,6 +14,13 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
   set(static pic)
 endif()
 
+vcpkg_find_acquire_program(PYTHON3)
+x_vcpkg_get_python_packages(
+    PYTHON_VERSION 3
+    PYTHON_EXECUTABLE "${PYTHON3}"
+    PACKAGES "jinja2"
+)
+
 vcpkg_configure_meson(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS

--- a/ports/libsystemd/vcpkg.json
+++ b/ports/libsystemd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libsystemd",
   "version": "257.8",
+  "port-version": 1,
   "description": "Libsystemd",
   "homepage": "https://github.com/systemd/systemd",
   "license": null,
@@ -15,6 +16,10 @@
     "libmount",
     "libxcrypt",
     "lz4",
+    {
+      "name": "vcpkg-get-python-packages",
+      "host": true
+    },
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5570,7 +5570,7 @@
     },
     "libsystemd": {
       "baseline": "257.8",
-      "port-version": 0
+      "port-version": 1
     },
     "libtar": {
       "baseline": "1.2.20",

--- a/versions/l-/libsystemd.json
+++ b/versions/l-/libsystemd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a7380e250b16232a48738c3e0798f07006c24c8",
+      "version": "257.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "833061d783b7e1f4f983d04f07c56914f20794bc",
       "version": "257.8",
       "port-version": 0


### PR DESCRIPTION
Fixes #48622

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
