### PR TITLE
[portaudio] Add `asio` feature

### DIFF
--- a/ports/asiosdk/Findasiosdk.cmake
+++ b/ports/asiosdk/Findasiosdk.cmake
@@ -32,7 +32,7 @@ if (NOT "${ASIOSDK_ROOT_DIR}" STREQUAL "")
 	set (ASIOSDK_INCLUDE_DIR
 		${ASIOSDK_ROOT_DIR}/common
 		${ASIOSDK_ROOT_DIR}/host
-		${ASIOSDK_ROOT_DIR}/hostpc
+		${ASIOSDK_ROOT_DIR}/host/pc
 	)
 endif()
 

--- a/ports/asiosdk/Findasiosdk.cmake
+++ b/ports/asiosdk/Findasiosdk.cmake
@@ -3,6 +3,9 @@ else(WIN32)
   message(FATAL_ERROR "Findasiosdk.cmake: Unsupported platform ${CMAKE_SYSTEM_NAME}" )
 endif(WIN32)
 
+file(READ "${CMAKE_CURRENT_LIST_DIR}/usage" usage)
+message(WARNING "find_package(asiosdk) is deprecated.\n${usage}")
+
 # if this script is invoked multiple times, we end up adding
 # "asiosdk" to the directory multiple times, leading to incorrect
 # include paths

--- a/ports/asiosdk/fix-new-delete-mismatch.patch
+++ b/ports/asiosdk/fix-new-delete-mismatch.patch
@@ -1,0 +1,13 @@
+diff --git a/host/pc/asiolist.cpp b/host/pc/asiolist.cpp
+index 320a98a..4bdc789 100644
+--- a/host/pc/asiolist.cpp
++++ b/host/pc/asiolist.cpp
+@@ -154,7 +154,7 @@ static void deleteDrvStruct (LPASIODRVSTRUCT lpdrv)
+ 			iasio = (IASIO *)lpdrv->asiodrv;
+ 			iasio->Release();
+ 		}
+-		delete lpdrv;
++		delete[] lpdrv;
+ 	}
+ }
+ 

--- a/ports/asiosdk/portfile.cmake
+++ b/ports/asiosdk/portfile.cmake
@@ -33,4 +33,6 @@ file(
         "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
 
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-asiosdk-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-asiosdk")
+
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/asiosdk/portfile.cmake
+++ b/ports/asiosdk/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     SOURCE_BASE "${VERSION}"
+    PATCHES
+        fix-new-delete-mismatch.patch
 )
 
 file(INSTALL "${SOURCE_PATH}/asio/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/asio")

--- a/ports/asiosdk/unofficial-asiosdk-config.cmake
+++ b/ports/asiosdk/unofficial-asiosdk-config.cmake
@@ -1,0 +1,26 @@
+if(NOT WIN32)
+  message(FATAL_ERROR "unofficial-asiosdk-config.cmake: Unsupported platform ${CMAKE_SYSTEM_NAME}")
+endif()
+
+if(NOT TARGET unofficial::asiosdk::host)
+  find_path(asiosdk_ROOT_DIR asiosdk REQUIRED)
+  set(asiosdk_ROOT_DIR "${asiosdk_ROOT_DIR}/asiosdk")
+
+  add_library(unofficial::asiosdk::host INTERFACE IMPORTED)
+
+  target_sources(unofficial::asiosdk::host INTERFACE
+    "${asiosdk_ROOT_DIR}/common/asio.cpp"
+    "${asiosdk_ROOT_DIR}/host/asiodrivers.cpp"
+    "${asiosdk_ROOT_DIR}/host/pc/asiolist.cpp"
+  )
+
+  target_include_directories(unofficial::asiosdk::host INTERFACE
+    "${asiosdk_ROOT_DIR}/common"
+    "${asiosdk_ROOT_DIR}/host"
+    "${asiosdk_ROOT_DIR}/host/pc"
+  )
+
+  target_link_libraries(unofficial::asiosdk::host INTERFACE ole32 uuid)
+
+  unset(asiosdk_ROOT_DIR)
+endif()

--- a/ports/asiosdk/usage
+++ b/ports/asiosdk/usage
@@ -1,4 +1,4 @@
-The package asiosdk provides CMake integration:
+asiosdk provides CMake targets:
 
-    find_package(asiosdk REQUIRED)
-    target_include_directories(main PRIVATE ${ASIOSDK_INCLUDE_DIR})
+    find_package(unofficial-asiosdk CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::asiosdk::host)

