### PR TITLE
[sleepy-discord] update to 2025-12-18

### DIFF
--- a/ports/sleepy-discord/portfile.cmake
+++ b/ports/sleepy-discord/portfile.cmake
@@ -8,8 +8,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yourWaifu/sleepy-discord
-    REF ae26f3f573f625bc32561776126b4b06707d985c
-    SHA512 68ba8d9a1e48a9cd0374b0a3ec1ae05da54bf3238b1551726c6d5b99e368a995b86a13c7067cd017cdda7eb85085300d19d84f0e7d8a31df5df5f129d6fff904
+    REF 13455925f9e122c8898c6d6407e9ff7624dd0a17
+    SHA512 ebb5d7e5b517fd03554dfeecfb369c33544dce2605e4bb73512dd5b12ff4a393dfa7d19e7002b129841b6b7bb3eab404cfee1d3b58a08e3b591a2625ddc708d6
     HEAD_REF master
     PATCHES
         fix-messing-header.patch

--- a/ports/sleepy-discord/vcpkg.json
+++ b/ports/sleepy-discord/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sleepy-discord",
-  "version-date": "2025-02-08",
+  "version-date": "2025-12-18",
   "description": "C++ library for the Discord chat client",
   "homepage": "https://yourwaifu.dev/sleepy-discord/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9133,7 +9133,7 @@
       "port-version": 1
     },
     "sleepy-discord": {
-      "baseline": "2025-02-08",
+      "baseline": "2025-12-18",
       "port-version": 0
     },
     "slick-logger": {

--- a/versions/s-/sleepy-discord.json
+++ b/versions/s-/sleepy-discord.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aff81b53c24f80235a10c19ff91f90dade9b2410",
+      "version-date": "2025-12-18",
+      "port-version": 0
+    },
+    {
       "git-tree": "54d97afb9a3148a60f7fac2da8e1b9a81e0b330f",
       "version-date": "2025-02-08",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

