### PR TITLE
[ta-lib] update talib to 0.6.4. Add macOS build support

### DIFF
--- a/ports/talib/portfile.cmake
+++ b/ports/talib/portfile.cmake
@@ -1,82 +1,90 @@
-vcpkg_from_sourceforge(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO "ta-lib/ta-lib"
-    REF "${VERSION}"
-    FILENAME "ta-lib-${VERSION}-msvc.zip"
-    SHA512 5f211327b6a1d4f00d0a2b9e276adadd118d7aa29fc87c6771d550fda124a863b4a20e3803f325f7c903c82ea12bfb23121a5f0566eeaa434e0f107a6eedb737
+    REPO "TA-Lib/ta-lib"
+    REF "v${VERSION}"
+    SHA512 189702beda83f9ebe16ef7d08d8bba76068a71b63409e2e00f1a5a4a06997037d54f048778323fcc6482fe1e5ce9125314b4d4b7a12dee5d64c5b0d3879fca45
 )
 
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
-    set(LFLAG "d")
-else()
-    set(LFLAG "m")
-endif()
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+    if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+        set(LFLAG "d")
+    else()
+        set(LFLAG "m")
+    endif()
 
-# Debug build
-if (NOT VCPKG_BUILD_TYPE)
+    # Debug build
+    if (NOT VCPKG_BUILD_TYPE)
+        vcpkg_execute_build_process(
+            COMMAND nmake -f Makefile
+            WORKING_DIRECTORY "${SOURCE_PATH}/c/make/c${LFLAG}d/win32/msvc"
+            LOGNAME build-${TARGET_TRIPLET}-dbg
+        )
+
+        file(
+            INSTALL "${SOURCE_PATH}/c/lib/ta_abstract_c${LFLAG}d.lib"
+            DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+            RENAME ta_abstract.lib
+        )
+        file(
+            INSTALL "${SOURCE_PATH}/c/lib/ta_libc_c${LFLAG}d.lib"
+            DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+            RENAME ta_libc.lib
+        )
+        file(
+            INSTALL "${SOURCE_PATH}/c/lib/ta_func_c${LFLAG}d.lib"
+            DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+            RENAME ta_func.lib
+        )
+        file(
+            INSTALL "${SOURCE_PATH}/c/lib/ta_common_c${LFLAG}d.lib"
+            DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+            RENAME ta_common.lib
+        )
+    endif()
+
+    # Release build
     vcpkg_execute_build_process(
         COMMAND nmake -f Makefile
-        WORKING_DIRECTORY "${SOURCE_PATH}/c/make/c${LFLAG}d/win32/msvc"
-        LOGNAME build-${TARGET_TRIPLET}-dbg
+        WORKING_DIRECTORY "${SOURCE_PATH}/c/make/c${LFLAG}r/win32/msvc"
+        LOGNAME build-${TARGET_TRIPLET}-rel
     )
 
     file(
-        INSTALL "${SOURCE_PATH}/c/lib/ta_abstract_c${LFLAG}d.lib"
-        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+        INSTALL "${SOURCE_PATH}/c/lib/ta_abstract_c${LFLAG}r.lib"
+        DESTINATION ${CURRENT_PACKAGES_DIR}/lib
         RENAME ta_abstract.lib
     )
     file(
-        INSTALL "${SOURCE_PATH}/c/lib/ta_libc_c${LFLAG}d.lib"
-        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+        INSTALL "${SOURCE_PATH}/c/lib/ta_libc_c${LFLAG}r.lib"
+        DESTINATION ${CURRENT_PACKAGES_DIR}/lib
         RENAME ta_libc.lib
     )
     file(
-        INSTALL "${SOURCE_PATH}/c/lib/ta_func_c${LFLAG}d.lib"
-        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+        INSTALL "${SOURCE_PATH}/c/lib/ta_func_c${LFLAG}r.lib"
+        DESTINATION ${CURRENT_PACKAGES_DIR}/lib
         RENAME ta_func.lib
     )
     file(
-        INSTALL "${SOURCE_PATH}/c/lib/ta_common_c${LFLAG}d.lib"
-        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+        INSTALL "${SOURCE_PATH}/c/lib/ta_common_c${LFLAG}r.lib"
+        DESTINATION ${CURRENT_PACKAGES_DIR}/lib
         RENAME ta_common.lib
     )
