### PR TITLE
[level-zero] update to 1.26.3

### DIFF
--- a/ports/level-zero/portfile.cmake
+++ b/ports/level-zero/portfile.cmake
@@ -1,18 +1,22 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oneapi-src/level-zero
     REF "v${VERSION}"
-    SHA512 d79701d2608353b4d3791be5ed67e9055fbd7cd7ba8ac76b50b0178bc455fc6ce7ec97d30a144cf81d17ca9ed3e72dd9a7d6e77521084228807b1bec9d027b2f
+    SHA512 fa0c9154563982a9b6bff684ce37fb29ed817e52c686081eb0da62b9630defc6006475c17d7823108023a7d50b73762875664e0a5d73c9749b11c52f4782fac6
     HEAD_REF master
     PATCHES spdlog_include.patch
 )
+
+vcpkg_list(SET options)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_list(APPEND options "-DBUILD_STATIC=1")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSYSTEM_SPDLOG=ON
+        ${options}
 )
 
 vcpkg_cmake_install()

--- a/ports/level-zero/vcpkg.json
+++ b/ports/level-zero/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "level-zero",
-  "version": "1.26.1",
-  "port-version": 1,
+  "version": "1.26.3",
   "description": "oneAPI Level Zero Specification Headers and Loader.",
   "homepage": "https://github.com/oneapi-src/level-zero",
   "license": "MIT",
-  "supports": "x64 & !static & (linux | (windows & !uwp))",
+  "supports": "x64 & (linux | (windows & !uwp))",
   "dependencies": [
     "spdlog",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4561,8 +4561,8 @@
       "port-version": 0
     },
     "level-zero": {
-      "baseline": "1.26.1",
-      "port-version": 1
+      "baseline": "1.26.3",
+      "port-version": 0
     },
     "leveldb": {
       "baseline": "1.23",

--- a/versions/l-/level-zero.json
+++ b/versions/l-/level-zero.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d05adfac091a3b685cf2a8dcf5b748489977da76",
+      "version": "1.26.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "3c58cab1269b5dca8d342aa37d72b3b03939689b",
       "version": "1.26.1",
       "port-version": 1


### PR DESCRIPTION
Added possibility to build this library statically that was implemented upstream in https://github.com/oneapi-src/level-zero/pull/224

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
