### PR TITLE
[openmvg] Remove cascade baseline entry

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -568,7 +568,6 @@ openmpi:arm-neon-android=fail
 openmpi:arm64-android=fail
 openmpi:x64-android=fail
 openmvg:arm64-windows-static-md=fail
-openmvg:arm64-windows=fail
 openmvs:arm64-windows-static-md=fail # no _M_ARM64 detection
 # MSVC is not supported
 openslide:x64-windows-release=fail


### PR DESCRIPTION
Fixes https://dev.azure.com/vcpkg/public/vcpkg%20team/_build/results?buildId=123984

REGRESSION: openmvg:arm64-windows is marked as fail but one dependency is not supported for arm64-windows.
