### PR TITLE
[simdutf] update to 7.7.1

### DIFF
--- a/ports/simdutf/portfile.cmake
+++ b/ports/simdutf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO simdutf/simdutf
     REF "v${VERSION}"
-    SHA512 9af2121d235e5b13589f64a9a9e2a2c83d287fbb1ebe1d5dee500bb229bf856efbb80ac2af1d8b764ca1f9d822a3c1b5b3aac0da958d661b1c84fc0f9a757a5b
+    SHA512 90d366d6e7f866d9e9bb92f7d40b40d9ca8353b93d2c221ad9333ed87579ba888f54dffd73b27d3ecd2357de8be502c6c2a58c6e64e343246e957d487b872113
     HEAD_REF master
 )
 

--- a/ports/simdutf/vcpkg.json
+++ b/ports/simdutf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdutf",
-  "version-semver": "7.7.0",
+  "version-semver": "7.7.1",
   "description": "Unicode validation and transcoding at billions of characters per second",
   "homepage": "https://github.com/simdutf/simdutf",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9089,7 +9089,7 @@
       "port-version": 0
     },
     "simdutf": {
-      "baseline": "7.7.0",
+      "baseline": "7.7.1",
       "port-version": 0
     },
     "simonbrunel-qtpromise": {

--- a/versions/s-/simdutf.json
+++ b/versions/s-/simdutf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59eb8b1c1f275b74a05885ff5e96b8fe14b762f1",
+      "version-semver": "7.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "378e2ed17280950bcb9b740fa36ba394ed1e199f",
       "version-semver": "7.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/simdutf/simdutf/releases/tag/v7.7.1
