### PR TITLE
[libmount] fix arm32 build.

### DIFF
--- a/ports/libmount/portfile.cmake
+++ b/ports/libmount/portfile.cmake
@@ -21,6 +21,9 @@ else()
     set(ENV{AUTOPOINT} true) # true, the program
     vcpkg_list(APPEND options "--disable-nls")
 endif()
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+    vcpkg_list(APPEND options "--disable-year2038")
+endif()
 
 vcpkg_configure_make(
     AUTOCONFIG

--- a/ports/libmount/vcpkg.json
+++ b/ports/libmount/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmount",
   "version": "2.40",
+  "port-version": 1,
   "description": "Block device identification library from util-linux",
   "homepage": "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/about/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5150,7 +5150,7 @@
     },
     "libmount": {
       "baseline": "2.40",
-      "port-version": 0
+      "port-version": 1
     },
     "libmpeg2": {
       "baseline": "0.5.1",

--- a/versions/l-/libmount.json
+++ b/versions/l-/libmount.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47e01a6a98fb0c3df918d784aa467a1c6f1455e1",
+      "version": "2.40",
+      "port-version": 1
+    },
+    {
       "git-tree": "e78ea57cae347c42d9b7cdc4d65c521f229e0ed4",
       "version": "2.40",
       "port-version": 0


### PR DESCRIPTION
I'm not really sure this fix needs to be added upstream. On one hand, there is still 12 more years before the deadline, and vcpkg still supports (as a community) arm32 triplet. On the other hand, this is quite a dangerous change.

In any case, it's up to the maintainers to decide, whether this should be landed into the main tree or not.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
