### PR TITLE
Add hazelcast client version 5.6.0

### DIFF
--- a/ports/hazelcast-cpp-client/portfile.cmake
+++ b/ports/hazelcast-cpp-client/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hazelcast/hazelcast-cpp-client
-    REF "eb19e7f9f8789be79d79fbc1b29a3cf6f2bb98ad"
+    REF "v${VERSION}"
     SHA512 bc37aae5fbd4272b7e3f1c489c05661c1c771e96fc3f0344ee02be8fe705e98a64234772e679e635f10a64788b8d62e069bc5eb119884b7eb9a78ccd66da62c4
     HEAD_REF master
 )

--- a/ports/hazelcast-cpp-client/portfile.cmake
+++ b/ports/hazelcast-cpp-client/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hazelcast/hazelcast-cpp-client
-    REF "e8adeabb6ab39b4df946896cc01f3ceb103c2218"
-    SHA512 6a4d55bb37a66b19d57c4ecf429505e1fc93680d8e9380f0c87176baf6b9d340a99df5fedb78ae832e40a6d3a98560b058653cb7d4e6c9a2ee7f9b372f8736b0
+    REF "eb19e7f9f8789be79d79fbc1b29a3cf6f2bb98ad"
+    SHA512 bc37aae5fbd4272b7e3f1c489c05661c1c771e96fc3f0344ee02be8fe705e98a64234772e679e635f10a64788b8d62e069bc5eb119884b7eb9a78ccd66da62c4
     HEAD_REF master
 )
 

--- a/ports/hazelcast-cpp-client/vcpkg.json
+++ b/ports/hazelcast-cpp-client/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hazelcast-cpp-client",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "C++ client library for Hazelcast in-memory database.",
   "homepage": "https://github.com/hazelcast/hazelcast-cpp-client",
   "documentation": "https://docs.hazelcast.com/hazelcast/latest/clients/cplusplus",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3745,7 +3745,7 @@
       "port-version": 4
     },
     "hazelcast-cpp-client": {
-      "baseline": "5.5.0",
+      "baseline": "5.6.0",
       "port-version": 0
     },
     "hdf5": {

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "eb19e7f9f8789be79d79fbc1b29a3cf6f2bb98ad",
+      "git-tree": "54a6e866d23d83381bc711cb9de3e46c74f5d756",
       "version": "5.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     {
       "git-tree": "85552d598eb1e3da76903e0675a0af12b38c2ddf",

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "54a6e866d23d83381bc711cb9de3e46c74f5d756",
+      "git-tree": "25fdd1f6ac8b5c5a794f887f473184d9ac8bff15",
       "version": "5.6.0",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "85552d598eb1e3da76903e0675a0af12b38c2ddf",

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb19e7f9f8789be79d79fbc1b29a3cf6f2bb98ad",
+      "version": "5.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "85552d598eb1e3da76903e0675a0af12b38c2ddf",
       "version": "5.5.0",
       "port-version": 0


### PR DESCRIPTION
Add new version for hazelcast client version 5.6.0

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

