### PR TITLE
[zint] update to 2.16.0

### DIFF
--- a/ports/zint/portfile.cmake
+++ b/ports/zint/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zint/zint
     REF ${VERSION}
-    SHA512 70838fdc88aa8e157ce8a0099fe1184b98c8e5fd0a980a8ecdb40d7e4cbf1519b99a2326ffe7a1b3272dc58aa20fafa06fa0d3e6fb26f445eaa59b4b20be18cc
+    SHA512 819d1f91186106acf7dacada85b69e409358e3d39ad9b714297d00168c76d363f92c12c57ca8b11bc08fbe2c078ed4ac5c0cfc0e3e6391048acafa59b662c098
     HEAD_REF master
 )
 
@@ -26,7 +26,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/zint)
 vcpkg_copy_pdbs()
 
 vcpkg_copy_tools(TOOL_NAMES zint AUTO_CLEAN)

--- a/ports/zint/vcpkg.json
+++ b/ports/zint/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zint",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "A barcode encoding library supporting over 50 symbologies",
   "homepage": "https://github.com/zint/zint",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10925,7 +10925,7 @@
       "port-version": 1
     },
     "zint": {
-      "baseline": "2.15.0",
+      "baseline": "2.16.0",
       "port-version": 0
     },
     "zix": {

--- a/versions/z-/zint.json
+++ b/versions/z-/zint.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b96939e1e327516044be9cf6cc7767380e5a87da",
+      "version": "2.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "34af8fb2128fa290d00b594c08e9cbedf6db5543",
       "version": "2.15.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/zint/zint/releases/tag/2.16.0
