### PR TITLE
[pango] update to 1.57.0

### DIFF
--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(SOURCE_ARCHIVE
         "https://download.gnome.org/sources/pango/${VERSION_MAJOR_MINOR}/pango-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "pango-${VERSION}.tar.xz"
-    SHA512 19471618a66b68e19786c458387f2bc8027ecbda5aaf29efcc025a99b3a74402765c6c4c6ea2997d8f1219ef7f1bea817e6ca55e494dff24780f5d3f2a6242a2
+    SHA512 e3d251e0c2d5cb7f2e9d26e675aa2fae0c3cedce9e73b77f92a4abbeff55eaa819811e4c064ca036d3964a3ee4592f596ebfa7c0a760189b9d8c38a5f3a4ea3a
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${SOURCE_ARCHIVE}"

--- a/ports/pango/vcpkg.json
+++ b/ports/pango/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pango",
-  "version": "1.56.4",
-  "port-version": 1,
+  "version": "1.57.0",
   "description": "Text and font handling library.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7409,8 +7409,8 @@
       "port-version": 0
     },
     "pango": {
-      "baseline": "1.56.4",
-      "port-version": 1
+      "baseline": "1.57.0",
+      "port-version": 0
     },
     "pangolin": {
       "baseline": "0.9.4",

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9483477b9620b97176c93ed584a80ace1e845cff",
+      "version": "1.57.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c27bbe339409b04085e455bf49a9a54a46ceb545",
       "version": "1.56.4",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
