### PR TITLE
[multiple] Add usage files for 20 ports

### DIFF
--- a/ports/3fd/usage
+++ b/ports/3fd/usage
@@ -1,0 +1,4 @@
+The package 3fd provides CMake targets:
+
+    find_package(3fd CONFIG REQUIRED)
+    target_link_libraries(your_target_name PRIVATE 3fd::3fd)

--- a/ports/7zip/usage
+++ b/ports/7zip/usage
@@ -1,0 +1,4 @@
+The package 7zip provides CMake targets:
+
+    find_package(7zip REQUIRED)
+    target_link_libraries(your_target_name PRIVATE 7zip::7zip)

--- a/ports/ableton-link/usage
+++ b/ports/ableton-link/usage
@@ -1,0 +1,4 @@
+The package ableton-link provides CMake targets:
+
+    find_package(ableton-link CONFIG REQUIRED)
+    target_link_libraries(your_target_name PRIVATE ableton-link::ableton-link)

--- a/ports/absent/usage
+++ b/ports/absent/usage
@@ -1,0 +1,4 @@
+The package absent provides CMake targets:
+
+    find_package(absent CONFIG REQUIRED)
+    target_link_libraries(your_target_name PRIVATE absent::absent)

--- a/ports/ace/usage
+++ b/ports/ace/usage
@@ -1,0 +1,4 @@
+The package ace provides CMake targets:
+
+    find_package(ACE REQUIRED)
+    target_link_libraries(your_target_name PRIVATE ACE::ACE)

--- a/ports/acl/usage
+++ b/ports/acl/usage
@@ -1,0 +1,4 @@
+The package acl provides CMake targets:
+
+    find_package(acl CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE acl::acl)

--- a/ports/activemq-cpp/usage
+++ b/ports/activemq-cpp/usage
@@ -1,0 +1,4 @@
+The package activemq-cpp provides CMake targets:
+
+    find_package(activemq-cpp CONFIG REQUIRED)
+    target_link_libraries(your_target_name PRIVATE activemq-cpp::activemq-cpp)

--- a/ports/ada-idna/usage
+++ b/ports/ada-idna/usage
@@ -1,0 +1,4 @@
+The package ada-idna provides CMake targets:
+
+    find_package(ada-idna CONFIG REQUIRED)
+    target_link_libraries(your_target_name PRIVATE ada-idna::ada-idna)

--- a/ports/ada-url/usage
+++ b/ports/ada-url/usage
@@ -1,0 +1,4 @@
+The package ada-url provides CMake targets:
+
+    find_package(ada-url CONFIG REQUIRED)
+    target_link_libraries(your_target_name PRIVATE ada-url::ada-url)

--- a/ports/ade/usage
+++ b/ports/ade/usage
@@ -1,0 +1,4 @@
+The package ade provides CMake targets:
+
+    find_package(ade REQUIRED)
+    target_link_libraries(your_target_name PRIVATE ade::ade)

--- a/ports/air-ctl/usage
+++ b/ports/air-ctl/usage
@@ -1,0 +1,4 @@
+The package air-ctl provides CMake targets:
+
+    find_package(air-ctl CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE air-ctl::air-ctl)

--- a/ports/aixlog/usage
+++ b/ports/aixlog/usage
@@ -1,0 +1,4 @@
+The package aixlog provides CMake targets:
+
+    find_package(aixlog CONFIG REQUIRED)
+    target_link_libraries(your_target PRIVATE aixlog::aixlog)

--- a/ports/alac-decoder/usage
+++ b/ports/alac-decoder/usage
@@ -1,0 +1,4 @@
+The package alac-decoder provides CMake targets:
+
+    find_package(alac-decoder CONFIG REQUIRED)
+    target_link_libraries(your_target_name PRIVATE alac-decoder::alac-decoder)

--- a/ports/alac/usage
+++ b/ports/alac/usage
@@ -1,0 +1,4 @@
+The package alac provides CMake targets:
+
+    find_package(alac CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE alac::alac)

--- a/ports/alembic/usage
+++ b/ports/alembic/usage
@@ -1,0 +1,4 @@
+The package alembic provides CMake targets:
+
+    find_package(alembic CONFIG REQUIRED)
+    target_link_libraries(your_target PRIVATE Alembic::Alembic)

--- a/ports/aliyun-oss-c-sdk/usage
+++ b/ports/aliyun-oss-c-sdk/usage
@@ -1,0 +1,4 @@
+The package aliyun-oss-c-sdk provides CMake targets:
+
+    find_package(aliyun-oss-c-sdk CONFIG REQUIRED)
+    target_link_libraries(your_target_name PRIVATE aliyun-oss-c-sdk::aliyun-oss-c-sdk)

--- a/ports/alpaca/usage
+++ b/ports/alpaca/usage
@@ -1,0 +1,4 @@
+The package alpaca provides CMake targets:
+
+    find_package(alpaca CONFIG REQUIRED)
+    target_link_libraries(your_target_name PRIVATE alpaca::alpaca)

--- a/ports/amd-adl-sdk/usage
+++ b/ports/amd-adl-sdk/usage
@@ -1,0 +1,4 @@
+The package amd-adl-sdk provides CMake targets:
+
+    find_package(amd-adl-sdk CONFIG REQUIRED)
+    target_link_libraries(your_target PRIVATE amd-adl-sdk::amd-adl-sdk)

--- a/ports/ampl-asl/usage
+++ b/ports/ampl-asl/usage
@@ -1,0 +1,4 @@
+The package ampl-asl provides CMake targets:
+
+    find_package(ampl-asl CONFIG REQUIRED)
+    target_link_libraries(your_target_name PRIVATE ampl-asl::ampl-asl)

--- a/ports/ampl-mp/usage
+++ b/ports/ampl-mp/usage
@@ -1,0 +1,4 @@
+The package ampl-mp provides CMake targets:
+
+    find_package(ampl-mp CONFIG REQUIRED)
+    target_link_libraries(your_target_name PRIVATE ampl-mp::ampl-mp)


### PR DESCRIPTION
Added `usage` files for:
- 3fd
- 7zip
- ableton-link
- absent
- ace
- acl
- activemq-cpp
- ada-idna
- ada-url
- ade
- air-ctl
- aixlog
- alac
- alac-decoder
- alembic
- aliyun-oss-c-sdk
- alpaca
- amd-adl-sdk
- ampl-asl
- ampl-mp

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
