### PR TITLE
[h3] Update to 4.4.1

### DIFF
--- a/ports/h3/portfile.cmake
+++ b/ports/h3/portfile.cmake
@@ -3,13 +3,13 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO uber/h3
-    REF v${VERSION}
-    SHA512 7b9a18ff1714465d8c980607cf62b4e73e2be199f02f24d85004760b48d523686cb9e7f8891d821545b4ef8a2d547c6eb9880e419d0799a4f549323b7f8e9f94
+    REF "v${VERSION}"
+    SHA512 e8a87c109ba917887483c73b0410bfd11f9259815ba7f9b967779963c9a7a5c208d70f0d6f6ae586ff371feeab3e19d96273137b42fd03a84ae08965bb8ea643
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_BENCHMARKS=OFF
         -DBUILD_FUZZERS=OFF
@@ -20,7 +20,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 vcpkg_copy_pdbs()
 

--- a/ports/h3/vcpkg.json
+++ b/ports/h3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "h3",
-  "version-semver": "4.4.0",
+  "version-semver": "4.4.1",
   "description": "A Hexagonal Hierarchical Geospatial Indexing System",
   "homepage": "https://github.com/uber/h3",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3689,7 +3689,7 @@
       "port-version": 2
     },
     "h3": {
-      "baseline": "4.4.0",
+      "baseline": "4.4.1",
       "port-version": 0
     },
     "h5py-lzf": {

--- a/versions/h-/h3.json
+++ b/versions/h-/h3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53c6e7764ef0ad4f33491e8f5f5d55d7dd430c54",
+      "version-semver": "4.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "26f3948db4de0052ad771d5e084177af88ae9fc8",
       "version-semver": "4.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
