### PR TITLE
[curve-coco] add new port

### DIFF
--- a/ports/curve-coco/portfile.cmake
+++ b/ports/curve-coco/portfile.cmake
@@ -1,0 +1,30 @@
+# Header-only library
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Curve/coco
+    REF "v${VERSION}"
+    SHA512 7c011553834dba0030ad01d45fcdd3b092ca1b30ccb6f500bbc3e53ed5ee3c0eb57a581347f9879e5b3746cdc3e3214d41329a6ef04988c64c9f55350d8948a3
+    HEAD_REF master
+    PATCHES
+        remove-cpm.patch
+)
+
+# Replace CPM and download PackageProject directly to avoid issues with FETCHCONTENT_FULLY_DISCONNECTED
+vcpkg_from_github(
+    OUT_SOURCE_PATH PACKAGE_PROJECT_PATH
+    REPO TheLartians/PackageProject.cmake
+    REF "v1.13.0"
+    SHA512 3cf0523bddc213f206ed0ca57803550cb7db9e293392d3741138be47f49d9027ef517e1656235a349a62b492d35c3fc677714dc00afe59e2d36144a9689cfa8f
+    HEAD_REF master
+)
+file(RENAME "${PACKAGE_PROJECT_PATH}" "${SOURCE_PATH}/cmake/packageproject.cmake")
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/coco-${VERSION})
+
+# remove empty lib and debug/lib directories (and duplicate files from debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/curve-coco/portfile.cmake
+++ b/ports/curve-coco/portfile.cmake
@@ -1,4 +1,4 @@
-# Header-only library
+set(VCPKG_BUILD_TYPE release) # Header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Curve/coco
@@ -22,9 +22,8 @@ file(RENAME "${PACKAGE_PROJECT_PATH}" "${SOURCE_PATH}/cmake/packageproject.cmake
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/coco-${VERSION})
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/coco-${VERSION}" PACKAGE_NAME "coco")
 
-# remove empty lib and debug/lib directories (and duplicate files from debug/include)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")  # from CMake config
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/curve-coco/remove-cpm.patch
+++ b/ports/curve-coco/remove-cpm.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3a2434c..ae2b342 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,7 +13,6 @@ option(coco_exceptions "Enable exception support (Respects -fno-exceptions even
+ # +-------------------------------------------------------------------------------------------------------+
+ 
+ add_library(${PROJECT_NAME} STATIC "src/latch.cpp" "src/stray.cpp")
+-add_library(cr::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+ 
+ target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
+ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20 CXX_EXTENSIONS OFF CXX_STANDARD_REQUIRED ON)
+@@ -50,13 +49,7 @@ endif()
+ # | Package Config                                                                                        |
+ # +-------------------------------------------------------------------------------------------------------+
+ 
+-include("cmake/cpm.cmake")
+-
+-CPMFindPackage(
+-  NAME           PackageProject
+-  VERSION        1.13.0
+-  GIT_REPOSITORY "https://github.com/TheLartians/PackageProject.cmake"
+-)
++add_subdirectory(cmake/packageproject.cmake)
+ 
+ packageProject(
+   NAMESPACE cr

--- a/ports/curve-coco/vcpkg.json
+++ b/ports/curve-coco/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "curve-coco",
+  "version": "4.3.0",
+  "description": "a C++20 coroutine library that aims to be convenient and simple to use.",
+  "homepage": "https://github.com/Curve/coco",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2276,6 +2276,10 @@
       "baseline": "2018-06-15",
       "port-version": 11
     },
+    "curve-coco": {
+      "baseline": "4.3.0",
+      "port-version": 0
+    },
     "cute-headers": {
       "baseline": "2019-09-20",
       "port-version": 2

--- a/versions/c-/curve-coco.json
+++ b/versions/c-/curve-coco.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1bb2afbddd90028c4b34d4b268d8be42fc315f2e",
+      "version": "4.3.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/curve-coco.json
+++ b/versions/c-/curve-coco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1bb2afbddd90028c4b34d4b268d8be42fc315f2e",
+      "git-tree": "428adea8bb4f40ac5b13d1331ea8e5a6a7d9abb9",
       "version": "4.3.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Curve/coco/

[ereignis](https://github.com/Curve/ereignis) requires coco since 5.0.0.