### PR TITLE
[libfyaml] New port

### DIFF
--- a/ports/libfyaml/portfile.cmake
+++ b/ports/libfyaml/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO pantoniou/libfyaml
+    REF "v${VERSION}"
+    SHA512 04d8ef638a9995a2b0e2d561fd615aca24c4091f7369a1d2d3cb38f048ee13eccafeac90d92d758022e8fb2db273c97939fec3b9872cdb9a6ef6b42b511adf85
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/libfyaml")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libfyaml/vcpkg.json
+++ b/ports/libfyaml/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "libfyaml",
+  "version": "0.9.3",
+  "description": "A fully-featured YAML 1.2 and JSON parser/writer with zero-copy operation and no artificial limits.",
+  "homepage": "https://github.com/pantoniou/libfyaml",
+  "license": "MIT",
+  "supports": "!windows | mingw",
+  "dependencies": [
+    "pthreads",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4920,6 +4920,10 @@
       "baseline": "3.17.3",
       "port-version": 0
     },
+    "libfyaml": {
+      "baseline": "0.9.3",
+      "port-version": 0
+    },
     "libgcrypt": {
       "baseline": "1.11.1",
       "port-version": 0

--- a/versions/l-/libfyaml.json
+++ b/versions/l-/libfyaml.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1810a07e123b9c10f3c04274eb661650c4e35970",
+      "version": "0.9.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

Couldn't verify usage file as this doesn't build under Windows and I think there is no output of this in the CI.

Port required to update `appstream` >= 1.1.0

`"supports": "!windows | mingw"`, because of [this](https://github.com/pantoniou/libfyaml/blob/433d75fabd2b746e11c01d66348549625653e961/CMakeLists.txt#L143-L148) and further issues (e.g., `ignoring unknown option '-msse4.1'`, so compiler specific flags)
