### PR TITLE
[kdgpu] Add new port

### DIFF
--- a/ports/kdgpu/portfile.cmake
+++ b/ports/kdgpu/portfile.cmake
@@ -1,0 +1,57 @@
+vcpkg_find_acquire_program(PKGCONFIG)
+set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDAB/KDGpu
+    REF v${VERSION}
+    SHA512 ff8c0caa83b68a6507f30935d0d7cb5c64b0ba882e93e85c868d4f44415b1545d562c529656b7bc86b4ed5a1e4635d5b70c11855d347a85220f67cfae9e750cf
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+	kdgpuutils   KDGPU_BUILD_KDGPUUTILS
+	kdgpukdgui   KDGPU_BUILD_KDGPUKDGUI
+	kdgpuexample KDGPU_BUILD_KDGPUEXAMPLE
+	openxr	     KDGPU_BUILD_KDXR
+	hlsl	     KDGPU_HLSL_SUPPORT
+	slang	     KDGPU_SLANG_SUPPORT
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" KDGPU_BUILD_SHARED_LIBS)
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DKDGPU_BUILD_SHARED_LIBS=${KDGPU_BUILD_SHARED_LIBS}
+        -DVCPKG_HOST_TRIPLET=${HOST_TRIPLET}
+        -DKDGPU_BUILD_EXAMPLES=OFF
+        -DKDGPU_BUILD_TESTS=OFF
+)
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# Fix up optional components only if they exist
+if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/KDGpuUtils")
+    vcpkg_cmake_config_fixup(PACKAGE_NAME kdgputuils CONFIG_PATH lib/cmake/KDGpuUtils DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/KDGpuKDGui")
+    vcpkg_cmake_config_fixup(PACKAGE_NAME kdgpukdgui CONFIG_PATH lib/cmake/KDGpuKDGui DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/KDXr")
+    vcpkg_cmake_config_fixup(PACKAGE_NAME kdxr CONFIG_PATH lib/cmake/KDXr DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/KDGpuExample")
+    vcpkg_cmake_config_fixup(PACKAGE_NAME kdgpuexample CONFIG_PATH lib/cmake/KDGpuExample DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endif()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME kdgpu CONFIG_PATH lib/cmake/KDGpu)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*.txt")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kdgpu/usage
+++ b/ports/kdgpu/usage
@@ -1,0 +1,20 @@
+kdgpu provides CMake targets:
+
+ find_package(KDGpu REQUIRED)
+ target_link_libraries(main PRIVATE KDGpu::KDGpu)
+
+ # KDGpuKDGui (optional, feature "kdgpukdgui")
+ find_package(KDGpuKDGui REQUIRED)
+ target_link_libraries(main PRIVATE KDGpu::KDGpuKDGui)
+
+ # KDGpuUtils (optional, feature "kdgpuutils")
+ find_package(KDGpuUtils REQUIRED)
+ target_link_libraries(main PRIVATE KDGpu::KDGpuUtils)
+
+ # KDXr (optional, feature "openxr")
+ find_package(KDXr REQUIRED)
+ target_link_libraries(main PRIVATE KDXr::KDXr)
+
+ # KDGpuExample (optional, feature "kdgpuexample")
+ find_package(KDGpuExample REQUIRED)
+ target_link_libraries(main PRIVATE KDGpu::KDGpuExample)

--- a/ports/kdgpu/vcpkg.json
+++ b/ports/kdgpu/vcpkg.json
@@ -1,0 +1,75 @@
+{
+  "name": "kdgpu",
+  "version": "0.10.0",
+  "description": "KDGPU Library - C++ Vulkan wrapper for GPU programming",
+  "homepage": "https://github.com/KDAB/kdgpu",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "glslang",
+      "host": true,
+      "features": [
+        "tools"
+      ]
+    },
+    "kdutils",
+    "spdlog",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "vulkan-sdk-components"
+  ],
+  "features": {
+    "hlsl": {
+      "description": "Enable HLSL shader support",
+      "supports": "(windows & !arm32 & !uwp & !xbox) | (linux & x64)",
+      "dependencies": [
+        {
+          "name": "directx-dxc",
+          "host": true
+        }
+      ]
+    },
+    "kdgpuexample": {
+      "description": "Enable KDGpuExample",
+      "dependencies": [
+        "glm",
+        {
+          "name": "imgui",
+          "features": [
+            "vulkan-binding"
+          ]
+        }
+      ]
+    },
+    "kdgpukdgui": {
+      "description": "Enable KDGui integration"
+    },
+    "kdgpuutils": {
+      "description": "Enable KDGpuUtils"
+    },
+    "openxr": {
+      "description": "Enable OpenXR support for VR/AR",
+      "dependencies": [
+        "kdbindings",
+        "openxr-loader"
+      ]
+    },
+    "slang": {
+      "description": "Enable Slang shader support",
+      "supports": "(windows & !arm32 & !uwp & !xbox) | (linux & x64)",
+      "dependencies": [
+        {
+          "name": "shader-slang",
+          "host": true
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4208,6 +4208,10 @@
       "baseline": "2.4.0",
       "port-version": 1
     },
+    "kdgpu": {
+      "baseline": "0.10.0",
+      "port-version": 0
+    },
     "kdiagram": {
       "baseline": "2.8.0",
       "port-version": 0

--- a/versions/k-/kdgpu.json
+++ b/versions/k-/kdgpu.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9c5d86b65de66b7ed1445b736d722fc0cb406ea5",
+      "version": "0.10.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.