### PR TITLE
[cimg] Fix hash

### DIFF
--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -3,7 +3,7 @@ set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO GreycLab/CImg
     REF "v.${VERSION}"
-    SHA512 0f3a4ddb5fcfb26f403e7f9aaa1e76bce1fc85e27934619f692572efaf111ec2c568b55c8b48d9629a15cb9ae7eeeac70d86f7dfb36082419b2d07c5fd0a0c8e
+    SHA512 7a0a66cf8dfb9923be0ee576f5dc6c53a8704a92ce9b1b3b8d1a7c6b5a1d94f231fce25a813f0fb6e6afd0f75111a8efb91f3e05c57621900ef588e00bf8d06c
     HEAD_REF master
 )
 

--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -1,9 +1,9 @@
 set(VCPKG_BUILD_TYPE release) # header-only
 
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
-    REPO dtschump/CImg
+    REPO GreycLab/CImg
     REF "v.${VERSION}"
-    SHA512 dd9f53817aca7317adde6ba26bba4f84160b3a03c755551d3a2a5604354315254b0f6c9581c9feea00e534ae494dc6def9ab64dbaca7fe493df94a7f0dd3986f
+    SHA512 0f3a4ddb5fcfb26f403e7f9aaa1e76bce1fc85e27934619f692572efaf111ec2c568b55c8b48d9629a15cb9ae7eeeac70d86f7dfb36082419b2d07c5fd0a0c8e
     HEAD_REF master
 )
 

--- a/ports/cimg/vcpkg.json
+++ b/ports/cimg/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "cimg",
   "version": "3.6.5",
+  "port-version": 1,
   "description": "The CImg Library is a small, open-source, and modern C++ toolkit for image processing",
-  "homepage": "https://github.com/dtschump/CImg",
+  "homepage": "https://github.com/GreycLab/CImg",
   "license": "CECILL-C AND CECILL-2.0",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1738,7 +1738,7 @@
     },
     "cimg": {
       "baseline": "3.6.5",
-      "port-version": 0
+      "port-version": 1
     },
     "cinatra": {
       "baseline": "0.9.7",

--- a/versions/c-/cimg.json
+++ b/versions/c-/cimg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ccd09e217b5b1980af47e27bd5f21ada33fd416",
+      "version": "3.6.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "affca00ae202a1e6d0180c2feaf39475d7e1483f",
       "version": "3.6.5",
       "port-version": 0

--- a/versions/c-/cimg.json
+++ b/versions/c-/cimg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4ccd09e217b5b1980af47e27bd5f21ada33fd416",
+      "git-tree": "3fce3d2b620c8eec111d885d3f134cbd22ee11b4",
       "version": "3.6.5",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #48932

Please note that I also changed the GitHub repo from `dtschump/CImg` to `GreycLab/CImg` because https://github.com/dtschump/CImg redirects to https://github.com/GreycLab/CImg .

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
