### PR TITLE
[jsoncons] update to 1.5.0

### DIFF
--- a/ports/jsoncons/portfile.cmake
+++ b/ports/jsoncons/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO danielaparker/jsoncons
     REF v${VERSION}
-    SHA512 01b6df6354b3f6f29dcc341b74d94f6a45846546e67adf34cff3bd1befcf436390fa246faf5da4153f6ce3a5c5b3ec8c160e5bc9a0e1a7dc2b092a3e3f0fd69d
+    SHA512 ce4ff8aaf31ad781e5caaf27172c867a8009bcc322dee5e34c6815434dbb234bf0d22ee9caa82c0ee1a9b25f3355da4363b5d663fded46a9ffc58ca802dad4ae
     HEAD_REF master
 )
 

--- a/ports/jsoncons/vcpkg.json
+++ b/ports/jsoncons/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jsoncons",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "A C++, header-only library for constructing JSON and JSON-like text and binary data formats, with JSON Pointer, JSON Patch, JSON Schema, JSONPath, JMESPath, CSV, MessagePack, CBOR, BSON, UBJSON",
   "homepage": "https://github.com/danielaparker/jsoncons",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4141,7 +4141,7 @@
       "port-version": 7
     },
     "jsoncons": {
-      "baseline": "1.4.3",
+      "baseline": "1.5.0",
       "port-version": 0
     },
     "jsoncpp": {

--- a/versions/j-/jsoncons.json
+++ b/versions/j-/jsoncons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8f729702dbf8e87bb20b385d360dd13e45ee008",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1e23eb44d494a6bde830ce417b097344386b1841",
       "version": "1.4.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/danielaparker/jsoncons/releases/tag/v1.5.0
