### PR TITLE
[babl,gegl] update to 0.1.118. update to 0.4.66

### DIFF
--- a/ports/babl/portfile.cmake
+++ b/ports/babl/portfile.cmake
@@ -3,19 +3,21 @@ string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.gimp.org/pub/babl/${VERSION_MAJOR_MINOR}/babl-${VERSION}.tar.xz"
     FILENAME "babl-${VERSION}.tar.xz"
-    SHA512 ff410c9839f4fe4d6afd4dec7e4d02af34b1c8a4edbc05483784ed82f91045b1102414fc1c58357866044b7f1ab499eda24fe744f5dd692af5804020c76b2382
+    SHA512 6a361135045566b5a35b7c2df8e9f0a0b1c6e910aa73aafecb621446d333bcbfc50e925ceac675b83b548a872d53eba2c03bcbccb504b47089c737b0ffb53d9d
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+    PATCHES
+        remove-consistency-check.patch
 )
 
 set(feature_options "")
 if("cmyk-icc" IN_LIST FEATURES)
-    list(APPEND feature_options "-Dwith-lcms=true")
+    list(APPEND feature_options "-Dwith-lcms=enabled")
 else()
-    list(APPEND feature_options "-Dwith-lcms=false")
+    list(APPEND feature_options "-Dwith-lcms=disabled")
 endif()
 
 if("introspection" IN_LIST FEATURES)

--- a/ports/babl/remove-consistency-check.patch
+++ b/ports/babl/remove-consistency-check.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 8206d36..095e024 100644
+--- a/meson.build
++++ b/meson.build
+@@ -578,7 +578,7 @@ if build_docs
+ endif
+ subdir('bin')
+ 
+-if not platform_win32 and not platform_osx
++if false
+   # Verify .def files for Windows.
+   # Ironically we only check this on non-Windows platform, since the
+   # script expects .so libraries, and I'm not sure that the `nm` tool is

--- a/ports/babl/vcpkg.json
+++ b/ports/babl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "babl",
-  "version": "0.1.114",
+  "version": "0.1.118",
   "description": "A pixel encoding and color space conversion engine.",
   "homepage": "https://gegl.org/babl/",
   "license": "LGPL-3.0-or-later",

--- a/ports/gegl/portfile.cmake
+++ b/ports/gegl/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS https://download.gimp.org/pub/gegl/${VERSION_MAJOR_MINOR}/gegl-${VERSION}.tar.xz
     FILENAME "gegl-${VERSION}.tar.xz"
-    SHA512 bf4801588abe8b568ae3d1daafa97af28516bbbdd44d2a0798c87412b49301f621db3cf1c7a3ec33f19d96ab4dbd37d80824f04460116a896dd7415aa0d5229d
+    SHA512 ed1f809aaea8768b1eff2a6adcf66b3ef7c11e03d410ef8952051822017f9a6bcee0e29dd32708dd6937d49416c6db55cd8d34458619022ea750311253899ae9
 )
 
 vcpkg_extract_source_archive(
@@ -12,13 +12,21 @@ vcpkg_extract_source_archive(
     PATCHES
         disable_tests.patch
         remove_execinfo_support.patch
+        remove-consistency-check.patch
 )
+
+if("introspection" IN_LIST FEATURES)
+    list(APPEND feature_options "-Dintrospection=true")
+    vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+else()
+    list(APPEND feature_options "-Dintrospection=false")
+endif()
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${feature_options}
         -Ddocs=false
-        -Dintrospection=false
         -Dgdk-pixbuf=disabled
         -Dgexiv2=disabled
         -Dgraphviz=disabled
@@ -45,6 +53,9 @@ vcpkg_configure_meson(
         -Dsdl2=disabled
         -Dumfpack=disabled
         -Dwebp=disabled
+    ADDITIONAL_BINARIES
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
 )
 
 vcpkg_install_meson()

--- a/ports/gegl/remove-consistency-check.patch
+++ b/ports/gegl/remove-consistency-check.patch
@@ -1,0 +1,14 @@
+diff --git a/meson.build b/meson.build
+--- a/meson.build
++++ b/meson.build
+@@ -664,9 +664,9 @@
+ subdir('po')
+ subdir('docs')
+ 
+ 
+-if not os_win32 and not os_osx
++if false
+   # Verify .def files for Windows.
+   # Ironically we only check this on non-Windows platform, since the
+   # script expects .so libraries, and I'm not sure that the `nm` tool is
+   # available on Windows.

--- a/ports/gegl/vcpkg.json
+++ b/ports/gegl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gegl",
-  "version": "0.4.62",
+  "version": "0.4.66",
   "description": "Generic Graphical Library.",
   "homepage": "https://gegl.org/",
   "license": "LGPL-3.0-or-later",
@@ -14,5 +14,20 @@
       "name": "vcpkg-tool-meson",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "introspection": {
+      "description": "Enable introspection",
+      "supports": "!static",
+      "dependencies": [
+        {
+          "name": "babl",
+          "features": [
+            "introspection"
+          ]
+        },
+        "gobject-introspection"
+      ]
+    }
+  }
 }

--- a/versions/b-/babl.json
+++ b/versions/b-/babl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f814a1ccb9b3f9e5e475acdb8c48c87c61d94f77",
+      "version": "0.1.118",
+      "port-version": 0
+    },
+    {
       "git-tree": "cad9c6bb5734a52689427bed4145c2d0d9a80fca",
       "version": "0.1.114",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -613,7 +613,7 @@
       "port-version": 2
     },
     "babl": {
-      "baseline": "0.1.114",
+      "baseline": "0.1.118",
       "port-version": 0
     },
     "backward-cpp": {
@@ -3245,7 +3245,7 @@
       "port-version": 6
     },
     "gegl": {
-      "baseline": "0.4.62",
+      "baseline": "0.4.66",
       "port-version": 0
     },
     "gemmlowp": {

--- a/versions/g-/gegl.json
+++ b/versions/g-/gegl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a18d0d6cd7f4f7ccab7cfd2c4ef5b5cc331f6b9",
+      "version": "0.4.66",
+      "port-version": 0
+    },
+    {
       "git-tree": "9eddf53829c7d2dc14266b4002373790f09946de",
       "version": "0.4.62",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
