### PR TITLE
[tinyply] update to 3.0

### DIFF
--- a/ports/tinyply/portfile.cmake
+++ b/ports/tinyply/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ddiakopoulos/tinyply
-    REF 40aa4a0ae9e9c203e11893f78b8bcaf8a50e65f0 # 2.3.4
-    SHA512 c99bdfcfbcbb13af2e662763f15771d7d5905267fb72ad93b40aad83785e8fbb48feb2359ce2542fe838fcb22a42f8a65cebd9c22963a383638be1ef0100269a
+    REF c9bb690dfe5e9105961e9e28120c48c9ae084bc6 # 3.0
+    SHA512 4df803db4494e04a3f3bd7bc47d59a18d0c6dd8b0984b36e4ef38722590fbd441f226e284108c3971eea7733e3740f0e688ebd848bff493fc9f8c56426d1dab4
     HEAD_REF master
 )
 
@@ -24,7 +24,7 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # License
-file(READ "${SOURCE_PATH}/readme.md" readme_contents)
+file(READ "${SOURCE_PATH}/README.md" readme_contents)
 string(FIND "${readme_contents}" "## License" license_pos)
 string(SUBSTRING "${readme_contents}" ${license_pos} -1 license_contents)
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright "${license_contents}")

--- a/ports/tinyply/vcpkg.json
+++ b/ports/tinyply/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyply",
-  "version": "2.3.4",
+  "version": "3.0",
   "description": "C++11 ply 3d mesh format importer & exporter",
   "homepage": "https://github.com/ddiakopoulos/tinyply",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9861,7 +9861,7 @@
       "port-version": 0
     },
     "tinyply": {
-      "baseline": "2.3.4",
+      "baseline": "3.0",
       "port-version": 0
     },
     "tinyproto": {

--- a/versions/t-/tinyply.json
+++ b/versions/t-/tinyply.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3314d7080d3b51a590bd6c341c5db89890611e97",
+      "version": "3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "79787577d8bf66af02aa77e9592552a6b0b0d8d0",
       "version": "2.3.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ddiakopoulos/tinyply/releases/tag/3.0
