### PR TITLE
[wabt] Update to 1.0.39

### DIFF
--- a/ports/wabt/portfile.cmake
+++ b/ports/wabt/portfile.cmake
@@ -1,10 +1,10 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
-    OUT_SOURCE_PATH source_path
+    OUT_SOURCE_PATH SOURCE_PATH
     REPO WebAssembly/wabt
     REF "${VERSION}"
-    SHA512 1a468110a34ea4654a423c0e2c5cc1c915eddb6ca306452a4f54b623b3cb5ca2043a4d29899c528dccbf8ac5fe8ac69f964057e2d9837c8843a9fe26499a30b6
+    SHA512 be6424783fd9cb87d8b1b69babcd8ce257b71146b6c9df63989c2c2a3a83f321f94dd9441115eec8ad62b7c7b57aeade5b3803f23181c89265d027525fbabc6a
     HEAD_REF main
 )
 
@@ -17,7 +17,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS feature_options
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH "${source_path}"
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${feature_options}
         -DBUILD_LIBWASM=OFF
@@ -56,4 +56,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share/man")
 
-vcpkg_install_copyright(FILE_LIST "${source_path}/LICENSE")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/wabt/vcpkg.json
+++ b/ports/wabt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wabt",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "The WebAssembly Binary Toolkit",
   "homepage": "https://github.com/WebAssembly/wabt/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10481,7 +10481,7 @@
       "port-version": 0
     },
     "wabt": {
-      "baseline": "1.0.38",
+      "baseline": "1.0.39",
       "port-version": 0
     },
     "wampcc": {

--- a/versions/w-/wabt.json
+++ b/versions/w-/wabt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1100c04fab821bb1af1cf6ca015cea50934936af",
+      "version": "1.0.39",
+      "port-version": 0
+    },
+    {
       "git-tree": "228207bcc12c4fd701306b124d54882023c706d5",
       "version": "1.0.38",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
