### PR TITLE
Add rubberband feature to ffmpeg port.

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -599,6 +599,14 @@ else()
     set(WITH_ZMQ OFF)
 endif()
 
+if("rubberband" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-librubberband")
+    set(WITH_RUBBERBAND ON)
+else()
+    set(OPTIONS "${OPTIONS} --disable-librubberband")
+    set(WITH_RUBBERBAND OFF)
+endif()
+
 set(OPTIONS_CROSS "--enable-cross-compile")
 
 # ffmpeg needs --cross-prefix option to use appropriate tools for cross-compiling.

--- a/ports/ffmpeg/vcpkg-cmake-wrapper.cmake
+++ b/ports/ffmpeg/vcpkg-cmake-wrapper.cmake
@@ -313,6 +313,14 @@ if(@WITH_ZMQ@)
   endif()
 endif()
 
+if(@WITH_RUBBERBAND@)
+  pkg_check_modules(rubberband IMPORTED_TARGET rubberband)
+  list(APPEND FFMPEG_LIBRARIES PkgConfig::rubberband)
+  if(vcpkg_no_avfilter_target AND TARGET FFmpeg::avfilter)
+    target_link_libraries(FFmpeg::avfilter INTERFACE PkgConfig::rubberband)
+  endif()
+endif()
+
 endif()
 unset(z_vcpkg_using_vcpkg_find_ffmpeg)
 

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "7.1.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -565,6 +565,19 @@
       "description": "Intel QSV Codec",
       "dependencies": [
         "mfx-dispatch"
+      ]
+    },
+    "rubberband": {
+      "description": "Enable rubberband support",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "gpl"
+          ]
+        },
+        "rubberband"
       ]
     },
     "sdl2": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2918,7 +2918,7 @@
     },
     "ffmpeg": {
       "baseline": "7.1.2",
-      "port-version": 4
+      "port-version": 5
     },
     "ffnvcodec": {
       "baseline": "13.0.19.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf414f1e4f2a63ff7410444dc4eabb5b392f6d16",
+      "version": "7.1.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "4d296d54e7c2880504575318ca86ed35d6232eb6",
       "version": "7.1.2",
       "port-version": 4


### PR DESCRIPTION
If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

I tested this on arm64 debian and works fine.

