### PR TITLE
[openal-soft] update to 1.25.0

### DIFF
--- a/ports/openal-soft/devendor-fmt.diff
+++ b/ports/openal-soft/devendor-fmt.diff
@@ -1,36 +1,40 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d2a69d4..14fc9b8 100644
+index b65e924..814d59e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -159,7 +159,8 @@ if(MSVC)
-     endif()
+@@ -256,7 +256,8 @@ if(ALSOFT_ENABLE_MODULES)
  endif()
  
--add_subdirectory(fmt-11.1.1 EXCLUDE_FROM_ALL)
+ 
+-add_subdirectory(fmt-11.2.0 EXCLUDE_FROM_ALL)
 +find_package(fmt CONFIG REQUIRED)
 +add_library(alsoft::fmt ALIAS fmt::fmt)
  
  
  set(CPP_DEFS ) # C pre-processor, not C++
-@@ -1440,7 +1441,7 @@ if(LIBTYPE STREQUAL "STATIC")
-     add_library(${IMPL_TARGET} STATIC ${COMMON_OBJS} ${OPENAL_OBJS} ${ALC_OBJS} ${CORE_OBJS})
+@@ -1614,7 +1615,7 @@ if(LIBTYPE STREQUAL "STATIC")
      target_compile_definitions(${IMPL_TARGET} PUBLIC AL_LIBTYPE_STATIC)
+     target_include_directories(${IMPL_TARGET} PRIVATE ${OpenAL_SOURCE_DIR}/gsl/include)
      target_link_libraries(${IMPL_TARGET} PRIVATE ${LINKER_FLAGS} ${EXTRA_LIBS} ${MATH_LIB}
 -        $<BUILD_LOCAL_INTERFACE:alsoft::fmt>)
 +        alsoft::fmt)
  
-     if(WIN32)
-         # This option is for static linking OpenAL Soft into another project
+     if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND DEFINED CMAKE_OSX_DEPLOYMENT_TARGET
+         AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "10.13")
 diff --git a/OpenALConfig.cmake.in b/OpenALConfig.cmake.in
-index 9704d3c..ddabb81 100644
+index 4c1ad05..f462df5 100644
 --- a/OpenALConfig.cmake.in
 +++ b/OpenALConfig.cmake.in
-@@ -1,3 +1,5 @@
+@@ -2,6 +2,9 @@ if((NOT DEFINED CMAKE_VERSION) OR (CMAKE_VERSION VERSION_LESS "3.1"))
+    message(FATAL_ERROR "CMake >= 3.1 required")
+ endif()
+ 
 +include(CMakeFindDependencyMacro)
 +find_dependency(fmt CONFIG)
- cmake_minimum_required(VERSION 3.1...3.18)
- 
++
  include("${CMAKE_CURRENT_LIST_DIR}/OpenALTargets.cmake")
+ 
+ set(OPENAL_FOUND ON)
 diff --git a/openal.pc.in b/openal.pc.in
 index dfa6f57..e04e807 100644
 --- a/openal.pc.in

--- a/ports/openal-soft/pkgconfig-cxx.diff
+++ b/ports/openal-soft/pkgconfig-cxx.diff
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 060a740..d2a69d4 100644
+index c0f59f2..b65e924 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1379,6 +1379,15 @@ if(LIBTYPE STREQUAL "STATIC")
+@@ -1493,6 +1493,15 @@ if(LIBTYPE STREQUAL "STATIC")
              set(PKG_CONFIG_PRIVATE_LIBS "${PKG_CONFIG_PRIVATE_LIBS} -l${FLAG}")
          endif()
      endforeach()
@@ -17,4 +17,4 @@ index 060a740..d2a69d4 100644
 +    endforeach()
  endif()
  
- # End configuration
+ if(UNIX_ELF)

--- a/ports/openal-soft/portfile.cmake
+++ b/ports/openal-soft/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcat/openal-soft
     REF ${VERSION}
-    SHA512 3eebd18de4984691136738e8fe5851ac5dbdc8f17916cc9dcc599bd3bafc400c9dad9dc88844a9b77b1e8e372a041af342421bdf23746dffe4760f8385bd1e53
+    SHA512 33cdc03198c4fdbd6c67bae460328d8f910baf0a522891735590df140ef727a5d7a1acc64826128994700e7d75c75c938b20483858575ff4e0ebc3f120a9e206
     HEAD_REF master
     PATCHES
         pkgconfig-cxx.diff

--- a/ports/openal-soft/vcpkg.json
+++ b/ports/openal-soft/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openal-soft",
-  "version": "1.24.3",
-  "port-version": 1,
+  "version": "1.25.0",
   "description": "OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.",
   "homepage": "https://github.com/kcat/openal-soft",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7109,8 +7109,8 @@
       "port-version": 0
     },
     "openal-soft": {
-      "baseline": "1.24.3",
-      "port-version": 1
+      "baseline": "1.25.0",
+      "port-version": 0
     },
     "openblas": {
       "baseline": "0.3.29",

--- a/versions/o-/openal-soft.json
+++ b/versions/o-/openal-soft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b9ddf9723bc350b0b106d0d4f11b75181798dcde",
+      "version": "1.25.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e6c23049e3c80b2f0a031b0531fc92be404754a4",
       "version": "1.24.3",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/kcat/openal-soft/releases/tag/1.25.0
