### PR TITLE
[libserial] add new port

### DIFF
--- a/ports/libserial/portfile.cmake
+++ b/ports/libserial/portfile.cmake
@@ -1,0 +1,36 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO crayzeewulf/libserial
+    REF 50e0f443666d48d7c7e181dc73a6b35700517fae
+    SHA512 205b481b96bfd471804e3a039864221a8e08b40a9fd4681c5dd9433805eb711b782decca5aa7d121c15775646e853f6a7c6ad98d8ffd08d452123c60b3b62368
+    HEAD_REF master
+)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(LIBSERIAL_STATIC OFF)
+    set(LIBSERIAL_SHARED ON)
+else()
+    set(LIBSERIAL_STATIC ON)
+    set(LIBSERIAL_SHARED OFF)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLIBSERIAL_ENABLE_TESTING=OFF
+        -DLIBSERIAL_BUILD_EXAMPLES=OFF
+        -DLIBSERIAL_PYTHON_ENABLE=OFF
+        -DLIBSERIAL_BUILD_DOCS=OFF
+        -DINSTALL_STATIC=${LIBSERIAL_STATIC}
+        -DINSTALL_SHARED=${LIBSERIAL_SHARED}
+)
+vcpkg_cmake_install()
+
+file(REMOVE "${CURRENT_PACKAGES_DIR}/include/libserial/Makefile.am")
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/libserial/vcpkg.json
+++ b/ports/libserial/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libserial",
+  "version-date": "2025-09-03",
+  "description": "Serial Port Programming in C++ ",
+  "homepage": "https://github.com/crayzeewulf/libserial",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/libserial/vcpkg.json
+++ b/ports/libserial/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Serial Port Programming in C++ ",
   "homepage": "https://github.com/crayzeewulf/libserial",
   "license": "BSD-3-Clause",
+  "supports": "linux | osx",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5460,6 +5460,10 @@
       "baseline": "1.3.2",
       "port-version": 1
     },
+    "libserial": {
+      "baseline": "2025-09-03",
+      "port-version": 0
+    },
     "libsersi": {
       "baseline": "0.1.0",
       "port-version": 0

--- a/versions/l-/libserial.json
+++ b/versions/l-/libserial.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "94e163ae37a8b766a1d039de40e5a07a41896f8b",
+      "version-date": "2025-09-03",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libserial.json
+++ b/versions/l-/libserial.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "94e163ae37a8b766a1d039de40e5a07a41896f8b",
+      "git-tree": "610cb4dd475347505038a19d7b626a98f608de56",
       "version-date": "2025-09-03",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/crayzeewulf/libserial