### PR TITLE
[otl] Update to 4.0.497

### DIFF
--- a/ports/otl/portfile.cmake
+++ b/ports/otl/portfile.cmake
@@ -1,9 +1,9 @@
-set(OTL_VERSION 40496)
+set(OTL_VERSION 40497)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "http://otl.sourceforge.net/otlv4_${OTL_VERSION}.zip"
     FILENAME "otlv4_${OTL_VERSION}.zip"
-    SHA512 d2d37bd02c830e7a9e590aa1697ff258e067356813a83c62ce46c818c60968ff6ca8f50092eb5e9c419590b2ccd6ef6e6149d90b1498c6c4d9e8b7568ec1ccce
+    SHA512 1771ff05900c6034ef9d9c30463b9b2490a0510731b79424624f4821631fac93c65545c6a6cfb46fe844d6023c89af4391bd340411ca52c11e5bac081914577f
 )
 
 vcpkg_extract_source_archive(

--- a/ports/otl/vcpkg.json
+++ b/ports/otl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "otl",
-  "version": "4.0.496",
+  "version": "4.0.497",
   "description": "Oracle, Odbc and DB2-CLI Template Library",
   "homepage": "https://otl.sourceforge.net/",
   "license": "ISC"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7349,7 +7349,7 @@
       "port-version": 0
     },
     "otl": {
-      "baseline": "4.0.496",
+      "baseline": "4.0.497",
       "port-version": 0
     },
     "outcome": {

--- a/versions/o-/otl.json
+++ b/versions/o-/otl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47e056851e121f46c6b219278371435c99b3cff6",
+      "version": "4.0.497",
+      "port-version": 0
+    },
+    {
       "git-tree": "3964f6ba3bd6f1cec22d9575e43510c741543880",
       "version": "4.0.496",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.