### PR TITLE
[stella-cv-fbow] New port

### DIFF
--- a/ports/stella-cv-fbow/fix-arm-windows.patch
+++ b/ports/stella-cv-fbow/fix-arm-windows.patch
@@ -1,0 +1,75 @@
+diff --git a/include/fbow/cpu.h b/include/fbow/cpu.h
+index 7781c3a..f640b8c 100644
+--- a/include/fbow/cpu.h
++++ b/include/fbow/cpu.h
+@@ -31,7 +31,7 @@ THE SOFTWARE.
+ #include <cstdint>
+ #include <cstring>
+ #include <string>
+-#if defined(__ANDROID__) || defined(__arm64__) || defined(__arm__) || defined(__aarch64__)
++#if defined(__ANDROID__) || defined(__arm64__) || defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) || defined(_M_ARM)
+ 
+ #else
+ #if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
+@@ -76,7 +76,7 @@ private:
+     static bool inline detect_OS_AVX512();
+     static inline uint64_t xgetbv(unsigned int x);
+ };
+-#if defined(__ANDROID__) || defined(__arm64__) || defined(__arm__) || defined(__aarch64__)
++#if defined(__ANDROID__) || defined(__arm64__) || defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) || defined(_M_ARM)
+ 
+ void cpu::cpuid(int32_t out[4], int32_t x){}
+ #else
+@@ -119,7 +119,7 @@ bool  cpu::detect_OS_x64(){ return true;}
+ ////////////////////////////////////////////////////////////////////////////////
+ bool cpu::detect_OS_AVX(){
+     //  Copied from: http://stackoverflow.com/a/22521619/922184
+-#if !defined(__ANDROID__) && !defined(__arm64__) && !defined(__arm__) && !defined(__aarch64__)
++#if !defined(__ANDROID__) && !defined(__arm64__) && !defined(__arm__) && !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(_M_ARM)
+ 
+     bool avxSupported = false;
+     int cpuInfo[4]; cpuid(cpuInfo, 1);
+@@ -133,7 +133,7 @@ bool cpu::detect_OS_AVX(){
+ }
+ bool cpu::detect_OS_AVX512(){
+ 
+-#if !defined(__ANDROID__) && !defined(__arm64__) && !defined(__arm__) && !defined(__aarch64__)
++#if !defined(__ANDROID__) && !defined(__arm64__) && !defined(__arm__) && !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(_M_ARM)
+     if (!detect_OS_AVX())
+         return false;
+     uint64_t xcrFeatureMask = xgetbv(_XCR_XFEATURE_ENABLED_MASK);
+@@ -146,7 +146,7 @@ bool cpu::detect_OS_AVX512(){
+ std::string cpu::get_vendor_string(){ int32_t CPUInfo[4]; char name[13];cpuid(CPUInfo, 0); memcpy(name + 0, &CPUInfo[1], 4);memcpy(name + 4, &CPUInfo[3], 4); memcpy(name + 8, &CPUInfo[2], 4); name[12] = '\0'; return name;}
+ void cpu::detect_host(){
+ 
+-#if !defined(__ANDROID__) && !defined(__arm64__) && !defined(__arm__) && !defined(__aarch64__)
++#if !defined(__ANDROID__) && !defined(__arm64__) && !defined(__arm__) && !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(_M_ARM)
+ 
+     OS_x64 = detect_OS_x64();
+     OS_AVX = detect_OS_AVX();
+diff --git a/include/fbow/vocabulary.h b/include/fbow/vocabulary.h
+index 7160560..cd8447b 100644
+--- a/include/fbow/vocabulary.h
++++ b/include/fbow/vocabulary.h
+@@ -36,7 +36,7 @@ THE SOFTWARE.
+ #include <map>
+ #include <memory>
+ #include <bitset>
+-#if !defined(__ANDROID__) && !defined(__arm64__) && !defined(__arm__) && !defined(__aarch64__)
++#if !defined(__ANDROID__) && !defined(__arm64__) && !defined(__arm__) && !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(_M_ARM)
+ #if defined(USE_AVX)
+ #include <immintrin.h>
+ #endif
+diff --git a/src/fbow.cpp b/src/fbow.cpp
+index 024fcf7..ef4bcf1 100644
+--- a/src/fbow.cpp
++++ b/src/fbow.cpp
+@@ -99,7 +99,7 @@ struct L2_generic : public Lx<float, float, 4> {
+         return d;
+     }
+ };
+-#if defined(__ANDROID__) || defined(__arm64__) || defined(__arm__) || defined(__aarch64__) || !defined(USE_AVX)
++#if defined(__ANDROID__) || defined(__arm64__) || defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) || defined(_M_ARM) || !defined(USE_AVX)
+ //fake elements to allow compilation
+ struct L2_avx_generic : public Lx<uint64_t, float, 32> {
+     inline float computeDist(uint64_t* ptr) { return std::numeric_limits<float>::max(); }

--- a/ports/stella-cv-fbow/portfile.cmake
+++ b/ports/stella-cv-fbow/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+	OUT_SOURCE_PATH SOURCE_PATH
+	REPO stella-cv/FBoW
+	REF c6e3c29e3332a0b0834021797e2aa4e8eb66a3c1
+	SHA512 a7f80874c396163a8cbebfbcdf150ea1f1de99ac58a1bd26f69257046e7fe3d32478c80a89eeab329a845e9a6a8c1264cf8750ccd44b380d93def9535048dbb4
+)
+
+vcpkg_cmake_configure(
+	SOURCE_PATH "${SOURCE_PATH}"
+	OPTIONS
+		-DBUILD_UTILS=OFF
+		-DBUILD_TESTS=OFF
+		-DUSE_CONTRIB=OFF
+		-DUSE_AVX=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/fbow)
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+	"${CURRENT_PACKAGES_DIR}/debug/include"
+	"${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/stella-cv-fbow/portfile.cmake
+++ b/ports/stella-cv-fbow/portfile.cmake
@@ -3,6 +3,8 @@ vcpkg_from_github(
 	REPO stella-cv/FBoW
 	REF c6e3c29e3332a0b0834021797e2aa4e8eb66a3c1
 	SHA512 a7f80874c396163a8cbebfbcdf150ea1f1de99ac58a1bd26f69257046e7fe3d32478c80a89eeab329a845e9a6a8c1264cf8750ccd44b380d93def9535048dbb4
+	PATCHES
+		fix-arm-windows.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/stella-cv-fbow/vcpkg.json
+++ b/ports/stella-cv-fbow/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "This is a modified version of the original Fast Bag of Words by @rmsalinas.",
   "homepage": "https://github.com/stella-cv/FBoW",
   "license": "MIT",
-  "supports": "!(arm64 & windows)",
   "dependencies": [
     {
       "name": "opencv4",

--- a/ports/stella-cv-fbow/vcpkg.json
+++ b/ports/stella-cv-fbow/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "This is a modified version of the original Fast Bag of Words by @rmsalinas.",
   "homepage": "https://github.com/stella-cv/FBoW",
   "license": "MIT",
+  "supports": "!(arm64 & windows)",
   "dependencies": [
     {
       "name": "opencv4",

--- a/ports/stella-cv-fbow/vcpkg.json
+++ b/ports/stella-cv-fbow/vcpkg.json
@@ -1,0 +1,12 @@
+{
+	"name": "stella-cv-fbow",
+	"version": "0.0.1",
+	"description": "This is a modified version of the original Fast Bag of Words by @rmsalinas.",
+	"homepage": "https://github.com/stella-cv/FBoW",
+	"license": "MIT",
+	"dependencies": [
+		{ "name": "opencv4", "features": ["highgui"], "default-features": false },
+		{ "name": "vcpkg-cmake", "host": true },
+		{ "name": "vcpkg-cmake-config", "host": true }
+	]
+}

--- a/ports/stella-cv-fbow/vcpkg.json
+++ b/ports/stella-cv-fbow/vcpkg.json
@@ -1,12 +1,24 @@
 {
-	"name": "stella-cv-fbow",
-	"version": "0.0.1",
-	"description": "This is a modified version of the original Fast Bag of Words by @rmsalinas.",
-	"homepage": "https://github.com/stella-cv/FBoW",
-	"license": "MIT",
-	"dependencies": [
-		{ "name": "opencv4", "features": ["highgui"], "default-features": false },
-		{ "name": "vcpkg-cmake", "host": true },
-		{ "name": "vcpkg-cmake-config", "host": true }
-	]
+  "name": "stella-cv-fbow",
+  "version": "0.0.1",
+  "description": "This is a modified version of the original Fast Bag of Words by @rmsalinas.",
+  "homepage": "https://github.com/stella-cv/FBoW",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "opencv4",
+      "default-features": false,
+      "features": [
+        "highgui"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9436,6 +9436,10 @@
       "baseline": "4.7.0",
       "port-version": 0
     },
+    "stella-cv-fbow": {
+      "baseline": "0.0.1",
+      "port-version": 0
+    },
     "stftpitchshift": {
       "baseline": "1.4.1",
       "port-version": 0

--- a/versions/s-/stella-cv-fbow.json
+++ b/versions/s-/stella-cv-fbow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f434b9ec13f6d42051f51c8a1c0d7889917b5fbf",
+      "git-tree": "4d8e2970ea045fd6d130d15087325b7935d862d2",
       "version": "0.0.1",
       "port-version": 0
     }

--- a/versions/s-/stella-cv-fbow.json
+++ b/versions/s-/stella-cv-fbow.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f434b9ec13f6d42051f51c8a1c0d7889917b5fbf",
+      "version": "0.0.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/stella-cv-fbow.json
+++ b/versions/s-/stella-cv-fbow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4d8e2970ea045fd6d130d15087325b7935d862d2",
+      "git-tree": "c20434a432aa792b77f7951c9d65c2f0d660a62b",
       "version": "0.0.1",
       "port-version": 0
     }


### PR DESCRIPTION
This is a [modified Fast Bag of Words from Stella](https://github.com/stella-cv/FBoW); typing `fbow` in repology yields [`stella-cv-fbow`](https://repology.org/project/stella-cv-fbow/versions).

Here is the new port check list:
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
