### PR TITLE
[behaviortree-cpp] Update to 4.8.4

### DIFF
--- a/ports/behaviortree-cpp/portfile.cmake
+++ b/ports/behaviortree-cpp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BehaviorTree/BehaviorTree.CPP
-    REF ${VERSION}
-    SHA512 b4450226ad2036e64e1c56c99e3fca670d8ca472e563721eaf4bdc4416562d682748b4aeaaea699f3c6be337f9ac51cc453cf28ca13fdea1886e40224786ed8a
+    REF "${VERSION}"
+    SHA512 5e445fdb5ba8bcd12f03c87ba5b4b3146f3a6508bfd84873157daf6b4c5817ca7b8eb5c4f189bbb777cd59bd38620f5d3f0d97ce2080ac294363efc4b08380a1
     HEAD_REF master
     PATCHES
         fix-x86_build.patch
@@ -11,11 +11,7 @@ vcpkg_from_github(
 )
 
 # Set BTCPP_SHARED_LIBS based on VCPKG_LIBRARY_LINKAGE
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    set(BTCPP_SHARED_LIBS ON)
-else()
-    set(BTCPP_SHARED_LIBS OFF)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BTCPP_SHARED_LIBS)
 
 # Remove vendored lexy directory to prevent conflicts with foonathan-lexy port
 file(REMOVE_RECURSE "${SOURCE_PATH}/3rdparty/lexy")

--- a/ports/behaviortree-cpp/vcpkg.json
+++ b/ports/behaviortree-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "behaviortree-cpp",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "Behavior Trees Library in C++.",
   "homepage": "https://www.behaviortree.dev",
   "supports": "!uwp",

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "97faac40d918e1212eb03be8ecfa894abcb014b8",
+      "version": "4.8.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "122bc5da73f14884aea62dcb2631fecf6aa80de8",
       "version": "4.8.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -657,7 +657,7 @@
       "port-version": 0
     },
     "behaviortree-cpp": {
-      "baseline": "4.8.3",
+      "baseline": "4.8.4",
       "port-version": 0
     },
     "benchmark": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
