### PR TITLE
[libxrender] update to 0.9.12

### DIFF
--- a/ports/libxrender/fix-configure.patch
+++ b/ports/libxrender/fix-configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index 6bc1c90..28e1ac5 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -34,7 +34,6 @@ AC_INIT(libXrender, [0.9.12],
+ 	[libXrender])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ PACKAGE_BRIEF="Library for the Render Extension to the X11 protocol"
+ AC_SUBST(PACKAGE_BRIEF)

--- a/ports/libxrender/portfile.cmake
+++ b/ports/libxrender/portfile.cmake
@@ -4,12 +4,14 @@ if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
 else()
 
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxrender
-    REF  845716f8f14963d338e5a8d5d2424baafc90fb30 # 0.9.10
-    SHA512  a7e8d383a8400d63eb726b741cd25a1e9e671c7eadef04beddc4e31fec59b384ae4fa3f305e62a2aecbaedffc76c7b0626f525ec8634c9940a29de058e4a653c
+    REPO "lib/libxrender"
+    REF "libXrender-${VERSION}"
+    SHA512 681ddad409bf9a16810a43cca9fde22a352310acb7262a5d634b05f235e51ca8e6023a8874110eb97b5f00c87a7a2466f4d8a6afcf0321fc3c4f3c0676d516a6
     HEAD_REF master
+    PATCHES
+        fix-configure.patch
 )
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
@@ -31,5 +33,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 endif()

--- a/ports/libxrender/vcpkg.json
+++ b/ports/libxrender/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxrender",
-  "version": "0.9.10",
+  "version": "0.9.12",
   "description": "library for the Render Extension to the X11 protocol",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxrender",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5853,7 +5853,7 @@
       "port-version": 0
     },
     "libxrender": {
-      "baseline": "0.9.10",
+      "baseline": "0.9.12",
       "port-version": 0
     },
     "libxres": {

--- a/versions/l-/libxrender.json
+++ b/versions/l-/libxrender.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb43ffc694025be4dc92beff6c3a7d43780a4b53",
+      "version": "0.9.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "f0ef5b766bea2ae48efec7303a59faefdbb0bb96",
       "version": "0.9.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
