### PR TITLE
[cppad] support include_eigen

### DIFF
--- a/ports/cppad/portfile.cmake
+++ b/ports/cppad/portfile.cmake
@@ -4,6 +4,13 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 f2dffaeaaf46dcd051a3354478c7ba61ed6a3538cdcc39c066fd9eb22ef58f0cde30079595e9db273d6484a31c8f73c84061ac7f5a5028f920ec74ef26c8e7c1
     HEAD_REF master
+    PATCHES
+        support_include_eigen.diff
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        eigen   include_eigen
 )
 
 vcpkg_cmake_configure(
@@ -11,6 +18,7 @@ vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -Dcppad_prefix=${CURRENT_PACKAGES_DIR}
+        ${FEATURE_OPTIONS}
     OPTIONS_RELEASE
         -Dcmake_install_libdirs=lib
     OPTIONS_DEBUG

--- a/ports/cppad/support_include_eigen.diff
+++ b/ports/cppad/support_include_eigen.diff
@@ -1,0 +1,109 @@
+Index: CMakeLists.txt
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>GBK
+===================================================================
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	(revision baf37ba33d98d19c2eb0aac2535cc58da903f158)
++++ b/CMakeLists.txt	(date 1767023874397)
+@@ -127,11 +127,11 @@
+    )
+ ENDIF( cmake_needs_dot_slash )
+ #
+-IF( include_eigen )
+-   MESSAGE(FATAL_ERROR
+-      "include_eigen was removed; see release notes for 2024-10-02"
+-   )
+-ENDIF( )
++# IF( include_eigen )
++#    MESSAGE(FATAL_ERROR
++#       "include_eigen was removed; see release notes for 2024-10-02"
++#    )
++# ENDIF( )
+ # -----------------------------------------------------------------------------
+ # Current Arguments
+ #
+Index: cmake/eigen_info.cmake
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>GBK
+===================================================================
+diff --git a/cmake/eigen_info.cmake b/cmake/eigen_info.cmake
+--- a/cmake/eigen_info.cmake	(revision baf37ba33d98d19c2eb0aac2535cc58da903f158)
++++ b/cmake/eigen_info.cmake	(date 1767024793360)
+@@ -4,8 +4,14 @@
+ # ----------------------------------------------------------------------------
+ # eigen_info()
+ #
++# include_eigen: (in)
++# is set by this macro to a cache BOOL variable initialized as false.
++# It can be changed by the cmake command line or gui.
++# If it is true, there must be a pkg-config file for eigen3 and
++# the corresponding include directories added using INCLUDE_DIRECTORIES.
++#
+ # cppad_has_eigen: (out)
+-# is 1 (0) if eigen is found (not found)
++# is 1 if include_eigen is true and eigen is found, 0 otherwise.
+ # If this is 1, the include directory for eigen will automatically be
+ # added using INCLUDE_DIRECTORIES with the SYSTEM flag.
+ #
+@@ -17,27 +23,38 @@
+ # This macro may use variables with the name eigen_*
+ MACRO(eigen_info)
+    #
+-   # check for pkg-config
+-   IF( NOT PKG_CONFIG_FOUND )
+-      FIND_PACKAGE(PkgConfig REQUIRED)
+-   ENDIF( )
+-   #
+-   #
+-   IF( NOT ${use_cplusplus_2014_ok} )
+-      MESSAGE(STATUS "Eigen not supportedL: because c++14 not supported")
+-      SET(cppad_has_eigen 0)
+-   ELSE( )
+-      #
+-      # eigen_*
+-      pkg_check_modules(eigen QUIET eigen3 )
+-      #
+-      IF( eigen_FOUND )
+-         MESSAGE(STATUS "Eigen found")
+-         SET(cppad_has_eigen 1)
+-         INCLUDE_DIRECTORIES( SYSTEM ${eigen_INCLUDE_DIRS} )
+-      ELSE( )
+-         MESSAGE(STATUS "Eigen not Found: eigen3.pc not in PKG_CONFIG_PATH")
+-         SET(cppad_has_eigen 0)
++   # include_eigen
++   SET(
++      include_eigen
++      FALSE CACHE BOOL "include eigen using its pkgconfig file"
++   )
++   print_variable( include_eigen )
++   IF( NOT include_eigen )
++      SET(cppad_has_eigen 0)
++   ELSE( )
++      #
++      # check for pkg-config
++      IF( NOT PKG_CONFIG_FOUND )
++         FIND_PACKAGE(PkgConfig REQUIRED)
++      ENDIF( )
++      #
++      #
++      IF( NOT ${use_cplusplus_2014_ok} )
++         MESSAGE(STATUS "Eigen not supportedL: because c++14 not supported")
++         SET(cppad_has_eigen 0)
++      ELSE( )
++         #
++         # eigen_*
++         pkg_check_modules(eigen QUIET eigen3 )
++         #
++         IF( eigen_FOUND )
++            MESSAGE(STATUS "Eigen found")
++            SET(cppad_has_eigen 1)
++            INCLUDE_DIRECTORIES( SYSTEM ${eigen_INCLUDE_DIRS} )
++         ELSE( )
++            MESSAGE(STATUS "Eigen not Found: eigen3.pc not in PKG_CONFIG_PATH")
++            SET(cppad_has_eigen 0)
++         ENDIF( )
+       ENDIF( )
+    ENDIF( )
+    #

--- a/ports/cppad/vcpkg.json
+++ b/ports/cppad/vcpkg.json
@@ -2,7 +2,7 @@
   "$comment": "See related issue for compilation failure on UWP and ARM: https://github.com/microsoft/vcpkg/pull/12560#issuecomment-668412073",
   "name": "cppad",
   "version": "20250000.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "CppAD: A Package for Differentiation of C++ Algorithms",
   "homepage": "https://github.com/coin-or/CppAD",
   "license": "EPL-2.0",
@@ -13,5 +13,16 @@
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "default-features": [
+    "eigen"
+  ],
+  "features": {
+    "eigen": {
+      "description": "Use Eigen for matrix operations",
+      "dependencies": [
+        "eigen3"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2042,7 +2042,7 @@
     },
     "cppad": {
       "baseline": "20250000.3",
-      "port-version": 1
+      "port-version": 2
     },
     "cppcms": {
       "baseline": "2.0.1",

--- a/versions/c-/cppad.json
+++ b/versions/c-/cppad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "328042f1ca648d9ef9b5fad26a874e52eb892542",
+      "version": "20250000.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "90c3b29013bfbdc5ad4bf24f4ce909b082884960",
       "version": "20250000.3",
       "port-version": 1


### PR DESCRIPTION
Fixed https://github.com/microsoft/vcpkg/pull/49148#discussion_r2650485383

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

