### PR TITLE
[liblsl] update to 1.17.5

### DIFF
--- a/ports/liblsl/portfile.cmake
+++ b/ports/liblsl/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sccn/liblsl
     REF v${VERSION}
-    SHA512 b50d2e276a6c824da5a19e517e3684b1f4c33fa31ed839772f33faa5756b19c934bc4f1587bb488819345549fa063533ad05d2ec41d2798f158150b4f4a48ff5
+    SHA512 5b540c9b7c0b6fb5827dbb8afdc85267d8e36e3b807704af11ed89865754f1d786f28414adf1c3c7df15956143a0bfc82c449c5ff8656d18f1a6e03c4c1e89ce
     HEAD_REF master
     PATCHES
         use-find-package-asio.patch

--- a/ports/liblsl/vcpkg.json
+++ b/ports/liblsl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liblsl",
-  "version": "1.17.4",
+  "version": "1.17.5",
   "description": "C++ lsl library for multi-modal time-synched data transmission over the local network",
   "homepage": "https://github.com/sccn/liblsl",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5105,7 +5105,7 @@
       "port-version": 0
     },
     "liblsl": {
-      "baseline": "1.17.4",
+      "baseline": "1.17.5",
       "port-version": 0
     },
     "liblsquic": {

--- a/versions/l-/liblsl.json
+++ b/versions/l-/liblsl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "650466afe7379871fce32ddc014d7aaf9f09b23d",
+      "version": "1.17.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "3f1884b94f2778c21afe3fc3767676fc239fcfc3",
       "version": "1.17.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/sccn/liblsl/releases/tag/v1.17.5
