### PR TITLE
[cpp-lazy] Update to 9.0.0

### DIFF
--- a/ports/cpp-lazy/portfile.cmake
+++ b/ports/cpp-lazy/portfile.cmake
@@ -1,18 +1,23 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Kaaserne/cpp-lazy
-    REF "${VERSION}"
-    SHA512 9ca34fc3c532602e1e92480080a020eb9f44de751159f9fd028552413f15f08f9705898eacb306668ab3cb243bb629b7f9e68078a0fcd882b886154b6bd69430
+    REF "v${VERSION}"
+    SHA512 e93a63e434be1fd25d842c0930159d9f31a565b905eb5d93d9066f32a0140034314c4228842bc534b3573b7ed8778fd01c0f7d4c35ca53ea1b73f86007e0873a
     HEAD_REF master
 )
 
 # header-only
 set(VCPKG_BUILD_TYPE "release")
 
-vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCPP_LAZY_INSTALL=ON
+        -DCPP_LAZY_USE_INSTALLED_FMT=ON
+)
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME cpp-lazy CONFIG_PATH lib/cmake/cpp-lazy)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/cpp-lazy)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 

--- a/ports/cpp-lazy/vcpkg.json
+++ b/ports/cpp-lazy/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "cpp-lazy",
-  "version": "8.0.1",
+  "version": "9.0.0",
   "description": "C++11 (and onwards) library for lazy evaluation ",
   "homepage": "https://github.com/Kaaserne/cpp-lazy",
   "license": "MIT",
   "dependencies": [
+    "fmt",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2009,7 +2009,7 @@
       "port-version": 0
     },
     "cpp-lazy": {
-      "baseline": "8.0.1",
+      "baseline": "9.0.0",
       "port-version": 0
     },
     "cpp-netlib": {

--- a/versions/c-/cpp-lazy.json
+++ b/versions/c-/cpp-lazy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fdd733245c81c0a7567873cc407970aba4d03e19",
+      "version": "9.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e5b9aeb15614e9ea580a39d803f09f561e6dd28f",
       "version": "8.0.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.