### PR TITLE
[ragel] Replace dead website

### DIFF
--- a/ports/ragel/vcpkg.json
+++ b/ports/ragel/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "ragel",
   "version": "6.10",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Ragel State Machine Compiler",
-  "homepage": "https://www.colm.net/files/ragel",
+  "homepage": "https://www.colm.net/open-source/ragel/",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8342,7 +8342,7 @@
     },
     "ragel": {
       "baseline": "6.10",
-      "port-version": 6
+      "port-version": 7
     },
     "random123": {
       "baseline": "1.14.0",

--- a/versions/r-/ragel.json
+++ b/versions/r-/ragel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a67ab66a7a6b2740b235a60128c18080add97e51",
+      "version": "6.10",
+      "port-version": 7
+    },
+    {
       "git-tree": "efacd9dde74b0cd221344329fd3f950f60ba39ca",
       "version": "6.10",
       "port-version": 6


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
