### PR TITLE
[opencolorio] update to 2.5.1

### DIFF
--- a/ports/opencolorio/portfile.cmake
+++ b/ports/opencolorio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/OpenColorIO
     REF "v${VERSION}"
-    SHA512 2d3d6dcda60b10386a3dacb1cdb966b640917739091237d5788c4984a4c498a55b94c464b2076d6d82ee5fe0271150ee1767ebff14a94dc49039890b87189a29
+    SHA512 93d370a96882523defbaeb3c546860bf08cb152e430ff28cf02a976d265f0785d92aed1ab69a44db9ae4fc220ab1adaf0c5c1ecd2426d6b192a48add4c479364
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/opencolorio/vcpkg.json
+++ b/ports/opencolorio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "opencolorio",
-  "version-semver": "2.5.0",
+  "version-semver": "2.5.1",
   "description": "OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation. OCIO provides a straightforward and consistent user experience across all supporting applications while allowing for sophisticated back-end configuration options suitable for high-end production usage. OCIO is compatible with the Academy Color Encoding Specification (ACES) and is LUT-format agnostic, supporting many popular formats.",
   "homepage": "https://opencolorio.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7157,7 +7157,7 @@
       "port-version": 1
     },
     "opencolorio": {
-      "baseline": "2.5.0",
+      "baseline": "2.5.1",
       "port-version": 0
     },
     "opencsg": {

--- a/versions/o-/opencolorio.json
+++ b/versions/o-/opencolorio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c93839d15538806025747d1ea8148a02524cdea",
+      "version-semver": "2.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9cea4a8a4fde4bcbde4b9697b7b724e64a537d52",
       "version-semver": "2.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/AcademySoftwareFoundation/OpenColorIO/releases/tag/v2.5.1
