### PR TITLE
[projectm-eval] update to 1.0.6

### DIFF
--- a/ports/projectm-eval/portfile.cmake
+++ b/ports/projectm-eval/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO projectM-visualizer/projectm-eval
     REF "v${VERSION}"
-    SHA512 "5d7875b8cc64eb8fe5d2a9379d50e5dd0bb46cf72b36da65bf3b47f827ca3ec14f324d43518b2c34fb67c1b0431b7140006adbb4ea957f763a49445f438ee0cf"
+    SHA512 "b0c44d4f6cbad8dc203a108c5f46784d0a32d40502fd23d5f7c8acaa0f5f0539e43f839f3a9cd36992aacf49482a4f8cb02f5186fa5162be404ed9f941e681bb"
     HEAD_REF master
 )
 

--- a/ports/projectm-eval/vcpkg.json
+++ b/ports/projectm-eval/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "projectm-eval",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "The projectM Expression Evaluation Library. A portable drop-in replacement of Milkdrop's \"ns-eel2\" expression parser for use in Milkdrop, projectM and other applications.",
   "homepage": "https://github.com/projectM-visualizer/projectm-eval",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7777,7 +7777,7 @@
       "port-version": 0
     },
     "projectm-eval": {
-      "baseline": "1.0.5",
+      "baseline": "1.0.6",
       "port-version": 0
     },
     "prometheus-cpp": {

--- a/versions/p-/projectm-eval.json
+++ b/versions/p-/projectm-eval.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a4384d6e578ce2cb0a83398e52cac96fa870fb5c",
+      "version": "1.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "0ca5c6bcb7d9c601b02222688f757341c2896d3c",
       "version": "1.0.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/projectM-visualizer/projectm-eval/releases/tag/v1.0.6
