### PR TITLE
[fadbad] Fix URLs

### DIFF
--- a/ports/fadbad/portfile.cmake
+++ b/ports/fadbad/portfile.cmake
@@ -1,20 +1,20 @@
 vcpkg_download_distfile(ARCHIVE
-  URLS "http://www.fadbad.com/download/FADBAD++-2.1.tar.gz"
+  URLS "https://uning.dk/download/FADBAD++-2.1.tar.gz"
   FILENAME "FADBAD++-2.1.tar.gz"
   SHA512 7a82c51c03acb0806d673853f391379ea974e304c831ee15ef05a90c30661736ff572481b5b8254b2646c63968043ee90a06cba88261b87fc34d01f92403360a
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
 )
 
 file(INSTALL
-  ${SOURCE_PATH}/tadiff.h
-  ${SOURCE_PATH}/fadbad.h
-  ${SOURCE_PATH}/fadiff.h
-  ${SOURCE_PATH}/badiff.h
-  DESTINATION ${CURRENT_PACKAGES_DIR}/include
+  "${SOURCE_PATH}/tadiff.h"
+  "${SOURCE_PATH}/fadbad.h"
+  "${SOURCE_PATH}/fadiff.h"
+  "${SOURCE_PATH}/badiff.h"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/include"
 )
 
-file(INSTALL ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/fadbad RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYRIGHT")

--- a/ports/fadbad/vcpkg.json
+++ b/ports/fadbad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fadbad",
   "version": "2.1.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "FADBAD++ Templates for Automatic Differentiation",
-  "homepage": "https://www.fadbad.com/"
+  "homepage": "https://uning.dk/fadbad.html"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2826,7 +2826,7 @@
     },
     "fadbad": {
       "baseline": "2.1.0",
-      "port-version": 2
+      "port-version": 3
     },
     "faiss": {
       "baseline": "1.8.0",

--- a/versions/f-/fadbad.json
+++ b/versions/f-/fadbad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28d7ffaf41ded7467e9a471dc5ff7f35b5b9a801",
+      "version": "2.1.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "a607ac03a90c00969c67d2ec609924e9b80795bc",
       "version": "2.1.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

[Repology complained](https://repology.org/repository/vcpkg/problems):
> Homepage link https://www.fadbad.com/ is [dead](https://repology.org/link/https://www.fadbad.com/) (SSL error: certificate issued for different hostname) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).

So I checked the webarchiv and found out, it redirects since beginning of 2022 (or maybe already end of 2021) to another url. Therefore adjusted the URLs to it.