### PR TITLE
[ampl-mp] update to 4.1.0

### DIFF
--- a/ports/ampl-mp/fix-arm-build.patch
+++ b/ports/ampl-mp/fix-arm-build.patch
@@ -1,45 +1,33 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 92089a3..d4c6762 100644
+index 05fc783..e367344 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -240,4 +240,4 @@
+@@ -313,7 +313,7 @@ add_mp_library(format OBJECT
  set(MP_EXPR_INFO_FILE ${MP_SOURCE_DIR}/src/expr-info.cc)
+ set(MP_NL_OPCODES_FILE
+   ${MP_SOURCE_DIR}/nl-writer2/include/mp/nl-opcodes.h)
 -add_executable(gen-expr-info EXCLUDE_FROM_ALL
 +add_executable(gen-expr-info
    src/gen-expr-info.cc $<TARGET_OBJECTS:format>)
  if (MINGW)
-@@ -257,9 +257,15 @@ if (CMAKE_CROSSCOMPILING)
-     COMMAND ${CMAKE_COMMAND} -E echo
-       "warning: cannot re-generate ${MP_EXPR_INFO_FILE}")
- else ()
-+  if (ARITHCHK_EXEC)
-+  add_custom_command(OUTPUT ${MP_EXPR_INFO_FILE}
-+    COMMAND ${WINE} ${ARITHCHK_EXEC} ${MP_EXPR_INFO_FILE}
-+    DEPENDS gen-expr-info)
-+  else()
-   add_custom_command(OUTPUT ${MP_EXPR_INFO_FILE}
-     COMMAND ${WINE} $<TARGET_FILE:gen-expr-info> ${MP_EXPR_INFO_FILE}
-     DEPENDS gen-expr-info)
-+  endif()
- endif ()
+   SET_TARGET_PROPERTIES(gen-expr-info PROPERTIES
+@@ -505,7 +505,7 @@ if (NOT SKIP_BUILD_MP)
+ 	install(DIRECTORY include/mp DESTINATION include)
+ 	install(TARGETS mp DESTINATION lib RUNTIME DESTINATION bin)
+ 	install(FILES LICENSE.rst DESTINATION share/mp)
+-
++  install(TARGETS gen-expr-info RUNTIME DESTINATION bin)
+ endif()   ## NOT SKIP_BUILD_MP
  
- add_prefix(MP_HEADERS include/mp/
-@@ -359,3 +365,4 @@ endif()
- install(DIRECTORY include/mp DESTINATION include)
- install(TARGETS mp DESTINATION lib RUNTIME DESTINATION bin)
- install(FILES LICENSE.rst DESTINATION share/mp)
-+install(TARGETS gen-expr-info RUNTIME DESTINATION bin)
-\ No newline at end of file
+ # If we want to generate the op file only, we are done here.
 diff --git a/src/amplsig/CMakeLists.txt b/src/amplsig/CMakeLists.txt
-index 81312e9..f44c847 100644
+index a9b75d0..0dcfe3e 100644
 --- a/src/amplsig/CMakeLists.txt
 +++ b/src/amplsig/CMakeLists.txt
-@@ -14,6 +14,6 @@ find_library(WS2_32_LIBRARY Ws2_32
+@@ -17,5 +17,5 @@ find_library(WS2_32_LIBRARY Ws2_32
  PATHS ${WIN_LIBRARY_DIR} NO_DEFAULT_PATH)
  if (WS2_32_LIBRARY)
    add_ampl_library(amplsig amplsig.cc)
--  message(WS2_32_LIBRARY ${WS2_32_LIBRARY})
 -  target_link_libraries(amplsig mp ${WS2_32_LIBRARY})
-+  message(WS2_32_LIBRARY ws2_32)
 +  target_link_libraries(amplsig mp ws2_32)
  endif ()

--- a/ports/ampl-mp/fix-build.patch
+++ b/ports/ampl-mp/fix-build.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 904cfb1..13f11cb 100644
+index 9754d35..2b53eb0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -61,6 +61,8 @@ set_cache(BUILD "" STRING
+@@ -112,6 +112,8 @@ set_cache(BUILD "" STRING
  if (BUILD)
    if (BUILD STREQUAL all)
      set(MP_MODULES all)
@@ -11,7 +11,7 @@ index 904cfb1..13f11cb 100644
    else ()
      string(REGEX MATCHALL "[^,]+" MP_MODULES "${BUILD}")
    endif ()
-@@ -200,7 +202,7 @@ function (add_mp_library name)
+@@ -268,7 +270,7 @@ function (add_mp_library name)
      add_dependencies(${name} ${add_mp_library_DEPENDS})
    endif ()
    # Add library linked with dynamic runtime.
@@ -20,23 +20,3 @@ index 904cfb1..13f11cb 100644
      add_library(${name}-dynrt ${libtype} EXCLUDE_FROM_ALL
        ${add_mp_library_UNPARSED_ARGUMENTS} ${dynrt-objects})
      target_compile_options(${name}-dynrt PUBLIC /MD$<$<CONFIG:Debug>:d>)
-@@ -308,16 +310,17 @@ if (RT_LIBRARY)
-   target_link_libraries(mp ${RT_LIBRARY})
- endif ()
- 
-+if (MP_VARIADIC_TEMPLATES)
- # Check if variadic templates are working and not affected by GCC bug 39653:
- # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=39653
- check_cxx_source_compiles("
-   template <class T, class ...Types>
-   struct S { typedef typename S<Types...>::type type; };
-   int main() {}" MP_VARIADIC_TEMPLATES)
--
--if (MP_VARIADIC_TEMPLATES)
-+  if (MP_VARIADIC_TEMPLATES)
-   add_executable(nl-example src/nl-example.cc)
-   target_link_libraries(nl-example mp)
-+  endif()
- endif ()
- 
- add_subdirectory(doc)

--- a/ports/ampl-mp/fix-dependency-asl.patch
+++ b/ports/ampl-mp/fix-dependency-asl.patch
@@ -1,18 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 13f11cb..92089a3 100644
+index 2b53eb0..05fc783 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -323,9 +323,9 @@ check_cxx_source_compiles("
-   endif()
- endif ()
+@@ -497,7 +497,7 @@ if (NOT SKIP_BUILD_MP)
+ 		struct S { typedef typename S<Types...>::type type; };
+ 		int main() {}" MP_VARIADIC_TEMPLATES)
  
-+find_package(ampl-asl CONFIG REQUIRED)
- add_subdirectory(doc)
- add_subdirectory(src/amplsig)
--add_subdirectory(src/asl)
- add_subdirectory(src/cp)
- add_subdirectory(solvers)
- 
+-	add_subdirectory(src/asl)
++	find_package(ampl-asl CONFIG REQUIRED)
+ 	add_subdirectory(src/amplsig)
+ 	add_subdirectory(src/cp)
+ 	add_subdirectory(solvers)
 diff --git a/src/cp/cp.cc b/src/cp/cp.cc
 index d4adc35..ca8f35b 100644
 --- a/src/cp/cp.cc

--- a/ports/ampl-mp/install-targets.patch
+++ b/ports/ampl-mp/install-targets.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e367344..fffdbeb 100644
+index e367344..9338151 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -264,7 +264,7 @@ function (add_mp_library name)
@@ -11,6 +11,24 @@ index e367344..fffdbeb 100644
    set_property(TARGET ${name}  PROPERTY CXX_STANDARD 17)
    if (add_mp_library_DEPENDS)
      add_dependencies(${name} ${add_mp_library_DEPENDS})
+@@ -444,7 +444,7 @@ if (NOT SKIP_BUILD_MP)
+   ${MP_ALL_HEADERS}
+ 		${MP_SOURCES} ${MP_FLAT_SOURCES} ${MP_EXPR_INFO_FILE}
+ 		COMPILE_DEFINITIONS MP_DATE=${MP_DATE} MP_SYSINFO="${MP_SYSINFO}"
+-		INCLUDE_DIRECTORIES src include OBJECT_LIBRARIES format)
++		INCLUDE_DIRECTORIES $<BUILD_INTERFACE:src> include OBJECT_LIBRARIES format)
+ 	set_target_properties(mp PROPERTIES
+ 		VERSION ${MP_VERSION} SOVERSION ${MP_VERSION_MAJOR})
+ 
+@@ -487,7 +487,7 @@ if (NOT SKIP_BUILD_MP)
+ 	# Link with librt for clock_gettime (Linux on i386).
+ 	find_library(RT_LIBRARY rt)
+ 	if (RT_LIBRARY)
+-		target_link_libraries(mp ${RT_LIBRARY})
++		target_link_libraries(mp rt)
+ 	endif ()
+ 
+ 	# Check if variadic templates are working and not affected by GCC bug 39653:
 @@ -503,8 +503,9 @@ if (NOT SKIP_BUILD_MP)
  	add_subdirectory(solvers)
  

--- a/ports/ampl-mp/install-targets.patch
+++ b/ports/ampl-mp/install-targets.patch
@@ -1,23 +1,24 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d4c6762..c7b15b6 100644
+index e367344..fffdbeb 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -197,7 +197,7 @@ function (add_mp_library name)
+@@ -264,7 +264,7 @@ function (add_mp_library name)
    target_compile_definitions(${name}
      PUBLIC ${add_mp_library_COMPILE_DEFINITIONS})
    target_include_directories(${name}
 -    PUBLIC ${add_mp_library_INCLUDE_DIRECTORIES})
 +    PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/${add_mp_library_INCLUDE_DIRECTORIES}> $<INSTALL_INTERFACE:include>)
+   set_property(TARGET ${name}  PROPERTY CXX_STANDARD 17)
    if (add_mp_library_DEPENDS)
      add_dependencies(${name} ${add_mp_library_DEPENDS})
-   endif ()
-@@ -363,6 +363,7 @@ if(BUILD_TESTING)
- endif()
+@@ -503,8 +503,9 @@ if (NOT SKIP_BUILD_MP)
+ 	add_subdirectory(solvers)
  
- install(DIRECTORY include/mp DESTINATION include)
--install(TARGETS mp DESTINATION lib RUNTIME DESTINATION bin)
-+install(TARGETS mp EXPORT unofficial-mp-targets DESTINATION lib RUNTIME DESTINATION bin)
- install(FILES LICENSE.rst DESTINATION share/mp)
-+include(0007-unofficial-export.cmake)
- install(TARGETS gen-expr-info RUNTIME DESTINATION bin)
-\ No newline at end of file
+ 	install(DIRECTORY include/mp DESTINATION include)
+-	install(TARGETS mp DESTINATION lib RUNTIME DESTINATION bin)
++	install(TARGETS mp EXPORT unofficial-mp-targets DESTINATION lib RUNTIME DESTINATION bin)
+ 	install(FILES LICENSE.rst DESTINATION share/mp)
++  include(0007-unofficial-export.cmake)
+   install(TARGETS gen-expr-info RUNTIME DESTINATION bin)
+ endif()   ## NOT SKIP_BUILD_MP
+ 

--- a/ports/ampl-mp/portfile.cmake
+++ b/ports/ampl-mp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ampl/mp
-    REF bb7d616605dd23e4a453a834b0fc8c0a2a71b5aa
-    SHA512 558321f700a2ffe9d13f29f7c034825f5644a49c55da8490160d7ee8303484de5f9a636783387cc108bd238cdc3d2afa6b28cafecce73ee7893d792f5293712a
+    REF v${VERSION}
+    SHA512 913777afbc9b125207e5c3ad5c01d303b4a772f3569521cb897e7b841a6eb584c4ccec01af459237e2a510303192d3ef95a1756af881058a9cf429f48b4a8808
     HEAD_REF master
     PATCHES
         disable-matlab-mex.patch
@@ -26,7 +26,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD=no
-        -DBUILD_TESTING=OFF
+        -DBUILD_TESTS=OFF
         -DMP_VARIADIC_TEMPLATES=OFF
         -DARITHCHK_EXEC=${ARITHCHK_EXEC}
 )

--- a/ports/ampl-mp/vcpkg.json
+++ b/ports/ampl-mp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ampl-mp",
-  "version-date": "2020-11-11",
-  "port-version": 5,
+  "version": "4.1.0",
   "description": "An open-source library for mathematical programming",
   "homepage": "https://github.com/ampl/mp",
   "supports": "!uwp",

--- a/versions/a-/ampl-mp.json
+++ b/versions/a-/ampl-mp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e0bc184cf2bfdc48557880059021d45bed42714e",
+      "version": "4.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5d383d7b192993a98f67775f292f9443d041e516",
       "version-date": "2020-11-11",
       "port-version": 5

--- a/versions/a-/ampl-mp.json
+++ b/versions/a-/ampl-mp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e0bc184cf2bfdc48557880059021d45bed42714e",
+      "git-tree": "9cf101e1affc823467c0b53d82827ef309f451de",
       "version": "4.1.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -121,8 +121,8 @@
       "port-version": 0
     },
     "ampl-mp": {
-      "baseline": "2020-11-11",
-      "port-version": 5
+      "baseline": "4.1.0",
+      "port-version": 0
     },
     "amqpcpp": {
       "baseline": "4.3.27",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ampl/mp/releases/tag/v4.1.0
