### PR TITLE
[flagpp] Update to 3.1.0

### DIFF
--- a/ports/flagpp/portfile.cmake
+++ b/ports/flagpp/portfile.cmake
@@ -2,14 +2,25 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Curve/flagpp
     REF "v${VERSION}"
-    SHA512 c0a9c63846075677b89af38aecd0536df430d7a2600115067644af58aefb6941f56a0e5bd13a4006b032cd96804cc0acde9be2725ddd79691c878f7e5ed04b92
+    SHA512 92e324b1cd773ae256c50d389fe1b30ac71237dfb299bae1e413e97b8057433dccb8a6c93ce16f05edc0de624893165491ac621e1b9da9f512df531bd69b504b
     HEAD_REF master
+    PATCHES
+        remove-cpm.patch # Note: Removed also the ALIAS library as packageProject creates it
 )
 
-vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+# Replace CPM and download PackageProject directly to avoid issues with FETCHCONTENT_FULLY_DISCONNECTED
+vcpkg_from_github(
+    OUT_SOURCE_PATH PACKAGE_PROJECT_PATH
+    REPO TheLartians/PackageProject.cmake
+    REF "v1.13.0"
+    SHA512 3cf0523bddc213f206ed0ca57803550cb7db9e293392d3741138be47f49d9027ef517e1656235a349a62b492d35c3fc677714dc00afe59e2d36144a9689cfa8f
+    HEAD_REF master
+)
+file(RENAME "${PACKAGE_PROJECT_PATH}" "${SOURCE_PATH}/cmake/packageproject.cmake")
 
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
-
+vcpkg_cmake_config_fixup(CONFIG_PATH "share/cmake/${PORT}-${VERSION}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/flagpp/remove-cpm.patch
+++ b/ports/flagpp/remove-cpm.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 052b07e..fcd8583 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,6 @@ option(flagpp_tests "Whether or not tests should be enabled" OFF)
+ # --------------------------------------------------------------------------------------------------------
+ 
+ add_library(${PROJECT_NAME} INTERFACE)
+-add_library(cr::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+ 
+ target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_23)
+ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 23 CXX_EXTENSIONS OFF CXX_STANDARD_REQUIRED ON)
+@@ -39,13 +38,7 @@ endif()
+ # Install Targets
+ # --------------------------------------------------------------------------------------------------------
+ 
+-include("cmake/cpm.cmake")
+-
+-CPMFindPackage(
+-  NAME           PackageProject
+-  VERSION        1.13.0
+-  GIT_REPOSITORY "https://github.com/TheLartians/PackageProject.cmake"
+-)
++add_subdirectory(cmake/packageproject.cmake)
+ 
+ packageProject(
+   NAMESPACE cr

--- a/ports/flagpp/vcpkg.json
+++ b/ports/flagpp/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "flagpp",
-  "version": "2.1",
+  "version": "3.1.0",
   "description": "A C++20 library that provides (opt-in) bit-wise operations for arbitrary `enum class`es",
   "homepage": "https://github.com/Curve/flagpp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/ports/saucer/0001-use-local-packages.patch
+++ b/ports/saucer/0001-use-local-packages.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 32fdea7..26036d8 100644
+index 32fdea7..e1dea41 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -286,62 +286,24 @@ endif()
+@@ -286,62 +286,22 @@ endif()
  include("cmake/nuget.cmake")
  include("cmake/module.cmake")
  
@@ -62,9 +62,6 @@ index 32fdea7..26036d8 100644
 -
 -target_link_libraries(${PROJECT_NAME} ${saucer_linkage} boost_preprocessor cr::lockpp cr::flagpp)
 -target_link_libraries(${PROJECT_NAME} PUBLIC            boost_callable_traits cr::ereignis fmt::fmt cr::rebind cr::poolparty cr::eraser)
-+find_path(FLAGPP_INCLUDE_DIRS "flagpp")
-+add_library(cr::flagpp INTERFACE IMPORTED)
-+target_include_directories(cr::flagpp INTERFACE ${FLAGPP_INCLUDE_DIRS})
 +find_path(EREIGNIS_INCLUDE_DIRS "ereignis")
 +add_library(cr::ereignis INTERFACE IMPORTED)
 +target_include_directories(cr::ereignis INTERFACE ${EREIGNIS_INCLUDE_DIRS})
@@ -74,6 +71,7 @@ index 32fdea7..26036d8 100644
 +
 +find_package(fmt CONFIG REQUIRED)
 +find_package(eraser REQUIRED)
++find_package(flagpp REQUIRED)
 +find_package(lockpp REQUIRED)
 +find_package(rebind REQUIRED)
 +find_package(Boost REQUIRED COMPONENTS callable_traits preprocessor)
@@ -83,7 +81,7 @@ index 32fdea7..26036d8 100644
  
  # --------------------------------------------------------------------------------------------------------
  # Setup Backends
-@@ -405,7 +367,7 @@ if (saucer_backend STREQUAL "WebView2")
+@@ -405,7 +365,7 @@ if (saucer_backend STREQUAL "WebView2")
    target_compile_definitions(${PROJECT_NAME} PRIVATE UNICODE=1 _UNICODE=1 NOMINMAX=1)
  
    include("cmake/webview2.cmake")
@@ -92,7 +90,7 @@ index 32fdea7..26036d8 100644
  endif()
  
  # --------------------------------------------------------------------------------------------------------
-@@ -418,12 +380,8 @@ if (saucer_serializer STREQUAL "Glaze")
+@@ -418,12 +378,8 @@ if (saucer_serializer STREQUAL "Glaze")
    )
  
    target_sources(${PROJECT_NAME} PRIVATE ${glaze_sources})

--- a/ports/saucer/vcpkg.json
+++ b/ports/saucer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "saucer",
   "version": "6.0.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Next-gen desktop apps with web-frontend in C++",
   "homepage": "https://saucer.github.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8814,7 +8814,7 @@
     },
     "saucer": {
       "baseline": "6.0.1",
-      "port-version": 4
+      "port-version": 5
     },
     "sbgecom": {
       "baseline": "5.3.2276",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2977,7 +2977,7 @@
       "port-version": 0
     },
     "flagpp": {
-      "baseline": "2.1",
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "flann": {

--- a/versions/f-/flagpp.json
+++ b/versions/f-/flagpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eeacc489f8bd0bfb4293bc3991000007c98f3dc5",
+      "version": "3.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "faf42d8daa5b595fe7225a10072be86387a41947",
       "version": "2.1",
       "port-version": 0

--- a/versions/s-/saucer.json
+++ b/versions/s-/saucer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ab0cbef843f2d8ae45703c3f03f84f3b43265fe0",
+      "version": "6.0.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "78d86530fca014f2279bf537410f01af5ea6f917",
       "version": "6.0.1",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
