### PR TITLE
[pffft] Update to 1.0.0

### DIFF
--- a/ports/pffft/fix-invalid-command.patch
+++ b/ports/pffft/fix-invalid-command.patch
@@ -1,9 +1,9 @@
 diff --git a/pffft.c b/pffft.c
-index d12f572..7cc0546 100644
+index ad905fd..df6ed31 100644
 --- a/pffft.c
 +++ b/pffft.c
-@@ -173,7 +173,11 @@ typedef float32x4_t v4sf;
- #  define VALIGNED(ptr) ((((long long)(ptr)) & 0x3) == 0)
+@@ -192,7 +192,11 @@ typedef float32x4_t v4sf;
+ #  define VALIGNED(ptr) ((((size_t)(ptr)) & 0x3) == 0)
  #else
  #  if !defined(PFFFT_SIMD_DISABLE)
 -#    warning "building with simd disabled !\n";

--- a/ports/pffft/portfile.cmake
+++ b/ports/pffft/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_bitbucket(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jpommier/pffft
-    REF ed78751d751e51bbd94c41d24f748b400f272d69
-    SHA512 44f65c7f7e5b71f549dca2e03d58b1fd64e698858f79e4c2833a9ae3dff8a835cf9d5e14be2341c6370f800012cb69b05b9226d6918b12e67f7f7e81ed8e9ad4
+    REF "v${VERSION}"
+    SHA512 074c7a60ee99acddc6e04c7653b9585c6a306b4a1f05a553191021ae1916fff31cc1291ff24fd53cc1988b26142b704f9319df636af1f99a5df0099d5157eba0
     HEAD_REF master
     PATCHES
         fix-invalid-command.patch

--- a/ports/pffft/vcpkg.json
+++ b/ports/pffft/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pffft",
-  "version-date": "2021-10-09",
-  "port-version": 1,
+  "version": "1.0.0",
   "description": "PFFFT, a pretty fast Fourier Transform.",
   "homepage": "https://bitbucket.org/jpommier/pffft/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7521,8 +7521,8 @@
       "port-version": 0
     },
     "pffft": {
-      "baseline": "2021-10-09",
-      "port-version": 1
+      "baseline": "1.0.0",
+      "port-version": 0
     },
     "pfring": {
       "baseline": "8.8.0",

--- a/versions/p-/pffft.json
+++ b/versions/p-/pffft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b49d36ae42997eec99adcbdb4b74064e7acac538",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "525bc1ec4fd9aa77feeaba44fc6f0cf717716ae1",
       "version-date": "2021-10-09",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
