### PR TITLE
[tree-sitter-cli] update to 0.26.2

### DIFF
--- a/ports/tree-sitter-cli/portfile.cmake
+++ b/ports/tree-sitter-cli/portfile.cmake
@@ -65,7 +65,7 @@ if(key STREQUAL "Windows-x64" OR VCPKG_TREE_SITTER_UPDATE)
     vcpkg_download_distfile(archive_path
         URLS "https://github.com/tree-sitter/tree-sitter/releases/download/v${VERSION}/tree-sitter-windows-x64.gz"
         FILENAME "${filename}"
-        SHA512 d59a933adc82818570444e09394d28261a416887d12c5fc11839807f01fcd3719ef982344bb4827ffd5c1b72462ed625520803aff86fd24f4f566873fbd9dcd83333
+        SHA512 d59a933adc82818570444e09394d28261a416887d12c5fc11839807f01fcd3719ef982344bb4827ffd5c1b72462ed625520803aff86fd24f4f566873fbd9dcd8
     )
 endif()
 if(NOT archive_path)

--- a/ports/tree-sitter-cli/portfile.cmake
+++ b/ports/tree-sitter-cli/portfile.cmake
@@ -10,18 +10,18 @@ endif()
 vcpkg_download_distfile(license
 	URLS "https://github.com/tree-sitter/tree-sitter/raw/refs/tags/v${VERSION}/LICENSE"
 	FILENAME "tree-sitter-v${VERSION}-LICENSE"
-	SHA512 50781942281117c409cd4fe79b18314bf26560107e13539bfd8f1e5ded538ab7e00b8e7e665dbc6acb69a6ca524d1a3a5ef2fb3d0156aa0984f68c178d6aeb6e
+	SHA512 568a9113476b2f4a542303ae3b329686e2fffd0b29b96a0acc50181ff248ac144f63017d5e376d9b870e33f3bd6063a2aba1d1c0a6c7708dd589ffb67a17491a
 )
 
 set(archive_path NOTFOUND)
-# For convenient updates, use 
+# For convenient updates, use
 # vcpkg install tree-sitter-cli --cmake-args=-DVCPKG_TREE_SITTER_UPDATE=1
 if(key STREQUAL "Linux-arm64" OR VCPKG_TREE_SITTER_UPDATE)
     set(filename "tree-sitter-${VERSION}-linux-arm64.gz")
     vcpkg_download_distfile(archive_path
         URLS "https://github.com/tree-sitter/tree-sitter/releases/download/v${VERSION}/tree-sitter-linux-arm64.gz"
         FILENAME "${filename}"
-        SHA512 749578d0d9928ae0da5b030df67e76bd548623cda1317316ac6c2a9025ae1c0d5ca2843e88b10b9b900dc39419099a4234ad67fd93b422a4f9a280f80523a47e
+        SHA512 da03ba55087a13233e014b8034697dad1d0106f676e6e60fc805477cd10e9671af56e3845d49ad692f9f2d0ea33e242c09e526c247ceb5094bb105834381ae35
     )
 endif()
 if(key STREQUAL "Linux-x64" OR VCPKG_TREE_SITTER_UPDATE)
@@ -29,7 +29,7 @@ if(key STREQUAL "Linux-x64" OR VCPKG_TREE_SITTER_UPDATE)
     vcpkg_download_distfile(archive_path
         URLS "https://github.com/tree-sitter/tree-sitter/releases/download/v${VERSION}/tree-sitter-linux-x64.gz"
         FILENAME "${filename}"
-        SHA512 29f9b5890338d9b37adaa2112daabe66dca999a5bbc1e47853481fcd388c0676b38d6134dab614e683c0b9c793f1b8036f09999abbc744a9ccecdbdf4943873b
+        SHA512 86caf799166ad945b8ed4ddf2b48b9d9acb5ae3e5536244f069467f2996da584a7fe23d45edb37ad7e63a7db8be02525971357fa0a7e7868e3136da68567c578
     )
 endif()
 if(key STREQUAL "Darwin-arm64" OR VCPKG_TREE_SITTER_UPDATE)
