### PR TITLE
[libXau] update to 1.0.12

### DIFF
--- a/ports/libxau/fix-configure-ac.patch
+++ b/ports/libxau/fix-configure-ac.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile.am b/Makefile.am
+index cb3adbe..dd17d48 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -62,6 +62,5 @@ ChangeLog:
+ 
+ dist-hook: ChangeLog INSTALL
+ 
+-ACLOCAL_AMFLAGS = -I m4
+ 
+-EXTRA_DIST = meson.build meson_options.txt
+\ No newline at end of file
++EXTRA_DIST = meson.build meson_options.txt
+diff --git a/configure.ac b/configure.ac
+index e1182b6..97b9d41 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -26,7 +26,6 @@ AC_INIT([libXau], [1.0.12],
+ 	[https://gitlab.freedesktop.org/xorg/lib/libxau/-/issues], [libXau])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ AC_USE_SYSTEM_EXTENSIONS
+ 
+ # Initialize Automake

--- a/ports/libxau/portfile.cmake
+++ b/ports/libxau/portfile.cmake
@@ -4,13 +4,15 @@ if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
 else()
 
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxau
-    REF d9443b2c57b512cfb250b35707378654d86c7dea # 1.0.9 
-    SHA512  d46d2be838b8ea7116ee0e312adafa80f6551762b5f7b5e503bd40e74fc0b43b45255e8135d03f831d5c483b98aac992fcd91a7e22119261e76778571a72ef07
+    REPO "lib/libxau"
+    REF "libXau-${VERSION}"
+    SHA512 d76ea5a7d5f70159b3d40242cee66b4a763b98ce57b0b5660ce47cac9bc240d51fb20eec969f8fffdfd79fa46ec8e1b9bf2aa4ca9d39d1f45d515e75afb23a7d
     HEAD_REF master
-) 
+    PATCHES
+        fix-configure-ac.patch
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 
@@ -27,5 +29,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 endif()

--- a/ports/libxau/vcpkg.json
+++ b/ports/libxau/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxau",
-  "version": "1.0.9",
+  "version": "1.0.12",
   "description": "Functions for handling Xauthority files and entries.",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxau",
   "license": "MIT-open-group",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5741,7 +5741,7 @@
       "port-version": 4
     },
     "libxau": {
-      "baseline": "1.0.9",
+      "baseline": "1.0.12",
       "port-version": 0
     },
     "libxaw": {

--- a/versions/l-/libxau.json
+++ b/versions/l-/libxau.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "559dda6d5a14d58ebfeabafc9e17c230c44bb781",
+      "version": "1.0.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "d82d4195d09a023e7a7fbc1c3a726a2f9f917a33",
       "version": "1.0.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
