### PR TITLE
[gmp] Fix build failure by forcing Autoconf 2.71 on Windows

### DIFF
--- a/ports/gmp/portfile.cmake
+++ b/ports/gmp/portfile.cmake
@@ -89,9 +89,7 @@ vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
     ADDITIONAL_MSYS_PACKAGES
-        DIRECT_PACKAGES
-            "https://mirror.msys2.org/msys/x86_64/autoconf2.71-2.71-3-any.pkg.tar.zst"
-            dd312c428b2e19afd00899eb53ea4255794dea4c19d1d6dea2419cb6a54209ea2130d48abbc20af12196b9f628143436f736fbf889809c2c2291be0c69c0e306
+        autoconf2.71
     OPTIONS
         ${OPTIONS}
         --enable-cxx

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -276,7 +276,7 @@ macro(z_vcpkg_acquire_msys_declare_all_packages)
         URL "https://mirror.msys2.org/msys/x86_64/autoconf-wrapper-20250528-1-any.pkg.tar.zst"
         SHA512 a25b4d2a239bce094e6d4019d943c8381df92e3f982464f01cdb6fd79a449094ba44e0e45032270bd0f9e6c98cdaf0ab3560fc97084aaaeb708812297ee62996
         PROVIDES autoconf
-        DEPS autoconf2.72 bash sed
+        DEPS autoconf2.72 autoconf2.71 bash sed
     )
     z_vcpkg_acquire_msys_declare_package(
         URL "https://mirror.msys2.org/msys/x86_64/autoconf2.72-2.72-3-any.pkg.tar.zst"

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -284,6 +284,11 @@ macro(z_vcpkg_acquire_msys_declare_all_packages)
         DEPS awk bash diffutils m4 perl sed
     )
     z_vcpkg_acquire_msys_declare_package(
+        URL "https://mirror.msys2.org/msys/x86_64/autoconf2.71-2.71-3-any.pkg.tar.zst"
+        SHA512 dd312c428b2e19afd00899eb53ea4255794dea4c19d1d6dea2419cb6a54209ea2130d48abbc20af12196b9f628143436f736fbf889809c2c2291be0c69c0e306
+        DEPS awk bash diffutils m4 perl sed
+    )
+    z_vcpkg_acquire_msys_declare_package(
         URL "https://mirror.msys2.org/msys/x86_64/autoconf-archive-2024.10.16-1-any.pkg.tar.zst"
         SHA512 bb7a1a14d5e291da646c00e0bcc6663500c9c0ac00079a88d06956fa2e37749c3c2431cba647e41ce3840f323b73198ea0cf54e07014ac2345de47e7069d0581
     )


### PR DESCRIPTION
#Fixes #48764
The `gmp` build fails on Windows due to a regression in `Autoconf 2.72`. Although @dg0yt's PR #41814 attempts to fix this, it did not work in my environment. By explicitly declaring `autoconf2.71` in `vcpkg_acquire_msys.cmake` and requesting it in the portfile, I was able to achieve a successful build. 

I am submitting this alternative approach for review and would appreciate guidance on the best way to resolve this regression.