### PR TITLE
[slick-net] update to v1.2.2

### DIFF
--- a/ports/slick-net/portfile.cmake
+++ b/ports/slick-net/portfile.cmake
@@ -1,9 +1,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO SlickQuant/slick_net
+    REPO SlickQuant/slick-net
     REF "v${VERSION}"
-    SHA512 b56901ea8c819076c4b5ef979a57dd69279bfbb0cf408e822896dd2123b9475a5e1b5a09ac8f9e6b7ff47ae2acbbb3a458f8cae8a70f293a69b506b418ad8d1d
+    SHA512 2cfceabe3b4828f73506a607b163bdffa2ceec42d017bf1e060a3787f150d8e6dbd32699dccacb1effc329afbdc7c8e8314aa1f32f07fe20088b3cf9a1bb76b3
     HEAD_REF main
+    PATCHES
+        slick-queue.patch
 )
 
 vcpkg_cmake_configure(
@@ -15,7 +17,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME slick_net CONFIG_PATH share/slick_net)
+vcpkg_cmake_config_fixup(PACKAGE_NAME slick-net CONFIG_PATH share/slick-net)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/slick-net/portfile.cmake
+++ b/ports/slick-net/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-net
     REF "v${VERSION}"
-    SHA512 2cfceabe3b4828f73506a607b163bdffa2ceec42d017bf1e060a3787f150d8e6dbd32699dccacb1effc329afbdc7c8e8314aa1f32f07fe20088b3cf9a1bb76b3
+    SHA512 5871099ac415fb8afa223798e5590afeded1e7a40aa071e727408e07bb8920293354f16024cbe6cbfb53c0935de8be27828f4681e53ea790e5404f06dbcdf603
     HEAD_REF main
     PATCHES
         slick-queue.patch

--- a/ports/slick-net/slick-queue.patch
+++ b/ports/slick-net/slick-queue.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0b2b6fd..89493aa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,15 +25,5 @@
+ find_package(Boost CONFIG REQUIRED COMPONENTS beast context)
+ find_package(OpenSSL REQUIRED)
+-
+-include(FetchContent)
+-
+-# Disable tests for slick-queue
+-set(BUILD_SLICK_QUEUE_TESTS OFF CACHE BOOL "" FORCE)
+-FetchContent_Declare(
+-    slick-queue
+-    GIT_REPOSITORY https://github.com/SlickQuant/slick-queue.git
+-    GIT_TAG v1.2.2
+-)
+-FetchContent_MakeAvailable(slick-queue)
++find_package(slick-queue 1.2.2 CONFIG REQUIRED)
+ 
+ message(STATUS "OpenSSL: ${OPENSSL_INCLUDE_DIR}")

--- a/ports/slick-net/slick-queue.patch
+++ b/ports/slick-net/slick-queue.patch
@@ -1,21 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0b2b6fd..89493aa 100644
+index 6bd7e39..f5dab2f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -25,15 +25,5 @@
+@@ -22,7 +22,7 @@ if (LINK_STATICALLY)
+ endif()
  find_package(Boost CONFIG REQUIRED COMPONENTS beast context)
- find_package(OpenSSL REQUIRED)
--
--include(FetchContent)
--
--# Disable tests for slick-queue
--set(BUILD_SLICK_QUEUE_TESTS OFF CACHE BOOL "" FORCE)
--FetchContent_Declare(
--    slick-queue
--    GIT_REPOSITORY https://github.com/SlickQuant/slick-queue.git
--    GIT_TAG v1.2.2
--)
--FetchContent_MakeAvailable(slick-queue)
+ find_package(OpenSSL CONFIG REQUIRED)
+-find_package(slick-queue 1.2.2 CONFIG QUIET)
 +find_package(slick-queue 1.2.2 CONFIG REQUIRED)
  
- message(STATUS "OpenSSL: ${OPENSSL_INCLUDE_DIR}")
+ if (NOT slick-queue_FOUND)
+     message(STATUS "Fetching slick-queue...")

--- a/ports/slick-net/usage
+++ b/ports/slick-net/usage
@@ -1,4 +1,4 @@
 slick-net provides CMake targets:
 
-    find_package(slick_net CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE slick_net::slick_net)
+    find_package(slick-net CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE slick::net)

--- a/ports/slick-net/vcpkg.json
+++ b/ports/slick-net/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-net",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A modern C++20 networking library providing HTTP/HTTPS client, WebSocket/WebSocket Secure client, and HTTP streaming support built on Boost.Beast and Boost.Asio",
-  "homepage": "https://github.com/SlickQuant/slick_net",
+  "homepage": "https://github.com/SlickQuant/slick-net",
   "license": "MIT",
   "supports": "!(uwp | arm)",
   "dependencies": [
@@ -26,6 +26,10 @@
     {
       "name": "openssl",
       "version>=": "3.0.2"
+    },
+    {
+      "name": "slick-queue",
+      "version>=": "1.2.2"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9133,7 +9133,7 @@
       "port-version": 0
     },
     "slick-net": {
-      "baseline": "1.2.1",
+      "baseline": "1.2.2",
       "port-version": 0
     },
     "slick-object-pool": {

--- a/versions/s-/slick-net.json
+++ b/versions/s-/slick-net.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "16859970d6b98939b948b3ab0551bf462b76f2e1",
+      "git-tree": "3697c5a0ef76a8bc2a5af8ed6bed23fcc8903fea",
       "version": "1.2.2",
       "port-version": 0
     },

--- a/versions/s-/slick-net.json
+++ b/versions/s-/slick-net.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3697c5a0ef76a8bc2a5af8ed6bed23fcc8903fea",
+      "git-tree": "5521a9c944a91e20ac1b9690816b151ecfdad358",
       "version": "1.2.2",
       "port-version": 0
     },

--- a/versions/s-/slick-net.json
+++ b/versions/s-/slick-net.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "16859970d6b98939b948b3ab0551bf462b76f2e1",
+      "version": "1.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ed9ca82290384f7d655b0a8fcbc0ee01dfc13c9c",
       "version": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
