### PR TITLE
[stlab] Disable cpm.

### DIFF
--- a/ports/stlab/portfile.cmake
+++ b/ports/stlab/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
         devendoring.patch
 )
 
+file(WRITE "${SOURCE_PATH}/cmake/CPM.cmake" "# disabled by vcpkg")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS

--- a/ports/stlab/vcpkg.json
+++ b/ports/stlab/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "stlab",
   "version": "2.0.2",
+  "port-version": 1,
   "description": [
     "stlab is the ongoing work of what was Adobe Software Technology Lab.",
     "The Concurrency library provides futures and channels, high level constructs for implementing algorithms that eases the use of multiple CPU cores while minimizing contention. This library solves several problems of the C++11 and C++17 TS futures."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9450,7 +9450,7 @@
     },
     "stlab": {
       "baseline": "2.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "stlab-copy-on-write": {
       "baseline": "1.0.3",

--- a/versions/s-/stlab.json
+++ b/versions/s-/stlab.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "831304d7a4aa1c40e2a66e42813d8702484b908a",
+      "version": "2.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "7fed61847637cfc3abc4e0d0609bf169111c2117",
       "version": "2.0.2",
       "port-version": 0


### PR DESCRIPTION
Hopefully resolves

```console
REGRESSION: stlab:arm64-osx failed with BUILD_FAILED. If expected, add stlab:arm64-osx=fail to /Users/vcpkg/Data/work/2/s/scripts/azure-pipelines/../ci.baseline.txt.
```

from https://dev.azure.com/vcpkg/public/_build/results?buildId=124082

I borrowed this way to disable from @dg0yt https://github.com/microsoft/vcpkg/pull/48312#discussion_r2615345297
