### PR TITLE
[libspatialite,readosm,spatialite-tools] Control dllexport, simplify

### DIFF
--- a/ports/libspatialite/fix-makefiles.patch
+++ b/ports/libspatialite/fix-makefiles.patch
@@ -1,44 +1,43 @@
 diff --git a/makefile.vc b/makefile.vc
-index 120090eba..049c0d0b0 100644
+index 9ae0b83..2a80b03 100644
 --- a/makefile.vc
 +++ b/makefile.vc
-@@ -93,7 +93,7 @@ LIBOBJ = src\gaiaaux\gg_sqlaux.obj src\gaiaaux\gg_utf8.obj \
- SPATIALITE_DLL = spatialite$(VERSION).dll
- 
- CFLAGS = /nologo -I.\src\headers -I.\src\topology \
--	-I. -IC:\OSGeo4W\include $(OPTFLAGS)
-+	-I. $(OPTFLAGS)
+@@ -100,7 +100,8 @@ CFLAGS = /nologo -I.\src\headers -I.\src\topology \
  
  default:	all
  
-@@ -107,12 +107,9 @@ spatialite.lib:	$(LIBOBJ)
- $(SPATIALITE_DLL):	spatialite_i.lib
+-all: spatialite.lib spatialite_i.lib
++WANT_LIB = spatialite.lib
++all: $(WANT_LIB)
+ #$(EXIF_LOADER_EXE)
  
+ spatialite.lib:	$(LIBOBJ)
+@@ -112,10 +113,7 @@ $(SPATIALITE_DLL):	spatialite_i.lib
  spatialite_i.lib:     $(LIBOBJ)
--	link /dll /out:$(SPATIALITE_DLL) \
-+	link $(LINK_FLAGS) /dll /out:$(SPATIALITE_DLL) \
+ 	link /dll /out:$(SPATIALITE_DLL) \
  		/implib:spatialite_i.lib $(LIBOBJ) \
 -		C:\OSGeo4W\lib\proj_i.lib C:\OSGeo4W\lib\geos_c.lib \
 -		C:\OSGeo4w\lib\freexl_i.lib C:\OSGeo4w\lib\iconv.lib \
 -		C:\OSGeo4W\lib\sqlite3_i.lib C:\OSGeo4W\lib\zlib.lib \
 -		C:\OSGeo4W\lib\libxml2.lib C:\OSGeo4W\lib\librttopo.lib
-+		$(LIBS_ALL)
++		$(LIBS)
  	if exist $(SPATIALITE_DLL).manifest mt -manifest \
  		$(SPATIALITE_DLL).manifest -outputresource:$(SPATIALITE_DLL);2
  		
+@@ -146,12 +144,14 @@ clean:
  
-diff --git a/nmake.opt b/nmake.opt
-index c048aa758..be68e21cd 100644
---- a/nmake.opt
-+++ b/nmake.opt
-@@ -1,8 +1,8 @@
- # Directory tree where SpatiaLite will be installed.
--INSTDIR=C:\OSGeo4W
-+INSTDIR=$(INST_DIR)
- 
- # Uncomment the first for an optimized build, or the second for debug.
--OPTFLAGS=	/nologo /Ox /fp:precise /W4 /MD /D_CRT_SECURE_NO_WARNINGS \
-+OPTFLAGS=	/nologo /fp:precise /W4 $(CL_FLAGS) /D_CRT_SECURE_NO_WARNINGS \
- 		/DDLL_EXPORT /DYY_NO_UNISTD_H
- #OPTFLAGS=	/nologo /Zi /MD /Fdspatialite.pdb /DDLL_EXPORT
- 
+ install: all
+ 	-mkdir $(INSTDIR)
+-	-mkdir $(INSTDIR)\bin
+ 	-mkdir $(INSTDIR)\lib
+ 	-mkdir $(INSTDIR)\include
+ 	-mkdir $(INSTDIR)\include\spatialite
++!IF "$(WANT_LIB)" == "spatialite_i.lib"
++	-mkdir $(INSTDIR)\bin
+ 	copy *.dll $(INSTDIR)\bin
+-	copy *.lib $(INSTDIR)\lib
++!ENDIF
++	copy /Y $(WANT_LIB) $(INSTDIR)\lib\spatialite.lib
+ 	copy src\headers\spatialite.h $(INSTDIR)\include
+ 	copy src\headers\spatialite\*.h $(INSTDIR)\include\spatialite
+ 	

