### PR TITLE
[qt-advanced-docking-system] update to 4.5.0

### DIFF
--- a/ports/qt-advanced-docking-system/fix_windows_version_resources_generation.patch
+++ b/ports/qt-advanced-docking-system/fix_windows_version_resources_generation.patch
@@ -1,0 +1,103 @@
+diff --git a/cmake/modules/Versioning.cmake b/cmake/modules/Versioning.cmake
+index e492370..380d97e 100644
+--- a/cmake/modules/Versioning.cmake
++++ b/cmake/modules/Versioning.cmake
+@@ -10,51 +10,54 @@ set(_VERSIONING_MODULE_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "Versionin
+ # ------------------------------------------------------------
+ # Extract version information from Git
+ # ------------------------------------------------------------
++if(NOT ADS_VERSION)
++    # Get tag (expected: v1.2.3 or 1.2.3 or 1.2.3-12-gHASH)
++    execute_process(
++        COMMAND git describe --tags --dirty
++        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
++        OUTPUT_VARIABLE GIT_DESC_RAW
++        OUTPUT_STRIP_TRAILING_WHITESPACE
++    )
++
++    # Remove leading "v" if present
++    string(REGEX REPLACE "^v" "" GIT_DESC "${GIT_DESC_RAW}")
++
++    # Extract major.minor.patch
++    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" _ "${GIT_DESC}")
++    set(PROJECT_VERSION_MAJOR "${CMAKE_MATCH_1}")
++    set(PROJECT_VERSION_MINOR "${CMAKE_MATCH_2}")
++    set(PROJECT_VERSION_PATCH "${CMAKE_MATCH_3}")
++
++    set(PROJECT_VERSION_STRING
++        "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
++    )
++
++    # Commit hash (full + short)
++    execute_process(
++        COMMAND git rev-parse HEAD
++        OUTPUT_VARIABLE PROJECT_GIT_HASH
++        OUTPUT_STRIP_TRAILING_WHITESPACE
++    )
++
++    execute_process(
++        COMMAND git rev-parse --short HEAD
++        OUTPUT_VARIABLE PROJECT_GIT_HASH_SHORT
++        OUTPUT_STRIP_TRAILING_WHITESPACE
++    )
+ 
+-# Get tag (expected: v1.2.3 or 1.2.3 or 1.2.3-12-gHASH)
+-execute_process(
+-    COMMAND git describe --tags --dirty
+-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+-    OUTPUT_VARIABLE GIT_DESC_RAW
+-    OUTPUT_STRIP_TRAILING_WHITESPACE
+-)
+-
+-# Remove leading "v" if present
+-string(REGEX REPLACE "^v" "" GIT_DESC "${GIT_DESC_RAW}")
+-
+-# Extract major.minor.patch
+-string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" _ "${GIT_DESC}")
+-set(PROJECT_VERSION_MAJOR "${CMAKE_MATCH_1}")
+-set(PROJECT_VERSION_MINOR "${CMAKE_MATCH_2}")
+-set(PROJECT_VERSION_PATCH "${CMAKE_MATCH_3}")
+-
+-set(PROJECT_VERSION_STRING
+-    "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
+-)
+-
+-# Commit hash (full + short)
+-execute_process(
+-    COMMAND git rev-parse HEAD
+-    OUTPUT_VARIABLE PROJECT_GIT_HASH
+-    OUTPUT_STRIP_TRAILING_WHITESPACE
+-)
+-
+-execute_process(
+-    COMMAND git rev-parse --short HEAD
+-    OUTPUT_VARIABLE PROJECT_GIT_HASH_SHORT
+-    OUTPUT_STRIP_TRAILING_WHITESPACE
+-)
+-
+-# Export variables to parent scope
+-set(PROJECT_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}" PARENT_SCOPE)
+-set(PROJECT_VERSION_MINOR "${PROJECT_VERSION_MINOR}" PARENT_SCOPE)
+-set(PROJECT_VERSION_PATCH "${PROJECT_VERSION_PATCH}" PARENT_SCOPE)
+-set(PROJECT_VERSION_STRING "${PROJECT_VERSION_STRING}" PARENT_SCOPE)
+-set(PROJECT_GIT_HASH "${PROJECT_GIT_HASH}" PARENT_SCOPE)
+-set(PROJECT_GIT_HASH_SHORT "${PROJECT_GIT_HASH_SHORT}" PARENT_SCOPE)
+-
+-# Public variable for users
+-set(PROJECT_AUTO_VERSION "${PROJECT_VERSION_STRING}" PARENT_SCOPE)
++    # Export variables to parent scope
++    set(PROJECT_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}" PARENT_SCOPE)
++    set(PROJECT_VERSION_MINOR "${PROJECT_VERSION_MINOR}" PARENT_SCOPE)
++    set(PROJECT_VERSION_PATCH "${PROJECT_VERSION_PATCH}" PARENT_SCOPE)
++    set(PROJECT_VERSION_STRING "${PROJECT_VERSION_STRING}" PARENT_SCOPE)
++    set(PROJECT_GIT_HASH "${PROJECT_GIT_HASH}" PARENT_SCOPE)
++    set(PROJECT_GIT_HASH_SHORT "${PROJECT_GIT_HASH_SHORT}" PARENT_SCOPE)
++
++    # Public variable for users
++    set(PROJECT_AUTO_VERSION "${PROJECT_VERSION_STRING}" PARENT_SCOPE)
++else()
++    set(PROJECT_VERSION_STRING "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
++endif()
+ 
+ # ------------------------------------------------------------
+ # Reusable function: Attach Windows version resources to target

--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         set_cmake_module_path.patch
+        fix_windows_version_resources_generation.patch
 )
 
 if(VCPKG_CROSSCOMPILING)

--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -1,18 +1,9 @@
-vcpkg_download_distfile(
-    patch_gui_private
-    URLS https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/commit/893af516b2a312751edc460f5a9117e319865485.diff
-    FILENAME 893af516b2a312751edc460f5a9117e319865485.diff
-    SHA512 7ab7f02546723225a9869e39b0525a8e3f9f2e6b6265c883a399249482522d883b062250972c66c78c611046eba48a323a9cfecac90400dc676302f68c3cc8ac
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO githubuser0xFFFF/Qt-Advanced-Docking-System
     REF "${VERSION}"
-    SHA512 c5a7ddeb18e86cbda32829d0fc1e8fa7f14fdc7057dff1d1fb416a29f394ca676bcc611c3d537ebf496929ea4090ca9c1b2c9d1273117022de863565cdc3a1a6
+    SHA512 ae9345e0876a80e2f2dfa393d12176215cdcf17ed1985d2e46527d12a3abf4ea2b7796217871b562aaab9c7c876bef226de661d5e9cbdc862c8f49d57e9e8173
     HEAD_REF master
-    PATCHES
-      ${patch_gui_private}
 )
 
 if(VCPKG_CROSSCOMPILING)

--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 ae9345e0876a80e2f2dfa393d12176215cdcf17ed1985d2e46527d12a3abf4ea2b7796217871b562aaab9c7c876bef226de661d5e9cbdc862c8f49d57e9e8173
     HEAD_REF master
+    PATCHES
+        set_cmake_module_path.patch
 )
 
 if(VCPKG_CROSSCOMPILING)

