### PR TITLE
[picobench] Add new port

### DIFF
--- a/ports/picobench/portfile.cmake
+++ b/ports/picobench/portfile.cmake
@@ -4,7 +4,7 @@ set(VCPKG_BUILD_TYPE release)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO iboB/picobench
-    REF "v${VERSION}"
+    REF "v2.08"
     SHA512 fcf0f459afa70cc7eb41fceb2485976fdceb4731652c9f3420d8b072fb1286b8afcb59d568f4693ef3f704e2fd779f134a6cce2773b1af7c47e8a3546bae0937
     HEAD_REF main
 )

--- a/ports/picobench/portfile.cmake
+++ b/ports/picobench/portfile.cmake
@@ -4,8 +4,8 @@ set(VCPKG_BUILD_TYPE release)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO iboB/picobench
-    REF "v2.08"
-    SHA512 fcf0f459afa70cc7eb41fceb2485976fdceb4731652c9f3420d8b072fb1286b8afcb59d568f4693ef3f704e2fd779f134a6cce2773b1af7c47e8a3546bae0937
+    REF "v${VERSION}"
+    SHA512 2c516c56fa558c395549c3c8daf5cc29fd2cae5e5af00d5b5e079b15f472979db6c4edf078e294715a2fb12d6ad8ba1dc5fe216e2de837a290bb418e0f78d166
     HEAD_REF main
 )
 

--- a/ports/picobench/portfile.cmake
+++ b/ports/picobench/portfile.cmake
@@ -1,0 +1,14 @@
+# header-only library
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO iboB/picobench
+    REF "v${VERSION}"
+    SHA512 fcf0f459afa70cc7eb41fceb2485976fdceb4731652c9f3420d8b072fb1286b8afcb59d568f4693ef3f704e2fd779f134a6cce2773b1af7c47e8a3546bae0937
+    HEAD_REF main
+)
+
+file(COPY "${SOURCE_PATH}/include/picobench/picobench.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include/picobench")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/picobench/vcpkg.json
+++ b/ports/picobench/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "picobench",
+  "version-string": "2.08",
+  "description": "A micro microbenchmarking library for C++11 in a single header file",
+  "homepage": "https://github.com/iboB/picobench",
+  "license": "MIT"
+}

--- a/ports/picobench/vcpkg.json
+++ b/ports/picobench/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "picobench",
-  "version-string": "2.08",
+  "version": "2.8",
   "description": "A micro microbenchmarking library for C++11 in a single header file",
   "homepage": "https://github.com/iboB/picobench",
   "license": "MIT"

--- a/ports/picobench/vcpkg.json
+++ b/ports/picobench/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "picobench",
-  "version": "2.8",
+  "version": "2.8.0",
   "description": "A micro microbenchmarking library for C++11 in a single header file",
   "homepage": "https://github.com/iboB/picobench",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7560,6 +7560,10 @@
       "baseline": "5.5.0",
       "port-version": 1
     },
+    "picobench": {
+      "baseline": "2.08",
+      "port-version": 0
+    },
     "picojson": {
       "baseline": "1.3.0",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7561,7 +7561,7 @@
       "port-version": 1
     },
     "picobench": {
-      "baseline": "2.8",
+      "baseline": "2.8.0",
       "port-version": 0
     },
     "picojson": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7561,7 +7561,7 @@
       "port-version": 1
     },
     "picobench": {
-      "baseline": "2.08",
+      "baseline": "2.8",
       "port-version": 0
     },
     "picojson": {

--- a/versions/p-/picobench.json
+++ b/versions/p-/picobench.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "c5f7edc27eee63ed8cd9151e24bdb4220eccac07",
-      "version-string": "2.08",
+      "git-tree": "f356289577629c263961a7842d226d9c2144a0bf",
+      "version": "2.8",
       "port-version": 0
     }
   ]

--- a/versions/p-/picobench.json
+++ b/versions/p-/picobench.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c5f7edc27eee63ed8cd9151e24bdb4220eccac07",
+      "version-string": "2.08",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/p-/picobench.json
+++ b/versions/p-/picobench.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "f356289577629c263961a7842d226d9c2144a0bf",
-      "version": "2.8",
+      "git-tree": "51e1b690dede38d0055e909352c4f3b61a36c06e",
+      "version": "2.8.0",
       "port-version": 0
     }
   ]


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.