### PR TITLE
[libxslt] Update to 1.1.45

### DIFF
--- a/ports/libxslt/portfile.cmake
+++ b/ports/libxslt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/libxslt
     REF "v${VERSION}"
-    SHA512 51d9e9586f78c5aa69ac67fac64b865625fefb16bf06f1f06dede0a57b3e382e78dea69145c7c0c59f06735b738bed209751e691dd9045c3cc33df096963f89d
+    SHA512 8b824fc1ecbcfbf6e3eb29e6fef30b7e20a19181869dd3f3b6cbbd6d796789b167d8ed76a6f727236f34ffaab0f8b2a531765fee63feb9ed61e689bc9e21c9dd
     HEAD_REF master
     PATCHES
         cxx-for-libxml2-icu.diff

--- a/ports/libxslt/vcpkg.json
+++ b/ports/libxslt/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxslt",
-  "version": "1.1.43",
-  "port-version": 1,
+  "version": "1.1.45",
   "description": "Libxslt is a XSLT library implemented in C for XSLT 1.0 and most of EXSLT",
   "homepage": "https://github.com/GNOME/libxslt",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5877,8 +5877,8 @@
       "port-version": 0
     },
     "libxslt": {
-      "baseline": "1.1.43",
-      "port-version": 1
+      "baseline": "1.1.45",
+      "port-version": 0
     },
     "libxt": {
       "baseline": "1.3.0",

--- a/versions/l-/libxslt.json
+++ b/versions/l-/libxslt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb9c99b14f727fe2ab51a025a621b221a6468a84",
+      "version": "1.1.45",
+      "port-version": 0
+    },
+    {
       "git-tree": "e1f6fcb93d8c22da682e05de3b458ce33679976e",
       "version": "1.1.43",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
