### PR TITLE
[webview2 ] Update to 1.0.3595.46

### DIFF
--- a/ports/webview2/portfile.cmake
+++ b/ports/webview2/portfile.cmake
@@ -5,7 +5,7 @@ endif()
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${VERSION}"
     FILENAME "microsoft.web.webview2.${VERSION}.zip"
-    SHA512 dd447d7526e82a0e4522447d0e861f347ad72f2a73dfa82cca2537f633afe54b2764c2d437f717cf22aeb339641f79c04f9cbce0b68a100eef716bd58c1a8989
+    SHA512 cce1e82cc057469ada77c116b9192957e83553c32fb794874dc7723148a81408b1d9d544e6eb4b61c2fe1ce99b6b8a705068f8f0e037eb39b556f7a093674fad
 )
 
 vcpkg_extract_source_archive(

--- a/ports/webview2/vcpkg.json
+++ b/ports/webview2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "webview2",
-  "version": "1.0.3240.44",
+  "version": "1.0.3595.46",
   "description": "The WebView2 control allows you to embed web technologies (HTML, CSS, and JavaScript) using Microsoft Edge",
   "homepage": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",
   "documentation": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9120,12 +9120,12 @@
       "baseline": "1.0.1",
       "port-version": 1
     },
-    "slick-object-pool": {
-      "baseline": "0.1.2",
-      "port-version": 0
-    },
     "slick-queue": {
       "baseline": "1.1.2",
+      "port-version": 0
+    },
+    "slick-object-pool": {
+      "baseline": "0.1.2",
       "port-version": 0
     },
     "slikenet": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9120,12 +9120,12 @@
       "baseline": "1.0.1",
       "port-version": 1
     },
-    "slick-queue": {
-      "baseline": "1.1.2",
-      "port-version": 0
-    },
     "slick-object-pool": {
       "baseline": "0.1.2",
+      "port-version": 0
+    },
+    "slick-queue": {
+      "baseline": "1.1.2",
       "port-version": 0
     },
     "slikenet": {
@@ -10509,7 +10509,7 @@
       "port-version": 0
     },
     "webview2": {
-      "baseline": "1.0.3240.44",
+      "baseline": "1.0.3595.46",
       "port-version": 0
     },
     "wepoll": {

--- a/versions/w-/webview2.json
+++ b/versions/w-/webview2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fbbf64077d76db48c83fa3514e04a1a5d0ad864e",
+      "version": "1.0.3595.46",
+      "port-version": 0
+    },
+    {
       "git-tree": "fb78e84ec816749c5862dae33417f25fc5362eaf",
       "version": "1.0.3240.44",
       "port-version": 0


### PR DESCRIPTION
This PR updates the webview2 port to latest stable Microsoft.Web.WebView2 version 1.0.3595.46.

- Updated vcpkg.json version to 1.0.3595.46
- Refreshed SHA512 for the new NuGet package
- Updated baseline.json and versions/webview2.json via `x-add-version`
- Validated builds locally for x64-windows and x86-windows

- [X ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ X] SHA512s are updated for each updated download.
- [ X] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ X] Any patches that are no longer applied are deleted from the port's directory.
- [ X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ X] Only one version is added to each modified port's versions file.


