### PR TITLE
[nvidia-cutlass] Fix finding cudnn

### DIFF
--- a/ports/nvidia-cutlass/fix-cudnn-path.patch
+++ b/ports/nvidia-cutlass/fix-cudnn-path.patch
@@ -1,0 +1,24 @@
+diff --git a/cuDNN.cmake b/cuDNN.cmake
+index 30b58581..fdbc8314 100644
+--- a/cuDNN.cmake
++++ b/cuDNN.cmake
+@@ -43,7 +43,8 @@ find_path(
+     $ENV{CUDNN_PATH}/include
+     $ENV{CUDA_PATH}/include
+     ${CUDNN_PATH}/include
+-    /usr/include)
++    /usr/include
++    $ENV{CUDNN_PATH})
+ 
+ find_library(
+     _CUDNN_LIBRARY cudnn
+@@ -61,7 +62,8 @@ find_library(
+     ${CUDNN_PATH}/lib/x64
+     ${CUDNN_PATH}/lib
+     /usr/lib/x86_64-linux-gnu
+-    /usr/lib)
++    /usr/lib
++    $ENV{CUDNN_PATH})
+ 
+ if(_CUDNN_INCLUDE_DIR AND _CUDNN_LIBRARY)
+ 

--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 16ef4f68d819f50f4e3f250ddf41fc19105fa1155a86fc42970be0f84e32129cfb05f2730466e9491e84ca5faed595b3e5fbeee7c48a27da812e1927f842623e
     HEAD_REF main
+    PATCHES
+        fix-cudnn-path.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -16,6 +16,11 @@ list(APPEND FEATURE_OPTIONS
     "-DCUDAToolkit_ROOT=${cuda_toolkit_root}"
 )
 
+list(APPEND CMAKE_MODULE_PATH "${CURRENT_INSTALLED_DIR}/share/cudnn")
+find_package(CUDNN REQUIRED)
+get_filename_component(CUDNN_LIBRARY_DIR "${CUDNN_LIBRARIES}" DIRECTORY)
+set(ENV{CUDNN_PATH} "${CUDNN_LIBRARY_DIR};${CUDNN_INCLUDE_DIRS}")
+
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/nvidia-cutlass/vcpkg.json
+++ b/ports/nvidia-cutlass/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nvidia-cutlass",
   "version": "4.3.1",
+  "port-version": 1,
   "description": "CUDA Templates for Linear Algebra Subroutines",
   "homepage": "https://github.com/NVIDIA/cutlass",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7006,7 +7006,7 @@
     },
     "nvidia-cutlass": {
       "baseline": "4.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "nvtt": {
       "baseline": "2.1.2",

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "10a4f8f65f3048805e18a5946a68338eb80484ba",
+      "git-tree": "4b8b0baa5678553b337b62d27a5d63181a8ad8cf",
       "version": "4.3.1",
       "port-version": 1
     },

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "10a4f8f65f3048805e18a5946a68338eb80484ba",
+      "version": "4.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "1afd6dcf96aa421e2ff8849c2fee7f220f294eb4",
       "version": "4.3.1",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cutlass/issues/2885
Fixes #43081

I'm sorry, I do not have the "Allow edits from maintainers" checkbox, probably due to this issue: https://github.com/orgs/community/discussions/5634

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.