### PR TITLE
[faiss] update to 1.13.2

### DIFF
--- a/ports/faiss/portfile.cmake
+++ b/ports/faiss/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebookresearch/faiss
     REF "v${VERSION}"
-    SHA512 1a04ec120aee8f1111a2224d4cccfe59e0108a90c35cfa38dfc53fd75a433ea557f8adf56b3aab09d04c7332cf033d87bc77b8c806421b061a5fde847c7c357c
+    SHA512 64d333e3cf561a65a9dcb78bb04f76073047b1149ce4778e4d65aa809928bedbd43b2b0a3362e8336664feae3d09167702ef68abddce3c86bc70cdb9551bc65c
     HEAD_REF master
     PATCHES
         msvc-template.diff

--- a/ports/faiss/vcpkg.json
+++ b/ports/faiss/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "faiss",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Faiss is a library for efficient similarity search and clustering of dense vectors.",
   "homepage": "https://faiss.ai/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2829,7 +2829,7 @@
       "port-version": 3
     },
     "faiss": {
-      "baseline": "1.13.1",
+      "baseline": "1.13.2",
       "port-version": 0
     },
     "fakeit": {

--- a/versions/f-/faiss.json
+++ b/versions/f-/faiss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cd4f990f998d5f43b86ecf274102ec0c9f15353d",
+      "version": "1.13.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "87bcb7a78e0d37a6396ae1eb64ab5078df439c44",
       "version": "1.13.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/facebookresearch/faiss/releases/tag/v1.13.2
