### PR TITLE
[libheif] update to 1.21.2

### DIFF
--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  strukturag/libheif
     REF "v${VERSION}"
-    SHA512 556cc0e365aacad662d8c20282b68856b51af168659acd0f2662dcb399e5fed9dea9c259f5d5ffcd383f4b4a00a93acbdc06e90b340cc1dd2098e94c30c8a606
+    SHA512 c953cb9c3a4c0f1052f4d1e0475143cfea6c0a1ab787acb33a2fd173e0460b665717a56a99b864226dfe62bd139c92a66fe5dec75b91e2a333b77a0571e3c5a8
     HEAD_REF master
     PATCHES
         cxx-linkage-pkgconfig.diff

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libheif",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "description": "libheif is an HEIF and AVIF file format decoder and encoder.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4989,7 +4989,7 @@
       "port-version": 6
     },
     "libheif": {
-      "baseline": "1.21.1",
+      "baseline": "1.21.2",
       "port-version": 0
     },
     "libhsplasma": {

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3f38b30737445a0602a87de8ddce70a09e99df4",
+      "version": "1.21.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a19ab14c1690f453d939abf1b7c2bdcb5ac448b",
       "version": "1.21.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/strukturag/libheif/releases/tag/v1.21.2
