### PR TITLE
[cluestering] New port

### DIFF
--- a/ports/cluestering/portfile.cmake
+++ b/ports/cluestering/portfile.cmake
@@ -1,0 +1,17 @@
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+	REPO cms-patatrack/CLUEstering
+    REF ${VERSION}
+    SHA512 17bfdc76526623442d264133b8424542f3177a3d6c23c5b1ed8d042bf14651d8658361c97df20d5982287efebc477409a77606aa1a517b0988eb52ac919a6bbf
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}")
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/CLUEstering")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cluestering/portfile.cmake
+++ b/ports/cluestering/portfile.cmake
@@ -15,3 +15,8 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/CLUEstering")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/lib"
+    "${CURRENT_PACKAGES_DIR}/debug"
+)

--- a/ports/cluestering/usage
+++ b/ports/cluestering/usage
@@ -1,0 +1,4 @@
+CLUEstering provides CMake targets:
+
+    find_package(CLUEstering CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE CLUEstering::CLUEstering)

--- a/ports/cluestering/vcpkg.json
+++ b/ports/cluestering/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "cluestering",
+  "version": "2.9.0",
+  "description": "A high-performance density-based weighted clustering library developed at CERN",
+  "homepage": "https://github.com/cms-patatrack/CLUEstering",
+  "license": "MPL-2.0",
+  "dependencies": [
+    "alpaka",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1832,6 +1832,10 @@
       "baseline": "1.0.0",
       "port-version": 0
     },
+    "cluestering": {
+      "baseline": "2.9.0",
+      "port-version": 0
+    },
     "cmakerc": {
       "baseline": "2023-07-24",
       "port-version": 0

--- a/versions/c-/cluestering.json
+++ b/versions/c-/cluestering.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2a96eb933718445a6be6effc6d9f26f8f3ec8bda",
+      "version": "2.9.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
