### PR TITLE
[slick-object-pool] update to v0.1.3

### DIFF
--- a/ports/slick-object-pool/portfile.cmake
+++ b/ports/slick-object-pool/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO SlickQuant/slick_object_pool
+    REPO SlickQuant/slick-object-pool
     REF "v${VERSION}"
-    SHA512 fa1aac51f829b92ae297f0e4bc469af374e80c464d1e644139482782fa95ada99fd4e5b77b2fab6741c851afa612364a1d908eeb27a611c043720a3c47e1a986
+    SHA512 932eb5fe590c624b5dca477d874a1eb7822b2528bdb684f151d325b6808866baafa3010a3925ab0e2f4c7374f09163ac205065959a445dd5ef6f15546c433fb4
     HEAD_REF main
 )
 
@@ -14,7 +14,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/slick_object_pool)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/slick-object-pool)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/slick-object-pool/usage
+++ b/ports/slick-object-pool/usage
@@ -1,4 +1,4 @@
 slick-object-pool is header-only and can be used from CMake via:
 
-    find_package(slick_object_pool CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE slick::slick_object_pool)
+    find_package(slick-object-pool CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE slick::object-pool)

--- a/ports/slick-object-pool/vcpkg.json
+++ b/ports/slick-object-pool/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-object-pool",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A high-performance, lock-free object pool for C++20 with multi-threading support",
-  "homepage": "https://github.com/SlickQuant/slick_object_pool",
+  "homepage": "https://github.com/SlickQuant/slick-object-pool",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9129,7 +9129,7 @@
       "port-version": 0
     },
     "slick-object-pool": {
-      "baseline": "0.1.2",
+      "baseline": "0.1.3",
       "port-version": 0
     },
     "slick-queue": {

--- a/versions/s-/slick-object-pool.json
+++ b/versions/s-/slick-object-pool.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9daeba909b593f52c51a393b53ad95174c4a93f1",
+      "version": "0.1.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "f04d9b77888512324e08d6380a9e9d6a58741c9d",
       "version": "0.1.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
