### PR TITLE
[kdutils] Add new port

### DIFF
--- a/ports/kdutils/portfile.cmake
+++ b/ports/kdutils/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDAB/KDUtils
+    REF 0ee5bf54fe82c4ef59f1ee586bf7e2b343758f62
+    SHA512 0410017b79f2d650457f5b2406b5ca3c5163b57ed4ce67d94c9761c865e1662e23d4148c8a77233adf8ecd2d77906cf9e231d802834425a7f1c1903871e30516
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        testing    KDUTILS_BUILD_TESTS
+        mqtt       KDUTILS_BUILD_MQTT_SUPPORT
+)
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH}
+                      OPTIONS
+                      -DKDUTILS_BUILD_EXAMPLES=OFF
+                      ${FEATURE_OPTIONS})
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# Fix CMake config files - each module goes to its own subdirectory in share/
+vcpkg_cmake_config_fixup(PACKAGE_NAME KDUtils CONFIG_PATH lib/cmake/KDUtils DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_cmake_config_fixup(PACKAGE_NAME KDGui CONFIG_PATH lib/cmake/KDGui DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_cmake_config_fixup(PACKAGE_NAME KDFoundation CONFIG_PATH lib/cmake/KDFoundation)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/kdutils/usage
+++ b/ports/kdutils/usage
@@ -1,0 +1,7 @@
+kdutils provides CMake targets:
+
+find_package(KDUtils REQUIRED)
+find_package(KDFoundation REQUIRED)
+find_package(KDGui REQUIRED)
+
+target_link_libraries(main PRIVATE KDUtils::KDUtils KDUtils::KDFoundation KDUtils::KDGui)

--- a/ports/kdutils/vcpkg.json
+++ b/ports/kdutils/vcpkg.json
@@ -1,0 +1,54 @@
+{
+  "name": "kdutils",
+  "version": "0.1.12",
+  "description": "KD Utilities Library - Core utilities and helper functions",
+  "homepage": "https://github.com/KDAB/kdutils",
+  "license": "MIT",
+  "supports": "!uwp & (windows | linux | android | osx) & (arm | x86 | x64)",
+  "dependencies": [
+    {
+      "name": "kdbindings",
+      "version>=": "1.1.0"
+    },
+    {
+      "name": "mio",
+      "version>=": "2023-03-03"
+    },
+    {
+      "name": "spdlog",
+      "version>=": "1.15.3"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "whereami",
+      "version>=": "2024-08-26"
+    }
+  ],
+  "features": {
+    "mqtt": {
+      "description": "Enable mqtt support",
+      "dependencies": [
+        {
+          "name": "mosquitto",
+          "version>=": "2.0.20"
+        }
+      ]
+    },
+    "testing": {
+      "description": "Enable testing support",
+      "dependencies": [
+        {
+          "name": "doctest",
+          "version>=": "2.4.12"
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4212,6 +4212,10 @@
       "baseline": "2.0.0",
       "port-version": 2
     },
+    "kdutils": {
+      "baseline": "0.1.12",
+      "port-version": 0
+    },
     "kealib": {
       "baseline": "1.6.2",
       "port-version": 0

--- a/versions/k-/kdutils.json
+++ b/versions/k-/kdutils.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "18f16d9d44d86a9ec180a5e9b27143094b780d50",
+      "version": "0.1.12",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.