### PR TITLE
[rest-rpc] Update to 0.21

### DIFF
--- a/ports/rest-rpc/portfile.cmake
+++ b/ports/rest-rpc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO qicosmos/rest_rpc
     REF "v${VERSION}"
-    SHA512 1d88085acc6c4f913901631725acd08a688a079878677d064d441c3c89167275c5eed371d24e370feb88879ac06270e9316b91c67ea41e350523fe670406ecc1
+    SHA512 59c9ca70ae53809b2710cc83c7a338a05d9bc76840def7786ee940f9a3cc03c88040a7b721980114d231042608dab23d6061cbc5ebe4dcda984989beec056eda
     HEAD_REF master
 )
 
@@ -12,8 +12,8 @@ file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/incl
 
 vcpkg_replace_string(
     "${CURRENT_PACKAGES_DIR}/include/rest_rpc.hpp"
-    "#include \"rest_rpc/rpc_server.h\""
-    "#define ASIO_STANDALONE\n#include \"rest_rpc/rpc_server.h\""
+    "#include \"rest_rpc/rpc_server.hpp\""
+    "#define ASIO_STANDALONE\n#include \"rest_rpc/rpc_server.hpp\""
 )
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-rest-rpc-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-rest-rpc-config")

--- a/ports/rest-rpc/vcpkg.json
+++ b/ports/rest-rpc/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "rest-rpc",
-  "version": "0.12",
-  "port-version": 1,
+  "version": "0.21",
   "description": "c++11, high performance, cross platform, easy to use rpc framework",
   "homepage": "https://github.com/qicosmos/rest_rpc",
+  "license": "MIT",
   "dependencies": [
     "asio",
     "msgpack"

--- a/scripts/test_ports/vcpkg-ci-rest-rpc/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-rest-rpc/project/CMakeLists.txt
@@ -1,9 +1,5 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.12)
 project(soci-test CXX)
-
-if(APPLE)
-    set(CMAKE_CXX_STANDARD 11)
-endif()
 
 add_executable(main main.cpp)
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8557,8 +8557,8 @@
       "port-version": 0
     },
     "rest-rpc": {
-      "baseline": "0.12",
-      "port-version": 1
+      "baseline": "0.21",
+      "port-version": 0
     },
     "restbed": {
       "baseline": "4.8",

--- a/versions/r-/rest-rpc.json
+++ b/versions/r-/rest-rpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "83dc3d4be49ab0811b86becdc6a0bb92183c0828",
+      "version": "0.21",
+      "port-version": 0
+    },
+    {
       "git-tree": "e119fcd580545a243afd65efb7160242a2b02b73",
       "version": "0.12",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Note: Updated test port, as the port now requires C++20 and this requires [CMake 3.12](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html).
