### PR TITLE
[daw-json-link] update to 3.31.0

### DIFF
--- a/ports/daw-json-link/portfile.cmake
+++ b/ports/daw-json-link/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beached/daw_json_link
     REF "v${VERSION}"
-    SHA512 1a74a943b06dd9c058ba1be6352da1c2f7b9a3a6fe95f298ad69f72aa092a912c1aa971952e8b123b61f01b3345269f9607675666bf58293cd91023a86431ac3
+    SHA512 47d351c9ab00434f80a01b06ae870132f1a013502140a72f54f0e8054df827d38e9923d7650c0a0e2ffabd6ca7887fafb92d31a5964567bdb7443410856d5b21
     HEAD_REF release
 )
 
@@ -20,7 +20,7 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/${PORT}/cmake)
 # remove empty lib and debug/lib directories (and duplicate files from debug/include)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
-# Append the json-link and dragonbox license information into a single 
+# Append the json-link and dragonbox license information into a single
 # copyright file (they are both Boost v1.0 but it is good to be clear).
 file(APPEND "${SOURCE_PATH}/copyright" [=[+----------------------------------------------------------------------------+
 |                            json-link copywrite                             |

--- a/ports/daw-json-link/vcpkg.json
+++ b/ports/daw-json-link/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "daw-json-link",
-  "version": "3.30.2",
+  "version": "3.31.0",
   "description": "Perhaps the fastest JSON deserializer/serializer posssible or at least close to it.",
   "homepage": "https://github.com/beached/daw_json_link",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2361,7 +2361,7 @@
       "port-version": 0
     },
     "daw-json-link": {
-      "baseline": "3.30.2",
+      "baseline": "3.31.0",
       "port-version": 0
     },
     "daw-utf-range": {

--- a/versions/d-/daw-json-link.json
+++ b/versions/d-/daw-json-link.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "adff77028a14a01041e44293459578a1c06bedd1",
+      "version": "3.31.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7d47b7a42320ccb9a5b38a046648b6a6c31edb00",
       "version": "3.30.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/beached/daw_json_link/releases/tag/v3.31.0
