### PR TITLE
[faudio] Update to 26.01

### DIFF
--- a/ports/faudio/portfile.cmake
+++ b/ports/faudio/portfile.cmake
@@ -1,8 +1,11 @@
+# FAudio uses calender versioning (e.g., 26.01), but vcpkg drops them in versions
+string(REGEX REPLACE "^([0-9]+)\\.([1-9])$" "\\1.0\\2" FAUDIO_REF "${VERSION}")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FNA-XNA/faudio
-    REF "${VERSION}"
-    SHA512 2d9f7c93bc6d82934765d2e1468ce4facbe0396cf7905dca4de4b178cf5eabcb0535a8380d27c40bb8f5c72473e1a8af4791dd81931571102c333dcbd44cbdc2
+    REF "${FAUDIO_REF}"
+    SHA512 004567c6339ce006afbf19c44ee88e4fab8bfcd7b3e50b25058569584cd0caa891aeaf7087089bafabd646e9739ccc036f984f9f0fb271ba154406e1d30eb2e1
     HEAD_REF master
 )
 

--- a/ports/faudio/vcpkg.json
+++ b/ports/faudio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "faudio",
-  "version": "25.12",
+  "version": "26.1",
   "description": "FAudio - accuracy-focused XAudio reimplementation for open platforms",
   "homepage": "https://fna-xna.github.io/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2909,7 +2909,7 @@
       "port-version": 0
     },
     "faudio": {
-      "baseline": "25.12",
+      "baseline": "26.1",
       "port-version": 0
     },
     "fawdlstty-libfv": {

--- a/versions/f-/faudio.json
+++ b/versions/f-/faudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c1b1d3985adfa8386a97466d7b61cd5857d23867",
+      "version": "26.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "df61870ba2a02909ddb97ea48d4475d7c4d4da92",
       "version": "25.12",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.