### PR TITLE
[gexiv2] add introspection feature

### DIFF
--- a/ports/gexiv2/portfile.cmake
+++ b/ports/gexiv2/portfile.cmake
@@ -15,20 +15,29 @@ vcpkg_extract_source_archive(
         msvc_def.patch
 )
 
+if("introspection" IN_LIST FEATURES)
+    list(APPEND feature_options "-Dintrospection=true")
+    vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+else()
+    list(APPEND feature_options "-Dintrospection=false")
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -Dintrospection=false
+        ${feature_options}
         -Dvapi=false
         -Dgtk_doc=false
         -Dpython3=false
         -Dtests=false
         -Dtools=false
     ADDITIONAL_BINARIES
-        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+        "glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'"
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
 )
 
-vcpkg_install_meson()
+vcpkg_install_meson(ADD_BIN_TO_PATH)
 
 vcpkg_copy_pdbs()
 

--- a/ports/gexiv2/vcpkg.json
+++ b/ports/gexiv2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gexiv2",
   "version": "0.14.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A GObject-based Exiv2 wrapper.",
   "homepage": "https://gitlab.gnome.org/GNOME/gexiv2/",
   "license": "GPL-2.0-or-later",
@@ -16,5 +16,14 @@
       "name": "vcpkg-tool-meson",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "introspection": {
+      "description": "Enable introspection",
+      "supports": "!static & !windows",
+      "dependencies": [
+        "gobject-introspection"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3298,7 +3298,7 @@
     },
     "gexiv2": {
       "baseline": "0.14.3",
-      "port-version": 2
+      "port-version": 3
     },
     "gflags": {
       "baseline": "2.3.0",

--- a/versions/g-/gexiv2.json
+++ b/versions/g-/gexiv2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9678b2c75bb1e3a83eaa9cfe8a0575a1e6a1b1d6",
+      "version": "0.14.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "fef5255b3edb46d8fd8b574720127964141d52f2",
       "version": "0.14.3",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
