### PR TITLE
[iguana] update to 1.1.0

### DIFF
--- a/ports/iguana/portfile.cmake
+++ b/ports/iguana/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO qicosmos/iguana
     REF "${VERSION}"
-    SHA512 278d96bc3586104904c91bd62c5579b1db6a844ab5ef64ba3853f55bd04852cf7c035e4c88211bbab3348fba662edab5e6fd1df0d113d41cfed7b455467f9fb3
+    SHA512 dc0e3002ade1075c7a8be8146e891aceb9b6a4ccc12a918f5c74c99f0aee8d47b087f4ca220115146c7b40ee40ae9187f81570b87aac442aea677df8f2cd19d8
     HEAD_REF master
 )
 

--- a/ports/iguana/vcpkg.json
+++ b/ports/iguana/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "iguana",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Header-only C++ serialization library used by Cinatra.",
   "homepage": "https://github.com/qicosmos/iguana",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3893,7 +3893,7 @@
       "port-version": 0
     },
     "iguana": {
-      "baseline": "1.0.9",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "iir1": {

--- a/versions/i-/iguana.json
+++ b/versions/i-/iguana.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c521eef7fc4480ddb610aa5a6e427ce5c4deab8",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "90f06f21dc0c5e3d0435f011b51971ee3cd60df2",
       "version": "1.0.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/qicosmos/iguana/releases/tag/1.1.0
