### PR TITLE
[bgfx] Update to 1.135.9062-502

### DIFF
--- a/ports/bgfx/fix-dependencies.patch
+++ b/ports/bgfx/fix-dependencies.patch
@@ -60,6 +60,7 @@ index 865879e..c6a3d84 100644
  #define IMGUI_H_HEADER_GUARD
  
  #include <bgfx/bgfx.h>
+ #include <bx/bx.h>
 -#include <dear-imgui/imgui.h>
 +#include <imgui.h>
  #include <iconfontheaders/icons_kenney.h>
@@ -97,22 +98,18 @@ index d79a80e..7740272 100644
  #define BGFX_GEOMETRYC_VERSION_MAJOR 1
  #define BGFX_GEOMETRYC_VERSION_MINOR 0
 diff --git a/bgfx/tools/shaderc/shaderc_metal.cpp b/bgfx/tools/shaderc/shaderc_metal.cpp
-index 9f073b9..e8fd208 100644
+index f7910de..a844cc0 100644
 --- a/bgfx/tools/shaderc/shaderc_metal.cpp
 +++ b/bgfx/tools/shaderc/shaderc_metal.cpp
-@@ -20,11 +20,11 @@ BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wshadow") // warning: declaration of 'u
- #include <spirv_reflect.hpp>
- 
+@@ -22,7 +22,7 @@
  #define ENABLE_OPT 1
 -#include <ShaderLang.h>
 -#include <ResourceLimits.h>
 -#include <SPIRV/GlslangToSpv.h>
--#include <SPIRV/SPVRemapper.h>
 -#include <SPIRV/SpvTools.h>
 +#include <glslang/Public/ShaderLang.h>
 +#include <glslang/Include/ResourceLimits.h>
 +#include <glslang/SPIRV/GlslangToSpv.h>
-+#include <glslang/SPIRV/SPVRemapper.h>
 +#include <glslang/SPIRV/SpvTools.h>
  #include <spirv-tools/optimizer.hpp>
  BX_PRAGMA_DIAGNOSTIC_POP()
@@ -121,23 +118,20 @@ diff --git a/bgfx/tools/shaderc/shaderc_spirv.cpp b/bgfx/tools/shaderc/shaderc_s
 index f7910de..a844cc0 100644
 --- a/bgfx/tools/shaderc/shaderc_spirv.cpp
 +++ b/bgfx/tools/shaderc/shaderc_spirv.cpp
-@@ -20,11 +20,11 @@ BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wshadow") // warning: declaration of 'u
- #include <spirv_reflect.hpp>
- 
+@@ -22,7 +22,7 @@
  #define ENABLE_OPT 1
 -#include <ShaderLang.h>
 -#include <ResourceLimits.h>
--#include <SPIRV/SPVRemapper.h>
 -#include <SPIRV/GlslangToSpv.h>
 -#include <SPIRV/SpvTools.h>
 +#include <glslang/Public/ShaderLang.h>
 +#include <glslang/Include/ResourceLimits.h>
-+#include <glslang/SPIRV/SPVRemapper.h>
 +#include <glslang/SPIRV/GlslangToSpv.h>
 +#include <glslang/SPIRV/SpvTools.h>
  #include <spirv-tools/optimizer.hpp>
  BX_PRAGMA_DIAGNOSTIC_POP()
- 
+
+
 diff --git a/bimg/src/image_decode.cpp b/bimg/src/image_decode.cpp
 index 798eaba..a4cd3ef 100644
 --- a/bimg/src/image_decode.cpp

--- a/ports/bgfx/portfile.cmake
+++ b/ports/bgfx/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_download_distfile(
   ARCHIVE_FILE
   URLS https://github.com/bkaradzic/bgfx.cmake/releases/download/v${VERSION}/bgfx.cmake.v${VERSION}.tar.gz
   FILENAME bgfx.cmake.v${VERSION}.tar.gz
-  SHA512 520c542b65e76e92eae818e32eeb62bb2347ac89a1e10fc07cd5059a3b8a9a543cadca87d451a3bc157c415f6183b1f0e5031248e38fae704b8efd54679d482b
+  SHA512 ff5caa1ccd35b527c80e625fa55dc6af18e7851a73b34a34caf481313c2b26ba3a8fec835852dd4f6646bf51e46de32ca40de53f73d0ccc01ee949b5bafacfd1
 )
 
 vcpkg_extract_source_archive(

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bgfx",
-  "version": "1.129.8940-496",
+  "version": "1.135.9062-502",
   "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
   "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
   "homepage": "https://bkaradzic.github.io/bgfx/overview.html",

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "tracy",
-  "version": "0.11.1",
-  "port-version": 2,
+  "version": "0.13.1",
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ace42e3f3e4e4793970d7451e9da7661bb20a3ec",
+      "version": "1.135.9062-502",
+      "port-version": 0
+    },
+    {
       "git-tree": "0649ad4eb640389c105dbac3a302e9c27e0a04b0",
       "version": "1.129.8940-496",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9901,8 +9901,8 @@
       "port-version": 6
     },
     "tracy": {
-      "baseline": "0.11.1",
-      "port-version": 2
+      "baseline": "0.13.1",
+      "port-version": 0
     },
     "transwarp": {
       "baseline": "2.2.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -705,7 +705,7 @@
       "port-version": 0
     },
     "bgfx": {
-      "baseline": "1.129.8940-496",
+      "baseline": "1.135.9062-502",
       "port-version": 0
     },
     "bigint": {

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "502251f858908fbbdfe3f924693acda8cdb68841",
+      "version": "0.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff802e1b85c20b5f276c4b82aaa60fc933444ab2",
       "version": "0.11.1",
       "port-version": 2


### PR DESCRIPTION
Updated bgfx to version 1.135.9062-502 (latest), including changes to the fix-dependencies.patch. 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning ./vcpkg x-add-version --all and committing the result.
- [x] Only one version is added to each modified port's versions file.