### PR TITLE
[sdl1] Fix post build checks failures.

### DIFF
--- a/ports/sdl1/portfile.cmake
+++ b/ports/sdl1/portfile.cmake
@@ -67,6 +67,9 @@ else()
 
     vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+            --disable-pulseaudio
+            --disable-video-directfb
     )
 
     vcpkg_install_make()

--- a/ports/sdl1/vcpkg.json
+++ b/ports/sdl1/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl1",
   "version": "1.2.15",
-  "port-version": 22,
+  "port-version": 23,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8854,7 +8854,7 @@
     },
     "sdl1": {
       "baseline": "1.2.15",
-      "port-version": 22
+      "port-version": 23
     },
     "sdl1-mixer": {
       "baseline": "2025-09-10",

--- a/versions/s-/sdl1.json
+++ b/versions/s-/sdl1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce602236456efacf078c795efe1c78688554f019",
+      "version": "1.2.15",
+      "port-version": 23
+    },
+    {
       "git-tree": "41898dff1a370c45aee480e8e525ab5a1a7e40ab",
       "version": "1.2.15",
       "port-version": 22


### PR DESCRIPTION
https://github.com/microsoft/vcpkg/pull/48418 caused feature detection in sdl1's build system to drag in some bits that emit absolute paths, so disable that. 

Fixes the failure in https://dev.azure.com/vcpkg/public/_build/results?buildId=123776&view=results

Also disabled pulseaudio as it similarly differs in the CI logs vs. my local testing.