### PR TITLE
[slick-shm] new port

### DIFF
--- a/ports/slick-shm/portfile.cmake
+++ b/ports/slick-shm/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO SlickQuant/slick_shm
+    REF "v${VERSION}"
+    SHA512 bffa11f9c1171c13ce31c0f2a3da0194ed679557fa7162463115334caf04c8308492d52c8fc6e1a7fbda14ebba355607f67dd1df329176a23d31e92127925a26 
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSLICK_SHM_BUILD_EXAMPLES=OFF
+        -DSLICK_SHM_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+
+# Fix up CMake config files before removing lib directory
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME slick_shm
+    CONFIG_PATH lib/cmake/slick_shm
+)
+
+# Header-only library - remove lib directory after config fixup
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+
+# Install license
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/slick-shm/usage
+++ b/ports/slick-shm/usage
@@ -1,0 +1,4 @@
+slick-shm provides CMake targets:
+
+  find_package(slick_shm CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE slick::shm)

--- a/ports/slick-shm/vcpkg.json
+++ b/ports/slick-shm/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "slick-shm",
+  "version-semver": "0.1.1",
+  "description": "A modern C++17 header-only, cross-platform shared memory library",
+  "homepage": "https://github.com/SlickQuant/slick_shm",
+  "license": "MIT",
+  "supports": "windows | linux | osx",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9164,6 +9164,10 @@
       "baseline": "1.2.0",
       "port-version": 0
     },
+    "slick-shm": {
+      "baseline": "0.1.1",
+      "port-version": 0
+    },
     "slikenet": {
       "baseline": "2021-06-07",
       "port-version": 3

--- a/versions/s-/slick-shm.json
+++ b/versions/s-/slick-shm.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "edf3473b514736fb5b7fcc257ec52170c56e9cc9",
+      "version-semver": "0.1.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

## Slick SHM
A modern C++17 header-only, cross-platform shared memory library.

### Features
Header-only: No compilation required, just include and use
Cross-platform: Works on Windows, Linux, and macOS
Modern C++17: Uses modern C++ features and idioms
RAII: Automatic resource management
Hybrid error handling: Both exception and no-throw variants
Type-safe: Clean, type-safe API