### PR TITLE
[liblsquic] update to 4.4.2

### DIFF
--- a/ports/liblsquic/disable-asan.patch
+++ b/ports/liblsquic/disable-asan.patch
@@ -1,23 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 65c4776..5d4086a 100644
+index 8d67e7d..5417a62 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -60,12 +60,12 @@ ENDIF()
+@@ -63,13 +63,6 @@ ENDIF()
  
  IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
      SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -O0 -g3")
 -    IF(CMAKE_C_COMPILER MATCHES "clang" AND
+-                        NOT CMAKE_SYSTEM_NAME STREQUAL "Android" AND
 -                        NOT "$ENV{TRAVIS}" MATCHES "^true$" AND
 -                        NOT "$ENV{EXTRA_CFLAGS}" MATCHES "-fsanitize")
 -        SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -fsanitize=address")
 -        SET(LIBS ${LIBS} -fsanitize=address)
 -    ENDIF()
-+    # IF(CMAKE_C_COMPILER MATCHES "clang" AND
-+    #                     NOT "$ENV{TRAVIS}" MATCHES "^true$" AND
-+    #                     NOT "$ENV{EXTRA_CFLAGS}" MATCHES "-fsanitize")
-+    #     SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -fsanitize=address")
-+    #     SET(LIBS ${LIBS} -fsanitize=address)
-+    # ENDIF()
      # Uncomment to enable cleartext protocol mode (no crypto):
      #SET (MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -DLSQUIC_ENABLE_HANDSHAKE_DISABLE=1")
  ELSE()

--- a/ports/liblsquic/fix-found-boringssl.patch
+++ b/ports/liblsquic/fix-found-boringssl.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5d4086a..e085a83 100644
+index 5417a62..4da0d6c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -120,10 +120,12 @@ IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
+@@ -123,10 +123,12 @@ IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
      SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -Od")
      #SET (MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -DFIU_ENABLE=1")
      #SET(LIBS ${LIBS} fiu)
@@ -15,39 +15,31 @@ index 5d4086a..e085a83 100644
  ENDIF()
  
  ENDIF() #MSVC
-@@ -191,7 +193,7 @@ IF (NOT DEFINED BORINGSSL_LIB AND DEFINED BORINGSSL_DIR)
- ELSE()
+@@ -197,20 +199,21 @@ MESSAGE(STATUS "Compiler flags: ${CMAKE_C_FLAGS}")
  
- 
+ IF (NOT DEFINED LIBSSL_LIB AND DEFINED LIBSSL_DIR)
+     SET(LIBSSL_LIB ${LIBSSL_DIR})
 -    FOREACH(LIB_NAME ssl crypto)
 +    FOREACH(LIB ${LIB_NAME})
