### PR TITLE
[rebind] Update to 5.3.1

### DIFF
--- a/ports/rebind/portfile.cmake
+++ b/ports/rebind/portfile.cmake
@@ -2,12 +2,25 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Curve/rebind
     REF "v${VERSION}"
-    SHA512 8c310eba61a65268fb9820aab0529d04900d1e95544e4fbc6c70a004e4cf64152ab8e2b636d6bd5ad16a381dcbad03f303d176848aedd6e3b29e3037371cf624
+    SHA512 3b0fba09f8bd6257c055a6619094646c70e90fbb55967165dd94eb1914c1477443a86e5745c08a4dd722656ab124fffcbaabbd9d2b8ec82be30d741799eff93d
     HEAD_REF master
+    PATCHES
+        remove-cpm.patch # Note: Removed also the ALIAS library as packageProject creates it
 )
 
-vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+# Replace CPM and download PackageProject directly to avoid issues with FETCHCONTENT_FULLY_DISCONNECTED
+vcpkg_from_github(
+    OUT_SOURCE_PATH PACKAGE_PROJECT_PATH
+    REPO TheLartians/PackageProject.cmake
+    REF "v1.13.0"
+    SHA512 3cf0523bddc213f206ed0ca57803550cb7db9e293392d3741138be47f49d9027ef517e1656235a349a62b492d35c3fc677714dc00afe59e2d36144a9689cfa8f
+    HEAD_REF master
+)
+file(RENAME "${PACKAGE_PROJECT_PATH}" "${SOURCE_PATH}/cmake/packageproject.cmake")
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/cmake/${PORT}-${VERSION}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rebind/remove-cpm.patch
+++ b/ports/rebind/remove-cpm.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 52e60bd..6f9eb7e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,6 @@ option(rebind_tests "Run tests" OFF)
+ # --------------------------------------------------------------------------------------------------------
+ 
+ add_library(${PROJECT_NAME} INTERFACE)
+-add_library(cr::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+ 
+ target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_23)
+ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 23 CXX_EXTENSIONS OFF CXX_STANDARD_REQUIRED ON)
+@@ -39,13 +38,7 @@ endif()
+ # Install Targets
+ # --------------------------------------------------------------------------------------------------------
+ 
+-include("cmake/cpm.cmake")
+-
+-CPMFindPackage(
+-  NAME           PackageProject
+-  VERSION        1.13.0
+-  GIT_REPOSITORY "https://github.com/TheLartians/PackageProject.cmake"
+-)
++add_subdirectory(cmake/packageproject.cmake)
+ 
+ packageProject(
+   NAMESPACE cr

--- a/ports/rebind/vcpkg.json
+++ b/ports/rebind/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "rebind",
-  "version": "5.2.2",
+  "version": "5.3.1",
   "description": "A C++23 reflection library for aggregates and enums",
   "homepage": "https://github.com/Curve/rebind",
   "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/ports/saucer/0001-use-local-packages.patch
+++ b/ports/saucer/0001-use-local-packages.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 32fdea7..cc311e0 100644
+index 32fdea7..26036d8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -286,62 +286,26 @@ endif()
+@@ -286,62 +286,24 @@ endif()
  include("cmake/nuget.cmake")
  include("cmake/module.cmake")
  
@@ -68,9 +68,6 @@ index 32fdea7..cc311e0 100644
 +find_path(EREIGNIS_INCLUDE_DIRS "ereignis")
 +add_library(cr::ereignis INTERFACE IMPORTED)
 +target_include_directories(cr::ereignis INTERFACE ${EREIGNIS_INCLUDE_DIRS})
-+find_path(REBIND_INCLUDE_DIRS "rebind")
-+add_library(cr::rebind INTERFACE IMPORTED)
-+target_include_directories(cr::rebind INTERFACE ${REBIND_INCLUDE_DIRS})
 +find_path(POOLPARTY_INCLUDE_DIRS "poolparty")
 +add_library(cr::poolparty INTERFACE IMPORTED)
 +target_include_directories(cr::poolparty INTERFACE ${POOLPARTY_INCLUDE_DIRS})
@@ -78,6 +75,7 @@ index 32fdea7..cc311e0 100644
 +find_package(fmt CONFIG REQUIRED)
 +find_package(eraser REQUIRED)
 +find_package(lockpp REQUIRED)
++find_package(rebind REQUIRED)
 +find_package(Boost REQUIRED COMPONENTS callable_traits preprocessor)
 +
 +target_link_libraries(${PROJECT_NAME} ${saucer_linkage} Boost::preprocessor cr::lockpp cr::flagpp)
@@ -85,7 +83,7 @@ index 32fdea7..cc311e0 100644
  
  # --------------------------------------------------------------------------------------------------------
  # Setup Backends
-@@ -405,7 +369,7 @@ if (saucer_backend STREQUAL "WebView2")
+@@ -405,7 +367,7 @@ if (saucer_backend STREQUAL "WebView2")
    target_compile_definitions(${PROJECT_NAME} PRIVATE UNICODE=1 _UNICODE=1 NOMINMAX=1)
  
    include("cmake/webview2.cmake")
@@ -94,7 +92,7 @@ index 32fdea7..cc311e0 100644
  endif()
  
  # --------------------------------------------------------------------------------------------------------
-@@ -418,12 +382,8 @@ if (saucer_serializer STREQUAL "Glaze")
+@@ -418,12 +380,8 @@ if (saucer_serializer STREQUAL "Glaze")
    )
  
    target_sources(${PROJECT_NAME} PRIVATE ${glaze_sources})

--- a/ports/saucer/vcpkg.json
+++ b/ports/saucer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "saucer",
   "version": "6.0.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Next-gen desktop apps with web-frontend in C++",
   "homepage": "https://saucer.github.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8814,7 +8814,7 @@
     },
     "saucer": {
       "baseline": "6.0.1",
-      "port-version": 3
+      "port-version": 4
     },
     "sbgecom": {
       "baseline": "5.3.2276",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8513,7 +8513,7 @@
       "port-version": 1
     },
     "rebind": {
-      "baseline": "5.2.2",
+      "baseline": "5.3.1",
       "port-version": 0
     },
     "recast": {

--- a/versions/r-/rebind.json
+++ b/versions/r-/rebind.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8104299d45643e9ad1bd65056c334986dcbee8f",
+      "version": "5.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "42b5b44679f26d440626ddee67a467b5690584f9",
       "version": "5.2.2",
       "port-version": 0

--- a/versions/s-/saucer.json
+++ b/versions/s-/saucer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78d86530fca014f2279bf537410f01af5ea6f917",
+      "version": "6.0.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "b99624fc80699236806ad50e5793fb8dbac38ed8",
       "version": "6.0.1",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.