### PR TITLE
[yara] Update to 4.5.5

### DIFF
--- a/ports/yara/portfile.cmake
+++ b/ports/yara/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO VirusTotal/yara
   REF "v${VERSION}"
-  SHA512 b1da40636f9e55bb07cc911479e6dfa8dc7a4fa3f6b9f10b9f669d741d7af51a1d31e044f9842ec3ab9c6ac9788fbdb89a1686c9e3f22f68d1f9e5fb3db22167
+  SHA512 e71d6e435cb2ad7b5875ccabcfe3abe42e2f37187a22e778867c5c5762134961369c2cbd4bea8da9193d5381af4569e39a50156d4077dc3a23b9a2240b741b60
   HEAD_REF master
   PATCHES
     # Module elf request new library tlshc(https://github.com/avast/tlshc), the related upstream PR: https://github.com/VirusTotal/yara/pull/1624.

--- a/ports/yara/vcpkg.json
+++ b/ports/yara/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yara",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "description": "The pattern matching swiss knife",
   "homepage": "https://github.com/VirusTotal/yara",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10837,7 +10837,7 @@
       "port-version": 0
     },
     "yara": {
-      "baseline": "4.5.4",
+      "baseline": "4.5.5",
       "port-version": 0
     },
     "yas": {

--- a/versions/y-/yara.json
+++ b/versions/y-/yara.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51f25fc5e840d01388514f0476dfa508a5ed7124",
+      "version": "4.5.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "87f57135883f8bed5a44b56f1477d83021258d5c",
       "version": "4.5.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
