### PR TITLE
[libxtst] update to 1.2.5

### DIFF
--- a/ports/libxtst/fix-configure.patch
+++ b/ports/libxtst/fix-configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index e0d2256..6113dfd 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -26,7 +26,6 @@ AC_INIT([libXtst], [1.2.5],
+ 	[https://gitlab.freedesktop.org/xorg/lib/libxtst/-/issues], [libXtst])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ # Initialize Automake
+ AM_INIT_AUTOMAKE([foreign dist-xz])

--- a/ports/libxtst/portfile.cmake
+++ b/ports/libxtst/portfile.cmake
@@ -4,13 +4,15 @@ if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
 else()
 
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxtst
-    REF 99b89c3bcb0ebb0b6dd86bfdc9d276715eaea889 
-    SHA512  6479294057c73e91a086891e461e98d2717ae1fbe746cd74c9d13036a59bce931b8b0d5293d3c5ab4feeea426f2297647335179997e06a040b847697c7557199
+    REPO "lib/libxtst"
+    REF "libXtst-${VERSION}"
+    SHA512 d48df671f212a1784ef1aefe69b16bc42395ff4ae083b7087dc55827fa6f8635b17adb5e26d976c8f8c7f02aeeb51f66c9808a037ef783c44139483c1c76ce3e
     HEAD_REF master
-) 
+    PATCHES
+        fix-configure.patch
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 
@@ -26,5 +28,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
 endif()

--- a/ports/libxtst/vcpkg.json
+++ b/ports/libxtst/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxtst",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Xlib-based library for XTEST & RECORD extensions",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxtst",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5873,7 +5873,7 @@
       "port-version": 0
     },
     "libxtst": {
-      "baseline": "1.2.4",
+      "baseline": "1.2.5",
       "port-version": 0
     },
     "libxv": {

--- a/versions/l-/libxtst.json
+++ b/versions/l-/libxtst.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9494732c1aa47be37810d1a22b1faa566b7a8d4b",
+      "version": "1.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "8b2a80b040031d2b2c9952e885bc68884f13c099",
       "version": "1.2.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
