### PR TITLE
[libice] Update to 1.1.2

### DIFF
--- a/ports/libice/portfile.cmake
+++ b/ports/libice/portfile.cmake
@@ -1,17 +1,19 @@
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
+    return()
+endif()
 
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libice
-    REF be1888a46e446dfcaa62ac0a97d96bb77b6816d4 # 1.1.1
+    REF "libICE-${VERSION}"
     SHA512  0892ee9210302e787297763bcf0c7788bcd5f5572d5fd86472e8104dc291e7e190effc0100bbca98c6b048b445bd9e8bdf490287e1dbf2a64693aa1895950610
     HEAD_REF master
-    PATCHES fix_build.patch
-            replace_macros.patch
+    PATCHES
+        fix_build.patch
+        replace_macros.patch
 ) 
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
@@ -27,6 +29,4 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-endif()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libice/vcpkg.json
+++ b/ports/libice/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libice",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Inter-Client Exchange Library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libice",
   "license": "MIT-open-group",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4993,7 +4993,7 @@
       "port-version": 0
     },
     "libice": {
-      "baseline": "1.1.1",
+      "baseline": "1.1.2",
       "port-version": 0
     },
     "libiconv": {

--- a/versions/l-/libice.json
+++ b/versions/l-/libice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "16385399a461bc7d4d4e4bc012c0f397a448a93f",
+      "version": "1.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "6c69693bd283d8e6b8e9c1303f7cafbd0ecec572",
       "version": "1.1.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.