### PR TITLE
[opendnp3] Update to 3.1.2

### DIFF
--- a/ports/opendnp3/portfile.cmake
+++ b/ports/opendnp3/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dnp3/opendnp3
-    REF 3.1.1
-    SHA512 2d7b26753fa03596ab73944236e5f1d82656f38248cc23fd00f7a2cdac27f481e5fe51e68b5896b6740db1a6d9560f0262e473648e001601125f4af8b4a652c2
+    REF "${VERSION}"
+    SHA512 b0fe4774f8a2eea73eacbc98033a5dff673d29500ee585350aa550557242d71ac4d4f6acc1a2b378f6292edabd31c58e0b3b18938f3c1bb2efa39b33ffaa556f
 )
 
 file(READ "${SOURCE_PATH}/deps/ser4cpp.cmake" ser4cpp_cmake)

--- a/ports/opendnp3/vcpkg.json
+++ b/ports/opendnp3/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "opendnp3",
-  "version": "3.1.1",
-  "port-version": 1,
+  "version": "3.1.2",
   "description": "DNP3 (IEEE-1815) protocol stack. Modern C++ with bindings for .NET and Java.",
   "homepage": "https://github.com/dnp3/opendnp3/",
+  "license": "Apache-2.0",
   "supports": "!uwp",
   "dependencies": [
     "asio",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7197,8 +7197,8 @@
       "port-version": 9
     },
     "opendnp3": {
-      "baseline": "3.1.1",
-      "port-version": 1
+      "baseline": "3.1.2",
+      "port-version": 0
     },
     "openexr": {
       "baseline": "3.4.3",

--- a/versions/o-/opendnp3.json
+++ b/versions/o-/opendnp3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17f89c92ff4d1989ff7691489a1e14367a2e06d2",
+      "version": "3.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e9315f4a8ad7564c1fc8b81c4a9f4c7b0305c0b3",
       "version": "3.1.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Is there any indication that a port is outdated and that users should be advised not to use it anymore? The project was [discontinued some time ago](https://dnp3.github.io) in favor of a commercial Rust successor.
