### PR TITLE
[coppad] support arm64-osx

### DIFF
--- a/ports/cppad/vcpkg.json
+++ b/ports/cppad/vcpkg.json
@@ -2,10 +2,11 @@
   "$comment": "See related issue for compilation failure on UWP and ARM: https://github.com/microsoft/vcpkg/pull/12560#issuecomment-668412073",
   "name": "cppad",
   "version": "20250000.3",
+  "port-version": 1,
   "description": "CppAD: A Package for Differentiation of C++ Algorithms",
   "homepage": "https://github.com/coin-or/CppAD",
   "license": "EPL-2.0",
-  "supports": "!(arm | uwp)",
+  "supports": "!uwp",
   "dependencies": [
     "pkgconf",
     {

--- a/ports/cppad/vcpkg.json
+++ b/ports/cppad/vcpkg.json
@@ -6,7 +6,7 @@
   "description": "CppAD: A Package for Differentiation of C++ Algorithms",
   "homepage": "https://github.com/coin-or/CppAD",
   "license": "EPL-2.0",
-  "supports": "!uwp",
+  "supports": "!uwp & !(windows & arm64)",
   "dependencies": [
     "pkgconf",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2058,7 +2058,7 @@
     },
     "cppad": {
       "baseline": "20250000.3",
-      "port-version": 0
+      "port-version": 1
     },
     "cppcms": {
       "baseline": "2.0.1",

--- a/versions/c-/cppad.json
+++ b/versions/c-/cppad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4950c56c1a5407db162ebbbf10bf8fed4a296a2c",
+      "version": "20250000.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "dde4cbc6637519c09af91fe6050f58824a5063e6",
       "version": "20250000.3",
       "port-version": 0

--- a/versions/c-/cppad.json
+++ b/versions/c-/cppad.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4950c56c1a5407db162ebbbf10bf8fed4a296a2c",
+      "git-tree": "90c3b29013bfbdc5ad4bf24f4ce909b082884960",
       "version": "20250000.3",
       "port-version": 1
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

