### PR TITLE
[spix] Add port

### DIFF
--- a/ports/spix/portfile.cmake
+++ b/ports/spix/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO faaxm/spix
+    REF "v${VERSION}"
+    SHA512 5b66ca35e122f933eb73d9f6cc4ea4ad8f49f9dd29a9345b746b41e918634332e45699cd1a335b1a3e960b6c018913beda4ee02fb54803841ea10a57d0288330
+    HEAD_REF master
+)
+
+# Check features for QtQuick and QtWidgets
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        qtquick     SPIX_BUILD_QTQUICK
+        qtwidgets   SPIX_BUILD_QTWIDGETS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSPIX_BUILD_EXAMPLES=OFF
+        -DSPIX_BUILD_TESTS=OFF
+        -DSPIX_QT_MAJOR=6
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_copy_pdbs()

--- a/ports/spix/portfile.cmake
+++ b/ports/spix/portfile.cmake
@@ -9,13 +9,13 @@ vcpkg_from_github(
 # Check features for QtQuick and QtWidgets
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        qtquick     SPIX_BUILD_QTQUICK
         qtwidgets   SPIX_BUILD_QTWIDGETS
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DSPIX_BUILD_QTQUICK=ON
         -DSPIX_BUILD_EXAMPLES=OFF
         -DSPIX_BUILD_TESTS=OFF
         -DSPIX_QT_MAJOR=6

--- a/ports/spix/usage
+++ b/ports/spix/usage
@@ -1,0 +1,11 @@
+spix provides CMake targets:
+
+    find_package(Spix CONFIG REQUIRED)
+
+For test of QtQuick/QML based applications (requires qtquick feature enabled):
+
+    target_link_libraries(main PRIVATE Spix::QtQuick)
+
+For test of QWidget based applications (requires qtwidgets feature enabled):
+
+    target_link_libraries(main PRIVATE Spix::QtWidgets)

--- a/ports/spix/usage
+++ b/ports/spix/usage
@@ -2,7 +2,7 @@ spix provides CMake targets:
 
     find_package(Spix CONFIG REQUIRED)
 
-For test of QtQuick/QML based applications (requires qtquick feature enabled):
+For test of QtQuick/QML based applications:
 
     target_link_libraries(main PRIVATE Spix::QtQuick)
 

--- a/ports/spix/vcpkg.json
+++ b/ports/spix/vcpkg.json
@@ -8,10 +8,6 @@
   "dependencies": [
     "anyrpc",
     {
-      "name": "qtbase",
-      "default-features": false
-    },
-    {
       "name": "vcpkg-cmake",
       "host": true
     },
@@ -25,7 +21,7 @@
   ],
   "features": {
     "qtquick": {
-      "description": "Build QtQuick support",
+      "description": "Build the QtQuick scene library.",
       "dependencies": [
         {
           "name": "qtdeclarative",
@@ -34,7 +30,16 @@
       ]
     },
     "qtwidgets": {
-      "description": "Build QtWidgets support (Qt6 only)"
+      "description": "Build the QtWidgets scene library.",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "widgets"
+          ]
+        }
+      ]
     }
   }
 }

--- a/ports/spix/vcpkg.json
+++ b/ports/spix/vcpkg.json
@@ -1,0 +1,40 @@
+{
+  "name": "spix",
+  "version": "0.14",
+  "description": "A minimally invasive UI testing library for Qt/QML applications. Control your application and verify its behavior using a simple C++ API.",
+  "homepage": "https://github.com/faaxm/spix",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    "anyrpc",
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "qtquick"
+  ],
+  "features": {
+    "qtquick": {
+      "description": "Build QtQuick support",
+      "dependencies": [
+        {
+          "name": "qtdeclarative",
+          "default-features": false
+        }
+      ]
+    },
+    "qtwidgets": {
+      "description": "Build QtWidgets support (Qt6 only)"
+    }
+  }
+}

--- a/ports/spix/vcpkg.json
+++ b/ports/spix/vcpkg.json
@@ -8,6 +8,10 @@
   "dependencies": [
     "anyrpc",
     {
+      "name": "qtdeclarative",
+      "default-features": false
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
@@ -16,19 +20,7 @@
       "host": true
     }
   ],
-  "default-features": [
-    "qtquick"
-  ],
   "features": {
-    "qtquick": {
-      "description": "Build the QtQuick scene library.",
-      "dependencies": [
-        {
-          "name": "qtdeclarative",
-          "default-features": false
-        }
-      ]
-    },
     "qtwidgets": {
       "description": "Build the QtWidgets scene library.",
       "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9320,6 +9320,10 @@
       "baseline": "1.4.328.0",
       "port-version": 0
     },
+    "spix": {
+      "baseline": "0.14",
+      "port-version": 0
+    },
     "spout2": {
       "baseline": "2.007.010",
       "port-version": 0

--- a/versions/s-/spix.json
+++ b/versions/s-/spix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a27fad9664aaa512a2518d6c583ae2d78d2d1a3f",
+      "version": "0.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "242f18b432502d15fba249b9b830ee7a4781599b",
       "version": "0.5",
       "port-version": 0

--- a/versions/s-/spix.json
+++ b/versions/s-/spix.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a27fad9664aaa512a2518d6c583ae2d78d2d1a3f",
+      "git-tree": "7e833da81cd361945adddc2d33167b2f420566c8",
       "version": "0.14",
       "port-version": 0
     },

--- a/versions/s-/spix.json
+++ b/versions/s-/spix.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7e833da81cd361945adddc2d33167b2f420566c8",
+      "git-tree": "a9388d01dfd64497ebc8dfb7dae1d95c2dc5f5be",
       "version": "0.14",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.