### PR TITLE
[htslib] update to 1.23

### DIFF
--- a/ports/htslib/portfile.cmake
+++ b/ports/htslib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO samtools/htslib
     REF "${VERSION}"
-    SHA512 3537149d4118bf27424845a44fdfdb5ffce2376bf956ba15cd61686b84efa320c66fed76eab2fc381f344d61607f7e63494fdd6ef8cf4e40cdb3ac6fe29f86ad
+    SHA512 bb1a9c03d3b9f113a030c2c36e7c354e60395f7deb9377ca1993e4d26fb1e1df69570a60a5a4696841d29266df1052558eed7ddb877d1248a82103520a695150
     HEAD_REF develop
     PATCHES
         0001-set-linkage.patch

--- a/ports/htslib/vcpkg.json
+++ b/ports/htslib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "htslib",
-  "version": "1.22.1",
+  "version": "1.23",
   "description": "C library for high-throughput sequencing data formats",
   "homepage": "https://github.com/samtools/htslib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3821,7 +3821,7 @@
       "port-version": 0
     },
     "htslib": {
-      "baseline": "1.22.1",
+      "baseline": "1.23",
       "port-version": 0
     },
     "http-parser": {

--- a/versions/h-/htslib.json
+++ b/versions/h-/htslib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b776c03599b6e6e52bca75dcc040ef91895e7eae",
+      "version": "1.23",
+      "port-version": 0
+    },
+    {
       "git-tree": "494ffb1a8f9ed145a2b89295a532c585d22eaa71",
       "version": "1.22.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/samtools/htslib/releases/tag/1.23
