### PR TITLE
[wcslib] Update to 8.5

### DIFF
--- a/ports/wcslib/portfile.cmake
+++ b/ports/wcslib/portfile.cmake
@@ -1,16 +1,16 @@
 vcpkg_download_distfile(archive
-    URLS "http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-${VERSION}.tar.bz2"
+    URLS "https://www.atnf.csiro.au/computing/software/wcs/wcslib-releases/wcslib-${VERSION}.tar.bz2"
     FILENAME "wcslib-${VERSION}.tar.bz2"
-    SHA512 1989f8f5788fd6d9fa102b771ad7db188b0899f716e11360516c96742f81f50755881279f90fce388451e8857f24003c85751f06aea83377e04bb5230523469f
+    SHA512 f63fe02d89b9296f2502dfb2e3715a0c20c1393d057396af9db7e0c240a6585faacb43c12c5e9456dc5e4ccec009b9d0a2534262515f5c83f11644fabe3d5a7f
 )
 
 vcpkg_extract_source_archive(
-    src
+    SOURCE_PATH
     ARCHIVE "${archive}"
 )
 
 vcpkg_configure_make(
-    SOURCE_PATH ${src}
+    SOURCE_PATH "${SOURCE_PATH}"
     COPY_SOURCE
     OPTIONS
         --disable-flex
@@ -20,7 +20,7 @@ vcpkg_configure_make(
 
 vcpkg_install_make(MAKEFILE GNUmakefile)
 vcpkg_fixup_pkgconfig()
-vcpkg_install_copyright(FILE_LIST "${src}/COPYING")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/wcslib/vcpkg.json
+++ b/ports/wcslib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wcslib",
-  "version": "8.4",
+  "version": "8.5",
   "description": "World Coordinate System (WCS) (Library)",
   "homepage": "https://www.atnf.csiro.au/people/mcalabre/WCS/",
   "supports": "!windows"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10517,7 +10517,7 @@
       "port-version": 0
     },
     "wcslib": {
-      "baseline": "8.4",
+      "baseline": "8.5",
       "port-version": 0
     },
     "websocketpp": {

--- a/versions/w-/wcslib.json
+++ b/versions/w-/wcslib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f68709eb560c079971a0f9be700f643696874290",
+      "version": "8.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "4aabfdd25c7d79ce7cd97e339cdad70959798a39",
       "version": "8.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
