### PR TITLE
[kfr] Update kfr to 7.0.1

### DIFF
--- a/ports/kfr/fix-alac-dep.patch
+++ b/ports/kfr/fix-alac-dep.patch
@@ -1,0 +1,34 @@
+diff --git a/src/audio/CMakeLists.txt b/src/audio/CMakeLists.txt
+index bfa4de1..0039940 100644
+--- a/src/audio/CMakeLists.txt
++++ b/src/audio/CMakeLists.txt
+@@ -1,3 +1,4 @@
++
+ cmake_minimum_required(VERSION 3.16)
+ 
+ add_kfr_library(
+@@ -40,22 +41,8 @@ if (TARGET Ogg::ogg)
+     message(STATUS "Ogg found")
+ endif ()
+ 
+-find_path(
+-    ALAC_INCLUDE_DIRS "alac/ALACDecoder.h"
+-    PATH_SUFFIXES include
+-    CMAKE_FIND_ROOT_PATH_BOTH)
+-find_library(
+-    ALAC_LIBRARY
+-    NAMES libalac alac
+-    PATH_SUFFIXES lib
+-    CMAKE_FIND_ROOT_PATH_BOTH)
+-
+-if (ALAC_INCLUDE_DIRS AND ALAC_LIBRARY)
+-    add_library(ALAC::ALAC UNKNOWN IMPORTED)
+-    set_target_properties(
+-        ALAC::ALAC
+-        PROPERTIES IMPORTED_LOCATION "${ALAC_LIBRARY}"
+-                   INTERFACE_INCLUDE_DIRECTORIES "${ALAC_INCLUDE_DIR}")
++find_package(ALAC CONFIG)
++if (TARGET ALAC::ALAC)
+     message(STATUS "ALAC found, enabling ALAC support in kfr_audio")
+     target_link_libraries(kfr_audio PUBLIC $<BUILD_INTERFACE:ALAC::ALAC>)
+     target_compile_definitions(kfr_audio

--- a/ports/kfr/portfile.cmake
+++ b/ports/kfr/portfile.cmake
@@ -4,8 +4,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kfrlib/kfr
     REF "${VERSION}"
-    SHA512 2bf6698efc4eb577104308bcb0477bf631f39848842129993222227fcaad7793e776c04dbe7ec66b155018a5e9f09c15fe0864576860362effc63ced8f22bba5
+    SHA512 5cd65ee75a0526d4be6923e25cf3adcf91083192f4e81248205c6822e230c36590a281bf65a1421f21bb842548b7522093dc8e36a375ee7b74aac11170dbc55a
     HEAD_REF main
+    PATCHES
+        fix-alac-dep.patch
 )
 
 vcpkg_check_features(
@@ -13,6 +15,10 @@ vcpkg_check_features(
     FEATURES
         capi KFR_ENABLE_CAPI_BUILD
         dft KFR_ENABLE_DFT
+        audio KFR_ENABLE_AUDIO
+        io KFR_ENABLE_IO
+        dsp KFR_ENABLE_DSP
+	dsp KFR_USE_BOOST
 )
 
 vcpkg_cmake_configure(
@@ -32,6 +38,11 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+list(LENGTH FEATURES features_len)
+if(features_len EQUAL 1 AND FEATURES STREQUAL "core")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+endif()
 
 vcpkg_install_copyright(
     COMMENT [[

--- a/ports/kfr/vcpkg.json
+++ b/ports/kfr/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "kfr",
-  "version-semver": "6.3.1",
+  "version-semver": "7.0.1",
   "description": "Fast, modern C++ DSP framework.",
   "homepage": "https://www.kfr.dev/",
   "license": null,
-  "supports": "!(arm64 & windows) & !xbox",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -16,6 +16,30 @@
     }
   ],
   "features": {
+    "alac": {
+      "description": "Enable ALAC audio module",
+      "dependencies": [
+        "alac",
+        {
+          "name": "kfr",
+          "features": [
+            "audio"
+          ]
+        }
+      ]
+    },
+    "audio": {
+      "description": "Enable Audio modules",
+      "dependencies": [
+        {
+          "name": "kfr",
+          "features": [
+            "dsp",
+            "io"
+          ]
+        }
+      ]
+    },
     "capi": {
       "description": "Enable C API build.",
       "dependencies": [
@@ -23,13 +47,48 @@
           "name": "kfr",
           "default-features": false,
           "features": [
-            "dft"
+            "audio",
+            "dft",
+            "dsp"
           ]
         }
       ]
     },
     "dft": {
       "description": "Enable DFT and related algorithms."
+    },
+    "dsp": {
+      "description": "Enable DSP modules",
+      "dependencies": [
+        "boost-math"
+      ]
+    },
+    "flac": {
+      "description": "Enable FLAC audio module",
+      "dependencies": [
+        {
+          "name": "kfr",
+          "features": [
+            "audio"
+          ]
+        },
+        "libflac"
+      ]
+    },
+    "io": {
+      "description": "Enable IO modules"
+    },
+    "ogg": {
+      "description": "Enable OGG audio module",
+      "dependencies": [
+        {
+          "name": "kfr",
+          "features": [
+            "audio"
+          ]
+        },
+        "libogg"
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4393,7 +4393,7 @@
       "port-version": 0
     },
     "kfr": {
-      "baseline": "6.3.1",
+      "baseline": "7.0.1",
       "port-version": 0
     },
     "kinectsdk1": {

--- a/versions/k-/kfr.json
+++ b/versions/k-/kfr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6baa222e43ac5c62a31bfd0fbb34755b0dbdaab4",
+      "version-semver": "7.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "cafa14cb92257ee3677ab044da2e429bad61efdc",
       "version-semver": "6.3.1",
       "port-version": 0


### PR DESCRIPTION
Fixes [#48396](https://github.com/microsoft/vcpkg/issues/48396)
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
~~- [ ] Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.