### PR TITLE
[leaf] Delist

### DIFF
--- a/ports/leaf/portfile.cmake
+++ b/ports/leaf/portfile.cmake
@@ -1,1 +1,0 @@
-set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/ports/leaf/vcpkg.json
+++ b/ports/leaf/vcpkg.json
@@ -1,9 +1,0 @@
-{
-  "name": "leaf",
-  "version": "0.2.2",
-  "port-version": 2,
-  "description": "Deprecated boost-leaf port.",
-  "dependencies": [
-    "boost-leaf"
-  ]
-}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4512,10 +4512,6 @@
       "baseline": "2.17",
       "port-version": 0
     },
-    "leaf": {
-      "baseline": "0.2.2",
-      "port-version": 2
-    },
     "lely-core": {
       "baseline": "2.3.5",
       "port-version": 0


### PR DESCRIPTION
Boost 0.2.2 was released Jul 28, 2019 and 0.2.3 Nov 3, 2019. So I think no one still requires this alias.