### PR TITLE
[dpdk] Update to 25.11

### DIFF
--- a/ports/dpdk/0001-enable-either-static-or-shared-build.patch
+++ b/ports/dpdk/0001-enable-either-static-or-shared-build.patch
@@ -2,7 +2,7 @@ diff --git a/config/meson.build b/config/meson.build
 index b6b3558e11..34b85f10b5 100644
 --- a/config/meson.build
 +++ b/config/meson.build
-@@ -94,7 +94,9 @@ eal_pmd_path = join_paths(get_option('prefix'), driver_install_path)
+@@ -95,7 +95,9 @@ eal_pmd_path = join_paths(get_option('prefix'), driver_install_path)
  # driver .so files often depend upon the bus drivers for their connect bus,
  # e.g. ixgbe depends on librte_bus_pci. This means that the bus drivers need
  # to be in the library path, so symlink the drivers from the main lib directory.
@@ -17,7 +17,7 @@ diff --git a/drivers/meson.build b/drivers/meson.build
 index 495e21b54a..ff7b5983cb 100644
 --- a/drivers/meson.build
 +++ b/drivers/meson.build
-@@ -252,7 +252,7 @@ foreach subpath:subdirs
+@@ -322,7 +322,7 @@ foreach subpath:subdirs
                  include_directories: includes,
                  dependencies: static_deps,
                  c_args: cflags,
@@ -25,17 +25,17 @@ index 495e21b54a..ff7b5983cb 100644
 +                install: get_option('default_library') == 'static')
  
          # now build the shared driver
-         version_map = '@0@/@1@/version.map'.format(meson.current_source_dir(), drv_path)
-@@ -297,7 +297,7 @@ foreach subpath:subdirs
-         else
-             lk_args = ['-Wl,--version-script=' + version_map]
+         if is_ms_linker
+@@ -359,7 +359,7 @@ foreach subpath:subdirs
+                     output: lib_name + '.sym_chk',
+                     depends: [version_map])
          endif
 -
 +      if get_option('default_library') == 'shared'
