### PR TITLE
[babl] Update to 0.1.120

### DIFF
--- a/ports/babl/portfile.cmake
+++ b/ports/babl/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.gimp.org/pub/babl/${VERSION_MAJOR_MINOR}/babl-${VERSION}.tar.xz"
     FILENAME "babl-${VERSION}.tar.xz"
-    SHA512 6a361135045566b5a35b7c2df8e9f0a0b1c6e910aa73aafecb621446d333bcbfc50e925ceac675b83b548a872d53eba2c03bcbccb504b47089c737b0ffb53d9d
+    SHA512 9134586cc43c6e8596e7518b35a5fec99ab5d9e64270f12d77ebb04f08c4926bba84e068c08006858791334a4e3df063485419394876a76618cfdf3abded29da
 )
 
 vcpkg_extract_source_archive(

--- a/ports/babl/vcpkg.json
+++ b/ports/babl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "babl",
-  "version": "0.1.118",
+  "version": "0.1.120",
   "description": "A pixel encoding and color space conversion engine.",
   "homepage": "https://gegl.org/babl/",
   "license": "LGPL-3.0-or-later",

--- a/versions/b-/babl.json
+++ b/versions/b-/babl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c1409be45a461d0fb090f1e89759ad6f347d616",
+      "version": "0.1.120",
+      "port-version": 0
+    },
+    {
       "git-tree": "f814a1ccb9b3f9e5e475acdb8c48c87c61d94f77",
       "version": "0.1.118",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -613,7 +613,7 @@
       "port-version": 2
     },
     "babl": {
-      "baseline": "0.1.118",
+      "baseline": "0.1.120",
       "port-version": 0
     },
     "backward-cpp": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
