### PR TITLE
[alsa] update to 1.2.15.3

### DIFF
--- a/ports/alsa/portfile.cmake
+++ b/ports/alsa/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alsa-project/alsa-lib
     REF "v${VERSION}"
-    SHA512 c28e9fbd2cdf8f6482ed8fb1d48235441e6de9939406b7e1d2b595a9c6587c39e408dd892bca55af0e8e892b30622d89e796fbff2c0bde67f730a34be2017aa1
+    SHA512 0b8a7d83a0bbce2153475923dff0fe47ed946a8adf2022f5f99c027465bd1c04a4eb06861c72bd88943b1af9b46b7967f8417f14c0261623e130ebde4e833e5d
     HEAD_REF master
     PATCHES
         fix-plugin-dir.patch
@@ -52,7 +52,7 @@ vcpkg_fixup_pkgconfig()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-file(REMOVE_RECURSE 
+file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
     "${CURRENT_PACKAGES_DIR}/debug/tools/alsa/debug"

--- a/ports/alsa/vcpkg.json
+++ b/ports/alsa/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "alsa",
-  "version": "1.2.14",
-  "port-version": 1,
+  "version": "1.2.15.3",
   "description": "The Advanced Linux Sound Architecture (ALSA) - library",
   "homepage": "https://www.alsa-project.org/",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/alsa.json
+++ b/versions/a-/alsa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "053cc16615541eea1435bf777fdde7f17bdf56f4",
+      "version": "1.2.15.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "3ada7fb50cf76c48bc6455ccaf2f1250c1db0669",
       "version": "1.2.14",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -105,8 +105,8 @@
       "port-version": 0
     },
     "alsa": {
-      "baseline": "1.2.14",
-      "port-version": 1
+      "baseline": "1.2.15.3",
+      "port-version": 0
     },
     "amd-adl-sdk": {
       "baseline": "17.1",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/alsa-project/alsa-lib/releases/tag/v1.2.15.3
