### PR TITLE
Add libds4

### DIFF
--- a/ports/libds4/portfile.cmake
+++ b/ports/libds4/portfile.cmake
@@ -1,0 +1,26 @@
+# portfile.cmake
+
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Tm24sense/libds4
+    
+    REF 5f493a0818801d371e929ab1aab1bac527d49d41
+    SHA512 023e9299ab66998e58a3eb79e3592b839d23d44b93ed9e44f9953250e75177b6178621baec0c17144bc5e6bf3ac309f2ee3c6ce855369b007ee9702d278dee95
+)
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_cmake_config_fixup(PACKAGE_NAME libds4)
+
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libds4/vcpkg.json
+++ b/ports/libds4/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libds4",
+  "version": "0.1.0",
+  "description": "C/C++ library for DualShock 4 controllers.",
+  "homepage": "https://github.com/Tm24sense/libds4",
+  "license": "MIT",
+  "dependencies": [
+    "hidapi",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4800,6 +4800,10 @@
       "baseline": "1.1.5",
       "port-version": 0
     },
+    "libds4": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "libdshowcapture": {
       "baseline": "2025-02-08",
       "port-version": 0

--- a/versions/l-/libds4.json
+++ b/versions/l-/libds4.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "acf5e15d858c6dcfa39a4a1e755de1ded06a97b9",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

 If this PR adds a new port, please uncomment and fill out this checklist:

- [✅ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [✅] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [✅  ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [✅  ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [✅  ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ✅ ] The installed as the "copyright" file matches what upstream says.
- [✅  ] The source code of the component installed comes from an authoritative source.
- [✅  ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ✅ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [✅  ] Only one version is in the new port's versions file.
- [✅  ] Only one version is added to each modified port's versions file.


