### PR TITLE
[skyr-url] Update to 3.0.0

### DIFF
--- a/ports/skyr-url/portfile.cmake
+++ b/ports/skyr-url/portfile.cmake
@@ -1,10 +1,8 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO cpp-netlib/url
-        REF v1.13.0
-        SHA512 187898f5c0d2919095b293c7fbb6757d7b1391c9c79ccc3467ffc8b76a10685fd91faf9e9b8b0c0c21d0a9aecb3a50d52f2eab52823e770fc10ecd6ed874a748
+        REF 3.0.0
+        SHA512 dcc0a7613877ca7aac7c970fb4bcea9e2416ded7f8fe59693bf254406f0400bc170b64eb002eb7de88b3b996416f2219c9b5d6b3c72cdf0d4fb639d906ed9876
         HEAD_REF main
 )
 
@@ -14,16 +12,15 @@ vcpkg_cmake_configure(
             -Dskyr_BUILD_TESTS=OFF
             -Dskyr_BUILD_DOCS=OFF
             -Dskyr_BUILD_EXAMPLES=OFF
+            -Dskyr_BUILD_BENCHMARKS=OFF
             -Dskyr_WARNINGS_AS_ERRORS=OFF
 )
 
 vcpkg_cmake_install()
-vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/skyr-url)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE_1_0.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/skyr-url/vcpkg.json
+++ b/ports/skyr-url/vcpkg.json
@@ -1,13 +1,10 @@
 {
   "name": "skyr-url",
-  "version": "1.13.0",
-  "port-version": 2,
+  "version": "3.0.0",
   "description": "A C++ library that implements the WhatWG URL specification",
   "homepage": "https://github.com/cpp-netlib/url",
   "dependencies": [
     "nlohmann-json",
-    "range-v3",
-    "tl-expected",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9069,8 +9069,8 @@
       "port-version": 0
     },
     "skyr-url": {
-      "baseline": "1.13.0",
-      "port-version": 2
+      "baseline": "3.0.0",
+      "port-version": 0
     },
     "sleef": {
       "baseline": "3.9.0",

--- a/versions/s-/skyr-url.json
+++ b/versions/s-/skyr-url.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "33f1b9aeb5f4af881cd81641892a6ecbfaea21b8",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "429bf1616eeeb9c2315b09d9a6c741245e3eae6a",
       "version": "1.13.0",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
