### PR TITLE
[harfbuzz] update to 12.3.1

### DIFF
--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
     REF ${VERSION}
-    SHA512 b8f0acf2d25abd64881b4dcef52d0a2d43eefd9ead6833878b5183f38bcac8659b9c6c26358dd0624b4f6633da4c3a536f60bcf8b471d451a518dec45fd44f7a
+    SHA512 fef2d3a858472b717ed7c0df6ff1bc638daeb4f122ba9245b41f788b0c533ac9bd8f3411b475cc89e733236951b1478dd3f4f6768a8ebffa345e6e399a049460
     HEAD_REF master
     PATCHES
         fix-win32-build.patch

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "harfbuzz",
-  "version": "12.3.0",
+  "version": "12.3.1",
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "license": "MIT-Modern-Variant",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3729,7 +3729,7 @@
       "port-version": 2
     },
     "harfbuzz": {
-      "baseline": "12.3.0",
+      "baseline": "12.3.1",
       "port-version": 0
     },
     "hash-library": {

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a0c2be422e5d5d156e617d787fe577eb1c00a8b0",
+      "version": "12.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8d5d30281bc0f3753723040b88a95d9e3eb4815c",
       "version": "12.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/harfbuzz/harfbuzz/releases/tag/12.3.1
