### PR TITLE
[wolftpm] update to version 3.10.0

### DIFF
--- a/ports/wolftpm/portfile.cmake
+++ b/ports/wolftpm/portfile.cmake
@@ -1,32 +1,9 @@
-# Download patches from upstream
-vcpkg_download_distfile(PATCH_PR430
-    URLS https://github.com/wolfssl/wolftpm/pull/430.diff?full_index=1
-    FILENAME wolftpm-pr430.diff
-    SHA512 b795e720ebc92a1208462df7261d004067c7989218f44cb686d980a4521192c1244428c8442f4293ec3e178680ef862ff6e7dead9420a11c0a4dca8def3631c2
-)
-
-vcpkg_download_distfile(PATCH_PR432  
-    URLS https://github.com/wolfssl/wolftpm/pull/432.diff?full_index=1
-    FILENAME wolftpm-pr432.diff
-    SHA512 95c0373e4b7275ed2430ad3087c74dab66351ffe13c8e28ddca465d9956757264ce7a6b544a61d896c3b04458e64775770e6995028b7ac59165526ade9cf5e20
-)
-
-vcpkg_download_distfile(PATCH_PR433  
-    URLS https://github.com/wolfssl/wolftpm/pull/433.diff?full_index=1
-    FILENAME wolftpm-pr433.diff
-    SHA512 c06af5e337aadf70282e10b6c9af02c1ef4a1a19da6ac7b6d4370472adf79f13c090bca6f4afbce14313847b25bf96e2aa8964b75f439b3339f5f704afd93206
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfssl/wolftpm
     REF v${VERSION}
-    SHA512 e6b73ec95f6c0cd37a71063c13db2a95175c54d2c63f69959ed68b4992277f1304136e1ecc5419ce4ff070d9162dbb30a9c6f78c7238383d72c686f1cdc1ab7c
+    SHA512 6d09ce6d069481d659e8062b0c04940af0c54a3a5ee02178336252d0cde28f339340df72a31e38dfc67d7d5ead192ddf9351cab76360e220b6236f8e5357bb30
     HEAD_REF master
-    PATCHES
-      ${PATCH_PR430}
-      ${PATCH_PR432}
-      ${PATCH_PR433}
     )
 
 vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH}

--- a/ports/wolftpm/vcpkg.json
+++ b/ports/wolftpm/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "wolftpm",
-  "version": "3.9.2",
-  "port-version": 1,
+  "version": "3.10.0",
   "description": "TPM library used with wolfSSL library for many platforms",
   "homepage": "https://wolfssl.com",
-  "license": "GPL-2.0-or-later",
+  "license": "GPL-3.0-or-later",
   "supports": "!uwp & !xbox",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9120,12 +9120,12 @@
       "baseline": "1.0.1",
       "port-version": 1
     },
-    "slick-queue": {
-      "baseline": "1.1.2",
-      "port-version": 0
-    },
     "slick-object-pool": {
       "baseline": "0.1.2",
+      "port-version": 0
+    },
+    "slick-queue": {
+      "baseline": "1.1.2",
       "port-version": 0
     },
     "slikenet": {
@@ -9333,8 +9333,8 @@
       "port-version": 0
     },
     "sqlite-flux": {
-	  "baseline": "1.1.1",
-	  "port-version": 0
+      "baseline": "1.1.1",
+      "port-version": 0
     },
     "sqlite-modern-cpp": {
       "baseline": "2023-12-03",
@@ -10601,8 +10601,8 @@
       "port-version": 0
     },
     "wolftpm": {
-      "baseline": "3.9.2",
-      "port-version": 1
+      "baseline": "3.10.0",
+      "port-version": 0
     },
     "wordnet": {
       "baseline": "3.0",

--- a/versions/w-/wolftpm.json
+++ b/versions/w-/wolftpm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd6c6c73981bc1373b50719ea3f996f7d31f3c11",
+      "version": "3.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ccc3e9bfb8ad4289c8a081558e00ef389aa7409b",
       "version": "3.9.2",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
