### PR TITLE
[Log4cxx] Add 1.6.1

### DIFF
--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/logging/log4cxx/${VERSION}/apache-log4cxx-${VERSION}.tar.gz"
     FILENAME "apache-log4cxx-${VERSION}.tar.gz"
-    SHA512 60cedb41511cca6646682d0041a4dfac1d9e50f29fac7c7d31ef2f6c5c200dba84c010c79aed8a5f453795408a8905669d1a6b2002af6728d5734808369af075
+    SHA512 6ee406314bd7ab02a46c98cc8a0d5ad5aec8928a23716a81a152775ca315cd3b950d600b2e221d5b4a88416ae9bbda1215fae43626107feea4df2f3e074303ad
 )
 
 vcpkg_extract_source_archive(

--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "log4cxx",
-  "version": "1.5.0",
+  "version": "1.6.1",
   "description": "Apache log4cxx is a logging framework for C++ patterned after Apache log4j, which uses Apache Portable Runtime for most platform-specific code and should be usable on any platform supported by APR",
   "homepage": "https://logging.apache.org/log4cxx",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6001,7 +6001,7 @@
       "port-version": 0
     },
     "log4cxx": {
-      "baseline": "1.5.0",
+      "baseline": "1.6.1",
       "port-version": 0
     },
     "loguru": {

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0fada2ffa95a8b1d0baf79688ad4c6d30b0f630b",
+      "version": "1.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d4c714dba951a913b02c99e4cc855545171381be",
       "version": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
