### PR TITLE
[libheif] update to 1.21.1

### DIFF
--- a/ports/libheif/find-modules.diff
+++ b/ports/libheif/find-modules.diff
@@ -1,14 +1,14 @@
 diff --git a/cmake/modules/FindAOM.cmake b/cmake/modules/FindAOM.cmake
-index 61c5961..1ecf364 100644
+index a357cf7..970630b 100644
 --- a/cmake/modules/FindAOM.cmake
 +++ b/cmake/modules/FindAOM.cmake
-@@ -15,6 +15,7 @@ unset(CMAKE_REQUIRED_INCLUDES)
+@@ -17,6 +17,7 @@ else()
  
- find_library(AOM_LIBRARY
-     NAMES libaom aom
-+    NAMES_PER_DIR
-     HINTS ${AOM_PKGCONF_LIBRARY_DIRS} ${AOM_PKGCONF_LIBDIR}
- )
+   find_library(AOM_LIBRARY
+       NAMES libaom aom
++      NAMES_PER_DIR
+       HINTS ${AOM_PKGCONF_LIBRARY_DIRS} ${AOM_PKGCONF_LIBDIR}
+   )
  
 diff --git a/cmake/modules/FindLIBDE265.cmake b/cmake/modules/FindLIBDE265.cmake
 index c9a7fcb..95fc5bf 100644

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  strukturag/libheif
     REF "v${VERSION}"
-    SHA512 4497d1afbccc15806cc11c22653e83d7900a009ad584a8d6b1ada6fac1ace9a70d834eb32653da567f0ddabc23ec641c5d69503282e303bf1bf2def72544b1b5
+    SHA512 556cc0e365aacad662d8c20282b68856b51af168659acd0f2662dcb399e5fed9dea9c259f5d5ffcd383f4b4a00a93acbdc06e90b340cc1dd2098e94c30c8a606
     HEAD_REF master
     PATCHES
         cxx-linkage-pkgconfig.diff

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -27,6 +27,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         openjpeg    WITH_OpenJPEG_DECODER
         openjpeg    WITH_OpenJPEG_ENCODER
         openjpeg    VCPKG_LOCK_FIND_PACKAGE_OpenJPEG
+        h264        WITH_X264
+        openh264    WITH_OpenH264_DECODER
 )
 
 vcpkg_find_acquire_program(PKGCONFIG)

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libheif",
-  "version": "1.20.2",
+  "version": "1.21.1",
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -34,6 +34,13 @@
         "gdk-pixbuf"
       ]
     },
+    "h264-decoder": {
+      "description": "OpenH264 decoder",
+      "license": "BSD-2-Clause",
+      "dependencies": [
+        "openh264"
+      ]
+    },
     "hevc": {
       "description": "HEVC encoding via x265",
       "license": "GPL-2.0-or-later",
@@ -60,6 +67,13 @@
       "license": "BSD-2-Clause",
       "dependencies": [
         "openjpeg"
+      ]
+    },
+    "x264": {
+      "description": "x264 AVC encoder",
+      "license": "GPL-2.0-or-later",
+      "dependencies": [
+        "x264"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4945,7 +4945,7 @@
       "port-version": 6
     },
     "libheif": {
-      "baseline": "1.20.2",
+      "baseline": "1.21.1",
       "port-version": 0
     },
     "libhsplasma": {

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4457f74fe097ba25c84ca6119e51ba0282631051",
+      "version": "1.21.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "71519f65f5aa00ded247297c0c899ff679d869b9",
       "version": "1.20.2",
       "port-version": 0

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4457f74fe097ba25c84ca6119e51ba0282631051",
+      "git-tree": "4a19ab14c1690f453d939abf1b7c2bdcb5ac448b",
       "version": "1.21.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/strukturag/libheif/releases/tag/v1.21.1
https://github.com/strukturag/libheif/releases/tag/v1.21.0
