### PR TITLE
[aws-c-event-stream] Update to 0.5.9

### DIFF
--- a/ports/aws-c-event-stream/portfile.cmake
+++ b/ports/aws-c-event-stream/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-event-stream
     REF "v${VERSION}"
-    SHA512 87867d9c8ad7058e433ebcdfddb762c92d6abd3fe61a5332bf18e9a5fa98930181615417d4aeecb4118b5eb27c12afc8f21ab740d3b81f07bc86e9a7e0ecc3b4
+    SHA512 dcfbfa4cfd38ec6fa7714813e00ed67df915554c028053803b8b1a779da797aef06e38add974b063175614b22be54cb72525f25a2a0ea6f9a53edcdf318bf677
     HEAD_REF master
 )
 

--- a/ports/aws-c-event-stream/vcpkg.json
+++ b/ports/aws-c-event-stream/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-event-stream",
-  "version": "0.5.7",
+  "version": "0.5.9",
   "description": "C99 implementation of the vnd.amazon.event-stream content-type.",
   "homepage": "https://github.com/awslabs/aws-c-event-stream",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-event-stream.json
+++ b/versions/a-/aws-c-event-stream.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8a1a811cc54a280308cc030df340e7bf616e689",
+      "version": "0.5.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "93f9bfc5f6c53c2e27d80ad0e5ceff24f57450a9",
       "version": "0.5.7",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -457,7 +457,7 @@
       "port-version": 0
     },
     "aws-c-event-stream": {
-      "baseline": "0.5.7",
+      "baseline": "0.5.9",
       "port-version": 0
     },
     "aws-c-http": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
