### PR TITLE
[icu] update to 78.2

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS "https://github.com/unicode-org/icu/releases/download/release-${VERSION}/icu4c-${VERSION}-sources.tgz"
     FILENAME "icu4c-${VERSION}-sources.tgz"
-    SHA512 c366398fdb50afc6355a8c45ed1d68a18eaa5f07a5d1c4555becbcfb9d4073e65ebe1e9caf24b93779b11b36cd813c98dd59e4b19f008851f25c7262811c112d
+    SHA512 92feddfe81c57336f386c7cbc9f6d976bf349db148a77a247c4559676f51116115c8c52c4d907feb50933f72ab75fd8e48be092bf9c8ca33a3e8fabc9372a5d6
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "icu",
-  "version": "78.1",
-  "port-version": 1,
+  "version": "78.2",
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3857,8 +3857,8 @@
       "port-version": 1
     },
     "icu": {
-      "baseline": "78.1",
-      "port-version": 1
+      "baseline": "78.2",
+      "port-version": 0
     },
     "ideviceinstaller": {
       "baseline": "2023-07-21",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c024a43e88d0dafa064363ddf49ec0cde221b8a",
+      "version": "78.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1fee992f7c429f4f5411338bede36139266337d4",
       "version": "78.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/unicode-org/icu/releases/tag/release-78.2
