### PR TITLE
Adding WebCraft to vcpkg

### DIFF
--- a/ports/webcraft/portfile.cmake
+++ b/ports/webcraft/portfile.cmake
@@ -1,12 +1,11 @@
-# ports/webcraft/portfile.cmake
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO adityarao2005/WebCraft   # <--- CHANGE THIS to your actual User/Repo
-    REF v${VERSION}                         # <--- The tag/commit you want to release (can be empty if only using --head)
+    REPO adityarao2005/WebCraft
+    REF v${VERSION}
     SHA512 8ebdd1eb2976457269cc37f1e75c9fdad46460b3ca2314dd138889488d6b0c940bf6659dfd16cdd06dc399d507a9952940c360e4298f614cc474e08eecc7b2c7
-    HEAD_REF main                      # <--- The branch to use when building with --head
+    HEAD_REF main
 )
 
 if (VCPKG_TARGET_IS_LINUX)

--- a/ports/webcraft/portfile.cmake
+++ b/ports/webcraft/portfile.cmake
@@ -4,10 +4,15 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO adityarao2005/WebCraft   # <--- CHANGE THIS to your actual User/Repo
-    REF 0294f663255271b328da8f8643489ba9e91b6845                         # <--- The tag/commit you want to release (can be empty if only using --head)
-    SHA512 65a1ffbd07770d02083e1fd61152ca50b1f203f423199daa7d5d8a960a6ee12c7f1ba11df876eef0a78e419c4ec2a073c05f10396d46db98d309a0e24a8b0fb1
+    REF v${VERSION}                         # <--- The tag/commit you want to release (can be empty if only using --head)
+    SHA512 8ebdd1eb2976457269cc37f1e75c9fdad46460b3ca2314dd138889488d6b0c940bf6659dfd16cdd06dc399d507a9952940c360e4298f614cc474e08eecc7b2c7
     HEAD_REF main                      # <--- The branch to use when building with --head
 )
+
+if (VCPKG_TARGET_IS_LINUX)
+    vcpkg_find_acquire_program(PKGCONFIG)
+    set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -17,9 +22,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(
-    PACKAGE_NAME WebCraft 
-)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/WebCraft)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/webcraft/portfile.cmake
+++ b/ports/webcraft/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO adityarao2005/WebCraft   # <--- CHANGE THIS to your actual User/Repo
-    REF v1.0.1                         # <--- The tag/commit you want to release (can be empty if only using --head)
-    SHA512 e6ac8bc32167d6b8f367d33236af8178213149131c35ece167a2d0098844542126a4eca93f76d8a1e9e94e0811cdd337ade448c32ebdb27583c4c7ec3e808557                           # <--- Keep as 0. We will get the real hash in Step 3.
+    REF 8eaab1781be6617fead4c234cb3d6fddd730e2c6                         # <--- The tag/commit you want to release (can be empty if only using --head)
+    SHA512 138ffb972b0dad20f8db5f55ff6033bb782548e2c9e2f5fce43232d01f3cdab3324e7cc3572b95fc527a3222461fcffdf320000998205559e4fd2edefc2b6e27
     HEAD_REF main                      # <--- The branch to use when building with --head
 )
 
@@ -18,7 +18,7 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME WebCraft 
-    CONFIG_PATH share/webcraft
+    CONFIG_PATH share/WebCraft
 )
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/webcraft/portfile.cmake
+++ b/ports/webcraft/portfile.cmake
@@ -22,7 +22,10 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH share/WebCraft)
+vcpkg_cmake_config_fixup(
+	PACKAGE_NAME WebCraft
+	CONFIG_PATH share/WebCraft
+)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/webcraft/portfile.cmake
+++ b/ports/webcraft/portfile.cmake
@@ -1,0 +1,25 @@
+# ports/webcraft/portfile.cmake
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO adityarao2005/WebCraft   # <--- CHANGE THIS to your actual User/Repo
+    REF v1.0.1                         # <--- The tag/commit you want to release (can be empty if only using --head)
+    SHA512 e6ac8bc32167d6b8f367d33236af8178213149131c35ece167a2d0098844542126a4eca93f76d8a1e9e94e0811cdd337ade448c32ebdb27583c4c7ec3e808557                           # <--- Keep as 0. We will get the real hash in Step 3.
+    HEAD_REF main                      # <--- The branch to use when building with --head
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DWEBCRAFT_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME WebCraft 
+    CONFIG_PATH share/webcraft
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/webcraft/portfile.cmake
+++ b/ports/webcraft/portfile.cmake
@@ -1,10 +1,11 @@
 # ports/webcraft/portfile.cmake
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO adityarao2005/WebCraft   # <--- CHANGE THIS to your actual User/Repo
-    REF 8eaab1781be6617fead4c234cb3d6fddd730e2c6                         # <--- The tag/commit you want to release (can be empty if only using --head)
-    SHA512 138ffb972b0dad20f8db5f55ff6033bb782548e2c9e2f5fce43232d01f3cdab3324e7cc3572b95fc527a3222461fcffdf320000998205559e4fd2edefc2b6e27
+    REF 0294f663255271b328da8f8643489ba9e91b6845                         # <--- The tag/commit you want to release (can be empty if only using --head)
+    SHA512 65a1ffbd07770d02083e1fd61152ca50b1f203f423199daa7d5d8a960a6ee12c7f1ba11df876eef0a78e419c4ec2a073c05f10396d46db98d309a0e24a8b0fb1
     HEAD_REF main                      # <--- The branch to use when building with --head
 )
 
