### PR TITLE
[cminpack] Update to 1.3.11

### DIFF
--- a/ports/cminpack/portfile.cmake
+++ b/ports/cminpack/portfile.cmake
@@ -1,25 +1,14 @@
-# Must be removed on next release
-vcpkg_download_distfile(DLLEXPORT_PATCH
-    URLS https://github.com/devernay/cminpack/commit/0d40c5359674448aa6f78accaddca1d79befff1f.patch?full_index=1
-    FILENAME devernay-cminpack-pr-50-dllexport.patch
-    SHA512 558c21c4d43ff64a38945643810eafaee46c5f61c0e2a98931f9ba2283cf46e234a74f12ce6db4e64289de58f8da190af936f847f42636fd812fdf82ff733763
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO devernay/cminpack
-    REF v1.3.8
-    SHA512 0cab275074a31af69dbaf3ef6d41b20184c7cf9f33c78014a69ae7a022246fa79e7b4851341c6934ca1e749955b7e1096a40b4300a109ad64ebb1b2ea5d1d8ae
-    PATCHES
-        ${DLLEXPORT_PATCH}
+    REF "v${VERSION}"
+    SHA512 97655252f99a01bda00da136bdfbd3719888f6c2fe191b5ed70a339900b0606ad4ee2504cb87a223bc46b84645fb051a228d742fdbe2979693527a27578c0360
 )
-vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt" [[ STRING "CMinpack]] [[) # ("CMinpack]])
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_EXAMPLES=OFF
-        -DCMINPACK_LIB_INSTALL_DIR=lib
         -DUSE_BLAS=OFF
 )
 
@@ -27,17 +16,9 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/cminpack-1/cminpack.h" [[!defined(CMINPACK_NO_DLL)]] 0)
-endif()
-if(NOT VCPKG_BUILD_TYPE)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/cminpack.pc" "-lcminpack" "-lcminpack_d")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/cminpacks.pc" "-lcminpacks" "-lcminpacks_d")
-    if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/cminpackld.pc")
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/cminpackld.pc" "-lcminpackld" "-lcminpackld_d")
-    endif()
 endif()
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/cminpack/vcpkg.json
+++ b/ports/cminpack/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cminpack",
-  "version": "1.3.8",
-  "port-version": 4,
+  "version": "1.3.11",
   "description": "A C/C++ rewrite of the MINPACK software (originally in FORTRAN) for solving nonlinear equations and nonlinear least squares problems",
   "homepage": "http://devernay.free.fr/hacks/cminpack/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1853,8 +1853,8 @@
       "port-version": 0
     },
     "cminpack": {
-      "baseline": "1.3.8",
-      "port-version": 4
+      "baseline": "1.3.11",
+      "port-version": 0
     },
     "cmocka": {
       "baseline": "2.0.2",

--- a/versions/c-/cminpack.json
+++ b/versions/c-/cminpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78753657f07f23e8be5148beefd106317b3f0aaa",
+      "version": "1.3.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "0401d2c926529b034913ab84852eef3fac28f6d4",
       "version": "1.3.8",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
