### PR TITLE
[daxa] Update to 3.3.1

### DIFF
--- a/ports/daxa/daxa_swp_current_cpu_timeline_value.patch
+++ b/ports/daxa/daxa_swp_current_cpu_timeline_value.patch
@@ -1,0 +1,13 @@
+diff --git a/src/impl_swapchain.cpp b/src/impl_swapchain.cpp
+index dfbdebc5..e190490b 100644
+--- a/src/impl_swapchain.cpp
++++ b/src/impl_swapchain.cpp
+@@ -238,7 +238,7 @@ auto daxa_swp_gpu_timeline_semaphore(daxa_Swapchain self) -> daxa_TimelineSemaph
+ 
+ auto daxa_swp_current_cpu_timeline_value(daxa_Swapchain self) -> u64
+ {
+-    return static_cast<u64>(std::max(0ll, self->cpu_frame_timeline));
++    return static_cast<u64>(std::max(int64_t{0}, self->cpu_frame_timeline));
+ }
+ 
+ auto daxa_swp_info(daxa_Swapchain self) -> daxa_SwapchainInfo const *

--- a/ports/daxa/portfile.cmake
+++ b/ports/daxa/portfile.cmake
@@ -2,8 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Ipotrick/Daxa
     REF ${VERSION}
-    SHA512 5843d95ced3ec154d46e31ad5bf822a8470c785415819d235d5b499c3de629c30f5e4afe12b68ef3505ef7287afc68a70f06e255379136fae2e63976310ca3e0
+    SHA512 2cdb653be68e9c70fd023d1d3c450830b9fb9fcd3d7257e85715390f422501ae17633b01fdc1b9da7b9563ace1c4b524f8b69e5a24636b387b7960b52906ed94
     HEAD_REF master
+    PATCHES
+        daxa_swp_current_cpu_timeline_value.patch # fix std::max(long long int, long int), as int64_t is long int on some platforms
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/daxa/vcpkg.json
+++ b/ports/daxa/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "daxa",
-  "version": "3.0.3",
+  "version": "3.3.1",
   "description": "Daxa C++ Vulkan Abstraction",
   "homepage": "https://github.com/Ipotrick/Daxa",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2361,7 +2361,7 @@
       "port-version": 1
     },
     "daxa": {
-      "baseline": "3.0.3",
+      "baseline": "3.3.1",
       "port-version": 0
     },
     "dbg-macro": {

--- a/versions/d-/daxa.json
+++ b/versions/d-/daxa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c30760c6064005bb2e6aa81acf15a861506ec18b",
+      "version": "3.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "bc183994ac48b1065f51a6a7d05c10a6eab487cc",
       "version": "3.0.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
