### PR TITLE
[poco] update to 1.14.2

### DIFF
--- a/ports/poco/0001-static-pcre.patch
+++ b/ports/poco/0001-static-pcre.patch
@@ -1,10 +1,10 @@
 diff --git a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
-index d5f3b26..cb29e69 100644
+index 8508261..cb31e67 100644
 --- a/Foundation/CMakeLists.txt
 +++ b/Foundation/CMakeLists.txt
 @@ -101,6 +101,31 @@ set_target_properties(Foundation
  if(POCO_UNBUNDLED)
- 	target_link_libraries(Foundation PUBLIC Pcre2::Pcre2 ZLIB::ZLIB Utf8Proc::Utf8Proc)
+ 	target_link_libraries(Foundation PRIVATE Pcre2::Pcre2 ZLIB::ZLIB Utf8Proc::Utf8Proc)
  	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED)
 +	add_definitions(
 +		-D_pcre2_utf8_table1=_poco_pcre2_utf8_table1
@@ -30,7 +30,7 @@ index d5f3b26..cb29e69 100644
 +		-D_pcre2_ucd_records_8=_poco_pcre2_ucd_records_8
 +		-D_pcre2_ucd_stage1_8=_poco_pcre2_ucd_stage1_8
 +		-D_pcre2_ucd_stage2_8=_poco_pcre2_ucd_stage2_8
-+)
++	)
  else()
  	target_compile_definitions(Foundation PUBLIC UTF8PROC_STATIC)
  endif(POCO_UNBUNDLED)

--- a/ports/poco/0003-fix-dependency.patch
+++ b/ports/poco/0003-fix-dependency.patch
@@ -1,17 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 861c27c..d2701ce 100644
+index e88e561..0f5544d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -80,8 +80,6 @@ option(ENABLE_NETSSL_WIN "Enable NetSSL Windows" OFF)
- 
- if(ENABLE_CRYPTO OR ENABLE_NETSSL OR ENABLE_JWT)
- 	find_package(OpenSSL REQUIRED)
--else()
--	find_package(OpenSSL)
- endif()
- 
- if(OPENSSL_FOUND)
-@@ -111,24 +109,19 @@ else()
+@@ -111,24 +111,19 @@ else()
  	option(ENABLE_APACHECONNECTOR "Enable ApacheConnector" OFF)
  endif()
  
@@ -30,11 +21,11 @@ index 861c27c..d2701ce 100644
 -	option(ENABLE_DATA "Enable Data" OFF)
 -	option(ENABLE_DATA_MYSQL "Enable Data MySQL or MariaDB" OFF)
 +if(ENABLE_DATA_MYSQL)
-+    find_package(libmysql)
-+    if (NOT libmysql_FOUND)
-+        find_package(unofficial-libmariadb CONFIG REQUIRED)
-+        set(MYSQL_LIBRARIES unofficial::libmariadb)
-+    endif()
++	find_package(libmysql)
++	if (NOT libmysql_FOUND)
++		find_package(unofficial-libmariadb CONFIG REQUIRED)
++		set(MYSQL_LIBRARIES unofficial::libmariadb)
++	endif()
  endif()
  
  if(ENABLE_DATA_POSTGRESQL)
@@ -44,13 +35,13 @@ index 861c27c..d2701ce 100644
  endif()
  
  if(PostgreSQL_FOUND)
-@@ -266,6 +259,9 @@ include(DefinePlatformSpecific)
+@@ -265,7 +260,8 @@ include(DefinePlatformSpecific)
+ 
  # Collect the built libraries and include dirs, the will be used to create the PocoConfig.cmake file
  set(Poco_COMPONENTS "")
- 
+-
 +# Do not declare the link library in the code!
 +add_definitions(-DPOCO_NO_AUTOMATIC_LIBS)
-+
  if(ENABLE_TESTS)
  	add_subdirectory(CppUnit)
  	set(ENABLE_XML ON CACHE BOOL "Enable XML" FORCE)
@@ -130,7 +121,7 @@ index 7141112..0c73beb 100644
  		POCO_UNBUNDLED
  		SQLITE_THREADSAFE=1
 diff --git a/XML/CMakeLists.txt b/XML/CMakeLists.txt
