### PR TITLE
[jwsung91-unilink] fix cmake package discovery 

### DIFF
--- a/ports/jwsung91-unilink/portfile.cmake
+++ b/ports/jwsung91-unilink/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
+    PACKAGE_NAME unilink
     CONFIG_PATH "lib/cmake/unilink"
 )
 

--- a/ports/jwsung91-unilink/vcpkg.json
+++ b/ports/jwsung91-unilink/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "jwsung91-unilink",
   "version": "0.1.9",
+  "port-version": 1,
   "description": "Cross-platform communication middleware (Serial/TCP/UDP) using Boost.Asio.",
   "homepage": "https://github.com/jwsung91/unilink",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4166,7 +4166,7 @@
     },
     "jwsung91-unilink": {
       "baseline": "0.1.9",
-      "port-version": 0
+      "port-version": 1
     },
     "jwt-cpp": {
       "baseline": "0.7.1",

--- a/versions/j-/jwsung91-unilink.json
+++ b/versions/j-/jwsung91-unilink.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "666dd46459115a7c5ba0d0c1244860a8a5349c96",
+      "version": "0.1.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "beeb6624605470dd869f07ec364f54af06762451",
       "version": "0.1.9",
       "port-version": 0


### PR DESCRIPTION
This PR improves the CMake package discovery behavior for the `jwsung91-unilink` port.

The port name is intentionally scoped as `jwsung91-unilink` to avoid naming conflicts, while the upstream CMake package name remains `unilink`.
To preserve the expected upstream usage pattern (`find_package(unilink CONFIG REQUIRED)`), this PR updates the port to explicitly set the CMake package name during config fixup.

Specifically, `PACKAGE_NAME unilink` is specified in `vcpkg_cmake_config_fixup()`, ensuring that the generated CMake config files are installed under `share/unilink/` and are discoverable by CMake without requiring additional hints such as `CMAKE_PREFIX_PATH`.

This change does not affect the public API, versioning, or supported platforms, and only improves integration consistency with standard CMake workflows.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