--- a/ports/asiosdk/vcpkg.json
+++ b/ports/asiosdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "asiosdk",
   "version": "2.3.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "ASIO is a low latency audio API from Steinberg.",
   "homepage": "https://www.steinberg.net/developers/asiosdk-open/",
   "supports": "windows & !uwp"

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -13,17 +13,17 @@ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" PA_DLL_LINK_WITH_STATIC_RUN
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" PA_BUILD_SHARED)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" PA_BUILD_STATIC)
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        asio PA_USE_ASIO
+)
+
 vcpkg_list(SET options)
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_list(APPEND options
         -DPA_DLL_LINK_WITH_STATIC_RUNTIME=${PA_DLL_LINK_WITH_STATIC_RUNTIME}
         -DPA_LIBNAME_ADD_SUFFIX=OFF
     )
-    if("asio" IN_LIST FEATURES)
-        vcpkg_list(APPEND options
-            -DPA_USE_ASIO=ON
-        )
-    endif()
 elseif(VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_OSX)
     vcpkg_list(APPEND options
         # avoid absolute paths
@@ -47,6 +47,7 @@ vcpkg_cmake_configure(
         ${options}
         -DPA_BUILD_SHARED=${PA_BUILD_SHARED}
         -DPA_BUILD_STATIC=${PA_BUILD_STATIC}
+        -DPA_USE_ASIO=${PA_USE_ASIO}
     OPTIONS_DEBUG
         -DPA_ENABLE_DEBUG_OUTPUT:BOOL=ON
 )

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     PATCHES
         jack.diff
         fix-guid-linker-errors.patch
+        use-vcpkg-asiosdk.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" PA_DLL_LINK_WITH_STATIC_RUNTIME)
@@ -15,10 +16,23 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" PA_BUILD_STATIC)
 vcpkg_list(SET options)
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_list(APPEND options
-        -DPA_USE_ASIOSDK=OFF
         -DPA_DLL_LINK_WITH_STATIC_RUNTIME=${PA_DLL_LINK_WITH_STATIC_RUNTIME}
         -DPA_LIBNAME_ADD_SUFFIX=OFF
     )
+
+    if("asio" IN_LIST FEATURES)
+        if(NOT ASIOSDK_FOUND)
+            message(FATAL_ERROR "Steinberg ASIO audio driver SDK not found")
+        endif()
+        vcpkg_list(APPEND options
+            -DPA_USE_ASIO=ON
+            -DASIOSDK_ROOT_DIR="${ASIOSDK_ROOT_DIR}"
+        )
+    else()
+        vcpkg_list(APPEND options
+            -DPA_USE_ASIO=OFF
+        )
+    endif()
 elseif(VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_OSX)
     vcpkg_list(APPEND options
         # avoid absolute paths

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -19,18 +19,9 @@ if(VCPKG_TARGET_IS_WINDOWS)
         -DPA_DLL_LINK_WITH_STATIC_RUNTIME=${PA_DLL_LINK_WITH_STATIC_RUNTIME}
         -DPA_LIBNAME_ADD_SUFFIX=OFF
     )
-
     if("asio" IN_LIST FEATURES)
-        if(NOT ASIOSDK_FOUND)
-            message(FATAL_ERROR "Steinberg ASIO audio driver SDK not found")
-        endif()
         vcpkg_list(APPEND options
             -DPA_USE_ASIO=ON
-            -DASIOSDK_ROOT_DIR="${ASIOSDK_ROOT_DIR}"
-        )
-    else()
-        vcpkg_list(APPEND options
-            -DPA_USE_ASIO=OFF
         )
     endif()
 elseif(VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_OSX)

--- a/ports/portaudio/use-vcpkg-asiosdk.patch
+++ b/ports/portaudio/use-vcpkg-asiosdk.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 122fe93..cfff7e4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -146,12 +146,6 @@ IF(WIN32)
+ 
+   # Try to find ASIO SDK (assumes that portaudio and asiosdk folders are side-by-side, see
+   # http://www.portaudio.com/trac/wiki/TutorialDir/Compile/WindowsASIOMSVC)
+-  FIND_PACKAGE(ASIOSDK)
+-  IF(ASIOSDK_FOUND)
+-    OPTION(PA_USE_ASIO "Enable support for ASIO" ON)
+-  ELSE()
+-    OPTION(PA_USE_ASIO "Enable support for ASIO" OFF)
+-  ENDIF()
+   IF(PA_USE_ASIO)
+     SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/common)
+     SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host)

--- a/ports/portaudio/use-vcpkg-asiosdk.patch
+++ b/ports/portaudio/use-vcpkg-asiosdk.patch
@@ -1,11 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 122fe93..cfff7e4 100644
+index 122fe93..5cd36c4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -146,12 +146,6 @@ IF(WIN32)
+@@ -144,15 +144,8 @@ IF(WIN32)
  
