### PR TITLE
[wolfssl] Add feature option to enable curve25519 support

### DIFF
--- a/ports/wolfssl/portfile.cmake
+++ b/ports/wolfssl/portfile.cmake
@@ -25,6 +25,12 @@ else()
     set(ENABLE_QUIC no)
 endif()
 
+if ("curve25519" IN_LIST FEATURES)
+    set(ENABLE_CURVE25519 yes)
+else()
+    set(ENABLE_CURVE25519 no)
+endif()
+
 vcpkg_cmake_get_vars(cmake_vars_file)
 include("${cmake_vars_file}")
 
@@ -57,6 +63,7 @@ vcpkg_cmake_configure(
       -DWOLFSSL_DTLS_CID=${ENABLE_DTLS}
       -DWOLFSSL_QUIC=${ENABLE_QUIC}
       -DWOLFSSL_SESSION_TICKET=${ENABLE_QUIC}
+      -DWOLFSSL_CURVE25519=${ENABLE_CURVE25519}
     OPTIONS_RELEASE
       -DCMAKE_C_FLAGS=${VCPKG_COMBINED_C_FLAGS_RELEASE}
     OPTIONS_DEBUG

--- a/ports/wolfssl/vcpkg.json
+++ b/ports/wolfssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "wolfssl",
   "version": "5.8.4",
+  "port-version": 1,
   "description": "TLS and Cryptographic library for many platforms",
   "homepage": "https://wolfssl.com",
   "license": "GPL-3.0-or-later",
@@ -23,6 +24,9 @@
     "asio": {
       "description": "Enable asio support"
     },
+    "curve25519": {
+      "description": "Enables Curve25519 support"
+    },
     "dtls": {
       "description": "DTLS support"
     },
@@ -31,9 +35,6 @@
     },
     "secret-callback": {
       "description": "Enables callback to provide TLS keys for debugging"
-    },
-    "curve25519": {
-      "description": "Enables curve25519 algorithm support"
     }
   }
 }

--- a/ports/wolfssl/vcpkg.json
+++ b/ports/wolfssl/vcpkg.json
@@ -31,6 +31,9 @@
     },
     "secret-callback": {
       "description": "Enables callback to provide TLS keys for debugging"
+    },
+    "curve25519": {
+      "description": "Enables curve25519 algorithm support"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10674,7 +10674,7 @@
     },
     "wolfssl": {
       "baseline": "5.8.4",
-      "port-version": 0
+      "port-version": 1
     },
     "wolftpm": {
       "baseline": "3.10.0",

--- a/versions/w-/wolfssl.json
+++ b/versions/w-/wolfssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20f0274c9dd43541ec99a3678ce958a7f1009841",
+      "version": "5.8.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "c671ed47b3bdefeaa595d9ec6a86d6dbbfbc2ff3",
       "version": "5.8.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.