### PR TITLE
[xbitmaps] Update 1.1.3

### DIFF
--- a/ports/xbitmaps/portfile.cmake
+++ b/ports/xbitmaps/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO data/bitmaps
-    REF  61eebdfde170841ae933cf65ba27346fbf2f8018
-    SHA512 dd8acefc6f96d65e4b5d4807221aa3b87faca7b8b50e9de76081351503c9abb127a3063f3bb23ca71a0e3521640e7fdf7686e33cca5c7b7ad8d67a7ac26e65b5
+    REF  "xbitmaps-${VERSION}"
+    SHA512 e9a90555cf38c9c8800f58e1ec92bae3c44cedc491fb6184ad6da575e7fbaf3ee380a3fc2d33072d0ef5f313204588ff9c3668a58726b1251dbb2a4ad362d119
     HEAD_REF master
 )
 
@@ -20,5 +20,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}/pkgconfig/")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 file(TOUCH "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage")

--- a/ports/xbitmaps/vcpkg.json
+++ b/ports/xbitmaps/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xbitmaps",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "X BitMap (XBM) format bitmaps commonly used in X.Org applications",
   "homepage": "https://gitlab.freedesktop.org/xorg/data/bitmaps",
   "license": null,

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -728,6 +728,7 @@ xbitmaps:arm-neon-android=fail
 xbitmaps:arm64-android=fail
 xbitmaps:arm64-osx=skip
 xbitmaps:x64-android=fail
+xbitmaps:x64-linux=fail
 zeroc-ice:arm-neon-android=fail
 zeroc-ice:arm64-android=fail
 zeroc-ice:x64-android=fail

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -1782,7 +1782,7 @@ vtk-m[omp](osx) = feature-fails # no openmp on default osx toolchain
 vtk-m[omp](windows) = feature-fails # needs openmp 4.0, msvc has openmp 2.0
 wasmedge[aot] = feature-fails # ar: /libzstd.a: No such file or directory. See https://github.com/microsoft/vcpkg/issues/32146
 wayland[force-build](native) = feature-fails # error: To build wayland libraries the `force-build` feature must be enabled and the X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES triplet variable must be set.
-xbitmaps(osx) = fail # error: must install xorg-macros 1.3 or later before running autoconf/autogen
+xbitmaps(!windows) = fail # error: must install xorg-macros 1.20 or later before running autoconf/autogen
 xerces-c[xmlch-wchar](!windows) = feature-fails # wchar_t must be 16 bit and not 32
 
 # skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10697,7 +10697,7 @@
       "port-version": 0
     },
     "xbitmaps": {
-      "baseline": "1.1.2",
+      "baseline": "1.1.3",
       "port-version": 0
     },
     "xbyak": {

--- a/versions/x-/xbitmaps.json
+++ b/versions/x-/xbitmaps.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c443c2cbc8193a259df5f3f816d96e88d08e8e7d",
+      "version": "1.1.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "8559532a1b6db036c16c36bb7f46207a8280b976",
       "version": "1.1.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Requires #49263