-         # If BORINGSSL_LIB is defined, try find each lib. Otherwise, user should define BORINGSSL_LIB_ssl,
-         # BORINGSSL_LIB_crypto and so on explicitly. For example, including boringssl and lsquic both via
-         # add_subdirectory:
-@@ -201,20 +203,20 @@ ELSE()
-         #   add_subdirectory(third_party/lsquic)
-         IF (DEFINED BORINGSSL_LIB)
-             IF (CMAKE_SYSTEM_NAME STREQUAL Windows)
--                FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
--                    NAMES ${LIB_NAME}
-+                FIND_LIBRARY(BORINGSSL_LIB_${LIB}
-+                    NAMES ${LIB}
-                     PATHS ${BORINGSSL_LIB}
-                     PATH_SUFFIXES Debug Release MinSizeRel RelWithDebInfo
-                     NO_DEFAULT_PATH)
-             ELSE()
--                FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
--                    NAMES lib${LIB_NAME}${LIB_SUFFIX}
-+                FIND_LIBRARY(BORINGSSL_LIB_${LIB}
-+                    NAMES lib${LI}${LIB_SUFFIX}
-                     PATHS ${BORINGSSL_LIB}
--                    PATH_SUFFIXES ${LIB_NAME}
-+                    PATH_SUFFIXES ${LIB}
-                     NO_DEFAULT_PATH)
-             ENDIF()
-         ENDIF()
--        IF(BORINGSSL_LIB_${LIB_NAME})
-+        IF(BORINGSSL_LIB_${LIB})
-             MESSAGE(STATUS "Found ${LIB_NAME} library: ${BORINGSSL_LIB_${LIB_NAME}}")
+         IF (CMAKE_SYSTEM_NAME STREQUAL Windows)
+-            FIND_LIBRARY(LIBSSL_LIB_${LIB_NAME}
+-                NAMES ${LIB_NAME}
++            FIND_LIBRARY(BORINGSSL_LIB_${LIB}
++                NAMES ${LIB}
+                 PATHS ${LIBSSL_LIB}/ ${LIBSSL_LIB}/lib/ ${LIBSSL_LIB}/ssl/ ${LIBSSL_LIB}/crypto/
+                 PATH_SUFFIXES Debug Release MinSizeRel RelWithDebInfo
+                 NO_DEFAULT_PATH)
          ELSE()
-             MESSAGE(FATAL_ERROR "BORINGSSL_LIB_${LIB_NAME} library not found")
+-            FIND_LIBRARY(LIBSSL_LIB_${LIB_NAME}
+-                NAMES lib${LIB_NAME}${LIB_SUFFIX}
++            FIND_LIBRARY(BORINGSSL_LIB_${LIB}
++                NAMES lib${LIB}${LIB_SUFFIX}
+                 PATHS ${LIBSSL_LIB} ${LIBSSL_LIB}/lib/ ${LIBSSL_LIB}/ssl/ ${LIBSSL_LIB}/crypto/
++                PATH_SUFFIXES ${LIB}
+                 NO_DEFAULT_PATH)
+         ENDIF()
+-        IF(LIBSSL_LIB_${LIB_NAME})
++        IF(BORINGSSL_LIB_${LIB})
+             MESSAGE(STATUS "Found ${LIB_NAME} library: ${LIBSSL_LIB_${LIB_NAME}}")
+         ELSE()
+             MESSAGE(STATUS "${LIB_NAME} library not found")

--- a/ports/liblsquic/portfile.cmake
+++ b/ports/liblsquic/portfile.cmake
@@ -7,7 +7,7 @@ endif()
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO litespeedtech/lsquic
     REF v${VERSION}
-    SHA512 2f1f01761499f834d5ef43a80e2f9eb94f008c17bc1417eef6cde42d33de485627a9b921fc4ebb288b87cb2c9478fb7149d426a60a0e9abbf5067b9edfb97cde
+    SHA512 cd6525b3328d3496c49d2b4f9587b0683c192b02de0214c79215a9100600821868e9b19bf45b5ebe616a53946688ebe7a3471f604a43541bbfdde07b6cf40227
     HEAD_REF master
     PATCHES
         disable-asan.patch

--- a/ports/liblsquic/portfile.cmake
+++ b/ports/liblsquic/portfile.cmake
@@ -7,9 +7,9 @@ endif()
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO litespeedtech/lsquic
     REF v${VERSION}
-    SHA512 40d742779bfa2dc6fdaf0ee8e9349498d373dcffcc6dd27867c18d87309a288ea6811d693043b5d98364d816b818b49445214497475844201241193c0f37b349
+    SHA512 2f1f01761499f834d5ef43a80e2f9eb94f008c17bc1417eef6cde42d33de485627a9b921fc4ebb288b87cb2c9478fb7149d426a60a0e9abbf5067b9edfb97cde
     HEAD_REF master
-    PATCHES 
+    PATCHES
         disable-asan.patch
         fix-found-boringssl.patch
 )
@@ -17,9 +17,9 @@ vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
 # Submodules
 vcpkg_from_github(OUT_SOURCE_PATH LSQPACK_SOURCE_PATH
     REPO litespeedtech/ls-qpack
-    REF v2.5.3
+    REF v2.6.2
     HEAD_REF master
-    SHA512 f90502c763abc84532f33d1b8f952aea7869e4e0c5f6bd344532ddd51c4a180958de4086d88b9ec96673a059c806eec9e70007651d4d4e1a73395919dee47ce0
+    SHA512 9b38ba1b4b12d921385a285e8c833a0ae9cdcc153cff4f1857f88ceb82174304decb5fccbdf9267d08a21c5a26c71fdd884dcacd12afd19256a347a8306b9b90
 )
 if(NOT EXISTS "${SOURCE_PATH}/src/ls-hpack/CMakeLists.txt")
     file(REMOVE_RECURSE "${SOURCE_PATH}/src/liblsquic/ls-qpack")
@@ -28,9 +28,9 @@ endif()
 
 vcpkg_from_github(OUT_SOURCE_PATH LSHPACK_SOURCE_PATH
     REPO litespeedtech/ls-hpack
-    REF v2.3.2
+    REF v2.3.4
     HEAD_REF master
-    SHA512 45d6c8296e8eee511e6a083f89460d5333fc9a49bc078dac55fdec6c46db199de9f150379f02e054571f954a5e3c79af3864dbc53dc57d10a8d2ed26a92d4278
+    SHA512 86a3c869597f4f181e3ecc9648a7ce73139c8e201547072203ad60802a1df37885389c332231efb0521b1bf2357cdb9d866ade48f59af1cbb6c5cbba8148a0ff
 )
 if(NOT EXISTS "${SOURCE_PATH}/src/lshpack/CMakeLists.txt")
     file(REMOVE_RECURSE "${SOURCE_PATH}/src/lshpack")
@@ -67,8 +67,8 @@ endif()
 vcpkg_cmake_config_fixup(PACKAGE_NAME lsquic)
 
 # Concatenate license files and install
-vcpkg_install_copyright(FILE_LIST 
-  "${SOURCE_PATH}/LICENSE" 
+vcpkg_install_copyright(FILE_LIST
+  "${SOURCE_PATH}/LICENSE"
   "${SOURCE_PATH}/LICENSE.chrome"
 )
 

--- a/ports/liblsquic/vcpkg.json
+++ b/ports/liblsquic/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "liblsquic",
-  "version": "3.3.2",
-  "port-version": 1,
+  "version": "4.4.1",
   "description": "An implementation of the QUIC and HTTP/3 protocols.",
   "homepage": "https://github.com/litespeedtech/lsquic",
   "license": "MIT AND BSD-3-Clause",

--- a/ports/liblsquic/vcpkg.json
+++ b/ports/liblsquic/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liblsquic",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "An implementation of the QUIC and HTTP/3 protocols.",
   "homepage": "https://github.com/litespeedtech/lsquic",
   "license": "MIT AND BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5089,7 +5089,7 @@
       "port-version": 0
     },
     "liblsquic": {
-      "baseline": "4.4.1",
+      "baseline": "4.4.2",
       "port-version": 0
     },
     "libltdl": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5089,8 +5089,8 @@
       "port-version": 0
     },
     "liblsquic": {
-      "baseline": "3.3.2",
-      "port-version": 1
+      "baseline": "4.4.1",
+      "port-version": 0
     },
     "libltdl": {
       "baseline": "2.5.4",

--- a/versions/l-/liblsquic.json
+++ b/versions/l-/liblsquic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb4fb9c0b0251dcdb633340bc52fed6446463175",
+      "version": "4.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b53bed814e5b6c755b6b1a52fe4346e5d5fa6308",
       "version": "3.3.2",
       "port-version": 1

--- a/versions/l-/liblsquic.json
+++ b/versions/l-/liblsquic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb74684ffe1e2bec3c78c4867afda372519c0f81",
+      "version": "4.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "cb4fb9c0b0251dcdb633340bc52fed6446463175",
       "version": "4.4.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/litespeedtech/lsquic/releases/tag/v4.4.2
https://github.com/litespeedtech/lsquic/releases/tag/v4.4.1
