### PR TITLE
[aom] Fix building with 3.x NASM

### DIFF
--- a/ports/aom/aom-fix-nasm.diff
+++ b/ports/aom/aom-fix-nasm.diff
@@ -1,0 +1,22 @@
+diff --git a/build/cmake/aom_optimization.cmake b/build/cmake/aom_optimization.cmake
+index 9cc34de..2750a0b 100644
+--- a/build/cmake/aom_optimization.cmake
++++ b/build/cmake/aom_optimization.cmake
+@@ -212,7 +212,7 @@
+ # Currently checks only for presence of required object formats and support for
+ # the -Ox argument (multipass optimization).
+ function(test_nasm)
+-  execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -hf
++  execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -hO
+                   OUTPUT_VARIABLE nasm_helptext)
+ 
+   if(NOT "${nasm_helptext}" MATCHES "-Ox")
+@@ -220,6 +220,8 @@
+       FATAL_ERROR "Unsupported nasm: multipass optimization not supported.")
+   endif()
+ 
++  execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -hf
++                  OUTPUT_VARIABLE nasm_helptext)
+   if("${AOM_TARGET_CPU}" STREQUAL "x86")
+     if("${AOM_TARGET_SYSTEM}" STREQUAL "Darwin")
+       if(NOT "${nasm_helptext}" MATCHES "macho32")

--- a/ports/aom/portfile.cmake
+++ b/ports/aom/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_git(
     PATCHES
         aom-rename-static.diff
         aom-uninitialized-pointer.diff
+        aom-fix-nasm.diff # TODO: remove this patch after the next release
 )
 
 vcpkg_find_acquire_program(NASM)

--- a/ports/aom/vcpkg.json
+++ b/ports/aom/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "aom",
   "version-semver": "3.13.1",
+  "port-version": 1,
   "description": "AV1 codec library",
   "homepage": "https://aomedia.googlesource.com/aom",
   "license": "BSD-2-Clause",

--- a/versions/a-/aom.json
+++ b/versions/a-/aom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26fd05f1c9967caa611538c4e2f11edb8303288f",
+      "version-semver": "3.13.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "86c7b66df4a104a0d19e5208d9bc591d24f44d7c",
       "version-semver": "3.13.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -166,7 +166,7 @@
     },
     "aom": {
       "baseline": "3.13.1",
-      "port-version": 0
+      "port-version": 1
     },
     "apache-datasketches": {
       "baseline": "5.1.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


Newer NASM versions have a different help text format which caused `test_nasm` to fail on x86 builds, which results in the build failing.

This fix is cherry-picked from upstream on master (https://aomedia-review.googlesource.com/c/aom/+/203481), but there's no new release tagged with the fix in yet, hence the need for the patch.

This should fix the issues with https://github.com/microsoft/vcpkg/pull/47629
