### PR TITLE
[docopt] Add boost-regex feature

### DIFF
--- a/ports/docopt/portfile.cmake
+++ b/ports/docopt/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-if("boost-regex" IN_LIST FEATURES)
+if(VCPKG_TAGET_IS_WINDOWS)
     set(USE_BOOST_REGEX ON)
 else()
     set(USE_BOOST_REGEX OFF)

--- a/ports/docopt/portfile.cmake
+++ b/ports/docopt/portfile.cmake
@@ -25,7 +25,7 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/docopt)
 
 # Add find_dependency for Boost if boost-regex feature is enabled
-if("boost-regex" IN_LIST FEATURES)
+if(USE_BOOST_REGEX)
     file(READ "${CURRENT_PACKAGES_DIR}/share/docopt/docopt-config.cmake" _contents)
     string(REPLACE "include(\"\${CMAKE_CURRENT_LIST_DIR}/docopt-targets.cmake\")" 
         "include(CMakeFindDependencyMacro)\nfind_dependency(Boost REQUIRED COMPONENTS regex)\ninclude(\"\${CMAKE_CURRENT_LIST_DIR}/docopt-targets.cmake\")" 

--- a/ports/docopt/portfile.cmake
+++ b/ports/docopt/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-if(VCPKG_TAGET_IS_WINDOWS)
+if(VCPKG_TARGET_IS_WINDOWS)
     set(USE_BOOST_REGEX ON)
 else()
     set(USE_BOOST_REGEX OFF)

--- a/ports/docopt/portfile.cmake
+++ b/ports/docopt/portfile.cmake
@@ -6,17 +6,33 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+if("boost-regex" IN_LIST FEATURES)
+    set(USE_BOOST_REGEX ON)
+else()
+    set(USE_BOOST_REGEX OFF)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DWITH_EXAMPLE=OFF
         -DWITH_TESTS=OFF
-        -DUSE_BOOST_REGEX=OFF
+        -DUSE_BOOST_REGEX=${USE_BOOST_REGEX}
 )
 
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/docopt)
+
+# Add find_dependency for Boost if boost-regex feature is enabled
+if("boost-regex" IN_LIST FEATURES)
+    file(READ "${CURRENT_PACKAGES_DIR}/share/docopt/docopt-config.cmake" _contents)
+    string(REPLACE "include(\"\${CMAKE_CURRENT_LIST_DIR}/docopt-targets.cmake\")" 
+        "include(CMakeFindDependencyMacro)\nfind_dependency(Boost REQUIRED COMPONENTS regex)\ninclude(\"\${CMAKE_CURRENT_LIST_DIR}/docopt-targets.cmake\")" 
+        _contents "${_contents}")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/docopt/docopt-config.cmake" "${_contents}")
+endif()
+
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/docopt/vcpkg.json
+++ b/ports/docopt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "docopt",
   "version-date": "2022-03-15",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Command line arguments parser that will make you smile (C++11 port).",
   "license": "MIT OR BSL-1.0",
   "dependencies": [
@@ -13,5 +13,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "boost-regex": {
+      "description": "Use Boost.Regex instead of std::regex",
+      "dependencies": [
+        "boost-regex"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2530,7 +2530,7 @@
     },
     "docopt": {
       "baseline": "2022-03-15",
-      "port-version": 1
+      "port-version": 2
     },
     "doctest": {
       "baseline": "2.4.12",

--- a/versions/d-/docopt.json
+++ b/versions/d-/docopt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b1bcd504e70373da774f4616049d3c4cda2c5fb8",
+      "git-tree": "c45831ab876e6c089eda7abea5300915910d5cd3",
       "version-date": "2022-03-15",
       "port-version": 2
     },

--- a/versions/d-/docopt.json
+++ b/versions/d-/docopt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0f5be50ba636cbfb377ddb67555f13f1cf5101d7",
+      "git-tree": "b1bcd504e70373da774f4616049d3c4cda2c5fb8",
       "version-date": "2022-03-15",
       "port-version": 2
     },

--- a/versions/d-/docopt.json
+++ b/versions/d-/docopt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c45831ab876e6c089eda7abea5300915910d5cd3",
+      "git-tree": "6330f8b6824219ddb2554c59f2206899bbfcf021",
       "version-date": "2022-03-15",
       "port-version": 2
     },

--- a/versions/d-/docopt.json
+++ b/versions/d-/docopt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0f5be50ba636cbfb377ddb67555f13f1cf5101d7",
+      "version-date": "2022-03-15",
+      "port-version": 2
+    },
+    {
       "git-tree": "9b5aa0bd1e02e5c3a66e56b084c951069a591151",
       "version-date": "2022-03-15",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.