### PR TITLE
[xtensor-fftw] Update to 0.2.6

### DIFF
--- a/ports/xtensor-fftw/portfile.cmake
+++ b/ports/xtensor-fftw/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xtensor-fftw
-    REF 29f0442c98f1a219e970c96e99d7be8a42954a0b
-    SHA512 09b02fe6b906cde2a7f9071673a140c994316d50aaf639eb402706aaa52b66e73bc77fa1beb683d3740914ff5157283891634a806809c03f12c1def85b49595a
+    REF "${VERSION}"
+    SHA512 278676eb92767677622bac961b65be599804ea86eba4df4cd72f237f9c9f8f2d20b7daec045bde6c09d7c72e29f5c5e01e6abda7350ac706543f34434c8d40f2
     HEAD_REF master
 )
 
@@ -23,10 +23,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_fixup_pkgconfig()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/xtensor-fftw/vcpkg.json
+++ b/ports/xtensor-fftw/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "xtensor-fftw",
-  "version-date": "2019-11-30",
-  "port-version": 4,
+  "version": "0.2.6",
   "description": "FFTW bindings for the xtensor C++14 multi-dimensional array library",
   "homepage": "https://github.com/xtensor-stack/xtensor-fftw",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10829,8 +10829,8 @@
       "port-version": 0
     },
     "xtensor-fftw": {
-      "baseline": "2019-11-30",
-      "port-version": 4
+      "baseline": "0.2.6",
+      "port-version": 0
     },
     "xtensor-io": {
       "baseline": "0.13.0",

--- a/versions/x-/xtensor-fftw.json
+++ b/versions/x-/xtensor-fftw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02f73d323d3c7618c488972dde094fae5402d4e9",
+      "version": "0.2.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "8f535672e2935cbbf33bd2a3f332d3a100cf6a4a",
       "version-date": "2019-11-30",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
