### PR TITLE
[slick-queue] Update to 1.2.0

### DIFF
--- a/ports/slick-queue/portfile.cmake
+++ b/ports/slick-queue/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick_queue
     REF "v${VERSION}"
-    SHA512 52254f1e271e39ccaa9ca52bad7c53c261ee271803ed89e718798d93f9c78d8303eb3916f88933191595ed278b540d24afe351c5a55ee1f09cbdf09631c32dd3
+    SHA512 20a8d01776a01f54d6f6c2439bb7dbdde691a7e7fe46d3d739e31f2cedd78670d8e98af0bdc5edbb47d91fb2f4feb3cbb3b602df96804b94efa2a0d6ce8dea6e 
     HEAD_REF main
 )
 

--- a/ports/slick-queue/portfile.cmake
+++ b/ports/slick-queue/portfile.cmake
@@ -24,3 +24,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib
 
 # Install license
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/slick-queue/usage
+++ b/ports/slick-queue/usage
@@ -1,0 +1,4 @@
+slick-queue is header-only and can be used from CMake via:
+
+    find_package(slick_queue CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE slick::slick_queue)

--- a/ports/slick-queue/vcpkg.json
+++ b/ports/slick-queue/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-queue",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A C++ Lock-Free MPMC queue - header-only library for high throughput concurrent messaging with optional shared memory support",
   "homepage": "https://github.com/SlickQuant/slick_queue",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9153,7 +9153,7 @@
       "port-version": 0
     },
     "slick-queue": {
-      "baseline": "1.1.2",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "slikenet": {

--- a/versions/s-/slick-queue.json
+++ b/versions/s-/slick-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5aad36a62f233d0966958dd31ee54566f0c37574",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a71580caa0ade9054b2f21cf6892bb3352229383",
       "version": "1.1.2",
       "port-version": 0

--- a/versions/s-/slick-queue.json
+++ b/versions/s-/slick-queue.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5aad36a62f233d0966958dd31ee54566f0c37574",
+      "git-tree": "9b1b93882c14f49591a1f0bef1de74f9c62bada0",
       "version": "1.2.0",
       "port-version": 0
     },


### PR DESCRIPTION
### Description
Update slick-queue to version 1.2.0

### Changes
- Update version to 1.2.0
- Update REF to v1.2.0
- Update SHA512 hash

### Release Notes (v1.2.0)
- Refactored `reserved_info` to packed uint64_t for guaranteed lock-free atomics
- Added `HEADER_SIZE` constant for shared memory layout
- Added element size validation in shared memory
- Updated documentation with vcpkg installation and lock-free implementation details

### Testing
- [x] Built on Windows x64
- [x] Built on Linux x64
- [x] Built on macOS
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