--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -4,8 +4,7 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 2745b373e31cea58623224def6090c491b58409803bb71231450dfa2cfdf3aafc3fc6f680585d55d085008f8cf362c3062ae67ffc7d80257775a22eb81ef1e57
 )
 
-vcpkg_extract_source_archive(
-    SOURCE_PATH
+vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
         fix-makefiles.patch
@@ -35,67 +34,62 @@ if(ENABLE_RTTOPO)
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-    set(CL_FLAGS "")
-    if(NOT ENABLE_FREEXL)
-        string(APPEND CL_FLAGS " /DOMIT_FREEXL")
-    endif()
-    if(ENABLE_GCP)
-        string(APPEND CL_FLAGS " /DENABLE_GCP")
-    endif()
-    if(ENABLE_RTTOPO)
-        string(APPEND CL_FLAGS " /DENABLE_RTTOPO")
-    endif()
-
     x_vcpkg_pkgconfig_get_modules(
         PREFIX PKGCONFIG
         MODULES --msvc-syntax ${pkg_config_modules}
-        LIBS
         CFLAGS
+        LIBS
     )
-    
-    set(CL_FLAGS_RELEASE "${CL_FLAGS} ${PKGCONFIG_CFLAGS_RELEASE}")
-    set(CL_FLAGS_DEBUG "${CL_FLAGS} ${PKGCONFIG_CFLAGS_DEBUG}")
 
-    # vcpkg_build_nmake doesn't supply cmake's implicit link libraries
-    if(PKGCONFIG_LIBS_RELEASE MATCHES "libcrypto")
-        string(APPEND PKGCONFIG_LIBS_RELEASE " user32.lib")
-        string(APPEND PKGCONFIG_LIBS_DEBUG " user32.lib")
+    # cherry-picked from Makefile.vc (CFLAGS) and nmake.opt (OPTFLAGS)
+    set(CFLAGS "/fp:precise /W4 /D_CRT_SECURE_NO_WARNINGS /DYY_NO_UNISTD_H -I./src/headers -I./src/topology -I.")
+    set(WANT_LIB spatialite.lib)
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        string(APPEND CFLAGS " /DDLL_EXPORT")
+        set(WANT_LIB spatialite_i.lib)
     endif()
+    if(NOT ENABLE_FREEXL)
+        string(APPEND CFLAGS " /DOMIT_FREEXL")
+    endif()
+    if(ENABLE_GCP)
+        string(APPEND CFLAGS " /DENABLE_GCP")
+    endif()
+    if(ENABLE_RTTOPO)
+        string(APPEND CFLAGS " /DENABLE_RTTOPO")
+    endif()
+
+    set(SYSTEM_LIBS "iconv.lib charset.lib")
 
     file(TO_NATIVE_PATH "${CURRENT_PACKAGES_DIR}" INST_DIR)
 
     vcpkg_install_nmake(
         SOURCE_PATH "${SOURCE_PATH}"
-        PREFER_JOM
         CL_LANGUAGE C
-        OPTIONS_RELEASE
-            "CL_FLAGS=${CL_FLAGS_RELEASE}"
-            "INST_DIR=${INST_DIR}"
-            "LIBS_ALL=${PKGCONFIG_LIBS_RELEASE} iconv.lib charset.lib"
+        OPTIONS
+            "WANT_LIB=${WANT_LIB}"
+         OPTIONS_RELEASE
+            "CFLAGS=${CFLAGS} ${PKGCONFIG_CFLAGS_RELEASE}"
+            "LIBS=${PKGCONFIG_LIBS_RELEASE} ${SYSTEM_LIBS}"
+            "INSTDIR=${INST_DIR}"
         OPTIONS_DEBUG
-            "CL_FLAGS=${CL_FLAGS_DEBUG}"
-            "INST_DIR=${INST_DIR}\\debug"
-            "LIBS_ALL=${PKGCONFIG_LIBS_DEBUG} iconv.lib charset.lib"
-            "LINK_FLAGS=/debug"
+            "CFLAGS=${CFLAGS} ${PKGCONFIG_CFLAGS_DEBUG}"
+            "LIBS=${PKGCONFIG_LIBS_DEBUG} ${SYSTEM_LIBS}"
+            "INSTDIR=${INST_DIR}\\debug"
     )
     vcpkg_copy_pdbs()
 
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+    file(GLOB_RECURSE headers "${CURRENT_PACKAGES_DIR}/include/*.h")
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
-        file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/spatialite_i.lib")
-        if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-            file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
-            file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/spatialite_i.lib")
-        endif()
+        foreach(file IN LISTS headers)
+            vcpkg_replace_string("${file}" "#ifdef DLL_EXPORT" "#if 0" IGNORE_UNCHANGED)
+        endforeach()
     else()
-        file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/spatialite.lib")
-        file(RENAME "${CURRENT_PACKAGES_DIR}/lib/spatialite_i.lib" "${CURRENT_PACKAGES_DIR}/lib/spatialite.lib")
-        if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-            file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/spatialite.lib")
-            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/spatialite_i.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/spatialite.lib")
-        endif()
+        foreach(file IN LISTS headers)
+            vcpkg_replace_string("${file}" "#ifdef DLL_EXPORT" "#if 1" IGNORE_UNCHANGED)
+            vcpkg_replace_string("${file}" "__declspec(dllexport)" "__declspec(dllimport)" IGNORE_UNCHANGED)
+        endforeach()
     endif()
 
     set(infile "${SOURCE_PATH}/spatialite.pc.in")
@@ -140,7 +134,7 @@ else()
     list(REMOVE_ITEM pkg_config_modules libxml2) # handled properly by configure
     x_vcpkg_pkgconfig_get_modules(
         PREFIX PKGCONFIG
-        MODULES ${pkg_config_modules} 
+        MODULES ${pkg_config_modules}
         LIBS
     )
     if(VCPKG_TARGET_IS_MINGW)

--- a/ports/libspatialite/vcpkg.json
+++ b/ports/libspatialite/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libspatialite",
   "version": "5.1.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities.",
   "homepage": "https://www.gaia-gis.it/fossil/libspatialite/index",
   "license": null,

--- a/ports/readosm/fix-makefiles.patch
+++ b/ports/readosm/fix-makefiles.patch
@@ -1,48 +1,38 @@
 diff --git a/makefile.vc b/makefile.vc
-index 8edb536b9..33fd83e35 100644
+index 8edb536..0132067 100644
 --- a/makefile.vc
 +++ b/makefile.vc
-@@ -8,7 +8,7 @@ LIBOBJ	               =	src\readosm.obj src\osmxml.obj \
- 							src\protobuf.obj src\osm_objects.obj
- READOSM_DLL	 	       =	readosm$(VERSION).dll
- 
--CFLAGS	=	/nologo -I. -Iheaders -IC:\OSGeo4W\include $(OPTFLAGS)
-+CFLAGS	=	/nologo -I. -Iheaders -I$(INSTALLED_ROOT)\include $(OPTFLAGS)
+@@ -12,7 +12,8 @@ CFLAGS	=	/nologo -I. -Iheaders -IC:\OSGeo4W\include $(OPTFLAGS)
  
  default:	all
  
-@@ -21,9 +21,9 @@ readosm.lib:	$(LIBOBJ)
- $(READOSM_DLL):	readosm_i.lib
+-all: readosm.lib readosm_i.lib
++WANT_LIB = readosm.lib
++all: $(WANT_LIB)
  
+ readosm.lib:	$(LIBOBJ)
+ 	if exist readosm.lib del readosm.lib
+@@ -23,7 +24,7 @@ $(READOSM_DLL):	readosm_i.lib
  readosm_i.lib:	$(LIBOBJ)
--	link /dll /out:$(READOSM_DLL) \
-+	link $(LINK_FLAGS) /dll /out:$(READOSM_DLL) \
+ 	link /dll /out:$(READOSM_DLL) \
  		/implib:readosm_i.lib $(LIBOBJ) \
 -		C:\OSGeo4w\lib\libexpat.lib C:\OSGeo4w\lib\zlib.lib
-+		$(LIBS_ALL)
++		$(LIBS)
  	if exist $(READOSM_DLL).manifest mt -manifest \
  		$(READOSM_DLL).manifest -outputresource:$(READOSM_DLL);2 
  		
-@@ -35,7 +35,7 @@ clean:
- 	del *.exp
- 	del *.manifest
- 	del *.lib
--	del *.obj
-+	del src\*.obj
- 	del *.pdb
+@@ -40,10 +41,12 @@ clean:
  
  install: all
-
-diff --git a/nmake.opt b/nmake.opt
-index 5e45c0e..61c44f9 100644
---- a/nmake.opt
-+++ b/nmake.opt
-@@ -2,7 +2,7 @@
- INSTDIR=C:\OSGeo4W
+ 	-mkdir $(INSTDIR)
+-	-mkdir $(INSTDIR)\bin
+ 	-mkdir $(INSTDIR)\lib
+ 	-mkdir $(INSTDIR)\include
++!IF "$(WANT_LIB)" == "readosm_i.lib"
++	-mkdir $(INSTDIR)\bin
+ 	copy *.dll $(INSTDIR)\bin
+-	copy *.lib $(INSTDIR)\lib
++!ENDIF
++	copy /Y $(WANT_LIB) $(INSTDIR)\lib\readosm.lib
+ 	copy headers\readosm.h $(INSTDIR)\include	
  
- # Uncomment the first for an optimized build, or the second for debug.
--OPTFLAGS=	/nologo /Ox /fp:precise /W3 /MD /D_CRT_SECURE_NO_WARNINGS \
-+OPTFLAGS=	/nologo /fp:precise /W3 $(CL_FLAGS) /D_CRT_SECURE_NO_WARNINGS \
- 			/DDLL_EXPORT
- #OPTFLAGS=	/nologo /Zi /MD /Fdreadosm.pdb /DDLL_EXPORT
-

--- a/ports/readosm/portfile.cmake
+++ b/ports/readosm/portfile.cmake
@@ -1,7 +1,6 @@
-set(READOSM_VERSION_STR "1.1.0a")
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.gaia-gis.it/gaia-sins/readosm-sources/readosm-${READOSM_VERSION_STR}.tar.gz"
-    FILENAME "readosm-${READOSM_VERSION_STR}.tar.gz"
+    URLS "https://www.gaia-gis.it/gaia-sins/readosm-sources/readosm-${VERSION}.tar.gz"
+    FILENAME "readosm-${VERSION}.tar.gz"
     SHA512 ec8516cdd0b02027cef8674926653f8bc76e2082c778b02fb2ebcfa6d01e21757aaa4fd5d5104059e2f5ba97190183e60184f381bfd592a635805aa35cd7a682
 )
 
