### PR TITLE
[eastl] update to 3.27.01

### DIFF
--- a/ports/eabase/portfile.cmake
+++ b/ports/eabase/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO electronicarts/EABase
-    REF 123363eb82e132c0181ac53e43226d8ee76dea12
-    SHA512 8df5279d1b303047e832b8b0ddb6cdf51cca753efaeb2a36f7fa5ebc015c2f37cc6a68184b919deb45f09dfd89f9f8f79f18c487817d231f1b049102ceae610f
+    REF 0699a15efdfd20b6cecf02153bfa5663decb653c
+    SHA512 6852fcef08002c503d7ca23a22ef25d4b3136787c505d9b7ad55e821a6369d1dcc1773ff8042d7a9c306a52f33dd8da35b2f3fdbd8ea0ff1ca0f765fbe7ac240
     HEAD_REF master
     PATCHES
     fix_cmake_install.patch

--- a/ports/eabase/vcpkg.json
+++ b/ports/eabase/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "eabase",
-  "version-date": "2024-08-18",
+  "version-date": "2025-08-01",
   "description": "Electronic Arts Base. EABase is a small set of header files that define platform-independent data types and macros.",
   "homepage": "https://github.com/electronicarts/EABase",
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/eastl/0001-fix-cmake-install.patch
+++ b/ports/eastl/0001-fix-cmake-install.patch
@@ -37,7 +37,7 @@ index a5870f8..1553513 100644
 -FetchContent_Declare(
 -  EABase
 -  GIT_REPOSITORY https://github.com/electronicarts/EABase.git
--  GIT_TAG        123363eb82e132c0181ac53e43226d8ee76dea12
+-  GIT_TAG        0699a15efdfd20b6cecf02153bfa5663decb653c
 -  GIT_SUBMODULES "" # This should be temporary until we update the cyclic submodule dependencies in EABase.
 +
 +target_link_libraries(EASTL PUBLIC EABase)

--- a/ports/eastl/portfile.cmake
+++ b/ports/eastl/portfile.cmake
@@ -1,10 +1,13 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+# EASTL uses leading zeros in tags (e.g., 3.27.01), but vcpkg drops them in versions
+string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$" "\\1.\\2.0\\3" EASTL_REF "${VERSION}")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO electronicarts/EASTL
-    REF "${VERSION}"
-    SHA512 b061660b58aea8944b7b1488bbf344d004a93a06c89fa43881a02cdaf9d0fce5db3db3c5efd9c09e3e000b502c5dc197ab57b298d1bc935fc7603d285f8563db
+    REF "${EASTL_REF}"
+    SHA512 08ac403fceb032cc8622e3f15eef0b00246b8abb2daceb8fabd66d23408c738e82126a4b5187201ec7f6606df46cca1fcda1ec646cfe18ec8e9e081a057101e3
     HEAD_REF master
     PATCHES
         0001-fix-cmake-install.patch

--- a/ports/eastl/vcpkg.json
+++ b/ports/eastl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "eastl",
-  "version": "3.21.23",
+  "version": "3.27.1",
   "description": "Electronic Arts Standard Template Library. It is a C++ template library of containers, algorithms, and iterators useful for runtime and tool development across multiple platforms. It is a fairly extensive and robust implementation of such a library and has an emphasis on high performance above all other considerations.",
   "homepage": "https://github.com/electronicarts/EASTL",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2625,7 +2625,7 @@
       "port-version": 0
     },
     "eabase": {
-      "baseline": "2024-08-18",
+      "baseline": "2025-08-01",
       "port-version": 0
     },
     "earcut-hpp": {
@@ -2633,7 +2633,7 @@
       "port-version": 0
     },
     "eastl": {
-      "baseline": "3.21.23",
+      "baseline": "3.27.1",
       "port-version": 0
     },
     "easycl": {

--- a/versions/e-/eabase.json
+++ b/versions/e-/eabase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1efd9d29b604be799cd16293cad542689c44a6fb",
+      "version-date": "2025-08-01",
+      "port-version": 0
+    },
+    {
       "git-tree": "414a2b49e81c82eefcd778b01c1dc66ade9ad4fc",
       "version-date": "2024-08-18",
       "port-version": 0

--- a/versions/e-/eastl.json
+++ b/versions/e-/eastl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b7286404f816e9615ccb0b595180bda6b0111fa3",
+      "version": "3.27.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "608dd9b821938172ad3c17c982e0883f8f6a8287",
       "version": "3.21.23",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
