### PR TITLE
[libpq] Fix x64-linux build (#48024)

### DIFF
--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -106,6 +106,20 @@ else()
     if(VCPKG_DETECTED_CMAKE_OSX_SYSROOT)
         list(APPEND BUILD_OPTS "PG_SYSROOT=${VCPKG_DETECTED_CMAKE_OSX_SYSROOT}")
     endif()
+    if(NOT VCPKG_TARGET_IS_WINDOWS)
+        # Pass the location of timezone data. This is necessary, because
+        # fix-configure.patch sets cross_compiling=yes to avoid conftest issues.
+        set(TZDATA_PATH "/usr/share/zoneinfo")
+
+        # Allow override from triplet for non-standard system configurations
+        if(DEFINED VCPKG_SYSTEM_TZDATA_PATH)
+            set(TZDATA_PATH "${VCPKG_SYSTEM_TZDATA_PATH}")
+        endif()
+
+        if(EXISTS "${TZDATA_PATH}")
+            list(APPEND BUILD_OPTS --with-system-tzdata=${TZDATA_PATH})
+        endif()
+    endif()
     vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}"
         COPY_SOURCE

--- a/ports/libpq/usage
+++ b/ports/libpq/usage
@@ -2,3 +2,6 @@ The package libpq provides CMake integration:
 
     find_package(PostgreSQL REQUIRED)
     target_link_libraries(main PRIVATE PostgreSQL::PostgreSQL)
+
+For custom timezone data locations on Unix-like systems, set VCPKG_SYSTEM_TZDATA_PATH
+in your triplet file. Default is /usr/share/zoneinfo.

--- a/ports/libpq/vcpkg.json
+++ b/ports/libpq/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libpq",
   "version": "16.9",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The official database access API of postgresql",
   "homepage": "https://www.postgresql.org/",
   "license": "PostgreSQL",


### PR DESCRIPTION
Configure with --with-system-tzdata on non-Windows systems if /usr/share/zoneinfo exists.

The port forces configure to think that it's crosscompiling, and that requires a zic executable or already available tzdata.

Fixes #48024

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.

