### PR TITLE
[cddlib] Update to 0.94n

### DIFF
--- a/ports/cddlib/portfile.cmake
+++ b/ports/cddlib/portfile.cmake
@@ -1,12 +1,20 @@
+vcpkg_download_distfile(
+    MSVC_PATCH
+    URLS https://github.com/cddlib/cddlib/commit/cf2c7939d6b5c40f1eb66860a9ef56015df58c8f.patch?full_index=1
+    SHA512 09b9ca12b768a16e3a61aa03e6223802d5fbd8020a89cd33c1648ee04ff7a66ce9056e2d773cdc853f7d8b8870d29c068192178d1a932a0f629981aa0ea2238c
+    FILENAME pr_86.patch
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cddlib/cddlib
-    REF ${VERSION}
-    SHA512 8591ebe9e2a09683bb01b478df6536d1291012927d343013f8593126d3570f7883e125c63c68cd21eeea142a450847dc609e373e39cffb308bed1b56d6342ac1
+    REF "${VERSION}"
+    SHA512 08314d757a55065fc09ca2b514d8425b651eee2f5a195d5fbc1369acde1dc704c31a7c0e85ef3f8ec72e36f5f6a10618acef95157fa78989da96ce34bc9bc7f9
     HEAD_REF master
     PATCHES
         0001-disable-doc-target.patch  # disable building docs, as they require latex
         0002-disable-dd-log.patch  # windows does not export global variables
+        ${MSVC_PATCH}
 )
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/cddlib/vcpkg.json
+++ b/ports/cddlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cddlib",
-  "version-string": "0.94m",
+  "version-string": "0.94n",
   "description": "C implementation of the Double Description Method",
   "homepage": "https://github.com/cddlib/cddlib",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1641,7 +1641,7 @@
       "port-version": 0
     },
     "cddlib": {
-      "baseline": "0.94m",
+      "baseline": "0.94n",
       "port-version": 0
     },
     "cdt": {

--- a/versions/c-/cddlib.json
+++ b/versions/c-/cddlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50b8720eab35c7a9f1cbf62cd6eab00850bbe001",
+      "version-string": "0.94n",
+      "port-version": 0
+    },
+    {
       "git-tree": "0bb4839476e2e904a3afcde5003ae2fe7237efd7",
       "version-string": "0.94m",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
