### PR TITLE
[duvc-ctl] Add new port v2.0.1#0

### DIFF
--- a/ports/duvc-ctl/portfile.cmake
+++ b/ports/duvc-ctl/portfile.cmake
@@ -6,11 +6,19 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(DUVC_BUILD_SHARED ON)
+    set(DUVC_BUILD_STATIC OFF)
+else()
+    set(DUVC_BUILD_SHARED OFF)
+    set(DUVC_BUILD_STATIC ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DDUVC_BUILD_SHARED=ON
-        -DDUVC_BUILD_STATIC=ON
+        -DDUVC_BUILD_SHARED=${DUVC_BUILD_SHARED}
+        -DDUVC_BUILD_STATIC=${DUVC_BUILD_STATIC}
         -DDUVC_BUILD_C_API=OFF
         -DDUVC_BUILD_CLI=OFF
         -DDUVC_BUILD_TESTS=OFF
@@ -21,15 +29,24 @@ vcpkg_configure_cmake(
         -DDUVC_INSTALL_CMAKE_CONFIG=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/duvc-ctl)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/duvc-ctl")
+vcpkg_fixup_pkgconfig()
+
 
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug/include"
-    "${CURRENT_PACKAGES_DIR}/debug/share"
-)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/include")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+     RENAME copyright)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/duvc-ctl/portfile.cmake
+++ b/ports/duvc-ctl/portfile.cmake
@@ -6,13 +6,8 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    set(DUVC_BUILD_SHARED ON)
-    set(DUVC_BUILD_STATIC OFF)
-else()
-    set(DUVC_BUILD_SHARED OFF)
-    set(DUVC_BUILD_STATIC ON)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" DUVC_BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DUVC_BUILD_SHARED)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -44,9 +39,7 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-     RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/duvc-ctl/portfile.cmake
+++ b/ports/duvc-ctl/portfile.cmake
@@ -1,0 +1,35 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO allanhanan/duvc-ctl
+    REF "v${VERSION}"
+    SHA512 5cc63ef7c3a46fb351015ae2b1b96837ea46dbb7656ab1cf633af6027d32ae447dfc60a8757677eae07dabfb3ec1aca90f7019a6d7b5344c66324d39e9f0c464
+    HEAD_REF main
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DDUVC_BUILD_SHARED=ON
+        -DDUVC_BUILD_STATIC=ON
+        -DDUVC_BUILD_C_API=OFF
+        -DDUVC_BUILD_CLI=OFF
+        -DDUVC_BUILD_TESTS=OFF
+        -DDUVC_BUILD_EXAMPLES=OFF
+        -DDUVC_BUILD_PYTHON=OFF
+        -DDUVC_BUILD_DOCS=OFF
+        -DDUVC_INSTALL=ON
+        -DDUVC_INSTALL_CMAKE_CONFIG=ON
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/duvc-ctl)
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/duvc-ctl/usage
+++ b/ports/duvc-ctl/usage
@@ -1,0 +1,11 @@
+duvc-ctl provides CMake targets:
+
+    find_package(duvc CONFIG REQUIRED)
+
+for static linking:
+
+    target_link_libraries(main PRIVATE duvc::core-static)
+
+Or for shared linking:
+
+    target_link_libraries(main PRIVATE duvc::core-shared)

--- a/ports/duvc-ctl/usage
+++ b/ports/duvc-ctl/usage
@@ -1,11 +1,4 @@
 duvc-ctl provides CMake targets:
 
     find_package(duvc CONFIG REQUIRED)
-
-for static linking:
-
-    target_link_libraries(main PRIVATE duvc::core-static)
-
-Or for shared linking:
-
-    target_link_libraries(main PRIVATE duvc::core-shared)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:duvc::core-static>,duvc::core-static,duvc::core-shared>)

--- a/ports/duvc-ctl/vcpkg.json
+++ b/ports/duvc-ctl/vcpkg.json
@@ -5,5 +5,15 @@
   "description": "Windows DirectShow UVC camera control library",
   "homepage": "https://github.com/allanhanan/duvc-ctl",
   "license": "MIT",
-  "supports": "windows"
+  "supports": "windows & !uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/duvc-ctl/vcpkg.json
+++ b/ports/duvc-ctl/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "duvc-ctl",
+  "version": "2.0.1",
+  "description": "Windows DirectShow UVC camera control library",
+  "homepage": "https://github.com/allanhanan/duvc-ctl",
+  "license": "MIT",
+  "supports": "windows"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2596,6 +2596,10 @@
       "baseline": "2.0.3",
       "port-version": 0
     },
+    "duvc-ctl": {
+      "baseline": "2.0.1",
+      "port-version": 0
+    },
     "dv-processing": {
       "baseline": "2.0.2",
       "port-version": 0

--- a/versions/d-/duvc-ctl.json
+++ b/versions/d-/duvc-ctl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "97dd1e5a642ee69388849c84db7aaa522d3af4a6",
+      "version": "2.0.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/d-/duvc-ctl.json
+++ b/versions/d-/duvc-ctl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "97dd1e5a642ee69388849c84db7aaa522d3af4a6",
+      "git-tree": "1c50cac55382709d8b9a5b22250fd6f37d9566e8",
       "version": "2.0.1",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

This is my first time creating a port, Let me know if theres any changes to be made!