### PR TITLE
[qt5-base] Fix macOS SDK version detection

### DIFF
--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -79,7 +79,7 @@ set(PATCHES
     patches/qmake-arm64.patch          # Fix by Oliver Wolff to support ARM64 hosts on Windows
 )
 if(VCPKG_TARGET_IS_OSX)
-    execute_process(COMMAND xcrun --show-sdk-version
+    execute_process(COMMAND xcrun --sdk macosx --show-sdk-version
             OUTPUT_VARIABLE OSX_SDK_VERSION
             OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(${OSX_SDK_VERSION} VERSION_GREATER_EQUAL 26)

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8e81b72172f73e4e8492adbb64ba0d1e96d08baf",
+      "git-tree": "aa733ded6eec8435a809e3548fb2ab897d687180",
       "version": "5.15.18",
       "port-version": 1
     },


### PR DESCRIPTION
Follow-up to #48298

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

For some reason, `xcrun --show-sdk-version` alone doesn't work anymore, but `xcrun --sdk macosx --show-sdk-version` does.