### PR TITLE
[at-spi2-core] Update 2.59.0

### DIFF
--- a/ports/at-spi2-core/portfile.cmake
+++ b/ports/at-spi2-core/portfile.cmake
@@ -8,18 +8,29 @@ vcpkg_download_distfile(ARCHIVE
         "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
-    SHA512 8d85df75f886c4a19d829d14e5a9412b607b9cbe2d1b7ecb95b4082602f0624e90747fe955f96d378c3a52bc0e732074b97008bb34e6acc2722c7056b2c0504e
+    SHA512 46bed060b61e62d0e53047bb59741367cf5e4a79ff4aa4486c62ca282aacd0d9d77f6f711bac3b9215fc120126685b9c6fdfea451841bcefbf0665b9c742da6b
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
 
+if("introspection" IN_LIST FEATURES)
+    list(APPEND OPTIONS_RELEASE -Dintrospection=enabled)
+    vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+else()
+    list(APPEND OPTIONS_RELEASE -Dintrospection=disabled)
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -Dintrospection=no
+    OPTIONS_RELEASE
+        ${OPTIONS_RELEASE}
+    OPTIONS_DEBUG
+        -Dintrospection=disabled
     ADDITIONAL_BINARIES
         glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
         glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
 )
 
 vcpkg_install_meson()

--- a/ports/at-spi2-core/vcpkg.json
+++ b/ports/at-spi2-core/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "at-spi2-core",
-  "version": "2.44.1",
-  "port-version": 5,
+  "version": "2.59.0",
   "description": "Base DBus XML interfaces for accessibility, the accessibility registry daemon, and atspi library.",
   "homepage": "https://www.gtk.org/",
   "license": null,
@@ -23,5 +22,14 @@
       "name": "vcpkg-tool-meson",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "introspection": {
+      "description": "Build with introspection",
+      "supports": "!static",
+      "dependencies": [
+        "gobject-introspection"
+      ]
+    }
+  }
 }

--- a/ports/dpdk/vcpkg.json
+++ b/ports/dpdk/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "name": "dpdk",
   "version": "25.11",
+  "port-version": 1,
   "description": "A set of libraries and drivers for fast packet processing",
   "homepage": "https://www.dpdk.org/",
   "documentation": "https://doc.dpdk.org/guides/",
   "license": "BSD-3-Clause",
-  "supports": "freebsd | linux | (windows & x64)",
+  "supports": "freebsd | linux",
   "dependencies": [
     {
       "name": "libarchive",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -49,6 +49,8 @@ arpack-ng:x64-windows-static=fail
 arrayfire:x64-linux=fail
 atliac-minitest:arm64-uwp=fail
 atliac-minitest:x64-uwp=fail
+# Conflicts with at-spi2-core
+atk:x64-linux=skip
 avro-c:arm-neon-android=fail
 avro-c:arm64-android=fail
 avro-c:x64-android=fail

--- a/versions/a-/at-spi2-core.json
+++ b/versions/a-/at-spi2-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "baf81e6874d3bb3fdbca29c23ff6c92cf8b6101f",
+      "version": "2.59.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "06c6d76c43fffcbc98dc24430c71e11c70d5cf7f",
       "version": "2.44.1",
       "port-version": 5

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -353,8 +353,8 @@
       "port-version": 2
     },
     "at-spi2-core": {
-      "baseline": "2.44.1",
-      "port-version": 5
+      "baseline": "2.59.0",
+      "port-version": 0
     },
     "atk": {
       "baseline": "2.38.0",
@@ -2542,7 +2542,7 @@
     },
     "dpdk": {
       "baseline": "25.11",
-      "port-version": 0
+      "port-version": 1
     },
     "dpp": {
       "baseline": "10.1.4",

--- a/versions/d-/dpdk.json
+++ b/versions/d-/dpdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ae5ab5a636f2c9dc7972c69a9c554bfe16823b5",
+      "version": "25.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "cc65391748bf0876d288a5a18f8ac58798b367d0",
       "version": "25.11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Remove dpdk support of windows, due to:
```
../src/v25.11-3cc4f3a5aa.clean/lib/metrics/rte_metrics_telemetry.c(142): error C2057: expected constant expression
../src/v25.11-3cc4f3a5aa.clean/lib/metrics/rte_metrics_telemetry.c(142): error C2466: cannot allocate an array of constant size 0
../src/v25.11-3cc4f3a5aa.clean/lib/metrics/rte_metrics_telemetry.c(142): error C2133: 'xstats_values': unknown size
../src/v25.11-3cc4f3a5aa.clean/lib/metrics/rte_metrics_telemetry.c(390): error C2057: expected constant expression
../src/v25.11-3cc4f3a5aa.clean/lib/metrics/rte_metrics_telemetry.c(390): error C2466: cannot allocate an array of constant size 0
../src/v25.11-3cc4f3a5aa.clean/lib/metrics/rte_metrics_telemetry.c(390): error C2133: 'stat_names': unknown size
```
As the C compiler of MSVC never learned VLAs...

// Edit: conflicts with port `atk` which is already a archived project. As far as I can see `atk` is developed now within `at-spi2-core` (compare these [commits](https://gitlab.gnome.org/Archive/atk/-/commits/master/atk) with [these](https://gitlab.gnome.org/GNOME/at-spi2-core/-/commits/main/atk)). So not sure whether delist `atk` or just mark it as known issue. The code for `gobject-introspection` is taken from the atk port.