### PR TITLE
[assimp] update to 6.0.3

### DIFF
--- a/ports/assimp/build_fixes.patch
+++ b/ports/assimp/build_fixes.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index cd8f515..da59d84 100644
+index 1242bba..eba5242 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -343,7 +343,6 @@ ELSEIF(MSVC)
+@@ -354,7 +354,6 @@ ELSEIF(MSVC)
    ENDIF()
    # supress warning for double to float conversion if Double precision is activated
    ADD_COMPILE_OPTIONS(/wd4244)
@@ -10,16 +10,16 @@ index cd8f515..da59d84 100644
    # Allow user to disable PDBs
    if(ASSIMP_INSTALL_PDB)
      SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
-@@ -351,7 +350,7 @@ ELSEIF(MSVC)
+@@ -362,7 +361,7 @@ ELSEIF(MSVC)
    elseif((GENERATOR_IS_MULTI_CONFIG) OR (CMAKE_BUILD_TYPE MATCHES Release))
      message("-- MSVC PDB generation disabled. Release binary will not be debuggable.")
    endif()
--  if(NOT /utf-8 IN_LIST CMAKE_CXX_FLAGS)
+-  if(NOT CMAKE_CXX_FLAGS MATCHES "/utf-8")
 +  if(NOT CMAKE_CXX_FLAGS MATCHES /utf-8)
      # Source code is encoded in UTF-8
      ADD_COMPILE_OPTIONS(/source-charset:utf-8)
-   endif ()
-@@ -483,7 +482,7 @@ ENDIF()
+   endif()
+@@ -493,7 +492,7 @@ ENDIF()
  
  set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
  
