### PR TITLE
[babl, gegl, gexiv2, mypaint-brushes] updates ports. add introspection feature

### DIFF
--- a/ports/babl/portfile.cmake
+++ b/ports/babl/portfile.cmake
@@ -1,9 +1,11 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
 string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.gimp.org/pub/babl/${VERSION_MAJOR_MINOR}/babl-${VERSION}.tar.xz"
     FILENAME "babl-${VERSION}.tar.xz"
-    SHA512 ff410c9839f4fe4d6afd4dec7e4d02af34b1c8a4edbc05483784ed82f91045b1102414fc1c58357866044b7f1ab499eda24fe744f5dd692af5804020c76b2382
+    SHA512 6a361135045566b5a35b7c2df8e9f0a0b1c6e910aa73aafecb621446d333bcbfc50e925ceac675b83b548a872d53eba2c03bcbccb504b47089c737b0ffb53d9d
 )
 
 vcpkg_extract_source_archive(
@@ -13,9 +15,9 @@ vcpkg_extract_source_archive(
 
 set(feature_options "")
 if("cmyk-icc" IN_LIST FEATURES)
-    list(APPEND feature_options "-Dwith-lcms=true")
+    list(APPEND feature_options "-Dwith-lcms=enabled")
 else()
-    list(APPEND feature_options "-Dwith-lcms=false")
+    list(APPEND feature_options "-Dwith-lcms=disabled")
 endif()
 
 if("introspection" IN_LIST FEATURES)

--- a/ports/babl/vcpkg.json
+++ b/ports/babl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "babl",
-  "version": "0.1.114",
+  "version": "0.1.118",
   "description": "A pixel encoding and color space conversion engine.",
   "homepage": "https://gegl.org/babl/",
   "license": "LGPL-3.0-or-later",

--- a/ports/gegl/portfile.cmake
+++ b/ports/gegl/portfile.cmake
@@ -1,9 +1,11 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
 string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 
 vcpkg_download_distfile(ARCHIVE
     URLS https://download.gimp.org/pub/gegl/${VERSION_MAJOR_MINOR}/gegl-${VERSION}.tar.xz
     FILENAME "gegl-${VERSION}.tar.xz"
-    SHA512 bf4801588abe8b568ae3d1daafa97af28516bbbdd44d2a0798c87412b49301f621db3cf1c7a3ec33f19d96ab4dbd37d80824f04460116a896dd7415aa0d5229d
+    SHA512 ed1f809aaea8768b1eff2a6adcf66b3ef7c11e03d410ef8952051822017f9a6bcee0e29dd32708dd6937d49416c6db55cd8d34458619022ea750311253899ae9
 )
 
 vcpkg_extract_source_archive(
@@ -14,11 +16,18 @@ vcpkg_extract_source_archive(
         remove_execinfo_support.patch
 )
 
+if("introspection" IN_LIST FEATURES)
+    list(APPEND feature_options "-Dintrospection=true")
+    vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+else()
+    list(APPEND feature_options "-Dintrospection=false")
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${feature_options}
         -Ddocs=false
-        -Dintrospection=false
         -Dgdk-pixbuf=disabled
         -Dgexiv2=disabled
         -Dgraphviz=disabled
@@ -45,6 +54,9 @@ vcpkg_configure_meson(
         -Dsdl2=disabled
         -Dumfpack=disabled
         -Dwebp=disabled
+    ADDITIONAL_BINARIES
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
 )
 
 vcpkg_install_meson()

--- a/ports/gegl/vcpkg.json
+++ b/ports/gegl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gegl",
-  "version": "0.4.62",
+  "version": "0.4.66",
   "description": "Generic Graphical Library.",
   "homepage": "https://gegl.org/",
   "license": "LGPL-3.0-or-later",
@@ -14,5 +14,20 @@
       "name": "vcpkg-tool-meson",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "introspection": {
+      "description": "Enable introspection",
+      "supports": "!static",
+      "dependencies": [
+        {
+          "name": "babl",
+          "features": [
+            "introspection"
+          ]
+        },
+        "gobject-introspection"
+      ]
+    }
+  }
 }

--- a/ports/gexiv2/portfile.cmake
+++ b/ports/gexiv2/portfile.cmake
@@ -15,20 +15,29 @@ vcpkg_extract_source_archive(
         msvc_def.patch
 )
 
+if("introspection" IN_LIST FEATURES)
+    list(APPEND feature_options "-Dintrospection=true")
+    vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+else()
+    list(APPEND feature_options "-Dintrospection=false")
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -Dintrospection=false
+        ${feature_options}
         -Dvapi=false
         -Dgtk_doc=false
         -Dpython3=false
         -Dtests=false
         -Dtools=false
     ADDITIONAL_BINARIES
-        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+        "glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'"
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
 )
 
-vcpkg_install_meson()
+vcpkg_install_meson(ADD_BIN_TO_PATH)
 
 vcpkg_copy_pdbs()
 

