### PR TITLE
[plf-stack] update to 2.0.13

### DIFF
--- a/ports/plf-stack/portfile.cmake
+++ b/ports/plf-stack/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mattreecebentley/plf_stack
-    REF 9d046154d8954eafc12f8d4845505beec8c4a5da
-    SHA512 2202bbff0e93bf515ae7b237551d084dcba9b870bca82f49b4e1a64446f4574079b0cb45fb91f0ad0472e008f21ad014464b45e307ffa6dab19affc6dc38626a
+    REF fd497417c17119dd73068d69749b67a6f9ff00b7 # 2.0.13
+    SHA512 77796cb7e9e008744f28f6de8ab72afa3366ea578be9aec36a4b5eb623cc1efaafb26ebf55456d311b9ce11e6e0e61ba9c030ecf0c7df63c185a13ff2fe2f39b
     HEAD_REF master
 )
 

--- a/ports/plf-stack/vcpkg.json
+++ b/ports/plf-stack/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "plf-stack",
-  "version-date": "2019-08-10",
-  "port-version": 2,
+  "version": "2.0.13",
   "description": "A C++ data container replicating std::stack functionality but with better performance",
   "homepage": "https://www.plflib.org/"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7641,8 +7641,8 @@
       "port-version": 0
     },
     "plf-stack": {
-      "baseline": "2019-08-10",
-      "port-version": 2
+      "baseline": "2.0.13",
+      "port-version": 0
     },
     "plib": {
       "baseline": "1.8.5",

--- a/versions/p-/plf-stack.json
+++ b/versions/p-/plf-stack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c06e4de984a2d6291d94ff1694783994600880c5",
+      "version": "2.0.13",
+      "port-version": 0
+    },
+    {
       "git-tree": "c49e48114d693f6ef74eddadd15ceafffb125ac8",
       "version-date": "2019-08-10",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/mattreecebentley/plf_stack/commit/fd497417c17119dd73068d69749b67a6f9ff00b7
