### PR TITLE
[libxi] update to 1.8.2

### DIFF
--- a/ports/libxi/fix-configure.patch
+++ b/ports/libxi/fix-configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index 3351124..1fb3977 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -5,7 +5,6 @@ AC_INIT([libXi], [1.8.2],
+ 	[https://gitlab.freedesktop.org/xorg/lib/libXi/issues], [libXi])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([src/config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ # Initialize Automake
+ AM_INIT_AUTOMAKE([foreign dist-xz])

--- a/ports/libxi/portfile.cmake
+++ b/ports/libxi/portfile.cmake
@@ -4,13 +4,15 @@ if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
 else()
 
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxi
-    REF f24d7f43ab4d97203e60677a3d42e11dbc80c8b4 # 1.8
-    SHA512 bc98d03f1c53f26d0c2063de5a0b58951c9db44dfcfb44519efca89f20c8f8f50599c264d11546357164430f3486dd263742657de426cc7fbb3a306be0bc8866
+    REPO "lib/libxi"
+    REF "libXi-${VERSION}"
+    SHA512 3928777184c89f93182d5d6b0d8e37e0ec797c37c0e73305ac843a8c874c3c1261e37338d61edf526e9ca74120bf6dcc1832760ebe9af2550e9f8279dd2f6f6f
     HEAD_REF master
-) 
+    PATCHES
+        fix-configure.patch
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 
@@ -31,5 +33,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 endif()

--- a/ports/libxi/vcpkg.json
+++ b/ports/libxi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxi",
-  "version": "1.8",
+  "version": "1.8.2",
   "description": "Xlib library for the X Input Extension",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxi",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5793,7 +5793,7 @@
       "port-version": 0
     },
     "libxi": {
-      "baseline": "1.8",
+      "baseline": "1.8.2",
       "port-version": 0
     },
     "libxinerama": {

--- a/versions/l-/libxi.json
+++ b/versions/l-/libxi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "442dac4fd9d10dce6acb891baaef94d2c9f6f313",
+      "version": "1.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "af8e343976780e89ba9aca93f5dafcf3e0dcfecf",
       "version": "1.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
