### PR TITLE
[libplacebo] Add libplacebo port

### DIFF
--- a/ports/libplacebo/fix-glslang-spirv.patch
+++ b/ports/libplacebo/fix-glslang-spirv.patch
@@ -1,0 +1,57 @@
+diff --git a/src/glsl/meson.build b/src/glsl/meson.build
+index b1f4c8d0..f2789264 100644
+--- a/src/glsl/meson.build
++++ b/src/glsl/meson.build
+@@ -29,8 +29,16 @@ if glslang_req.auto() and shaderc.found()
+ 
+ elif not glslang_req.disabled()
+ 
++  lib_dirs = ''
++  cmake_prefix_path = get_option('cmake_prefix_path')
++  if cmake_prefix_path.length() > 0
++    lib_dirs = cmake_prefix_path[0] / 'lib'
++  else
++    error('cmake_prefix_path is empty')
++  endif
++
+   glslang_deps = [
+-    cxx.find_library('glslang-default-resource-limits', required: false)
++    cxx.find_library('glslang-default-resource-limits', required: false, dirs: lib_dirs)
+   ]
+ 
+   # meson doesn't respect generator expressions in INTERFACE_LINK_LIBRARIES
+@@ -44,7 +52,7 @@ elif not glslang_req.disabled()
+     static   = arg[0]
+     required = arg[1]
+ 
+-    spirv = cxx.find_library('SPIRV', required: required, static: static)
++    spirv = cxx.find_library('SPIRV', required: false, static: static, dirs: lib_dirs)
+ 
+     if not spirv.found()
+       continue
+@@ -54,18 +62,18 @@ elif not glslang_req.disabled()
+ 
+     # Glslang 15.0.0 moved some code around, add also linking to glslang, while
+     # this is not needed for older versions, it will still work.
+-    glslang_deps += cxx.find_library('glslang', required: required, static: static)
++    glslang_deps += cxx.find_library('glslang', required: required, static: static, dirs: lib_dirs)
+ 
+     if static
+       glslang_deps += [
+         # Always required for static linking
+-        cxx.find_library('MachineIndependent', required: false, static: true),
+-        cxx.find_library('OSDependent',        required: false, static: true),
+-        cxx.find_library('OGLCompiler',        required: false, static: true),
+-        cxx.find_library('GenericCodeGen',     required: false, static: true),
++        cxx.find_library('MachineIndependent', required: false, static: true, dirs: lib_dirs),
++        cxx.find_library('OSDependent',        required: false, static: true, dirs: lib_dirs),
++        cxx.find_library('OGLCompiler',        required: false, static: true, dirs: lib_dirs),
++        cxx.find_library('GenericCodeGen',     required: false, static: true, dirs: lib_dirs),
+         # SPIRV-Tools are required only if optimizer is enabled in glslang build
+-        cxx.find_library('SPIRV-Tools',        required: false, static: true),
+-        cxx.find_library('SPIRV-Tools-opt',    required: false, static: true),
++        cxx.find_library('SPIRV-Tools',        required: false, static: true, dirs: lib_dirs),
++        cxx.find_library('SPIRV-Tools-opt',    required: false, static: true, dirs: lib_dirs),
+       ]
+     endif
+ 

--- a/ports/libplacebo/fix-pkgconfig-cxx.patch
+++ b/ports/libplacebo/fix-pkgconfig-cxx.patch
@@ -1,0 +1,12 @@
+diff --git a/src/meson.build b/src/meson.build
+index ea5d9b4c..42b77c7d 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -294,6 +294,7 @@ pkg.generate(
+   version: version,
+   variables: pc_vars,
+   extra_cflags: extra_cflags,
++  libraries_private: meson.get_external_property('extra_libs', []),
+ )
+ 
+ 

