### PR TITLE
[avro-c] Update to 1.12.1

### DIFF
--- a/ports/avro-c/bswap.patch
+++ b/ports/avro-c/bswap.patch
@@ -1,0 +1,14 @@
+diff --git a/lang/c/src/codec.c b/lang/c/src/codec.c
+index 613a91437..176fb21d6 100644
+--- a/lang/c/src/codec.c
++++ b/lang/c/src/codec.c
+@@ -27,6 +27,9 @@
+ #  elif defined(_WIN32)
+ #    include <stdlib.h>
+ #    define __bswap_32 _byteswap_ulong
++#  elif defined(__ANDROID__)
++#    include <byteswap.h>
++#    define __bswap_32 bswap_32
+ #  else
+ #    include <byteswap.h>
+ #  endif

--- a/ports/avro-c/portfile.cmake
+++ b/ports/avro-c/portfile.cmake
@@ -7,10 +7,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/avro
     REF "release-${VERSION}"
-    SHA512 8cc6ef3cf1e0a919118c8ba5817a1866dc4f891fa95873c0fe1b4b388858fbadee8ed50406fa0006882cab40807fcf00c5a2dcd500290f3868d9d06b287eacb6
+    SHA512 4e7fd7ebb41f6149a499d0d38babd99d07f936143b47a60f7c568a589fb0e6369301c7230bde518b554eaeaa9ded1ed1fae2661cbd5ebc49fb5f22d97c066f05
     HEAD_REF master
     PATCHES
         avro.patch          # Private vcpkg build fixes
+        bswap.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/avro-c/vcpkg.json
+++ b/ports/avro-c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "avro-c",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Apache Avro is a data serialization system",
   "homepage": "https://github.com/apache/avro",
   "license": "Apache-2.0",

--- a/versions/a-/avro-c.json
+++ b/versions/a-/avro-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6eb4af0464788cbbe42de42b1061e0e5cd7c7e07",
+      "version": "1.12.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9776bebec8f77c6ea2322fec051fae2d12a1f524",
       "version": "1.12.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -429,7 +429,7 @@
       "port-version": 0
     },
     "avro-c": {
-      "baseline": "1.12.0",
+      "baseline": "1.12.1",
       "port-version": 0
     },
     "avro-cpp": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
