### PR TITLE
[influxdb-cxx] Update to 0.8.1

### DIFF
--- a/ports/influxdb-cxx/portfile.cmake
+++ b/ports/influxdb-cxx/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO offa/influxdb-cxx
     REF "v${VERSION}"
-    SHA512 59749a9215de7e4e7af80478f1ee87d932ac255b2e9eb0343296511adf1af2213174f878d9be3b4da1475e35ba869ab5222ea81bf009cfabd96997ea253716b5
+    SHA512 bd21c67988fe3ffddcfe11c26c2d23954702a542f138751e78d027d98f980c5c8e969776a1697d6104a704c0dddf63130b9c1f9c9df6e8e6bcb27bf9f8303218
     HEAD_REF master
     PATCHES
         fix-dllexports.patch

--- a/ports/influxdb-cxx/vcpkg.json
+++ b/ports/influxdb-cxx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "influxdb-cxx",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "InfluxDB C++ client library",
   "homepage": "https://github.com/offa/influxdb-cxx",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3973,7 +3973,7 @@
       "port-version": 0
     },
     "influxdb-cxx": {
-      "baseline": "0.8.0",
+      "baseline": "0.8.1",
       "port-version": 0
     },
     "infoware": {

--- a/versions/i-/influxdb-cxx.json
+++ b/versions/i-/influxdb-cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "389e36a96ad0ec2f8a04f271fe8cfec2d666a877",
+      "version": "0.8.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f9f5109533c891500c4d32dc636905aef5beccdd",
       "version": "0.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
