### PR TITLE
[icu] Fix build on *BSD and Solaris

### DIFF
--- a/ports/icu/fix_bsd_and_solaris.patch
+++ b/ports/icu/fix_bsd_and_solaris.patch
@@ -1,0 +1,19 @@
+diff --git a/source/configure b/source/configure
+index d1b5812..7b93221 100755
+--- a/source/configure
++++ b/source/configure
+@@ -7008,12 +7008,12 @@ printf %s "checking for genccode assembly... " >&6; }
+ # Check to see if genccode can generate simple assembly.
+ GENCCODE_ASSEMBLY=
+ case "${host}" in
+-*-linux*|*-kfreebsd*-gnu*|i*86-*-*bsd*|i*86-pc-gnu)
++*-linux*|*-kfreebsd*-gnu*|*86*-*bsd*|*86*-pc-gnu)
+     if test "$GCC" = yes; then
+         # We're using gcc, and the simple -a gcc command line works for genccode
+         GENCCODE_ASSEMBLY="-a gcc"
+     fi ;;
+-i*86-*-solaris*)
++*86*-solaris*)
+     if test "$GCC" = yes; then
+         # When using gcc, look if we're also using GNU as.
+         # When using GNU as, the simple -a gcc command line works for genccode.

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
         disable-static-prefix.patch # https://gitlab.kitware.com/cmake/cmake/-/issues/16617; also mingw.
+        fix_bsd_and_solaris.patch
         fix_parallel_build_on_windows.patch
         mh-darwin.patch
         mh-mingw.patch

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "icu",
   "version": "78.1",
+  "port-version": 1,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3842,7 +3842,7 @@
     },
     "icu": {
       "baseline": "78.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ideviceinstaller": {
       "baseline": "2023-07-21",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1fee992f7c429f4f5411338bede36139266337d4",
+      "version": "78.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "283be8dda7e30d7082255f38b6f18fb16c5f80c0",
       "version": "78.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.