### PR TITLE
[xtensor] Update 0.27.1

### DIFF
--- a/ports/xtensor/fix-find-tbb-and-install-destination.patch
+++ b/ports/xtensor/fix-find-tbb-and-install-destination.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c7ec920..6f46641 100644
+index 38b5ba17..ccf71c51 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -75,8 +75,8 @@ if(XTENSOR_USE_XSIMD)
+@@ -86,8 +86,8 @@ if(XTENSOR_USE_XSIMD)
  endif()
  
  if(XTENSOR_USE_TBB)
@@ -13,7 +13,7 @@ index c7ec920..6f46641 100644
      message(STATUS "Found intel TBB: ${TBB_INCLUDE_DIRS}")
  endif()
  
-@@ -260,7 +260,7 @@ export(EXPORT ${PROJECT_NAME}-targets
+@@ -272,7 +272,7 @@ export(EXPORT ${PROJECT_NAME}-targets
  install(DIRECTORY ${XTENSOR_INCLUDE_DIR}/xtensor
          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  
@@ -22,12 +22,12 @@ index c7ec920..6f46641 100644
      STRING "install path for xtensorConfig.cmake")
  
  configure_package_config_file(${PROJECT_NAME}Config.cmake.in
-@@ -287,7 +287,7 @@ configure_file(${PROJECT_NAME}.pc.in
+@@ -299,7 +299,7 @@ configure_file(${PROJECT_NAME}.pc.in
                 "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
                  @ONLY)
  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
 -        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig/")
 +        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
  
- # Write single include
- # ====================
+ install(DIRECTORY ${XTENSOR_TAGFILES_DIR}
+         DESTINATION ${XTENSOR_DATA_DIR})

--- a/ports/xtensor/portfile.cmake
+++ b/ports/xtensor/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xtensor
     REF "${VERSION}"
-    SHA512 52616a61f9c74c9a37daea5615edb210ff9ef636620266c04ef3e145a067ed685c36febdee4d225ff7c4865e45384e92034a0e7bf9d255727aca7100bc45143c
+    SHA512 3f3fe2391df91518cfef4983ff66bf3b79940136582bb99c6270f87481bf9d2cc15605b13f9b70b6ee9a7a89b389037dd2b26362fcae0fdc49f5204872ee5291
     HEAD_REF master
     PATCHES
         fix-find-tbb-and-install-destination.patch

--- a/ports/xtensor/vcpkg.json
+++ b/ports/xtensor/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xtensor",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "C++ tensors with broadcasting and lazy computing",
   "homepage": "https://github.com/xtensor-stack/xtensor",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10793,7 +10793,7 @@
       "port-version": 0
     },
     "xtensor": {
-      "baseline": "0.27.0",
+      "baseline": "0.27.1",
       "port-version": 0
     },
     "xtensor-blas": {

--- a/versions/x-/xtensor.json
+++ b/versions/x-/xtensor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b780dfb77f45d45a844650e567178fb1229055c6",
+      "version": "0.27.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "43291e36aaad6a1ec14605cbb7eb6059f3c4ccec",
       "version": "0.27.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
