### PR TITLE
[kubernetes] Test and fix cmake config

### DIFF
--- a/ports/kubernetes/Config.cmake.in
+++ b/ports/kubernetes/Config.cmake.in
@@ -1,0 +1,6 @@
+include(CMakeFindDependencyMacro)
+find_dependency(CURL)
+find_dependency(libwebsockets)
+find_dependency(OpenSSL)
+find_dependency(yaml)
+include("${CMAKE_CURRENT_LIST_DIR}/kubernetesTargets.cmake")

--- a/ports/kubernetes/portfile.cmake
+++ b/ports/kubernetes/portfile.cmake
@@ -8,19 +8,15 @@ vcpkg_from_github(
         001-fix-destination.patch
         002-disable-werror.patch
 )
+file(COPY "${CURRENT_PORT_DIR}/Config.cmake.in" DESTINATION "${SOURCE_PATH}/kubernetes")
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}/kubernetes
+    SOURCE_PATH "${SOURCE_PATH}/kubernetes"
 )
-
 vcpkg_cmake_install()
-
-if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL debug)
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-endif()
-
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
-
 vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/kubernetes)
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/kubernetes/vcpkg.json
+++ b/ports/kubernetes/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "kubernetes",
   "version": "0.14.0",
+  "port-version": 1,
   "description": "Kubernetes C client",
   "homepage": "https://github.com/kubernetes-client/c/",
   "license": "Apache-2.0",
   "supports": "!windows | mingw",
   "dependencies": [
-    "curl",
+    {
+      "name": "curl",
+      "default-features": false
+    },
     "libwebsockets",
     "libyaml",
     "openssl",

--- a/scripts/test_ports/vcpkg-ci-kubernetes/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-kubernetes/portfile.cmake
@@ -1,0 +1,18 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kubernetes-client/c
+    REF v0.14.0
+    SHA512 8324049f030201e9a031556a799defcbc90fe41bc7b40e2997ed0c706f97660af39b84d679065e83adce85b66c832d406468a9c543367b64c5b702fc5896ee07
+    HEAD_REF master
+    PATCHES
+        standalone.diff
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+    OPTIONS
+        "-DSOURCE_FILE=${SOURCE_PATH}/examples/generic/main.c"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-kubernetes/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-kubernetes/project/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.30)
+project(kubernetes-test C)
+
+find_package(kubernetes CONFIG REQUIRED)
+
+set(SOURCE_FILE "REQUIRED" CACHE STRING "")
+add_executable(main "${SOURCE_FILE}")
+target_link_libraries(main PRIVATE kubernetes::kubernetes)

--- a/scripts/test_ports/vcpkg-ci-kubernetes/standalone.diff
+++ b/scripts/test_ports/vcpkg-ci-kubernetes/standalone.diff
@@ -1,14 +1,16 @@
 diff --git a/examples/generic/main.c b/examples/generic/main.c
-index 2984bcc..ca25c34 100644
+index 2984bcc..74d7be7 100644
 --- a/examples/generic/main.c
 +++ b/examples/generic/main.c
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
 -#include <kube_config.h>
 -#include <apiClient.h>
 -#include <generic.h>
+-#include <malloc.h>
 +#include <kubernetes/config/kube_config.h>
 +#include <kubernetes/include/apiClient.h>
 +#include <kubernetes/include/generic.h>
- #include <malloc.h>
++#include <stdlib.h>
  #include <stdio.h>
  #include <errno.h>
+ 

--- a/scripts/test_ports/vcpkg-ci-kubernetes/standalone.diff
+++ b/scripts/test_ports/vcpkg-ci-kubernetes/standalone.diff
@@ -1,0 +1,14 @@
+diff --git a/examples/generic/main.c b/examples/generic/main.c
+index 2984bcc..ca25c34 100644
+--- a/examples/generic/main.c
++++ b/examples/generic/main.c
+@@ -1,6 +1,6 @@
+-#include <kube_config.h>
+-#include <apiClient.h>
+-#include <generic.h>
++#include <kubernetes/config/kube_config.h>
++#include <kubernetes/include/apiClient.h>
++#include <kubernetes/include/generic.h>
+ #include <malloc.h>
+ #include <stdio.h>
+ #include <errno.h>

--- a/scripts/test_ports/vcpkg-ci-kubernetes/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-kubernetes/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "vcpkg-ci-kubernetes",
+  "version-string": "ci",
+  "description": "Port to force features of kubernetes within CI",
+  "homepage": "https://github.com/microsoft/vcpkg",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "kubernetes",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4434,7 +4434,7 @@
     },
     "kubernetes": {
       "baseline": "0.14.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kuku": {
       "baseline": "2.1.0",

--- a/versions/k-/kubernetes.json
+++ b/versions/k-/kubernetes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1778889e7b38d8e6d1c59ac75cf7ee45678a49e2",
+      "version": "0.14.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e25593431c9c23fffbf82fff82d08a784adbd3ed",
       "version": "0.14.0",
       "port-version": 0


### PR DESCRIPTION
Noticed while preparing curl 8.18.

FTR this port should be `kubernetes-client-c`. It is "Based on Kubernetes release 1.34" but uses a different version: 
https://github.com/kubernetes-client/c/releases/tag/v0.14.0
https://repology.org/projects/k/?search=kubernetes

