### PR TITLE
[mypaint-brushes] Update homepage URL

### DIFF
--- a/ports/mypaint-brushes/vcpkg.json
+++ b/ports/mypaint-brushes/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "mypaint-brushes",
   "version": "1.3.1",
+  "port-version": 1,
   "description": "Data package. Brushes used by MyPaint and other software using libmypaint.",
-  "homepage": "mypaint.org",
+  "homepage": "https://github.com/mypaint/mypaint-brushes",
   "license": "CC0-1.0",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6686,7 +6686,7 @@
     },
     "mypaint-brushes": {
       "baseline": "1.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "mysql-connector-cpp": {
       "baseline": "9.1.0",

--- a/versions/m-/mypaint-brushes.json
+++ b/versions/m-/mypaint-brushes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8b34f24005a58c820ac3cd0f072344f756940a0",
+      "version": "1.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "1b3d02f7d8b0780de1a8e2e7e0fefc307fd7a7eb",
       "version": "1.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

See https://github.com/microsoft/vcpkg-tool/issues/1880. Reason for new URL see #48810.