### PR TITLE
Add iceoryx2 port

### DIFF
--- a/ports/iceoryx2/portfile.cmake
+++ b/ports/iceoryx2/portfile.cmake
@@ -1,0 +1,35 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO eclipse-iceoryx/iceoryx2
+    REF 6a84763cefcec0f0a8dd4e56f4a2e146b1473b1b # "2025-12-09"
+    SHA512 c7176fd24ecdd64931e1729c10522d4d3ec00c30ab4b68c414258afe61de8575badb83c9ee200ce6e00e27af7ecf36176600e04c2eee96059f8afd1ee7b35aa7
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+        "build-cxx"                 BUILD_CXX
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME iceoryx2-c CONFIG_PATH lib/cmake/iceoryx2-c DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_cmake_config_fixup(PACKAGE_NAME iceoryx2-bb-cxx CONFIG_PATH lib/cmake/iceoryx2-bb-cxx DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_cmake_config_fixup(PACKAGE_NAME iceoryx2-cxx CONFIG_PATH lib/cmake/iceoryx2-cxx)
+
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/doc"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-APACHE" "${SOURCE_PATH}/LICENSE-MIT")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/iceoryx2/usage
+++ b/ports/iceoryx2/usage
@@ -1,0 +1,10 @@
+iceoryx2 provides CMake targets:
+
+    find_package(iceoryx2-c CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE iceoryx2-c::static-lib>)
+
+    find_package(iceoryx2-bb-cxx CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE iceoryx2-bb-cxx::iceoryx2-bb-cxx)
+
+    find_package(iceoryx2-cxx CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE iceoryx2-cxx::static-lib-cxx)

--- a/ports/iceoryx2/vcpkg.json
+++ b/ports/iceoryx2/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "iceoryx2",
+  "version": "2025-12-09",
+  "description": "Zero-Copy Lock-Free IPC with a Rust Core",
+  "homepage": "https://iceoryx.io",
+  "license": "Apache-2.0 OR MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "build-cxx"
+  ],
+  "features": {
+    "build-cxx": {
+      "description": "Build the C++ Language Binding for iceoryx2."
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3860,6 +3860,10 @@
       "baseline": "2.0.6",
       "port-version": 1
     },
+    "iceoryx2": {
+      "baseline": "2025-12-09",
+      "port-version": 0
+    },
     "icu": {
       "baseline": "78.1",
       "port-version": 0

--- a/versions/i-/iceoryx2.json
+++ b/versions/i-/iceoryx2.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9dc7a96a38b4cc75d60c5366c3c22c8d7f6b15be",
+      "version": "2025-12-09",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

We would like to introduce the `iceoryx2` port which is a Rust-based implementation of the `iceoryx` port.
GitHub Repo: https://github.com/eclipse-iceoryx/iceoryx2
Homepage: https://iceoryx.io/

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.


