### PR TITLE
[neko-schema] Update to v1.1.5

### DIFF
--- a/ports/neko-schema/portfile.cmake
+++ b/ports/neko-schema/portfile.cmake
@@ -1,8 +1,8 @@
 ﻿vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO moehoshio/NekoSchema
-    REF v1.1.4
-    SHA512 2b246d62c25cf502a8c15d0d7ef2c23a6a2c3a3de5c1710e9720d9d95efff11ccd6d5e852bd7ff4eba0f3ecffb3d565381687d6af651fff22a845738032048dc
+    REF v1.1.5
+    SHA512 a4383927168a06fc50623e8a0cdb4c1d9dabfa8a6f2ae6408aff5b468cd9a3bdca57262187c231231ad70eb2a6b65d5574a824cc0d4be6a43e62c4ecf342ef0b
     HEAD_REF main
 )
 

--- a/ports/neko-schema/vcpkg.json
+++ b/ports/neko-schema/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "neko-schema",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A lightweight C++20 header-only library providing fundamental type definitions and utilities for the Neko ecosystem",
   "homepage": "https://github.com/moehoshio/NekoSchema",
   "license": "MIT OR Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6817,7 +6817,7 @@
       "port-version": 0
     },
     "neko-schema": {
-      "baseline": "1.1.4",
+      "baseline": "1.1.5",
       "port-version": 0
     },
     "neko-system": {

--- a/versions/n-/neko-schema.json
+++ b/versions/n-/neko-schema.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "d0a231efb19d1206306da2ae3c5e688dde75a241",
-      "version": "1.1.4",
+      "git-tree": "0cb7e01bf0741f74d40345c23fe0183fcd9fd4ec",
+      "version": "1.1.5",
       "port-version": 0
     }
   ]


### PR DESCRIPTION
Update `neko-schema` to v1.1.5

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.