-index cf66250..89e6c8f 100644
+index 4d7b36d..89e6c8f 100644
 --- a/XML/CMakeLists.txt
 +++ b/XML/CMakeLists.txt
 @@ -20,7 +20,7 @@ endif()
@@ -146,42 +137,29 @@ index cf66250..89e6c8f 100644
  )
  
  if(POCO_UNBUNDLED)
--	target_link_libraries(XML PUBLIC EXPAT::EXPAT)
+-	target_link_libraries(XML PRIVATE EXPAT::EXPAT)
 +	target_link_libraries(XML PUBLIC expat::expat)
  	target_compile_definitions(XML PUBLIC POCO_UNBUNDLED)
  else()
  	if(WIN32)
-diff --git a/XML/cmake/PocoXMLConfig.cmake b/XML/cmake/PocoXMLConfig.cmake
-index ef58207..4ed94ec 100644
---- a/XML/cmake/PocoXMLConfig.cmake
-+++ b/XML/cmake/PocoXMLConfig.cmake
-@@ -4,7 +4,7 @@ if(@POCO_UNBUNDLED@)
- 	if(CMAKE_VERSION VERSION_LESS "3.10")
- 		list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/V39")
- 	endif()
--	find_dependency(EXPAT REQUIRED)
-+	find_dependency(expat CONFIG REQUIRED)
- endif()
- 
- include("${CMAKE_CURRENT_LIST_DIR}/PocoXMLTargets.cmake")
 diff --git a/cmake/PocoConfig.cmake.in b/cmake/PocoConfig.cmake.in
-index 173eacd..90f68fc 100644
+index 173eacd..e7ced26 100644
 --- a/cmake/PocoConfig.cmake.in
 +++ b/cmake/PocoConfig.cmake.in
-@@ -8,6 +8,12 @@ if (NOT Poco_FIND_COMPONENTS)
+@@ -7,7 +7,11 @@ if (NOT Poco_FIND_COMPONENTS)
+     set(Poco_FOUND False)
      return()
  endif()
- 
+-
 +include(CMakeFindDependencyMacro)
 +find_dependency(ZLIB REQUIRED)
 +if(Poco_FIND_REQUIRED_XML)
 +    find_dependency(expat CONFIG REQUIRED)
 +endif()
-+
  set(_Poco_FIND_PARTS_REQUIRED)
  if (Poco_FIND_REQUIRED)
      set(_Poco_FIND_PARTS_REQUIRED REQUIRED)
-@@ -23,7 +29,7 @@ set(_Poco_NOTFOUND_MESSAGE)
+@@ -23,7 +27,7 @@ set(_Poco_NOTFOUND_MESSAGE)
  
  # Let components find each other, but don't overwrite CMAKE_PREFIX_PATH
  set(_Poco_CMAKE_PREFIX_PATH_old ${CMAKE_PREFIX_PATH})
