### PR TITLE
[yalantinglibs] update to 0.5.7

### DIFF
--- a/ports/yalantinglibs/portfile.cmake
+++ b/ports/yalantinglibs/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alibaba/yalantinglibs
     REF "${VERSION}"
-    SHA512 b63de698b92470b9442b459ac90a6dc59b811532cc2fc90d58da13e30c57dda86f5733c0d12d7a287cb1c943e47490bc67944e4e8922f9087b1efccaff827c3f
+    SHA512 f739c0747d84d6fcbb5a94f8491c29d941e992ea7306aa4b9d2cec459f3e4466e63eb86536ac03fbf5e106541535fadbdfe03795de3ece067a297a4381adef89
     HEAD_REF main
     PATCHES
         use-external-libs.patch

--- a/ports/yalantinglibs/vcpkg.json
+++ b/ports/yalantinglibs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yalantinglibs",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "A Collection of C++20 libraries, include struct_pack, struct_json, struct_xml, struct_yaml, struct_pb, easylog, coro_rpc, coro_http and async_simple",
   "homepage": "https://github.com/alibaba/yalantinglibs",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10845,7 +10845,7 @@
       "port-version": 5
     },
     "yalantinglibs": {
-      "baseline": "0.5.6",
+      "baseline": "0.5.7",
       "port-version": 0
     },
     "yaml-cpp": {

--- a/versions/y-/yalantinglibs.json
+++ b/versions/y-/yalantinglibs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b545824d734f3539ee846af113d8f5c6e0eedf7",
+      "version": "0.5.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "699280331e8a0c133e314833ace7c73fb6bfcf4a",
       "version": "0.5.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/alibaba/yalantinglibs/releases/tag/0.5.7