+
+    # Include files
+    file(
+        INSTALL "${SOURCE_PATH}/c/include"
+        DESTINATION ${CURRENT_PACKAGES_DIR}
+        PATTERN Makefile.* EXCLUDE
+    )
+else()
+    vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE)
+    vcpkg_cmake_install()
+    file(INSTALL
+        "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+    )
 endif()
-
-# Release build
-vcpkg_execute_build_process(
-    COMMAND nmake -f Makefile
-    WORKING_DIRECTORY "${SOURCE_PATH}/c/make/c${LFLAG}r/win32/msvc"
-    LOGNAME build-${TARGET_TRIPLET}-rel
-)
-
-file(
-    INSTALL "${SOURCE_PATH}/c/lib/ta_abstract_c${LFLAG}r.lib"
-    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
-    RENAME ta_abstract.lib
-)
-file(
-    INSTALL "${SOURCE_PATH}/c/lib/ta_libc_c${LFLAG}r.lib"
-    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
-    RENAME ta_libc.lib
-)
-file(
-    INSTALL "${SOURCE_PATH}/c/lib/ta_func_c${LFLAG}r.lib"
-    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
-    RENAME ta_func.lib
-)
-file(
-    INSTALL "${SOURCE_PATH}/c/lib/ta_common_c${LFLAG}r.lib"
-    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
-    RENAME ta_common.lib
-)
-
-# Include files
-file(
-    INSTALL "${SOURCE_PATH}/c/include"
-    DESTINATION ${CURRENT_PACKAGES_DIR}
-    PATTERN Makefile.* EXCLUDE
-)
-
 # License file
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.TXT")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/talib/portfile.cmake
+++ b/ports/talib/portfile.cmake
@@ -15,6 +15,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
 
     # Debug build
     if (NOT VCPKG_BUILD_TYPE)
+        file(MAKE_DIRECTORY "${SOURCE_PATH}/temp/c${LFLAG}d")
         vcpkg_execute_build_process(
             COMMAND nmake -f Makefile
             WORKING_DIRECTORY "${SOURCE_PATH}/make/c${LFLAG}d/win32/msvc"
@@ -44,6 +45,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     endif()
 
     # Release build
+    file(MAKE_DIRECTORY "${SOURCE_PATH}/temp/c${LFLAG}r")
     vcpkg_execute_build_process(
         COMMAND nmake -f Makefile
         WORKING_DIRECTORY "${SOURCE_PATH}/make/c${LFLAG}r/win32/msvc"

--- a/ports/talib/portfile.cmake
+++ b/ports/talib/portfile.cmake
@@ -81,6 +81,7 @@ else()
     vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE)
     vcpkg_cmake_install()
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
     file(INSTALL
         "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
         DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"

--- a/ports/talib/portfile.cmake
+++ b/ports/talib/portfile.cmake
@@ -17,27 +17,27 @@ if(VCPKG_TARGET_IS_WINDOWS)
     if (NOT VCPKG_BUILD_TYPE)
         vcpkg_execute_build_process(
             COMMAND nmake -f Makefile
-            WORKING_DIRECTORY "${SOURCE_PATH}/c/make/c${LFLAG}d/win32/msvc"
+            WORKING_DIRECTORY "${SOURCE_PATH}/make/c${LFLAG}d/win32/msvc"
             LOGNAME build-${TARGET_TRIPLET}-dbg
         )
 
         file(
-            INSTALL "${SOURCE_PATH}/c/lib/ta_abstract_c${LFLAG}d.lib"
+            INSTALL "${SOURCE_PATH}/lib/ta_abstract_c${LFLAG}d.lib"
             DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
             RENAME ta_abstract.lib
         )
         file(
-            INSTALL "${SOURCE_PATH}/c/lib/ta_libc_c${LFLAG}d.lib"
+            INSTALL "${SOURCE_PATH}/lib/ta_libc_c${LFLAG}d.lib"
             DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
             RENAME ta_libc.lib
         )
         file(
-            INSTALL "${SOURCE_PATH}/c/lib/ta_func_c${LFLAG}d.lib"
+            INSTALL "${SOURCE_PATH}/lib/ta_func_c${LFLAG}d.lib"
             DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
             RENAME ta_func.lib
         )
         file(
-            INSTALL "${SOURCE_PATH}/c/lib/ta_common_c${LFLAG}d.lib"
+            INSTALL "${SOURCE_PATH}/lib/ta_common_c${LFLAG}d.lib"
             DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
             RENAME ta_common.lib
         )
@@ -46,34 +46,34 @@ if(VCPKG_TARGET_IS_WINDOWS)
     # Release build
     vcpkg_execute_build_process(
         COMMAND nmake -f Makefile
-        WORKING_DIRECTORY "${SOURCE_PATH}/c/make/c${LFLAG}r/win32/msvc"
+        WORKING_DIRECTORY "${SOURCE_PATH}/make/c${LFLAG}r/win32/msvc"
         LOGNAME build-${TARGET_TRIPLET}-rel
     )
 
     file(
-        INSTALL "${SOURCE_PATH}/c/lib/ta_abstract_c${LFLAG}r.lib"
+        INSTALL "${SOURCE_PATH}/lib/ta_abstract_c${LFLAG}r.lib"
         DESTINATION ${CURRENT_PACKAGES_DIR}/lib
         RENAME ta_abstract.lib
     )
     file(
-        INSTALL "${SOURCE_PATH}/c/lib/ta_libc_c${LFLAG}r.lib"
+        INSTALL "${SOURCE_PATH}/lib/ta_libc_c${LFLAG}r.lib"
         DESTINATION ${CURRENT_PACKAGES_DIR}/lib
         RENAME ta_libc.lib
     )
     file(
-        INSTALL "${SOURCE_PATH}/c/lib/ta_func_c${LFLAG}r.lib"
+        INSTALL "${SOURCE_PATH}/lib/ta_func_c${LFLAG}r.lib"
         DESTINATION ${CURRENT_PACKAGES_DIR}/lib
         RENAME ta_func.lib
     )
     file(
-        INSTALL "${SOURCE_PATH}/c/lib/ta_common_c${LFLAG}r.lib"
+        INSTALL "${SOURCE_PATH}/lib/ta_common_c${LFLAG}r.lib"
         DESTINATION ${CURRENT_PACKAGES_DIR}/lib
         RENAME ta_common.lib
     )
 
     # Include files
     file(
-        INSTALL "${SOURCE_PATH}/c/include"
+        INSTALL "${SOURCE_PATH}/include"
         DESTINATION ${CURRENT_PACKAGES_DIR}
         PATTERN Makefile.* EXCLUDE
     )

--- a/ports/talib/portfile.cmake
+++ b/ports/talib/portfile.cmake
@@ -16,11 +16,15 @@ if(VCPKG_TARGET_IS_WINDOWS)
     # Debug build
     if (NOT VCPKG_BUILD_TYPE)
         file(MAKE_DIRECTORY "${SOURCE_PATH}/temp/c${LFLAG}d")
-        vcpkg_execute_build_process(
-            COMMAND nmake -f Makefile
-            WORKING_DIRECTORY "${SOURCE_PATH}/make/c${LFLAG}d/win32/msvc"
-            LOGNAME build-${TARGET_TRIPLET}-dbg
-        )
+        file(MAKE_DIRECTORY "${SOURCE_PATH}/temp/c${LFLAG}d/gen_code")
+        set(TALIB_SUBDIRS ta_common ta_func ta_abstract ta_libc gen_code)
+        foreach(subdir IN LISTS TALIB_SUBDIRS)
+            vcpkg_execute_build_process(
+                COMMAND nmake /nologo -f Makefile
+                WORKING_DIRECTORY "${SOURCE_PATH}/make/c${LFLAG}d/win32/msvc/${subdir}"
+                LOGNAME build-${TARGET_TRIPLET}-dbg-${subdir}
+            )
+        endforeach()
 
         file(
             INSTALL "${SOURCE_PATH}/lib/ta_abstract_c${LFLAG}d.lib"
@@ -46,11 +50,15 @@ if(VCPKG_TARGET_IS_WINDOWS)
 
     # Release build
     file(MAKE_DIRECTORY "${SOURCE_PATH}/temp/c${LFLAG}r")
-    vcpkg_execute_build_process(
-        COMMAND nmake -f Makefile
-        WORKING_DIRECTORY "${SOURCE_PATH}/make/c${LFLAG}r/win32/msvc"
-        LOGNAME build-${TARGET_TRIPLET}-rel
-    )
+    file(MAKE_DIRECTORY "${SOURCE_PATH}/temp/c${LFLAG}r/gen_code")
+    set(TALIB_SUBDIRS ta_common ta_func ta_abstract ta_libc gen_code)
+    foreach(subdir IN LISTS TALIB_SUBDIRS)
+        vcpkg_execute_build_process(
+            COMMAND nmake /nologo -f Makefile
+            WORKING_DIRECTORY "${SOURCE_PATH}/make/c${LFLAG}r/win32/msvc/${subdir}"
+            LOGNAME build-${TARGET_TRIPLET}-rel-${subdir}
+        )
+    endforeach()
 
     file(
         INSTALL "${SOURCE_PATH}/lib/ta_abstract_c${LFLAG}r.lib"
@@ -78,6 +86,15 @@ if(VCPKG_TARGET_IS_WINDOWS)
         INSTALL "${SOURCE_PATH}/include"
         DESTINATION ${CURRENT_PACKAGES_DIR}
         PATTERN Makefile.* EXCLUDE
+    )
+    file(
+        INSTALL "${SOURCE_PATH}/include/"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/include/ta-lib"
+        PATTERN Makefile.* EXCLUDE
+    )
+    file(INSTALL
+        "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     )
 else()
     vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/talib/vcpkg-cmake-wrapper.cmake
+++ b/ports/talib/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,49 @@
+get_filename_component(_prefix "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+
+# Header lives at: <prefix>/include/ta-lib/ta_libc.h
+find_path(talib_INCLUDE_DIR
+  NAMES ta-lib/ta_libc.h
+  PATHS "${_prefix}/include"
+  NO_DEFAULT_PATH
+)
+
+# Lib lives at: <prefix>/(debug/)?lib/libta-lib.*
+find_library(talib_LIBRARY_RELEASE
+  NAMES ta-lib
+  PATHS "${_prefix}/lib"
+  NO_DEFAULT_PATH
+)
+find_library(talib_LIBRARY_DEBUG
+  NAMES ta-lib
+  PATHS "${_prefix}/debug/lib"
+  NO_DEFAULT_PATH
+)
+
+include(SelectLibraryConfigurations)
+select_library_configurations(talib) # sets talib_LIBRARY based on config
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(talib
+  REQUIRED_VARS talib_INCLUDE_DIR talib_LIBRARY
+)
+
+if(talib_FOUND AND NOT TARGET talib::talib)
+  add_library(talib::talib UNKNOWN IMPORTED)
+  set_target_properties(talib::talib PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${talib_INCLUDE_DIR}"
+  )
+
+  if(talib_LIBRARY_RELEASE)
+    set_property(TARGET talib::talib APPEND PROPERTY IMPORTED_CONFIGURATIONS Release)
+    set_target_properties(talib::talib PROPERTIES
+      IMPORTED_LOCATION_RELEASE "${talib_LIBRARY_RELEASE}"
+    )
+  endif()
+
+  if(talib_LIBRARY_DEBUG)
+    set_property(TARGET talib::talib APPEND PROPERTY IMPORTED_CONFIGURATIONS Debug)
+    set_target_properties(talib::talib PROPERTIES
+      IMPORTED_LOCATION_DEBUG "${talib_LIBRARY_DEBUG}"
+    )
+  endif()
+endif()

--- a/ports/talib/vcpkg-cmake-wrapper.cmake
+++ b/ports/talib/vcpkg-cmake-wrapper.cmake
@@ -1,13 +1,13 @@
 get_filename_component(_prefix "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
 
-# Header lives at: <prefix>/include/ta-lib/ta_libc.h
+# Header lives at: <prefix>/include/ta_libc.h (Windows) or <prefix>/include/ta-lib/ta_libc.h (Unix)
 find_path(talib_INCLUDE_DIR
-  NAMES ta-lib/ta_libc.h
+  NAMES ta_libc.h ta-lib/ta_libc.h
   PATHS "${_prefix}/include"
   NO_DEFAULT_PATH
 )
 
-# Lib lives at: <prefix>/(debug/)?lib/libta-lib.*
+# Unix-style single lib
 find_library(talib_LIBRARY_RELEASE
   NAMES ta-lib
   PATHS "${_prefix}/lib"
@@ -19,31 +19,57 @@ find_library(talib_LIBRARY_DEBUG
   NO_DEFAULT_PATH
 )
 
-include(SelectLibraryConfigurations)
-select_library_configurations(talib) # sets talib_LIBRARY based on config
+set(talib_LIBRARIES_RELEASE "")
+set(talib_LIBRARIES_DEBUG "")
+
+if(talib_LIBRARY_RELEASE OR talib_LIBRARY_DEBUG)
+  if(talib_LIBRARY_RELEASE)
+    list(APPEND talib_LIBRARIES_RELEASE "${talib_LIBRARY_RELEASE}")
+  endif()
+  if(talib_LIBRARY_DEBUG)
+    list(APPEND talib_LIBRARIES_DEBUG "${talib_LIBRARY_DEBUG}")
+  endif()
+else()
+  foreach(component ta_common ta_func ta_abstract ta_libc)
+    find_library(talib_${component}_LIBRARY_RELEASE
+      NAMES ${component}
+      PATHS "${_prefix}/lib"
+      NO_DEFAULT_PATH
+    )
+    find_library(talib_${component}_LIBRARY_DEBUG
+      NAMES ${component}
+      PATHS "${_prefix}/debug/lib"
+      NO_DEFAULT_PATH
+    )
+
+    if(talib_${component}_LIBRARY_RELEASE)
+      list(APPEND talib_LIBRARIES_RELEASE "${talib_${component}_LIBRARY_RELEASE}")
+    endif()
+    if(talib_${component}_LIBRARY_DEBUG)
+      list(APPEND talib_LIBRARIES_DEBUG "${talib_${component}_LIBRARY_DEBUG}")
+    endif()
+  endforeach()
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(talib
-  REQUIRED_VARS talib_INCLUDE_DIR talib_LIBRARY
+  REQUIRED_VARS talib_INCLUDE_DIR talib_LIBRARIES_RELEASE
 )
 
 if(talib_FOUND AND NOT TARGET talib::talib)
-  add_library(talib::talib UNKNOWN IMPORTED)
-  set_target_properties(talib::talib PROPERTIES
+  add_library(talib::talib INTERFACE IMPORTED)
+  set_property(TARGET talib::talib PROPERTY
     INTERFACE_INCLUDE_DIRECTORIES "${talib_INCLUDE_DIR}"
   )
 
-  if(talib_LIBRARY_RELEASE)
-    set_property(TARGET talib::talib APPEND PROPERTY IMPORTED_CONFIGURATIONS Release)
-    set_target_properties(talib::talib PROPERTIES
-      IMPORTED_LOCATION_RELEASE "${talib_LIBRARY_RELEASE}"
-    )
+  if(NOT talib_LIBRARIES_DEBUG)
+    set(talib_LIBRARIES_DEBUG "${talib_LIBRARIES_RELEASE}")
   endif()
 
-  if(talib_LIBRARY_DEBUG)
-    set_property(TARGET talib::talib APPEND PROPERTY IMPORTED_CONFIGURATIONS Debug)
-    set_target_properties(talib::talib PROPERTIES
-      IMPORTED_LOCATION_DEBUG "${talib_LIBRARY_DEBUG}"
-    )
-  endif()
+  target_link_libraries(talib::talib INTERFACE
+    $<$<CONFIG:Debug>:${talib_LIBRARIES_DEBUG}>
+    $<$<CONFIG:RelWithDebInfo>:${talib_LIBRARIES_RELEASE}>
+    $<$<CONFIG:Release>:${talib_LIBRARIES_RELEASE}>
+    $<$<CONFIG:MinSizeRel>:${talib_LIBRARIES_RELEASE}>
+  )
 endif()

--- a/ports/talib/vcpkg.json
+++ b/ports/talib/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "talib",
-  "version-semver": "0.4.0",
-  "port-version": 1,
+  "version-semver": "0.6.4",
+  "port-version": 2,
   "description": "TA-Lib - Technical Analysis Library",
   "homepage": "https://ta-lib.github.io/",
   "license": "BSD-2-Clause",
-  "supports": "windows & !uwp",
+  "supports": "osx | (windows & !uwp)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/talib/vcpkg.json
+++ b/ports/talib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "talib",
   "version-semver": "0.6.4",
-  "port-version": 2,
   "description": "TA-Lib - Technical Analysis Library",
   "homepage": "https://ta-lib.github.io/",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9597,8 +9597,8 @@
       "port-version": 0
     },
     "talib": {
-      "baseline": "0.4.0",
-      "port-version": 1
+      "baseline": "0.6.4",
+      "port-version": 0
     },
     "tanakh-cmdline": {
       "baseline": "2014-02-04",

--- a/versions/t-/talib.json
+++ b/versions/t-/talib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60973e454b0e279656492115b61181038e92f06f",
+      "version-semver": "0.6.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "b21601e58da50f810bacb160a8960a131227aa28",
       "version-semver": "0.4.0",
       "port-version": 1

--- a/versions/t-/talib.json
+++ b/versions/t-/talib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "60973e454b0e279656492115b61181038e92f06f",
+      "git-tree": "13b295fd12e2eb8df1c2a2c9cb751205dbf871a1",
       "version-semver": "0.6.4",
       "port-version": 0
     },


### PR DESCRIPTION
Summary:
- Update talib version.
- Change source of the TA-Lib from source forge to github.
- Add CMake wrapper so that the consumer application side CMake can perform:
`find_package(talib CONFIG REQUIRED)`
and 
`target_link_libraries(my-technical-analisys-app PRIVATE talib::talib)`
- Added support for arm64 osx platform.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