@@ -190,16 +168,3 @@ index 173eacd..90f68fc 100644
  
  foreach(module ${Poco_FIND_COMPONENTS})
      find_package(Poco${module}
-diff --git a/Foundation/cmake/PocoFoundationConfig.cmake b/Foundation/cmake/PocoFoundationConfig.cmake
-index 82c5788..739adef 100644
---- a/Foundation/cmake/PocoFoundationConfig.cmake
-+++ b/Foundation/cmake/PocoFoundationConfig.cmake
-@@ -3,7 +3,7 @@ if(@POCO_UNBUNDLED@)
- 	list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
- 	find_dependency(ZLIB REQUIRED)
- 	find_dependency(PCRE2 REQUIRED)
--	find_dependency(Utf8Proc REQUIRED)
-+	find_dependency(unofficial-utf8proc REQUIRED)
- endif()
- 
- include("${CMAKE_CURRENT_LIST_DIR}/PocoFoundationTargets.cmake")

--- a/ports/poco/0003-fix-dependency.patch
+++ b/ports/poco/0003-fix-dependency.patch
@@ -1,8 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e88e561..0f5544d 100644
+index e88e561..6ec85e5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -111,24 +111,19 @@ else()
+@@ -80,8 +80,6 @@ option(ENABLE_NETSSL_WIN "Enable NetSSL Windows" OFF)
+ 
+ if(ENABLE_CRYPTO OR ENABLE_NETSSL OR ENABLE_JWT)
+ 	find_package(OpenSSL REQUIRED)
+-else()
+-	find_package(OpenSSL)
+ endif()
+ 
+ if(OPENSSL_FOUND)
+@@ -111,24 +109,19 @@ else()
  	option(ENABLE_APACHECONNECTOR "Enable ApacheConnector" OFF)
  endif()
  
@@ -35,7 +44,7 @@ index e88e561..0f5544d 100644
  endif()
  
  if(PostgreSQL_FOUND)
-@@ -265,7 +260,8 @@ include(DefinePlatformSpecific)
+@@ -265,7 +258,8 @@ include(DefinePlatformSpecific)
  
  # Collect the built libraries and include dirs, the will be used to create the PocoConfig.cmake file
  set(Poco_COMPONENTS "")
@@ -45,7 +54,7 @@ index e88e561..0f5544d 100644
  if(ENABLE_TESTS)
  	add_subdirectory(CppUnit)
  	set(ENABLE_XML ON CACHE BOOL "Enable XML" FORCE)
-@@ -398,8 +394,11 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/Prometheus AND ENABLE_PROMETHEUS)
+@@ -398,8 +392,11 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/Prometheus AND ENABLE_PROMETHEUS)
  	list(APPEND Poco_COMPONENTS "Prometheus")
  endif()
  

--- a/ports/poco/0007-find-pcre2.patch
+++ b/ports/poco/0007-find-pcre2.patch
@@ -1,5 +1,5 @@
 diff --git a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
-index d8df9dc..fe2b000 100644
+index cb31e67..e349be5 100644
 --- a/Foundation/CMakeLists.txt
 +++ b/Foundation/CMakeLists.txt
 @@ -27,9 +27,12 @@ POCO_MESSAGES(SRCS Logging src/pocomsg.mc)
@@ -21,13 +21,13 @@ index d8df9dc..fe2b000 100644
  )
  
  if(POCO_UNBUNDLED)
