### PR TITLE
[htscodecs] Update to 1.6.5

### DIFF
--- a/ports/htscodecs/configure_bz2.patch
+++ b/ports/htscodecs/configure_bz2.patch
@@ -1,0 +1,19 @@
+diff --git a/configure.ac b/configure.ac
+index 082783a..b94ce25 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -97,9 +97,11 @@ AC_ARG_ENABLE([bz2],
+ 
+ if test "$enable_bz2" != no; then
+   bz2_devel=ok
+-  AC_CHECK_LIB([bz2], [BZ2_bzBuffToBuffCompress], [
+-	LIBS="-lbz2 $LIBS"
+-	AC_DEFINE([HAVE_LIBBZ2],1,[Define to 1 if you have the libbz2 library.])], [bz2_devel=missing])
++  PKG_CHECK_MODULES([BZ2_PKG], [bzip2], [
++      AC_DEFINE([HAVE_LIBBZ2],1,[Define to 1 if you have the libbz2 library.])
++      LIBS="$LIBS $BZ2_PKG_LIBS"
++      CFLAGS="$CFLAGS $BZ2_PKG_CFLAGS"
++    ], [bz2_devel=missing])
+   if test "$bz2_devel" != "ok"; then
+     AC_MSG_ERROR([libbzip2 development files not found.
+ 

--- a/ports/htscodecs/portfile.cmake
+++ b/ports/htscodecs/portfile.cmake
@@ -2,10 +2,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO samtools/htscodecs
     REF "v${VERSION}"
-    SHA512 5e3e1f916cb14fe7e1292f3a07e9d9704b11be38014db5884b334235c25dbe61dffecf3f12c448a7a13f65c6d19dbc7cc5c77ba0861b31a0375d71030dd02480
+    SHA512 ef1017c432937926a6d7723e5e012a5e38bdbbf3ffd2f35b0cbac4a804f8f3163058c4f736a6998151eb4e73a127fa52d1ac4d734d05a35d7e5b3fa60ebf2a28
     HEAD_REF master
     PATCHES
         0001-no-tests.patch # https://github.com/samtools/htscodecs/pull/120
+        configure_bz2.patch
 )
 
 set(FEATURE_OPTIONS "")

--- a/ports/htscodecs/vcpkg.json
+++ b/ports/htscodecs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "htscodecs",
-  "version": "1.6.1",
+  "version": "1.6.5",
   "description": "Custom compression for CRAM and others.",
   "homepage": "https://github.com/samtools/htscodecs",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3837,7 +3837,7 @@
       "port-version": 0
     },
     "htscodecs": {
-      "baseline": "1.6.1",
+      "baseline": "1.6.5",
       "port-version": 0
     },
     "htslib": {

--- a/versions/h-/htscodecs.json
+++ b/versions/h-/htscodecs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "81db613651d03b5619af9686a1aa58b63f0e2c94",
+      "version": "1.6.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "a7eaba66bb4d3bf35e1a6b9b70e91edccaccf071",
       "version": "1.6.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
