### PR TITLE
[oboe] Update to v1.10

### DIFF
--- a/ports/oboe/portfile.cmake
+++ b/ports/oboe/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/oboe
     REF ${VERSION}
-    SHA512 7eeaf85f9889e03dd1e7f5de0e9f2cee815fc555fddfdb8c4d3450d67f6ae11b0ca43b63c73e869bfc4629d2f8e5bdb23a5833c665ca5226c339f74b9b34a8ad
+    SHA512 ce4011afe7345370d4ead3b891cd69a5ef224b129535783586c0ca75051d303ed446e6c7f10bde8da31fff58d6e307f1732a3ffd03b249f9ef1fd48fd4132715
     HEAD_REF master
     PATCHES
         fix_install.patch

--- a/ports/oboe/vcpkg.json
+++ b/ports/oboe/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "oboe",
-  "version": "1.8.0",
+  "version": "1.10.0",
   "description": "Oboe is a C++ library which makes it easy to build high-performance audio apps on Android",
   "homepage": "https://developer.android.com/games/sdk/oboe",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7053,7 +7053,7 @@
       "port-version": 2
     },
     "oboe": {
-      "baseline": "1.8.0",
+      "baseline": "1.10.0",
       "port-version": 0
     },
     "observer-ptr-lite": {

--- a/versions/o-/oboe.json
+++ b/versions/o-/oboe.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f26abf2b477baa0acc15beb97c673baa5a49cbb7",
+      "version": "1.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "844ba873a3df24fb50fcb6fc5deef22642dfccb1",
       "version": "1.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.