### PR TITLE
[slick-queue] Update to version 1.2.2

### DIFF
--- a/ports/slick-queue/portfile.cmake
+++ b/ports/slick-queue/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO SlickQuant/slick_queue
+    REPO SlickQuant/slick-queue
     REF "v${VERSION}"
-    SHA512 3d0dff64edcbf3d4f5e45f844ee440ccfedb508fd5801a051eaa1f9b7fb9108cb6558c5d9ba8ea351d45ee83cfdaeec304eccf472feb7cc45875ee52e3752bf3 
+    SHA512 aa25b726c8ab670d515063511f240dad7d4d48bbf3b46c103a47c7f14681e5121b18c12b54a1f9fb5829b4b96bf92a87a4fe30f6637beaa8be3e0a6dc860c894
     HEAD_REF main
 )
 
@@ -15,8 +15,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME slick_queue
-    CONFIG_PATH lib/cmake/slick_queue
+    PACKAGE_NAME slick-queue
+    CONFIG_PATH lib/cmake/slick-queue
 )
 
 # Header-only library - remove lib directory

--- a/ports/slick-queue/usage
+++ b/ports/slick-queue/usage
@@ -1,4 +1,4 @@
 slick-queue is header-only and can be used from CMake via:
 
-    find_package(slick_queue CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE slick::slick_queue)
+    find_package(slick-queue CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE slick::slick-queue)

--- a/ports/slick-queue/vcpkg.json
+++ b/ports/slick-queue/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-queue",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A C++ Lock-Free MPMC queue - header-only library for high throughput concurrent messaging with optional shared memory support",
-  "homepage": "https://github.com/SlickQuant/slick_queue",
+  "homepage": "https://github.com/SlickQuant/slick-queue",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [

--- a/ports/slick-shm/portfile.cmake
+++ b/ports/slick-shm/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO SlickQuant/slick_shm
+    REPO SlickQuant/slick-shm
     REF "v${VERSION}"
-    SHA512 bffa11f9c1171c13ce31c0f2a3da0194ed679557fa7162463115334caf04c8308492d52c8fc6e1a7fbda14ebba355607f67dd1df329176a23d31e92127925a26 
+    SHA512 b43bde89dbd318c48b04e01cad4065a42410ca95d3b9c3de3f3c816ee3fe27b768d59321f302b34257b897c4d9d26decb380a6c359e14e03ed49a88d67f54c14 
     HEAD_REF main
 )
 
@@ -17,8 +17,8 @@ vcpkg_cmake_install()
 
 # Fix up CMake config files before removing lib directory
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME slick_shm
-    CONFIG_PATH lib/cmake/slick_shm
+    PACKAGE_NAME slick-shm
+    CONFIG_PATH lib/cmake/slick-shm
 )
 
 # Header-only library - remove lib directory after config fixup

--- a/ports/slick-shm/usage
+++ b/ports/slick-shm/usage
@@ -1,4 +1,4 @@
 slick-shm provides CMake targets:
 
-  find_package(slick_shm CONFIG REQUIRED)
+  find_package(slick-shm CONFIG REQUIRED)
   target_link_libraries(main PRIVATE slick::shm)

--- a/ports/slick-shm/vcpkg.json
+++ b/ports/slick-shm/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-shm",
-  "version-semver": "0.1.1",
+  "version-semver": "0.1.2",
   "description": "A modern C++17 header-only, cross-platform shared memory library",
-  "homepage": "https://github.com/SlickQuant/slick_shm",
+  "homepage": "https://github.com/SlickQuant/slick-shm",
   "license": "MIT",
   "supports": "windows | linux | osx",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9133,7 +9133,7 @@
       "port-version": 0
     },
     "slick-queue": {
-      "baseline": "1.2.1",
+      "baseline": "1.2.2",
       "port-version": 0
     },
     "slick-shm": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9137,7 +9137,7 @@
       "port-version": 0
     },
     "slick-shm": {
-      "baseline": "0.1.1",
+      "baseline": "0.1.2",
       "port-version": 0
     },
     "slikenet": {

--- a/versions/s-/slick-queue.json
+++ b/versions/s-/slick-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cffe6d581e5d1169ab546dda3451fd31e7d0b1bd",
+      "version": "1.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "5cc087e034508e15f1b5534d920d95a4eb62696c",
       "version": "1.2.1",
       "port-version": 0

--- a/versions/s-/slick-shm.json
+++ b/versions/s-/slick-shm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dea1e35cd408d5f0928a50b95dea80a1fab6239c",
+      "version-semver": "0.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "edf3473b514736fb5b7fcc257ec52170c56e9cc9",
       "version-semver": "0.1.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
