### PR TITLE
[plf-hive] update to 2025-12-22

### DIFF
--- a/ports/plf-hive/portfile.cmake
+++ b/ports/plf-hive/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mattreecebentley/plf_hive
-    REF 39dfcc5712125cc645df123c120006b7a6fd95d6
-    SHA512 81a1f185ca8293b6fb83605c05ecf14d024194334cb64932daa29ecae064918241fa7f3e4a688dc2b19b4b5dd8a2605d60947bd513f7cd30299fd6ba25aa8b35
+    REF 5d4f13cafdc1bd5e23c4b5435e0f33f347d3b003
+    SHA512 9f32c8ad70851ba9e2db32c6d47999c2fe554f5e7fdab5803c3743c5df5ca881afacebeb37594dbb8a587df793eab9c7ccae05f20c48e7931cfbb30dd680f5ee
     HEAD_REF master
 )
 

--- a/ports/plf-hive/vcpkg.json
+++ b/ports/plf-hive/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "plf-hive",
-  "version-date": "2021-12-11",
+  "version-date": "2025-12-22",
   "description": "plf::hive is a fork of plf::colony to match the current C++ standards proposal.",
   "homepage": "https://plflib.org/colony.htm"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7621,7 +7621,7 @@
       "port-version": 0
     },
     "plf-hive": {
-      "baseline": "2021-12-11",
+      "baseline": "2025-12-22",
       "port-version": 0
     },
     "plf-indiesort": {

--- a/versions/p-/plf-hive.json
+++ b/versions/p-/plf-hive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "61ec29501054eb034d51dc67343095d71772f3f9",
+      "version-date": "2025-12-22",
+      "port-version": 0
+    },
+    {
       "git-tree": "8e5c8a3892eb3ca1cade64672eaa76d3a9c74990",
       "version-date": "2021-12-11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
