### PR TITLE
[libxrandr] update to 1.5.4

### DIFF
--- a/ports/libxrandr/fix-configure.patch
+++ b/ports/libxrandr/fix-configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index 99e3944..d6e6159 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -34,7 +34,6 @@ AC_INIT([libXrandr], [1.5.4],
+         [libXrandr])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ # Initialize Automake
+ AM_INIT_AUTOMAKE([foreign dist-xz])

--- a/ports/libxrandr/portfile.cmake
+++ b/ports/libxrandr/portfile.cmake
@@ -4,13 +4,15 @@ if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
 else()
 
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxrandr
-    REF 55dcda4518eda8ae03ef25ea29d3c994ad71eb0a # 1.5.2
-    SHA512  63a3a7c5db8d41c73ef2f55e86a47bdae0112ac39802efa5da4fa26a8794066d6906d4a5e4e9af5abb5838a061f2583dc2b8865e38754ee3f2a8e3918de87168
+    REPO "lib/libxrandr"
+    REF "libXrandr-${VERSION}"
+    SHA512 50b92b5c62ced66418381d816f6b61d9d3eb7e7b2794f7b2c58b263875ff6001a57e1750e32b9317a0d5e3e311bf0657156dfe5b4875d863499583b25b700b68
     HEAD_REF master
-) 
+    PATCHES
+        fix-configure.patch
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 
@@ -31,5 +33,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 endif()

--- a/ports/libxrandr/vcpkg.json
+++ b/ports/libxrandr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxrandr",
-  "version": "1.5.2",
+  "version": "1.5.4",
   "description": "Xlib Resize, Rotate and Reflection (RandR) extension library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxrandr",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5849,7 +5849,7 @@
       "port-version": 0
     },
     "libxrandr": {
-      "baseline": "1.5.2",
+      "baseline": "1.5.4",
       "port-version": 0
     },
     "libxrender": {

--- a/versions/l-/libxrandr.json
+++ b/versions/l-/libxrandr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "db25e01ef34386e8dd199536c1eafe7ad6118dd5",
+      "version": "1.5.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "a2319ebdf2506031a67829f725660eba807869cc",
       "version": "1.5.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
