### PR TITLE
[openvpn3] update openvpn3 to 3.11.5

### DIFF
--- a/ports/openvpn3/dependencies.diff
+++ b/ports/openvpn3/dependencies.diff
@@ -1,20 +1,30 @@
 diff --git a/cmake/findcoredeps.cmake b/cmake/findcoredeps.cmake
-index b7d00d4..e180dc1 100644
+index a9dd56ac..2f5819de 100644
 --- a/cmake/findcoredeps.cmake
 +++ b/cmake/findcoredeps.cmake
-@@ -29,8 +29,10 @@ endif ()
- 
+@@ -30,18 +30,9 @@ endif ()
  function(add_ssl_library target)
+     find_package(PkgConfig REQUIRED)
      if (${USE_MBEDTLS})
-+        # Works with mbedtls 2.x and 3.x
-+        set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
-         find_package(mbedTLS REQUIRED)
--        set(SSL_LIBRARY mbedTLS::mbedTLS)
-+        set(SSL_LIBRARY "${MBEDTLS_LIBRARIES}")
+-        # mbedtls3.6 for Fedora 41+
+-        pkg_search_module(mbedTLS IMPORTED_TARGET mbedtls3.6 mbedtls)
+-        if (mbedTLS_FOUND)
+-            # Only added as Requires.Private, so we need to look them up ourselves
+-            pkg_search_module(mbedCrypto REQUIRED IMPORTED_TARGET mbedcrypto3.6 mbedcrypto)
+-            pkg_search_module(mbedX509 REQUIRED IMPORTED_TARGET mbedx5093.6 mbedx509)
+-            set(SSL_LIBRARY PkgConfig::mbedTLS PkgConfig::mbedCrypto PkgConfig::mbedX509)
+-        else ()
+-            # mbedTLS 2.x doesn't have pkg-config files
+-            find_package(mbedTLS REQUIRED)
+-            set(SSL_LIBRARY mbedTLS::mbedTLS)
+-        endif ()
++	set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
++        find_package(mbedTLS REQUIRED)
++	set(SSL_LIBRARY "${MBEDTLS_LIBRARIES}")
          target_compile_definitions(${target} PRIVATE -DUSE_MBEDTLS)
      else ()
-         find_package(OpenSSL REQUIRED)
-@@ -38,7 +40,7 @@ function(add_ssl_library target)
+         pkg_search_module(OpenSSL REQUIRED IMPORTED_TARGET openssl)
+@@ -49,7 +40,7 @@ function(add_ssl_library target)
          target_compile_definitions(${target} PRIVATE -DUSE_OPENSSL)
      endif ()
  
@@ -23,7 +33,7 @@ index b7d00d4..e180dc1 100644
  endfunction()
  
  
-@@ -93,10 +95,10 @@ function(add_core_dependencies target)
+@@ -126,10 +117,10 @@ function(add_corelibrary_dependencies target)
      # a patched version. So we want to prefer its include
      # directories.
      find_package(asio REQUIRED)
@@ -36,19 +46,19 @@ index b7d00d4..e180dc1 100644
  
      add_ssl_library(${target})
  
-@@ -105,14 +107,16 @@ function(add_core_dependencies target)
+@@ -138,14 +129,16 @@ function(add_corelibrary_dependencies target)
          find_library(iokit IOKit)
          find_library(coreServices CoreServices)
          find_library(systemConfiguration SystemConfiguration)
 -        target_link_libraries(${target} ${coreFoundation} ${iokit} ${coreServices} ${systemConfiguration} ${lz4})
-+        target_link_libraries(${target} PUBLIC ${coreFoundation} ${iokit} ${coreServices} ${systemConfiguration} ${lz4})
++	target_link_libraries(${target} PUBLIC ${coreFoundation} ${iokit} ${coreServices} ${systemConfiguration} ${lz4})
      endif()
  
      if(UNIX)
 -        target_link_libraries(${target} pthread)
 +        set(THREADS_PREFER_PTHREAD_FLAG 1)
-+        find_package(Threads REQUIRED)
-+        target_link_libraries(${target} PUBLIC Threads::Threads)
++	find_package(Threads REQUIRED)
++	target_link_libraries(${target} PUBLIC Threads::Threads)
      endif()
  
 -    target_link_libraries(${target} ${EXTRA_LIBS})

