### PR TITLE
[xtensor-blas] Update to 0.23.0

### DIFF
--- a/ports/xtensor-blas/portfile.cmake
+++ b/ports/xtensor-blas/portfile.cmake
@@ -4,30 +4,31 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xtensor-blas
     REF "${VERSION}"
-    SHA512 d20d97e655de7e54415e174cfa8f99fe95f755af46e00160fa3c613b079003c113fbf137ec88991443cab30dac1ff1b28675183ade348221d00955f0fad31188
+    SHA512 4fcc5e485a2ddd9fee48dda75a38b976355c40a5e4722d4bc1e9fefa231c6c38f97afffeaef510c6c2290cf1f29cbbae889a131d121278055d23374d72d09712
     HEAD_REF master
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
-    OPTIONS_RELEASE -DCXXBLAS_DEBUG=OFF
-    OPTIONS_DEBUG -DCXXBLAS_DEBUG=ON
+    OPTIONS_RELEASE
+        -DCXXBLAS_DEBUG=OFF
+    OPTIONS_DEBUG
+        -DCXXBLAS_DEBUG=ON
     OPTIONS
         -DXTENSOR_USE_FLENS_BLAS=OFF
         -DBUILD_TESTS=OFF
         -DBUILD_BENCHMARK=OFF
-        -DDOWNLOAD_GTEST=OFF
-        -DDOWNLOAD_GBENCHMARK=OFF
 )
 
 vcpkg_cmake_install()
 
 file(REMOVE "${CURRENT_PACKAGES_DIR}/include/xtensor-blas/xblas_config_cling.hpp")
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/xflens/cxxblas/netlib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/xtensor-blas/vcpkg.json
+++ b/ports/xtensor-blas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xtensor-blas",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "BLAS extension to xtensor",
   "homepage": "https://github.com/xtensor-stack/xtensor-blas",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10825,7 +10825,7 @@
       "port-version": 0
     },
     "xtensor-blas": {
-      "baseline": "0.22.0",
+      "baseline": "0.23.0",
       "port-version": 0
     },
     "xtensor-fftw": {

--- a/versions/x-/xtensor-blas.json
+++ b/versions/x-/xtensor-blas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92c0a435f6acf643bdcd1a8a621c6bf7ec974412",
+      "version": "0.23.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "12537e071589d4b31097eaf455cdf9d5ac6976e0",
       "version": "0.22.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
