### PR TITLE
[mathter] Update to 2.0.1

### DIFF
--- a/ports/mathter/portfile.cmake
+++ b/ports/mathter/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO petiaccja/Mathter
     REF "v${VERSION}"
-    SHA512 da4fc266a8e3bdbe388e85e5f65e7a8b54fe65264175f5348f1fbb1a5bfbcf1b2ddf4ffaecd4a1f0ac22e78fdc665a52f4929a872592ce20ce69112187d6a6e0
+    SHA512 f03578f816703c436baa052fe074a9c752b94b24ffece97a43148c9b8a680b4f89f513b79c58e9e68f9e76720d237b1eae91ea19405ff522a7e374282f4a7828
     HEAD_REF master
     PATCHES
         support-xsimd-14.patch

--- a/ports/mathter/vcpkg.json
+++ b/ports/mathter/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "mathter",
-  "version": "2.0.0",
-  "port-version": 1,
+  "version": "2.0.1",
   "description": "A flexible and fast matrix, transform, and geometry library.",
   "homepage": "https://github.com/petiaccja/Mathter",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6269,8 +6269,8 @@
       "port-version": 7
     },
     "mathter": {
-      "baseline": "2.0.0",
-      "port-version": 1
+      "baseline": "2.0.1",
+      "port-version": 0
     },
     "matio": {
       "baseline": "1.5.29",

--- a/versions/m-/mathter.json
+++ b/versions/m-/mathter.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af8166eefcc149f23725431846286518b3c1140c",
+      "version": "2.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3846d4cd9718cc9c67c887fd57238394056ec659",
       "version": "2.0.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
