### PR TITLE
[qtbase] Fix build on FreeBSD 15

### DIFF
--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -29,6 +29,7 @@ set(${PORT}_PATCHES
         fix-libresolv-test.patch
         2d4915.diff
         framework.patch
+        use_inotify_on_freebsd.patch
 )
  
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/qtbase/use_inotify_on_freebsd.patch
+++ b/ports/qtbase/use_inotify_on_freebsd.patch
@@ -1,0 +1,13 @@
+diff --git a/src/corelib/io/qfilesystemwatcher.cpp b/src/corelib/io/qfilesystemwatcher.cpp
+index cd72f21a..2fba878f 100644
+--- a/src/corelib/io/qfilesystemwatcher.cpp
++++ b/src/corelib/io/qfilesystemwatcher.cpp
+@@ -11,7 +11,7 @@
+ #include <qloggingcategory.h>
+ #include <qset.h>
+ 
+-#if (defined(Q_OS_LINUX) || defined(Q_OS_QNX)) && QT_CONFIG(inotify)
++#if (defined(Q_OS_LINUX) || defined(Q_OS_QNX) || defined(Q_OS_FREEBSD)) && QT_CONFIG(inotify)
+ #define USE_INOTIFY
+ #endif
+ 

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.10.0",
+  "port-version": 1,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8138,7 +8138,7 @@
     },
     "qtbase": {
       "baseline": "6.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qtcharts": {
       "baseline": "6.10.0",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ab7c7c7654ecd1fa22b8c05c9cfc3c3e91aadc8",
+      "version": "6.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c59faa7f07b2a2e49ad0bfdee81d55ff8b5068a5",
       "version": "6.10.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.