### PR TITLE
[rapidfuzz-cpp] Renamed from rapidfuzz

### DIFF
--- a/ports/rapidfuzz-cpp/portfile.cmake
+++ b/ports/rapidfuzz-cpp/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO maxbachmann/rapidfuzz-cpp
+    REF "v${VERSION}"
+    SHA512 51d3e38ca0ec2592ee5562208180bc11d6e4b4663405d3541768c060e6fef72cb35338a53c03e7411601123e42480b35749fb59530f52dfa99b5ed18d21aa5ec
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME rapidfuzz
+    CONFIG_PATH lib/cmake/rapidfuzz
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rapidfuzz-cpp/vcpkg.json
+++ b/ports/rapidfuzz-cpp/vcpkg.json
@@ -1,10 +1,17 @@
 {
-  "name": "rapidfuzz",
-  "version-string": "deprecated",
+  "name": "rapidfuzz-cpp",
+  "version": "3.3.3",
   "description": "Rapid fuzzy string matching library for C++ using the Levenshtein Distance.",
   "homepage": "https://github.com/maxbachmann/rapidfuzz-cpp",
   "license": "MIT",
   "dependencies": [
-    "rapidfuzz-cpp"
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/rapidfuzz/portfile.cmake
+++ b/ports/rapidfuzz/portfile.cmake
@@ -1,18 +1,1 @@
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO maxbachmann/rapidfuzz-cpp
-    REF "v${VERSION}"
-    SHA512 51d3e38ca0ec2592ee5562208180bc11d6e4b4663405d3541768c060e6fef72cb35338a53c03e7411601123e42480b35749fb59530f52dfa99b5ed18d21aa5ec
-    HEAD_REF master
-)
-
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-)
-
-vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8405,6 +8405,10 @@
       "port-version": 0
     },
     "rapidfuzz": {
+      "baseline": "deprecated",
+      "port-version": 0
+    },
+    "rapidfuzz-cpp": {
       "baseline": "3.3.3",
       "port-version": 0
     },

--- a/versions/r-/rapidfuzz-cpp.json
+++ b/versions/r-/rapidfuzz-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "114d779da3cba2c67a438f8715d7188502080c1e",
+      "version": "3.3.3",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/r-/rapidfuzz.json
+++ b/versions/r-/rapidfuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66ec151d624bc1139fabb9d47d17a259df22d1d5",
+      "version-string": "deprecated",
+      "port-version": 0
+    },
+    {
       "git-tree": "73c7d30319b51bf541018870a77e7ca5a1c183bd",
       "version": "3.3.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

I [requested a split](https://repology.org/project/rapidfuzz/report) from rapidfuzz at Repology because the [Python repo](https://github.com/rapidfuzz/rapidfuzz) and the [Cpp repo](https://github.com/rapidfuzz/rapidfuzz-cpp) had different version numbers. Due to this split, the old port name is now marked as [`rapidfuzz-misnamed`](https://repology.org/project/rapidfuzz-misnamed). Therefore, I followed the renaming at Repology, which also reflects the name used in [many other repos](https://repology.org/project/rapidfuzz-cpp).