--- a/ports/libplacebo/fix-python-3.14.patch
+++ b/ports/libplacebo/fix-python-3.14.patch
@@ -1,0 +1,14 @@
+diff --git a/src/vulkan/utils_gen.py b/src/vulkan/utils_gen.py
+index 9a97d35f..9b803d82 100644
+--- a/src/vulkan/utils_gen.py
++++ b/src/vulkan/utils_gen.py
+@@ -202,7 +202,8 @@ if __name__ == '__main__':
+     if not xmlfile or xmlfile == '':
+         xmlfile = find_registry_xml(datadir)
+ 
+-    registry = VkXML(ET.parse(xmlfile))
++    tree = ET.parse(xmlfile)
++    registry = VkXML(tree.getroot())
+     with open(outfile, 'w') as f:
+         f.write(TEMPLATE.render(
+             vkresults = get_vkenum(registry, 'VkResult'),

--- a/ports/libplacebo/fix-spirv-cross.patch
+++ b/ports/libplacebo/fix-spirv-cross.patch
@@ -1,0 +1,28 @@
+diff --git a/src/d3d11/meson.build b/src/d3d11/meson.build
+index d4c4b441..ee59a522 100644
+--- a/src/d3d11/meson.build
++++ b/src/d3d11/meson.build
+@@ -4,8 +4,19 @@ d3d11_headers_extra = [ # needed internally
+   cc.check_header('d3d11_4.h', required: d3d11),
+   cc.check_header('dxgi1_6.h', required: d3d11),
+ ]
++is_win_debug = get_option('debug') and host_machine.system() == 'windows'
++dirs = get_option('cmake_prefix_path')[0] / 'lib'
+ d3d11_deps = [
+-  dependency('spirv-cross-c-shared', version: '>=0.29.0', required: d3d11),
++  dependency('spirv-cross-c', version: '>=0.29.0', required: d3d11),
++  cc.find_library(is_win_debug ? 'spirv-cross-cored' : 'spirv-cross-core', required: d3d11, dirs: dirs),
++  cc.find_library(is_win_debug ? 'spirv-cross-glsld' : 'spirv-cross-glsl', required: d3d11, dirs: dirs),
++  cc.find_library(is_win_debug ? 'spirv-cross-hlsld' : 'spirv-cross-hlsl', required: d3d11, dirs: dirs),
++  cc.find_library(is_win_debug ? 'spirv-cross-msld' : 'spirv-cross-msl', required: d3d11, dirs: dirs),
++  cc.find_library(is_win_debug ? 'spirv-cross-reflectd' : 'spirv-cross-reflect', required: d3d11, dirs: dirs),
++  cc.find_library(is_win_debug ? 'spirv-cross-utild' : 'spirv-cross-util', required: d3d11, dirs: dirs),
++  cc.find_library(is_win_debug ? 'spirv-cross-cppd' : 'spirv-cross-cpp', required: d3d11, dirs: dirs),
+-  cc.find_library('version', required: d3d11),
+ ]
++if not meson.get_external_property('no_static_windows_libs', false)
++  d3d11_deps += cc.find_library('version', required: d3d11)
++endif
+ 
+ d3d11 = d3d11.require(d3d11_header)
+ foreach h : d3d11_headers_extra

--- a/ports/libplacebo/fix-vulkan.patch
+++ b/ports/libplacebo/fix-vulkan.patch
@@ -1,0 +1,14 @@
+diff --git a/src/vulkan/meson.build b/src/vulkan/meson.build
+index d22883ce..6279da5f 100644
+--- a/src/vulkan/meson.build
++++ b/src/vulkan/meson.build
+@@ -1,7 +1,8 @@
+ vulkan_build = get_option('vulkan')
+ vulkan_link = get_option('vk-proc-addr')
+ vulkan_loader = dependency('vulkan', required: false)
+-vulkan_headers = vulkan_loader.partial_dependency(includes: true, compile_args: true)
++vulkan_headers_inc = meson.get_external_property('vulkan_headers_inc', [])
++vulkan_headers = declare_dependency(include_directories: vulkan_headers_inc)
+ registry_xml = get_option('vulkan-registry')
+ 
+ # Prefer our Vulkan headers for portability

--- a/ports/libplacebo/fix-vulkan.patch
+++ b/ports/libplacebo/fix-vulkan.patch
@@ -17,6 +17,6 @@ index d22883ce..52e47b2c 100644
      tests += 'vulkan.c'
    endif
 -else
-+elif vulkan_headers.found()
++elif false
    sources += 'vulkan/stubs.c'
  endif

--- a/ports/libplacebo/fix-vulkan.patch
+++ b/ports/libplacebo/fix-vulkan.patch
@@ -1,5 +1,5 @@
 diff --git a/src/vulkan/meson.build b/src/vulkan/meson.build
-index d22883ce..6279da5f 100644
+index d22883ce..52e47b2c 100644
 --- a/src/vulkan/meson.build
 +++ b/src/vulkan/meson.build
 @@ -1,7 +1,8 @@
@@ -12,3 +12,11 @@ index d22883ce..6279da5f 100644
  registry_xml = get_option('vulkan-registry')
  
  # Prefer our Vulkan headers for portability
+@@ -52,6 +53,6 @@ if vulkan_build.allowed()
+     build_deps += vulkan_loader
+     tests += 'vulkan.c'
+   endif
+-else
++elif vulkan_headers.found()
+   sources += 'vulkan/stubs.c'
+ endif

--- a/ports/libplacebo/fix-win-shlwapi.patch
+++ b/ports/libplacebo/fix-win-shlwapi.patch
@@ -1,0 +1,13 @@
+diff --git a/src/meson.build b/src/meson.build
+index ea5d9b4c..a9f0b4a2 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -7,7 +7,7 @@ conf_internal.set('PL_HAVE_DBGHELP', dbghelp)
+ conf_internal.set('PL_HAVE_UNWIND', unwind.found())
+ conf_internal.set('PL_HAVE_EXECINFO', has_execinfo)
+ if dbghelp
+-  build_deps += cc.find_library('shlwapi', required: true)
++  build_deps += cc.find_library('shlwapi', required: not meson.get_external_property('no_static_windows_libs', false))
+ elif unwind.found()
+   build_deps += [unwind, cc.find_library('dl', required : false)]
+ elif has_execinfo

--- a/ports/libplacebo/portfile.cmake
+++ b/ports/libplacebo/portfile.cmake
@@ -1,0 +1,205 @@
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL https://code.videolan.org/videolan/libplacebo.git
+    REF 3188549fba13bbdf3a5a98de2a38c2e71f04e21e
+    HEAD_REF master
+    PATCHES
+        "${CMAKE_CURRENT_LIST_DIR}/fix-glslang-spirv.patch"
+        "${CMAKE_CURRENT_LIST_DIR}/fix-pkgconfig-cxx.patch"
+        "${CMAKE_CURRENT_LIST_DIR}/fix-python-3.14.patch" # cherry picked from upstream, remove in next version update
+        "${CMAKE_CURRENT_LIST_DIR}/fix-spirv-cross.patch"
+        "${CMAKE_CURRENT_LIST_DIR}/fix-vulkan.patch"
+        "${CMAKE_CURRENT_LIST_DIR}/fix-win-shlwapi.patch"
+)
+
+set (JINJA_VERSION "3.1.6")
+set (MARKUPSAFE_VERSION "3.0.2")
+set (GLAD2_VERSION "2.0.8")
+
+# Find python3 for meson
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
+vcpkg_add_to_path("${PYTHON3_DIR}")
+
+x_vcpkg_get_python_packages(OUT_PYTHON_VAR PYTHON3 PYTHON_VERSION "3" PACKAGES jinja2==${JINJA_VERSION} markupsafe==${MARKUPSAFE_VERSION} glad2==${GLAD2_VERSION})
+
+# Build meson options list
+set(MESON_OPTIONS
+    -Ddemos=false
+    -Dtests=false
+    -Dbench=false
+    -Dfuzz=false
+    -Ddebug-abort=false
+    -Dvk-proc-addr=disabled
+)
+
+# Set prefer_static when building static libraries to help Meson find static libs
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND MESON_OPTIONS -Dprefer_static=true)
+endif()
+
+# Handle optional features (Meson uses 'enabled', 'disabled', or 'auto')
+if("vulkan" IN_LIST FEATURES)
+    list(APPEND MESON_OPTIONS -Dvulkan=enabled)
+    # Point to vcpkg-installed Vulkan registry
+    set(VULKAN_REGISTRY "${CURRENT_INSTALLED_DIR}/share/vulkan/registry/vk.xml")
+    # check if the file exists
+    message(STATUS "Checking if Vulkan registry exists at ${VULKAN_REGISTRY}")
+    if(EXISTS "${VULKAN_REGISTRY}")
+        list(APPEND MESON_OPTIONS -Dvulkan-registry=${VULKAN_REGISTRY})
+    else()
+        message(FATAL_ERROR "Vulkan registry not found at ${VULKAN_REGISTRY}")
+    endif()
+else()
+    list(APPEND MESON_OPTIONS -Dvulkan=disabled)
+endif()
+
+if("opengl" IN_LIST FEATURES)
+    list(APPEND MESON_OPTIONS -Dopengl=enabled)
+else()
+    list(APPEND MESON_OPTIONS -Dopengl=disabled)
+endif()
+
+if("d3d11" IN_LIST FEATURES)
+    list(APPEND MESON_OPTIONS -Dd3d11=enabled)
+else()
+    list(APPEND MESON_OPTIONS -Dd3d11=disabled)
+endif()
+
+if("glslang" IN_LIST FEATURES)
+    list(APPEND MESON_OPTIONS -Dglslang=enabled)
+else()
+    list(APPEND MESON_OPTIONS -Dglslang=disabled)
+endif()
+
+if("shaderc" IN_LIST FEATURES)
+    list(APPEND MESON_OPTIONS -Dshaderc=enabled)
+else()
+    list(APPEND MESON_OPTIONS -Dshaderc=disabled)
+endif()
+
+if("lcms" IN_LIST FEATURES)
+    list(APPEND MESON_OPTIONS -Dlcms=enabled)
+else()
+    list(APPEND MESON_OPTIONS -Dlcms=disabled)
+endif()
+
+if("xxhash" IN_LIST FEATURES)
+    list(APPEND MESON_OPTIONS -Dxxhash=enabled)
+else()
+    list(APPEND MESON_OPTIONS -Dxxhash=disabled)
+endif()
+
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+set(cxx_link_libraries "")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    block(PROPAGATE cxx_link_libraries)
+        list(REMOVE_ITEM VCPKG_DETECTED_CMAKE_CXX_IMPLICIT_LINK_LIBRARIES ${VCPKG_DETECTED_CMAKE_C_IMPLICIT_LINK_LIBRARIES})
+        list(TRANSFORM VCPKG_DETECTED_CMAKE_CXX_IMPLICIT_LINK_LIBRARIES REPLACE "^([^/]+)\$" "'-l\\1'")
+        string(JOIN ", " cxx_link_libraries ${VCPKG_DETECTED_CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
+    endblock()
+endif()
+set(extra_libs "[ ${cxx_link_libraries} ]")
+
+set(NO_STATIC_WINDOWS_LIBS false)
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    # Searching for windows libraries when `prefer_static` is enabled is broken in Meson when using clang-cl, 
+    # so we need to disable finding them and add them manually to the pkgconfig file
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        set(NO_STATIC_WINDOWS_LIBS true)
+    endif()
+
+    # libplacebo is not compatible with MSVC, use clang-cl
+    if(VCPKG_DETECTED_CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+        vcpkg_find_acquire_program(CLANG)
+        cmake_path(GET CLANG PARENT_PATH CLANG_PARENT_PATH)
+        set(CLANG_CL "${CLANG_PARENT_PATH}/clang-cl.exe")
+        set(LLD_LINK "${CLANG_PARENT_PATH}/lld-link.exe")
+        set(compiler_flags "")
+        set(linker_flags "")
+        if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+            string(APPEND compiler_flags " --target=i686-pc-windows-msvc -m32")
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+            string(APPEND compiler_flags " --target=x86_64-pc-windows-msvc")
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+            string(APPEND compiler_flags " --target=arm-pc-windows-msvc")
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+            string(APPEND compiler_flags " --target=arm64-pc-windows-msvc")
+        endif()
+        file(READ "${cmake_vars_file}" contents)
+        string(APPEND contents "\nset(VCPKG_DETECTED_CMAKE_C_COMPILER \"${CLANG_CL}\")")
+        string(APPEND contents "\nset(VCPKG_DETECTED_CMAKE_CXX_COMPILER \"${CLANG_CL}\")")
+        string(APPEND contents "\nset(VCPKG_DETECTED_CMAKE_LINKER \"${LLD_LINK}\")")
+        string(APPEND contents "\nset(VCPKG_DETECTED_CMAKE_C_FLAGS \"${VCPKG_DETECTED_CMAKE_C_FLAGS} ${compiler_flags}\")")
+        string(APPEND contents "\nset(VCPKG_DETECTED_CMAKE_CXX_FLAGS \"${VCPKG_DETECTED_CMAKE_CXX_FLAGS} ${compiler_flags}\")")
+        string(APPEND contents "\nset(VCPKG_COMBINED_C_FLAGS_DEBUG \"${VCPKG_COMBINED_C_FLAGS_DEBUG} ${compiler_flags}\")")
+        string(APPEND contents "\nset(VCPKG_COMBINED_C_FLAGS_RELEASE \"${VCPKG_COMBINED_C_FLAGS_RELEASE} ${compiler_flags}\")")
+        string(APPEND contents "\nset(VCPKG_COMBINED_CXX_FLAGS_DEBUG \"${VCPKG_COMBINED_CXX_FLAGS_DEBUG} ${compiler_flags}\")")
+        string(APPEND contents "\nset(VCPKG_COMBINED_CXX_FLAGS_RELEASE \"${VCPKG_COMBINED_CXX_FLAGS_RELEASE} ${compiler_flags}\")")
+        file(WRITE "${cmake_vars_file}" "${contents}")
+    endif()
+    set(cmake_vars_file "${cmake_vars_file}" CACHE INTERNAL "") # Don't run z_vcpkg_get_cmake_vars twice
+endif()
+
+
+
+# Set up meson
+vcpkg_configure_meson(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS ${MESON_OPTIONS}
+    ADDITIONAL_PROPERTIES
+        "vulkan_headers_inc = '${CURRENT_INSTALLED_DIR}/include'\nextra_libs = ${extra_libs}\nno_static_windows_libs = ${NO_STATIC_WINDOWS_LIBS}"
+)
+
+# Meson and/or Ninja is spuriously adding /MACHINE:arm to the ar flags in an non-configurable way, so we have to remove it manually
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64" AND VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/build.ninja" "/MACHINE:arm " "")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/build.ninja" "/MACHINE:arm " "")
+    endif()
+endif()
+
+vcpkg_install_meson()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    set(pkgconfig_file "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/meson-private/libplacebo.pc")
+    if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+        if(NO_STATIC_WINDOWS_LIBS)
+            if("d3d11" IN_LIST FEATURES)
+                vcpkg_replace_string("${pkgconfig_file}" "spirv-cross-cpp.lib" "spirv-cross-cpp.lib -lversion")
+            endif()
+            vcpkg_replace_string("${pkgconfig_file}" "Libs: " "Libs: -lshlwapi ")
+        else()
+            vcpkg_replace_string("${pkgconfig_file}" "-lplacebo" "-llibplacebo")
+        endif()
+    endif()
+    file(COPY "${pkgconfig_file}" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+endif()
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    set(pkgconfig_file "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/meson-private/libplacebo.pc")
+    if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+        if(NO_STATIC_WINDOWS_LIBS)
+            if("d3d11" IN_LIST FEATURES)
+                vcpkg_replace_string("${pkgconfig_file}" "spirv-cross-cppd.lib" "spirv-cross-cppd.lib -lversion")
+            endif()
+            vcpkg_replace_string("${pkgconfig_file}" "Libs: " "Libs: -lshlwapi ")
+        else()
+            vcpkg_replace_string("${pkgconfig_file}" "-lplacebo" "-llibplacebo")
+        endif()
+    endif()
+    file(COPY "${pkgconfig_file}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+endif()
+
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+# Remove debug files
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/LICENSE)
+

--- a/ports/libplacebo/vcpkg.json
+++ b/ports/libplacebo/vcpkg.json
@@ -1,0 +1,93 @@
+{
+  "name": "libplacebo",
+  "version": "7.351.0",
+  "description": "A library of GPU-accelerated image/video processing primitives",
+  "homepage": "https://code.videolan.org/videolan/libplacebo",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!uwp",
+  "dependencies": [
+    "fast-float",
+    {
+      "name": "python3",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
+    {
+      "name": "vcpkg-get-python-packages",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "d3d11",
+      "platform": "windows | uwp | xbox"
+    },
+    "lcms",
+    {
+      "name": "opengl",
+      "platform": "!uwp & !xbox"
+    },
+    "shaderc",
+    {
+      "name": "vulkan",
+      "platform": "!uwp & !xbox"
+    },
+    "xxhash"
+  ],
+  "features": {
+    "d3d11": {
+      "description": "Direct3D 11 based renderer",
+      "supports": "windows | uwp | xbox",
+      "dependencies": [
+        "spirv-cross"
+      ]
+    },
+    "glslang": {
+      "description": "glslang SPIR-V compiler",
+      "dependencies": [
+        "glslang",
+        "spirv-cross",
+        "spirv-tools"
+      ]
+    },
+    "lcms": {
+      "description": "LittleCMS 2 support",
+      "dependencies": [
+        "lcms"
+      ]
+    },
+    "opengl": {
+      "description": "OpenGL-based renderer",
+      "supports": "!uwp & !xbox",
+      "dependencies": [
+        "glad"
+      ]
+    },
+    "shaderc": {
+      "description": "libshaderc SPIR-V compiler",
+      "dependencies": [
+        "shaderc"
+      ]
+    },
+    "vulkan": {
+      "description": "Vulkan-based renderer",
+      "supports": "!uwp & !xbox",
+      "dependencies": [
+        "vulkan-headers"
+      ]
+    },
+    "xxhash": {
+      "description": "Use libxxhash as a faster replacement for internal siphash",
+      "dependencies": [
+        "xxhash"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5336,6 +5336,10 @@
       "baseline": "9.0.23",
       "port-version": 0
     },
+    "libplacebo": {
+      "baseline": "7.351.0",
+      "port-version": 0
+    },
     "libplist": {
       "baseline": "2.7.0",
       "port-version": 0

--- a/versions/l-/libplacebo.json
+++ b/versions/l-/libplacebo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "12437fd7d5cbae7d15477ae67ff620b5b821a771",
+      "git-tree": "45cface309427df8839611af19be6a08e1fe9ef9",
       "version": "7.351.0",
       "port-version": 0
     },

--- a/versions/l-/libplacebo.json
+++ b/versions/l-/libplacebo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c41393f7917cea4ebc4630ae926477b3fd32ca62",
+      "git-tree": "12437fd7d5cbae7d15477ae67ff620b5b821a771",
       "version": "7.351.0",
       "port-version": 0
     },

--- a/versions/l-/libplacebo.json
+++ b/versions/l-/libplacebo.json
@@ -1,0 +1,14 @@
+{
+  "versions": [
+    {
+      "git-tree": "c41393f7917cea4ebc4630ae926477b3fd32ca62",
+      "version": "7.351.0",
+      "port-version": 0
+    },
+    {
+      "git-tree": "483012fabe2dac491ba10898ee3177205eeb39df",
+      "version": "7.358.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Depends on #48995

Adds a port for `libplacebo`.

I am not sure which default features make sense for this; the build files in upstream state:
```
if not (components.get('vulkan') or components.get('opengl') or components.get('d3d11'))
  warning('Building without any graphics API. libplacebo built this way still ' +
          'has some limited use (e.g. generating GLSL shaders), but most of ' +
          'its functionality will be missing or impaired!')
endif

has_spirv = components.get('shaderc') or components.get('glslang')
needs_spirv = components.get('vulkan') or components.get('d3d11')
if needs_spirv and not has_spirv
  warning('Building without any GLSL compiler (shaderc, glslang), but with ' +
          'APIs required that require one (vulkan, d3d11). This build is very ' +
          'likely to be very limited in functionality!')
endif
```

So we need at least one renderer backend for this port to be any use at all, and the shader compiler dependencies are required for the renderer backends. I would appreciate advice on this.