### PR TITLE
[cppad] Update to 20250000.3

### DIFF
--- a/ports/cppad/portfile.cmake
+++ b/ports/cppad/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO coin-or/CppAD
     REF "${VERSION}"
-    SHA512 c94637d1859a8f3ac2ac3064d8f9f0baefefe8da6d4534bfa6a1602d610844bb3838bd9a2fcaf8ae1cce5dc2a2adb5e7eacaeccf006d746552eb2ff3ca75494a
+    SHA512 f2dffaeaaf46dcd051a3354478c7ba61ed6a3538cdcc39c066fd9eb22ef58f0cde30079595e9db273d6484a31c8f73c84061ac7f5a5028f920ec74ef26c8e7c1
     HEAD_REF master
 )
 

--- a/ports/cppad/vcpkg.json
+++ b/ports/cppad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$comment": "See related issue for compilation failure on UWP and ARM: https://github.com/microsoft/vcpkg/pull/12560#issuecomment-668412073",
   "name": "cppad",
-  "version": "20250000.2",
+  "version": "20250000.3",
   "description": "CppAD: A Package for Differentiation of C++ Algorithms",
   "homepage": "https://github.com/coin-or/CppAD",
   "license": "EPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2057,7 +2057,7 @@
       "port-version": 0
     },
     "cppad": {
-      "baseline": "20250000.2",
+      "baseline": "20250000.3",
       "port-version": 0
     },
     "cppcms": {

--- a/versions/c-/cppad.json
+++ b/versions/c-/cppad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dde4cbc6637519c09af91fe6050f58824a5063e6",
+      "version": "20250000.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "8ae82a3ae42d62a6db772e387dae2f45150b27c6",
       "version": "20250000.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.