### PR TITLE
[gdk-pixbuf] download tarball from download.gnome.org

### DIFF
--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -1,10 +1,14 @@
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.gnome.org/
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO GNOME/gdk-pixbuf
-    REF "${VERSION}"
-    SHA512 f95c92974ed6efac9845790ef5c4ed74dd6e28b182ea3732013c46b016166e92f8bc10c1994358d79ff53e988c615c43cb1a2130c6ef531ef9d84c2fdcc87e52
-    HEAD_REF master
+
+string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://download.gnome.org/sources/gdk-pixbuf/${VERSION_MAJOR_MINOR}/gdk-pixbuf-${VERSION}.tar.xz"
+    FILENAME "GNOME-gdk-pixbuf-${VERSION}.tar.xz"
+    SHA512 ae9fcc9b4e8fd10a4c9bf34c3a755205dae7bbfe13fbc93ec4e63323dad10cc862df6a9e2e2e63c84ffa01c5e120a3be06ac9fad2a7c5e58d3dc6ba14d1766e8
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         fix_build_error_windows.patch
         loaders-cache.patch

--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -1,4 +1,3 @@
-
 string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.gnome.org/sources/gdk-pixbuf/${VERSION_MAJOR_MINOR}/gdk-pixbuf-${VERSION}.tar.xz"

--- a/ports/gdk-pixbuf/vcpkg.json
+++ b/ports/gdk-pixbuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdk-pixbuf",
   "version": "2.42.12",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3234,7 +3234,7 @@
     },
     "gdk-pixbuf": {
       "baseline": "2.42.12",
-      "port-version": 4
+      "port-version": 5
     },
     "gegl": {
       "baseline": "0.4.62",

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e277310a04bf1f2eb60e6ab12d01b41252fb6b7c",
+      "git-tree": "2093dcb9cfdd7839e8dc1cd4ffbb9ef2fd8ff244",
       "version": "2.42.12",
       "port-version": 5
     },

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2093dcb9cfdd7839e8dc1cd4ffbb9ef2fd8ff244",
+      "git-tree": "673e8c302ea38a1e3f1607806204bfad2c7fa03f",
       "version": "2.42.12",
       "port-version": 5
     },

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e277310a04bf1f2eb60e6ab12d01b41252fb6b7c",
+      "version": "2.42.12",
+      "port-version": 5
+    },
+    {
       "git-tree": "c85870a45af5037596827e00ea1263515dc75fd7",
       "version": "2.42.12",
       "port-version": 4


### PR DESCRIPTION
Fixes #48350 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


