### PR TITLE
[gegl] add cairo feature

### DIFF
--- a/ports/gegl/portfile.cmake
+++ b/ports/gegl/portfile.cmake
@@ -22,6 +22,12 @@ else()
     list(APPEND feature_options "-Dintrospection=false")
 endif()
 
+if("cairo" IN_LIST FEATURES)
+    list(APPEND feature_options "-Dcairo=enabled")
+else()
+    list(APPEND feature_options "-Dcairo=disabled")
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -45,7 +51,6 @@ vcpkg_configure_meson(
         -Dmaxflow=disabled
         -Dopenexr=disabled
         -Dopenmp=disabled
-        -Dcairo=disabled
         -Dpango=disabled
         -Dpangocairo=disabled
         -Dpoppler=disabled

--- a/ports/gegl/vcpkg.json
+++ b/ports/gegl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gegl",
   "version": "0.4.66",
+  "port-version": 1,
   "description": "Generic Graphical Library.",
   "homepage": "https://gegl.org/",
   "license": "LGPL-3.0-or-later",
@@ -16,6 +17,15 @@
     }
   ],
   "features": {
+    "cairo": {
+      "description": "Add cairo support",
+      "dependencies": [
+        {
+          "name": "cairo",
+          "default-features": false
+        }
+      ]
+    },
     "introspection": {
       "description": "Enable introspection",
       "supports": "!static",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3250,7 +3250,7 @@
     },
     "gegl": {
       "baseline": "0.4.66",
-      "port-version": 0
+      "port-version": 1
     },
     "gemmlowp": {
       "baseline": "2021-09-28",

--- a/versions/g-/gegl.json
+++ b/versions/g-/gegl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0090e814efd26e2ece837a00748aae0e2cf00ee6",
+      "version": "0.4.66",
+      "port-version": 1
+    },
+    {
       "git-tree": "5a18d0d6cd7f4f7ccab7cfd2c4ef5b5cc331f6b9",
       "version": "0.4.66",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
