### PR TITLE
[libgig] Update to 4.5.2

### DIFF
--- a/ports/libgig/portfile.cmake
+++ b/ports/libgig/portfile.cmake
@@ -1,15 +1,17 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.linuxsampler.org/packages/libgig-${VERSION}.tar.bz2"
     FILENAME "libgig-${VERSION}.tar.bz2"
-    SHA512 7844d31acba4bd2f2a499511c3f45ec0a883336193a1422d6d0cd1a8d0c2e97f9f89230176969e5a80b483890914d424eb778338afd583197fdea8bee3c08627
+    SHA512 df7b1146c7326306c052113dd69fe7731127104340818cf939da04eff10a42c88b629121fd15519d5efa211e73a61fb318754bff6d02175ea2b28df2567b59c3
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+    PATCHES
+        replace_cpp23warning.patch
 )
 
-string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} dynamic LIBGIG_BUILD_SHARED)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LIBGIG_BUILD_SHARED)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
@@ -22,6 +24,7 @@ vcpkg_cmake_configure(
     OPTIONS
         ${FEATURE_OPTIONS}
         -DLIBGIG_BUILD_SHARED=${LIBGIG_BUILD_SHARED}
+        -DLIBGIG_ENABLE_TESTING=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/libgig/replace_cpp23warning.patch
+++ b/ports/libgig/replace_cpp23warning.patch
@@ -1,0 +1,15 @@
+diff --git "a/src/RIFF.h" "b/src/RIFF.h"
+index f6e7fc8..7746609 100644
+--- "a/src/RIFF.h"
++++ "b/src/RIFF.h"
+@@ -24,8 +24,8 @@
+ #ifndef __RIFF_H__
+ #define __RIFF_H__
+ 
+-#if __cplusplus < 201103L
+-# warning C++11 or higher required for libgig
++#if __cplusplus < 201103L && !defined(_MSC_VER)
++# pragma message("C++11 or higher required for libgig")
+ #endif
+ 
+ #include <string>

--- a/ports/libgig/vcpkg.json
+++ b/ports/libgig/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgig",
-  "version": "4.4.1",
+  "version": "4.5.2",
   "description": "C++ library for loading Gigasampler files and DLS Level 1/2 files",
   "homepage": "https://www.linuxsampler.org/libgig/",
   "license": "GPL-2.0-or-later",
@@ -16,12 +16,6 @@
     }
   ],
   "features": {
-    "tests": {
-      "description": "Build test cases",
-      "dependencies": [
-        "cppunit"
-      ]
-    },
     "tools": {
       "description": "Build extra tools",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4921,7 +4921,7 @@
       "port-version": 0
     },
     "libgig": {
-      "baseline": "4.4.1",
+      "baseline": "4.5.2",
       "port-version": 0
     },
     "libgit2": {

--- a/versions/l-/libgig.json
+++ b/versions/l-/libgig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b2a2ca46d0591d0ad2be21e3892b379412488451",
+      "version": "4.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "0e6d75a1433a7c49812af830bee40c2cd54c71ee",
       "version": "4.4.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Removed the tests options, as usually there is nor reason to build test test with vcpkg and the library itself claims to be C++11, but is using a C++23 feature `#warning` and C++20 in the tests (I'm getting 22x ` error C7555: use of designated initializers requires at least '/std:c++20'` in the tests and I don't think it is worth to patch this).