### PR TITLE
[e-dant-watcher] add new port

### DIFF
--- a/ports/e-dant-watcher/fix-install.patch
+++ b/ports/e-dant-watcher/fix-install.patch
@@ -1,0 +1,48 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b9872dc..86cb5fb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -109,10 +109,11 @@ if(ANDROID)
+   # Android's stdlib ("bionic") doesn't need to be linked with (p)threads.
+   set(LINK_LIBRARIES "${LINK_LIBRARIES}")
+ else()
++  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+   find_package(Threads REQUIRED)
+   set(LINK_LIBRARIES
+     "${LINK_LIBRARIES}"
+-    "Threads::Threads"
++    "${CMAKE_THREAD_LIBS_INIT}"
+   )
+   if(APPLE)
+     list(APPEND LINK_LIBRARIES
+@@ -409,7 +410,7 @@ wtr_add_hdr_target(
+   "wtr.hdr_watcher"
+   "include/wtr/watcher.hpp"
+ )
+-
++if(0)
+ wtr_add_hdr_target(
+   "watcher-c-hdr"
+   "watcher-c/include/wtr/watcher-c.h"
+@@ -468,17 +469,17 @@ wtr_add_bin_target(
+   ""
+   ""
+ )
+-
++endif()
+ set(PC_WATCHER_LIBS_PRIVATE "${LINK_LIBRARIES}")
+ set(PC_WATCHER_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+-set(PC_WATCHER_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/wtr")
++set(PC_WATCHER_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include/wtr")
+ wtr_add_pkg_config_target("watcher.pc" "watcher.pc.in")
+-
++if(0)
+ set(PC_LIBWATCHER_C_LIBS_PRIVATE "${LINK_LIBRARIES}")
+ set(PC_LIBWATCHER_C_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+ set(PC_LIBWATCHER_C_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/wtr")
+ wtr_add_pkg_config_target("watcher-c.pc" "watcher-c/watcher-c.pc.in")
+-
++endif()
+ if(BUILD_TESTING)
+   message(STATUS "wtr.test_tool_test_all: Added (BUILD_TESTING=${BUILD_TESTING})")
+   add_test(

--- a/ports/e-dant-watcher/portfile.cmake
+++ b/ports/e-dant-watcher/portfile.cmake
@@ -1,0 +1,26 @@
+set(VCPKG_BUILD_TYPE release) # header-only
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO e-dant/watcher
+    REF "${VERSION}"
+    SHA512 94f4a7074598ca490db4e2171eafa4cfc7a1d9a6107c3e24780a4716c84af3e3466030fb21c9b2a56c34ee18d5ec6842f741bcb92e252a45702a2e64945f3450
+    HEAD_REF release
+    PATCHES
+        fix-install.patch
+)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_LIB=OFF
+        -DBUILD_BIN=OFF
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+
+# remove empty lib and debug/lib directories (and duplicate files from debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/license")

--- a/ports/e-dant-watcher/vcpkg.json
+++ b/ports/e-dant-watcher/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "e-dant-watcher",
+  "version": "0.14.3",
+  "description": "Filesystem watcher. Works anywhere. Simple, efficient and friendly.",
+  "homepage": "https://github.com/e-dant/watcher",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2636,6 +2636,10 @@
       "baseline": "2019-11-13",
       "port-version": 0
     },
+    "e-dant-watcher": {
+      "baseline": "0.14.3",
+      "port-version": 0
+    },
     "eabase": {
       "baseline": "2025-08-01",
       "port-version": 0

--- a/versions/e-/e-dant-watcher.json
+++ b/versions/e-/e-dant-watcher.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "991f44857b733c9c4a764adc108f0c9346f1fd4a",
+      "version": "0.14.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/e-dant/watcher

Try to close https://github.com/microsoft/vcpkg/issues/49326.
