### PR TITLE
[libwebsockets] update to 4.5.2

### DIFF
--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO warmcat/libwebsockets
     REF "v${VERSION}"
-    SHA512 25fc588088a712c4906b8a4c83524705bbed3b31494a70cc8455ddd10751d0978d942b21bf218400de1fee8e93dab6a4e0c942044bb36c31465567d5db7e5104
+    SHA512 8427ade9325051b486321b9d0b07b136428ed28f34972a3cc0b0440a9f1efab7b34ee82b6b778eb39669dea08d47976eef04a99f8e15ba03cb6b3c1dc28cb9f9
     HEAD_REF master
     PATCHES
         fix-dependency-libuv.patch

--- a/ports/libwebsockets/vcpkg.json
+++ b/ports/libwebsockets/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libwebsockets",
-  "version-semver": "4.5.0",
+  "version-semver": "4.5.2",
   "description": "Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.",
   "homepage": "https://libwebsockets.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5737,7 +5737,7 @@
       "port-version": 2
     },
     "libwebsockets": {
-      "baseline": "4.5.0",
+      "baseline": "4.5.2",
       "port-version": 0
     },
     "libx11": {

--- a/versions/l-/libwebsockets.json
+++ b/versions/l-/libwebsockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f79e4a4f1c0c7285bfc482fe0ba568a64197ca83",
+      "version-semver": "4.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1115704d2ab44a991d58f33bcb01e60a98475ce3",
       "version-semver": "4.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/warmcat/libwebsockets/releases/tag/v4.5.2
https://github.com/warmcat/libwebsockets/releases/tag/v4.5.1
