### PR TITLE
[cpptoml] Update to 0.1.2

### DIFF
--- a/ports/cpptoml/portfile.cmake
+++ b/ports/cpptoml/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO skystrife/cpptoml
+    REPO chadaustin/cpptoml
     REF "v${VERSION}"
-    SHA512 14edce576514d53a7e13562d7f8d2b66ea2b95f44038396c0e26232ec81783042ebecec31ee272a99afef96d5c8582a8e81ea5167a787844b98de6ee6f545cc5
+    SHA512 80fa659b529b242e02ae233d2870b666c3c7cfd9d6d6bb9d07cd5539d7778c8809e614b46a3d4cf97f9a2b0b5d5f953bba170fb1d95b5b920c395f3df52f2c9a
     HEAD_REF master
 )
 

--- a/ports/cpptoml/vcpkg.json
+++ b/ports/cpptoml/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "cpptoml",
-  "version": "0.1.1",
-  "port-version": 4,
+  "version": "0.1.2",
   "description": "A header-only library for parsing TOML configuration files.",
-  "homepage": "https://github.com/skystrife/cpptoml",
+  "homepage": "https://github.com/chadaustin/cpptoml",
   "license": "MIT",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2105,8 +2105,8 @@
       "port-version": 0
     },
     "cpptoml": {
-      "baseline": "0.1.1",
-      "port-version": 4
+      "baseline": "0.1.2",
+      "port-version": 0
     },
     "cpptrace": {
       "baseline": "1.0.4",

--- a/versions/c-/cpptoml.json
+++ b/versions/c-/cpptoml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f6dc48b141c43d40cc247fba89eb64e335808ee",
+      "version": "0.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "6993c08a35db3961ad0543456f236e3e5a2492c9",
       "version": "0.1.1",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Saw [here](https://repology.org/project/cpptoml/packages) that some repos have a newer version, even in the origin repo nothing happened since 8 years. Seems the other are switching to a fork to include a GCC include fix. As I don't think the origin project will be continued, I think this should be fine, to follow the other repos.
