### PR TITLE
[sonivox] add new port

### DIFF
--- a/ports/sonivox/option-install-dependencies.patch
+++ b/ports/sonivox/option-install-dependencies.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f5302cb..74b0306 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -38,6 +38,7 @@ option(SF2_SUPPORT "Enable SF2 support and float DCF" TRUE)
+ option(ZLIB_SUPPORT "Enable XMF ZLIB Unpacker support" TRUE)
+ option(EAS_WT_SYNTH "Enable WaveTable Synth" TRUE)
+ option(EAS_FM_SYNTH "Enable FM Synth" FALSE)
++option(INSTALL_DEPENDENCIES "Deploy dependency libraries" FALSE)
+ 
+ if (NOT (EAS_WT_SYNTH OR EAS_FM_SYNTH OR EAS_HYBRID_SYNTH))
+     message(FATAL_ERROR "At least one synthesizer type must be enabled: EAS_WT_SYNTH, EAS_FM_SYNTH, EAS_HYBRID_SYNTH.")
+@@ -490,7 +491,7 @@ if (BUILD_APPLICATION)
+     add_subdirectory(example)
+ endif()
+ 
+-if (CMAKE_SYSTEM_NAME MATCHES "Windows")
++if (INSTALL_DEPENDENCIES)
+     message(STATUS "DEPENDENCY_DIRS: ${DEPENDENCY_DIRS}")
+     install(RUNTIME_DEPENDENCY_SET sonivox-dependencies
+         COMPONENT sonivox_runtime

--- a/ports/sonivox/portfile.cmake
+++ b/ports/sonivox/portfile.cmake
@@ -15,7 +15,8 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-if(NOT ANDROID)
+
+if(NOT VCPKG_TARGET_IS_ANDROID)
 	vcpkg_copy_tools(TOOL_NAMES sonivoxrender AUTO_CLEAN)
 endif()
 

--- a/ports/sonivox/portfile.cmake
+++ b/ports/sonivox/portfile.cmake
@@ -15,7 +15,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_copy_tools(TOOL_NAMES sonivoxrender AUTO_CLEAN)
+if(NOT ANDROID)
+	vcpkg_copy_tools(TOOL_NAMES sonivoxrender AUTO_CLEAN)
+endif()
 
 vcpkg_cmake_config_fixup(
 	PACKAGE_NAME "sonivox"

--- a/ports/sonivox/portfile.cmake
+++ b/ports/sonivox/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO EmbeddedSynth/sonivox
+    REF "v${VERSION}"
+    SHA512 d9f8fb18f151ef3ba2352bcd66a97bc71056aab8ab9f78a061ffa475f68a80ede3c2c0deb374ad21eb2c1cb1d7521c3d7f8eeda72640e11f71c3526b275f5468
+    HEAD_REF master
+	PATCHES "option-install-dependencies.patch"
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+	OPTIONS 
+		-DBUILD_TESTING:BOOL=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_copy_tools(TOOL_NAMES sonivoxrender AUTO_CLEAN)
+
+vcpkg_cmake_config_fixup(
+	PACKAGE_NAME "sonivox"
+	CONFIG_PATH lib/cmake/sonivox
+)
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/man")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/sonivox/usage
+++ b/ports/sonivox/usage
@@ -1,0 +1,9 @@
+sonivox provides CMake targets:
+
+find_package(sonivox CONFIG REQUIRED)
+target_link_libraries(main PRIVATE sonivox::sonivox)
+
+sonivox provides pkg-config modules:
+
+  # Sonivox EAS Software Synthesizer
+  sonivox

--- a/ports/sonivox/vcpkg.json
+++ b/ports/sonivox/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Software MIDI synthesizer evolved from the AOSP 'platform_external_sonivox' project to use it outside of Android. Uses embedded samples allowing also SF2 and DLS files. Plays MID, XMF, and RMI files.",
   "homepage": "https://github.com/EmbeddedSynth/sonivox",
   "license": "Apache-2.0",
+  "supports": "!x86"
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/sonivox/vcpkg.json
+++ b/ports/sonivox/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "sonivox",
+  "version": "4.0.0",
+  "description": "Software MIDI synthesizer evolved from the AOSP 'platform_external_sonivox' project to use it outside of Android. Uses embedded samples allowing also SF2 and DLS files. Plays MID, XMF, and RMI files.",
+  "homepage": "https://github.com/EmbeddedSynth/sonivox",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "zlib",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/sonivox/vcpkg.json
+++ b/ports/sonivox/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Software MIDI synthesizer evolved from the AOSP 'platform_external_sonivox' project to use it outside of Android. Uses embedded samples allowing also SF2 and DLS files. Plays MID, XMF, and RMI files.",
   "homepage": "https://github.com/EmbeddedSynth/sonivox",
   "license": "Apache-2.0",
-  "supports": "!x86"
+  "supports": "!x86",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/sonivox/vcpkg.json
+++ b/ports/sonivox/vcpkg.json
@@ -5,7 +5,6 @@
   "homepage": "https://github.com/EmbeddedSynth/sonivox",
   "license": "Apache-2.0",
   "dependencies": [
-    "zlib",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -13,6 +12,7 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
+    "zlib"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9184,6 +9184,10 @@
       "baseline": "3.5.8",
       "port-version": 3
     },
+    "sonivox": {
+      "baseline": "4.0.0",
+      "port-version": 0
+    },
     "sophus": {
       "baseline": "1.24.6",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9184,10 +9184,6 @@
       "baseline": "3.5.8",
       "port-version": 3
     },
-    "sonivox": {
-      "baseline": "4.0.0",
-      "port-version": 0
-    },
     "sophus": {
       "baseline": "1.24.6",
       "port-version": 0

--- a/versions/s-/sonivox.json
+++ b/versions/s-/sonivox.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c874a7c1a3ef188845db0a6786f5a14501c02fe5",
+      "version": "4.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/sonivox.json
+++ b/versions/s-/sonivox.json
@@ -1,9 +1,0 @@
-{
-  "versions": [
-    {
-      "git-tree": "6b4c6ccb96120f71573e848de69dcf4dc4cb09f1",
-      "version": "4.0.0",
-      "port-version": 0
-    }
-  ]
-}

--- a/versions/s-/sonivox.json
+++ b/versions/s-/sonivox.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "68f02c1894e118c2ca20e7bddbc4d5dab885aa89",
+      "version": "4.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/sonivox.json
+++ b/versions/s-/sonivox.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6b4c6ccb96120f71573e848de69dcf4dc4cb09f1",
+      "version": "4.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/sonivox.json
+++ b/versions/s-/sonivox.json
@@ -1,9 +1,0 @@
-{
-  "versions": [
-    {
-      "git-tree": "68f02c1894e118c2ca20e7bddbc4d5dab885aa89",
-      "version": "4.0.0",
-      "port-version": 0
-    }
-  ]
-}


### PR DESCRIPTION
## Description

This project originated as a fork of the Android Open Source Project 'platform_external_sonivox', including a CMake based build system to be used not on Android, but on any other computer Operating System. Google licensed this work originally named Sonivox EAS (Embedded Audio Synthesis) from the company Sonic Network Inc. under the terms of the Apache License 2.0.

This is a Wave Table synthesizer, not using external soundfont files by default but embedded samples. It also supports external DLS or SF2 soundfont files for better rendering quality. It is also a real time GM synthesizer. It consumes very little resources, so it may be indicated in projects for small embedded devices. There is neither MIDI input nor Audio output facilities included in the library. You need to provide your own input/output.

### GitHub repository:
https://github.com/EmbeddedSynth/sonivox

### Repology records;
https://repology.org/project/sonivox/versions

### Dependencies:
* zlib

### Patches:
(already applied to upstream development branch)
https://github.com/EmbeddedSynth/sonivox/commit/da56630e26b1bde90cc66212b6c2b8a9f54bc62b.patch

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