--	target_link_libraries(Foundation PUBLIC Pcre2::Pcre2 ZLIB::ZLIB Utf8Proc::Utf8Proc)
+-	target_link_libraries(Foundation PRIVATE Pcre2::Pcre2 ZLIB::ZLIB Utf8Proc::Utf8Proc)
 +	target_link_libraries(Foundation PUBLIC ${PCRE2_LIBRARY} ZLIB::ZLIB utf8proc)
  	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED)
  	add_definitions(
  		-D_pcre2_utf8_table1=_poco_pcre2_utf8_table1
 diff --git a/cmake/FindPCRE2.cmake b/cmake/FindPCRE2.cmake
-index e730f32..6e10df2 100644
+index e730f32..9a443db 100644
 --- a/cmake/FindPCRE2.cmake
 +++ b/cmake/FindPCRE2.cmake
 @@ -54,7 +54,7 @@ Hints
@@ -39,7 +39,7 @@ index e730f32..6e10df2 100644
  
  find_path(PCRE2_INCLUDE_DIR
    NAMES pcre2.h
-@@ -66,8 +66,8 @@ find_path(PCRE2_INCLUDE_DIR
+@@ -66,8 +66,17 @@ find_path(PCRE2_INCLUDE_DIR
    DOC "Specify the include directory containing pcre2.h"
  )
  
@@ -47,15 +47,6 @@ index e730f32..6e10df2 100644
 -  NAMES pcre2-8
 +find_library(PCRE2_LIBRARY_DEBUG
 +  NAMES pcre2-8d pcre2-8-staticd
-   HINTS
-         ${PCRE2_ROOT_DIR}/lib
-         ${PCRE2_ROOT_LIBRARY_DIRS}
-@@ -76,6 +76,19 @@ find_library(PCRE2_LIBRARY
-   DOC "Specify the lib directory containing pcre2"
- )
- 
-+find_library(PCRE2_LIBRARY_RELEASE
-+  NAMES pcre2-8 pcre2-8-static
 +  HINTS
 +        ${PCRE2_ROOT_DIR}/lib
 +        ${PCRE2_ROOT_LIBRARY_DIRS}
@@ -63,14 +54,21 @@ index e730f32..6e10df2 100644
 +        ${PC_PCRE2_LIBRARY_DIRS}
 +  DOC "Specify the lib directory containing pcre2"
 +)
-+
++find_library(PCRE2_LIBRARY_RELEASE
++  NAMES pcre2-8 pcre2-8-static
+   HINTS
+         ${PCRE2_ROOT_DIR}/lib
+         ${PCRE2_ROOT_LIBRARY_DIRS}
+@@ -76,6 +85,8 @@ find_library(PCRE2_LIBRARY
+   DOC "Specify the lib directory containing pcre2"
+ )
+ 
 +include(SelectLibraryConfigurations)
 +select_library_configurations(PCRE2)
-+
  set(PCRE2_VERSION ${PC_PCRE2_VERSION})
  
  find_package_handle_standard_args(PCRE2
-@@ -87,7 +100,6 @@ find_package_handle_standard_args(PCRE2
+@@ -87,7 +98,6 @@ find_package_handle_standard_args(PCRE2
  )
  
  if(PCRE2_FOUND)

--- a/ports/poco/0007-find-pcre2.patch
+++ b/ports/poco/0007-find-pcre2.patch
@@ -14,15 +14,15 @@ index cb31e67..e349be5 100644
 +	find_library(PCRE2_LIBRARY_DEBUG NAMES pcre2-8d pcre2-8-staticd HINTS ${INSTALLED_LIB_PATH})
 +	find_library(PCRE2_LIBRARY_RELEASE NAMES pcre2-8 pcre2-8-static HINTS ${INSTALLED_LIB_PATH})
 +	select_library_configurations(PCRE2)
- 
+
  	#HACK: Unicode.cpp requires functions from these files. The can't be taken from the library
  	POCO_SOURCES(SRCS RegExp
 @@ -99,7 +102,7 @@ set_target_properties(Foundation
  )
- 
+
  if(POCO_UNBUNDLED)
 -	target_link_libraries(Foundation PRIVATE Pcre2::Pcre2 ZLIB::ZLIB Utf8Proc::Utf8Proc)
-+	target_link_libraries(Foundation PUBLIC ${PCRE2_LIBRARY} ZLIB::ZLIB utf8proc)
++	target_link_libraries(Foundation PRIVATE ${PCRE2_LIBRARY} ZLIB::ZLIB utf8proc)
  	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED)
  	add_definitions(
  		-D_pcre2_utf8_table1=_poco_pcre2_utf8_table1
@@ -32,21 +32,21 @@ index e730f32..9a443db 100644
 +++ b/cmake/FindPCRE2.cmake
 @@ -54,7 +54,7 @@ Hints
  include(FindPackageHandleStandardArgs)
- 
+
  find_package(PkgConfig QUIET)
 -pkg_check_modules(PC_PCRE2 QUIET pcre2)
 +pkg_check_modules(PC_PCRE2 QUIET libpcre2-8)
- 
+
  find_path(PCRE2_INCLUDE_DIR
    NAMES pcre2.h
 @@ -66,8 +66,17 @@ find_path(PCRE2_INCLUDE_DIR
    DOC "Specify the include directory containing pcre2.h"
  )
- 
+
 -find_library(PCRE2_LIBRARY
 -  NAMES pcre2-8
 +find_library(PCRE2_LIBRARY_DEBUG
-+  NAMES pcre2-8d pcre2-8-staticd
++  NAMES pcre2-8d pcre2-8-staticd NAMES_PER_DIR
 +  HINTS
 +        ${PCRE2_ROOT_DIR}/lib
 +        ${PCRE2_ROOT_LIBRARY_DIRS}
@@ -55,22 +55,22 @@ index e730f32..9a443db 100644
 +  DOC "Specify the lib directory containing pcre2"
 +)
 +find_library(PCRE2_LIBRARY_RELEASE
-+  NAMES pcre2-8 pcre2-8-static
++  NAMES pcre2-8 pcre2-8-static NAMES_PER_DIR
    HINTS
          ${PCRE2_ROOT_DIR}/lib
          ${PCRE2_ROOT_LIBRARY_DIRS}
 @@ -76,6 +85,8 @@ find_library(PCRE2_LIBRARY
    DOC "Specify the lib directory containing pcre2"
  )
- 
+
 +include(SelectLibraryConfigurations)
 +select_library_configurations(PCRE2)
  set(PCRE2_VERSION ${PC_PCRE2_VERSION})
- 
+
  find_package_handle_standard_args(PCRE2
 @@ -87,7 +98,6 @@ find_package_handle_standard_args(PCRE2
  )
- 
+
  if(PCRE2_FOUND)
 -  set(PCRE2_LIBRARIES ${PCRE2_LIBRARY})
    set(PCRE2_INCLUDE_DIRS ${PCRE2_INCLUDE_DIR})

--- a/ports/poco/0009-fix-zip-to-xml-dependency.patch
+++ b/ports/poco/0009-fix-zip-to-xml-dependency.patch
@@ -1,11 +1,8 @@
- CMakeLists.txt | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e88e5612a..23b4c992f 100644
+index 6ec85e5..99e6188 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -459,12 +459,12 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/ActiveRecord/Compiler AND ENABLE_ACTIVERECORD_CO
+@@ -456,12 +456,12 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/ActiveRecord/Compiler AND ENABLE_ACTIVERECORD_CO
  	list(APPEND Poco_COMPONENTS "ActiveRecordCompiler")
  endif()
  

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pocoproject/poco
     REF "poco-${VERSION}-release"
-    SHA512 e192818a5f731ec6f6bddf062573d7bedfd15754157f145882c2c9d9bce497b92cf23f639f989d9e5605cb83029c4f303752cab655b525b5a5b5e5b704714725
+    SHA512 3bd90fd270f8becc583e6615a9399a2abe6f1e06fd42cbb33fb8eac061ac29ba36c3831f0a88451c173c1fa0ef2505ddd773c29c842e4924be835f4f570b1468
     HEAD_REF devel
     PATCHES
         # Fix embedded copy of pcre in static linking mode
@@ -59,7 +59,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         cpp-parser              ENABLE_CPPPARSER
 )
 
-# POCO_ENABLE_NETSSL_WIN: 
+# POCO_ENABLE_NETSSL_WIN:
 # Use the unreleased NetSSL_Win module instead of (OpenSSL) NetSSL.
 # This is a variable which can be set in the triplet file.
 if(POCO_ENABLE_NETSSL_WIN)

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "poco",
-  "version": "1.14.1",
-  "port-version": 2,
+  "version": "1.14.2",
   "description": "Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.",
   "homepage": "https://github.com/pocoproject/poco",
   "license": "BSL-1.0",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -1039,7 +1039,6 @@ plplot[x11]:x64-windows-static = cascade
 plplot[x11]:x64-windows-static-md = cascade
 plplot[x11]:x86-windows = cascade
 pmdk:x64-uwp=cascade
-poco[mysql]:x86-windows = cascade
 prometheus-cpp[pull]:arm64-uwp = cascade
 prometheus-cpp[pull]:arm64-windows = cascade
 prometheus-cpp[pull]:x64-uwp = cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7697,8 +7697,8 @@
       "port-version": 1
     },
     "poco": {
-      "baseline": "1.14.1",
-      "port-version": 2
+      "baseline": "1.14.2",
+      "port-version": 0
     },
     "podofo": {
       "baseline": "1.0.3",

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b26b4229e014211079912bb6fabaedb3a601eff",
+      "version": "1.14.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1b7c8e1c9662ffc308a12a2382fdbd3ac105801c",
       "version": "1.14.1",
       "port-version": 2

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3b26b4229e014211079912bb6fabaedb3a601eff",
+      "git-tree": "2ca859d6f8c2adc05174fbfa094c33b726675c62",
       "version": "1.14.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/pocoproject/poco/releases/tag/poco-1.14.2-release

Try to solve https://github.com/microsoft/vcpkg/issues/49454.
