### PR TITLE
[coin-or-clp] Update to 1.17.10

### DIFF
--- a/ports/coin-or-clp/dep.patch
+++ b/ports/coin-or-clp/dep.patch
@@ -1,31 +1,35 @@
 diff --git a/configure.ac b/configure.ac
-index a3f2fb9c4..e6f53f26c 100644
+index d0f9e15f..5c5b74b6 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -16,6 +16,8 @@ All Rights Reserved.
- This file is part of the open source package Clp which is distributed
- under the Eclipse Public License.])
+@@ -22,6 +22,8 @@ under the Eclipse Public License.])
+ 
+ AC_REVISION(0.9)
  
 +AC_CONFIG_MACRO_DIR([m4])
 +
  # List one file in the package so that the configure script can test
- # whether the package is actually there.
- AC_CONFIG_SRCDIR(src/ClpSimplex.cpp)
-@@ -63,7 +63,7 @@ AC_COIN_CHK_PKG(Osi,[OsiClpLib OsiClpUnitTest])
- AC_COIN_CHK_PKG(OsiTests,[OsiClpUnitTest],[osi-unittests])
- AC_COIN_CHK_PKG(Sample,,[coindatasample],[],dataonly)
- AC_COIN_CHK_PKG(Netlib,,[coindatanetlib],[],dataonly)
--AC_COIN_CHK_PKG(Glpk,[ClpLib],[coinglpk])
-+AC_COIN_CHK_PKG(Glpk,[ClpLib],[glpk])
+ # whether the package is actually there
+ AC_CONFIG_SRCDIR(configure.ac)
+diff --git a/Clp/configure.ac b/Clp/configure.ac
+index dca9dd7d..e34be283 100644
+--- a/Clp/configure.ac
++++ b/Clp/configure.ac
+@@ -108,7 +108,7 @@ LIBS="$coin_save_LIBS"
  
- #############################################################################
- #                                    Aboca                                  #
-@@ -96,7 +96,7 @@ AC_COIN_CHK_LIBHDR(CHOLMOD,[ClpLib],[-lcholmod],[-I/usr/include/suitesparse],[],
- # bothered to build it, we should use it. If it's not present, try for a
- # system installation. If we find it, define CLP_HAS_MUMPS for export to code
- # using clp.
--AC_COIN_CHK_PKG(MUMPS,[ClpLib],[coinmumps])
-+AC_COIN_CHK_PKG(MUMPS,[ClpLib],[mumps])
- if test $coin_has_mumps = no ; then
-   AC_COIN_CHK_LIBHDR(MUMPS,[ClpLib],[-ldmumps],[-I/usr/include/MUMPS],[],
-     [dmumps_c((DMUMPS_STRUC_C*)0)],
+ # Glpk also brings AMD
+ if test $coin_has_cholmod = false -a $coin_has_amd = false ; then
+-  AC_COIN_CHECK_PACKAGE(Glpk, [coinglpk], [ClpLib])
++  AC_COIN_CHECK_PACKAGE(Glpk, [glpk], [ClpLib])
+   if test $coin_has_glpk = yes ; then
+     AC_MSG_NOTICE([using AMD from GLPK package])
+     AC_DEFINE(COIN_HAS_AMD,[1],[Define to 1 if the AMD package is available])
+@@ -119,7 +119,7 @@ else
+ fi
+ 
+ # MUMPS
+-AC_COIN_CHECK_PACKAGE(Mumps, [coinmumps], [ClpLib])
++AC_COIN_CHECK_PACKAGE(Mumps, [mumps], [ClpLib])
+ 
+ # WSMP
+ AC_ARG_WITH([wsmp],

--- a/ports/coin-or-clp/portfile.cmake
+++ b/ports/coin-or-clp/portfile.cmake
@@ -1,9 +1,10 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO coin-or/Clp
-    REF 5315ef2e93f5f532a600e16ab604ac439a416e59
-    SHA512 78dc8f562e7c1bff3e86c81eda4eda9780a4075921bcdd2338191f37820699baee94eec86b6f63b1b27e5bca7346a2611d669a7cdf3e47e1c032b072ca10bdab
-    PATCHES dep.patch
+    REF 5c9a9ee60e7c0bdd1e62c6b974484ddee5755bc8 # Parent revision of release, as the release commit is not part of the official repo
+    SHA512 594ff9dbfb50c9c9bfed9b153170a555350178a710f4c5c2e64e854473372b1ffa1cc4dd47cfdf3e4866f7e3c6752d1d17a09d84efbac7793430bd89ebc286bc
+    PATCHES
+        dep.patch
 )
 
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SOURCE_PATH}")
@@ -36,4 +37,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/coin-or/ClpModel.hpp" "\"glpk.h\"" "\"../glpk.h\"")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/coin-or-clp/vcpkg.json
+++ b/ports/coin-or-clp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "coin-or-clp",
-  "version-date": "2023-02-01",
-  "port-version": 1,
+  "version": "1.17.10",
   "description": "Clp (Coin-or linear programming) is an open-source linear programming solver written in C++. It is primarily meant to be used as a callable library, but a basic, stand-alone executable version is also available.",
   "license": "EPL-2.0",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1897,8 +1897,8 @@
       "port-version": 1
     },
     "coin-or-clp": {
-      "baseline": "2023-02-01",
-      "port-version": 1
+      "baseline": "1.17.10",
+      "port-version": 0
     },
     "coin-or-ipopt": {
       "baseline": "2023-02-01",

--- a/versions/c-/coin-or-clp.json
+++ b/versions/c-/coin-or-clp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2d37e85eac48bd8c96ce61765b83318fb0b6eff",
+      "version": "1.17.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d85c9aa311204d69278ce481b9c008e417298cd",
       "version-date": "2023-02-01",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
