### PR TITLE
[ecal] Update 5.13.4

### DIFF
--- a/ports/ecal/portfile.cmake
+++ b/ports/ecal/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eclipse-ecal/ecal
     REF "v${VERSION}"
-    SHA512 8134873a3ac0ba48955fdb837aaeaccbd76b81cde6af0099060daedb26bca107cb472af39058358ad094da02ead8f735afb73acd627b19ab210c42039ffa92b8 
+    SHA512 ae34bfc4aa021ab049758373dbac90dfcee34e92f94590813797d88b854420f9e4419f35fbd0db41c7b8aedbfcd24e46dd385f3017a7e0c1a04ee6863c4f948a 
     HEAD_REF master
     PATCHES
         0001-disable-app-plugins.patch
@@ -67,9 +67,9 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # global ini files not strictly required
 if (VCPKG_TARGET_IS_WINDOWS)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cfg" "${CURRENT_PACKAGES_DIR}/debug/cfg")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/cfg" "${CURRENT_PACKAGES_DIR}/debug/cfg")
 else()
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/etc" "${CURRENT_PACKAGES_DIR}/debug/etc")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/etc" "${CURRENT_PACKAGES_DIR}/debug/etc")
 endif()
 
 # Install copyright and usage

--- a/ports/ecal/vcpkg.json
+++ b/ports/ecal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ecal",
-  "version-semver": "5.13.3",
+  "version-semver": "5.13.4",
   "description": "eCAL - enhanced Communication Abstraction Layer",
   "homepage": "https://eclipse-ecal.github.io/ecal/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2649,7 +2649,7 @@
       "port-version": 1
     },
     "ecal": {
-      "baseline": "5.13.3",
+      "baseline": "5.13.4",
       "port-version": 0
     },
     "ecm": {

--- a/versions/e-/ecal.json
+++ b/versions/e-/ecal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a8c5a410198bed18e75075bae53595116a85725d",
+      "version-semver": "5.13.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "e8ddc8c3ae20bd64dea86af3d825bcb5e58cf998",
       "version-semver": "5.13.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Note: There exist already 6.0.x, but I think this requires a bit more work than just updating the version and hash (due to [Qt 6 support](https://eclipse-ecal.github.io/ecal/releases/ecal_6_0_0.html#ecal-release-page-6-0-0)) and as 5.13 is still not EOL, just update the 5.13 version for now