### PR TITLE
[vcpkg scripts] Update `git-for-windows` to latest

### DIFF
--- a/scripts/cmake/vcpkg_find_acquire_program(GIT).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(GIT).cmake
@@ -1,11 +1,11 @@
 set(program_name git)
 if(CMAKE_HOST_WIN32)
-    set(base_version 2.32.0)
-    set(program_version 2.32.0.2)
-    set(tool_subdirectory "git-${program_version}-2-windows")
-    set(download_urls "https://github.com/git-for-windows/git/releases/download/v${base_version}.windows.2/PortableGit-${program_version}-32-bit.7z.exe")
+    set(base_version 2.50.1)
+    set(program_version 2.50.1)
+    set(tool_subdirectory "git-${program_version}-1-windows")
+    set(download_urls "https://github.com/git-for-windows/git/releases/download/v${base_version}.windows.1/PortableGit-${program_version}-32-bit.7z.exe")
     set(download_filename "PortableGit-${program_version}-32-bit.7z.exe")
-    set(download_sha512 867d8534972cbaf7a4224e25a14d484f8d17ef186f8d79e9a758afb90cf69541375cb7615a39702311f4809cb8371ef85c2b1a15bfffe9e48f0e597ac011b348)
+    set(download_sha512 42ed5df38c8cc9a07add601df166cfcb5755b11d179b11b900216dcd2a9499fec5ef74018fb000c93274f612c1c9b711adf0db8e5e642aa94567a0654d1f29b6)
     set(paths_to_search
         "${DOWNLOADS}/tools/${tool_subdirectory}/mingw32/bin"
         "${DOWNLOADS}/tools/git/${tool_subdirectory}/mingw32/bin")

--- a/scripts/vcpkg-tools.json
+++ b/scripts/vcpkg-tools.json
@@ -94,9 +94,9 @@
       "arch": "arm64",
       "version": "2.7.4",
       "executable": "clangarm64/bin/git.exe",
-      "url": "https://github.com/git-for-windows/git/releases/download/v2.51.0.windows.1/PortableGit-2.51.0-arm64.7z.exe",
-      "sha512": "877b4cc5c91108488c55b9a75059d864915f50929cc4ebfa741074216e5e597ae3b7f4e35dea7a1e667f8d712ba8d1f6813d66d11d00bf42b0bb681322386e76",
-      "archive": "PortableGit-2.47.1.2-arm64.7z.exe"
+      "url": "https://github.com/git-for-windows/git/releases/download/v2.52.0.windows.1/PortableGit-2.52.0-arm64.7z.exe",
+      "sha512": "3727c345f18888300f1a99d45c6464ccb17e39b2377c3747bc44deee2c7c4b7a5e942b92a2887f850fe198f5d5358df0b93b788a38abcce928885f38429cf11d",
+      "archive": "PortableGit-2.52.0-arm64.7z.exe"
     },
     {
       "name": "git",
@@ -104,9 +104,9 @@
       "arch": "amd64",
       "version": "2.7.4",
       "executable": "mingw64/bin/git.exe",
-      "url": "https://github.com/git-for-windows/git/releases/download/v2.51.0.windows.1/PortableGit-2.51.0-64-bit.7z.exe",
-      "sha512": "74680d7d4573e2f428bbaa0d38d6506ddf870f2a20f4ec3118bc3012cb9ca766e03508f074fd4b3b0b034bbd05d2c4eecde321c73e18613fe11fbc7510c731c7",
-      "archive": "PortableGit-2.47.1.2-64-bit.7z.exe"
+      "url": "https://github.com/git-for-windows/git/releases/download/v2.52.0.windows.1/PortableGit-2.52.0-64-bit.7z.exe",
+      "sha512": "b56f64b17954a060beb775c26ae03cbd165878b504b4c91ae5102fc84079fb3f8c2fa9886337c594ea905dad48a854eb1497849dab837d6a877b5b4f73b9b31e",
+      "archive": "PortableGit-2.52.0-64-bit.7z.exe"
     },
     {
       "name": "git",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.
____

* arm64/amd64 -> `2.52.0`
* 32-bit -> `2.50.1`
>Note: As a courtesy, this release includes a last, unplanned, "after warranty" 32-bit installer.

https://github.com/git-for-windows/git/releases/tag/v2.50.1.windows.1