### PR TITLE
[tesseract] update to 5.5.2

### DIFF
--- a/ports/tesseract/portfile.cmake
+++ b/ports/tesseract/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tesseract-ocr/tesseract
     REF "${VERSION}"
-    SHA512 37c9cc2ac1bcd26b783f76a0cd8ef266d2dd54746c73d983202d150bf885b50fd32d9f1745d1df65f4cddccd9fc24b1b871e8dea8dcba3454a27363297423cdd
+    SHA512 e9103c68ba186821aedd38de4d9949cd6732da93a2d0764de18aaaac70eb9c305384a6eb1fe656a8a269bee833178a583a91dd72027ae26d27c8329ed722f4a9
     PATCHES
         fix_static_link_icu.patch
         fix-link-include-path.patch

--- a/ports/tesseract/vcpkg.json
+++ b/ports/tesseract/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tesseract",
-  "version": "5.5.1",
-  "port-version": 1,
+  "version": "5.5.2",
   "description": "An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.",
   "homepage": "https://github.com/tesseract-ocr/tesseract",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9737,8 +9737,8 @@
       "port-version": 0
     },
     "tesseract": {
-      "baseline": "5.5.1",
-      "port-version": 1
+      "baseline": "5.5.2",
+      "port-version": 0
     },
     "tevclient": {
       "baseline": "2023-12-04",

--- a/versions/t-/tesseract.json
+++ b/versions/t-/tesseract.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ed497e10dafba7808ea1f33bd10954d3923396a8",
+      "version": "5.5.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "5e3fdcd84fb65d4a9db9034093d5f8b78b5d91ba",
       "version": "5.5.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/tesseract-ocr/tesseract/releases/tag/5.5.2
