### PR TITLE
[intel-mkl] Fix for dynamic and static

### DIFF
--- a/ports/intel-mkl/vcpkg.json
+++ b/ports/intel-mkl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "intel-mkl",
   "version": "2025.2.0",
+  "port-version": 1,
   "description": "Intel® Math Kernel Library (Intel® MKL) accelerates math processing routines, increases application performance, and reduces development time on Intel® processors.",
   "homepage": "https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3966,7 +3966,7 @@
     },
     "intel-mkl": {
       "baseline": "2025.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "intelrdfpmathlib": {
       "baseline": "20U2",

--- a/versions/i-/intel-mkl.json
+++ b/versions/i-/intel-mkl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1222d2ac2c699ac0664b004a12aad9239ac94d5",
+      "version": "2025.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "68757c04f7759c50a2cd81b097e862da93673334",
       "version": "2025.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



