### PR TITLE
[libgit2] Add SHA256 support via a feature

### DIFF
--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -71,6 +71,7 @@ vcpkg_check_features(
     OUT_FEATURE_OPTIONS GIT2_FEATURES
     FEATURES
         tools   BUILD_CLI
+        sha256  EXPERIMENTAL_SHA256
 )
 
 vcpkg_cmake_configure(
@@ -96,6 +97,11 @@ vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 if("tools" IN_LIST FEATURES)
+    # Since SHA256 is considered an "experimental" feature, it renames the executable. This renames it back.
+    if("sha256" IN_LIST FEATURES)
+        file(RENAME "${CURRENT_PACKAGES_DIR}/bin/git2-experimental${VCPKG_TARGET_EXECUTABLE_SUFFIX}" "${CURRENT_PACKAGES_DIR}/bin/git2${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+    endif()
+
     vcpkg_copy_tools(TOOL_NAMES git2 AUTO_CLEAN)
 endif()
 

--- a/ports/libgit2/vcpkg.json
+++ b/ports/libgit2/vcpkg.json
@@ -51,6 +51,9 @@
       "description": "SSL support (sectransp)",
       "supports": "osx"
     },
+    "sha256": {
+      "description": "[experimental] SHA256 OID support"
+    },
     "ssh": {
       "description": "SSH support via libssh2",
       "dependencies": [

--- a/scripts/test_ports/vcpkg-ci-libgit2/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-libgit2/vcpkg.json
@@ -1,14 +1,15 @@
 {
   "name": "vcpkg-ci-libgit2",
   "version-string": "ci",
-  "description": "Validates libgit2 with ssh and tools.",
+  "description": "Validates libgit2 with ssh, tools, and sha256.",
   "dependencies": [
     {
       "name": "libgit2",
       "default-features": false,
       "features": [
         "ssh",
-        "tools"
+        "tools",
+        "sha256"
       ]
     }
   ]

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3132df66e48bd17fb623b7b7f052b73e4d8ad7a3",
+      "git-tree": "2fd041b43ab1c68f47f7a23ff487e7dfe3f92d30",
       "version-semver": "1.9.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.