### PR TITLE
[wt] fix HPDF::HPDF link error

### DIFF
--- a/ports/wt/0007-fix-haru.patch
+++ b/ports/wt/0007-fix-haru.patch
@@ -1,0 +1,51 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5826718..37ce1fb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -275,8 +275,7 @@ find_package(GLEW)
+ 
+ find_package(Asciidoctor)
+ 
+-set(HPDF_ROOT ${HARU_PREFIX})
+-find_package(HPDF)
++find_package(unofficial-libharu CONFIG REQUIRED)
+ 
+ set(OPENSSL_ROOT_DIR ${SSL_PREFIX})
+ find_package(OpenSSL)
+@@ -578,7 +577,7 @@ IF(NOT EXISTS ${CONFIGDIR}/wt_config.xml)
+   INSTALL(FILES ${WT_BINARY_DIR}/wt_config.xml DESTINATION ${CONFIGDIR})
+ ENDIF (NOT EXISTS ${CONFIGDIR}/wt_config.xml)
+ 
+-if(ENABLE_HARU AND HPDF_FOUND)
++if(ENABLE_HARU)
+   set(HAVE_HARU ON)
+   set(WT_HAS_WPDFIMAGE true)
+ endif()
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 4033d78..939d8aa 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -654,7 +654,7 @@ if(HAVE_HARU)
+   # Even though WPdfImage.h exposes <hpdf.h>, we mark it as private here, because most users of Wt don't need it.
+   # We don't want to include it in the INTERFACE_LINK_LIBRARIES in the generated wt-target-wt.cmake file, since
+   # FindHPDF.cmake is not a standard find module.
+-  target_link_libraries(wt PRIVATE HPDF::HPDF)
++  target_link_libraries(wt PRIVATE unofficial::libharu::hpdf)
+ else()
+   message("** Disabling PDF support (WPdfImage, WPdfRenderer): requires libharu.")
+   if(ENABLE_HARU)
+diff --git a/wt-config.cmake.in b/wt-config.cmake.in
+index a3693d3..4df41c2 100644
+--- a/wt-config.cmake.in
++++ b/wt-config.cmake.in
+@@ -5,7 +5,9 @@ if(@_WTCONFIG_CMAKE_FIND_BOOST@)
+   find_package(Boost QUIET
+     COMPONENTS @Boost_COMPONENTS@)
+ endif()
+-
++if(@ENABLE_HARU@)
++  find_package(unofficial-libharu QUIET)
++endif()
+ # Required target
+ include(${CMAKE_CURRENT_LIST_DIR}/wt-target-wt.cmake)
+ # Optional targets

--- a/ports/wt/0007-fix-haru.patch
+++ b/ports/wt/0007-fix-haru.patch
@@ -1,39 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5826718..37ce1fb 100644
+index 5826718..06cfe04 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -275,8 +275,7 @@ find_package(GLEW)
+@@ -275,8 +275,8 @@ find_package(GLEW)
  
  find_package(Asciidoctor)
  
 -set(HPDF_ROOT ${HARU_PREFIX})
 -find_package(HPDF)
-+find_package(unofficial-libharu CONFIG REQUIRED)
++find_package(HPDF NAMES unofficial-libharu CONFIG REQUIRED)
++add_library(HPDF::HPDF ALIAS unofficial::libharu::hpdf)
  
  set(OPENSSL_ROOT_DIR ${SSL_PREFIX})
  find_package(OpenSSL)
-@@ -578,7 +577,7 @@ IF(NOT EXISTS ${CONFIGDIR}/wt_config.xml)
-   INSTALL(FILES ${WT_BINARY_DIR}/wt_config.xml DESTINATION ${CONFIGDIR})
- ENDIF (NOT EXISTS ${CONFIGDIR}/wt_config.xml)
- 
--if(ENABLE_HARU AND HPDF_FOUND)
-+if(ENABLE_HARU)
-   set(HAVE_HARU ON)
-   set(WT_HAS_WPDFIMAGE true)
- endif()
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 4033d78..939d8aa 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -654,7 +654,7 @@ if(HAVE_HARU)
-   # Even though WPdfImage.h exposes <hpdf.h>, we mark it as private here, because most users of Wt don't need it.
-   # We don't want to include it in the INTERFACE_LINK_LIBRARIES in the generated wt-target-wt.cmake file, since
-   # FindHPDF.cmake is not a standard find module.
--  target_link_libraries(wt PRIVATE HPDF::HPDF)
-+  target_link_libraries(wt PRIVATE unofficial::libharu::hpdf)
- else()
-   message("** Disabling PDF support (WPdfImage, WPdfRenderer): requires libharu.")
-   if(ENABLE_HARU)
 diff --git a/wt-config.cmake.in b/wt-config.cmake.in
 index a3693d3..4df41c2 100644
 --- a/wt-config.cmake.in

--- a/ports/wt/portfile.cmake
+++ b/ports/wt/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         0005-XML_file_path.patch
         0006-GraphicsMagick.patch
+        0007-fix-haru.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SHARED_LIBS)

--- a/ports/wt/vcpkg.json
+++ b/ports/wt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "wt",
   "version": "4.12.1",
+  "port-version": 1,
   "description": "Wt is a C++ library for developing web applications",
   "homepage": "https://github.com/emweb/wt",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10702,7 +10702,7 @@
     },
     "wt": {
       "baseline": "4.12.1",
-      "port-version": 0
+      "port-version": 1
     },
     "wtl": {
       "baseline": "10.0.10320",

--- a/versions/w-/wt.json
+++ b/versions/w-/wt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "223b6df402f41bd7305d3a77fa50cb6449f223b4",
+      "version": "4.12.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "1f3bb1d5df5750aa6f518109e039a2892cb75315",
       "version": "4.12.1",
       "port-version": 0

--- a/versions/w-/wt.json
+++ b/versions/w-/wt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "223b6df402f41bd7305d3a77fa50cb6449f223b4",
+      "git-tree": "82c24ff24e915a936ca2151fb8efc9657657146b",
       "version": "4.12.1",
       "port-version": 1
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

I met compilation errors on linking wt.
This PR tries to fix it.
```
CMake Error at build/vcpkg_installed/x64-linux/share/wt/wt-target-wt.cmake:61 (set_target_properties):
  The link interface of target "Wt::Wt" contains:

    HPDF::HPDF

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

