### PR TITLE
[gmmlib] update to 22.9.0

### DIFF
--- a/ports/gmmlib/portfile.cmake
+++ b/ports/gmmlib/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/gmmlib
     REF "intel-gmmlib-${VERSION}"
-    SHA512 516e2cc0d678d8fd44d8d2b1bfdf61c05670c01c906bd7f55a807846cd6399d4b616f86e6a1d85e2a6a0480c4616a40e9d5b29a3f45fbf588cc4d725ada71d49
+    SHA512 c54581e4927bfedd7cb4084111cce69c9ee14f0047f6d16d26358e9d41feb8d28d5158f7fbdfbe4980dae904e7c2065deed19fd2f91e32b49fd7b984d47c0f44
     HEAD_REF master
 )
 

--- a/ports/gmmlib/vcpkg.json
+++ b/ports/gmmlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gmmlib",
-  "version": "22.5.2",
+  "version": "22.9.0",
   "description": "Intel(R) Graphics Memory Management Library",
   "homepage": "https://github.com/intel/gmmlib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3405,7 +3405,7 @@
       "port-version": 1
     },
     "gmmlib": {
-      "baseline": "22.5.2",
+      "baseline": "22.9.0",
       "port-version": 0
     },
     "gmp": {

--- a/versions/g-/gmmlib.json
+++ b/versions/g-/gmmlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4bd80365a1635192362a759364118463a1681bd0",
+      "version": "22.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "22cc6e33aa67a6775a390d87f897e480b99e0a5f",
       "version": "22.5.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/intel/gmmlib/releases/tag/intel-gmmlib-22.9.0
