### PR TITLE
[guile] Update to 3.0.11

### DIFF
--- a/ports/guile/portfile.cmake
+++ b/ports/guile/portfile.cmake
@@ -1,17 +1,20 @@
-vcpkg_download_distfile(GUILE_ARCHIVE 
+vcpkg_download_distfile(ARCHIVE 
     URLS
         "https://ftpmirror.gnu.org/guile/guile-${VERSION}.tar.gz"    
         "https://ftp.gnu.org/gnu/guile/guile-${VERSION}.tar.gz"
     FILENAME "guile-${VERSION}.tar.gz"
-    SHA512 8b0e6354fdfccd009fd92a5618828f8a8343faf20d1d3698be77a6ef7a8fe56ce633fd1239520e6a6be511ba4ca75eb90c8a81c45888b8b73d938cd2908d7a1f
+    SHA512 bf81eca9554d22dcfcff4797739dee18758c257bd2c848fdf508e3fd6e58ffd9754b08a57d8ba31c80a69b0444fff3b045e22ec88fc34ef787cd71f5466fafe8
 )
 
-vcpkg_extract_source_archive(GUILE_SOURCES ARCHIVE "${GUILE_ARCHIVE}")
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+)
 
 vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/gperf")
 
 vcpkg_configure_make(
-    SOURCE_PATH "${GUILE_SOURCES}"
+    SOURCE_PATH "${SOURCE_PATH}"
     ADD_BIN_TO_PATH
     AUTOCONFIG
 )
@@ -33,4 +36,4 @@ foreach(file guile-tools guile-config guild)
 endforeach()
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/guile-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../..")
 
-vcpkg_install_copyright(FILE_LIST "${GUILE_SOURCES}/COPYING.LESSER")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.LESSER")

--- a/ports/guile/vcpkg.json
+++ b/ports/guile/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "guile",
-  "version": "3.0.10",
-  "port-version": 1,
+  "version": "3.0.11",
   "description": "GNU's programming and extension language",
   "homepage": "https://www.gnu.org/software/guile/",
   "documentation": "https://www.gnu.org/software/guile/manual/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3553,8 +3553,8 @@
       "port-version": 2
     },
     "guile": {
-      "baseline": "3.0.10",
-      "port-version": 1
+      "baseline": "3.0.11",
+      "port-version": 0
     },
     "guilite": {
       "baseline": "2022-05-05",

--- a/versions/g-/guile.json
+++ b/versions/g-/guile.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06121df6c331708a9b5c44bcbff82df32315f035",
+      "version": "3.0.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "883037b0117f33c721a52c8f50d82f8ff2ff4a33",
       "version": "3.0.10",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.