### PR TITLE
[solid3] Add missing meta information

### DIFF
--- a/ports/solid3/no-sse.patch
+++ b/ports/solid3/no-sse.patch
@@ -10,7 +10,7 @@ index be43838..fe71394 100644
 -  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -Wall -ffast-math -msse2 -mfpmath=sse")
 +  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -ffast-math")
 +  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -Wall -ffast-math")
-+  if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm")    
++  if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|aarch64)")
 +    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2 -mfpmath=sse")
 +    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -mfpmath=sse")
 +  endif()

--- a/ports/solid3/portfile.cmake
+++ b/ports/solid3/portfile.cmake
@@ -10,14 +10,10 @@ vcpkg_from_github(
         no-sse.patch
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    set(DYNAMIC_SOLID OFF)
-else()
-    set(DYNAMIC_SOLID ON)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DYNAMIC_SOLID)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DDYNAMIC_SOLID=${DYNAMIC_SOLID}
 )
@@ -26,14 +22,19 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/solid3)
 
-file(COPY ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/solid3)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/solid3/README.md ${CURRENT_PACKAGES_DIR}/share/solid3/copyright)
-file(COPY ${SOURCE_PATH}/LICENSE_GPL.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/solid3)
-file(COPY ${SOURCE_PATH}/LICENSE_QPL.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/solid3)
-
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/bin"
+        "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
 endif()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/README.md"
+        "${SOURCE_PATH}/LICENSE_GPL.txt"
+        "${SOURCE_PATH}/LICENSE_QPL.txt"
+)

--- a/ports/solid3/vcpkg.json
+++ b/ports/solid3/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "solid3",
   "version": "3.5.8",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Software Library for Interference Detection",
+  "homepage": "https://github.com/dtecta/solid3",
   "license": "GPL-2.0-only OR QPL-1.0",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9222,7 +9222,7 @@
     },
     "solid3": {
       "baseline": "3.5.8",
-      "port-version": 2
+      "port-version": 3
     },
     "sophus": {
       "baseline": "1.24.6-r1",

--- a/versions/s-/solid3.json
+++ b/versions/s-/solid3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c7f3b953e0d8133b17e02e33d852f36e9fdca73d",
+      "version": "3.5.8",
+      "port-version": 3
+    },
+    {
       "git-tree": "d02f4f19962318fca6af9450781fcd281af86652",
       "version": "3.5.8",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Should fix the issue described [here](https://repology.org/project/solid-unclassified/report).

Edit: The build `arm64-android` failed with
```
clang++: error: unsupported option '-msse2' for target 'aarch64-none-linux-android28'
```
Therefore adjusted the file `no-sse.patch`