--- a/ports/qt-advanced-docking-system/set_cmake_module_path.patch
+++ b/ports/qt-advanced-docking-system/set_cmake_module_path.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f9b1d7f..6a2f7b7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,12 +4,13 @@ if (POLICY CMP0091)
+   cmake_policy(SET CMP0091 NEW)
+ endif (POLICY CMP0091)
+ 
++set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
++
+ # By default, the version information is extracted from the git index. However,
+ # we can override this behavior by explicitly setting ADS_VERSION and
+ # skipping the git checks. This is useful for cases where this project is being
+ # used independently of its original git repo (e.g. vendored in another project)
+ if(NOT ADS_VERSION)
+-    set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
+     include(GetGitRevisionDescription)
+     git_describe(GitTagVersion --tags)
+     string(REGEX REPLACE "^([0-9]+)\\..*" "\\1" VERSION_MAJOR "${GitTagVersion}")

--- a/ports/qt-advanced-docking-system/vcpkg.json
+++ b/ports/qt-advanced-docking-system/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "qt-advanced-docking-system",
-  "version": "4.4.1",
-  "port-version": 1,
+  "version": "4.5.0",
   "description": "Create customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio",
   "homepage": "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7953,8 +7953,8 @@
       "port-version": 0
     },
     "qt-advanced-docking-system": {
-      "baseline": "4.4.1",
-      "port-version": 1
+      "baseline": "4.5.0",
+      "port-version": 0
     },
     "qt3d": {
       "baseline": "6.10.0",

--- a/versions/q-/qt-advanced-docking-system.json
+++ b/versions/q-/qt-advanced-docking-system.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00d6c1eec50728586f972193d3d4f43e425f9340",
+      "version": "4.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a2de0df50be5a2814cd1eb1162ae13c1e0573cba",
       "version": "4.4.1",
       "port-version": 1

--- a/versions/q-/qt-advanced-docking-system.json
+++ b/versions/q-/qt-advanced-docking-system.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "00d6c1eec50728586f972193d3d4f43e425f9340",
+      "git-tree": "e653a7064257e466beb3f2d2aba16b32bb38e48b",
       "version": "4.5.0",
       "port-version": 0
     },

--- a/versions/q-/qt-advanced-docking-system.json
+++ b/versions/q-/qt-advanced-docking-system.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e653a7064257e466beb3f2d2aba16b32bb38e48b",
+      "git-tree": "773e973d82a8300b36da83aadd1a073d3dd7ec8c",
       "version": "4.5.0",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.