--- a/ports/openvpn3/portfile.cmake
+++ b/ports/openvpn3/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenVPN/openvpn3
     REF "release/${VERSION}"
-    SHA512 f096644078c10022685c1a8f7e0afddf352b4a5c229a772d24adbc6ec3f44e27501beabd28c4da1b6b182ae9d220b80865757693d52d085817d42f2322b71213
+    SHA512 ff763703eb7d292c768b569cff3c575993d1f304221dcc423c869b84aa13d07bfd3c572977792fed8eb8c24f6fce9a462d6190468d1ce071fcc41ed7aba62603
     HEAD_REF master
     PATCHES
         dependencies.diff
@@ -46,4 +46,4 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-openvpn3)
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-openvpnConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-openvpn")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.rst" "${SOURCE_PATH}/COPYRIGHT.AGPLV3")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/openvpn3/portfile.cmake
+++ b/ports/openvpn3/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_cmake_configure(
         -DCMAKE_DISABLE_FIND_PACKAGE_SWIG=ON
         -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON
         -DUSE_MBEDTLS=1   # vcpkg legacy choice
+	-DPKG_CONFIG_EXECUTABLE="${CURRENT_INSTALLED_DIR}/tools/pkgconf/pkgconf${VCPKG_TARGET_EXECUTABLE_SUFFIX}"
 )
 
 vcpkg_cmake_install()

--- a/ports/openvpn3/vcpkg.json
+++ b/ports/openvpn3/vcpkg.json
@@ -1,15 +1,16 @@
 {
   "name": "openvpn3",
-  "version": "3.10",
-  "port-version": 1,
+  "version": "3.11.5",
   "description": "a C++ class library that implements the functionality of an OpenVPN client, and is protocol-compatible with the OpenVPN 2.x branch.",
   "homepage": "https://openvpn.net",
   "license": "AGPL-3.0-only",
   "supports": "!uwp & !xbox",
   "dependencies": [
     "asio",
+    "jsoncpp",
     "lz4",
     "mbedtls",
+    "pkgconf",
     {
       "name": "tap-windows6",
       "platform": "windows"

--- a/ports/openvpn3/vcpkg.json
+++ b/ports/openvpn3/vcpkg.json
@@ -10,7 +10,10 @@
     "jsoncpp",
     "lz4",
     "mbedtls",
-    "pkgconf",
+    {
+      "name": "pkgconf",
+      "host": true
+    },
     {
       "name": "tap-windows6",
       "platform": "windows"

--- a/ports/openvpn3/vcpkg.json
+++ b/ports/openvpn3/vcpkg.json
@@ -10,10 +10,7 @@
     "jsoncpp",
     "lz4",
     "mbedtls",
-    {
-      "name": "pkgconf",
-      "host": true
-    },
+    "pkgconf",
     {
       "name": "tap-windows6",
       "platform": "windows"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7273,8 +7273,8 @@
       "port-version": 0
     },
     "openvpn3": {
-      "baseline": "3.10",
-      "port-version": 1
+      "baseline": "3.11.5",
+      "port-version": 0
     },
     "openvr": {
       "baseline": "2.12.14",

--- a/versions/o-/openvpn3.json
+++ b/versions/o-/openvpn3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd6d0dc2bb84afe52db3af1ffe097d2126cc5ea4",
+      "version": "3.11.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "33c2d9bf4e949b0ddd3779a93c4339a3eab65e67",
       "version": "3.10",
       "port-version": 1

--- a/versions/o-/openvpn3.json
+++ b/versions/o-/openvpn3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fd6d0dc2bb84afe52db3af1ffe097d2126cc5ea4",
+      "git-tree": "973f6661e3aec165a7b79787ec539d2dba153cd6",
       "version": "3.11.5",
       "port-version": 0
     },

--- a/versions/o-/openvpn3.json
+++ b/versions/o-/openvpn3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "973f6661e3aec165a7b79787ec539d2dba153cd6",
+      "git-tree": "d3e4272c5d5633ca352415bb543d82f67b26b614",
       "version": "3.11.5",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/47753
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
~~- [ ] The "supports" clause reflects platforms that may be fixed by this new version.~~
~~- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~~
~~- [ ] Any patches that are no longer applied are deleted from the port's directory.~~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.