### PR TITLE
[arcticdb-sparrow] Add version 2.1

### DIFF
--- a/ports/arcticdb-sparrow/portfile.cmake
+++ b/ports/arcticdb-sparrow/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO man-group/sparrow
     REF "${VERSION}"
-    SHA512 d64ce9eb8b99aeae63cfe16187bdf1182039d4c5fcf76f5de9f1863c65d74650fbac7f2f05200e2b5458fa67a4844f6379cb92015fde49b3f9abc2f8ef5183c4
+    SHA512 9076fa8ddf284f54bb94437b4e5242ef3b8ee4b4127512e8f18fe8798d5715a21acc8fe9402ec7dec2f272c0b1a832cb091640fd67b2bcbc4fa2fdc096e6c935
     HEAD_REF main
 )
 

--- a/ports/arcticdb-sparrow/vcpkg.json
+++ b/ports/arcticdb-sparrow/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arcticdb-sparrow",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "C++20 idiomatic APIs for the Apache Arrow Columnar Format",
   "homepage": "https://github.com/man-group/sparrow",
   "license": "Apache-2.0",

--- a/versions/a-/arcticdb-sparrow.json
+++ b/versions/a-/arcticdb-sparrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2190db3660a3f9f46f10ed92b0953b554cc12e23",
+      "version": "2.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "83c19dd145fd82940fc76518ce591a8fc4e4fab8",
       "version": "2.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -209,7 +209,7 @@
       "port-version": 2
     },
     "arcticdb-sparrow": {
-      "baseline": "2.0.0",
+      "baseline": "2.1.0",
       "port-version": 0
     },
     "arcticdb-sparrow-extensions": {


### PR DESCRIPTION
Add version 2.1

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
