### PR TITLE
[safetyhook] disable cmkr generation

### DIFF
--- a/ports/safetyhook/portfile.cmake
+++ b/ports/safetyhook/portfile.cmake
@@ -6,12 +6,10 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-vcpkg_find_acquire_program(GIT)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        "-DGIT_EXECUTABLE=${GIT}"
+    	"-DCMKR_SKIP_GENERATION=ON"
         "-DSAFETYHOOK_FETCH_ZYDIS=OFF"
 )
 

--- a/ports/safetyhook/vcpkg.json
+++ b/ports/safetyhook/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "safetyhook",
   "version-semver": "0.6.9",
+  "port-version": 1,
   "description": "C++23 procedure hooking library.",
   "homepage": "https://github.com/cursey/safetyhook",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8754,7 +8754,7 @@
     },
     "safetyhook": {
       "baseline": "0.6.9",
-      "port-version": 0
+      "port-version": 1
     },
     "sail": {
       "baseline": "0.9.10",

--- a/versions/s-/safetyhook.json
+++ b/versions/s-/safetyhook.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ac0658e1033fbdd133327cbaab13843140ae998",
+      "version-semver": "0.6.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "7658fbbc48074ba37907ffd08da38a4220b7bef5",
       "version-semver": "0.6.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

---

Closes #48667

Enables `CMKR_SKIP_GENERATION` during configuration. [cmkr](https://cmkr.build/) is used to generate the `CMakeLists.txt` file, but this is redundant as it produces the same result as the existing `CMakeLists.txt` in the repository.

Removes the dependency on Git and speeds up building, as it no longer has to fetch, compile, and run cmkr.