### PR TITLE
[ereignis] update to 6.3.0

### DIFF
--- a/ports/curve-coco/portfile.cmake
+++ b/ports/curve-coco/portfile.cmake
@@ -1,4 +1,4 @@
-set(VCPKG_BUILD_TYPE release) # Header-only library
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY) # the project doesn't support SHARED
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Curve/coco
@@ -23,7 +23,5 @@ vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/coco-${VERSION}" PACKAGE_NAME "coco")
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")  # from CMake config
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/curve-coco/portfile.cmake
+++ b/ports/curve-coco/portfile.cmake
@@ -24,4 +24,6 @@ vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/coco-${VERSION}" PACKAGE_NAME "coco")
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/curve-coco/vcpkg.json
+++ b/ports/curve-coco/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "curve-coco",
   "version": "4.3.0",
+  "port-version": 1,
   "description": "a C++20 coroutine library that aims to be convenient and simple to use.",
   "homepage": "https://github.com/Curve/coco",
   "license": "MIT",

--- a/ports/ereignis/portfile.cmake
+++ b/ports/ereignis/portfile.cmake
@@ -2,12 +2,28 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Curve/ereignis
     REF "v${VERSION}"
-    SHA512 73b9fbf01caee6f0cc49de771ee5fc5e1da208acd2d3d40647c3e9c19df121b05c3403393539fa4bb510cb8e58769fe9afa5b036ce04c564266fc49b8ddea8e5
+    SHA512 f6a00270d02533aab41b3bddee0d7af8fc46e2f17bf832f7aa293a175631c4ed1ec92a345f7175d0785c90966d10bb0a4f8fba059e2d25eff2fdb357b8d64201
+    HEAD_REF master
+    PATCHES
+        remove-cpm.patch
+)
+
+file(WRITE "${SOURCE_PATH}/cmake/CPM.cmake" "# disabled by vcpkg")
+
+# Replace CPM and download PackageProject directly to avoid issues with FETCHCONTENT_FULLY_DISCONNECTED
+vcpkg_from_github(
+    OUT_SOURCE_PATH PACKAGE_PROJECT_PATH
+    REPO TheLartians/PackageProject.cmake
+    REF "v1.13.0"
+    SHA512 3cf0523bddc213f206ed0ca57803550cb7db9e293392d3741138be47f49d9027ef517e1656235a349a62b492d35c3fc677714dc00afe59e2d36144a9689cfa8f
     HEAD_REF master
 )
+file(RENAME "${PACKAGE_PROJECT_PATH}" "${SOURCE_PATH}/cmake/packageproject.cmake")
 
 vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/ereignis-${VERSION})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ereignis/remove-cpm.patch
+++ b/ports/ereignis/remove-cpm.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b42d8c8..af4aef0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,6 @@ option(ereignis_tests "Build tests" OFF)
+ # --------------------------------------------------------------------------------------------------------
+ 
+ add_library(${PROJECT_NAME} INTERFACE)
+-add_library(cr::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+ 
+ target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_23)
+ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 23 CXX_EXTENSIONS OFF CXX_STANDARD_REQUIRED ON)
+@@ -32,12 +31,7 @@ target_include_directories(
+ 
+ include("cmake/cpm.cmake")
+ 
+-CPMFindPackage(
+-  NAME           coco
+-  VERSION        4.3.0
+-  GIT_REPOSITORY "https://github.com/Curve/coco"
+-)
+-
++find_package(coco CONFIG REQUIRED)
+ target_link_libraries(${PROJECT_NAME} INTERFACE cr::coco)
+ 
+ # --------------------------------------------------------------------------------------------------------
+@@ -53,11 +47,7 @@ endif()
+ # Package Config
+ # --------------------------------------------------------------------------------------------------------
+ 
+-CPMFindPackage(
+-  NAME           PackageProject
+-  VERSION        1.13.0
+-  GIT_REPOSITORY "https://github.com/TheLartians/PackageProject.cmake"
+-)
++add_subdirectory(cmake/packageproject.cmake)
+ 
+ packageProject(
+   NAMESPACE cr

--- a/ports/ereignis/vcpkg.json
+++ b/ports/ereignis/vcpkg.json
@@ -1,12 +1,17 @@
 {
   "name": "ereignis",
-  "version": "4.3",
+  "version": "6.3.0",
   "description": "A thread-safe C++17 Event Library",
   "homepage": "https://github.com/Curve/ereignis",
   "license": "MIT",
   "dependencies": [
+    "curve-coco",
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2270,7 +2270,7 @@
     },
     "curve-coco": {
       "baseline": "4.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cute-headers": {
       "baseline": "2019-09-20",
@@ -2765,7 +2765,7 @@
       "port-version": 0
     },
     "ereignis": {
-      "baseline": "4.3",
+      "baseline": "6.3.0",
       "port-version": 0
     },
     "esaxx": {

--- a/versions/c-/curve-coco.json
+++ b/versions/c-/curve-coco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2143ab1332a81e1caf371d3ea16b43d822a1fe25",
+      "git-tree": "9f6f4c11fd9f4f210ba8748cc74325d1d018b44f",
       "version": "4.3.0",
       "port-version": 1
     },

--- a/versions/c-/curve-coco.json
+++ b/versions/c-/curve-coco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2143ab1332a81e1caf371d3ea16b43d822a1fe25",
+      "version": "4.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "428adea8bb4f40ac5b13d1331ea8e5a6a7d9abb9",
       "version": "4.3.0",
       "port-version": 0

--- a/versions/e-/ereignis.json
+++ b/versions/e-/ereignis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47ca2d4fb34db6f368c238f4bd923550dec88b4d",
+      "version": "6.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c6862f83bf3ac0d613de34f55545a7a8a219cf19",
       "version": "4.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Curve/ereignis/releases/tag/v6.3.0

- fix curve-coco port due to compilation errors on ereignis.