### PR TITLE
[crow] Don't download CPM

### DIFF
--- a/ports/crow/portfile.cmake
+++ b/ports/crow/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 32c956a36652ac14a9ffd41333b9e80031f86b99b09f54affb9cb0196c4672c5877daebf6327a359c735f5246dd4119cf17ac5d68271953bfa389d660f745e42
     HEAD_REF master
+    PATCHES remove-cpm.patch
 )
 
 vcpkg_cmake_configure(
@@ -11,6 +12,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DCROW_BUILD_EXAMPLES=OFF
         -DCROW_BUILD_TESTS=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_Python3=ON
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Crow)
@@ -18,4 +20,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Crow)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/crow/remove-cpm.patch
+++ b/ports/crow/remove-cpm.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 198235dd0..42ebedb21 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,7 +11,6 @@ project(Crow
+ 
+ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ 
+-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CPM.cmake)
+ 
+ # Make sure Findasio.cmake module is found
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/ports/crow/vcpkg.json
+++ b/ports/crow/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "crow",
   "version": "1.3.0",
+  "port-version": 1,
   "description": "Very fast and easy to use C++ micro web framework",
   "homepage": "https://github.com/CrowCpp/crow",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2186,7 +2186,7 @@
     },
     "crow": {
       "baseline": "1.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cryptopp": {
       "baseline": "2025-12-01",

--- a/versions/c-/crow.json
+++ b/versions/c-/crow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dd3873667277f4f5cfeee4775bea488199d7a5d6",
+      "version": "1.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "967d7ceb1140975fd062171ec90f1be240c59d63",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
CPM was downloaded manually and therefore bypassing asset caching.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
