### PR TITLE
[colmap] fix missing cassert issue

### DIFF
--- a/ports/colmap/add-missing-cassert.patch
+++ b/ports/colmap/add-missing-cassert.patch
@@ -1,0 +1,13 @@
+diff --git a/src/colmap/sfm/observation_manager.cc b/src/colmap/sfm/observation_manager.cc
+index 22d076da..53412449 100644
+--- a/src/colmap/sfm/observation_manager.cc
++++ b/src/colmap/sfm/observation_manager.cc
+@@ -36,6 +36,8 @@
+ #include "colmap/util/logging.h"
+ #include "colmap/util/misc.h"
+ 
++#include <cassert>
++
+ namespace colmap {
+ 
+ bool MergeAndFilterReconstructions(const double max_reproj_error,

--- a/ports/colmap/portfile.cmake
+++ b/ports/colmap/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         no-glu.diff
-	add-missing-cassert.patch
+        add-missing-cassert.patch
 )
 
 if (NOT TRIPLET_SYSTEM_ARCH STREQUAL "x64" AND ("cuda" IN_LIST FEATURES OR "cuda-redist" IN_LIST FEATURES))

--- a/ports/colmap/portfile.cmake
+++ b/ports/colmap/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         no-glu.diff
+	add-missing-cassert.patch
 )
 
 if (NOT TRIPLET_SYSTEM_ARCH STREQUAL "x64" AND ("cuda" IN_LIST FEATURES OR "cuda-redist" IN_LIST FEATURES))

--- a/ports/colmap/vcpkg.json
+++ b/ports/colmap/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "colmap",
   "version": "3.12.6",
+  "port-version": 1,
   "description": "COLMAP is a general-purpose Structure-from-Motion (SfM) and Multi-View Stereo (MVS) pipeline with a graphical and command-line interface. It offers a wide range of features for reconstruction of ordered and unordered image collections. The software is licensed under the new BSD license.",
   "homepage": "https://colmap.github.io/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1906,7 +1906,7 @@
     },
     "colmap": {
       "baseline": "3.12.6",
-      "port-version": 0
+      "port-version": 1
     },
     "color-console": {
       "baseline": "2022-03-20",

--- a/versions/c-/colmap.json
+++ b/versions/c-/colmap.json
@@ -6,7 +6,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "9fe29daf034660debe1855a9ca8053f055a37e4f",
+      "git-tree": "360970f724ed81ffbfa522c23b6a5ff6366b718a",
       "version": "3.12.6",
       "port-version": 0
     },

--- a/versions/c-/colmap.json
+++ b/versions/c-/colmap.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9fe29daf034660debe1855a9ca8053f055a37e4f",
+      "git-tree": "d2e915dff11888c4c6a3233cc50b1db00f4cae99",
       "version": "3.12.6",
       "port-version": 0
     },

--- a/versions/c-/colmap.json
+++ b/versions/c-/colmap.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "360970f724ed81ffbfa522c23b6a5ff6366b718a",
+      "git-tree": "9fe29daf034660debe1855a9ca8053f055a37e4f",
       "version": "3.12.6",
       "port-version": 0
     },

--- a/versions/c-/colmap.json
+++ b/versions/c-/colmap.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "d2e915dff11888c4c6a3233cc50b1db00f4cae99",
+      "git-tree": "868e9b94358a0830aad7c62adbc5beae1e52b6b7",
+      "version": "3.12.6",
+      "port-version": 1
+    },
+    {
+      "git-tree": "9fe29daf034660debe1855a9ca8053f055a37e4f",
       "version": "3.12.6",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes release failing to build on all platforms
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.