@@ -28,7 +28,7 @@ index cd8f515..da59d84 100644
    SET(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
    SET(CMAKE_CONFIG_TEMPLATE_FILE "cmake-modules/assimp-hunter-config.cmake.in")
    SET(NAMESPACE "${PROJECT_NAME}::")
-@@ -491,7 +490,7 @@ IF(ASSIMP_HUNTER_ENABLED)
+@@ -501,7 +500,7 @@ IF(ASSIMP_HUNTER_ENABLED)
    SET(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
    SET(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
  ELSE()
@@ -37,7 +37,7 @@ index cd8f515..da59d84 100644
    SET(CMAKE_CONFIG_TEMPLATE_FILE "cmake-modules/assimp-plain-config.cmake.in")
    string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWERCASE)
    SET(NAMESPACE "${PROJECT_NAME_LOWERCASE}::")
-@@ -506,7 +505,7 @@ set(INCLUDE_INSTALL_DIR "include")
+@@ -516,7 +515,7 @@ set(INCLUDE_INSTALL_DIR "include")
  include(CMakePackageConfigHelpers)
  
  # Note: PROJECT_VERSION is used as a VERSION
@@ -46,7 +46,7 @@ index cd8f515..da59d84 100644
  
  configure_package_config_file(
      ${CMAKE_CONFIG_TEMPLATE_FILE}
-@@ -535,14 +534,13 @@ ENDIF()
+@@ -545,14 +544,13 @@ ENDIF()
  
  # Search for external dependencies, and build them from source if not found
  # Search for zlib
@@ -65,7 +65,7 @@ index cd8f515..da59d84 100644
  ELSE()
    # If the zlib is already found outside, add an export in case assimpTargets can't find it.
    IF( ZLIB_FOUND AND ASSIMP_INSTALL)
-@@ -586,13 +584,13 @@ ELSE()
+@@ -596,13 +594,13 @@ ELSE()
    INCLUDE_DIRECTORIES(${ZLIB_INCLUDE_DIR})
  ENDIF()
  
@@ -82,13 +82,13 @@ index cd8f515..da59d84 100644
      ENDIF()
    ENDIF ()
 diff --git a/cmake-modules/assimp-plain-config.cmake.in b/cmake-modules/assimp-plain-config.cmake.in
-index 6551dcb..718ac04 100644
+index 6551dcb..dd65b0b 100644
 --- a/cmake-modules/assimp-plain-config.cmake.in
 +++ b/cmake-modules/assimp-plain-config.cmake.in
-@@ -1,4 +1,17 @@
+@@ -1,5 +1,17 @@
  @PACKAGE_INIT@
 +include(CMakeFindDependencyMacro)
-+
+ 
 +if(NOT "@BUILD_SHARED_LIBS@")
 +    find_dependency(zip CONFIG)
 +    find_dependency(unofficial-minizip CONFIG)
@@ -100,14 +100,14 @@ index 6551dcb..718ac04 100644
 +    find_dependency(utf8cpp CONFIG)
 +    find_dependency(ZLIB)
 +endif()
- 
  include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
  
+ set(ASSIMP_ROOT_DIR ${PACKAGE_PREFIX_DIR})
 diff --git a/code/AssetLib/3MF/D3MFExporter.cpp b/code/AssetLib/3MF/D3MFExporter.cpp
-index 64b94e5..5951279 100644
+index 71e3535..b8e5de3 100644
 --- a/code/AssetLib/3MF/D3MFExporter.cpp
 +++ b/code/AssetLib/3MF/D3MFExporter.cpp
-@@ -57,7 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+@@ -56,7 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  #ifdef ASSIMP_USE_HUNTER
  #include <zip/zip.h>
  #else
@@ -160,7 +160,7 @@ index 068ef40..be116f8 100644
  #include <deque>
  #include <forward_list>
 diff --git a/code/AssetLib/MMD/MMDPmxParser.cpp b/code/AssetLib/MMD/MMDPmxParser.cpp
-index 73d6b6c..27ebcd9 100644
+index 73d6b6c..69529ba 100644
 --- a/code/AssetLib/MMD/MMDPmxParser.cpp
 +++ b/code/AssetLib/MMD/MMDPmxParser.cpp
 @@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -168,12 +168,12 @@ index 73d6b6c..27ebcd9 100644
  #include "MMDPmxParser.h"
  #include <assimp/StringUtils.h>
 -#include "utf8.h"
-+#include <utf8cpp/utf8.h>
++#include "utf8cpp/utf8.h"
  #include <assimp/Exceptional.h>
  
  namespace pmx
 diff --git a/code/AssetLib/SIB/SIBImporter.cpp b/code/AssetLib/SIB/SIBImporter.cpp
-index 8e05846..dee6a5a 100644
+index 8e05846..9860c5f 100644
 --- a/code/AssetLib/SIB/SIBImporter.cpp
 +++ b/code/AssetLib/SIB/SIBImporter.cpp
 @@ -56,7 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -181,12 +181,12 @@ index 8e05846..dee6a5a 100644
  #include <assimp/StreamReader.h>
  #include <assimp/TinyFormatter.h>
 -#include "utf8.h"
-+#include <utf8cpp/utf8.h>
++#include "utf8cpp/utf8.h"
  #include <assimp/importerdesc.h>
  #include <assimp/scene.h>
  #include <assimp/DefaultLogger.hpp>
 diff --git a/code/AssetLib/STEPParser/STEPFileEncoding.cpp b/code/AssetLib/STEPParser/STEPFileEncoding.cpp
-index 7508e90..4b85c68 100644
+index 7508e90..281c387 100644
 --- a/code/AssetLib/STEPParser/STEPFileEncoding.cpp
 +++ b/code/AssetLib/STEPParser/STEPFileEncoding.cpp
 @@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -194,15 +194,15 @@ index 7508e90..4b85c68 100644
  #include "STEPFileEncoding.h"
  #include <assimp/fast_atof.h>
 -#include "utf8.h"
-+#include <utf8cpp/utf8.h>
++#include "utf8cpp/utf8.h"
  
  #include <memory>
  
 diff --git a/code/CMakeLists.txt b/code/CMakeLists.txt
-index 8728188..3d82854 100644
+index de2f650..e605bf8 100644
 --- a/code/CMakeLists.txt
 +++ b/code/CMakeLists.txt
-@@ -1116,8 +1116,7 @@ ELSE() # IF (ASSIMP_BUILD_USD_IMPORTER)
+@@ -1113,8 +1113,7 @@ ELSE() # IF (ASSIMP_BUILD_USD_IMPORTER)
  ENDIF() # IF (ASSIMP_BUILD_USD_IMPORTER)
  
  # pugixml
@@ -212,7 +212,7 @@ index 8728188..3d82854 100644
    find_package(pugixml CONFIG REQUIRED)
  ELSEIF(NOT TARGET pugixml::pugixml)
    SET( Pugixml_SRCS
-@@ -1130,30 +1129,27 @@ ELSEIF(NOT TARGET pugixml::pugixml)
+@@ -1127,30 +1126,27 @@ ELSEIF(NOT TARGET pugixml::pugixml)
  ENDIF()
  
  # utf8
@@ -229,7 +229,7 @@ index 8728188..3d82854 100644
 -#  hunter_add_package(polyclipping)
 -#  find_package(polyclipping CONFIG REQUIRED)
 -#ELSE()
-+IF(1)
++if(1)
 +  find_package(polyclipping CONFIG REQUIRED)
 +ELSE()
    SET( Clipper_SRCS
@@ -251,7 +251,7 @@ index 8728188..3d82854 100644
    SET( Poly2Tri_SRCS
      ../contrib/poly2tri/poly2tri/common/shapes.cc
      ../contrib/poly2tri/poly2tri/common/shapes.h
-@@ -1168,11 +1164,10 @@ ENDIF()
+@@ -1165,11 +1161,10 @@ ENDIF()
      ../contrib/poly2tri/poly2tri/sweep/sweep_context.h
    )
    SOURCE_GROUP( Contrib\\Poly2Tri FILES ${Poly2Tri_SRCS})
@@ -265,7 +265,7 @@ index 8728188..3d82854 100644
    find_package(minizip CONFIG REQUIRED)
  ELSE()
    SET( unzip_SRCS
-@@ -1188,8 +1183,7 @@ ENDIF()
+@@ -1185,8 +1180,7 @@ ENDIF()
  # zip (https://github.com/kuba--/zip)
  separate_arguments(ASSIMP_EXPORTERS_LIST UNIX_COMMAND ${ASSIMP_EXPORTERS_ENABLED})
  IF(3MF IN_LIST ASSIMP_EXPORTERS_LIST)
@@ -275,7 +275,7 @@ index 8728188..3d82854 100644
      find_package(zip CONFIG REQUIRED)
    ELSE()
      SET( ziplib_SRCS
-@@ -1210,7 +1204,7 @@ IF(3MF IN_LIST ASSIMP_EXPORTERS_LIST)
+@@ -1207,7 +1201,7 @@ IF(3MF IN_LIST ASSIMP_EXPORTERS_LIST)
  ENDIF()
  
  # openddlparser
@@ -284,7 +284,7 @@ index 8728188..3d82854 100644
    hunter_add_package(openddlparser)
    find_package(openddlparser CONFIG REQUIRED)
  ELSE()
-@@ -1233,7 +1227,7 @@ ELSE()
+@@ -1230,7 +1224,7 @@ ELSE()
  ENDIF()
  
  # Open3DGC
@@ -293,7 +293,7 @@ index 8728188..3d82854 100644
    # Nothing to do, not available in Hunter yet.
  ELSE()
    SET ( open3dgc_SRCS
-@@ -1268,6 +1262,7 @@ ELSE()
+@@ -1265,6 +1259,7 @@ ELSE()
      ../contrib/Open3DGC/o3dgcVector.inl
    )
    SOURCE_GROUP( Contrib\\open3dgc FILES ${open3dgc_SRCS})
@@ -301,7 +301,7 @@ index 8728188..3d82854 100644
  ENDIF()
  
  # Check dependencies for glTF importer with Open3DGC-compression.
-@@ -1276,7 +1271,7 @@ ENDIF()
+@@ -1273,7 +1268,7 @@ ENDIF()
  IF (NOT WIN32)
    FIND_PACKAGE(RT QUIET)
  ENDIF ()
@@ -310,7 +310,7 @@ index 8728188..3d82854 100644
    SET( ASSIMP_IMPORTER_GLTF_USE_OPEN3DGC 1 )
    ADD_DEFINITIONS( -DASSIMP_IMPORTER_GLTF_USE_OPEN3DGC=1 )
  ELSE ()
-@@ -1286,9 +1281,9 @@ ELSE ()
+@@ -1283,9 +1278,9 @@ ELSE ()
  ENDIF ()
  
  # RapidJSON
@@ -322,7 +322,7 @@ index 8728188..3d82854 100644
  ELSE()
    INCLUDE_DIRECTORIES("../contrib/rapidjson/include")
    ADD_DEFINITIONS( -DRAPIDJSON_HAS_STDSTRING=1)
-@@ -1299,9 +1294,8 @@ ELSE()
+@@ -1296,9 +1291,8 @@ ELSE()
  ENDIF()
  
  # stb
@@ -334,16 +334,16 @@ index 8728188..3d82854 100644
  ELSE()
    SET( stb_SRCS
      ../contrib/stb/stb_image.h
-@@ -1323,7 +1317,7 @@ IF( MSVC OR "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC") # clang with MSVC ABI
-   ADD_DEFINITIONS( -D_CRT_SECURE_NO_WARNINGS )
- endif ()
+@@ -1315,7 +1309,7 @@ if(MSVC10)
+   endif()
+ endif()
  
 -IF(NOT ASSIMP_HUNTER_ENABLED)
 +IF(0)
    if (UNZIP_FOUND)
      SET (unzip_compile_SRCS "")
    else ()
-@@ -1379,7 +1373,7 @@ SET( assimp_src
+@@ -1373,7 +1367,7 @@ SET( assimp_src
  )
  ADD_DEFINITIONS( -DOPENDDLPARSER_BUILD )
  
@@ -352,7 +352,7 @@ index 8728188..3d82854 100644
    INCLUDE_DIRECTORIES(
        ${IRRXML_INCLUDE_DIR}
        ../contrib/openddlparser/include
-@@ -1483,21 +1477,25 @@ TARGET_INCLUDE_DIRECTORIES ( assimp PUBLIC
+@@ -1476,21 +1470,24 @@ TARGET_INCLUDE_DIRECTORIES ( assimp PUBLIC
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>
    $<INSTALL_INTERFACE:${ASSIMP_INCLUDE_INSTALL_DIR}>
@@ -371,7 +371,6 @@ index 8728188..3d82854 100644
 -      utf8cpp
 +      PRIVATE
 +      polyclipping::polyclipping
-+      #openddlparser::openddl_parser
 +      ${OPENDDL_PARSER_LIBRARIES}
 +      poly2tri::poly2tri
 +      unofficial::minizip::minizip
@@ -387,7 +386,7 @@ index 8728188..3d82854 100644
    endif()
  
    if (ASSIMP_BUILD_DRACO)
-@@ -1520,9 +1518,9 @@ if(ASSIMP_ANDROID_JNIIOSYSTEM)
+@@ -1513,9 +1510,9 @@ if(ASSIMP_ANDROID_JNIIOSYSTEM)
  endif()
  
  IF (ASSIMP_BUILD_NONFREE_C4D_IMPORTER)
@@ -400,7 +399,7 @@ index 8728188..3d82854 100644
  ENDIF ()
  
  if( MSVC )
-@@ -1563,13 +1561,13 @@ if (MINGW)
+@@ -1556,13 +1553,13 @@ if (MINGW)
      ARCHIVE_OUTPUT_NAME assimp
    )
    if (NOT BUILD_SHARED_LIBS)
@@ -416,7 +415,7 @@ index 8728188..3d82854 100644
  endif()
  
  SET_TARGET_PROPERTIES( assimp PROPERTIES
-@@ -1599,14 +1597,14 @@ ENDIF()
+@@ -1592,14 +1589,14 @@ ENDIF()
  
  # Build against external unzip, or add ../contrib/unzip so
  # assimp can #include "unzip.h"
@@ -434,7 +433,7 @@ index 8728188..3d82854 100644
      endif()
    else ()
      INCLUDE_DIRECTORIES("../")
-@@ -1615,7 +1613,7 @@ ENDIF()
+@@ -1608,7 +1605,7 @@ ENDIF()
  
  # Add RT-extension library for glTF importer with Open3DGC-compression.
  IF (RT_FOUND AND ASSIMP_IMPORTER_GLTF_USE_OPEN3DGC)
@@ -444,7 +443,7 @@ index 8728188..3d82854 100644
  
  IF(ASSIMP_INSTALL)
 diff --git a/code/Common/BaseImporter.cpp b/code/Common/BaseImporter.cpp
-index 1894ad8..bfc10c0 100644
+index 1894ad8..e010080 100644
 --- a/code/Common/BaseImporter.cpp
 +++ b/code/Common/BaseImporter.cpp
 @@ -354,7 +354,7 @@ std::string BaseImporter::GetExtension(const std::string &pFile) {
@@ -452,12 +451,12 @@ index 1894ad8..bfc10c0 100644
  }
  
 -#include "utf8.h"
-+#include <utf8cpp/utf8.h>
++#include "utf8cpp/utf8.h"
  
  // ------------------------------------------------------------------------------------------------
  // Convert to UTF8 data
 diff --git a/code/Common/StbCommon.h b/code/Common/StbCommon.h
-index 6cec216..3e3c05a 100644
+index 6cec216..8c129f4 100644
 --- a/code/Common/StbCommon.h
 +++ b/code/Common/StbCommon.h
 @@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -474,7 +473,7 @@ index 6cec216..3e3c05a 100644
  #endif
  
 -#include "stb/stb_image.h"
-+#include <stb_image.h>
++#include "stb_image.h"
  
  #if _MSC_VER
  #pragma warning(pop)

--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO assimp/assimp
     REF "v${VERSION}"
-    SHA512 dc9637b183a1ab4c87d3548b1cacf4278fc5d30ffa4ca35436f94723c20b916932791e8e2c2f0d2a63786078457e61a42fb7aac8462551172f7f5bd2582ad9a9
+    SHA512 182c4ef0feca7c37d4c7d6fae801a77e6efd93d86ea4a3ff2f32fac98bd5f83c04df6e5a667036a070450f5811cd91a5d23bcd4d4a1d00ded3b1c5cc14bd0363
     HEAD_REF master
     PATCHES
         build_fixes.patch

--- a/ports/assimp/vcpkg.json
+++ b/ports/assimp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "assimp",
-  "version": "6.0.2",
-  "port-version": 1,
+  "version": "6.0.3",
   "description": "The Open Asset import library",
   "homepage": "https://github.com/assimp/assimp",
   "license": "BSD-3-Clause",

--- a/versions/a-/assimp.json
+++ b/versions/a-/assimp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc82b4fe481f060fd2525c8b83a00e91856b2183",
+      "version": "6.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "c5281ba1740ef8aeff54f666fbe1c60c0deac076",
       "version": "6.0.2",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -325,8 +325,8 @@
       "port-version": 0
     },
     "assimp": {
-      "baseline": "6.0.2",
-      "port-version": 1
+      "baseline": "6.0.3",
+      "port-version": 0
     },
     "astr": {
       "baseline": "0.3.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/assimp/assimp/releases/tag/v6.0.3
