### PR TITLE
[xorg-macros] Update 1.20.2

### DIFF
--- a/ports/xorg-macros/portfile.cmake
+++ b/ports/xorg-macros/portfile.cmake
@@ -3,7 +3,8 @@ set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
+    return()
+endif()
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     set(PATCHES skip_rawcpp.patch)
@@ -13,8 +14,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO util/macros
-    REF  b8766308d2f78bc572abe5198007cf7aeec9b761 #v1.19.3
-    SHA512 dc7383b1579dc6ef0473161764096c8161f23a4c4ba2182e7abd7f73f443eb0520e02f1dfaaba2f8ebb43e0ed93c1e6e5e7cf517561476b858d2471a8ecaf907
+    REF  "util-macros-${VERSION}"
+    SHA512 e3c8b625ac7bcb1d34869bece133d6c557e1c6e92ae7ecbfcb4e05a61006a600515e2aab51af2e1a00d9482a270265eda8e7c05f599dc5a007e996aac32db46b
     HEAD_REF master
     PATCHES ${PATCHES}
 ) 
@@ -64,4 +65,3 @@ vcpkg_fixup_pkgconfig()
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-endif()

--- a/ports/xorg-macros/skip_rawcpp.patch
+++ b/ports/xorg-macros/skip_rawcpp.patch
@@ -1,5 +1,5 @@
 diff --git a/xorg-macros.m4.in b/xorg-macros.m4.in
-index f0a16da3a..e1c0ff1ed 100644
+index b15daf1..3bddfcb 100644
 --- a/xorg-macros.m4.in
 +++ b/xorg-macros.m4.in
 @@ -63,38 +63,6 @@ AC_PATH_TOOL(RAWCPP, [cpp], [${CPP}],
@@ -26,10 +26,10 @@ index f0a16da3a..e1c0ff1ed 100644
 -
 -AC_MSG_CHECKING([if $RAWCPP requires -traditional])
 -AC_LANG_CONFTEST([AC_LANG_SOURCE([[Does cpp preserve   "whitespace"?]])])
--if test `${RAWCPP} < conftest.$ac_ext | grep -c 'preserve   \"'` -eq 1 ; then
+-if test `${RAWCPP} < conftest.$ac_ext | grep -c 'preserve   "'` -eq 1 ; then
 -	AC_MSG_RESULT([no])
 -else
--	if test `${RAWCPP} -traditional < conftest.$ac_ext | grep -c 'preserve   \"'` -eq 1 ; then
+-	if test `${RAWCPP} -traditional < conftest.$ac_ext | grep -c 'preserve   "'` -eq 1 ; then
 -		TRADITIONALCPPFLAGS="-traditional"
 -		RAWCPPFLAGS="${RAWCPPFLAGS} -traditional"
 -		AC_MSG_RESULT([yes])

--- a/ports/xorg-macros/vcpkg.json
+++ b/ports/xorg-macros/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "xorg-macros",
-  "version": "1.19.3",
-  "port-version": 1,
+  "version": "1.20.2",
   "description": "X.org macros utilities.",
   "homepage": "https://xcb.freedesktop.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10725,8 +10725,8 @@
       "port-version": 0
     },
     "xorg-macros": {
-      "baseline": "1.19.3",
-      "port-version": 1
+      "baseline": "1.20.2",
+      "port-version": 0
     },
     "xorstr": {
       "baseline": "2021-11-20",

--- a/versions/x-/xorg-macros.json
+++ b/versions/x-/xorg-macros.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f6bd7a14a7ce2d94a83bed21f6e26722d408b754",
+      "version": "1.20.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "766525189c81d40661731faecc566fb96d66fcc4",
       "version": "1.19.3",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
