### PR TITLE
[stlab-enum-ops] add new port

### DIFF
--- a/ports/stlab-enum-ops/disable-cpm.patch
+++ b/ports/stlab-enum-ops/disable-cpm.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 85bb21e..5a9878f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,16 +1,6 @@
+ cmake_minimum_required(VERSION 3.24)
+ 
+-include(cmake/CPM.cmake)
+-
+-# Fetch cpp-library before project()
+-# Check https://github.com/stlab/cpp-library/releases for the latest version
+-# CPMAddPackage(
+-#     NAME cpp-library
+-#     SOURCE_DIR "${CMAKE_SOURCE_DIR}/../cpp-library"
+-# )
+-# CPMAddPackage("gh:stlab/cpp-library#65dbed9fff9a0331355bd51dc1e8156262390154")
+-CPMAddPackage("gh:stlab/cpp-library@5.0.0")
+-include(${cpp-library_SOURCE_DIR}/cpp-library.cmake)
++include(cmake/cpp-library/cpp-library.cmake/)
+ 
+ # Enable dependency tracking before project()
+ cpp_library_enable_dependency_tracking()

--- a/ports/stlab-enum-ops/disable-tests.patch
+++ b/ports/stlab-enum-ops/disable-tests.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5a9878f..6ff9562 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,15 +8,10 @@ cpp_library_enable_dependency_tracking()
+ # Now declare project
+ project(enum-ops)
+ 
+-# Enable CTest infrastructure (required for tests/examples to work)
+-include(CTest)
+-
+ # Let cpp-library handle the project declaration and version detection
+ cpp_library_setup(
+     DESCRIPTION "Type-safe operators for enums"
+     NAMESPACE stlab
+     HEADERS enum_ops.hpp
+-    EXAMPLES enum_ops_example_test.cpp enum_ops_example_fail.cpp
+-    TESTS enum_ops_tests.cpp
+     DOCS_EXCLUDE_SYMBOLS "stlab::implementation"
+ )

--- a/ports/stlab-enum-ops/portfile.cmake
+++ b/ports/stlab-enum-ops/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO stlab/stlab-enum-ops
+    REF "v${VERSION}"
+    SHA512 d3aa11cfc2f2b7931e9e41ee661dbc5770023de12ebf0d1823bcdc063d2c57a393be18a214747cbc25296c0268e2b536b102b4bcecb863a12ecfba8badfd613d
+    HEAD_REF main
+    PATCHES
+        disable-cpm.patch
+        disable-tests.patch
+)
+
+# Replace CPM and download cpp-library directly to avoid issues with FETCHCONTENT_FULLY_DISCONNECTED
+vcpkg_from_github(
+    OUT_SOURCE_PATH PACKAGE_PROJECT_PATH
+    REPO stlab/cpp-library
+    REF "v5.0.0"
+    SHA512 5e158dbdcabe698f7ddaff460a68c490978a7f91af8cb90f19430456acc1ca0f115973f149303b07d5ed0fbb3b43cd857b133c46bc6b4e8cc96c1ee25b0e87a9
+    HEAD_REF master
+)
+file(RENAME "${PACKAGE_PROJECT_PATH}" "${SOURCE_PATH}/cmake/cpp-library")
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/stlab-enum-ops)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/stlab-enum-ops/vcpkg.json
+++ b/ports/stlab-enum-ops/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "stlab-enum-ops",
+  "version": "1.2.0",
+  "description": "Type-safe bitmask and arithmetic operators for enum types.",
+  "homepage": "https://github.com/stlab/stlab-enum-ops",
+  "license": "BSL-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9416,6 +9416,10 @@
       "baseline": "1.1.0",
       "port-version": 0
     },
+    "stlab-enum-ops": {
+      "baseline": "1.2.0",
+      "port-version": 0
+    },
     "stormlib": {
       "baseline": "9.26",
       "port-version": 0

--- a/versions/s-/stlab-enum-ops.json
+++ b/versions/s-/stlab-enum-ops.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0e22d64996e00da6f48232096e1fff796df963ec",
+      "version": "1.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/stlab/stlab-enum-ops

stlab requires stlab-enum-ops since 2.1.0.
https://github.com/stlab/stlab/releases/tag/v2.1.0