### PR TITLE
[ppqsort] Update to 1.0.6

### DIFF
--- a/ports/ppqsort/portfile.cmake
+++ b/ports/ppqsort/portfile.cmake
@@ -4,12 +4,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GabTux/PPQSort
     REF "v${VERSION}"
-    SHA512 404621a489cc530170196dca317cabf35ecb2f93e10465474a5af1a4e79352433ca57711236f1cc08a359ae40294d9dd62feed42ec1f6890fa5139473997c29c
+    SHA512 df1fe69dab0e3218c27227b510b0727dcd28a7f5bbdb90cdc906dc2c7d4176cc4b908300ee4353dfaa1809dddeff255a47a99b56128a21ff0b9b5633dd88a66f
     HEAD_REF master
     PATCHES
         remove-cpm.patch
 )
 
+# Replace CPM and download PackageProject directly to avoid issues with FETCHCONTENT_FULLY_DISCONNECTED
 vcpkg_from_github(
     OUT_SOURCE_PATH PACKAGE_PROJECT_PATH
     REPO TheLartians/PackageProject.cmake

--- a/ports/ppqsort/vcpkg.json
+++ b/ports/ppqsort/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ppqsort",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "a efficient implementation of parallel quicksort algorithm",
   "homepage": "https://gabtux.github.io/PPQSort/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7745,7 +7745,7 @@
       "port-version": 5
     },
     "ppqsort": {
-      "baseline": "1.0.5",
+      "baseline": "1.0.6",
       "port-version": 0
     },
     "pprint": {

--- a/versions/p-/ppqsort.json
+++ b/versions/p-/ppqsort.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf178851be868062f9f205f7ccaf248ae0b934f8",
+      "version": "1.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "a61c8f3a9114caf6eff79a4304f382557e331d67",
       "version": "1.0.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.