### PR TITLE
[trompeloeil] Update to 49

### DIFF
--- a/ports/trompeloeil/portfile.cmake
+++ b/ports/trompeloeil/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rollbear/trompeloeil
-    REF v${VERSION}
-    SHA512 d6ff22843ac3541eb68bb2a97f5eafc39495704cd13875658aa0dc30a68ddbcc2bcec75848e5529b4bf80f5cc0ad52fb4330e135933c4a47d43d3eed1b3587de
-    HEAD_REF master
+    REF "v${VERSION}"
+    SHA512 f1a7212eacfb79f73cea075a147066b4cb10da76a6826e4594c29412395ae69647bb852d12936dd3f9b5c5a7f0aad3ebae246fdfb4006072c39b1efcd51876f5
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(
@@ -14,11 +14,10 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/trompeloeil)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
-
-if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/include/trompeloeil.hpp")
-    message(FATAL_ERROR "Main includes have moved. Please update the forwarder.")
-endif()
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE_1_0.txt")
 

--- a/ports/trompeloeil/vcpkg.json
+++ b/ports/trompeloeil/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "trompeloeil",
-  "version": "48",
+  "version": "49",
   "description": "A thread-safe header-only mocking framework for C++11/14 using the Boost Software License 1.0",
   "homepage": "https://github.com/rollbear/trompeloeil",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10001,7 +10001,7 @@
       "port-version": 0
     },
     "trompeloeil": {
-      "baseline": "48",
+      "baseline": "49",
       "port-version": 0
     },
     "try-catcher": {

--- a/versions/t-/trompeloeil.json
+++ b/versions/t-/trompeloeil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa8566d3b504b1ad2de0f083c82cd566d6fccde1",
+      "version": "49",
+      "port-version": 0
+    },
+    {
       "git-tree": "d24143089754e699fc9761f7ce0913c1fb935100",
       "version": "48",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
