### PR TITLE
[libenvpp] update to 1.5.2

### DIFF
--- a/ports/libenvpp/portfile.cmake
+++ b/ports/libenvpp/portfile.cmake
@@ -1,5 +1,10 @@
 vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
 
+# No DLL export(yet)
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ph3at/libenvpp

--- a/ports/libenvpp/portfile.cmake
+++ b/ports/libenvpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ph3at/libenvpp
     REF v${VERSION}
-    SHA512 6a56a16a4ba0e3fe97dcf4de2fbf8aba17d2e237c9d6daf559599d237a3e89ec951d2aefc845b79758b73a6bb72a2c69fac25d679127027158a1173d561398aa
+    SHA512 d7d11736884c4991f9d52818b306feb62c9783b69f7ee0f9aae90ff29aced297050c4140b6485e5687b0edc4cb11b58372c28039ad67fa780cc31f0da2f381f0
     HEAD_REF main
     PATCHES
         fix-dependencies.patch

--- a/ports/libenvpp/portfile.cmake
+++ b/ports/libenvpp/portfile.cmake
@@ -1,5 +1,5 @@
 vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ph3at/libenvpp

--- a/ports/libenvpp/vcpkg.json
+++ b/ports/libenvpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libenvpp",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A modern C++ library for type-safe environment variable parsing",
   "homepage": "https://github.com/ph3at/libenvpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4817,7 +4817,7 @@
       "port-version": 0
     },
     "libenvpp": {
-      "baseline": "1.5.1",
+      "baseline": "1.5.2",
       "port-version": 0
     },
     "libepoxy": {

--- a/versions/l-/libenvpp.json
+++ b/versions/l-/libenvpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9c26dcb945259f342b58016b7087742c4f0a9992",
+      "version": "1.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c42c353b229625c66fa8f4407b24ee4fc75a79bd",
       "version": "1.5.1",
       "port-version": 0

--- a/versions/l-/libenvpp.json
+++ b/versions/l-/libenvpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eedb674ed2c6b3580c6d658dab2bbdf42ddf5d00",
+      "git-tree": "581d4c899ccde22efd257bb2e5f3a8caa0b1c711",
       "version": "1.5.2",
       "port-version": 0
     },

--- a/versions/l-/libenvpp.json
+++ b/versions/l-/libenvpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9c26dcb945259f342b58016b7087742c4f0a9992",
+      "git-tree": "eedb674ed2c6b3580c6d658dab2bbdf42ddf5d00",
       "version": "1.5.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ph3at/libenvpp/releases/tag/v1.5.2
