### PR TITLE
[nowide] Update to 11.3.1

### DIFF
--- a/ports/nowide/portfile.cmake
+++ b/ports/nowide/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/boostorg/nowide/releases/download/v${VERSION}/nowide_standalone_v${VERSION}.tar.gz"
     FILENAME "nowide_standalone_v${VERSION}.tar.gz"
-    SHA512 68e4d4b11db7265bf91e90b16e35ef2ea3a8ad80031b122067393a4cb89e20e26bacff81c7abddfc7a84d22c0d545875d7ba40b0288c665fb82028f08f957524
+    SHA512 81bd088024a4682f4caf7524358982cdbdd4657b7533f4bb5135a88d228a74c4c3afee7ca2e13af8ead291450b6ef5f6849685875ef0f2aabe8eb9f0cab20688
 )
 
 vcpkg_extract_source_archive(
@@ -11,7 +11,8 @@ vcpkg_extract_source_archive(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS -DBUILD_TESTING=OFF
+    OPTIONS
+        -DBUILD_TESTING=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/nowide/vcpkg.json
+++ b/ports/nowide/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nowide",
-  "version": "11.3.0",
+  "version": "11.3.1",
   "description": "Boost nowide module (standalone)",
   "homepage": "https://github.com/boostorg/nowide",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6941,7 +6941,7 @@
       "port-version": 0
     },
     "nowide": {
-      "baseline": "11.3.0",
+      "baseline": "11.3.1",
       "port-version": 0
     },
     "nrf-ble-driver": {

--- a/versions/n-/nowide.json
+++ b/versions/n-/nowide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c30ba64492e05326758196785365899a4626da2f",
+      "version": "11.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8d782a748c6b9013ca434f77a3c2b1838fce734d",
       "version": "11.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.