### PR TITLE
[cmocka] Update to 2.0.2

### DIFF
--- a/ports/cmocka/portfile.cmake
+++ b/ports/cmocka/portfile.cmake
@@ -2,15 +2,14 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.com
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cmocka/cmocka
-    REF 672c5cee79eb412025c3dd8b034e611c1f119055
-    SHA512 e02ffe780698ce3930aceb1b927f7d48c932c6bb251a32b1f4ab44ecb4ff6bfe5c2a6b9e2dfede49cd4cc1d68a8bb903ef1d26c28536abf3581a9d803287aa0a
+    REF "cmocka-${VERSION}"
+    SHA512 69d60cf4c40cba56575acb9a32a38649305266179ce33bd079fe9ea8e54498e2c585adc43bdc254579beefc38209c4d0ae622f093ad7acf4946ccaf9dcbba5ee
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DWITH_CMOCKERY_SUPPORT=ON
         -DUNIT_TESTING=OFF
         -DWITH_EXAMPLES=OFF
         -DPICKY_DEVELOPER=OFF
@@ -21,9 +20,8 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/cmocka/vcpkg.json
+++ b/ports/cmocka/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "cmocka",
-  "version-date": "2020-08-01",
-  "port-version": 3,
+  "version": "2.0.2",
   "description": "An elegant unit testing framework for C with support for mock objects",
-  "homepage": "https://cmocka.org/",
+  "homepage": "https://cmocka.org",
   "license": "Apache-2.0",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1845,8 +1845,8 @@
       "port-version": 4
     },
     "cmocka": {
-      "baseline": "2020-08-01",
-      "port-version": 3
+      "baseline": "2.0.2",
+      "port-version": 0
     },
     "cnats": {
       "baseline": "3.12.0",

--- a/versions/c-/cmocka.json
+++ b/versions/c-/cmocka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "338ee594499f4baf5080a799cb93360b69aa359b",
+      "version": "2.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "296011d6dba4e267659df3c55989319334655604",
       "version-date": "2020-08-01",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
