### PR TITLE
[launch-darkly-server] Fix cmake usage

### DIFF
--- a/ports/launch-darkly-server/launch-darkly-server-config.cmake
+++ b/ports/launch-darkly-server/launch-darkly-server-config.cmake
@@ -1,2 +1,2 @@
-include(${CMAKE_CURRENT_LIST_DIR}/ldserverapi-targets.cmake)
-
+include(CMakeFindDependencyMacro)
+find_dependency(ldserverapi CONFIG)

--- a/ports/launch-darkly-server/portfile.cmake
+++ b/ports/launch-darkly-server/portfile.cmake
@@ -76,6 +76,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(
 	CONFIG_PATH lib/cmake/ldserverapi
+	PACKAGE_NAME ldserverapi
 )
 
 file(REMOVE_RECURSE
@@ -85,8 +86,8 @@ file(REMOVE_RECURSE
 vcpkg_copy_pdbs()
 
 set(shareDir "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+# legacy vcpkg, unofficial
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/launch-darkly-server-config.cmake DESTINATION ${shareDir})
-file(RENAME ${shareDir}/ldserverapiTargets.cmake ${shareDir}/ldserverapi-targets.cmake)
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/launch-darkly-server/usage
+++ b/ports/launch-darkly-server/usage
@@ -1,5 +1,4 @@
-The package launchdarklyserver provides CMake targets:
+launch-darkly-server provides CMake targets:
 
-    find_package(launch-darkly-server CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE ldserverapi::ldserverapi)
- 
+  find_package(ldserverapi CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE ldserverapi::ldserverapi)

--- a/ports/launch-darkly-server/vcpkg.json
+++ b/ports/launch-darkly-server/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "launch-darkly-server",
   "version": "2.9.3",
+  "port-version": 1,
   "description": "LaunchDarkly server-side SDK for C/C++",
   "homepage": "https://github.com/launchdarkly/c-server-sdk",
   "license": "Apache-2.0",
   "supports": "!uwp",
   "dependencies": [
-    "curl",
+    {
+      "name": "curl",
+      "default-features": false
+    },
     "pcre",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4470,7 +4470,7 @@
     },
     "launch-darkly-server": {
       "baseline": "2.9.3",
-      "port-version": 0
+      "port-version": 1
     },
     "lazy-importer": {
       "baseline": "2023-08-03",

--- a/versions/l-/launch-darkly-server.json
+++ b/versions/l-/launch-darkly-server.json
@@ -1,8 +1,14 @@
 {
   "versions": [
     {
+      "git-tree": "a20f687358692521a83a44ddefdd0bb507f9f826",
+      "version": "2.9.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "f1cc29ee2a449604e38c80c1c864a3683b675e6c",
-      "version": "2.9.3"
+      "version": "2.9.3",
+      "port-version": 0
     },
     {
       "git-tree": "cf4d27e890d7becddd87f89a3a0622199892ebd2",


### PR DESCRIPTION
Official usage is `find_package(ldserverapi CONFIG REQUIRED)`.

Reviewed while preparing curl 8.18. No other changes in this PR. This port needs to be migrated to https://github.com/launchdarkly/cpp-sdks/tree/main/libs/server-sdk.