@@ -18,8 +19,9 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME WebCraft 
-    CONFIG_PATH share/WebCraft
 )
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/webcraft/usage
+++ b/ports/webcraft/usage
@@ -1,0 +1,4 @@
+WebCraft provides CMake targets:
+
+find_package(WebCraft CONFIG REQUIRED)
+target_link_libraries(main PRIVATE WebCraft::WebCraft)

--- a/ports/webcraft/usage
+++ b/ports/webcraft/usage
@@ -1,4 +1,4 @@
 WebCraft provides CMake targets:
 
-find_package(WebCraft CONFIG REQUIRED)
-target_link_libraries(main PRIVATE WebCraft::WebCraft)
+  find_package(WebCraft CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE WebCraft::WebCraft)

--- a/ports/webcraft/vcpkg.json
+++ b/ports/webcraft/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "webcraft",
+  "version": "1.0.1",
+  "description": "An async first C++ networking library leveraging powerful features of C++23 built for scale, speed, and ease.",
+  "homepage": "https://github.com/adityarao2005/WebCraft/",
+  "license": "MIT",
+  "supports": "!(uwp | android | emscripten)",
+  "dependencies": [
+    {
+      "name": "liburing",
+      "platform": "linux"
+    },
+    {
+      "name": "pkgconf",
+      "platform": "linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/webcraft/vcpkg.json
+++ b/ports/webcraft/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "webcraft",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An async first C++ networking library leveraging powerful features of C++23 built for scale, speed, and ease.",
   "homepage": "https://github.com/adityarao2005/WebCraft/",
   "license": "MIT",
@@ -8,10 +8,6 @@
   "dependencies": [
     {
       "name": "liburing",
-      "platform": "linux"
-    },
-    {
-      "name": "pkgconf",
       "platform": "linux"
     },
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10496,6 +10496,10 @@
       "baseline": "8.4",
       "port-version": 0
     },
+    "webcraft": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "websocketpp": {
       "baseline": "0.8.2",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10497,7 +10497,7 @@
       "port-version": 0
     },
     "webcraft": {
-      "baseline": "1.0.1",
+      "baseline": "1.0.2",
       "port-version": 0
     },
     "websocketpp": {

--- a/versions/w-/webcraft.json
+++ b/versions/w-/webcraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "45512543e65cd2ab7b994d6ee1382db2ea4f04ba",
+      "git-tree": "32bb0146d632f37877cd1e1bde04fbadcb301fdb",
       "version": "1.0.1",
       "port-version": 0
     }

--- a/versions/w-/webcraft.json
+++ b/versions/w-/webcraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "89dfd21fe3e3dec63a5ef6e87fb68ebbec35b4b6",
+      "git-tree": "d0281485d5a1d48a3683177859dc7c111f0f44f9",
       "version": "1.0.2",
       "port-version": 0
     }

--- a/versions/w-/webcraft.json
+++ b/versions/w-/webcraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cc5931a892b4c1dac8da89d7af7b43c412a9b8b3",
+      "git-tree": "ac6e97cd56eb18d5fd6463aeee4b0ba4160a7036",
       "version": "1.0.2",
       "port-version": 0
     }

--- a/versions/w-/webcraft.json
+++ b/versions/w-/webcraft.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "32bb0146d632f37877cd1e1bde04fbadcb301fdb",
-      "version": "1.0.1",
+      "git-tree": "cc5931a892b4c1dac8da89d7af7b43c412a9b8b3",
+      "version": "1.0.2",
       "port-version": 0
     }
   ]

--- a/versions/w-/webcraft.json
+++ b/versions/w-/webcraft.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f3eee10dcf3b5d4d6c3811c0ecc9323466ba77a4",
+      "version": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/w-/webcraft.json
+++ b/versions/w-/webcraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ac6e97cd56eb18d5fd6463aeee4b0ba4160a7036",
+      "git-tree": "89dfd21fe3e3dec63a5ef6e87fb68ebbec35b4b6",
       "version": "1.0.2",
       "port-version": 0
     }

--- a/versions/w-/webcraft.json
+++ b/versions/w-/webcraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f3eee10dcf3b5d4d6c3811c0ecc9323466ba77a4",
+      "git-tree": "45512543e65cd2ab7b994d6ee1382db2ea4f04ba",
       "version": "1.0.1",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
