### PR TITLE
[aeron] Add new port (version 1.49.3)

### DIFF
--- a/ports/aeron/portfile.cmake
+++ b/ports/aeron/portfile.cmake
@@ -1,0 +1,30 @@
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO aeron-io/aeron
+    REF "${VERSION}"
+    SHA512 6302b235285d897bb58d388c1883145c486f931575174b68161e67a04ae2efb48993d8045855d6e04ba378fdb58050c5339561c85fffb6b222abaa1952103d37
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DAERON_INSTALL_TARGETS=ON
+        -DAERON_TESTS=OFF
+        -DAERON_BUILD_SAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/aeron)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/aeron/portfile.cmake
+++ b/ports/aeron/portfile.cmake
@@ -30,8 +30,26 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/aeron)
 
-# Move DLLs from lib to bin (aeron builds both static and shared libraries)
-if(VCPKG_TARGET_IS_WINDOWS)
+# Aeron always builds both static and shared libraries regardless of VCPKG_LIBRARY_LINKAGE.
+# Handle the shared library artifacts based on linkage type.
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    # For static builds, remove shared library artifacts (DLLs, SOs, DYLIBs and their import libs)
+    file(REMOVE
+        "${CURRENT_PACKAGES_DIR}/lib/aeron.dll"
+        "${CURRENT_PACKAGES_DIR}/lib/aeron_client_shared.dll"
+        "${CURRENT_PACKAGES_DIR}/lib/aeron_driver.dll"
+        "${CURRENT_PACKAGES_DIR}/lib/aeron.lib"
+        "${CURRENT_PACKAGES_DIR}/lib/aeron_client_shared.lib"
+        "${CURRENT_PACKAGES_DIR}/lib/aeron_driver.lib"
+        "${CURRENT_PACKAGES_DIR}/debug/lib/aeron.dll"
+        "${CURRENT_PACKAGES_DIR}/debug/lib/aeron_client_shared.dll"
+        "${CURRENT_PACKAGES_DIR}/debug/lib/aeron_driver.dll"
+        "${CURRENT_PACKAGES_DIR}/debug/lib/aeron.lib"
+        "${CURRENT_PACKAGES_DIR}/debug/lib/aeron_client_shared.lib"
+        "${CURRENT_PACKAGES_DIR}/debug/lib/aeron_driver.lib"
+    )
+else()
+    # For dynamic builds, move DLLs from lib to bin
     file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
     file(GLOB RELEASE_DLLS "${CURRENT_PACKAGES_DIR}/lib/*.dll")
     file(GLOB DEBUG_DLLS "${CURRENT_PACKAGES_DIR}/debug/lib/*.dll")

--- a/ports/aeron/portfile.cmake
+++ b/ports/aeron/portfile.cmake
@@ -10,17 +10,43 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Set archive option based on feature
+if("archive" IN_LIST FEATURES)
+    set(BUILD_ARCHIVE ON)
+else()
+    set(BUILD_ARCHIVE OFF)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DAERON_INSTALL_TARGETS=ON
         -DAERON_TESTS=OFF
         -DAERON_BUILD_SAMPLES=OFF
