### PR TITLE
[trianglemeshdistance] update to release tag

### DIFF
--- a/ports/trianglemeshdistance/portfile.cmake
+++ b/ports/trianglemeshdistance/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO InteractiveComputerGraphics/TriangleMeshDistance
-    REF 566c9486533082fe7d9a3ffae15799bc5c125528 # 2025-12-05
-    SHA512 642bac995d6c42f9a898929cbdbbbe99f19eb2c1e5c067bad9b883d788be4797075062277fd7b0b510767888b2412f7a212039e68f8fd0982f36c019f0cb43aa
+    REF v${VERSION}
+    SHA512 5ef10d9b6376c1d399481e7cda645091823a463e92d4fb5c53a537ea3dec9dcd97459584d1c960081f80f00ff18c000733f4da79e1ea77dd66e63a17a1c08bbb
     PATCHES
         remove-tests.patch
 )

--- a/ports/trianglemeshdistance/vcpkg.json
+++ b/ports/trianglemeshdistance/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "trianglemeshdistance",
-  "version-date": "2025-12-05",
+  "version": "1.1.0",
   "description": "Header only library to compute the signed distance function (SDF) to a triangle mesh.",
   "homepage": "https://github.com/InteractiveComputerGraphics/TriangleMeshDistance",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9985,7 +9985,7 @@
       "port-version": 4
     },
     "trianglemeshdistance": {
-      "baseline": "2025-12-05",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "triton": {

--- a/versions/t-/trianglemeshdistance.json
+++ b/versions/t-/trianglemeshdistance.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2faf29b2fcc72740729ce95d8a1df492329f129f",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8a027543ee52a1e5bc5ea0befa3944a8adf2f9b8",
       "version-date": "2025-12-05",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
