### PR TITLE
[ggmsg] New port

### DIFF
--- a/ports/ggmsg/portfile.cmake
+++ b/ports/ggmsg/portfile.cmake
@@ -1,0 +1,99 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   CURRENT_INSTALLED_DIR     = ${VCPKG_ROOT_DIR}\installed\${TRIPLET}
+#   DOWNLOADS                 = ${VCPKG_ROOT_DIR}\downloads
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#   VCPKG_TOOLCHAIN           = ON OFF
+#   TRIPLET_SYSTEM_ARCH       = arm x86 x64
+#   BUILD_ARCH                = "Win32" "x64" "ARM"
+#   DEBUG_CONFIG              = "Debug Static" "Debug Dll"
+#   RELEASE_CONFIG            = "Release Static"" "Release DLL"
+#   VCPKG_TARGET_IS_WINDOWS
+#   VCPKG_TARGET_IS_UWP
+#   VCPKG_TARGET_IS_LINUX
+#   VCPKG_TARGET_IS_OSX
+#   VCPKG_TARGET_IS_FREEBSD
+#   VCPKG_TARGET_IS_ANDROID
+#   VCPKG_TARGET_IS_MINGW
+#   VCPKG_TARGET_EXECUTABLE_SUFFIX
+#   VCPKG_TARGET_STATIC_LIBRARY_SUFFIX
+#   VCPKG_TARGET_SHARED_LIBRARY_SUFFIX
+#
+# 	See additional helpful variables in /docs/maintainers/vcpkg_common_definitions.md
+
+# Also consider vcpkg_from_* functions if you can; the generated code here is for any web accessable
+# source archive.
+#  vcpkg_from_github
+#  vcpkg_from_gitlab
+#  vcpkg_from_bitbucket
+#  vcpkg_from_sourceforge
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/xhk/ggmsg/archive/refs/tags/version-20251206.tar.gz"
+    FILENAME "version-20251206.tar.gz"
+    SHA512 d8d895bfd965352dbfedc271e465254f61cc2abf3f706153500183622a165eb31a4b46093e2e55580a4ab054ffb21a7799ad19a035854e75286e19d5cc7dec5f
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    # (Optional) A friendly name to use instead of the filename of the archive (e.g.: a version number or tag).
+    # REF 1.0.0
+    # (Optional) Read the docs for how to generate patches at:
+    # https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/patching.md
+    # PATCHES
+    #   001_port_fixes.patch
+    #   002_more_port_fixes.patch
+)
+
+# # Check if one or more features are a part of a package installation.
+# # See /docs/maintainers/vcpkg_check_features.md for more details
+# vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+#   FEATURES
+#     tbb   WITH_TBB
+#   INVERTED_FEATURES
+#     tbb   ROCKSDB_IGNORE_PACKAGE_TBB
+# )
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
+
+vcpkg_cmake_build()
+
+# Install header files
+file(COPY "${SOURCE_PATH}/ggmsg/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/ggmsg")
+
+# Install release libraries
+if(EXISTS "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/ggmsg.dll")
+    file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/ggmsg.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin/")
+    file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/ggmsg.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/")
+elseif(EXISTS "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libggmsg.so")
+    file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libggmsg.so" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/")
+elseif(EXISTS "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libggmsg.dylib")
+    file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libggmsg.dylib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/")
+endif()
+
+# Install debug libraries
+if(EXISTS "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/ggmsg.dll")
+    file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/ggmsg.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/")
+    file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/ggmsg.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/")
+elseif(EXISTS "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/libggmsg.so")
+    file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/libggmsg.so" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/")
+elseif(EXISTS "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/libggmsg.dylib")
+    file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/libggmsg.dylib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/")
+endif()
+
+# Install the license file
+if(EXISTS "${SOURCE_PATH}/LICENSE")
+    vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+endif()

--- a/ports/ggmsg/portfile.cmake
+++ b/ports/ggmsg/portfile.cmake
@@ -35,9 +35,9 @@
 #  vcpkg_from_bitbucket
 #  vcpkg_from_sourceforge
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/xhk/ggmsg/archive/refs/tags/version-20251206.tar.gz"
-    FILENAME "version-20251206.tar.gz"
-    SHA512 d8d895bfd965352dbfedc271e465254f61cc2abf3f706153500183622a165eb31a4b46093e2e55580a4ab054ffb21a7799ad19a035854e75286e19d5cc7dec5f
+    URLS "https://github.com/xhk/ggmsg/archive/refs/tags/version-20251207.tar.gz"
+    FILENAME "version-20251207.tar.gz"
+    SHA512 bceb8b327656878e4a3b0e2d66cb6e7ae8eb1c7e682bbd03750cc3d0b104f812543cb0ffbcc1fa0575c9d52e2712267dd00e00b59b82f7bca04eca773f82dd41
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/ggmsg/vcpkg.json
+++ b/ports/ggmsg/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "ggmsg",
+  "version": "1.0.0.0",
+  "homepage": "https://github.com/xhk/ggmsg",
+  "description": "",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "boost"
+    }
+  ],
+
+  "default-features": [],
+  "features": {
+    "tools": {
+      "description": "net message middleware",
+      "dependencies": []
+    }
+  }
+}

--- a/ports/ggmsg/vcpkg.json
+++ b/ports/ggmsg/vcpkg.json
@@ -2,8 +2,8 @@
   "name": "ggmsg",
   "version": "1.0.0.0",
   "homepage": "https://github.com/xhk/ggmsg",
-  "description": "",
-  "supports": "(windows & x64) | (linux & x64)",
+  "description": "Library for net message middleware",
+  "supports": "!x86",
   "license": "MIT",
   "dependencies": [
     {

--- a/ports/ggmsg/vcpkg.json
+++ b/ports/ggmsg/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "1.0.0.0",
   "homepage": "https://github.com/xhk/ggmsg",
   "description": "",
+  "supports": "(windows & x64) | (linux & x64)",
   "license": "MIT",
   "dependencies": [
     {


### PR DESCRIPTION
- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