-         shared_lib = shared_library(lib_name, sources,
+         shared_lib = shared_library(lib_name, sources_pmd_info,
                  objects: objs,
                  include_directories: includes,
-@@ -315,10 +315,14 @@ foreach subpath:subdirs
+@@ -377,10 +377,14 @@ foreach subpath:subdirs
          shared_dep = declare_dependency(link_with: shared_lib,
                  include_directories: includes,
                  dependencies: shared_deps)
@@ -54,7 +54,7 @@ diff --git a/lib/meson.build b/lib/meson.build
 index ce92cb5537..40880bbf02 100644
 --- a/lib/meson.build
 +++ b/lib/meson.build
-@@ -249,7 +249,7 @@ foreach l:libraries
+@@ -274,7 +274,7 @@ foreach l:libraries
              c_args: cflags,
              dependencies: static_deps,
              include_directories: includes,
@@ -63,15 +63,15 @@ index ce92cb5537..40880bbf02 100644
      static_dep = declare_dependency(
              include_directories: includes,
              dependencies: static_deps)
-@@ -305,6 +305,7 @@ foreach l:libraries
-                 output: name + '.sym_chk')
+@@ -324,6 +324,7 @@ foreach l:libraries
+         cflags += '-DRTE_BUILD_SHARED_LIB'
      endif
  
 +  if get_option('default_library') == 'shared'
      shared_lib = shared_library(libname,
              sources,
              objects: objs,
-@@ -321,6 +322,9 @@ foreach l:libraries
+@@ -341,6 +342,9 @@ foreach l:libraries
              dependencies: shared_deps)
  
      dpdk_libraries = [shared_lib] + dpdk_libraries

--- a/ports/dpdk/0002-fix-dependencies.patch
+++ b/ports/dpdk/0002-fix-dependencies.patch
@@ -2,12 +2,12 @@ diff --git a/config/meson.build b/config/meson.build
 index 34b85f10b5..5ed4625d9e 100644
 --- a/config/meson.build
 +++ b/config/meson.build
-@@ -236,12 +236,10 @@ if meson.is_cross_build() and not meson.get_external_property('numa', true)
+@@ -238,12 +238,10 @@ if meson.is_cross_build() and not meson.get_external_property('numa', true)
      find_libnuma = false
  endif
  if find_libnuma
 -    numa_dep = cc.find_library('numa', required: false)
--    if numa_dep.found() and cc.has_header('numaif.h')
+-    if numa_dep.found() and cc.has_header('numaif.h') and cc.links(min_c_code, dependencies: numa_dep)
 +    numa_dep = dependency('numa', method: 'pkg-config', required: false)
 +    if numa_dep.found()
          dpdk_conf.set10('RTE_HAS_LIBNUMA', true)
@@ -39,4 +39,4 @@ index 51bcf17244..1099a0232f 100644
 +    ext_deps += numa_dep
      dpdk_conf.set10('RTE_LIBRTE_VHOST_NUMA', true)
  endif
- if (toolchain == 'gcc' and cc.version().version_compare('>=8.3.0'))
+ dpdk_conf.set('RTE_LIBRTE_VHOST_POSTCOPY', cc.has_header('linux/userfaultfd.h'))

--- a/ports/dpdk/0005-no-absolute-driver-path.patch
+++ b/ports/dpdk/0005-no-absolute-driver-path.patch
@@ -2,12 +2,12 @@ diff --git a/config/meson.build b/config/meson.build
 index 5ed4625d9e..3f89fd0768 100644
 --- a/config/meson.build
 +++ b/config/meson.build
-@@ -445,7 +445,7 @@ Please install libnuma, or set 'max_numa_nodes' option to '1' to build without N
+@@ -461,7 +461,7 @@ Please install libnuma, or set 'max_numa_nodes' option to '1' to build without N
  endif
  
  # set the install path for the drivers
 -dpdk_conf.set_quoted('RTE_EAL_PMD_PATH', eal_pmd_path)
 +dpdk_conf.set_quoted('RTE_EAL_PMD_PATH', '')
  
- install_headers(['rte_config.h'],
-         subdir: get_option('include_subdir_arch'))
+ dpdk_arch_headers += files('rte_config.h')
+ 

--- a/ports/dpdk/0006-rename-sched.h.patch
+++ b/ports/dpdk/0006-rename-sched.h.patch
@@ -43,8 +43,8 @@ index 9d69467..4df82dd 100644
 --- a/lib/eal/windows/include/rte_os.h
 +++ b/lib/eal/windows/include/rte_os.h
 @@ -14,7 +14,7 @@
- #include <stdlib.h>
  #include <string.h>
+ #include <malloc.h>
  
 -#include <sched.h>
 +#include <sched_from_dpdk.h>

--- a/ports/dpdk/vcpkg.json
+++ b/ports/dpdk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dpdk",
-  "version": "24.11.3",
-  "port-version": 1,
+  "version": "25.11",
   "description": "A set of libraries and drivers for fast packet processing",
   "homepage": "https://www.dpdk.org/",
   "documentation": "https://doc.dpdk.org/guides/",
@@ -28,9 +27,6 @@
   "features": {
     "docs": {
       "description": "Build and install docs"
-    },
-    "kmods": {
-      "description": "Build and install kernel modules"
     },
     "tests": {
       "description": "Build and install tests"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2545,8 +2545,8 @@
       "port-version": 1
     },
     "dpdk": {
-      "baseline": "24.11.3",
-      "port-version": 1
+      "baseline": "25.11",
+      "port-version": 0
     },
     "dpp": {
       "baseline": "10.1.4",

--- a/versions/d-/dpdk.json
+++ b/versions/d-/dpdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc65391748bf0876d288a5a18f8ac58798b367d0",
+      "version": "25.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "c7a3787ad80d51937e2b97a7ef9888afe4b80061",
       "version": "24.11.3",
       "port-version": 1


### PR DESCRIPTION
Option enable_kmods has been removed and enabled by default

Fixes  #48161

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
