### PR TITLE
[ffmpeg] fix msvc detection

### DIFF
--- a/ports/ffmpeg/0046-fix-msvc-detection.patch
+++ b/ports/ffmpeg/0046-fix-msvc-detection.patch
@@ -1,0 +1,29 @@
+diff --git a/configure b/configure
+index e8cce5d..d465a53 100644
+--- a/configure
++++ b/configure
+@@ -5178,12 +5178,12 @@ probe_cc(){
+         _flags_filter=msvc_flags_link
+         _ld_lib='lib%.a'
+         _ld_path='-libpath:'
+-    elif VSLANG=1033 $_cc -nologo- 2>&1 | grep -q ^Microsoft || { $_cc -v 2>&1 | grep -q clang && $_cc -? > /dev/null 2>&1; }; then
++    elif VSLANG=1033 $_cc -nologo- 2>&1 | grep -qi Microsoft || { $_cc -v 2>&1 | grep -q clang && $_cc -? > /dev/null 2>&1; }; then
+         _type=msvc
+-        if VSLANG=1033 $_cc -nologo- 2>&1 | grep -q ^Microsoft; then
++        if VSLANG=1033 $_cc -nologo- 2>&1 | grep -qi Microsoft; then
+             # Depending on the tool (cl.exe or link.exe), the version number
+             # is printed on the first line of stderr or stdout
+-            _ident=$(VSLANG=1033 $_cc 2>&1 | grep ^Microsoft | head -n1 | tr -d '\r')
++            _ident=$(VSLANG=1033 $_cc 2>&1 | grep -i Microsoft | head -n1 | tr -d '\r')
+         else
+             _ident=$($_cc --version 2>/dev/null | head -n1 | tr -d '\r')
+         fi
+@@ -5293,7 +5293,7 @@ if [ -z "$CC_DEPFLAGS" ] && [ "$dep_cc" != "$cc" ]; then
+     DEPCCFLAGS=$_flags
+ fi
+ 
+-if VSLANG=1033 $ar 2>&1 | grep -q ^Microsoft; then
++if VSLANG=1033 $ar 2>&1 | grep -qi Microsoft; then
+     arflags="-nologo"
+     ar_o='-out:$@'
+ elif $ar 2>&1 | grep -q "\[D\] "; then

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         0040-ffmpeg-add-av_stream_get_first_dts-for-chromium.patch # Do not remove this patch. It is required by chromium
         0044-fix-vulkan-debug-callback-abi.patch
         0045-use-prebuilt-bin2c.patch
+        0046-fix-msvc-detection.patch
 )
 
 if(SOURCE_PATH MATCHES " ")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "8.0.1",
+  "port-version": 1,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2930,7 +2930,7 @@
     },
     "ffmpeg": {
       "baseline": "8.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ffmpeg-bin2c": {
       "baseline": "8.0.1",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "623bc25a61ec9c63c4621dd8c2e9c8596cd3b307",
+      "version": "8.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "109d41404a6701389e5fedf92ff1c903798aff54",
       "version": "8.0.1",
       "port-version": 0


### PR DESCRIPTION
* [x]  Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
* [x]  SHA512s are updated for each updated download.
* [ ]  The "supports" clause reflects platforms that may be fixed by this new version.
* [ ]  Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
* [ ]  Any patches that are no longer applied are deleted from the port's directory.
* [x]  The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
* [x]  Only one version is added to each modified port's versions file.

This adds a simple patch to ffmpeg to fix msvc detection.
The original source search the output of "cl -logo-" for a string starting with Microsoft.
But localized version of Visual Studio don't always start with "Microsoft".
