### PR TITLE
[ormpp] Add ormpp port

### DIFF
--- a/ports/ormpp/portfile.cmake
+++ b/ports/ormpp/portfile.cmake
@@ -1,0 +1,15 @@
+# header-only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO qicosmos/ormpp
+    REF "0.2.0"
+    SHA512 69b41091653341a158b929004bb00b1aed909ddd12593a8dc7a2a7dc0f1b8d1a3b5716db17ffefe7134452cf997502750e1fc86ffd185f43ceb5e2d99e8ddcc5
+    HEAD_REF master
+)
+
+# Copy header files (iguana and frozen are provided as dependencies)
+file(INSTALL "${SOURCE_PATH}/ormpp/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/ormpp")
+
+# Handle license
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ormpp/vcpkg.json
+++ b/ports/ormpp/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "ormpp",
+  "version": "0.2.0",
+  "description": "A modern C++ ORM library for MySQL, PostgreSQL, and SQLite",
+  "homepage": "https://github.com/qicosmos/ormpp",
+  "license": "Apache-2.0",
+  "supports": "linux | osx | (windows & !uwp)",
+  "dependencies": [
+    "frozen",
+    "iguana"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7320,6 +7320,10 @@
       "baseline": "1.3.0",
       "port-version": 0
     },
+    "ormpp": {
+      "baseline": "0.2.0",
+      "port-version": 0
+    },
     "orocos-kdl": {
       "baseline": "1.5.3",
       "port-version": 0

--- a/versions/o-/ormpp.json
+++ b/versions/o-/ormpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ea5c12aaab3526270807a3078e675ecd9bdb7181",
+      "version": "0.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add ormpp port (modern C++ ORM library)

  ## ormpp
  ormpp is a modern C++ ORM library supporting MySQL, PostgreSQL, and SQLite.
  It is a header-only library that includes iguana (serialization library) and
  frozen (compile-time containers) as bundled dependencies.

  - **Version**: 0.2.0
  - **License**: Apache-2.0
  - **Homepage**: https://github.com/qicosmos/ormpp
  - **Supported platforms**: linux | osx | (windows & !uwp)

  ## Checklist
  - [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/bl
  ob/main/vcpkg/contributing/maintainer-guide.md)
  - [x] The name of the port matches an existing name for this component on
  https://repology.org/ if possible
  - [x] Optional dependencies are resolved in exactly one way
  - [x] The versioning scheme in `vcpkg.json` matches what upstream says
  - [x] The license declaration in `vcpkg.json` matches what upstream says
  - [x] The installed "copyright" file matches what upstream says
  - [x] The source code of the component installed comes from an authoritative source
  - [x] The generated "usage text" is accurate
  - [x] The version database is fixed by rerunning `./vcpkg x-add-version --all`
  - [x] Only one version is in the new port's versions file