### PR TITLE
[poselib] Update to 2.0.5

### DIFF
--- a/ports/poselib/fatal-errors.patch
+++ b/ports/poselib/fatal-errors.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 77df6c1..2391b20 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,7 +8,7 @@ if(MSVC)
+ 	target_compile_options(${build_target} PRIVATE /bigobj /fp:fast)
+ else()
+ 	target_compile_options(${build_target} PRIVATE
+-		-O3 -Wall -Werror -fPIC -Wno-sign-compare -Wfatal-errors)
++		-O3 -Wall -fPIC -Wno-sign-compare)
+ 	if(MARCH_NATIVE)
+ 		target_compile_options(${build_target} PRIVATE -march=native)
+ 	endif()

--- a/ports/poselib/portfile.cmake
+++ b/ports/poselib/portfile.cmake
@@ -6,8 +6,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PoseLib/PoseLib
     REF "v${VERSION}"
-    SHA512 adc43c4f0fd8544d2c7ef05538696a8ae614837f5e90c31b8b9c8f4b5a11eb773229c22444e01482de697a0f5b3137d4a63a24ba9fcc72b366a347252d3c16b1
+    SHA512 ed56d8cd6a3073776edbfe9d11e2ebf8e2bed4065f7f53a02541323c1631632bf6c161d305fc09674175351b024bf019211dfa9d7a48e74e3c5563941099f1ef
     HEAD_REF master
+    PATCHES
+        fatal-errors.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/poselib/vcpkg.json
+++ b/ports/poselib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "poselib",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Minimal solvers for calibrated camera pose estimation",
   "homepage": "https://github.com/PoseLib/PoseLib",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7741,7 +7741,7 @@
       "port-version": 0
     },
     "poselib": {
-      "baseline": "2.0.4",
+      "baseline": "2.0.5",
       "port-version": 0
     },
     "ppconsul": {

--- a/versions/p-/poselib.json
+++ b/versions/p-/poselib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39df61afaabfa902d11687df1b6996b2006ac8c9",
+      "version": "2.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "adf31292beb503a1ff13f6ecffd2697c0f56bbe2",
       "version": "2.0.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