+        -DBUILD_AERON_ARCHIVE_API=${BUILD_ARCHIVE}
 )
 
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/aeron)
+
+# Move DLLs from lib to bin (aeron builds both static and shared libraries)
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(GLOB RELEASE_DLLS "${CURRENT_PACKAGES_DIR}/lib/*.dll")
+    file(GLOB DEBUG_DLLS "${CURRENT_PACKAGES_DIR}/debug/lib/*.dll")
+    if(RELEASE_DLLS)
+        file(COPY ${RELEASE_DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+        file(REMOVE ${RELEASE_DLLS})
+    endif()
+    if(DEBUG_DLLS)
+        file(COPY ${DEBUG_DLLS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(REMOVE ${DEBUG_DLLS})
+    endif()
+endif()
+
+# Copy aeronmd tools
+vcpkg_copy_tools(TOOL_NAMES aeronmd aeronmd_s AUTO_CLEAN)
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/aeron/vcpkg.json
+++ b/ports/aeron/vcpkg.json
@@ -15,5 +15,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "archive": {
+      "description": "Build Aeron Archive API for recording and replaying message streams (requires Java)",
+      "supports": "!uwp & !xbox & !android"
+    }
+  }
 }

--- a/ports/aeron/vcpkg.json
+++ b/ports/aeron/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "aeron",
+  "version": "1.49.3",
+  "description": "Efficient reliable UDP unicast, UDP multicast, and IPC message transport",
+  "homepage": "https://github.com/aeron-io/aeron",
+  "license": "Apache-2.0",
+  "supports": "!uwp & !xbox & !android",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/aeron/vcpkg.json
+++ b/ports/aeron/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "Efficient reliable UDP unicast, UDP multicast, and IPC message transport",
   "homepage": "https://github.com/aeron-io/aeron",
   "license": "Apache-2.0",
-  "supports": "!uwp & !xbox & !android",
+  "supports": "(x64 & !uwp & !xbox) | ((x64 | arm64) & !windows & !android)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -19,7 +19,7 @@
   "features": {
     "archive": {
       "description": "Build Aeron Archive API for recording and replaying message streams (requires Java)",
-      "supports": "!uwp & !xbox & !android"
+      "supports": "(x64 & !uwp & !xbox) | ((x64 | arm64) & !windows & !android)"
     }
   }
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -38,6 +38,8 @@
 ##
 
 # Add new items alphabetically
+# aeron requires CMake 3.30+ which may not be available in CI
+aeron:arm64-osx=fail
 apr:arm-neon-android=fail
 apr:arm64-android=fail
 apr:x64-android=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -38,8 +38,6 @@
 ##
 
 # Add new items alphabetically
-# aeron requires CMake 3.30+ which may not be available in CI
-aeron:arm64-osx=fail
 apr:arm-neon-android=fail
 apr:arm64-android=fail
 apr:x64-android=fail

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -55,6 +55,7 @@ llvm = skip
 ace[tao]:arm-neon-android=feature-fails # tao requires a host tree with tao_idl compiled for the host
 ace[tao]:arm64-android=feature-fails
 ace[tao]:x64-android=feature-fails
+aeron[archive]=skip # archive feature requires Java for SBE code generation
 allegro5:arm64-windows=fail # Fails with "fatal error LNK1322: cannot avoid potential ARM hazard" even with /Gy
 apr:arm64-windows=fail # Cross compiling CI machine cannot run gen_test_char to generate apr_escape_test_char.h
 blitz:arm64-windows=fail

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9fc5fdb0db21b27422b87b937d1b80a182839a46",
+      "version": "1.49.3",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9fc5fdb0db21b27422b87b937d1b80a182839a46",
+      "git-tree": "06f04eab037505fe7eaa69f0a8ee69ac830baabc",
       "version": "1.49.3",
       "port-version": 0
     }

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "06f04eab037505fe7eaa69f0a8ee69ac830baabc",
+      "git-tree": "44788413f50414d098289891dfcdc63f664ef067",
       "version": "1.49.3",
       "port-version": 0
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -56,6 +56,10 @@
       "baseline": "2.1.1",
       "port-version": 0
     },
+    "aeron": {
+      "baseline": "1.49.3",
+      "port-version": 0
+    },
     "air-ctl": {
       "baseline": "1.1.2",
       "port-version": 3


### PR DESCRIPTION
  Efficient reliable UDP unicast, UDP multicast, and IPC message transport. Includes both C and C++ client libraries.

  - [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
  - [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
  - [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with
  [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
  - [x] The versioning scheme in `vcpkg.json` matches what upstream says.
  - [x] The license declaration in `vcpkg.json` matches what upstream says.
  - [x] The installed as the "copyright" file matches what upstream says.
  - [x] The source code of the component installed comes from an authoritative source.
  - [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
  - [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
  - [x] Only one version is in the new port's versions file.
  - [x] Only one version is added to each modified port's versions file.