@@ -37,7 +37,7 @@ if(key STREQUAL "Darwin-arm64" OR VCPKG_TREE_SITTER_UPDATE)
     vcpkg_download_distfile(archive_path
         URLS "https://github.com/tree-sitter/tree-sitter/releases/download/v${VERSION}/tree-sitter-macos-arm64.gz"
         FILENAME "${filename}"
-        SHA512 393580273793c8d376aea46ea2f73f224e442729b89985541371986123f1dc396e70310ab3eb213ae8eb1432633c3605d228296aac2545bd269583ef103949f2
+        SHA512 3b088390950f48745ea9afc4caea394abaf0ee445530252e6e5a9784a3ea85d7339a664f38cb337e4e6bbb2d3f05189cfa79316c616ee2c25c724e3a068ef4eb
     )
     # Avoid breaking the code signature.
     set(VCPKG_FIXUP_MACHO_RPATH OFF)
@@ -47,7 +47,7 @@ if(key STREQUAL "Darwin-x64" OR VCPKG_TREE_SITTER_UPDATE)
     vcpkg_download_distfile(archive_path
         URLS "https://github.com/tree-sitter/tree-sitter/releases/download/v${VERSION}/tree-sitter-macos-x64.gz"
         FILENAME "${filename}"
-        SHA512 5d9267b02b254377a508685ee3b522c5f186cc65aae4ae2d0099effeb3a8296a208e97fbf0fec77cd75b0c6427bc3d27beafd83bfe4776ec3345b87cd088c687
+        SHA512 b641e8bf21ee66c40f7d9a748fbed3239ac2617be24b0deaf1fdb24e1c9baa5f54bcc9311d4c6a7425cd87032ec9b635deefc62058cbd456839e4e6a52df621a
     )
     # Avoid breaking the code signature.
     set(VCPKG_FIXUP_MACHO_RPATH OFF)
@@ -57,7 +57,7 @@ if(key STREQUAL "Windows-arm64" OR VCPKG_TREE_SITTER_UPDATE)
     vcpkg_download_distfile(archive_path
         URLS "https://github.com/tree-sitter/tree-sitter/releases/download/v${VERSION}/tree-sitter-windows-arm64.gz"
         FILENAME "${filename}"
-        SHA512 07a2b8e0f2325b83e543e76a2ff4f248c230bad51486f870b1c0e856bca9aa4ac04d70b66535ef517bfa184b55081b3b5a78b07532a3ae750195579f45621d6d
+        SHA512 1d5e78ada1a4fd6f313b1115a97ac3b0e380de190ddbfb4879045cdfc95eefdff9f676aeb53d59ae788f86bf58360cc27c90698e5243ceb25c6b1febec596f1f
     )
 endif()
 if(key STREQUAL "Windows-x64" OR VCPKG_TREE_SITTER_UPDATE)
@@ -65,7 +65,7 @@ if(key STREQUAL "Windows-x64" OR VCPKG_TREE_SITTER_UPDATE)
     vcpkg_download_distfile(archive_path
         URLS "https://github.com/tree-sitter/tree-sitter/releases/download/v${VERSION}/tree-sitter-windows-x64.gz"
         FILENAME "${filename}"
-        SHA512 dd51eef2b0ca9d372ed0b66acb9b079a46a623adccffd1af40bbad9330b8caac71716f6163a98f6972ca26be1254978dc22b843b9b827a7420e074b8789d7f7e
+        SHA512 d59a933adc82818570444e09394d28261a416887d12c5fc11839807f01fcd3719ef982344bb4827ffd5c1b72462ed625520803aff86fd24f4f566873fbd9dcd83333
     )
 endif()
 if(NOT archive_path)

--- a/ports/tree-sitter-cli/vcpkg.json
+++ b/ports/tree-sitter-cli/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-cli",
-  "version": "0.25.3",
+  "version": "0.26.2",
   "description": "Tree-sitter is a parser generator tool and an incremental parsing library. This port installs the CLI executable.",
   "homepage": "https://github.com/tree-sitter/tree-sitter",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9965,7 +9965,7 @@
       "port-version": 0
     },
     "tree-sitter-cli": {
-      "baseline": "0.25.3",
+      "baseline": "0.26.2",
       "port-version": 0
     },
     "treehh": {

--- a/versions/t-/tree-sitter-cli.json
+++ b/versions/t-/tree-sitter-cli.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "829f96e4a1b9cfde36e50447864e6daa665be126",
+      "version": "0.26.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "73f51ab723ad9a1228e7c533eb824ddd2066d24a",
       "version": "0.25.3",
       "port-version": 0

--- a/versions/t-/tree-sitter-cli.json
+++ b/versions/t-/tree-sitter-cli.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "829f96e4a1b9cfde36e50447864e6daa665be126",
+      "git-tree": "cb05f0cb0114b1ec70e38141b59c05f415eda3ff",
       "version": "0.26.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Forgot to update in https://github.com/microsoft/vcpkg/pull/48791.
