### PR TITLE
[webview2] update to 1.0.3650.58

### DIFF
--- a/ports/webview2/portfile.cmake
+++ b/ports/webview2/portfile.cmake
@@ -5,7 +5,7 @@ endif()
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${VERSION}"
     FILENAME "microsoft.web.webview2.${VERSION}.zip"
-    SHA512 cce1e82cc057469ada77c116b9192957e83553c32fb794874dc7723148a81408b1d9d544e6eb4b61c2fe1ce99b6b8a705068f8f0e037eb39b556f7a093674fad
+    SHA512 583693b9a93bf7c22df2963c63ed831baf2a5992b0a39bb5531f240ef6838947b19ac0e17ea59dc352d1f3b62412a74f6bfd78484cb0559456ce0b4da0a2aaab
 )
 
 vcpkg_extract_source_archive(

--- a/ports/webview2/vcpkg.json
+++ b/ports/webview2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "webview2",
-  "version": "1.0.3595.46",
+  "version": "1.0.3650.58",
   "description": "The WebView2 control allows you to embed web technologies (HTML, CSS, and JavaScript) using Microsoft Edge",
   "homepage": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",
   "documentation": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10537,7 +10537,7 @@
       "port-version": 0
     },
     "webview2": {
-      "baseline": "1.0.3595.46",
+      "baseline": "1.0.3650.58",
       "port-version": 0
     },
     "wepoll": {

--- a/versions/w-/webview2.json
+++ b/versions/w-/webview2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5110d32a745f8b25568a5f31c448334e3886888c",
+      "version": "1.0.3650.58",
+      "port-version": 0
+    },
+    {
       "git-tree": "fbbf64077d76db48c83fa3514e04a1a5d0ad864e",
       "version": "1.0.3595.46",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
