### PR TITLE
[mypaint-brushes] update to 2.0.2

### DIFF
--- a/ports/mypaint-brushes/portfile.cmake
+++ b/ports/mypaint-brushes/portfile.cmake
@@ -3,7 +3,7 @@ set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/mypaint/mypaint-brushes/releases/download/v${VERSION}/mypaint-brushes-${VERSION}.tar.xz"
     FILENAME "mypaint-brushes-${VERSION}.tar.xz"
-    SHA512 22ff99c40a2fff71efd5c25a462cefb9948f0d258aee12e3eb924bac53733a2573e100454e2f3e4631d59eac013c2aaa7f32ff566843d23df971bf2aaa1181bd
+    SHA512 bae870e930381b818165e5e39d38b25782d5744c9a507a71dab37ae7ca2d4502896057f919a16eb9305d803a01db3a948a735d5c5b850893997a9afd6403144b
 )
 
 vcpkg_extract_source_archive(
@@ -21,7 +21,7 @@ vcpkg_make_install()
 
 vcpkg_copy_pdbs()
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/mypaint-brushes/pkgconfig/mypaint-brushes-1.0.pc" "${CURRENT_PACKAGES_DIR}/share/pkgconfig/mypaint-brushes-1.0.pc")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/mypaint-brushes/pkgconfig/mypaint-brushes-2.0.pc" "${CURRENT_PACKAGES_DIR}/share/pkgconfig/mypaint-brushes-2.0.pc")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/" "${CURRENT_PACKAGES_DIR}/share/mypaint-brushes/pkgconfig")
 vcpkg_fixup_pkgconfig()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/mypaint-brushes/vcpkg.json
+++ b/ports/mypaint-brushes/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mypaint-brushes",
-  "version": "1.3.1",
-  "port-version": 1,
+  "version": "2.0.2",
   "description": "Data package. Brushes used by MyPaint and other software using libmypaint.",
   "homepage": "https://github.com/mypaint/mypaint-brushes",
   "license": "CC0-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6693,8 +6693,8 @@
       "port-version": 4
     },
     "mypaint-brushes": {
-      "baseline": "1.3.1",
-      "port-version": 1
+      "baseline": "2.0.2",
+      "port-version": 0
     },
     "mysql-connector-cpp": {
       "baseline": "9.1.0",

--- a/versions/m-/mypaint-brushes.json
+++ b/versions/m-/mypaint-brushes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40a490771143fca05ae199fa1f1ff6b509768af5",
+      "version": "2.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e8b34f24005a58c820ac3cd0f072344f756940a0",
       "version": "1.3.1",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