@@ -12,53 +11,58 @@ vcpkg_extract_source_archive(SOURCE_PATH
         pc-file.patch
 )
 
-set(PKGCONFIG_MODULES expat zlib)
+set(pkg_config_modules expat zlib)
 
 if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     x_vcpkg_pkgconfig_get_modules(
         PREFIX PKGCONFIG
-        MODULES --msvc-syntax ${PKGCONFIG_MODULES}
+        MODULES --msvc-syntax ${pkg_config_modules}
+        CFLAGS
         LIBS
     )
 
+    # cherry-picked from Makefile.vc (CFLAGS) and nmake.opt (OPTFLAGS)
+    set(CFLAGS "/fp:precise /W3 /D_CRT_SECURE_NO_WARNINGS -I. -Iheaders")
+    set(WANT_LIB "readosm.lib")
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        string(APPEND CFLAGS " /DDLL_EXPORT")
+        set(WANT_LIB "readosm_i.lib")
+    endif()
+
+    set(SYSTEM_LIBS "")
     if(VCPKG_TARGET_IS_UWP)
-        set(UWP_LIBS windowsapp.lib)
+        set(SYSTEM_LIBS "windowsapp.lib")
     endif()
 
     file(TO_NATIVE_PATH "${CURRENT_PACKAGES_DIR}" INST_DIR)
 
     vcpkg_install_nmake(
         SOURCE_PATH "${SOURCE_PATH}"
-        PREFER_JOM
         CL_LANGUAGE C
+        OPTIONS
+            "WANT_LIB=${WANT_LIB}"
         OPTIONS_RELEASE
+            "CFLAGS=${CFLAGS} ${PKGCONFIG_CFLAGS_RELEASE}"
+            "LIBS=${PKGCONFIG_LIBS_RELEASE} ${SYSTEM_LIBS}"
             "INSTDIR=${INST_DIR}"
-            "LIBS_ALL=${PKGCONFIG_LIBS_RELEASE} ${UWP_LIBS}"
         OPTIONS_DEBUG
+            "CFLAGS=${CFLAGS} ${PKGCONFIG_CFLAGS_DEBUG}"
+            "LIBS=${PKGCONFIG_LIBS_DEBUG} ${SYSTEM_LIBS}"
             "INSTDIR=${INST_DIR}\\debug"
-            "LINK_FLAGS=/debug"
-            "LIBS_ALL=${PKGCONFIG_LIBS_DEBUG} ${UWP_LIBS}"
     )