-   # Try to find ASIO SDK (assumes that portaudio and asiosdk folders are side-by-side, see
-   # http://www.portaudio.com/trac/wiki/TutorialDir/Compile/WindowsASIOMSVC)
+   SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} winmm)
+ 
+-  # Try to find ASIO SDK (assumes that portaudio and asiosdk folders are side-by-side, see
+-  # http://www.portaudio.com/trac/wiki/TutorialDir/Compile/WindowsASIOMSVC)
 -  FIND_PACKAGE(ASIOSDK)
 -  IF(ASIOSDK_FOUND)
 -    OPTION(PA_USE_ASIO "Enable support for ASIO" ON)
@@ -13,5 +15,7 @@ index 122fe93..cfff7e4 100644
 -    OPTION(PA_USE_ASIO "Enable support for ASIO" OFF)
 -  ENDIF()
    IF(PA_USE_ASIO)
++    find_package(asiosdk REQUIRED)
      SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/common)
      SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host)
+     SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host/pc)

--- a/ports/portaudio/use-vcpkg-asiosdk.patch
+++ b/ports/portaudio/use-vcpkg-asiosdk.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 122fe93..5cd36c4 100644
+index 122fe93..616b6a9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -144,15 +144,8 @@ IF(WIN32)
+@@ -144,15 +144,11 @@ IF(WIN32)
  
    SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} winmm)
  
@@ -15,7 +15,10 @@ index 122fe93..5cd36c4 100644
 -    OPTION(PA_USE_ASIO "Enable support for ASIO" OFF)
 -  ENDIF()
    IF(PA_USE_ASIO)
-+    find_package(asiosdk REQUIRED)
++    # If -DASIOSDK_ROOT_DIR=/path/to/asiosdk is not provided, vcpkg's asiosdk will be used
++    if(NOT ASIOSDK_ROOT_DIR)
++      find_package(asiosdk REQUIRED)
++    endif()
      SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/common)
      SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host)
      SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host/pc)

--- a/ports/portaudio/use-vcpkg-asiosdk.patch
+++ b/ports/portaudio/use-vcpkg-asiosdk.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 122fe93..616b6a9 100644
+index 122fe93..b66ebe4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -144,15 +144,11 @@ IF(WIN32)
+@@ -144,26 +144,21 @@ IF(WIN32)
  
    SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} winmm)
  
@@ -14,11 +14,26 @@ index 122fe93..616b6a9 100644
 -  ELSE()
 -    OPTION(PA_USE_ASIO "Enable support for ASIO" OFF)
 -  ENDIF()
++  OPTION(PA_USE_ASIO "Enable support for ASIO" OFF)
    IF(PA_USE_ASIO)
-+    # If -DASIOSDK_ROOT_DIR=/path/to/asiosdk is not provided, vcpkg's asiosdk will be used
-+    if(NOT ASIOSDK_ROOT_DIR)
-+      find_package(asiosdk REQUIRED)
-+    endif()
-     SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/common)
-     SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host)
-     SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host/pc)
+-    SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/common)
+-    SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host)
+-    SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host/pc)
++    find_package(unofficial-asiosdk CONFIG REQUIRED)
++    get_target_property(PA_ASIOSDK_SOURCES unofficial::asiosdk::host INTERFACE_SOURCES)
++    get_target_property(PA_ASIOSDK_PRIVATE_INCLUDE_PATHS unofficial::asiosdk::host INTERFACE_INCLUDE_DIRECTORIES)
++    get_target_property(PA_ASIOSDK_LINK_LIBRARIES unofficial::asiosdk::host INTERFACE_LINK_LIBRARIES)
++
+     SET(PA_ASIO_SOURCES src/hostapi/asio/pa_asio.cpp src/hostapi/asio/iasiothiscallresolver.cpp)
+-    SET(PA_ASIOSDK_SOURCES ${ASIOSDK_ROOT_DIR}/common/asio.cpp ${ASIOSDK_ROOT_DIR}/host/pc/asiolist.cpp ${ASIOSDK_ROOT_DIR}/host/asiodrivers.cpp)
++    set(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${PA_ASIOSDK_PRIVATE_INCLUDE_PATHS})
+     SOURCE_GROUP("hostapi\\ASIO" FILES ${PA_ASIO_SOURCES})
+     SOURCE_GROUP("hostapi\\ASIO\\ASIOSDK" FILES ${PA_ASIOSDK_SOURCES})
+     SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_asio.h)
+     SET(PA_SOURCES ${PA_SOURCES} ${PA_ASIO_SOURCES})
+     SET(PA_NON_UNICODE_SOURCES ${PA_NON_UNICODE_SOURCES} ${PA_ASIOSDK_SOURCES})
+-    SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ole32 uuid)
++    SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ${PA_ASIOSDK_LINK_LIBRARIES})
+   ELSE()
+     # Set variables for DEF file expansion
+     SET(DEF_EXCLUDE_ASIO_SYMBOLS ";")

