### PR TITLE
[vcpkg scripts] Update `jom` to `1.1.6`

### DIFF
--- a/scripts/cmake/vcpkg_find_acquire_program(JOM).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(JOM).cmake
@@ -1,5 +1,5 @@
 set(program_name jom)
-set(program_version_string 1_1_4)
+set(program_version_string 1_1_6)
 if(CMAKE_HOST_WIN32)
     set(download_urls
         "https://download.qt.io/official_releases/jom/jom_${program_version_string}.zip"
@@ -7,7 +7,7 @@ if(CMAKE_HOST_WIN32)
         "https://mirrors.ukfast.co.uk/sites/qt.io/official_releases/jom/jom_${program_version_string}.zip"
     )
     set(download_filename "jom_${program_version_string}.zip")
-    set(download_sha512 a683bd829c84942223a791dae8abac5cfc2e3fa7de84c6fdc490ad3aa996a26c9fa0be0636890f02c9d56948bbe3225b43497cb590d1cb01e70c6fac447fa17b)
+    set(download_sha512 6fd99ad144e715cfdfe222b3999edcec0e1b82cfe216d79fedfd404942c56cfdd1827e445b8f7112148f75c02802d345f4b435321fc1530ac4b46e77bb9909b3)
     set(tool_subdirectory "jom-${program_version_string}")
     set(paths_to_search "${DOWNLOADS}/tools/jom/${tool_subdirectory}")
 endif()


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
____

https://download.qt.io/official_releases/jom/changelog.txt