### PR TITLE
[libxfixes] update to 6.0.2

### DIFF
--- a/ports/libxfixes/fix-configure.patch
+++ b/ports/libxfixes/fix-configure.patch
@@ -1,0 +1,21 @@
+diff --git a/Makefile.am b/Makefile.am
+index c626eaa..54252e7 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -37,4 +37,3 @@ ChangeLog:
+ dist-hook: ChangeLog INSTALL
+ 
+ EXTRA_DIST = README.md meson.build
+-ACLOCAL_AMFLAGS = -I m4
+diff --git a/configure.ac b/configure.ac
+index f70529a..8e3be3f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -37,7 +37,6 @@ AC_INIT(libXfixes, [6.0.2],
+ 	[libXfixes])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ # Initialize Automake
+ AM_INIT_AUTOMAKE([foreign dist-xz])

--- a/ports/libxfixes/portfile.cmake
+++ b/ports/libxfixes/portfile.cmake
@@ -3,13 +3,15 @@ if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 else()
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxfixes
-    REF 6fe3bd64dd82f704ed91478acb4c99ab5c00be16 # 6.0.0
-    SHA512  429e65f4183d92cee1380273a23be9bf157bdd19e01e164d8b9058a2a54601af8f4556888302a2cad062c2cfc4b3a37d6b8f5b7ac6bdd6b5c069c7b791422201
+    REPO "lib/libxfixes"
+    REF "libXfixes-${VERSION}"
+    SHA512 262fd84eebd663969a30e765fd78b7a1f39731c17797edfb8795ac63a5fa323ba54b0ff8182f999a6d219df754d09bd980ed531e264b13ef35943a4f71327d1d
     HEAD_REF master
-) 
+    PATCHES
+        fix-configure.patch
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 
@@ -25,5 +27,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 endif()

--- a/ports/libxfixes/vcpkg.json
+++ b/ports/libxfixes/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxfixes",
-  "version": "6.0.0",
+  "version": "6.0.2",
   "description": "Xlib-based library for the XFIXES Extension",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxfixes",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5781,7 +5781,7 @@
       "port-version": 0
     },
     "libxfixes": {
-      "baseline": "6.0.0",
+      "baseline": "6.0.2",
       "port-version": 0
     },
     "libxfont": {

--- a/versions/l-/libxfixes.json
+++ b/versions/l-/libxfixes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb3ffd9210493438267fe6077ceb5dcfe56ebaea",
+      "version": "6.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1f0262e8d5145c540a26a4740b62c84794244586",
       "version": "6.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
