### PR TITLE
[mdl-sdk] Add feature flag df-vulkan to build the MDL SDK df_vulkan example.

### DIFF
--- a/ports/mdl-sdk/portfile.cmake
+++ b/ports/mdl-sdk/portfile.cmake
@@ -1,3 +1,4 @@
+
 # Clang
 #
 # The MDL SDK includes a vendored copy of a specific LLVM version, to generate
@@ -89,6 +90,8 @@ vcpkg_find_acquire_program(PYTHON3)
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         dds           MDL_BUILD_DDS_PLUGIN
+        df-vulkan     MDL_BUILD_SDK_EXAMPLES
+        df-vulkan     MDL_ENABLE_VULKAN_EXAMPLES
         openimageio   MDL_BUILD_OPENIMAGEIO_PLUGIN
 )
 
@@ -105,10 +108,13 @@ vcpkg_cmake_configure(
     OPTIONS
         -DMDL_LOG_DEPENDENCIES:BOOL=ON
         -DMDL_BUILD_SDK:BOOL=ON
-        -DMDL_BUILD_SDK_EXAMPLES:BOOL=OFF
         -DMDL_BUILD_CORE_EXAMPLES:BOOL=OFF
         -DMDL_BUILD_DOCUMENTATION:BOOL=OFF
         -DMDL_BUILD_ARNOLD_PLUGIN:BOOL=OFF
+        -DMDL_ENABLE_CUDA_EXAMPLES:BOOL=OFF
+        -DMDL_ENABLE_D3D12_EXAMPLES:BOOL=OFF
+        -DMDL_ENABLE_OPENGL_EXAMPLES:BOOL=OFF
+        -DMDL_ENABLE_QT_EXAMPLES:BOOL=OFF
         -DMDL_ENABLE_UNIT_TESTS:BOOL=OFF
         -DMDL_ENABLE_PYTHON_BINDINGS:BOOL=OFF
         -DMDL_TREAT_RUNTIME_DEPS_AS_BUILD_DEPS:BOOL=OFF
@@ -127,18 +133,37 @@ vcpkg_copy_tools(
     AUTO_CLEAN
 )
 
+if (MDL_ENABLE_VULKAN_EXAMPLES)
+    # Install df_vulkan binary into tools/mdl-sdk
+    vcpkg_copy_tools(
+        TOOL_NAMES df_vulkan
+        SEARCH_DIR "${CURRENT_PACKAGES_DIR}/examples/mdl_sdk/df_vulkan"
+        AUTO_CLEAN
+    )
+    # Install df_vulkan shaders into share/mdl-sdk/examples/mdl_sdk/df_vulkan
+    file(COPY
+        "${CURRENT_PACKAGES_DIR}/examples/mdl_sdk/df_vulkan"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/examples/mdl_sdk")
+    # Install general example resources into share/mdl-sdk/examples/mdl
+    file(COPY
+        "${CURRENT_PACKAGES_DIR}/examples/mdl"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/examples")
+endif()
+
 vcpkg_cmake_config_fixup(PACKAGE_NAME "mdl")
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/doc"
+    "${CURRENT_PACKAGES_DIR}/debug/examples"
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/doc"
+    "${CURRENT_PACKAGES_DIR}/examples"
 )
 
-# install usage file
+# Install usage file
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-# merge all license files into copyright
+# Merge all license files into copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(READ "${SOURCE_PATH}/LICENSE_IMAGES.md" _images)
 file(APPEND "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "\n\n${_images}")

--- a/ports/mdl-sdk/vcpkg.json
+++ b/ports/mdl-sdk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mdl-sdk",
   "version": "2025.0.3",
+  "port-version": 1,
   "description": "NVIDIA Material Definition Language SDK",
   "homepage": "https://github.com/NVIDIA/MDL-SDK",
   "license": "BSD-3-Clause",
@@ -25,6 +26,15 @@
   "features": {
     "dds": {
       "description": "Build image plugin for DDS"
+    },
+    "df-vulkan": {
+      "description": "Build the MDL SDK df_vulkan example",
+      "dependencies": [
+        "glfw3",
+        "glslang",
+        "volk",
+        "vulkan-validationlayers"
+      ]
     },
     "openimageio": {
       "description": "Build image plugin for various image formats using OpenImageIO",

--- a/scripts/test_ports/vcpkg-ci-mdl-sdk/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-mdl-sdk/vcpkg.json
@@ -9,6 +9,7 @@
       "default-features": false,
       "features": [
         "dds",
+        "df-vulkan",
         "openimageio"
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6310,7 +6310,7 @@
     },
     "mdl-sdk": {
       "baseline": "2025.0.3",
-      "port-version": 0
+      "port-version": 1
     },
     "mdns": {
       "baseline": "1.4.3",

--- a/versions/m-/mdl-sdk.json
+++ b/versions/m-/mdl-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4e34de80b122b8b8e3e1160e4cbc40138ff0380",
+      "version": "2025.0.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "7d3c64b5b7f00bef724535ea3caaf2b7a920de5b",
       "version": "2025.0.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
