### PR TITLE
[nvidia-cutlass] Update to 4.3.4

### DIFF
--- a/ports/nvidia-cutlass/portfile.cmake
+++ b/ports/nvidia-cutlass/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NVIDIA/cutlass
     REF "v${VERSION}"
-    SHA512 eebeda9c72671521377bc7baef2eef4fc429de46bc43e22f31c6a605ebda501dc0223e53ff1ec6590d9c3b2855462b04ddc07a5f2871c6be64d54bbe9fd18061
+    SHA512 e7c0545e80e5c8626df81b6dabf63edd1219947d93df21f07c43d08efd3daa5f6526d331c40fc0274d91b2b9d3ec9c919ddf4e1f4ba0f2929492e1355e186e61
     HEAD_REF main
     PATCHES
         fix-cudnn-path.patch

--- a/ports/nvidia-cutlass/vcpkg.json
+++ b/ports/nvidia-cutlass/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nvidia-cutlass",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "CUDA Templates for Linear Algebra Subroutines",
   "homepage": "https://github.com/NVIDIA/cutlass",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6973,7 +6973,7 @@
       "port-version": 0
     },
     "nvidia-cutlass": {
-      "baseline": "4.3.3",
+      "baseline": "4.3.4",
       "port-version": 0
     },
     "nvtt": {

--- a/versions/n-/nvidia-cutlass.json
+++ b/versions/n-/nvidia-cutlass.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c7fbae845218147070b24f838014075934d9a78",
+      "version": "4.3.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "d8c23b758f03cf1092a9e7fe45f2ea6cb8bdb08f",
       "version": "4.3.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
