### PR TITLE
Install luafilesystem module to lib/lua

### DIFF
--- a/ports/luafilesystem/CMakeLists.txt
+++ b/ports/luafilesystem/CMakeLists.txt
@@ -10,7 +10,36 @@ add_library(lfs src/lfs.h src/lfs.c src/lfs.def)
 
 target_include_directories(lfs PRIVATE ${LFS_INCLUDES})
 target_link_libraries(lfs PRIVATE ${LFS_LIBRARIES})
-target_include_directories(lfs INTERFACE $<INSTALL_INTERFACE:include/luafilesystem>) 
+target_include_directories(lfs INTERFACE $<INSTALL_INTERFACE:include/luafilesystem>)
+
+# If BUILD_SHARED_LIBS is ON, then add_library() will build a DLL and we can copy that to lib/lua/
+# to be loaded by the Lua interpreter, otherwise the DLL as an extra target for that purpose.
+
+if(BUILD_SHARED_LIBS)
+  if(WIN32)
+    add_custom_command(TARGET lfs POST_BUILD
+      COMMAND "${CMAKE_COMMAND}" -E copy
+        "$<TARGET_FILE:lfs>"
+        "${CMAKE_INSTALL_PREFIX}/lib/lua/lfs.dll")
+  else()
+    add_custom_command(TARGET lfs POST_BUILD
+      COMMAND "${CMAKE_COMMAND}" -E copy
+        "$<TARGET_FILE:lfs>"
+        "${CMAKE_INSTALL_PREFIX}/lib/lua/lfs.so")
+  endif()
+else()
+  add_library(lfs-module MODULE src/lfs.h src/lfs.c src/lfs.def)
+
+  target_include_directories(lfs-module PRIVATE ${LFS_INCLUDES})
+  target_link_libraries(lfs-module PRIVATE ${LFS_LIBRARIES})
+
+  set_target_properties(lfs-module PROPERTIES OUTPUT_NAME "lfs")
+  set_target_properties(lfs-module PROPERTIES PREFIX "")
+
+  install(TARGETS lfs-module
+    RUNTIME DESTINATION lib/lua
+    LIBRARY DESTINATION lib/lua)
+endif()
 
 install(TARGETS lfs
     EXPORT "unofficial-${PROJECT_NAME}-targets"

--- a/ports/luafilesystem/portfile.cmake
+++ b/ports/luafilesystem/portfile.cmake
@@ -31,3 +31,6 @@ file(REMOVE_RECURSE
 # Handle copyright
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+# Allow DLLs in lib (lib/lua specifically)
+set(VCPKG_POLICY_ALLOW_DLLS_IN_LIB enabled)

--- a/ports/luafilesystem/vcpkg.json
+++ b/ports/luafilesystem/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "luafilesystem",
   "version": "1.9.0",
+  "port-version": 1,
   "description": "LuaFileSystem is a Lua library developed to complement the set of functions related to file systems offered by the standard Lua distribution.",
   "homepage": "https://github.com/keplerproject/luafilesystem",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6058,7 +6058,7 @@
     },
     "luafilesystem": {
       "baseline": "1.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "luajit": {
       "baseline": "2023-01-04",

--- a/versions/l-/luafilesystem.json
+++ b/versions/l-/luafilesystem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "264dcf5aec5e92a779f71fd4abbe3b21c8cb73fc",
+      "version": "1.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "668c7169ba07c8e74dfaa377c00a062c705490eb",
       "version": "1.9.0",
       "port-version": 0


### PR DESCRIPTION
This commit updates the luafilesystem port to always build and install a dynamic lfs.dll/lfs.so under lib/lua/, a more typical location to install Lua modules.

This may be a bit contentious since vcpkg isn't really aiming to be a Lua package manager, but we've already got luafilesystem and this change makes it a bit more useful (e.g. the module can be loaded when Lua is built for a static triplet).

See https://github.com/microsoft/vcpkg/discussions/49309 for more background/thoughts. Open to any feedback on how this could be improved/done differently.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.