### PR TITLE
[dawn] Use DXC instead of FXC

### DIFF
--- a/ports/dawn/011-fix-dxc.patch
+++ b/ports/dawn/011-fix-dxc.patch
@@ -1,0 +1,45 @@
+diff --git a/src/dawn/native/CMakeLists.txt b/src/dawn/native/CMakeLists.txt
+index 0c5dc4dbba..9f6a8a0c93 100644
+--- a/src/dawn/native/CMakeLists.txt
++++ b/src/dawn/native/CMakeLists.txt
+@@ -950,7 +950,6 @@ if (DAWN_ENABLE_D3D12)
+     if (DAWN_USE_BUILT_DXC)
+         target_compile_definitions(dawn_native PRIVATE "DAWN_USE_BUILT_DXC")
+         target_compile_definitions(dawn_native_objects PRIVATE "DAWN_USE_BUILT_DXC")
+-        add_dependencies(dawn_native copy_dxil_dll)
+     endif()
+ endif()
+ 
+@@ -1051,7 +1050,7 @@ endif ()
+ # They happen because dxcompiler is declared a shared library and bundle_libraries
+ # doesn't work well with shared libs
+ if (DAWN_USE_BUILT_DXC)
+-    target_link_libraries(dawn_native PRIVATE dxcompiler)
++    target_link_libraries(dawn_native PRIVATE Microsoft::DirectXShaderCompiler)
+ endif()
+ 
+ # Copy d3dcompiler_47.dll from Windows SDK when not using system component loading
+diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
+index e9dde19a4a..6346757268 100644
+--- a/third_party/CMakeLists.txt
++++ b/third_party/CMakeLists.txt
+@@ -126,6 +126,8 @@ if(NOT TARGET glslang AND (TINT_BUILD_GLSL_WRITER OR TINT_BUILD_GLSL_VALIDATOR)
+     add_library(glslang-default-resource-limits ALIAS glslang::glslang-default-resource-limits)
+ endif()
+ 
++find_package(directx-dxc CONFIG REQUIRED GLOBAL)
++
+ # Force ENABLE_RTTI in spirv-tools and glslang.
+ set(ENABLE_RTTI ${DAWN_ENABLE_RTTI} CACHE BOOL "" FORCE)
+ 
+@@ -360,10 +362,6 @@ function(AddSubdirectoryDXC)
+     endif()
+ endfunction()
+ 
+-if (DAWN_USE_BUILT_DXC)
+-    AddSubdirectoryDXC()
+-endif()
+-
+ if (TINT_BUILD_TINTD)
+     set(LANGSVR_JSON_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp")
+     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp" EXCLUDE_FROM_ALL)

--- a/ports/dawn/011-fix-dxc.patch
+++ b/ports/dawn/011-fix-dxc.patch
@@ -20,26 +20,15 @@ index 0c5dc4dbba..9f6a8a0c93 100644
  
  # Copy d3dcompiler_47.dll from Windows SDK when not using system component loading
 diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
-index e9dde19a4a..6346757268 100644
+index e9dde19a4a..5d64975fb6 100644
 --- a/third_party/CMakeLists.txt
 +++ b/third_party/CMakeLists.txt
-@@ -126,6 +126,8 @@ if(NOT TARGET glslang AND (TINT_BUILD_GLSL_WRITER OR TINT_BUILD_GLSL_VALIDATOR)
-     add_library(glslang-default-resource-limits ALIAS glslang::glslang-default-resource-limits)
- endif()
- 
-+find_package(directx-dxc CONFIG REQUIRED GLOBAL)
-+
- # Force ENABLE_RTTI in spirv-tools and glslang.
- set(ENABLE_RTTI ${DAWN_ENABLE_RTTI} CACHE BOOL "" FORCE)
- 
-@@ -360,10 +362,6 @@ function(AddSubdirectoryDXC)
-     endif()
+@@ -361,7 +361,7 @@ function(AddSubdirectoryDXC)
  endfunction()
  
--if (DAWN_USE_BUILT_DXC)
+ if (DAWN_USE_BUILT_DXC)
 -    AddSubdirectoryDXC()
--endif()
--
++    find_package(directx-dxc CONFIG REQUIRED GLOBAL)
+ endif()
+ 
  if (TINT_BUILD_TINTD)
-     set(LANGSVR_JSON_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp")
-     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp" EXCLUDE_FROM_ALL)

--- a/ports/dawn/portfile.cmake
+++ b/ports/dawn/portfile.cmake
@@ -45,6 +45,7 @@ vcpkg_from_github(
         008-wrong-dxcapi-include.patch
         009-fix-tint-install.patch
         010-fix-glslang.patch
+		011-fix-dxc.patch
 )
 
 # vcpkg_find_acquire_program(PYTHON3)
@@ -162,6 +163,7 @@ vcpkg_cmake_configure(
         -DDAWN_ENABLE_VULKAN=${DAWN_ENABLE_VULKAN}
         -DDAWN_USE_WAYLAND=${DAWN_USE_WAYLAND}
         -DDAWN_USE_X11=${DAWN_USE_X11}
+		-DDAWN_USE_BUILT_DXC=${VCPKG_TARGET_IS_WINDOWS}
 )
 
 vcpkg_cmake_install()

--- a/ports/dawn/portfile.cmake
+++ b/ports/dawn/portfile.cmake
@@ -137,6 +137,11 @@ vcpkg_check_features(
         tint    TINT_BUILD_CMD_TOOLS
 )
 
+set(DAWN_USE_BUILT_DXC OFF)
+if(DAWN_ENABLE_D3D11 OR DAWN_ENABLE_D3D12)
+	set(DAWN_USE_BUILT_DXC ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -163,7 +168,7 @@ vcpkg_cmake_configure(
         -DDAWN_ENABLE_VULKAN=${DAWN_ENABLE_VULKAN}
         -DDAWN_USE_WAYLAND=${DAWN_USE_WAYLAND}
         -DDAWN_USE_X11=${DAWN_USE_X11}
-		-DDAWN_USE_BUILT_DXC=${VCPKG_TARGET_IS_WINDOWS}
+		-DDAWN_USE_BUILT_DXC=${DAWN_USE_BUILT_DXC}
 )
 
 vcpkg_cmake_install()

--- a/ports/dawn/vcpkg.json
+++ b/ports/dawn/vcpkg.json
@@ -56,11 +56,17 @@
   "features": {
     "d3d11": {
       "description": "Direct3D 11 backend support",
-      "supports": "windows"
+      "supports": "windows",
+      "dependencies": [
+        "directx-dxc"
+      ]
     },
     "d3d12": {
       "description": "Direct3D 12 backend support",
-      "supports": "windows"
+      "supports": "windows",
+      "dependencies": [
+        "directx-dxc"
+      ]
     },
     "gl": {
       "description": "Desktop OpenGL backend support",

--- a/ports/dawn/vcpkg.json
+++ b/ports/dawn/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dawn",
   "version": "20251202.213730",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Dawn is an open-source and cross-platform implementation of the WebGPU standard.",
   "homepage": "https://dawn.googlesource.com/dawn",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2358,7 +2358,7 @@
     },
     "dawn": {
       "baseline": "20251202.213730",
-      "port-version": 1
+      "port-version": 2
     },
     "daxa": {
       "baseline": "3.3.1",

--- a/versions/d-/dawn.json
+++ b/versions/d-/dawn.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fef9f5b3464c9a72c518b8ca258af33014df7061",
+      "git-tree": "f9d0ccec0c29cc0028a3380a85ed8728dc40bf92",
       "version": "20251202.213730",
       "port-version": 2
     },

--- a/versions/d-/dawn.json
+++ b/versions/d-/dawn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fef9f5b3464c9a72c518b8ca258af33014df7061",
+      "version": "20251202.213730",
+      "port-version": 2
+    },
+    {
       "git-tree": "181678a52e8a7859b9b0f6759bacbb41069a78f9",
       "version": "20251202.213730",
       "port-version": 1


### PR DESCRIPTION
This PR switches Dawn to use DXC instead of FXC. This is necessary if we want to user modern features (notably, subgroups), as FXC will stay at Shader Model 5.1 while DXC currently handles Shader Model 6.0 (and beyond). See https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-part1


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.