### PR TITLE
[libmypaint] Update homepage URL

### DIFF
--- a/ports/libmypaint/vcpkg.json
+++ b/ports/libmypaint/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "libmypaint",
   "version": "1.6.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Brush library used by MyPaint",
-  "homepage": "mypaint.org",
+  "homepage": "https://github.com/mypaint/libmypaint",
   "license": "ISC",
   "supports": "!windows | mingw",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5210,7 +5210,7 @@
     },
     "libmypaint": {
       "baseline": "1.6.1",
-      "port-version": 1
+      "port-version": 2
     },
     "libmysofa": {
       "baseline": "1.3.3",

--- a/versions/l-/libmypaint.json
+++ b/versions/l-/libmypaint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0834136ddd7d0bbbc963915b18ef1cde2ef44093",
+      "version": "1.6.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "7abe278c8100389dac2602a26cb641fe28f9f990",
       "version": "1.6.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

See https://github.com/microsoft/vcpkg-tool/issues/1880

Possible fixes:
- `https://mypaint.org` <= SSL issue
- `http://mypaint.org` redirects to `https://www.mypaint.app`
- `https://www.mypaint.app` No [other repository](https://repology.org/project/libmypaint/packages) seems to use this URL
- Using GitHub URL => Like some other repos are doing it and I think the general homepage of the main project is to generic for just a sub library

