### PR TITLE
[xtrans] update to 1.6.0

### DIFF
--- a/ports/xtrans/portfile.cmake
+++ b/ports/xtrans/portfile.cmake
@@ -1,4 +1,4 @@
-set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled) 
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet")
@@ -6,15 +6,15 @@ if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
 else()
 
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxtrans
-    REF  3b5df889f58a99980a35a7b4a18eb4e7d2abeac4 #v1.4
-    SHA512 d1a1ecd8aa07d19a8b4936a37109cecd0c965b859a17ea838835230f9326c1a353feef388052df03173562cbf0f3e3764146c3669b1928698cd55ccc4f92992c
+    REPO "lib/libxtrans"
+    REF  "xtrans-${VERSION}"
+    SHA512 c7037cb6d2fb641486a43c9203949edec2038735ba758f8556add63598dbb3205166a2ec272700639884b1952642c171806e3dab566722cadd4c71ca98c0a1bf
     HEAD_REF master
     PATCHES win32.patch
             symbols.patch
-) 
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 vcpkg_configure_make(
@@ -27,7 +27,7 @@ vcpkg_install_make()
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/xorg")
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-# the include folder is moved since it contains source files. It is not meant as a traditional include folder but as a shared files folder for different x libraries. 
+# the include folder is moved since it contains source files. It is not meant as a traditional include folder but as a shared files folder for different x libraries.
 file(RENAME "${CURRENT_PACKAGES_DIR}/include" "${CURRENT_PACKAGES_DIR}/share/${PORT}/include")
 
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib")
@@ -38,7 +38,7 @@ if(NOT VCPKG_BUILD_TYPE)
     file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
     file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/" "${CURRENT_PACKAGES_DIR}/share/xorg/debug")
 endif()
-vcpkg_fixup_pkgconfig() # must be called after files have been moved 
+vcpkg_fixup_pkgconfig() # must be called after files have been moved
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/xtrans.pc" "includedir=\${prefix}/include" "includedir=\${prefix}/share/${PORT}/include")
 if(NOT VCPKG_BUILD_TYPE)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/xtrans.pc" "includedir=\${prefix}/../include" "includedir=\${prefix}/../share/${PORT}/include")
@@ -47,7 +47,6 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" "")
 endif()

--- a/ports/xtrans/symbols.patch
+++ b/ports/xtrans/symbols.patch
@@ -1,8 +1,8 @@
 diff --git a/Xtransutil.c b/Xtransutil.c
-index 413a02376..2f8af0efc 100644
+index 2aa4686..57c6ce3 100644
 --- a/Xtransutil.c
 +++ b/Xtransutil.c
-@@ -64,6 +64,10 @@ from The Open Group.
+@@ -60,6 +60,10 @@ from The Open Group.
  #ifdef WIN32
  #include <X11/Xlibint.h>
  #include <X11/Xwinsock.h>
@@ -11,5 +11,5 @@ index 413a02376..2f8af0efc 100644
 +# define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 +#endif
  #endif
- 
- #ifdef X11_t
+
+ #if defined(IPv6) && !defined(AF_INET6)

--- a/ports/xtrans/vcpkg.json
+++ b/ports/xtrans/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "xtrans",
-  "version": "1.4.0",
-  "port-version": 2,
+  "version": "1.6.0",
   "description": "xtrans - X Network Transport layer shared code",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxtrans",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10813,8 +10813,8 @@
       "port-version": 0
     },
     "xtrans": {
-      "baseline": "1.4.0",
-      "port-version": 2
+      "baseline": "1.6.0",
+      "port-version": 0
     },
     "xxhash": {
       "baseline": "0.8.3",

--- a/versions/x-/xtrans.json
+++ b/versions/x-/xtrans.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e5a0aefa1db4c7612a28bc4f007b30a5ccba9705",
+      "version": "1.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f7f94e9ba7b242ac5b0f38e38fc6b32ac63c3024",
       "version": "1.4.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