--- a/ports/gexiv2/vcpkg.json
+++ b/ports/gexiv2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gexiv2",
   "version": "0.14.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A GObject-based Exiv2 wrapper.",
   "homepage": "https://gitlab.gnome.org/GNOME/gexiv2/",
   "license": "GPL-2.0-or-later",
@@ -16,5 +16,14 @@
       "name": "vcpkg-tool-meson",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "introspection": {
+      "description": "Enable introspection",
+      "supports": "!static & !windows",
+      "dependencies": [
+        "gobject-introspection"
+      ]
+    }
+  }
 }

--- a/ports/mypaint-brushes/portfile.cmake
+++ b/ports/mypaint-brushes/portfile.cmake
@@ -3,7 +3,7 @@ set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/mypaint/mypaint-brushes/releases/download/v${VERSION}/mypaint-brushes-${VERSION}.tar.xz"
     FILENAME "mypaint-brushes-${VERSION}.tar.xz"
-    SHA512 22ff99c40a2fff71efd5c25a462cefb9948f0d258aee12e3eb924bac53733a2573e100454e2f3e4631d59eac013c2aaa7f32ff566843d23df971bf2aaa1181bd
+    SHA512 bae870e930381b818165e5e39d38b25782d5744c9a507a71dab37ae7ca2d4502896057f919a16eb9305d803a01db3a948a735d5c5b850893997a9afd6403144b
 )
 
 vcpkg_extract_source_archive(
@@ -21,7 +21,7 @@ vcpkg_make_install()
 
 vcpkg_copy_pdbs()
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/mypaint-brushes/pkgconfig/mypaint-brushes-1.0.pc" "${CURRENT_PACKAGES_DIR}/share/pkgconfig/mypaint-brushes-1.0.pc")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/mypaint-brushes/pkgconfig/mypaint-brushes-2.0.pc" "${CURRENT_PACKAGES_DIR}/share/pkgconfig/mypaint-brushes-2.0.pc")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/" "${CURRENT_PACKAGES_DIR}/share/mypaint-brushes/pkgconfig")
 vcpkg_fixup_pkgconfig()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/mypaint-brushes/vcpkg.json
+++ b/ports/mypaint-brushes/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mypaint-brushes",
-  "version": "1.3.1",
-  "port-version": 1,
+  "version": "2.0.2",
   "description": "Data package. Brushes used by MyPaint and other software using libmypaint.",
   "homepage": "https://github.com/mypaint/mypaint-brushes",
   "license": "CC0-1.0",

--- a/versions/b-/babl.json
+++ b/versions/b-/babl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b79b9a274e1fb3fa6ab0f06e8377b998a8c61a79",
+      "version": "0.1.118",
+      "port-version": 0
+    },
+    {
       "git-tree": "cad9c6bb5734a52689427bed4145c2d0d9a80fca",
       "version": "0.1.114",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -613,7 +613,7 @@
       "port-version": 2
     },
     "babl": {
-      "baseline": "0.1.114",
+      "baseline": "0.1.118",
       "port-version": 0
     },
     "backward-cpp": {
@@ -3245,7 +3245,7 @@
       "port-version": 6
     },
     "gegl": {
-      "baseline": "0.4.62",
+      "baseline": "0.4.66",
       "port-version": 0
     },
     "gemmlowp": {
@@ -3298,7 +3298,7 @@
     },
     "gexiv2": {
       "baseline": "0.14.3",
-      "port-version": 2
+      "port-version": 3
     },
     "gflags": {
       "baseline": "2.3.0",
@@ -6693,8 +6693,8 @@
       "port-version": 4
     },
     "mypaint-brushes": {
-      "baseline": "1.3.1",
-      "port-version": 1
+      "baseline": "2.0.2",
+      "port-version": 0
     },
     "mysql-connector-cpp": {
       "baseline": "9.1.0",

--- a/versions/g-/gegl.json
+++ b/versions/g-/gegl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4cc44624243af4411f89590d8f2b63782129f2c9",
+      "version": "0.4.66",
+      "port-version": 0
+    },
+    {
       "git-tree": "9eddf53829c7d2dc14266b4002373790f09946de",
       "version": "0.4.62",
       "port-version": 0

--- a/versions/g-/gexiv2.json
+++ b/versions/g-/gexiv2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9678b2c75bb1e3a83eaa9cfe8a0575a1e6a1b1d6",
+      "version": "0.14.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "fef5255b3edb46d8fd8b574720127964141d52f2",
       "version": "0.14.3",
       "port-version": 2

--- a/versions/m-/mypaint-brushes.json
+++ b/versions/m-/mypaint-brushes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40a490771143fca05ae199fa1f1ff6b509768af5",
+      "version": "2.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e8b34f24005a58c820ac3cd0f072344f756940a0",
       "version": "1.3.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
