### PR TITLE
[vtk-dicom] Update 0.8.17

### DIFF
--- a/ports/vtk-dicom/portfile.cmake
+++ b/ports/vtk-dicom/portfile.cmake
@@ -1,36 +1,22 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dgobbi/vtk-dicom
-    REF cfeceadfa68d2cc3172632bd1fd3ea8a38b6c609 # v0.8.16
-    SHA512 0715ef91a1c585c9c819efd2bd6e2b73d3bff73a626b89f4877812fa6587e8379fb55ad99a376fb4d8dfa46c438e7a7052ba02ae61feb950cafb00c95df09b3f
+    REF "v${VERSION}"
+    SHA512 ddc294acc60d18f9d60a00fb4e15fbc30743262ec041e4f0f0e6cbccdc821f2e7def4679446e55a9f3a658072c81c2e4b31d017cdc00760d7942452a85f051e8
     HEAD_REF master
 )
 
-if ("gdcm" IN_LIST FEATURES)
-    set(USE_GDCM                      ON )
-else()
-    set(USE_GDCM                      OFF )
-endif()
-
-if(USE_GDCM)
-    list(APPEND ADDITIONAL_OPTIONS
-        -DUSE_GDCM=ON
-        -DUSE_DCMTK=OFF
-    )
-endif()
-
-set(python_ver "")
-if(NOT VCPKG_TARGET_IS_WINDOWS)
-    set(python_ver "3")
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        gdcm USE_GDCM
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_PROGRAMS=OFF
         -DBUILD_EXAMPLES=OFF
-        "-DPython3_EXECUTABLE:PATH=${CURRENT_HOST_INSTALLED_DIR}/tools/python3/python${python_ver}${VCPKG_TARGET_EXECUTABLE_SUFFIX}"
-        ${ADDITIONAL_OPTIONS}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
@@ -41,4 +27,3 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/Copyright.txt")
-

--- a/ports/vtk-dicom/vcpkg.json
+++ b/ports/vtk-dicom/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vtk-dicom",
-  "version": "0.8.16",
-  "port-version": 2,
+  "version": "0.8.17",
   "description": "DICOM for VTK",
   "homepage": "https://github.com/dgobbi/vtk-dicom",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10381,8 +10381,8 @@
       "port-version": 1
     },
     "vtk-dicom": {
-      "baseline": "0.8.16",
-      "port-version": 2
+      "baseline": "0.8.17",
+      "port-version": 0
     },
     "vtk-m": {
       "baseline": "2.3.0",

--- a/versions/v-/vtk-dicom.json
+++ b/versions/v-/vtk-dicom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "254db7122781a16b911815c324a1801b82a47e58",
+      "version": "0.8.17",
+      "port-version": 0
+    },
+    {
       "git-tree": "e53703532b0212513a8604e7d613665841c307b5",
       "version": "0.8.16",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Note: `USE_DCMTK` is [`OFF` by default](https://github.com/dgobbi/vtk-dicom/blob/d29a996ab2a49375a59cef5e381c1c25185ffa50/Source/CMakeLists.txt#L4), so no need to set this variable

Currently Draft to verify the warning
```
  The following variables are not used in CMakeLists.txt:

      Python3_EXECUTABLE
```
//Edit: Python seems not to be necessary
