### PR TITLE
[libmount] update to 2.41.3

### DIFF
--- a/ports/libmount/portfile.cmake
+++ b/ports/libmount/portfile.cmake
@@ -1,7 +1,9 @@
+string(REGEX MATCH "^([0-9]+\\.[0-9]+)" VERSION_SHORT "${VERSION}")
+
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${VERSION}/util-linux-${VERSION}.tar.xz"
+    URLS "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${VERSION_SHORT}/util-linux-${VERSION}.tar.xz"
     FILENAME "util-linux-${VERSION}.tar.xz"
-    SHA512 f06e61d4ee0e196223f7341ec75a16a6671f82d6e353823490ecff17e947bb169a6b65177e3ab0da6e733e079b24d6a77905a0e8bbfed82ca9aa22a3facb6180
+    SHA512 3d299f0e05a4c982a04dbcbaaeff1222152feedf51c56c5dbdeb75999c68269d652a994f5cdf4c1ee42bb7b28475dd0792192c299fd9bc3b45198c5b153dad00
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libmount/vcpkg.json
+++ b/ports/libmount/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmount",
-  "version": "2.40",
-  "port-version": 1,
+  "version": "2.41.3",
   "description": "Block device identification library from util-linux",
   "homepage": "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/about/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5169,8 +5169,8 @@
       "port-version": 0
     },
     "libmount": {
-      "baseline": "2.40",
-      "port-version": 1
+      "baseline": "2.41.3",
+      "port-version": 0
     },
     "libmpeg2": {
       "baseline": "0.5.1",

--- a/versions/l-/libmount.json
+++ b/versions/l-/libmount.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7a3375e27b127dd9494e4089d3d4f562f6ecb9c",
+      "version": "2.41.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "47e01a6a98fb0c3df918d784aa467a1c6f1455e1",
       "version": "2.40",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
