### PR TITLE
[libcap] update to 2.77

### DIFF
--- a/ports/libcap/portfile.cmake
+++ b/ports/libcap/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-${VERSION}.tar.xz"
          "https://www.mirrorservice.org/sites/ftp.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-${VERSION}.tar.xz"
     FILENAME "libcap-${VERSION}.tar.xz"
-    SHA512 8ab72cf39bf029656b2a4a5972a0da4ab4b46a3d8a8da66d6cde925e06fe34df2fa5fc4d0b62c9cec4972b0b2678fdac6ef9421b6fb83c2a5bf869cf8d5fdb16
+    SHA512 c783cb43ffb40eb005fb880efe18e72667c743af79d647f67ee3201d5ff1e64446f9c850cced935a04b63a8ee3380bbf28dd91e2dfbcbddb561c8d096da610d0
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/libcap/vcpkg.json
+++ b/ports/libcap/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libcap",
-  "version": "2.73",
-  "port-version": 1,
+  "version": "2.77",
   "description": "A library for getting and setting POSIX.1e (formerly POSIX 6) draft 15 capabilities.",
   "homepage": "https://sites.google.com/site/fullycapable/",
   "license": "BSD-3-Clause OR GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4649,8 +4649,8 @@
       "port-version": 4
     },
     "libcap": {
-      "baseline": "2.73",
-      "port-version": 1
+      "baseline": "2.77",
+      "port-version": 0
     },
     "libcbor": {
       "baseline": "0.13.0",

--- a/versions/l-/libcap.json
+++ b/versions/l-/libcap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f0ad3332cef684d5db40df87da067adc339cfe1f",
+      "version": "2.77",
+      "port-version": 0
+    },
+    {
       "git-tree": "e52730d4bb30c73db44aacc92d4ef8f9d0a17997",
       "version": "2.73",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
