### PR TITLE
[clap-cleveraudio] Update to 1.2.7

### DIFF
--- a/ports/clap-cleveraudio/portfile.cmake
+++ b/ports/clap-cleveraudio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO free-audio/clap
     REF "${VERSION}"
-    SHA512 4a532acf85b89f7da733bff88bdef58a273dc19c14b4bb9bf747717d8c2450351e506fefab388cd8a644d01237b1d39ef5adb355957b30d7851aeb6a2f648492
+    SHA512 e99b20a8f8aeba9493d6d6110012a9147bb5facfdf78fce3d7ef4bfd2a16abba1b9e8b1ae55667eba9f11576d2b54d5391b972a09e52a3334ede81fe84ce22e8
     HEAD_REF main
 )
 
@@ -11,10 +11,9 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(
-    CONFIG_PATH "lib/cmake/clap"
-)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/clap")
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/clap-cleveraudio/vcpkg.json
+++ b/ports/clap-cleveraudio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "clap-cleveraudio",
-  "version-semver": "1.2.3",
+  "version-semver": "1.2.7",
   "description": "CLAP is an audio plugin ABI which defines a standard for Digital Audio Workstations and audio plugins to work together",
   "homepage": "https://cleveraudio.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1761,7 +1761,7 @@
       "port-version": 0
     },
     "clap-cleveraudio": {
-      "baseline": "1.2.3",
+      "baseline": "1.2.7",
       "port-version": 0
     },
     "clapack": {

--- a/versions/c-/clap-cleveraudio.json
+++ b/versions/c-/clap-cleveraudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "045acb6522440e83d524db6e79f841ed285f4830",
+      "version-semver": "1.2.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "2884e6902a1745b004b37b98bf014b624ed89fc3",
       "version-semver": "1.2.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
