### PR TITLE
[goldy] Add new port

### DIFF
--- a/ports/goldy/goldy-config.cmake
+++ b/ports/goldy/goldy-config.cmake
@@ -1,0 +1,22 @@
+include(CMakeFindDependencyMacro)
+
+if(NOT TARGET goldy::goldy)
+    add_library(goldy::goldy INTERFACE IMPORTED)
+    
+    get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)
+    
+    set_target_properties(goldy::goldy PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+    )
+    
+    if(WIN32)
+        set_target_properties(goldy::goldy PROPERTIES
+            INTERFACE_LINK_LIBRARIES "${_IMPORT_PREFIX}/lib/goldy_ffi.lib"
+        )
+    else()
+        find_library(_GOLDY_FFI_LIB goldy_ffi PATHS "${_IMPORT_PREFIX}/lib" NO_DEFAULT_PATH)
+        set_target_properties(goldy::goldy PROPERTIES
+            INTERFACE_LINK_LIBRARIES "${_GOLDY_FFI_LIB}"
+        )
+    endif()
+endif()

--- a/ports/goldy/portfile.cmake
+++ b/ports/goldy/portfile.cmake
@@ -1,0 +1,85 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO koubaa/goldy
+    REF "v${VERSION}"
+    SHA512 8ff9ac74d796cc5ac4660232cf55edda9f848aca4fd565e59d4e6a90c3d2c1ced444b96aa4f2ab4cfe300049eda5aaa275238ba4e7c341771ef3c8b723df79a0
+    HEAD_REF main
+)
+
+# Download pre-built native library for target platform
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    vcpkg_download_distfile(GOLDY_FFI_ARCHIVE
+        URLS "https://github.com/koubaa/goldy/releases/download/v${VERSION}/goldy_ffi-windows-x64.zip"
+        FILENAME "goldy_ffi-${VERSION}-windows-x64.zip"
+        SHA512 15142e06536046d4f2768c95256471efb8c0cb1b52a905f34aaab9636d5f98139b7a038afeace680879298695dfe952061a404eb7da5ef6999f65b8317455ef9
+    )
+elseif(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    vcpkg_download_distfile(GOLDY_FFI_ARCHIVE
+        URLS "https://github.com/koubaa/goldy/releases/download/v${VERSION}/goldy_ffi-linux-x64.tar.gz"
+        FILENAME "goldy_ffi-${VERSION}-linux-x64.tar.gz"
+        SHA512 ebc70ffdc0895ed8755a5e475d0e06e91114998e0dab1a6a2db4f909a1b606a3b6c150e9325a23ff498a3d82c67ff7e433fe5524399bbbb4e4308f2969ac527f
+    )
+elseif(VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    vcpkg_download_distfile(GOLDY_FFI_ARCHIVE
+        URLS "https://github.com/koubaa/goldy/releases/download/v${VERSION}/goldy_ffi-macos-x64.tar.gz"
+        FILENAME "goldy_ffi-${VERSION}-macos-x64.tar.gz"
+        SHA512 416ad1957f96fb7a9e6a5a0711ae58e75c0658f8f84014797b041b482698b4780fd422ffcd515e46796395a69400ece2487ff2225b7df729959c87b05da826e1
+    )
+elseif(VCPKG_TARGET_IS_OSX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    vcpkg_download_distfile(GOLDY_FFI_ARCHIVE
+        URLS "https://github.com/koubaa/goldy/releases/download/v${VERSION}/goldy_ffi-macos-arm64.tar.gz"
+        FILENAME "goldy_ffi-${VERSION}-macos-arm64.tar.gz"
+        SHA512 7451fb6cbec47f869c295db480a2d9f32a064e0602e40cc8b9742543e78fccf35fae542e24d883b0ea632d803cc2789a120dfe880ca84e806b5f0091edf5007a
+    )
+else()
+    message(FATAL_ERROR "Unsupported platform: ${VCPKG_TARGET_TRIPLET}")
+endif()
+
+vcpkg_extract_source_archive(
+    BINARY_PATH
+    ARCHIVE "${GOLDY_FFI_ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
+)
+
+# Install headers
+file(INSTALL "${SOURCE_PATH}/cpp/include/goldy.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(INSTALL "${SOURCE_PATH}/cpp/include/goldy.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+# Install native library
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(INSTALL "${BINARY_PATH}/lib/goldy_ffi.dll"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(INSTALL "${BINARY_PATH}/lib/goldy_ffi.dll.lib"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/lib"
+         RENAME "goldy_ffi.lib")
+    
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib")
+    file(INSTALL "${BINARY_PATH}/lib/goldy_ffi.dll"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(INSTALL "${BINARY_PATH}/lib/goldy_ffi.dll.lib"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib"
+         RENAME "goldy_ffi.lib")
+elseif(VCPKG_TARGET_IS_LINUX)
+    file(INSTALL "${BINARY_PATH}/lib/libgoldy_ffi.so"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib")
+    file(INSTALL "${BINARY_PATH}/lib/libgoldy_ffi.so"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+elseif(VCPKG_TARGET_IS_OSX)
+    file(INSTALL "${BINARY_PATH}/lib/libgoldy_ffi.dylib"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib")
+    file(INSTALL "${BINARY_PATH}/lib/libgoldy_ffi.dylib"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+endif()
+
+# Install CMake config and usage
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/goldy-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/goldy/usage
+++ b/ports/goldy/usage
@@ -1,0 +1,11 @@
+The package goldy provides CMake targets:
+
+    find_package(goldy CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE goldy::goldy)
+
+Include the headers:
+    #include <goldy.hpp>  // C++ RAII wrapper
+    #include <goldy.h>    // C API
+
+Note: goldy_ffi.dll must be in your PATH or next to your executable at runtime.
+The Slang compiler (slang.dll) is also required at runtime (from Vulkan SDK).

--- a/ports/goldy/vcpkg.json
+++ b/ports/goldy/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "goldy",
+  "version": "0.1.0",
+  "description": "Modern GPU library with Slang shader support",
+  "homepage": "https://github.com/koubaa/goldy",
+  "license": "MIT",
+  "supports": "!(static & staticcrt) & !uwp & ((x64 & (windows | linux)) | osx)",
+  "features": {
+    "examples": {
+      "description": "Build example programs"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3432,6 +3432,10 @@
       "baseline": "4.4",
       "port-version": 0
     },
+    "goldy": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "google-cloud-cpp": {
       "baseline": "2.37.0",
       "port-version": 0

--- a/versions/g-/goldy.json
+++ b/versions/g-/goldy.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e79add5844a325c6d5173a02a2e8c05dc5f5691a",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Add new port for **Goldy**, a modern GPU library with Slang shader support.

- **Homepage**: https://github.com/koubaa/goldy
- **License**: MIT
- **Version**: 0.1.0

## Architecture

Goldy provides:
- **Header-only C++ wrapper** (`goldy.hpp`) - built from source, full C++ ABI compatibility
- **Pre-built native library** (`goldy_ffi`) - C ABI, downloaded as binary

This follows the standard pattern for C++ packages wrapping native libraries with stable C ABI (similar to CUDA, Vulkan SDK, Intel MKL).

## Supported Platforms

| Platform | Architecture |
|----------|--------------|
| Windows  | x64          |
| Linux    | x64          |
| macOS    | x64, ARM64   |

## Checklist

- [x] Port builds successfully (`vcpkg install goldy`)
- [x] `vcpkg x-add-version` run
- [x] License file included
- [x] vcpkg.json formatted