### PR TITLE
[clay] Add new port

### DIFF
--- a/ports/clay/portfile.cmake
+++ b/ports/clay/portfile.cmake
@@ -1,0 +1,14 @@
+# header-only library
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nicbarker/clay
+    REF "v${VERSION}"
+    SHA512 f454940397653fbd845b05ad484405abf197c3063959fe7762d6bf94c94bc6e5046cedd2f80b52fc89cee4299567861c91b992539f9aa661b729a5a521719343
+    HEAD_REF main
+)
+
+file(COPY "${SOURCE_PATH}/clay.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/clay/vcpkg.json
+++ b/ports/clay/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "clay",
+  "version": "0.14",
+  "description": "High performance UI layout library in C",
+  "homepage": "https://www.nicbarker.com/clay",
+  "license": "Zlib"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1776,6 +1776,10 @@
       "baseline": "1.1.5",
       "port-version": 2
     },
+    "clay": {
+      "baseline": "0.14",
+      "port-version": 0
+    },
     "clblas": {
       "baseline": "2.12",
       "port-version": 8

--- a/versions/c-/clay.json
+++ b/versions/c-/clay.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "912e9c2fc1539d94262f0d0bee546dd4c59a3454",
+      "version": "0.14",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
