### PR TITLE
[slick-queue] Update to version 1.2.2

### DIFF
--- a/ports/slick-queue/portfile.cmake
+++ b/ports/slick-queue/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-queue
     REF "v${VERSION}"
-    SHA512 aa25b726c8ab670d515063511f240dad7d4d48bbf3b46c103a47c7f14681e5121b18c12b54a1f9fb5829b4b96bf92a87a4fe30f6637beaa8be3e0a6dc860c894
+    SHA512 7817da2e24f6b0077c692db5bc1f6f379916d9deb4c221a30b64ab66676c590d6532d2171591e0e25ce623323165c2a6a6e59404e89a64c0c9eff084ce297f59
     HEAD_REF main
 )
 
@@ -18,6 +18,19 @@ vcpkg_cmake_config_fixup(
     PACKAGE_NAME slick-queue
     CONFIG_PATH lib/cmake/slick-queue
 )
+
+# Temporary fix for legacy package name compatibility
+set(slick_queue_share "${CURRENT_PACKAGES_DIR}/share/slick_queue")
+file(MAKE_DIRECTORY "${slick_queue_share}")
+
+file(WRITE "${slick_queue_share}/slick_queueConfig.cmake"
+"include(\"${slick_queue_share}/../slick-queue/slick-queueConfig.cmake\")\n")
+
+file(COPY "${CURRENT_PACKAGES_DIR}/share/slick-queue/slick-queueConfigVersion.cmake"
+     DESTINATION "${slick_queue_share}")
+file(RENAME
+     "${slick_queue_share}/slick-queueConfigVersion.cmake"
+     "${slick_queue_share}/slick_queueConfigVersion.cmake")
 
 # Header-only library - remove lib directory
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/slick-queue/portfile.cmake
+++ b/ports/slick-queue/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO SlickQuant/slick_queue
+    REPO SlickQuant/slick-queue
     REF "v${VERSION}"
-    SHA512 3d0dff64edcbf3d4f5e45f844ee440ccfedb508fd5801a051eaa1f9b7fb9108cb6558c5d9ba8ea351d45ee83cfdaeec304eccf472feb7cc45875ee52e3752bf3 
+    SHA512 aa25b726c8ab670d515063511f240dad7d4d48bbf3b46c103a47c7f14681e5121b18c12b54a1f9fb5829b4b96bf92a87a4fe30f6637beaa8be3e0a6dc860c894
     HEAD_REF main
 )
 
@@ -15,8 +15,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME slick_queue
-    CONFIG_PATH lib/cmake/slick_queue
+    PACKAGE_NAME slick-queue
+    CONFIG_PATH lib/cmake/slick-queue
 )
 
 # Header-only library - remove lib directory

--- a/ports/slick-queue/portfile.cmake
+++ b/ports/slick-queue/portfile.cmake
@@ -23,8 +23,9 @@ vcpkg_cmake_config_fixup(
 set(slick_queue_share "${CURRENT_PACKAGES_DIR}/share/slick_queue")
 file(MAKE_DIRECTORY "${slick_queue_share}")
 
-file(WRITE "${slick_queue_share}/slick_queueConfig.cmake"
-"include(\"${slick_queue_share}/../slick-queue/slick-queueConfig.cmake\")\n")
+file(WRITE "${slick_queue_share}/slick_queueConfig.cmake" [=[
+include("${CMAKE_CURRENT_LIST_DIR}/../slick-queue/slick-queueConfig.cmake")
+]=])
 
 file(COPY "${CURRENT_PACKAGES_DIR}/share/slick-queue/slick-queueConfigVersion.cmake"
      DESTINATION "${slick_queue_share}")

--- a/ports/slick-queue/usage
+++ b/ports/slick-queue/usage
@@ -1,4 +1,4 @@
 slick-queue is header-only and can be used from CMake via:
 
     find_package(slick-queue CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE slick::slick-queue)
+    target_link_libraries(main PRIVATE slick::queue)

--- a/ports/slick-queue/usage
+++ b/ports/slick-queue/usage
@@ -1,4 +1,4 @@
 slick-queue is header-only and can be used from CMake via:
 
-    find_package(slick_queue CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE slick::slick_queue)
+    find_package(slick-queue CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE slick::slick-queue)

--- a/ports/slick-queue/vcpkg.json
+++ b/ports/slick-queue/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-queue",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A C++ Lock-Free MPMC queue - header-only library for high throughput concurrent messaging with optional shared memory support",
-  "homepage": "https://github.com/SlickQuant/slick_queue",
+  "homepage": "https://github.com/SlickQuant/slick-queue",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9133,7 +9133,7 @@
       "port-version": 0
     },
     "slick-queue": {
-      "baseline": "1.2.1",
+      "baseline": "1.2.2",
       "port-version": 0
     },
     "slick-shm": {

--- a/versions/s-/slick-queue.json
+++ b/versions/s-/slick-queue.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "addbdc93a7d5feac7cbf10c8e0af60b063339e56",
+      "git-tree": "30492b9878718b6481f536be1375cdcb7bd0c4ed",
       "version": "1.2.2",
       "port-version": 0
     },

--- a/versions/s-/slick-queue.json
+++ b/versions/s-/slick-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cffe6d581e5d1169ab546dda3451fd31e7d0b1bd",
+      "version": "1.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "5cc087e034508e15f1b5534d920d95a4eb62696c",
       "version": "1.2.1",
       "port-version": 0

--- a/versions/s-/slick-queue.json
+++ b/versions/s-/slick-queue.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cffe6d581e5d1169ab546dda3451fd31e7d0b1bd",
+      "git-tree": "8e53a471ce772b35182dd10c7c9eadbe77c4adf0",
       "version": "1.2.2",
       "port-version": 0
     },

--- a/versions/s-/slick-queue.json
+++ b/versions/s-/slick-queue.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8e53a471ce772b35182dd10c7c9eadbe77c4adf0",
+      "git-tree": "addbdc93a7d5feac7cbf10c8e0af60b063339e56",
       "version": "1.2.2",
       "port-version": 0
     },


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