--- a/ports/portaudio/vcpkg.json
+++ b/ports/portaudio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "portaudio",
   "version": "19.7",
-  "port-version": 8,
+  "port-version": 9,
   "description": "PortAudio Portable Cross-platform Audio I/O API PortAudio is a free, cross-platform, open-source, audio I/O library.  It lets you write simple audio programs in 'C' or C++ that will compile and run on many platforms including Windows, Macintosh OS X, and Unix (OSS/ALSA). It is intended to promote the exchange of audio software between developers on different platforms. Many applications use PortAudio for Audio I/O.",
   "homepage": "https://www.portaudio.com",
   "license": "MIT",

--- a/ports/portaudio/vcpkg.json
+++ b/ports/portaudio/vcpkg.json
@@ -28,7 +28,7 @@
   ],
   "features": {
     "asio": {
-      "description": "Enable support for the Steinberg Audio Streaming Input Output (ASIO) library",
+      "description": "Enable support for Steinberg Audio Stream Input/Output (ASIO)",
       "dependencies": [
         "asiosdk"
       ]

--- a/ports/portaudio/vcpkg.json
+++ b/ports/portaudio/vcpkg.json
@@ -20,6 +20,12 @@
       "host": true
     }
   ],
+  "default-features": [
+    {
+      "name": "asio",
+      "platform": "windows"
+    }
+  ],
   "features": {
     "asio": {
       "description": "Enable support for the Steinberg Audio Streaming Input Output (ASIO) library",

--- a/ports/portaudio/vcpkg.json
+++ b/ports/portaudio/vcpkg.json
@@ -19,5 +19,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "asio": {
+      "description": "Enable support for the Steinberg Audio Streaming Input Output (ASIO) library",
+      "dependencies": [
+        "asiosdk"
+      ]
+    }
+  }
 }

--- a/ports/portaudio/vcpkg.json
+++ b/ports/portaudio/vcpkg.json
@@ -20,12 +20,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    {
-      "name": "asio",
-      "platform": "windows"
-    }
-  ],
   "features": {
     "asio": {
       "description": "Enable support for Steinberg Audio Stream Input/Output (ASIO)",

--- a/versions/a-/asiosdk.json
+++ b/versions/a-/asiosdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f4a38624d2cf6d4de0949eecdf357fd18f5f852",
+      "version": "2.3.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "49043709b884e2123f167a92188476050ddb02c7",
       "version": "2.3.4",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7754,7 +7754,7 @@
     },
     "portaudio": {
       "baseline": "19.7",
-      "port-version": 8
+      "port-version": 9
     },
     "portmidi": {
       "baseline": "2.0.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -310,7 +310,7 @@
     },
     "asiosdk": {
       "baseline": "2.3.4",
-      "port-version": 1
+      "port-version": 2
     },
     "asmjit": {
       "baseline": "2025-10-13",

--- a/versions/p-/portaudio.json
+++ b/versions/p-/portaudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f91cfab586e7e22456ddd524c767445a80713bb",
+      "version": "19.7",
+      "port-version": 9
+    },
+    {
       "git-tree": "47dce0abd35ae2790f4fa16d09279a80f601db93",
       "version": "19.7",
       "port-version": 8

--- a/versions/p-/portaudio.json
+++ b/versions/p-/portaudio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1f91cfab586e7e22456ddd524c767445a80713bb",
+      "git-tree": "51d61dd99f84d511610276068e80f02513b7de2d",
       "version": "19.7",
       "port-version": 9
     },

--- a/versions/p-/portaudio.json
+++ b/versions/p-/portaudio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "51d61dd99f84d511610276068e80f02513b7de2d",
+      "git-tree": "e57ef3a109fb5a600bbe5054a2c3be16ab532475",
       "version": "19.7",
       "port-version": 9
     },

--- a/versions/p-/portaudio.json
+++ b/versions/p-/portaudio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e57ef3a109fb5a600bbe5054a2c3be16ab532475",
+      "git-tree": "f996c7be3260abdc0186fa1b7df4d5fa92d26fdf",
       "version": "19.7",
       "port-version": 9
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Adds a new `asio` feature to `portaudio` on Windows and MinGW which allows building PortAudio with Steinberg Audio Stream Input/Output (ASIO) support. Because the ASIO SDK is GPLv3-licensed while PortAudio is permissively licensed, I did not add `asio` as a default feature.

I also made some modifications to the `asiosdk` package - applying a patch that fixes a new/delete mismatch in the ASIO SDK, and adding a new unofficial CMake target.

Partially fixes #41006. JACK support on Windows won't be possible until either a new portaudio version is released or we decide to target a git snapshot [like Ubuntu is doing](https://github.com/PortAudio/portaudio/issues/884#issuecomment-3720248978).
