### PR TITLE
[asiosdk] Allow building for arm64

### DIFF
--- a/ports/asiosdk/vcpkg.json
+++ b/ports/asiosdk/vcpkg.json
@@ -3,5 +3,5 @@
   "version": "2.3.4",
   "description": "ASIO is a low latency audio API from Steinberg.",
   "homepage": "https://www.steinberg.net/developers/asiosdk-open/",
-  "supports": "windows & !(arm | uwp)"
+  "supports": "windows & !uwp"
 }

--- a/ports/asiosdk/vcpkg.json
+++ b/ports/asiosdk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "asiosdk",
   "version": "2.3.4",
+  "port-version": 1,
   "description": "ASIO is a low latency audio API from Steinberg.",
   "homepage": "https://www.steinberg.net/developers/asiosdk-open/",
   "supports": "windows & !uwp"

--- a/versions/a-/asiosdk.json
+++ b/versions/a-/asiosdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49043709b884e2123f167a92188476050ddb02c7",
+      "version": "2.3.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "995bc94ecf43d85d36831f063d9c11d3710a88e5",
       "version": "2.3.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -306,7 +306,7 @@
     },
     "asiosdk": {
       "baseline": "2.3.4",
-      "port-version": 0
+      "port-version": 1
     },
     "asmjit": {
       "baseline": "2025-10-13",


### PR DESCRIPTION
This PR allows `asiosdk` to be built for arm64, since according to the file "Steinberg ASIO Licensing Agreement.pdf" in the SDK and according to [this article](https://devblogs.microsoft.com/windows-music-dev/making-music-on-windows/#announcing:-new-low-latency-in-box-usb-audio-class-2-driver-with-asio-interface-on-arm64), arm64 hardware is supported. Arm64 support was added in version 2.3.4 of the ASIO SDK, which is the version used here in vcpkg.

Disclaimer: I have not built `asiosdk` or tested these changes - I'm only relaxing the port's requirements to reflect the change made in version 2.3.4 of the SDK.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
