### PR TITLE
[ggml] update to 2025-12-31

### DIFF
--- a/ports/ggml/portfile.cmake
+++ b/ports/ggml/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ggml-org/ggml
-    REF 55bc9320a4aae82af18e23eefd5de319a755d7b9
-    SHA512 9433c9c258bbbfa817051f2ba2a8c8f166ee885c953d3ee27198890d4af8366fdee11ba55514b8b8414c836615e56eceaa98f33a01ecf51846338bc60d34263b
+    REF ebc3a0f4a56be1c9424a89fbec09962ac34fde85
+    SHA512 46776e2d448cc32629a8a3dc93e8ab94735f1affd456637d0d9b1bbf07846941ecaa2c95f0d919708ab5234e8df472727c20bd03f2fb09da01f66338e8ed1a3b
     HEAD_REF master
     PATCHES
         cmake-config.diff

--- a/ports/ggml/vcpkg.json
+++ b/ports/ggml/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ggml",
-  "version-date": "2025-11-17",
-  "port-version": 1,
+  "version-date": "2025-12-31",
   "description": "Tensor library for machine learning",
   "homepage": "https://github.com/ggml-org/ggml",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3293,8 +3293,8 @@
       "port-version": 0
     },
     "ggml": {
-      "baseline": "2025-11-17",
-      "port-version": 1
+      "baseline": "2025-12-31",
+      "port-version": 0
     },
     "ghc-filesystem": {
       "baseline": "1.5.14",

--- a/versions/g-/ggml.json
+++ b/versions/g-/ggml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2dff43b373084f50948bf7f27636ceef2300ba1d",
+      "version-date": "2025-12-31",
+      "port-version": 0
+    },
+    {
       "git-tree": "56adeee23aaed103cd81d95b0f40f47ed308c761",
       "version-date": "2025-11-17",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ggml-org/ggml/releases/tag/v0.9.5
