### PR TITLE
[wxwidgets] add unicode-utf8 feature

### DIFF
--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -39,6 +39,7 @@ vcpkg_check_features(
         media   wxUSE_MEDIACTRL
         secretstore wxUSE_SECRETSTORE
         sound   wxUSE_SOUND
+        unicode-utf8 wxUSE_UNICODE_UTF8
         webview wxUSE_WEBVIEW
         webview wxUSE_WEBVIEW_EDGE
 )

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "wxwidgets",
   "version": "3.3.1",
+  "port-version": 1,
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",
@@ -98,6 +99,9 @@
           "platform": "!windows & !osx & !ios"
         }
       ]
+    },
+    "unicode-utf8": {
+      "description": "use UTF-8 representation for strings"
     },
     "webview": {
       "description": "The Edge backend uses Microsoft's Edge WebView2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10662,7 +10662,7 @@
     },
     "wxwidgets": {
       "baseline": "3.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "wyhash": {
       "baseline": "2023-12-03",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a0f08cbd9696eecef5376a9d8808cdaee9c0b8b7",
+      "version": "3.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "42070e5c6991073f4b9a5477d9fb2b9d1267008e",
       "version": "3.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

