### PR TITLE
[fluidsynth] Use gcem from vcpkg

### DIFF
--- a/ports/fluidsynth/fix-gcem.patch
+++ b/ports/fluidsynth/fix-gcem.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2bb396ba..25d3557b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -364,7 +364,7 @@ if ( WIN32 )
+   endif  ( MINGW )
+ endif ( WIN32 )
+ 
+-find_package ( GCEM REQUIRED )
++find_package ( gcem CONFIG REQUIRED )
+ 
+ set ( LIBFLUID_LIBS ${MATH_LIBRARY} )
+ if (NOT ((CMAKE_SYSTEM_NAME MATCHES "SunOS") OR (osal STREQUAL "embedded")))
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index cc43d691..3021d54f 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -295,7 +295,7 @@ target_include_directories ( libfluidsynth-OBJ PRIVATE
+     ${FluidSynth_SOURCE_DIR}/src/sfloader
+     ${FluidSynth_SOURCE_DIR}/src/bindings
+     ${FluidSynth_SOURCE_DIR}/include
+-    ${GCEM_INCLUDE_DIR}
++    ${gcem_INCLUDE_DIRS}
+ )
+ 
+ if ( LIBFLUID_CPPFLAGS )

--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 0e897a1a3e1499150c26dc0ce4fc1fa4e5323cd84e0f1b6cdf305b4cfd3fd46cbefddf490241e8645a9bd291e485a830d109b1c7a83e13b816f0345839c4c36c
     HEAD_REF master
+    PATCHES fix-gcem.patch
 )
 # Do not use or install FindSndFileLegacy.cmake and its deps
 file(REMOVE
@@ -14,6 +15,7 @@ file(REMOVE
     "${SOURCE_PATH}/cmake_admin/FindOpus.cmake"
     "${SOURCE_PATH}/cmake_admin/FindSndFileLegacy.cmake"
     "${SOURCE_PATH}/cmake_admin/FindVorbis.cmake"
+    "${SOURCE_PATH}/cmake_admin/FindGCEM.cmake"
 )
 
 vcpkg_check_features(
@@ -65,6 +67,7 @@ vcpkg_cmake_configure(
         ${DISABLED_OPTIONS}
         "-Dosal=cpp11" 
         "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+        -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
     MAYBE_UNUSED_VARIABLES
         ${OPTIONS_TO_DISABLE}
         enable-coverage

--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -58,15 +58,13 @@ foreach(_option IN LISTS OPTIONS_TO_DISABLE IGNORED_OPTIONS)
     list(APPEND DISABLED_OPTIONS "-D${_option}:BOOL=OFF")
 endforeach()
 
-vcpkg_find_acquire_program(PKGCONFIG)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
         ${ENABLED_OPTIONS}
         ${DISABLED_OPTIONS}
-        "-Dosal=cpp11" 
-        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+        "-Dosal=cpp11"
         -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
     MAYBE_UNUSED_VARIABLES
         ${OPTIONS_TO_DISABLE}
@@ -88,6 +86,6 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share/man")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-    
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fluidsynth",
   "version": "2.5.1",
+  "port-version": 1,
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "license": "LGPL-2.1-or-later",
@@ -10,6 +11,7 @@
       "name": "alsa",
       "platform": "linux"
     },
+    "gcem",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3034,7 +3034,7 @@
     },
     "fluidsynth": {
       "baseline": "2.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "flux": {
       "baseline": "0.4.0",

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "79171f661b6e9b6cef51dfdb8ab9b9c9341851d4",
+      "git-tree": "f98a0709faac3d5b5f86276086a59e8b9917942f",
       "version": "2.5.1",
       "port-version": 1
     },

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "79171f661b6e9b6cef51dfdb8ab9b9c9341851d4",
+      "version": "2.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "65ac79b7827cf71b8b3be865360d69c37268dec8",
       "version": "2.5.1",
       "port-version": 0


### PR DESCRIPTION
fluidsynth vendored gcem by manually downloading it from GitHub thereby bypassing asset caching. I discovered this issue here: https://github.com/microsoft/vcpkg/pull/48807#issuecomment-3644159087

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
