### PR TITLE
[libxkbfile] Update to 1.1.3

### DIFF
--- a/ports/libxkbfile/portfile.cmake
+++ b/ports/libxkbfile/portfile.cmake
@@ -1,41 +1,33 @@
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
+    return()
+endif()
 
 set(PATCHES "")
-if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(PATCHES symbol_visibility.patch)
-    list(APPEND VCPKG_C_FLAGS " /DXKBFILE_BUILD")
-    list(APPEND VCPKG_CXX_FLAGS " /DXKBFILE_BUILD")
+    list(APPEND VCPKG_C_FLAGS "/DXKBFILE_BUILD")
+    list(APPEND VCPKG_CXX_FLAGS "/DXKBFILE_BUILD")
 endif()
 
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/xorg
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lib/libxkbfile
-    REF  261992d42905f209cd5bf6afcf8a7ae3aa30b3ff #1.1.0
-    SHA512 5be520e408d25331c9a97648f2a6fa832f0d4f49f93f71490b89746da0fbbda404eaab3797c5fbe195287dc94581a6703fa4ecc2511e046127af057eab60378f
+    REF  "libxkbfile-${VERSION}"
+    SHA512 e4b0fc6d9525669fe85cd8ebb096ce4a9355de00e7356dbe6c3cb194f6aa2449ef345811ce4934bb8c09edb94eee08227f7f20ee1df4a8a49697a3dc85cd704e
     HEAD_REF master
-    PATCHES fix_u_char.patch 
-            ${PATCHES}
-) 
-
-set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
-
-vcpkg_configure_make(
-    SOURCE_PATH "${SOURCE_PATH}"
-    AUTOCONFIG
+    PATCHES
+        fix_u_char.patch
+        ${PATCHES}
 )
 
-vcpkg_install_make()
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-
-# Handle copyright
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}/")
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/" RENAME copyright)
-endif()
-
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libxkbfile/symbol_visibility.patch
+++ b/ports/libxkbfile/symbol_visibility.patch
@@ -1,8 +1,8 @@
 diff --git a/include/X11/extensions/XKBfile.h b/include/X11/extensions/XKBfile.h
-index 1455463e6..5bcabdd14 100644
---- a/include/X11/extensions/XKBfile.h	
+index 1455463..d883bda 100644
+--- a/include/X11/extensions/XKBfile.h
 +++ b/include/X11/extensions/XKBfile.h
-@@ -83,10 +83,15 @@ typedef void	(*XkbFileAddOnFunc)(
+@@ -83,10 +83,19 @@ typedef void	(*XkbFileAddOnFunc)(
  #define	_XkbErrXReqFailure		25
  #define	_XkbErrBadImplementation	26
  
@@ -10,10 +10,14 @@ index 1455463e6..5bcabdd14 100644
 -extern unsigned		_XkbErrCode;
 -extern const char *	_XkbErrLocation;
 -extern unsigned		_XkbErrData;
-+#if defined(_MSC_VER) && !defined(XKBFILE_BUILD)
-+#define XKBFILE_EXTERN __declspec(dllimport) extern
++#ifdef _MSC_VER
++# ifdef XKBFILE_BUILD
++#  define XKBFILE_EXTERN __declspec(dllexport)
++# else
++#  define XKBFILE_EXTERN __declspec(dllimport)
++# endif
 +#else
-+#define XKBFILE_EXTERN extern
++# define XKBFILE_EXTERN extern
 +#endif
 +XKBFILE_EXTERN const char *	_XkbErrMessages[];
 +XKBFILE_EXTERN unsigned		_XkbErrCode;

--- a/ports/libxkbfile/vcpkg.json
+++ b/ports/libxkbfile/vcpkg.json
@@ -1,12 +1,15 @@
 {
   "name": "libxkbfile",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "description": "XKB file handling routines",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxkbfile",
   "license": null,
   "dependencies": [
     "libx11",
-    "xorg-macros",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    },
     "xproto"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5833,7 +5833,7 @@
       "port-version": 0
     },
     "libxkbfile": {
-      "baseline": "1.1.0",
+      "baseline": "1.1.3",
       "port-version": 0
     },
     "libxlsxwriter": {

--- a/versions/l-/libxkbfile.json
+++ b/versions/l-/libxkbfile.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e3ad6a7944b9fa13961174ac72b4a9045cc71f82",
+      "version": "1.1.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "4b6df8dfd8284d03ff745d341c1269c191027811",
       "version": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Switching to meson, as autoconf is already removed on their master branch (so only 1.1.3 has both build systems).