### PR TITLE
[thermo] Add new port

### DIFF
--- a/ports/thermo/portfile.cmake
+++ b/ports/thermo/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO cleishm/thermo-cpp
+    REF "v${VERSION}"
+    SHA512 0e27b256aacf51fd25a619ba7bd7959c1bf4ce4d491d817664ebe7c90911753d15b051d312c56dd7f8a0dc33f9108c5ee32b53188b868f02913e4026fa4351c5
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DTHERMO_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME thermo CONFIG_PATH lib/cmake/thermo)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/thermo/vcpkg.json
+++ b/ports/thermo/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "thermo",
+  "version": "1.0.0",
+  "description": "Type-safe temperature handling library modeled after std::chrono",
+  "homepage": "https://github.com/cleishm/thermo-cpp",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/thermo/vcpkg.json
+++ b/ports/thermo/vcpkg.json
@@ -4,7 +4,6 @@
   "description": "Type-safe temperature handling library modeled after std::chrono",
   "homepage": "https://github.com/cleishm/thermo-cpp",
   "license": "MIT",
-  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9748,6 +9748,10 @@
       "baseline": "2.0",
       "port-version": 0
     },
+    "thermo": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "think-cell-range": {
       "baseline": "2023.1",
       "port-version": 1

--- a/versions/t-/thermo.json
+++ b/versions/t-/thermo.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b4af859bcbaa168dc48d978e1db0f7bc7496329b",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add thermo, a header-only C++20 library for type-safe temperature handling modeled after std::chrono.

  Features:
  - Type-safe temperatures with distinct types for Celsius, Kelvin, and Fahrenheit
  - Configurable precision (degree, decidegree, millidegree)
  - Implicit lossless conversions, explicit lossy conversions
  - Temperature deltas distinct from absolute temperatures
  - User-defined literals and std::format support
  - Fully constexpr

  Homepage: https://github.com/cleishm/thermo-cpp
  License: MIT