### PR TITLE
[whereami] Add new port

### DIFF
--- a/ports/whereami/CMakeLists.txt
+++ b/ports/whereami/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.25)
+project(whereami)
+set(PROJECT_VERSION ${PROJECT_VERSION_STRING})
+
+add_library(whereami STATIC src/whereami.c src/whereami.h)
+add_library(whereami::whereami ALIAS whereami)
+target_include_directories(whereami PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
+
+set_target_properties(whereami PROPERTIES PUBLIC_HEADER "src/whereami.h")
+
+include(GNUInstallDirs)
+install(TARGETS whereami
+        EXPORT whereamiTargets
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Create and install package files
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/unofficial-whereamiConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/unofficial-whereamiConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unofficial-whereami
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/unofficial-whereamiConfigVersion.cmake
+    COMPATIBILITY SameMajorVersion
+)
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/unofficial-whereamiConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/unofficial-whereamiConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unofficial-whereami
+)
+
+# Export Targets and install that to unofficial-whereamiTargets.cmake
+install(
+    EXPORT whereamiTargets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unofficial-whereami
+    NAMESPACE unofficial::whereami::
+    FILE unofficial-whereamiTargets.cmake
+)

--- a/ports/whereami/portfile.cmake
+++ b/ports/whereami/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gpakosz/whereami
+    REF dcb52a058dc14530ba9ae05e4339bd3ddfae0e0e
+    SHA512 afd5999316c398218d8a401b6dc6a9885c9e474bde6804f464d55eca42fdee126329856da5b337bdfad5582e6ed1364fc86a47c92b49b6d57f1bea4e3d5120e0
+    HEAD_REF master
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-whereamiConfig.cmake.in" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH}
+                      OPTIONS
+                      -DPROJECT_VERSION_STRING=${VERSION})
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-whereami CONFIG_PATH "lib/cmake/unofficial-whereami")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.MIT" "${SOURCE_PATH}/LICENSE.WTFPLv2")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/whereami/unofficial-whereamiConfig.cmake.in
+++ b/ports/whereami/unofficial-whereamiConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-whereamiTargets.cmake")

--- a/ports/whereami/vcpkg.json
+++ b/ports/whereami/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "whereami",
+  "version-date": "2024-08-26",
+  "description": "A drop-in two files library to locate the current executable and the current module on the file system.",
+  "homepage": "https://github.com/gpakosz/whereami",
+  "license": "MIT OR WTFPL",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10508,6 +10508,10 @@
       "baseline": "2019-08-13",
       "port-version": 2
     },
+    "whereami": {
+      "baseline": "2024-08-26",
+      "port-version": 0
+    },
     "whisper-cpp": {
       "baseline": "1.8.2",
       "port-version": 0

--- a/versions/w-/whereami.json
+++ b/versions/w-/whereami.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4256f3652c35f4756569b8c241d09f7bf05bf48e",
+      "version-date": "2024-08-26",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
