### PR TITLE
[xcb-util-m4] update to 2022-07-01

### DIFF
--- a/ports/xcb-util-m4/portfile.cmake
+++ b/ports/xcb-util-m4/portfile.cmake
@@ -1,13 +1,13 @@
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
 vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO util/xcb-util-m4
-    REF  f662e3a93ebdec3d1c9374382dcc070093a42fed #v1.19.2
-    SHA512 29840da449a434f169437fd2cef78273e0cba00a7f76d48790c838dc8f40fe55cb0932d96b649e1bd066c6c5e257dd2d9d71c663ce100aa5ca25a2ccec1b7e77
+    REPO "util/xcb-util-m4"
+    REF c617eee22ae5c285e79e81ec39ce96862fd3262f
+    SHA512 d2d977574a106ca59207988e3e4ec12ecbcf30852df46456f7ec5284983e49f31ee85025f404d863f8e3d766f193e6a79508f26a3dcd33173d7bbefccdb279fa
     HEAD_REF master
-) 
+)
 
 file(GLOB_RECURSE M4_FILES "${SOURCE_PATH}/*.m4")
 file(INSTALL ${M4_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/share/xorg/aclocal")

--- a/ports/xcb-util-m4/vcpkg.json
+++ b/ports/xcb-util-m4/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xcb-util-m4",
-  "version-date": "2022-01-24",
+  "version-date": "2022-07-01",
   "description": "GNU autoconf macros shared across XCB projects",
   "homepage": "https://gitlab.freedesktop.org/xorg/util/xcb-util-m4",
   "license": null

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10765,7 +10765,7 @@
       "port-version": 1
     },
     "xcb-util-m4": {
-      "baseline": "2022-01-24",
+      "baseline": "2022-07-01",
       "port-version": 0
     },
     "xcb-util-wm": {

--- a/versions/x-/xcb-util-m4.json
+++ b/versions/x-/xcb-util-m4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a249da5d1ea1ea6d2074cd48217741bec244acf",
+      "version-date": "2022-07-01",
+      "port-version": 0
+    },
+    {
       "git-tree": "3d9a0f48392c4845b152c9dfdfa702f9f0a932d9",
       "version-date": "2022-01-24",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
