### PR TITLE
[double-conversion] update to 3.4.0

### DIFF
--- a/ports/double-conversion/portfile.cmake
+++ b/ports/double-conversion/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/double-conversion
     REF "v${VERSION}"
-    SHA512 60cab2fe623204cfa8737150e6ffcae091266180461dba377231e4fe8dccf712e74c643cd317b62266240ab82f1c0f820cf825038d627934d2dd0af1426f0cca
+    SHA512 9a6f43497a772c78660d0c0f9bc42902f5cb99066a08f0ab50345db37ddf62bb491ae7f5ca45819251e3a1d41282e5646b269e912cbd24eca6b440a31409712f
     HEAD_REF master
 )
 
@@ -12,6 +12,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/double-conversion/vcpkg.json
+++ b/ports/double-conversion/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "double-conversion",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles.",
   "homepage": "https://github.com/google/double-conversion",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2525,7 +2525,7 @@
       "port-version": 0
     },
     "double-conversion": {
-      "baseline": "3.3.1",
+      "baseline": "3.4.0",
       "port-version": 0
     },
     "dp-thread-pool": {

--- a/versions/d-/double-conversion.json
+++ b/versions/d-/double-conversion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dde04ced6dca235e927274ecff2261da0d5ec8a9",
+      "version": "3.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a28a9c42d582dc61662c0407cca8362e6dc346ae",
       "version": "3.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/google/double-conversion/releases/tag/v3.4.0
