### PR TITLE
[luau] update to 0.702

### DIFF
--- a/ports/luau/cmake-config-export.patch
+++ b/ports/luau/cmake-config-export.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0ca0bdb..36402d7 100644
+index b3f172b..1172c6e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -67,45 +67,45 @@ add_library(Luau.VM.Internals INTERFACE)
+@@ -66,41 +66,41 @@ add_library(Luau.VM.Internals INTERFACE)
  include(Sources.cmake)
  
  target_compile_features(Luau.Common PUBLIC cxx_std_17)
@@ -33,23 +33,19 @@ index 0ca0bdb..36402d7 100644
  target_compile_features(Luau.Analysis PUBLIC cxx_std_17)
 -target_include_directories(Luau.Analysis PUBLIC Analysis/include)
 +target_include_directories(Luau.Analysis PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Analysis/include> $<INSTALL_INTERFACE:include/luau>)
- target_link_libraries(Luau.Analysis PUBLIC Luau.Ast Luau.EqSat Luau.Config)
+ target_link_libraries(Luau.Analysis PUBLIC Luau.Ast Luau.Config)
  target_link_libraries(Luau.Analysis PRIVATE Luau.Compiler Luau.VM)
- 
- target_compile_features(Luau.EqSat PUBLIC cxx_std_17)
--target_include_directories(Luau.EqSat PUBLIC EqSat/include)
-+target_include_directories(Luau.EqSat PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/EqSat/include> $<INSTALL_INTERFACE:include/luau>)
- target_link_libraries(Luau.EqSat PUBLIC Luau.Common)
  
  target_compile_features(Luau.CodeGen PRIVATE cxx_std_17)
 -target_include_directories(Luau.CodeGen PUBLIC CodeGen/include)
-+target_include_directories(Luau.VM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CodeGen/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
- target_link_libraries(Luau.CodeGen PRIVATE Luau.VM Luau.VM.Internals) # Code generation needs VM internals
+-target_link_libraries(Luau.CodeGen PRIVATE Luau.VM Luau.VM.Internals) # Code generation needs VM internals
++target_include_directories(Luau.CodeGen PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CodeGen/include> $<INSTALL_INTERFACE:include/luau>)
++target_link_libraries(Luau.CodeGen PRIVATE Luau.VM $<BUILD_INTERFACE:Luau.VM.Internals>) # Code generation needs VM internals
  target_link_libraries(Luau.CodeGen PUBLIC Luau.Common)
  
  target_compile_features(Luau.VM PRIVATE cxx_std_11)
 -target_include_directories(Luau.VM PUBLIC VM/include)
-+target_include_directories(Luau.VM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/VM/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++target_include_directories(Luau.VM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/VM/include> $<INSTALL_INTERFACE:include/luau>)
  target_link_libraries(Luau.VM PUBLIC Luau.Common)
  
  target_compile_features(Luau.Require PUBLIC cxx_std_17)
@@ -58,7 +54,7 @@ index 0ca0bdb..36402d7 100644
  target_link_libraries(Luau.Require PUBLIC Luau.Config Luau.VM)
  
  target_include_directories(isocline PUBLIC extern/isocline/include)
-@@ -190,22 +190,6 @@ if(MSVC AND LUAU_BUILD_CLI)
+@@ -184,22 +184,6 @@ if(MSVC AND LUAU_BUILD_CLI)
      set_target_properties(Luau.Repl.CLI PROPERTIES LINK_FLAGS_DEBUG /STACK:2097152)
  endif()
  
@@ -81,7 +77,7 @@ index 0ca0bdb..36402d7 100644
  # On Windows and Android threads are provided, on Linux/Mac/iOS we use pthreads
  add_library(osthreads INTERFACE)
  if(CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin|iOS")
-@@ -298,3 +282,54 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.EqSat Luau.Cod
+@@ -292,3 +276,56 @@ foreach(LIB Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.CodeGen Luau.V
          endif()
      endif()
  endforeach()
@@ -103,7 +99,7 @@ index 0ca0bdb..36402d7 100644
 +)
 +
 +install(
-+  TARGETS Luau.Common Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.VM Luau.CLI.lib Luau.EqSat
++  TARGETS Luau.Common Luau.Ast Luau.Compiler Luau.Config Luau.Analysis Luau.VM Luau.CLI.lib Luau.Require
 +  EXPORT unofficial-luau-targets
 +  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 +  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -124,8 +120,10 @@ index 0ca0bdb..36402d7 100644
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Compiler/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Config/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/Analysis/include/"
++    DIRECTORY "${CMAKE_SOURCE_DIR}/CodeGen/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/VM/include/"
 +    DIRECTORY "${CMAKE_SOURCE_DIR}/VM/src/"
++    DIRECTORY "${CMAKE_SOURCE_DIR}/Require/include/"
 +    DESTINATION "include/luau"
 +    FILES_MATCHING
 +    PATTERN "*.h"
@@ -138,9 +136,8 @@ index 0ca0bdb..36402d7 100644
 +)
 diff --git b/cmake/unofficial-luau-config.cmake b/cmake/unofficial-luau-config.cmake
 new file mode 100644
-index 0000000..2680ef3
+index 0000000..13fd463
 --- /dev/null
 +++ b/cmake/unofficial-luau-config.cmake
 @@ -0,0 +1 @@
 +include(${CMAKE_CURRENT_LIST_DIR}/unofficial-luau-targets.cmake)
-\ No newline at end of file

--- a/ports/luau/portfile.cmake
+++ b/ports/luau/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luau-lang/luau
     REF ${VERSION}
-    SHA512 e77595e3567822084624798030a01fd873af8253ea690352164f844247ab1d2aafd118842b6f668bcb0ed19067bf47f3efe6696532d23f0418e166121de4feb8
+    SHA512 4daad35cf8a642bb6d1d6aa9b2c62f0235b8f83e077ffb66693c00887bf605d5a04e57ad5f4399adf4df73f28ee62c3291fa866beae4696ffde7970ed96a313c
     HEAD_REF master
     PATCHES
         cmake-config-export.patch

--- a/ports/luau/vcpkg.json
+++ b/ports/luau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "luau",
-  "version": "0.701",
+  "version": "0.702",
   "description": "A fast, small, safe, gradually typed embeddable scripting language derived from Lua",
   "homepage": "https://github.com/luau-lang/luau",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6089,7 +6089,7 @@
       "port-version": 1
     },
     "luau": {
-      "baseline": "0.701",
+      "baseline": "0.702",
       "port-version": 0
     },
     "luminoengine": {

--- a/versions/l-/luau.json
+++ b/versions/l-/luau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6095825c74e0c7cbdafcfaf281d825bff9c5348c",
+      "version": "0.702",
+      "port-version": 0
+    },
+    {
       "git-tree": "b9550753b25467bdc70bee7b9be9520b06b9c4c6",
       "version": "0.701",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/luau-lang/luau/releases/tag/0.702
