### PR TITLE
[GitHub Actions] Updated workflows with newer revisions

### DIFF
--- a/.github/workflows/check_issues.yml
+++ b/.github/workflows/check_issues.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           script: |
             let issue_query = {

--- a/.github/workflows/check_tools_sha.yml
+++ b/.github/workflows/check_tools_sha.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Bootstrap vcpkg
         run: ./bootstrap-vcpkg.sh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,9 +30,9 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -46,6 +46,6 @@ jobs:
         ./vcpkg install alac-decoder breakpad[tools] gettimeofday modp-base64
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/untrustedPR.yml
+++ b/.github/workflows/untrustedPR.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # fetch-depth 50 tries to ensure we capture the whole history of the branch
           fetch-depth: 50
@@ -59,7 +59,7 @@ jobs:
           git reset HEAD~ --mixed
 
       - name: Generate Reply
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { promises: fs } = require('fs')


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
____

* Bumped `actions/checkout` to `v6`.
* Bumped `actions/github-script` to `v8`.
* Bumped `codeql-action/init` to `v4`.
* Bumped `codeql-action/analyze` to `v4`.
**Removes Annotation:**
CodeQL Action v3 will be deprecated in December 2026.
Please update all occurrences of the CodeQL Action in your workflow files to v4. For more information,
see https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/
____

* `actions\stale` left at `v8`.
#36674
https://github.com/actions/stale/issues/1133
