### PR TITLE
[xcb-util] fix hash due to the updated tag

### DIFF
--- a/ports/xcb-util/portfile.cmake
+++ b/ports/xcb-util/portfile.cmake
@@ -7,12 +7,12 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libxcb-util
-    REF  3a157762578a2e4253a7cb40d2854a3444d5a9df #v0.4.1
-    SHA512 d1ef49c1e16b7643a7afeca1495a96ab9ab9c537ea7669a13b3adda400a204626714afc8ed7fcc3d7532ebe1f89a3aa31e3ca0ee9617330d4df5b65b0c8e6dbc
+    REF  bffd8df1725c0fae9105a097e75b466e2f49d7bd #v0.4.1
+    SHA512 59ab4e34b44d720484b0d949bf26bac8ce56bf53f82d090b9229cda2f9c761cbad279774ab644a7a77b861674cdb173b7b597ae2b5860fbc9dfde8f5db3ab30e
     HEAD_REF master
     PATCHES
         ssize.patch
-) 
+)
 
 file(TOUCH "${SOURCE_PATH}/m4/dummy")
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")

--- a/ports/xcb-util/vcpkg.json
+++ b/ports/xcb-util/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "xcb-util",
   "version": "0.4.1",
+  "port-version": 1,
   "description": "C interface to the X Window System protocol, which replaces the traditional Xlib interface.",
   "homepage": "https://xcb.freedesktop.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10722,7 +10722,7 @@
     },
     "xcb-util": {
       "baseline": "0.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "xcb-util-errors": {
       "baseline": "1.0.1",

--- a/versions/x-/xcb-util.json
+++ b/versions/x-/xcb-util.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8db8f7c168cb70641a9e3479c57a68dd2955085b",
+      "version": "0.4.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "8b35e7887b520842dc9f67333ab0b7f04cc0c380",
       "version": "0.4.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
