### PR TITLE
[xcb-util] Update to 0.4.1

### DIFF
--- a/ports/xcb-util/portfile.cmake
+++ b/ports/xcb-util/portfile.cmake
@@ -7,10 +7,11 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libxcb-util
-    REF  acf790d7752f36e450d476ad79807d4012ec863b #v0.4.0
+    REF  3a157762578a2e4253a7cb40d2854a3444d5a9df #v0.4.1
     SHA512 d1ef49c1e16b7643a7afeca1495a96ab9ab9c537ea7669a13b3adda400a204626714afc8ed7fcc3d7532ebe1f89a3aa31e3ca0ee9617330d4df5b65b0c8e6dbc
     HEAD_REF master
-    PATCHES ssize.patch
+    PATCHES
+        ssize.patch
 ) 
 
 file(TOUCH "${SOURCE_PATH}/m4/dummy")
@@ -27,5 +28,5 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 endif()

--- a/ports/xcb-util/vcpkg.json
+++ b/ports/xcb-util/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xcb-util",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "C interface to the X Window System protocol, which replaces the traditional Xlib interface.",
   "homepage": "https://xcb.freedesktop.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10721,7 +10721,7 @@
       "port-version": 0
     },
     "xcb-util": {
-      "baseline": "0.4.0",
+      "baseline": "0.4.1",
       "port-version": 0
     },
     "xcb-util-errors": {

--- a/versions/x-/xcb-util.json
+++ b/versions/x-/xcb-util.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8b35e7887b520842dc9f67333ab0b7f04cc0c380",
+      "version": "0.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d5b50a3e395fcee958321601e06a2cfcbc75d925",
       "version": "0.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
