### PR TITLE
[libpq] fix x64-mingw-static build producing import libraries instead of static archives

### DIFF
--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_extract_source_archive(
         unix/single-linkage.patch
         unix/no-server-tools.patch
         unix/mingw-install.patch
+        unix/mingw-static-importlib-fix.patch
         unix/python.patch
         windows/macro-def.patch
         windows/win_bison_flex.patch

--- a/ports/libpq/unix/mingw-static-importlib-fix.patch
+++ b/ports/libpq/unix/mingw-static-importlib-fix.patch
@@ -1,0 +1,64 @@
+diff --git a/src/Makefile.shlib b/src/Makefile.shlib
+index f94d59d..77aa6bf 100644
+--- a/src/Makefile.shlib
++++ b/src/Makefile.shlib
+@@ -216,8 +216,10 @@ ifeq ($(PORTNAME), win32)
+   ifdef SO_MAJOR_VERSION
+     shlib		= lib$(NAME)$(DLSUFFIX)
+   endif
++ifneq ($(LIBPQ_LIBRARY_TYPE), static)
+   haslibarule   = yes
+ endif
++endif
+ 
+ 
+ # If the shared library doesn't have an export file, mark all symbols not
+@@ -323,8 +325,10 @@ else
+ # Win32 case
+ 
+ # See notes in src/backend/parser/Makefile about the following two rules
++ifneq ($(LIBPQ_LIBRARY_TYPE), static)
+ $(stlib): $(shlib)
+ 	touch $@
++endif
+ 
+ # XXX A backend that loads a module linked with libgcc_s_dw2-1.dll will exit
+ # uncleanly, hence -static-libgcc.  (Last verified with MinGW-w64 compilers
+
+diff --git a/src/makefiles/Makefile.win32 b/src/makefiles/Makefile.win32:
+index dc1aafa..1ab97a8 100644
+--- a/src/makefiles/Makefile.win32
++++ b/src/makefiles/Makefile.win32
+@@ -22,21 +22,32 @@ endif
+ endif
+ endif
+ 
++ifeq (,$(filter static,$(LIBPQ_LIBRARY_TYPE)))
+ ifneq (,$(findstring src/common,$(subdir)))
+ override CPPFLAGS+= -DBUILDING_DLL
+ endif
++endif
++
+ 
++ifeq (,$(filter static,$(LIBPQ_LIBRARY_TYPE)))
+ ifneq (,$(findstring src/port,$(subdir)))
+ override CPPFLAGS+= -DBUILDING_DLL
+ endif
++endif
++
+ 
++ifeq (,$(filter static,$(LIBPQ_LIBRARY_TYPE)))
+ ifneq (,$(findstring timezone,$(subdir)))
+ override CPPFLAGS+= -DBUILDING_DLL
+ endif
++endif
++
+ 
++ifeq (,$(filter static,$(LIBPQ_LIBRARY_TYPE)))
+ ifneq (,$(findstring ecpg/ecpglib,$(subdir)))
+ override CPPFLAGS+= -DBUILDING_DLL
+ endif
++endif
+ 
+ # required by Python headers
+ ifneq (,$(findstring src/pl/plpython,$(subdir)))

--- a/ports/libpq/vcpkg.json
+++ b/ports/libpq/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libpq",
   "version": "16.9",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The official database access API of postgresql",
   "homepage": "https://www.postgresql.org/",
   "license": "PostgreSQL",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5374,7 +5374,7 @@
     },
     "libpq": {
       "baseline": "16.9",
-      "port-version": 2
+      "port-version": 3
     },
     "libpqxx": {
       "baseline": "7.10.5",

--- a/versions/l-/libpq.json
+++ b/versions/l-/libpq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efbe73e3eb02f7ad96a35763a9270872ca78f4cf",
+      "version": "16.9",
+      "port-version": 3
+    },
+    {
       "git-tree": "d0e25acee8871632a68875de10a8b2803cad1d68",
       "version": "16.9",
       "port-version": 2


### PR DESCRIPTION
This pr fixes an issue where building `libpq` with the `x64-mingw-static` triplet resulted in an import library linked to a DLL, rather than a true static library.

### The Problem

When building libpq on MinGW static targets, the upstream build system defaults to the `win32` configuration which enforces shared library rules. Even when a static build is requested via vcpkg, the resulting `libpq.a` acts as an import library (essentially a wrapper) requiring `libpq.dll` at runtime. Applications linking against this `libpq.a` would compile successfully but fail at startup with "libpq.dll not found".

A patch has been applied to `src/Makefile.shlib` and `src/makefiles/Makefile.win32`. This patch introduces checks for a `LIBPQ_LIBRARY_TYPE` variable (passed during the build process).

1.   `src/Makefile.shlib`:
		When building statically, `haslibarule` is unset. This re-enables the standard `ar` archiving rule, allowing the creation of a genuine static archive (`.a`) directly from object files, decoupling it from the shared library generation.
2.   `src/makefiles/Makefile.win32`:
		The `-DBUILDING_DLL` preprocessor flag is suppressed during static builds. This prevents `__declspec(dllexport)` definitions, ensuring the object files are compiled suitable for static linking rather than as DLL exports.

***

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


***


### Reproduction & Proof

Since this is not a compilation or configuration error, I have prepared a reproduction repo to clearly demonstrate the issue. I believe it will make it easier for maintainers and reviewers to understand the issue.

You can see the issue in the link I will share below. The repo is written to be compatible with vcpkg. You can easily compile it. 
Additionally, I am adding the images to the description of this PR as well.


repo: https://github.com/SeanTolstoyevski/vcpkg-mingw-libpq-bug-reproducer?tab=readme-ov-file#result

1. Before Patch (Runtime Error)

![libpq.dll not found error window](https://github.com/SeanTolstoyevski/vcpkg-mingw-libpq-bug-reproducer/blob/main/resource/bug.png?raw=true)

2. After Patch (Success):

![success terminal screen](https://github.com/SeanTolstoyevski/vcpkg-mingw-libpq-bug-reproducer/blob/main/resource/after-patch.png?raw=true)
