### PR TITLE
[alembic] Avoid homepage SSL certificate issue

### DIFF
--- a/ports/alembic/vcpkg.json
+++ b/ports/alembic/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "alembic",
   "version": "1.8.10",
+  "port-version": 1,
   "description": "Alembic is an open framework for storing and sharing scene data that includes a C++ library, a file format, and client plugins and applications.",
-  "homepage": "https://alembic.io/",
+  "homepage": "https://www.alembic.io",
   "supports": "!(windows & x86) & !uwp",
   "dependencies": [
     "imath",

--- a/versions/a-/alembic.json
+++ b/versions/a-/alembic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cd41108665da5fd59679c198fb6103bd28250b96",
+      "version": "1.8.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "816ebf879602f9c3165374aad3fbe6746823d531",
       "version": "1.8.10",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -82,7 +82,7 @@
     },
     "alembic": {
       "baseline": "1.8.10",
-      "port-version": 0
+      "port-version": 1
     },
     "aliyun-oss-c-sdk": {
       "baseline": "3.11.2",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The SSL certificate is only valid for the website with `www`