### PR TITLE
[plf-indiesort] add new port

### DIFF
--- a/ports/plf-indiesort/portfile.cmake
+++ b/ports/plf-indiesort/portfile.cmake
@@ -1,0 +1,14 @@
+# header-only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mattreecebentley/plf_indiesort
+    REF fb28b3f24886253d4eaab5e05f23b8cf84238f1e
+    SHA512 1f8f7b8dbb698d22e02701d6991bf5525a825ac5404bdeba7b09bc7814175fedaeedebbd6aba4db587d5d93ab14d4f3e0dbe78a098b10e9c0d4efb1bc1456026
+    HEAD_REF master
+)
+
+file(COPY ${SOURCE_PATH}/plf_indiesort.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+# Handle copyright
+configure_file(${SOURCE_PATH}/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)

--- a/ports/plf-indiesort/vcpkg.json
+++ b/ports/plf-indiesort/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "plf-indiesort",
+  "version": "1.4.4",
+  "description": "A sort wrapper enabling both use of random-access sorting on non-random access containers, and increased performance for the sorting of large types.",
+  "homepage": "https://plflib.org/indiesort.htm"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7620,6 +7620,10 @@
       "baseline": "2021-12-11",
       "port-version": 0
     },
+    "plf-indiesort": {
+      "baseline": "1.4.4",
+      "port-version": 0
+    },
     "plf-list": {
       "baseline": "2019-08-10",
       "port-version": 2

--- a/versions/p-/plf-indiesort.json
+++ b/versions/p-/plf-indiesort.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9906c63b4c60e46551fe19219cdd73b197e3bc73",
+      "version": "1.4.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/mattreecebentley/plf_indiesort
