### PR TITLE
[parson] Fix version number

### DIFF
--- a/ports/parson/portfile.cmake
+++ b/ports/parson/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kgabis/parson
-    REF ba29f4eda9ea7703a9f6a9cf2b0532a2605723c3 # accessed on 2023-10-31
+    REF ba29f4eda9ea7703a9f6a9cf2b0532a2605723c3 # See commit message for version number
     SHA512 fdb8c66e9b8966488a22db2e6437d0bfa521c73abc043c7bd18227247fd52de9dd1856dec0d5ebd88f1dacce2493b2c68707b5e16ca4e3032ff6342933f16030
     HEAD_REF master
     PATCHES

--- a/ports/parson/vcpkg.json
+++ b/ports/parson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "parson",
-  "version-date": "2023-10-31",
+  "version": "1.5.3",
   "description": "a lightweight json library written in C",
   "homepage": "https://github.com/kgabis/parson",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7453,7 +7453,7 @@
       "port-version": 0
     },
     "parson": {
-      "baseline": "2023-10-31",
+      "baseline": "1.5.3",
       "port-version": 0
     },
     "pbc": {

--- a/versions/p-/parson.json
+++ b/versions/p-/parson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e39a1ef1c0767255c8bc9fd1f5619d5533e2a8a5",
+      "version": "1.5.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "bdf972c3f23e82b339cf0f57ab65d2a8cd6306e8",
       "version-date": "2023-10-31",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Seems vcpkg is the [only repo](https://repology.org/project/parson/versions) not using this version number
