### PR TITLE
[lua] update to 5.5.0

### DIFF
--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.lua.org/ftp/lua-${VERSION}.tar.gz"
     FILENAME "lua-${VERSION}.tar.gz"
-    SHA512 875ad1f6df3ba63722b5069564c9d3a4057b4c3564c691061bb49cf6cdf5d2e303f05762bd46797b444aaf992c03021f423df142123eebf86751fd77edaf8060
+    SHA512 3253d2cdc929da6438095a30d66ef16a1abdbb0ada8fee238705b3b38492f14be9553640fdca6b25661e01155ba5582032e0a2ef064e4c283e85efc0a128cabe
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/lua/vcpkg.json
+++ b/ports/lua/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "lua",
-  "version": "5.4.8",
+  "version": "5.5.0",
   "description": "A powerful, fast, lightweight, embeddable scripting language",
   "homepage": "https://www.lua.org",
   "license": null,

--- a/ports/luafilesystem/portfile.cmake
+++ b/ports/luafilesystem/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF ${LUAFILESYSTEM_REVISION}
     SHA512 ${LUAFILESYSTEM_HASH}
     HEAD_REF master
+    PATCHES
+        support-lua-5.5.patch # https://github.com/lunarmodules/luafilesystem/pull/180
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/luafilesystem/support-lua-5.5.patch
+++ b/ports/luafilesystem/support-lua-5.5.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lfs.c b/src/lfs.c
+index 95ab63b..e69dfec 100644
+--- a/src/lfs.c
++++ b/src/lfs.c
+@@ -324,7 +324,7 @@ static FILE *check_file(lua_State * L, int idx, const char *funcname)
+     return 0;
+   } else
+     return *fh;
+-#elif LUA_VERSION_NUM >= 502 && LUA_VERSION_NUM <= 504
++#elif LUA_VERSION_NUM >= 502 && LUA_VERSION_NUM <= 505
+   luaL_Stream *fh = (luaL_Stream *) luaL_checkudata(L, idx, "FILE*");
+   if (fh->closef == 0 || fh->f == NULL) {
+     luaL_error(L, "%s: closed file", funcname);

--- a/ports/luafilesystem/vcpkg.json
+++ b/ports/luafilesystem/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "luafilesystem",
   "version": "1.8.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "LuaFileSystem is a Lua library developed to complement the set of functions related to file systems offered by the standard Lua distribution.",
   "homepage": "https://github.com/keplerproject/luafilesystem",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6065,7 +6065,7 @@
       "port-version": 0
     },
     "lua": {
-      "baseline": "5.4.8",
+      "baseline": "5.5.0",
       "port-version": 0
     },
     "lua-compat53": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6082,7 +6082,7 @@
     },
     "luafilesystem": {
       "baseline": "1.8.0",
-      "port-version": 7
+      "port-version": 8
     },
     "luajit": {
       "baseline": "2023-01-04",

--- a/versions/l-/lua.json
+++ b/versions/l-/lua.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "68062c242e90605fcdab46f73a6cad3e93eab06b",
+      "version": "5.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "062ae235ae46d4bce8b00be2c74667e0763cc2c1",
       "version": "5.4.8",
       "port-version": 0

--- a/versions/l-/luafilesystem.json
+++ b/versions/l-/luafilesystem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c71a08434004929feda2471c686acb25a68c575",
+      "version": "1.8.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "00b7638338af5a3a2d95c3c9b1ed870ed0cfb9fc",
       "version": "1.8.0",
       "port-version": 7


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://lua.org/manual/5.5/readme.html#changes
