### PR TITLE
[bde] Update to 4.32.0.0

### DIFF
--- a/ports/bde/bigobj.patch
+++ b/ports/bde/bigobj.patch
@@ -1,0 +1,12 @@
+diff --git a/groups/bdl/CMakeLists.txt b/groups/bdl/CMakeLists.txt
+index 4f2371511..8483947ff 100644
+--- a/groups/bdl/CMakeLists.txt
++++ b/groups/bdl/CMakeLists.txt
+@@ -24,6 +24,7 @@ target_compile_options(bdlde-iface
+ # TODO: probably, make sense to make it default argument in
+ # the cl toolchain.
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
++    target_compile_options(bdlar PUBLIC /bigobj)
+     target_compile_options(bdlf INTERFACE /bigobj)
+     target_compile_options(bdlcc INTERFACE /bigobj)
+     target_link_libraries(bdlb-iface PRIVATE bcrypt)

--- a/ports/bde/portfile.cmake
+++ b/ports/bde/portfile.cmake
@@ -5,12 +5,12 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
 
 # Acquire BDE Tools and add them to PATH
-set (BDE_TOOLS_VER 4.13.0.0)
+set (BDE_TOOLS_VER 4.32.0.0)
 vcpkg_from_github(
     OUT_SOURCE_PATH TOOLS_PATH
     REPO "bloomberg/bde-tools"
     REF "${BDE_TOOLS_VER}"
-    SHA512 6a0eec25889a33fb0302af735ed2fcce38afa5ad2be9202d2589d76509f9fd85f9ddc0a73147df1b6471543f51df3b5b40e8c08d378ab1335d2703d89b5921e6
+    SHA512 26937ac8c3540825ea6e50bc50fc675850498eecd9996d03b3e56771514703ad8f4c62f44ed79502d55fd0cd4d928a4d2cf0c8b6adc279f8327b092da157ac69
     HEAD_REF main
 )
 
@@ -23,8 +23,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "bloomberg/bde"
     REF "${VERSION}"
-    SHA512 d6d7e453cf22f6e28f3513b818ab3f4b597db3e1d109587e0e0a8957338483c475494f55d953dfe86de507a6c292d1492d9cbb3c8be359044ef368fe80595448
+    SHA512 0228b861395737a5420a69c35c2ecbc1a3425863c5a7478752791cf3eecafd1ad0365497ad15c6f53308c4edafc6b74bb8b498c92a4cc042bd9a9e51363c34c6
     HEAD_REF main
+    PATCHES
+        bigobj.patch
 )
 
 vcpkg_cmake_configure(
@@ -34,12 +36,9 @@ vcpkg_cmake_configure(
         -DCMAKE_CXX_STANDARD=17
         -DCMAKE_CXX_STANDARD_REQUIRED=ON
         -DCMAKE_CXX_EXTENSIONS=OFF
-        -DBBS_BUILD_SYSTEM=1
+        -DBBS_BUILD_SYSTEM=ON
+        -DBDE_USE_EXTERNAL_PCRE2=ON
         "-DBdeBuildSystem_DIR:PATH=${TOOLS_PATH}/BdeBuildSystem"
-    OPTIONS_RELEASE
-        -DBDE_BUILD_TARGET_OPT=1
-    OPTIONS_DEBUG
-        -DBDE_BUILD_TARGET_DBG=1
 )
 
 # Build release
@@ -48,7 +47,7 @@ vcpkg_cmake_build()
 # Install release
 vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-list(APPEND SUBPACKAGES "ryu" "inteldfp" "pcre2" "s_baltst" "bsl" "bdl" "bal")
+list(APPEND SUBPACKAGES "bbryu" "inteldfp" "pcre2" "s_baltst" "bsl" "bdl" "bal")
 include(GNUInstallDirs) # needed for CMAKE_INSTALL_LIBDIR
 foreach(subpackage IN LISTS SUBPACKAGES)
     vcpkg_cmake_config_fixup(PACKAGE_NAME ${subpackage} CONFIG_PATH /${CMAKE_INSTALL_LIBDIR}/cmake/${subpackage} DO_NOT_DELETE_PARENT_CONFIG_PATH)

--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -1,13 +1,14 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "bde",
-  "version": "4.18.0.0",
+  "version": "4.32.0.0",
   "description": "Basic Development Environment - a set of foundational C++ libraries used at Bloomberg.",
   "homepage": "https://techatbloomberg.com/",
   "documentation": "https://bloomberg.github.io/bde/",
   "license": "Apache-2.0",
   "supports": "!android & !(arm64 & windows) & !uwp",
   "dependencies": [
+    "pcre2",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1038f3f09fbed66def8e133bbc07e95029edafed",
+      "version": "4.32.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "34499e736823b1b6b2fe34a37d9162ecab8e187c",
       "version": "4.18.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -649,7 +649,7 @@
       "port-version": 0
     },
     "bde": {
-      "baseline": "4.18.0.0",
+      "baseline": "4.32.0.0",
       "port-version": 0
     },
     "bdwgc": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Notes:
- `ryu` was renamed to `bbryu` in https://github.com/bloomberg/bde/commit/367d730566cba3c23b14aa8c56b925442814571b (4.19.0.0)
- Removed the `BDE_BUILD_TARGET_` options as the CI marks them as unused and I didn't found any code related to this in the CMake files (they are still defines in the C++ code). I believe they are obsolete since the bde-tool https://github.com/bloomberg/bde-tools/commit/011446c246f4636efce1305084eb264c74b3292c (3.123.0.0).   They were added here for 3.117.0.0