### PR TITLE
[spirv-cross] fix lib name in debug pkgconfig file

### DIFF
--- a/ports/spirv-cross/portfile.cmake
+++ b/ports/spirv-cross/portfile.cmake
@@ -25,7 +25,7 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+if(NOT VCPKG_BUILD_TYPE)
     if(VCPKG_TARGET_IS_WINDOWS)
         vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/spirv-cross-c.pc" "-lspirv-cross-c" "-lspirv-cross-cd")
     endif()

--- a/ports/spirv-cross/portfile.cmake
+++ b/ports/spirv-cross/portfile.cmake
@@ -25,6 +25,12 @@ vcpkg_cmake_configure(
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    if(VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/spirv-cross-c.pc" "-lspirv-cross-c" "-lspirv-cross-cd")
+    endif()
+    file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/spirv-cross-c.pc" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+endif()
 vcpkg_fixup_pkgconfig()
 
 foreach(COMPONENT core c cpp glsl hlsl msl reflect util)

--- a/ports/spirv-cross/vcpkg.json
+++ b/ports/spirv-cross/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "spirv-cross",
   "version": "1.4.328.0",
+  "port-version": 1,
   "description": "SPIRV-Cross is a practical tool and library for performing reflection on SPIR-V and disassembling SPIR-V back to high level languages.",
   "homepage": "https://github.com/KhronosGroup/SPIRV-Cross",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9314,7 +9314,7 @@
     },
     "spirv-cross": {
       "baseline": "1.4.328.0",
-      "port-version": 0
+      "port-version": 1
     },
     "spirv-headers": {
       "baseline": "1.4.328.0",

--- a/versions/s-/spirv-cross.json
+++ b/versions/s-/spirv-cross.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9bd4f8e8c67d1247df516be3244fe8a9f53ed229",
+      "git-tree": "eebb295972969b1d22708cb78088846bc204a9ba",
       "version": "1.4.328.0",
       "port-version": 1
     },

--- a/versions/s-/spirv-cross.json
+++ b/versions/s-/spirv-cross.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9bd4f8e8c67d1247df516be3244fe8a9f53ed229",
+      "version": "1.4.328.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5629c9d940b2cd523ed81ad587e6c8bb3e5609b4",
       "version": "1.4.328.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

This fixes linking against spirv-cross with the debug profile when pkgconfig is used; the debug name of the library has a `d` suffix, and the pkgconfig file did not reflect that.