### PR TITLE
[recycle] update to 8.0.0

### DIFF
--- a/ports/recycle/disable-tests.patch
+++ b/ports/recycle/disable-tests.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index df64f52..ac9a79d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.10)
+ project(recycle)
+ 
+ 
+-# Include common CMake settings
+-include("${STEINWURF_RESOLVE}/toolchains/common_settings.cmake")
+-
+ # Define library
+ add_library(recycle INTERFACE)
+ target_compile_features(recycle INTERFACE cxx_std_14)
+@@ -19,7 +16,7 @@ install(
+   PATTERN *.hpp)
+ 
+   # Is top level project?
+-if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
++if(0)
+ 
+   # Setup testing
+   enable_testing()

--- a/ports/recycle/portfile.cmake
+++ b/ports/recycle/portfile.cmake
@@ -2,7 +2,9 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO steinwurf/recycle
     REF "${VERSION}"
-    SHA512 c30cd3d388eeeea6a3db344e0e448878686c4a7bc106260c7de9d1eeb3477435eb1783bca09151356ba51200ecf14182891f97a38943959032c54b17ea0abac3
+    SHA512 cc11dffe5a5aa6cf1f1c1b0c53830332edf784d7bac21608c8d04f8e077381df2e4a65c8664319f23bb80fc01240a79d314bd60c70b90b988e0319b2704da60d
+    PATCHES
+        disable-tests.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/recycle/vcpkg.json
+++ b/ports/recycle/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "recycle",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Simple resource pool for recycling resources in C++",
   "homepage": "https://github.com/steinwurf/recycle",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8533,7 +8533,7 @@
       "port-version": 1
     },
     "recycle": {
-      "baseline": "7.0.0",
+      "baseline": "8.0.0",
       "port-version": 0
     },
     "red0124-ssp": {

--- a/versions/r-/recycle.json
+++ b/versions/r-/recycle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a5e0a88bdac196d7eebf7a8a6a138c6d54b35c4",
+      "version": "8.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "342b8bf7460c684c89e390b02194bcad6ef7eb64",
       "version": "7.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/steinwurf/recycle/releases/tag/8.0.0