+    vcpkg_copy_pdbs()
 
-    if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-        file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/readosm_i.lib")
-        if(NOT DEFINED VCPKG_BUILD_TYPE)
-            file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/readosm_i.lib")
-        endif()
-    else()
-        file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/readosm.lib")
-        file(RENAME "${CURRENT_PACKAGES_DIR}/lib/readosm_i.lib" "${CURRENT_PACKAGES_DIR}/lib/readosm.lib")
-        if(NOT DEFINED VCPKG_BUILD_TYPE)
-            file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/readosm.lib")
-            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/readosm_i.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/readosm.lib")
-        endif()
-    endif()
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/readosm.h" "#ifdef DLL_EXPORT" "#if 0")
+    else()
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/readosm.h" "#ifdef DLL_EXPORT" "#if 1")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/readosm.h" "__declspec(dllexport)" "__declspec(dllimport)")
+    endif()
 
     set(infile "${SOURCE_PATH}/readosm.pc.in")
     set(outfile "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/readosm.pc")
-    set(VERSION "${READOSM_VERSION_STR}")
+    set(VERSION "${VERSION}")
     set(exec_prefix [[${prefix}]])
     set(libdir [[${prefix}/lib]])
     set(includedir [[${prefix}/include]])
@@ -73,7 +77,7 @@ if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
 else()
     x_vcpkg_pkgconfig_get_modules(
         PREFIX PKGCONFIG
-        MODULES ${PKGCONFIG_MODULES}
+        MODULES ${pkg_config_modules}
         LIBS
     )
     vcpkg_configure_make(
@@ -90,5 +94,4 @@ endif()
 
 vcpkg_fixup_pkgconfig()
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/readosm/vcpkg.json
+++ b/ports/readosm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "readosm",
   "version-string": "1.1.0a",
-  "port-version": 4,
+  "port-version": 5,
   "description": "ReadOSM is an open source library to extract valid data from within an Open Street Map input file (.osm or .osm.pbf)",
   "homepage": "https://www.gaia-gis.it/gaia-sins/readosm-sources",
   "license": "MPL-1.1",

--- a/ports/spatialite-tools/fix-makefiles.patch
+++ b/ports/spatialite-tools/fix-makefiles.patch
@@ -2,15 +2,6 @@ diff --git a/makefile.vc b/makefile.vc
 index 53ef75197..d48fb02db 100644
 --- a/makefile.vc
 +++ b/makefile.vc
-@@ -16,7 +16,7 @@ SPATIALITE_OSM_RAW_EXE    = spatialite_osm_raw.exe
- SPATIALITE_OSM_FILTER_EXE = spatialite_osm_filter.exe
- SPATIALITE_GML_EXE        = spatialite_gml.exe
- 
--CFLAGS	=	/nologo -IC:\OSGeo4W\include $(OPTFLAGS)
-+CFLAGS	=	/nologo $(OPTFLAGS)
- 
- default:	all
- 
 @@ -27,96 +27,63 @@ all: $(SPATIALITE_EXE) $(SHP_DOCTOR_EXE) $(SPATIALITE_TOOL_EXE) \
  	$(SPATIALITE_OSM_FILTER_EXE) $(SHP_SANITIZE_EXE)
  
@@ -19,7 +10,7 @@ index 53ef75197..d48fb02db 100644
 -		C:\OSGeo4W\lib\iconv.lib C:\OSGeo4W\lib\geos_c.lib \
 -		C:\OSGeo4W\lib\spatialite_i.lib C:\OSGeo4W\lib\sqlite3_i.lib \
 -		/Fe$(SPATIALITE_EXE)
-+	cl shell.obj /Fe$(SPATIALITE_EXE) $(LIBS_ALL)
++	cl shell.obj /Fe$(SPATIALITE_EXE) /link $(LIBS)
  	if exist $(SPATIALITE_EXE).manifest mt -manifest \
  		$(SPATIALITE_EXE).manifest -outputresource:$(SPATIALITE_EXE);1
  
@@ -27,7 +18,7 @@ index 53ef75197..d48fb02db 100644
 -	cl exif_loader.obj C:\OSGeo4W\lib\proj_i.lib \
 -		C:\OSGeo4W\lib\iconv.lib C:\OSGeo4W\lib\geos_c.lib \
 -		C:\OSGeo4W\lib\spatialite_i.lib C:\OSGeo4W\lib\sqlite3_i.lib 
-+	cl exif_loader.obj $(LIBS_ALL)
++	cl exif_loader.obj /link $(LIBS)
  	if exist $(EXIF_LOADER_EXE).manifest mt -manifest \
  		$(EXIF_LOADER_EXE).manifest -outputresource:$(EXIF_LOADER_EXE);1
  
@@ -35,7 +26,7 @@ index 53ef75197..d48fb02db 100644
 -	cl shp_doctor.obj  C:\OSGeo4W\lib\proj_i.lib \
 -		C:\OSGeo4W\lib\iconv.lib C:\OSGeo4W\lib\geos_c.lib \
 -		C:\OSGeo4W\lib\spatialite_i.lib C:\OSGeo4W\lib\sqlite3_i.lib 
-+	cl shp_doctor.obj $(LIBS_ALL)
++	cl shp_doctor.obj /link $(LIBS)
  	if exist $(SHP_DOCTOR_EXE).manifest mt -manifest \
  		$(SHP_DOCTOR_EXE).manifest -outputresource:$(SHP_DOCTOR_EXE);1
  
@@ -43,7 +34,7 @@ index 53ef75197..d48fb02db 100644
 -	cl shp_sanitize.obj  C:\OSGeo4W\lib\proj_i.lib \
 -		C:\OSGeo4W\lib\iconv.lib C:\OSGeo4W\lib\geos_c.lib \
 -		C:\OSGeo4W\lib\spatialite_i.lib C:\OSGeo4W\lib\sqlite3_i.lib 
-+	cl shp_sanitize.obj $(LIBS_ALL)
++	cl shp_sanitize.obj /link $(LIBS)
  	if exist $(SHP_SANITIZE_EXE).manifest mt -manifest \
  		$(SHP_SANITIZE_EXE).manifest -outputresource:$(SHP_SANITIZE_EXE);1
  
@@ -51,7 +42,7 @@ index 53ef75197..d48fb02db 100644
 -	cl spatialite_network.obj C:\OSGeo4W\lib\proj_i.lib \
 -		C:\OSGeo4W\lib\iconv.lib \
 -		C:\OSGeo4W\lib\spatialite_i.lib C:\OSGeo4W\lib\sqlite3_i.lib 
-+	cl spatialite_network.obj $(LIBS_ALL)
++	cl spatialite_network.obj /link $(LIBS)
  	if exist $(SPATIALITE_NETWORK_EXE).manifest mt -manifest \
  		$(SPATIALITE_TOOL_EXE).manifest \
  		-outputresource:$(SPATIALITE_TOOL_EXE);1
@@ -60,7 +51,7 @@ index 53ef75197..d48fb02db 100644
 -	cl spatialite_tool.obj C:\OSGeo4W\lib\proj_i.lib \
 -		C:\OSGeo4W\lib\iconv.lib C:\OSGeo4W\lib\geos_c.lib \
 -		C:\OSGeo4W\lib\spatialite_i.lib C:\OSGeo4W\lib\sqlite3_i.lib 
-+	cl spatialite_tool.obj $(LIBS_ALL)
++	cl spatialite_tool.obj /link $(LIBS)
  	if exist $(SPATIALITE_TOOL_EXE).manifest mt -manifest \
  		$(SPATIALITE_TOOL_EXE).manifest \
  		-outputresource:$(SPATIALITE_TOOL_EXE);1
@@ -72,7 +63,7 @@ index 53ef75197..d48fb02db 100644
 -		C:\OSGeo4W\lib\libexpat.lib \
 -		C:\OSGeo4W\lib\zlib.lib \
 -		C:\OSGeo4W\lib\spatialite_i.lib C:\OSGeo4W\lib\sqlite3_i.lib 
-+	cl spatialite_osm_net.obj $(LIBS_ALL)
++	cl spatialite_osm_net.obj /link $(LIBS)
  	if exist $(SPATIALITE_OSM_EXE).manifest mt -manifest \
  		$(SPATIALITE_OSM_EXE).manifest \
  		-outputresource:$(SPATIALITE_OSM_NET_EXE);1
@@ -84,7 +75,7 @@ index 53ef75197..d48fb02db 100644
 -		C:\OSGeo4W\lib\libexpat.lib \
 -		C:\OSGeo4W\lib\zlib.lib \
 -		C:\OSGeo4W\lib\spatialite_i.lib C:\OSGeo4W\lib\sqlite3_i.lib 
-+	cl spatialite_osm_map.obj $(LIBS_ALL)
++	cl spatialite_osm_map.obj /link $(LIBS)
  	if exist $(SPATIALITE_OSM_MAP_EXE).manifest mt -manifest \
  		$(SPATIALITE_OSM_MAP_EXE).manifest \
  		-outputresource:$(SPATIALITE_OSM_MAP_EXE);1
@@ -94,7 +85,7 @@ index 53ef75197..d48fb02db 100644
 -		C:\OSGeo4W\lib\iconv.lib \
 -		C:\OSGeo4W\lib\libexpat.lib \
 -		C:\OSGeo4W\lib\spatialite_i.lib C:\OSGeo4W\lib\sqlite3_i.lib 
-+	cl spatialite_gml.obj $(LIBS_ALL)
++	cl spatialite_gml.obj /link $(LIBS)
  	if exist $(SPATIALITE_GML_EXE).manifest mt -manifest \
  		$(SPATIALITE_GML_EXE).manifest \
  		-outputresource:$(SPATIALITE_GML_EXE);1
@@ -106,7 +97,7 @@ index 53ef75197..d48fb02db 100644
 -		C:\OSGeo4W\lib\libexpat.lib \
 -		C:\OSGeo4W\lib\zlib.lib \
 -		C:\OSGeo4W\lib\spatialite_i.lib C:\OSGeo4W\lib\sqlite3_i.lib 
-+	cl spatialite_osm_raw.obj $(LIBS_ALL)
++	cl spatialite_osm_raw.obj /link $(LIBS)
  	if exist $(SPATIALITE_OSM_RAW_EXE).manifest mt -manifest \
  		$(SPATIALITE_OSM_RAW_EXE).manifest \
  		-outputresource:$(SPATIALITE_OSM_RAW_EXE);1
@@ -115,20 +106,7 @@ index 53ef75197..d48fb02db 100644
 -	cl spatialite_osm_filter.obj C:\OSGeo4W\lib\proj_i.lib \
 -		C:\OSGeo4W\lib\iconv.lib \
 -		C:\OSGeo4W\lib\spatialite_i.lib C:\OSGeo4W\lib\sqlite3_i.lib 
-+	cl spatialite_osm_filter.obj $(LIBS_ALL)
++	cl spatialite_osm_filter.obj /link $(LIBS)
  	if exist $(SPATIALITE_OSM_FILTER_EXE).manifest mt -manifest \
  		$(SPATIALITE_OSM_FILTER_EXE).manifest \
  		-outputresource:$(SPATIALITE_OSM_FILTER_EXE);1
-diff --git a/nmake.opt b/nmake.opt
-index 4f4a9538e..d9efecf7b 100644
---- a/nmake.opt
-+++ b/nmake.opt
-@@ -2,7 +2,7 @@
- INSTDIR=C:\OSGeo4W
- 
- # Uncomment the first for an optimized build, or the second for debug.
--OPTFLAGS=	/nologo /Ox /fp:precise /W3 /MD /D_CRT_SECURE_NO_WARNINGS \
-+OPTFLAGS=	/nologo /fp:precise /W3 $(CL_FLAGS) /D_CRT_SECURE_NO_WARNINGS \
- 	/D_LARGE_FILE=1 /D_FILE_OFFSET_BITS=64 /D_LARGEFILE_SOURCE=1
- #OPTFLAGS=	/nologo /Zi /MD /Fdspatialite.pdb
- 

--- a/ports/spatialite-tools/vcpkg.json
+++ b/ports/spatialite-tools/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "spatialite-tools",
   "version": "5.1.0-a",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Contains spatialite.exe and other command line tools to work with SpatiaLite databases (import, export, SQL queries)",
   "homepage": "https://www.gaia-gis.it/fossil/spatialite-tools/index",
   "license": "GPL-3.0-or-later",
@@ -23,7 +23,7 @@
     "readosm",
     {
       "name": "sqlite3",
-      "host": true
+      "default-features": false
     },
     {
       "name": "vcpkg-make",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8502,7 +8502,7 @@
     },
     "readosm": {
       "baseline": "1.1.0a",
-      "port-version": 4
+      "port-version": 5
     },
     "realm-core": {
       "baseline": "14.14.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5534,7 +5534,7 @@
     },
     "libspatialite": {
       "baseline": "5.1.0",
-      "port-version": 5
+      "port-version": 6
     },
     "libspnav": {
       "baseline": "0.2.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9282,7 +9282,7 @@
     },
     "spatialite-tools": {
       "baseline": "5.1.0-a",
-      "port-version": 1
+      "port-version": 2
     },
     "spdlog": {
       "baseline": "1.16.0",

--- a/versions/l-/libspatialite.json
+++ b/versions/l-/libspatialite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8b274963d26395ee2e6ad430255147714cdcc159",
+      "version": "5.1.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "1ace300b3fad0df1313bbc731284fc7fa80707a6",
       "version": "5.1.0",
       "port-version": 5

--- a/versions/r-/readosm.json
+++ b/versions/r-/readosm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3169b2f405b42de0c7ab5180eb6ad29b6d605ccd",
+      "version-string": "1.1.0a",
+      "port-version": 5
+    },
+    {
       "git-tree": "e91f30f55adfa57ccb0b2787e57991e5f3039921",
       "version-string": "1.1.0a",
       "port-version": 4

--- a/versions/s-/spatialite-tools.json
+++ b/versions/s-/spatialite-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "19421fdcd434d3d76200c363c33ba07995f18214",
+      "version": "5.1.0-a",
+      "port-version": 2
+    },
+    {
       "git-tree": "241e67a12966c5b26faa86909500e727788290aa",
       "version": "5.1.0-a",
       "port-version": 1


### PR DESCRIPTION
- Harmonize the nmake build of these packages.
- Build either static or dynamic lib. (`WANT_LIB`, install rules.)
- Do not apply `DLL_EXPORT` in static builds.
- Override nmake variables via nmake `OPTIONS` instead of patching.
- Fully rely on `vcpkg_build_nmake` setting `_CL_` and `_LINK_`.
- Burn-in `dllimport` for installed headers of dynamic build.
- Isolate installed headers from `DLL_EXPORT` in reverse dependencies.
- Do not use jom. It stumbles over `.c.obj` here.
- Fix libspatialite dependency on sqlite3 :facepalm: 
