### PR TITLE
[gimp] compile gimp 3.2.2

### DIFF
--- a/ports/gimp/gio.patch
+++ b/ports/gimp/gio.patch
@@ -1,0 +1,13 @@
+diff --git a/libgimp/meson.build b/libgimp/meson.build
+index c12e60c2cd..bd4ef1b8cd 100644
+--- a/libgimp/meson.build
++++ b/libgimp/meson.build
+@@ -381,6 +381,8 @@ else
+   gio_specific_gir = ''
+   gio_specific_vapi = ''
+ endif
++gio_specific_gir = ''
++gio_specific_vapi = ''
+ 
+ libgimp_deps_table = [
+     { 'gir': 'Babl-0.1',          'vapi': 'babl-0.1',        },

--- a/ports/gimp/glib_networking.patch
+++ b/ports/gimp/glib_networking.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+--- a/meson.build
++++ b/meson.build
+@@ -552,8 +552,9 @@
+         warnings += glib_warning
+     endif
+ endif
+ 
++glib_networking_works=true
+ if not glib_networking_works
+   error('Test for glib-networking failed. This is required.')
+ endif
+ 

--- a/ports/gimp/portfile.cmake
+++ b/ports/gimp/portfile.cmake
@@ -1,0 +1,84 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://download.gimp.org/gimp/v3.2/gimp-${VERSION}.tar.xz"
+    FILENAME "gimp-${VERSION}.tar.xz"
+    SHA512 b6b201b4f76966f96ab201761a61b4040907d31850c8786d3824d9aac14f04ae53697b74e5c9fee69640c4843fc1b7810a8990b19ba3d7a8131d8783aa5b6d0b
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        glib_networking.patch
+        gio.patch
+)
+
+set(ENV{PKG_CONFIG_PATH} "${CURRENT_INSTALLED_DIR}/lib/pkgconfig")
+set(ENV{BABL_PATH} "${CURRENT_INSTALLED_DIR}/debug/lib/babl-0.1:${CURRENT_INSTALLED_DIR}/lib/babl-0.1")
+set(ENV{GEGL_PATH} "${CURRENT_INSTALLED_DIR}/debug/lib/gegl-0.4:${CURRENT_INSTALLED_DIR}/lib/gegl-0.4")
+set(ENV{GI_TYPELIB_PATH} "${CURRENT_INSTALLED_DIR}/lib/girepository-1.0/")
+set(ENV{FONTCONFIG_PATH} "${CURRENT_INSTALLED_DIR}/share/fontconfig/conf.avail")
+vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/gettext/bin")
+vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/gtk3")
+vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/gdk-pixbuf")
+
+vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+
+execute_process(
+  COMMAND "${PYTHON3}" "-m" "pip" "install" "PyGObject"
+  RESULT_VARIABLE python_exit_code
+  OUTPUT_VARIABLE python_stdout
+  ERROR_VARIABLE python_stderr
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(NOT python_exit_code EQUAL 0)
+  message(FATAL_ERROR "Python failed: ${python_stderr}")
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Daa=disabled
+        -Dalsa=disabled
+        -Dappdata-test=disabled
+        -Dcairo-pdf=disabled
+        -Dfits=disabled
+        -Dghostscript=disabled
+        -Dgudev=disabled
+        -Dheif=disabled
+        -Dilbm=disabled
+        -Djpeg2000=disabled
+        -Djpeg-xl=disabled
+        -Dmng=disabled
+        -Dopenexr=disabled
+        -Dopenmp=disabled
+        -Dprint=false
+        -Dwebkit-unmaintained=false
+        -Dwebp=disabled
+        -Dwmf=disabled
+        -Dxcursor=disabled
+        -Dxpm=disabled
+        -Dheadless-tests=disabled
+        -Dfile-plug-ins-test=false
+        -Dcan-crosscompile-gir=false
+        -Dgi-docgen=disabled
+        -Dlinux-input=disabled
+        -Dvector-icons=true
+        -Dvala=disabled
+        -Djavascript=disabled
+        -Dlua=false
+        -Ddebug-self-in-build=false
+    ADDITIONAL_BINARIES
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
+)
+
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/gimp/vcpkg.json
+++ b/ports/gimp/vcpkg.json
@@ -1,0 +1,96 @@
+{
+  "name": "gimp",
+  "version": "3.2.2",
+  "description": "GNU Image Manipulation Program which is useful for photo retouching, image composition and image authoring.",
+  "homepage": "https://www.gimp.org/",
+  "license": "LGPL-3.0-or-later",
+  "supports": "!static & (!windows | mingw)",
+  "dependencies": [
+    "appstream",
+    {
+      "name": "babl",
+      "default-features": false,
+      "features": [
+        "introspection"
+      ]
+    },
+    "cairo",
+    "exiv2",
+    "fontconfig",
+    "freetype",
+    {
+      "name": "gdk-pixbuf",
+      "default-features": false,
+      "features": [
+        "introspection",
+        "others"
+      ]
+    },
+    {
+      "name": "gegl",
+      "default-features": false,
+      "features": [
+        "cairo",
+        "introspection"
+      ]
+    },
+    {
+      "name": "gettext",
+      "host": true
+    },
+    {
+      "name": "gexiv2",
+      "default-features": false,
+      "features": [
+        "introspection"
+      ]
+    },
+    {
+      "name": "glib-networking",
+      "default-features": false,
+      "features": [
+        "openssl"
+      ]
+    },
+    {
+      "name": "gobject-introspection",
+      "features": [
+        "cairo"
+      ]
+    },
+    {
+      "name": "gtk3",
+      "default-features": false,
+      "features": [
+        "introspection"
+      ]
+    },
+    "harfbuzz",
+    "json-glib",
+    "lcms",
+    "libarchive",
+    "libmypaint",
+    "librsvg",
+    "libxml2",
+    "mypaint-brushes",
+    {
+      "name": "pango",
+      "default-features": false,
+      "features": [
+        "introspection"
+      ]
+    },
+    {
+      "name": "poppler",
+      "features": [
+        "glib"
+      ]
+    },
+    "poppler-data",
+    "tiff",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3400,6 +3400,10 @@
       "baseline": "6.1.2",
       "port-version": 0
     },
+    "gimp": {
+      "baseline": "3.2.2",
+      "port-version": 0
+    },
     "ginkgo": {
       "baseline": "1.11.0",
       "port-version": 0

--- a/versions/g-/gimp.json
+++ b/versions/g-/gimp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "89d0200e29cdac7f8a6dab384321be0ef681505c",
+      "version": "3.2.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
I manage to compile gimp 3.2.0 rc2 only on linux dynamic.
In order to compile it on linux static (maybe also osx static) it needed to compile gir on static.
I leave it here as a draft if someone want to continue this work. 