### PR TITLE
[tree-sitter] update to 0.26.2

### DIFF
--- a/ports/tree-sitter/portfile.cmake
+++ b/ports/tree-sitter/portfile.cmake
@@ -6,14 +6,14 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tree-sitter/tree-sitter
     REF "v${VERSION}"
-    SHA512 f0465a2fabe303c1b62f1f55ed08aa57372ac11370d229adcccd99b5e8067be53e92da281cdfbcd034e2ecefb33ac90a119eeac9035670ac8fbaa4242cb87a11
+    SHA512 d6b25738ec3881aaddaf20c6db1138500c4cb37dcc95b8b29990371dee14224bc0bb520d479c2df4a2537f06a81bf034798ebc3b0dedcde9f8f92f64a42ec347
     HEAD_REF master
     PATCHES
         unofficial-cmake.diff
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/lib"
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()

--- a/ports/tree-sitter/unofficial-cmake.diff
+++ b/ports/tree-sitter/unofficial-cmake.diff
@@ -1,8 +1,17 @@
-diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index 4b44cc1..1b99f08 100644
---- a/lib/CMakeLists.txt
-+++ b/lib/CMakeLists.txt
-@@ -92,4 +92,12 @@ install(FILES include/tree_sitter/api.h
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 893a4d8..ab94312 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,7 +19,7 @@ endif()
+ 
+ add_library(tree-sitter ${TS_SOURCE_FILES})
+ 
+-target_include_directories(tree-sitter PRIVATE lib/src lib/src/wasm PUBLIC lib/include)
++target_include_directories(tree-sitter PRIVATE lib/src lib/src/wasm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/include>)
+ 
+ if(MSVC)
+   target_compile_options(tree-sitter PRIVATE
+@@ -92,4 +92,12 @@ install(FILES lib/include/tree_sitter/api.h
  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter.pc"
          DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
  install(TARGETS tree-sitter

--- a/ports/tree-sitter/vcpkg.json
+++ b/ports/tree-sitter/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter",
-  "version-semver": "0.25.10",
+  "version-semver": "0.26.2",
   "description": "An incremental parsing system for programming tools.",
   "homepage": "https://github.com/tree-sitter/tree-sitter",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9949,7 +9949,7 @@
       "port-version": 1
     },
     "tree-sitter": {
-      "baseline": "0.25.10",
+      "baseline": "0.26.2",
       "port-version": 0
     },
     "tree-sitter-c": {

--- a/versions/t-/tree-sitter.json
+++ b/versions/t-/tree-sitter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "80e0ec60e1b749c5010e024257cbe938ca690105",
+      "version-semver": "0.26.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "b86e93a72410148296d5e004b0cfe0a3bdb5843b",
       "version-semver": "0.25.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/tree-sitter/tree-sitter/releases/tag/v0.26.2
