### PR TITLE
[daw-header-libraries] update to 2.132.1

### DIFF
--- a/ports/daw-header-libraries/portfile.cmake
+++ b/ports/daw-header-libraries/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beached/header_libraries
     REF "v${VERSION}"
-    SHA512 e051626a3239288b3f2b8c9dfbb310eaa641e73dd2f995554798985a3ac48aaf93dedbf89481009f9cafe21a0d684b0eaa406dfdfa61fd8909c7afa9b6d0174d
+    SHA512 0c75ae477c4e971d479ecdd9891028053e278211b75ce71ed808165e522520acfd863cc96c1bce5c5c0570766f760b7456c5840cd383bd12f16cffff2ed09de0
     HEAD_REF master
 )
 

--- a/ports/daw-header-libraries/vcpkg.json
+++ b/ports/daw-header-libraries/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "daw-header-libraries",
-  "version": "2.131.0",
+  "version": "2.132.1",
   "description": "Set of header-only algorithms used in daw-utf8-range and daw-json-link.",
   "homepage": "https://github.com/beached/header_libraries",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2357,7 +2357,7 @@
       "port-version": 1
     },
     "daw-header-libraries": {
-      "baseline": "2.131.0",
+      "baseline": "2.132.1",
       "port-version": 0
     },
     "daw-json-link": {

--- a/versions/d-/daw-header-libraries.json
+++ b/versions/d-/daw-header-libraries.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cfe668913cf69e39fc65e3ea7398fe61803bd9e3",
+      "version": "2.132.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "978c302c230e301744f53c5717e8cb2b294549e8",
       "version": "2.131.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/beached/header_libraries/releases/tag/v2.132.1
https://github.com/beached/header_libraries/releases/tag/v2.132.0
