### PR TITLE
[stella-cv-fbow] Fix package name

### DIFF
--- a/ports/stella-cv-fbow/portfile.cmake
+++ b/ports/stella-cv-fbow/portfile.cmake
@@ -17,7 +17,9 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/fbow)
+vcpkg_cmake_config_fixup(
+	CONFIG_PATH share/cmake/fbow
+	PACKAGE_NAME fbow)
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 

--- a/ports/stella-cv-fbow/vcpkg.json
+++ b/ports/stella-cv-fbow/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "stella-cv-fbow",
   "version": "0.0.1",
+  "port-version": 1,
   "description": "This is a modified version of the original Fast Bag of Words by @rmsalinas.",
   "homepage": "https://github.com/stella-cv/FBoW",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9450,7 +9450,7 @@
     },
     "stella-cv-fbow": {
       "baseline": "0.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "stftpitchshift": {
       "baseline": "1.4.1",

--- a/versions/s-/stella-cv-fbow.json
+++ b/versions/s-/stella-cv-fbow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c20434a432aa792b77f7951c9d65c2f0d660a62b",
+      "git-tree": "c12158597276e2dfb9a63833d71f3850314e790d",
       "version": "0.0.1",
       "port-version": 0
     }

--- a/versions/s-/stella-cv-fbow.json
+++ b/versions/s-/stella-cv-fbow.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "c12158597276e2dfb9a63833d71f3850314e790d",
+      "git-tree": "2825c86e60eb70b58ab68c4105a5142a28c0b479",
+      "version": "0.0.1",
+      "port-version": 1
+    },
+    {
+      "git-tree": "c20434a432aa792b77f7951c9d65c2f0d660a62b",
       "version": "0.0.1",
       "port-version": 0
     }


### PR DESCRIPTION
This PR fixes an issue that [dg0yt found in my PR to add FBoW from Stella](https://github.com/microsoft/vcpkg/pull/48752#discussion_r2608138304).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.