### PR TITLE
[nggmsg] New port

### DIFF
--- a/ports/nggmsg/portfile.cmake
+++ b/ports/nggmsg/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xhk/nggmsg
-    REF version-20251208-2
+    REF "${VERSION}"
     SHA512 384595ce38dc6834e3a12e4f59b8c49512fe4005f2db906329a3e42512ade1d64e68f428303a5892ad0fba94d29433bc6bd60c00a2224df22fcfb63971ebf385
     HEAD_REF main
 )
@@ -12,19 +12,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-# 清理debug目录
+vcpkg_cmake_config_fixup(PACKAGE_NAME "my_sample_lib")
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# 安装usage文件
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
-# 清理空目录
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib" "${CURRENT_PACKAGES_DIR}/lib")
-
-# 安装版权文件
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
-
-# 禁用特定策略警告
-set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
-set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
-set(VCPKG_POLICY_ALLOW_EMPTY_FOLDERS enabled)

--- a/ports/nggmsg/portfile.cmake
+++ b/ports/nggmsg/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME "my_sample_lib")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "nggmsg")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/nggmsg/portfile.cmake
+++ b/ports/nggmsg/portfile.cmake
@@ -8,8 +8,6 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DBUILD_TESTING=OFF
 )
 
 vcpkg_cmake_install()
@@ -17,4 +15,16 @@ vcpkg_cmake_install()
 # 清理debug目录
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+# 安装usage文件
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+# 清理空目录
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib" "${CURRENT_PACKAGES_DIR}/lib")
+
+# 安装版权文件
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+# 禁用特定策略警告
+set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
+set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
+set(VCPKG_POLICY_ALLOW_EMPTY_FOLDERS enabled)

--- a/ports/nggmsg/portfile.cmake
+++ b/ports/nggmsg/portfile.cmake
@@ -13,8 +13,8 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME nggmsg CONFIG_PATH share/nggmsg/cmake)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+# 清理debug目录
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/nggmsg/portfile.cmake
+++ b/ports/nggmsg/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO xhk/nggmsg
+    REF version-20251208-2
+    SHA512 384595ce38dc6834e3a12e4f59b8c49512fe4005f2db906329a3e42512ade1d64e68f428303a5892ad0fba94d29433bc6bd60c00a2224df22fcfb63971ebf385
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME nggmsg CONFIG_PATH share/nggmsg/cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/nggmsg/usage
+++ b/ports/nggmsg/usage
@@ -1,0 +1,17 @@
+# Usage
+
+nggmsg is a simple message library.
+
+## Features
+- Simple API
+- Header only
+- Cross-platform
+
+## Example
+```cpp
+#include <nggmsg.h>
+
+int main() {
+    // 使用nggmsg库
+    return 0;
+}

--- a/ports/nggmsg/vcpkg.json
+++ b/ports/nggmsg/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "name": "nggmsg",
+  "name": "xhk-nggmsg",
   "version": "20251208-2",
   "description": "nggmsg - a message library",
   "homepage": "https://github.com/xhk/nggmsg",

--- a/ports/nggmsg/vcpkg.json
+++ b/ports/nggmsg/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "nggmsg",
+  "version": "20251208-2",
+  "description": "nggmsg - a message library",
+  "homepage": "https://github.com/xhk/nggmsg",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/nggmsg/vcpkg.json
+++ b/ports/nggmsg/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "20251208-2",
   "description": "nggmsg - a message library",
   "homepage": "https://github.com/xhk/nggmsg",
+  "supports": "!x86",
   "license": "MIT",
   "dependencies": [
     {


### PR DESCRIPTION
添加nggmsg库的vcpkg.json和portfile.cmake配置文件，支持通过vcpkg安装该库



- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

