### PR TITLE
[qt5-base] Devendor md4c

### DIFF
--- a/ports/qt5-base/patches/md4c.diff
+++ b/ports/qt5-base/patches/md4c.diff
@@ -1,0 +1,13 @@
+diff --git a/src/gui/text/qtextmarkdownimporter.cpp b/src/gui/text/qtextmarkdownimporter.cpp
+index 7296a6f..d62a195 100644
+--- a/src/gui/text/qtextmarkdownimporter.cpp
++++ b/src/gui/text/qtextmarkdownimporter.cpp
+@@ -48,7 +48,7 @@
+ #include <QTextDocumentFragment>
+ #include <QTextList>
+ #include <QTextTable>
+-#include "../../3rdparty/md4c/md4c.h"
++#include <md4c.h>
+ 
+ QT_BEGIN_NAMESPACE
+ 

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -62,6 +62,7 @@ set(PATCHES
     patches/vulkan-windows.diff        #Forces QMake to use vulkan from vcpkg instead of VULKAN_SDK system variable
     patches/egl.patch                  #Fix egl detection logic.
     patches/qtbug_96392.patch          #Backport fix for QTBUG-96392
+    patches/md4c.diff                  #Include vcpkg md4c.h
     patches/mysql_plugin_include.patch #Fix include path of mysql plugin
     patches/mysql-configure.patch      #Fix mysql project
     patches/patch-qtbase-memory_resource.diff # From https://bugreports.qt.io/browse/QTBUG-114316
@@ -91,12 +92,9 @@ endif()
 qt_download_submodule(OUT_SOURCE_PATH SOURCE_PATH PATCHES ${PATCHES})
 
 # Remove vendored dependencies to ensure they are not picked up by the build
-foreach(DEPENDENCY zlib freetype harfbuzz-ng libjpeg libpng double-conversion sqlite pcre2)
-    if(EXISTS ${SOURCE_PATH}/src/3rdparty/${DEPENDENCY})
-        file(REMOVE_RECURSE ${SOURCE_PATH}/src/3rdparty/${DEPENDENCY})
-    endif()
+foreach(DEPENDENCY IN ITEMS double-conversion freetype harfbuzz-ng libjpeg libpng md4c pcre2 sqlite zlib)
+    file(REMOVE_RECURSE "${SOURCE_PATH}/src/3rdparty/${DEPENDENCY}")
 endforeach()
-#file(REMOVE_RECURSE ${SOURCE_PATH}/include/QtZlib)
 
 #########################
 ## Setup Configure options
@@ -118,6 +116,7 @@ set(CORE_OPTIONS
 list(APPEND CORE_OPTIONS
     -system-zlib
     -system-libjpeg
+    -system-libmd4c
     -system-libpng
     -system-pcre
     -system-doubleconversion

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version": "5.15.18",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Base provides the basic non-GUI functionality required by all Qt applications.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -37,6 +37,7 @@
     },
     "libjpeg-turbo",
     "libpng",
+    "md4c",
     {
       "name": "opengl",
       "platform": "!windows"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7946,7 +7946,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.18",
-      "port-version": 1
+      "port-version": 2
     },
     "qt5-charts": {
       "baseline": "5.15.18",

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac9abc3027905d9a1f2558ba6f6a569cdfb03892",
+      "version": "5.15.18",
+      "port-version": 2
+    },
+    {
       "git-tree": "aa733ded6eec8435a809e3548fb2ab897d687180",
       "version": "5.15.18",
       "port-version": 1


### PR DESCRIPTION
Fixes installation order problem leading to
~~~
CMake Error at /mnt/vcpkg-ci/installed/x64-linux/share/cmake/Qt5Gui/Qt5GuiConfig.cmake:95 (message):
  Library not found: md4c
Call Stack (most recent call first):
  /mnt/vcpkg-ci/installed/x64-linux/share/cmake/Qt5Gui/Qt5GuiConfig.cmake:277 (_qt5_Gui_process_prl_file)
  /vcpkg/scripts/buildsystems/vcpkg.cmake:908 (_find_package)
  /mnt/vcpkg-ci/installed/x64-linux/share/cmake/Qt5/Qt5Config.cmake:28 (find_package)
  ...
~~~
Seen in https://dev.azure.com/vcpkg/public/_build/results?buildId=125220&view=results (opencv3[qt], mathgl[qt5]).