### PR TITLE
[libgpg-error] Update 1.58

### DIFF
--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/libgpg-error/libgpg-error-${VERSION}.tar.bz2"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-${VERSION}.tar.bz2"
     FILENAME "libgpg-error-${VERSION}.tar.bz2"
-    SHA512 d3f6ca9d9abefe81f5cbbc195fbe259d3362119018c535ad2621ee407cad3487011325a9f4c4a15442a9ac5a0fe7ce86dafd7b3d891a446516362ba6b7b9047b
+    SHA512 4f4cb7f24e6cf4266c30da3985b9e62d4ab6012d8f43e9969d6edfd344d2a08f6277ab10610627597f6c58d064b3127fd286ae678381b84610d611645db5bbb4
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/libgpg-error/vcpkg.json
+++ b/ports/libgpg-error/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgpg-error",
-  "version": "1.55",
+  "version": "1.58",
   "description": "A runtime library for GnuPG and other software which likes to use it.",
   "homepage": "https://gnupg.org/software/libgpg-error/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4929,7 +4929,7 @@
       "port-version": 0
     },
     "libgpg-error": {
-      "baseline": "1.55",
+      "baseline": "1.58",
       "port-version": 0
     },
     "libgpiod": {

--- a/versions/l-/libgpg-error.json
+++ b/versions/l-/libgpg-error.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e44e69b2c8b8c8dce5a8c3888f1159b137081300",
+      "version": "1.58",
+      "port-version": 0
+    },
+    {
       "git-tree": "f4971c700d870cc08ba2ea30ca2039b1aed144ff",
       "version": "1.55",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
