### PR TITLE
[cimg] update to 3.6.6

### DIFF
--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO GreycLab/CImg
     # Using commit id becuase upstream likes to change tags
-    REF 50674b2dcfe004673f629bbb37bc9c960f2ae614
-    SHA512 efdeab32fa4378818bb599c34590dcebef2b790594eacb822bb9eba9679c73b59f37c75b3ea2e348ea6cfa47866a72402dfc660a14b930514a7452d9a0bbc8ea
+    REF a5fb0fd2efff9af9c7482a2c064f82b8da7c3ceb
+    SHA512 c15ccab40400c8b00e8899a08c67cc5f867db1fd01222e420cb2a7f8b3f5cd625573900d8c192e22156e11930953c6e6676d83a97734cd4f1bd46fea47d7d735
     HEAD_REF master
 )
 

--- a/ports/cimg/vcpkg.json
+++ b/ports/cimg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cimg",
-  "version": "3.6.5",
-  "port-version": 2,
+  "version": "3.6.6",
   "description": "The CImg Library is a small, open-source, and modern C++ toolkit for image processing",
   "homepage": "https://github.com/GreycLab/CImg",
   "license": "CECILL-C AND CECILL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1729,8 +1729,8 @@
       "port-version": 0
     },
     "cimg": {
-      "baseline": "3.6.5",
-      "port-version": 2
+      "baseline": "3.6.6",
+      "port-version": 0
     },
     "cinatra": {
       "baseline": "0.9.7",

--- a/versions/c-/cimg.json
+++ b/versions/c-/cimg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fbf6f051b417d2fcd2a5c0992efe4c77c8615be6",
+      "version": "3.6.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "9fc45e348f2f2582f83d7b46bab8ed6ea83512a0",
       "version": "3.6.5",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/GreycLab/CImg/releases/tag/v.3.6.6
