### PR TITLE
[pthread-stubs] update to 0.5

### DIFF
--- a/ports/pthread-stubs/portfile.cmake
+++ b/ports/pthread-stubs/portfile.cmake
@@ -1,10 +1,10 @@
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/pthread-stubs
-    REF 50f0755a7f894acae168f19c66e52a3f139ca4ec # 0.4.0
-    SHA512  15fcb2144a8abb7b9b1b8f6d9732759351268fb440c7a59380b0ca6ddf48b74a37ce5afbf777ce58fc1993df0c8d6ffb82e452800ce2fcaf16edcbcc1750e338
+    REPO "lib/pthread-stubs"
+    REF "libpthread-stubs-${VERSION}"
+    SHA512 b2429828f51cc6c9bbb9879c9933ff747354574626ff8fcfbec22c41ded1e9bdf4049715485f580e72c561dfd54d48d731c1f6ae9fff229976890361e3276f2e
     HEAD_REF master
 )
 
@@ -19,8 +19,7 @@ vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES pthread)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 
 set(_file "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/pthread-stubs.pc")
 file(READ "${_file}" _contents)

--- a/ports/pthread-stubs/vcpkg.json
+++ b/ports/pthread-stubs/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pthread-stubs",
-  "version": "0.4",
-  "port-version": 1,
+  "version": "0.5",
   "description": "Stub replacements for POSIX Threads functions.",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/pthread-stubs",
   "license": "X11-distribute-modifications-variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7833,8 +7833,8 @@
       "port-version": 2
     },
     "pthread-stubs": {
-      "baseline": "0.4",
-      "port-version": 1
+      "baseline": "0.5",
+      "port-version": 0
     },
     "pthreadpool": {
       "baseline": "2024-11-04",

--- a/versions/p-/pthread-stubs.json
+++ b/versions/p-/pthread-stubs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9145367a18b4ecdaca65bd81dafa5ca62ebc54b",
+      "version": "0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "45c2f7d3d4c4372f9533bbaab04e8f5aefb61bc1",
       "version": "0.4",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
