### PR TITLE
[ms-ifc-sdk] Update to 0.43.5

### DIFF
--- a/ports/ms-ifc-sdk/portfile.cmake
+++ b/ports/ms-ifc-sdk/portfile.cmake
@@ -1,17 +1,9 @@
-vcpkg_download_distfile(ADD_CSTDINT_FIX
-    URLS https://github.com/microsoft/ifc/commit/48659fbaed5f971aecb1a0c8264e0cb2e9fe235f.diff?full_index=1
-    FILENAME ms-ifc-sdk-cstdint-48659fbaed5f971aecb1a0c8264e0cb2e9fe235f.diff
-    SHA512 56b97bf7cfcc37ddf31bc6f4eabe579197a7e4d259ac3df4dbcf8fdd2263215b7c9a3b1905a223c73f0f7f92d3e4d782f069a88cf4d114674bc56d5980634a94
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/ifc
-    REF 0.43.1
-    SHA512 c7ce8570d776f875c1a1fed929734ebc73b2cf25106e2a5e80625269f4f91d8106d19da34525cc4d7a694d750788d124e8e1ef082c54a13c9b34fe3da7f9e82d
+    REF "${VERSION}"
+    SHA512 9d6361bdb1ec78480b2be36fcff8197bc2be5fcd162b0bf31705fb69f63ba016750a9c57c264354a9c844701e04805f5d165d9a2ae37e2e6fd2b82986d59ad84
     HEAD_REF main
-    PATCHES
-        "${ADD_CSTDINT_FIX}"
 )
 
 set(config_path share/cmake/Microsoft.IFC)
@@ -26,6 +18,16 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME Microsoft.IFC
     CONFIG_PATH "${config_path}"
+)
+
+vcpkg_copy_tools(
+    TOOL_NAMES
+        ifc
+)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/bin/"
+    "${CURRENT_PACKAGES_DIR}/debug/bin/"
 )
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/ms-ifc-sdk/vcpkg.json
+++ b/ports/ms-ifc-sdk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ms-ifc-sdk",
-  "version": "0.43.1",
-  "port-version": 1,
+  "version": "0.43.5",
   "description": "SDK for the IFC specification at https://github.com/microsoft/ifc-spec",
   "homepage": "https://github.com/microsoft/ifc",
   "license": "Apache-2.0 WITH LLVM-exception",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6589,8 +6589,8 @@
       "port-version": 0
     },
     "ms-ifc-sdk": {
-      "baseline": "0.43.1",
-      "port-version": 1
+      "baseline": "0.43.5",
+      "port-version": 0
     },
     "msdfgen": {
       "baseline": "1.13",

--- a/versions/m-/ms-ifc-sdk.json
+++ b/versions/m-/ms-ifc-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03db5c432f02fdf0f44f6c1790aa7c000ace5f20",
+      "version": "0.43.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b5100599378870975a1e5bf22731715c4fc32ce",
       "version": "0.43.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Note: The tool was added in https://github.com/microsoft/ifc/pull/59 (0.43.2)