### PR TITLE
[libpcap] update to 1.10.6

### DIFF
--- a/ports/libpcap/portfile.cmake
+++ b/ports/libpcap/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO the-tcpdump-group/libpcap
     REF "libpcap-${VERSION}"
-    SHA512 bb8ba3a589425d71531312285a3c7ded4abdff5ea157b88195e06a2b4f8c93b4db0bca122e9ac853cff14cd16e9519dca30b6bdf0311e7749038fdce57325726
+    SHA512 eb0a627cabdc4fab8f56e81065469a6fad713681d06c43e7a3080896cad3925e8b22c6957fcc0439e9229b3ebf21af55d22cd89c8494342e4188bb0ac193c7ab
     HEAD_REF master
     PATCHES
         install.diff

--- a/ports/libpcap/vcpkg.json
+++ b/ports/libpcap/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libpcap",
-  "version-semver": "1.10.5",
+  "version-semver": "1.10.6",
   "description": "A portable C/C++ library for network traffic capture",
   "homepage": "https://www.tcpdump.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5289,7 +5289,7 @@
       "port-version": 5
     },
     "libpcap": {
-      "baseline": "1.10.5",
+      "baseline": "1.10.6",
       "port-version": 0
     },
     "libpff": {

--- a/versions/l-/libpcap.json
+++ b/versions/l-/libpcap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0ab17a2a48bbe68268a9b1e2b65796163ac4625f",
+      "version-semver": "1.10.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "bb54ee6890b51e54614371d548053020585027ea",
       "version-semver": "1.10.5",
       "port-version": 0


### PR DESCRIPTION
Fixes #49192 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
~~- [ ] The "supports" clause reflects platforms that may be fixed by this new version.~~
~~- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
~~- [ ] Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.