### PR TITLE
[fast-float] update to 8.2.2

### DIFF
--- a/ports/fast-float/portfile.cmake
+++ b/ports/fast-float/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fastfloat/fast_float
     REF "v${VERSION}"
-    SHA512 5c945facb30d7bfdf1d4f9fae4c53ae66e7f81e12fa0279ebcbc660e02cc093b28a3d1a2fe36b152bbf166c475dfbea57f30c313b00795974af9cb828ba41e4b
+    SHA512 a4bc2d11af67527421190bef07eef9dfca63efae6be1800f33a2419cb77031b0128ef9199b9909d01a76d72cdba56f79c6856a900c4cc7e7c75745d980f61340
     HEAD_REF master
 )
 

--- a/ports/fast-float/vcpkg.json
+++ b/ports/fast-float/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-float",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Fast and exact implementation of the C++ from_chars functions for float and double types: 4x faster than strtod",
   "homepage": "https://github.com/fastfloat/fast_float",
   "license": "Apache-2.0 OR BSL-1.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2849,7 +2849,7 @@
       "port-version": 0
     },
     "fast-float": {
-      "baseline": "8.2.1",
+      "baseline": "8.2.2",
       "port-version": 0
     },
     "fastcdr": {

--- a/versions/f-/fast-float.json
+++ b/versions/f-/fast-float.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3d6ec6632973d8ca6ab3eb1797cd20f1ce98b452",
+      "version": "8.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "41eb1e9b380bbcd57b94c128e8379b3ee572ac67",
       "version": "8.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/fastfloat/fast_float/releases/tag/v8.2.2
