### PR TITLE
[dawn] Add support for using DXC with D3D12 backend

### DIFF
--- a/ports/dawn/008-directx-dxc.patch
+++ b/ports/dawn/008-directx-dxc.patch
@@ -1,0 +1,37 @@
+diff --git a/src/dawn/native/CMakeLists.txt b/src/dawn/native/CMakeLists.txt
+index bf518be937..e6531283c4 100644
+--- a/src/dawn/native/CMakeLists.txt
++++ b/src/dawn/native/CMakeLists.txt
+@@ -956,7 +956,6 @@ if (DAWN_ENABLE_D3D12)
+     if (DAWN_USE_BUILT_DXC)
+         target_compile_definitions(dawn_native PRIVATE "DAWN_USE_BUILT_DXC")
+         target_compile_definitions(dawn_native_objects PRIVATE "DAWN_USE_BUILT_DXC")
+-        add_dependencies(dawn_native copy_dxil_dll)
+     endif()
+ endif()
+ 
+@@ -1057,7 +1056,8 @@ endif ()
+ # They happen because dxcompiler is declared a shared library and bundle_libraries
+ # doesn't work well with shared libs
+ if (DAWN_USE_BUILT_DXC)
+-    target_link_libraries(dawn_native PRIVATE dxcompiler)
++    find_package(directx-dxc CONFIG REQUIRED)
++    target_link_libraries(dawn_native PRIVATE Microsoft::DirectXShaderCompiler)
+ endif()
+ 
+ # Copy d3dcompiler_47.dll from Windows SDK when not using system component loading
+diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
+index 68497c0867..a1478d5c7f 100644
+--- a/third_party/CMakeLists.txt
++++ b/third_party/CMakeLists.txt
+@@ -366,10 +366,6 @@ function(AddSubdirectoryDXC)
+     endif()
+ endfunction()
+ 
+-if (DAWN_USE_BUILT_DXC)
+-    AddSubdirectoryDXC()
+-endif()
+-
+ if (TINT_BUILD_TINTD)
+     set(LANGSVR_JSON_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp")
+     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp" EXCLUDE_FROM_ALL)

--- a/ports/dawn/portfile.cmake
+++ b/ports/dawn/portfile.cmake
@@ -42,6 +42,7 @@ vcpkg_from_github(
         # When building dawn[core] which only enables dawns null backend and tints null writer, src/dawn/native/ShaderModule.cpp failed to compile
         # as it was expecting a transitive include of tint::Bindings from a shader language writer.
         007-fix-tint-null-only-writer.patch
+        008-directx-dxc.patch
 )
 
 # vcpkg_find_acquire_program(PYTHON3)
@@ -128,6 +129,10 @@ set(DAWN_ENABLE_D3D12 OFF)
 if("d3d12" IN_LIST FEATURES)
     set(DAWN_ENABLE_D3D12 ON)
 endif()
+set(DAWN_USE_BUILT_DXC OFF)
+if("dxc" IN_LIST FEATURES)
+    set(DAWN_USE_BUILT_DXC ON)
+endif()
 set(DAWN_ENABLE_DESKTOP_GL OFF)
 if("gl" IN_LIST FEATURES)
     set(DAWN_ENABLE_DESKTOP_GL ON)
@@ -169,6 +174,7 @@ vcpkg_cmake_configure(
         -DDAWN_ENABLE_NULL=${DAWN_ENABLE_NULL}
         -DDAWN_ENABLE_D3D11=${DAWN_ENABLE_D3D11}
         -DDAWN_ENABLE_D3D12=${DAWN_ENABLE_D3D12}
+        -DDAWN_USE_BUILT_DXC=${DAWN_USE_BUILT_DXC}
         -DDAWN_ENABLE_DESKTOP_GL=${DAWN_ENABLE_DESKTOP_GL}
         -DDAWN_ENABLE_OPENGLES=${DAWN_ENABLE_OPENGLES}
         -DDAWN_ENABLE_METAL=${DAWN_ENABLE_METAL}

--- a/ports/dawn/vcpkg.json
+++ b/ports/dawn/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dawn",
   "version": "20251202.213730",
+  "port-version": 1,
   "description": "Dawn is an open-source and cross-platform implementation of the WebGPU standard.",
   "homepage": "https://dawn.googlesource.com/dawn",
   "license": "BSD-3-Clause",
@@ -60,6 +61,20 @@
     "d3d12": {
       "description": "Direct3D 12 backend support",
       "supports": "windows"
+    },
+    "dxc": {
+      "description": "DirectX Shader Compiler support for Direct3D 12 backend",
+      "supports": "windows",
+      "dependencies": [
+        {
+          "name": "dawn",
+          "default-features": false,
+          "features": [
+            "d3d12"
+          ]
+        },
+        "directx-dxc"
+      ]
     },
     "gl": {
       "description": "Desktop OpenGL backend support",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2366,7 +2366,7 @@
     },
     "dawn": {
       "baseline": "20251202.213730",
-      "port-version": 0
+      "port-version": 1
     },
     "daxa": {
       "baseline": "3.3.1",

--- a/versions/d-/dawn.json
+++ b/versions/d-/dawn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c4702808b0a8314a160d9b48f726d08f220eb889",
+      "version": "20251202.213730",
+      "port-version": 1
+    },
+    {
       "git-tree": "22ddc1e39ab1be07b9a5a7e9fa0c29d69a1c1b1f",
       "version": "20251202.213730",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

