### PR TITLE
[libconfig] update to 1.8.2

### DIFF
--- a/ports/libconfig/portfile.cmake
+++ b/ports/libconfig/portfile.cmake
@@ -8,17 +8,11 @@ vcpkg_from_github(
         static-build.diff
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        cxx BUILD_CXX
-)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_EXAMPLES=OFF
         -DBUILD_TESTS=OFF
-        ${FEATURE_OPTIONS}
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
@@ -29,9 +23,7 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libconfig.h" "defined(LIBCONFIG_STATIC)" "1")
-    if ("cxx" IN_LIST FEATURES)
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libconfig.h++" "defined(LIBCONFIGXX_STATIC)" "1")
-    endif()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libconfig.h++" "defined(LIBCONFIGXX_STATIC)" "1")
 endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libconfig/portfile.cmake
+++ b/ports/libconfig/portfile.cmake
@@ -2,10 +2,15 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hyperrealm/libconfig
     REF "v${VERSION}"
-    SHA512 1d9d7b21baf73259c09b503ca02942bdf847741378f8c3d7e138c9b4979c5304aae510595958fe1842b726778cedf2aaeb1844f8b209a61ccb24debea592bd0c
+    SHA512 c3ed6c8f500b449c4d94976745a3acba1c7176f87497d5cb0deb05e62f2ff009ca0636c7c9848601f6d92dd113d82983cbd1132735f0f2d4e40b32d257f4aaa7
     HEAD_REF master
     PATCHES
         static-build.diff
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        cxx BUILD_CXX
 )
 
 vcpkg_cmake_configure(
@@ -13,6 +18,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DBUILD_EXAMPLES=OFF
         -DBUILD_TESTS=OFF
+        ${FEATURE_OPTIONS}
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
@@ -23,7 +29,9 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libconfig.h" "defined(LIBCONFIG_STATIC)" "1")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libconfig.h++" "defined(LIBCONFIGXX_STATIC)" "1")
+    if ("cxx" IN_LIST FEATURES)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libconfig.h++" "defined(LIBCONFIGXX_STATIC)" "1")
+    endif()
 endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libconfig/static-build.diff
+++ b/ports/libconfig/static-build.diff
@@ -1,5 +1,5 @@
 diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index 5f44454..d488e7a 100644
+index 0f2f550..4003e6c 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
 @@ -49,7 +49,6 @@ set(libinc_cpp
@@ -10,25 +10,29 @@ index 5f44454..d488e7a 100644
      libconfigcpp.cc)
  
  if(MSVC)
-@@ -82,8 +81,10 @@ set_version_info_from_makefile("Makefile.am" ${libname})
- set_version_info_from_makefile("Makefile.am" ${libname}++)
+@@ -92,11 +91,13 @@ endif()
  
  if(BUILD_SHARED_LIBS)
-+    target_sources(${libname}++ PRIVATE ${libsrc})
-     target_compile_definitions(${libname}++ PRIVATE LIBCONFIG_STATIC)
+     if(BUILD_CXX)
++      target_sources(${libname}++ PRIVATE ${libsrc})
+       target_compile_definitions(${libname}++ PRIVATE LIBCONFIG_STATIC)
+     endif()
  else()
-+    target_link_libraries(${libname}++ PRIVATE ${libname})
      target_compile_definitions(${libname} PUBLIC LIBCONFIG_STATIC)
-     target_compile_definitions(${libname}++ PUBLIC LIBCONFIG_STATIC LIBCONFIGXX_STATIC)
+     if(BUILD_CXX)
++      target_link_libraries(${libname}++ PRIVATE ${libname})
+       target_compile_definitions(${libname}++ PUBLIC LIBCONFIG_STATIC LIBCONFIGXX_STATIC)
+     endif()
  endif()
-@@ -134,8 +135,8 @@ if(MSVC)
+@@ -154,9 +155,9 @@ if(MSVC)
  endif()
  
  if(WIN32)
 -    target_link_libraries(${libname} shlwapi)
--    target_link_libraries(${libname}++ shlwapi)
-+    target_link_libraries(${libname} PRIVATE  shlwapi)
-+    target_link_libraries(${libname}++ PRIVATE shlwapi)
++    target_link_libraries(${libname} PRIVATE shlwapi)
+     if(BUILD_CXX)
+-      target_link_libraries(${libname}++ shlwapi)
++      target_link_libraries(${libname}++ PRIVATE shlwapi)
+     endif()
  endif()
  
- target_include_directories(${libname}

--- a/ports/libconfig/vcpkg.json
+++ b/ports/libconfig/vcpkg.json
@@ -12,10 +12,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "cxx": {
-      "description": "uild the C++ library in addition to the C library"
-    }
-  }
+  ]
 }

--- a/ports/libconfig/vcpkg.json
+++ b/ports/libconfig/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libconfig",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "C/C++ library for processing configuration files",
   "homepage": "https://github.com/hyperrealm/libconfig",
   "dependencies": [
@@ -12,5 +12,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "cxx": {
+      "description": "uild the C++ library in addition to the C library"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4685,7 +4685,7 @@
       "port-version": 0
     },
     "libconfig": {
-      "baseline": "1.8.1",
+      "baseline": "1.8.2",
       "port-version": 0
     },
     "libconfuse": {

--- a/versions/l-/libconfig.json
+++ b/versions/l-/libconfig.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e8a2fe8b8f4e2f650c2321d7a00fd6aca12f1d08",
+      "git-tree": "6283fb6ea57e7cdc8024e1d0eb893a1438f6e361",
       "version": "1.8.2",
       "port-version": 0
     },

--- a/versions/l-/libconfig.json
+++ b/versions/l-/libconfig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8a2fe8b8f4e2f650c2321d7a00fd6aca12f1d08",
+      "version": "1.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "56fc016e03a6c91fad520ee67122cfc8d6ca5242",
       "version": "1.8.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/hyperrealm/libconfig/releases/tag/v1.8.2

BUILD_CXX option has been added.
https://github.com/hyperrealm/libconfig/commit/1f3d7cc60870ff851b42fbdc86a4fb85b03d50b4