### PR TITLE
[zoe] Fix dependency import/export

### DIFF
--- a/ports/zoe/cmake.diff
+++ b/ports/zoe/cmake.diff
@@ -1,0 +1,99 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b5a3408..ecdeda8 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -57,16 +57,12 @@ set_target_properties(zoe PROPERTIES
+ 
+ target_include_directories(zoe
+ 	PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+-	PUBLIC $<INSTALL_INTERFACE:../include>
++	PUBLIC $<INSTALL_INTERFACE:include>
+ )
+ 
+ # CURL
+-find_package(CURL REQUIRED)
+-if(ZOE_BUILD_SHARED_LIBS)	
+-	target_link_libraries(zoe PRIVATE ${CURL_LIBRARIES})
+-else()
+-	target_link_libraries(zoe PUBLIC ${CURL_LIBRARIES})
+-endif()
++find_package(CURL CONFIG REQUIRED)
++target_link_libraries(zoe PRIVATE CURL::libcurl)
+ 
+ target_include_directories(zoe PRIVATE ${CURL_INCLUDE_DIRS})
+ 
+@@ -74,25 +70,16 @@ target_include_directories(zoe PRIVATE ${CURL_INCLUDE_DIRS})
+ find_package(OpenSSL)
+ if(OpenSSL_FOUND)
+ 	target_compile_definitions(zoe PRIVATE WITH_OPENSSL)
+-
+-	if(ZOE_BUILD_SHARED_LIBS)	
+-		target_link_libraries(zoe PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+-	else()
+-		target_link_libraries(zoe PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+-	endif()
++	target_link_libraries(zoe PRIVATE OpenSSL::SSL)
+ endif()
+ 
+ 
+-if (WIN32 OR _WIN32)
+-	if(ZOE_BUILD_SHARED_LIBS)
+-		target_link_libraries(zoe PRIVATE Ws2_32.lib Crypt32.lib)
+-	else()
+-		target_link_libraries(zoe PUBLIC Ws2_32.lib Crypt32.lib)
+-	endif()
++if (WIN32)
++	target_link_libraries(zoe PRIVATE ws2_32 crypt32)
+ endif()
+ 
+ install(TARGETS zoe
+-        EXPORT zoeConfig
++        EXPORT zoeTargets
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+@@ -101,15 +88,25 @@ install(TARGETS zoe
+ 
+ install(DIRECTORY ../include/zoe DESTINATION include)
+ 
+-install(EXPORT zoeConfig
++install(EXPORT zoeTargets
+     NAMESPACE zoe::
+     DESTINATION share/zoe
+ )
+ 
+ include(CMakePackageConfigHelpers)
++configure_package_config_file(zoeConfig.cmake.in
++	${CMAKE_CURRENT_BINARY_DIR}/zoeConfig.cmake
++	INSTALL_DESTINATION share/zoe
++	NO_SET_AND_CHECK_MACRO
++	NO_CHECK_REQUIRED_COMPONENTS_MACRO
++)
+ write_basic_package_version_file(
+     zoeConfigVersion.cmake
+     VERSION ${PROJECT_VERSION}
+     COMPATIBILITY AnyNewerVersion
+ )
+-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zoeConfigVersion.cmake DESTINATION share/zoe)
++install(FILES
++	${CMAKE_CURRENT_BINARY_DIR}/zoeConfig.cmake
++	${CMAKE_CURRENT_BINARY_DIR}/zoeConfigVersion.cmake
++	DESTINATION share/zoe
++)
+diff --git a/src/zoeConfig.cmake.in b/src/zoeConfig.cmake.in
+new file mode 100644
+index 0000000..28f29fe
+--- /dev/null
++++ b/src/zoeConfig.cmake.in
+@@ -0,0 +1,11 @@
++@PACKAGE_INIT@
++
++if(NOT "@ZOE_BUILD_SHARED_LIBS@")
++    include(CMakeFindDependencyMacro)
++    find_dependency(CURL)
++    if("@OpenSSL_FOUND@")
++        find_dependency(OpenSSL)
++    endif()
++endif()
++
++include("${CMAKE_CURRENT_LIST_DIR}/zoeTargets.cmake")

--- a/ports/zoe/portfile.cmake
+++ b/ports/zoe/portfile.cmake
@@ -4,25 +4,29 @@ vcpkg_from_github(
     HEAD_REF master
     REF "v${VERSION}"
     SHA512 af895f772b465b34eb938b712bfd9b00bb170d23125e05161843293c13329bfc1147bd22ce990b189580d0946b94e725b99cefaafd3aeca758de5c6a55bc33a9
+    PATCHES
+        cmake.diff
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS options
+    FEATURES
+        openssl     VCPKG_LOCK_FIND_PACKAGE_OpenSSL
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ZOE_BUILD_SHARED_LIBS)
-string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" ZOE_USE_STATIC_CRT)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DZOE_BUILD_SHARED_LIBS:BOOL=${ZOE_BUILD_SHARED_LIBS}
-        -DZOE_USE_STATIC_CRT:BOOL=${ZOE_USE_STATIC_CRT}
         -DZOE_BUILD_TESTS:BOOL=OFF
+        ${options}
 )
 
 vcpkg_cmake_install()
-
-vcpkg_cmake_config_fixup(CONFIG_PATH share/zoe)
-
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_copy_pdbs()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/zoe/vcpkg.json
+++ b/ports/zoe/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zoe",
   "version": "3.6",
+  "port-version": 1,
   "maintainers": "winsoft666 <winsoft666@outlook.com>",
   "description": "C++ File Download Library.",
   "homepage": "https://github.com/winsoft666/zoe",
@@ -18,5 +19,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "openssl": {
+      "description": "Enable OpenSSL capabilities",
+      "dependencies": [
+        "openssl"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10950,7 +10950,7 @@
     },
     "zoe": {
       "baseline": "3.6",
-      "port-version": 0
+      "port-version": 1
     },
     "zookeeper": {
       "baseline": "3.8.5",

--- a/versions/z-/zoe.json
+++ b/versions/z-/zoe.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0127b2e9f95b21e5f631d840065b01e26bfd75d5",
+      "version": "3.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "06279c8c377d2b0d3b9f3798bf8e5050184df2e7",
       "version": "3.6",
       "port-version": 0


### PR DESCRIPTION
Control OpenSSL.
Use `find_dependency`.
Fix exported include dir.