### PR TITLE
[liblzma] update to 5.8.2

### DIFF
--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tukaani-project/xz
     REF "v${VERSION}"
-    SHA512 2f51fb316adb2962e0f2ef6ccc8b544cdc45087b9ad26dcd33f2025784be56578ab937c618e5826b2220b49b79b8581dcb8c6d43cd50ded7ad9de9fe61610f46
+    SHA512 "a14c9d0a118c611d1156cd9a605269c706b976a752c048db7f2eea956e2bf717ce595f46186d951a6c4493e35658e08fa3fe4b256898c6ca08e3695c0ee7b0e5"
     HEAD_REF master
     PATCHES
         build-tools.patch

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liblzma",
-  "version": "5.8.1",
+  "version": "5.8.2",
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5113,7 +5113,7 @@
       "port-version": 1
     },
     "liblzma": {
-      "baseline": "5.8.1",
+      "baseline": "5.8.2",
       "port-version": 0
     },
     "libmad": {

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac8f26dab6f1bda59ca96900cda5c81a1cd0aa48",
+      "version": "5.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "55eb3803f1d0388aebca8fd293963721bbf0092c",
       "version": "5.8.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #48938

Update `liblzma` from 5.8.1 to 5.8.2. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
