### PR TITLE
[fastcgi] Update to 2.4.7

### DIFF
--- a/ports/fastcgi/portfile.cmake
+++ b/ports/fastcgi/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FastCGI-Archives/fcgi2
-    REF fc8c6547ae38faf9926205a23075c47fbd4370c8
-    SHA512   7f27b1060fbeaf0de9b8a43aa4ff954a004c49e99f7d6ea11119a438fcffe575fb469ba06262e71ac8132f92e74189e2097fd049595a6a61d4d5a5bac2733f7a
+    REF "${VERSION}"
+    SHA512   a8b49fe7d88fa5404ec6f9b9aba59f1c37c479820ba1ed7024260fe2539ff98dae9f71fb7c46192a257401b0eab1ce8cb6b2825286c85a73a33457f8cd9dd926
     HEAD_REF master
     PATCHES
         dll.patch
@@ -32,10 +32,6 @@ file(RENAME "${CURRENT_PACKAGES_DIR}/include2" "${CURRENT_PACKAGES_DIR}/include/
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 vcpkg_fixup_pkgconfig()
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/fcgi.pc" "Version: 2.4.2\n" "Version: 2.4.2\nCflags: -I\"\${prefix}/include/fastcgi\"\n")
-if(NOT VCPKG_BUILD_TYPE)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/fcgi.pc" "Version: 2.4.2\n" "Version: 2.4.2\nCflags: -I\"\${prefix}/../include/fastcgi\"\n")
-endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic" AND VCPKG_TARGET_IS_WINDOWS)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/${PORT}/fcgiapp.h" "ifdef LIBFCGI_DLL_IMPORT" "if 1")
@@ -43,5 +39,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic" AND VCPKG_TARGET_IS_WINDOWS)
 endif()
 vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.TERMS" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fastcgi/vcpkg.json
+++ b/ports/fastcgi/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "fastcgi",
-  "version-date": "2020-09-11",
-  "port-version": 5,
+  "version": "2.4.7",
   "description": "The FastCGI interface combines the best aspects of CGI and vendor APIs. Like CGI, FastCGI applications run in separate, isolated processes.",
-  "homepage": "https://fastcgi-archives.github.io/",
+  "homepage": "https://fastcgi-archives.github.io",
   "license": "OML",
   "supports": "!uwp"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2873,8 +2873,8 @@
       "port-version": 0
     },
     "fastcgi": {
-      "baseline": "2020-09-11",
-      "port-version": 5
+      "baseline": "2.4.7",
+      "port-version": 0
     },
     "fastdds": {
       "baseline": "3.4.1",

--- a/versions/f-/fastcgi.json
+++ b/versions/f-/fastcgi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c982c57e95887c5ac9b47596c1b1895271c49d82",
+      "version": "2.4.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "7aebdd65d1551d946470d43413d5265d409df3e7",
       "version-date": "2020-09-11",
       "port-version": 5


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
