### PR TITLE
[nmslib] fix homepage

### DIFF
--- a/ports/nmslib/vcpkg.json
+++ b/ports/nmslib/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "nmslib",
   "version": "2.1.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Non-Metric Space Library (NMSLIB) is an efficient similarity search library and a toolkit for evaluation of k-NN methods for generic non-metric spaces.",
-  "homepage": "https://github.com/searchivarius/nmslib",
+  "homepage": "https://github.com/nmslib/nmslib",
   "supports": "!(arm | uwp)",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6878,7 +6878,7 @@
     },
     "nmslib": {
       "baseline": "2.1.1",
-      "port-version": 2
+      "port-version": 3
     },
     "nng": {
       "baseline": "1.11",

--- a/versions/n-/nmslib.json
+++ b/versions/n-/nmslib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "320b708ff4b7b307f63ea174443ddb068debbd76",
+      "version": "2.1.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "7edc2aca06829ac2ee5b1d882ebafced774ff74b",
       "version": "2.1.1",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Currently, https://github.com/searchivarius/nmslib is returning a 404 error.
It needs to be corrected to a valid URL, the same one used in portfile.cmake.
