### PR TITLE
Add new port:chlog

### DIFF
--- a/ports/chlog/portfile.cmake
+++ b/ports/chlog/portfile.cmake
@@ -1,3 +1,5 @@
+set(VCPKG_BUILD_TYPE release) # header-only library
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jiannanya/chlog

--- a/ports/chlog/portfile.cmake
+++ b/ports/chlog/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_fixup_cmake_targets(
 # Header-only: remove empty lib directories created by CMake install/export.
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/chlog/portfile.cmake
+++ b/ports/chlog/portfile.cmake
@@ -23,8 +23,6 @@ vcpkg_fixup_cmake_targets(
 
 # Header-only: remove empty lib directories created by CMake install/export.
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/chlog/portfile.cmake
+++ b/ports/chlog/portfile.cmake
@@ -25,10 +25,6 @@ vcpkg_fixup_cmake_targets(
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
 
-# Header-only: remove debug tree if produced.
-if(EXISTS "${CURRENT_PACKAGES_DIR}/debug")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-endif()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 

--- a/ports/chlog/portfile.cmake
+++ b/ports/chlog/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jiannanya/chlog
+    REF v1.0.0
+    SHA512 a9c827f0c1b732a70b214746ca681c5759a71e4b759bfc95a5b0e4c8ac9b1b0b93c83e88ba0e46985d27774abe486cd15f3d93dbe253dd3024039e90f27d223d
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PREFER_NINJA
+    OPTIONS
+        -DCHLOG_BUILD_EXAMPLES=OFF
+        -DCHLOG_BUILD_BENCHMARKS=OFF
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(
+    CONFIG_PATH lib/cmake/chlog
+)
+
+# Header-only: remove empty lib directories created by CMake install/export.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib")
+
+# Header-only: remove debug tree if produced.
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+endif()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/chlog/usage
+++ b/ports/chlog/usage
@@ -1,0 +1,8 @@
+chlog provides a CMake package.
+
+find_package(chlog CONFIG REQUIRED)
+target_link_libraries(your_target PRIVATE chlog::chlog)
+
+# Optional: if you want to use {fmt} backend
+# find_package(fmt CONFIG REQUIRED)
+# target_compile_definitions(your_target PRIVATE CHLOG_USE_FMT=1)

--- a/ports/chlog/vcpkg.json
+++ b/ports/chlog/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "chlog",
-  "version-string": "1.0.0",
+  "version": "1.0.0",
   "description": "Header-only C++20 logging library with optional async and extensible sinks",
   "homepage": "https://github.com/jiannanya/chlog",
   "license": "MIT",

--- a/ports/chlog/vcpkg.json
+++ b/ports/chlog/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "chlog",
   "version": "1.0.0",
+  "port-version": 1,
   "description": "Header-only C++20 logging library with optional async and extensible sinks",
   "homepage": "https://github.com/jiannanya/chlog",
   "license": "MIT",

--- a/ports/chlog/vcpkg.json
+++ b/ports/chlog/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "chlog",
+  "version-string": "1.0.0",
+  "description": "Header-only C++20 logging library with optional async and extensible sinks",
+  "homepage": "https://github.com/jiannanya/chlog",
+  "license": "MIT",
+  "features": {
+    "fmt": {
+      "description": "Enable optional {fmt} backend integration (consumer defines CHLOG_USE_FMT)",
+      "dependencies": [
+        "fmt"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1712,6 +1712,10 @@
       "baseline": "7.0.3",
       "port-version": 7
     },
+    "chlog": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "chmlib": {
       "baseline": "0.40",
       "port-version": 8

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1714,7 +1714,7 @@
     },
     "chlog": {
       "baseline": "1.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "chmlib": {
       "baseline": "0.40",

--- a/versions/c-/chlog.json
+++ b/versions/c-/chlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b641bf71ec1f5c203172d9e9c0aafe59cbb48a2b",
+      "version": "1.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ed94bb8176d21d66541078139267bf97c27c2e70",
       "version": "1.0.0",
       "port-version": 0

--- a/versions/c-/chlog.json
+++ b/versions/c-/chlog.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ed94bb8176d21d66541078139267bf97c27c2e70",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

