### PR TITLE
[orc] Update to 2.2.2

### DIFF
--- a/ports/orc/portfile.cmake
+++ b/ports/orc/portfile.cmake
@@ -1,53 +1,53 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH
-  REPO apache/orc
-  REF "v${VERSION}"
-  SHA512 b81e1c2cebfd97757aaaa8dc9bed913810b0a47e599556bc3e9989dadf6b7665c335c37cd29d8430cd9b1af9048f37efaa56869872eb5f50fe35a570ec109a40
-  HEAD_REF master
-  PATCHES
-    external-project.diff
-    tools-build.diff
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO apache/orc
+    REF "v${VERSION}"
+    SHA512 43353b3c2ac752b388518de017ae9363f45088b9abe995ec0d740575c2b8514b14e0aca36454aab7cbb9d8adf7c93be188317a5997d8931b8ecf9f0a81a59553
+    HEAD_REF main
+    PATCHES
+        external-project.diff
+        tools-build.diff
 )
 file(GLOB modules "${SOURCE_PATH}/cmake_modules/Find*.cmake")
 file(REMOVE ${modules} "${SOURCE_PATH}/c++/libs/libhdfspp/libhdfspp.tar.gz")
 
 set(orc_format_version 1.1.1)
 vcpkg_download_distfile(ORC_FORMAT_ARCHIVE
-  URLS "https://dlcdn.apache.org/orc/orc-format-${orc_format_version}/orc-format-${orc_format_version}.tar.gz"
-  FILENAME "apache-orc-format-${orc_format_version}.tar.gz"
-  SHA512 8aa0bcd3345ed8be836995d4347175526f4b0fc91f41e27f29279fad39b94ff157f5cd597bc2d9f3dc403f5ba405807675a283abe822f8a83758b7c3b8292c1c
+    URLS "https://dlcdn.apache.org/orc/orc-format-${orc_format_version}/orc-format-${orc_format_version}.tar.gz"
+    FILENAME "apache-orc-format-${orc_format_version}.tar.gz"
+    SHA512 8aa0bcd3345ed8be836995d4347175526f4b0fc91f41e27f29279fad39b94ff157f5cd597bc2d9f3dc403f5ba405807675a283abe822f8a83758b7c3b8292c1c
 )
 set(ENV{ORC_FORMAT_URL} "file://${ORC_FORMAT_ARCHIVE}")
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS options
-  FEATURES
-    tools   BUILD_TOOLS
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools   BUILD_TOOLS
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)
-  list(APPEND options "-DHAS_PRE_1970=OFF" "-DHAS_POST_2038=OFF")
+  list(APPEND FEATURE_OPTIONS "-DHAS_PRE_1970=OFF" "-DHAS_POST_2038=OFF")
 endif()
 
 vcpkg_cmake_configure(
-  SOURCE_PATH "${SOURCE_PATH}"
-  OPTIONS
-    ${options}
-    -DBUILD_CPP_TESTS=OFF
-    -DBUILD_JAVA=OFF
-    -DINSTALL_VENDORED_LIBS=OFF
-    -DORC_PACKAGE_KIND=vcpkg
-    -DSTOP_BUILD_ON_WARNING=OFF
-  OPTIONS_DEBUG
-    -DBUILD_TOOLS=OFF
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DBUILD_CPP_TESTS=OFF
+        -DBUILD_JAVA=OFF
+        -DINSTALL_VENDORED_LIBS=OFF
+        -DORC_PACKAGE_KIND=vcpkg
+        -DSTOP_BUILD_ON_WARNING=OFF
+    OPTIONS_DEBUG
+        -DBUILD_TOOLS=OFF
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup()
 
 if("tools" IN_LIST FEATURES)
-  vcpkg_copy_tools(TOOL_NAMES csv-import orc-contents orc-memory orc-metadata orc-scan orc-statistics timezone-dump AUTO_CLEAN)
+    vcpkg_copy_tools(TOOL_NAMES csv-import orc-contents orc-memory orc-metadata orc-scan orc-statistics timezone-dump AUTO_CLEAN)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/orc/vcpkg.json
+++ b/ports/orc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "orc",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "The smallest, fastest columnar storage for Hadoop workloads.",
   "homepage": "https://orc.apache.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7341,7 +7341,7 @@
       "port-version": 0
     },
     "orc": {
-      "baseline": "2.2.1",
+      "baseline": "2.2.2",
       "port-version": 0
     },
     "orefkov-simstr": {

--- a/versions/o-/orc.json
+++ b/versions/o-/orc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e8ef729096ecae101ac7f536c3f83394f3de4b3",
+      "version": "2.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "8257ee1040f79b5efc737713fbd6b524518e0845",
       "version": "2.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.