### PR TITLE
[libgnutls] Update 3.8.11

### DIFF
--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/gnutls/v${GNUTLS_BRANCH}/gnutls-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnutls/v${GNUTLS_BRANCH}/gnutls-${VERSION}.tar.xz"
     FILENAME "gnutls-${VERSION}.tar.xz"
-    SHA512 d453bd4527af95cb3905ce8753ceafd969e3f442ad1d148544a233ebf13285b999930553a805a0511293cc25390bb6a040260df5544a7c55019640f920ad3d92
+    SHA512 68f9e5bec3aa6686fd3319cc9c88a5cc44e2a75144049fc9de5fb55fef2241b4e16996af4be5dd48308abbee8cfaed6c862903f6bb89aff5dfa5410075bd7386
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${tarball}"

--- a/ports/libgnutls/vcpkg.json
+++ b/ports/libgnutls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgnutls",
-  "version": "3.8.10",
+  "version": "3.8.11",
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols.",
   "homepage": "https://www.gnutls.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4917,7 +4917,7 @@
       "port-version": 1
     },
     "libgnutls": {
-      "baseline": "3.8.10",
+      "baseline": "3.8.11",
       "port-version": 0
     },
     "libgo": {

--- a/versions/l-/libgnutls.json
+++ b/versions/l-/libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f26d3afadb90f51ac17e8d5cc79768837d6adb26",
+      "version": "3.8.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "09964db14750ce0b11e2c267dd102ff9d2130e46",
       "version": "3.8.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
