### PR TITLE
[advobfuscator] Update to 2.1.0

### DIFF
--- a/ports/advobfuscator/cmake_export.patch
+++ b/ports/advobfuscator/cmake_export.patch
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 673ddbf..c0a736c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,24 +20,25 @@ install(TARGETS advobfuscator EXPORT advobfuscatorTargets)
+ install(EXPORT advobfuscatorTargets
+         FILE advobfuscatorTargets.cmake
+         NAMESPACE advobfuscator::
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/advobfuscator
++        DESTINATION ${CMAKE_INSTALL_DATADIR}/advobfuscator
+ )
+ 
+ include(CMakePackageConfigHelpers)
+ write_basic_package_version_file(
+-        "${CMAKE_CURRENT_BINARY_DIR}/mylibConfigVersion.cmake"
++        "${CMAKE_CURRENT_BINARY_DIR}/advobfuscatorConfigVersion.cmake"
+         VERSION ${PROJECT_VERSION}
+         COMPATIBILITY SameMajorVersion
++        ARCH_INDEPENDENT
+ )
+ configure_package_config_file(
+         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/AdvobfuscatorConfig.cmake.in"
+         "${CMAKE_CURRENT_BINARY_DIR}/advobfuscatorConfig.cmake"
+-        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/advobfuscator
++        INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/advobfuscator
+ )
+ install(FILES
+         "${CMAKE_CURRENT_BINARY_DIR}/advobfuscatorConfig.cmake"
+         "${CMAKE_CURRENT_BINARY_DIR}/advobfuscatorConfigVersion.cmake"
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/advobfuscator
++        DESTINATION ${CMAKE_INSTALL_DATADIR}/advobfuscator
+ )
+ 
+ if(BUILD_TESTING)

--- a/ports/advobfuscator/portfile.cmake
+++ b/ports/advobfuscator/portfile.cmake
@@ -1,14 +1,25 @@
-# Download the code from GitHub
+# Header only library
 vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH
-  REPO andrivet/ADVobfuscator
-  REF 1852a0eb75b03ab3139af7f938dfb617c292c600
-  SHA512 1bca72b21a3cbf9d8db21fb21d112dd4ca83cac695abfb8fc3d8065245a0cc84cb9e41eb9ff81481e8e0a9d214ff6f5c9aec5d1ba8a9d4387b08dd895ecf1cd5
-  HEAD_REF master
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO andrivet/ADVobfuscator
+    REF "v${VERSION}"
+    SHA512 904d42c034e95770c3d2c6bff9ca80f92fdcf097f00a32a60f236e022342e60977395bb27791a24794d1e9f2c3cabf183b0faf5a1545799aa412f00a9868b715
+    HEAD_REF main
+    PATCHES
+        cmake_export.patch # https://github.com/andrivet/ADVobfuscator/pull/43
 )
 
-# Install the header only source files to the right location
-file(INSTALL ${SOURCE_PATH}/Lib DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS 
+        -DBUILD_TESTING=OFF
+        -DBUILD_EXAMPLES=OFF
+)
 
-# The README.md conains the LICENSE details
-file(INSTALL ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/advobfuscator/portfile.cmake
+++ b/ports/advobfuscator/portfile.cmake
@@ -1,4 +1,3 @@
-# Header only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO andrivet/ADVobfuscator

--- a/ports/advobfuscator/usage
+++ b/ports/advobfuscator/usage
@@ -1,0 +1,4 @@
+advobfuscator provides CMake targets:
+
+  find_package(advobfuscator CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE advobfuscator::advobfuscator)

--- a/ports/advobfuscator/vcpkg.json
+++ b/ports/advobfuscator/vcpkg.json
@@ -1,8 +1,17 @@
 {
   "name": "advobfuscator",
-  "version-date": "2020-06-26",
-  "description": "Obfuscation library based on C++11/14 and metaprogramming",
+  "version": "2.1",
+  "description": "Obfuscation library based on C++20 and metaprogramming",
+  "homepage": "https://github.com/andrivet/ADVobfuscator",
+  "license": "BSD-3-Clause-Clear",
   "dependencies": [
-    "boost-msm"
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/a-/advobfuscator.json
+++ b/versions/a-/advobfuscator.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "22bfad6cbc3b68b3876552266b696a5a744616c6",
+      "git-tree": "c241d092a06888dba3a352ae22db508a55d58c6e",
       "version": "2.1",
       "port-version": 0
     },

--- a/versions/a-/advobfuscator.json
+++ b/versions/a-/advobfuscator.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22bfad6cbc3b68b3876552266b696a5a744616c6",
+      "version": "2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c2b62f4dec8c15ff80008d187ca640ec844679cf",
       "version-date": "2020-06-26",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -57,7 +57,7 @@
       "port-version": 0
     },
     "advobfuscator": {
-      "baseline": "2020-06-26",
+      "baseline": "2.1",
       "port-version": 0
     },
     "air-ctl": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.