### PR TITLE
[sjpeg] Update to 2025-06-04

### DIFF
--- a/ports/sjpeg/portfile.cmake
+++ b/ports/sjpeg/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/sjpeg
-    REF 676de227d75877eb5863ec805ba0a4b97fc2fc6c
-    SHA512 cf9e5a744f79996817679dc2e64be2efd64cbc9bb5f505f5c6530f92d60fe99715c57bcf71e0bb80c77732ace1d71fbf1ff9b4e4ec2562a9576c74a4410c2cb1
+    REF 46da5aec5fce05faabf1facf0066e36e6b1c4dff
+    SHA512 986e57c201a8ff00b01eb25e11b16736050f005cc8f6448ed6ad580234071ee1105408a7d2222715364ec40b3210c2054ae7a96dddf31657390cd3370154d444
     HEAD_REF master
 )
 
@@ -14,6 +14,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSJPEG_BUILD_EXAMPLES=OFF
+        "-DSJPEG_ANDROID_NDK_PATH=$ENV{ANDROID_NDK_HOME}"
 )
 
 vcpkg_cmake_install()
@@ -23,4 +24,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/man")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/sjpeg/vcpkg.json
+++ b/ports/sjpeg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sjpeg",
-  "version-date": "2021-10-31",
+  "version-date": "2025-06-04",
   "description": "Simple library for encoding baseline JPEG files",
   "homepage": "https://github.com/webmproject/sjpeg",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9113,7 +9113,7 @@
       "port-version": 0
     },
     "sjpeg": {
-      "baseline": "2021-10-31",
+      "baseline": "2025-06-04",
       "port-version": 0
     },
     "skcrypter": {

--- a/versions/s-/sjpeg.json
+++ b/versions/s-/sjpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99a41febc0ba01816674a922393e308d246f4b03",
+      "version-date": "2025-06-04",
+      "port-version": 0
+    },
+    {
       "git-tree": "fe20a97b3cdd0a6ad84ca9543670ea61673d1026",
       "version-date": "2021-10-31",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
