### PR TITLE
[sdl3-image] update to 3.4.0

### DIFF
--- a/ports/sdl3-image/portfile.cmake
+++ b/ports/sdl3-image/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libsdl-org/SDL_image
     REF "release-${VERSION}"
-    SHA512 243fa6e9523f8ca5c40579d0ce20e86eb53c87b962e82a6696ad0a9541a68d7fe9730510067a5a181361a77cdca83fab373fd353722367f353e0cd2a614906f0
+    SHA512 3e98854f92b2fbb3489408b413ce2e0cfbb3e3eea58fa6e7037948a9fa7bf6bf5af38c4087285d4b7340b1115699c2c4b9626ce65a3e3b449bd5d4ec2078c957
     HEAD_REF main
     PATCHES
         dependencies.diff
@@ -44,7 +44,7 @@ else()
     vcpkg_cmake_config_fixup(PACKAGE_NAME SDL3_image CONFIG_PATH lib/cmake/SDL3_image)
 endif()
 
-file(REMOVE_RECURSE 
+file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/share"
     "${CURRENT_PACKAGES_DIR}/debug/include"
 )

--- a/ports/sdl3-image/vcpkg.json
+++ b/ports/sdl3-image/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sdl3-image",
-  "version": "3.2.6",
+  "version": "3.4.0",
   "description": "SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV",
   "homepage": "https://github.com/libsdl-org/SDL_image",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8941,7 +8941,7 @@
       "port-version": 0
     },
     "sdl3-image": {
-      "baseline": "3.2.6",
+      "baseline": "3.4.0",
       "port-version": 0
     },
     "sdl3-ttf": {

--- a/versions/s-/sdl3-image.json
+++ b/versions/s-/sdl3-image.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03ff42d864ca8e4dc391835a5a4819b8178c403c",
+      "version": "3.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5a295bf04dadea6500bc3ac5f63f829f80cb3fdb",
       "version": "3.2.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/libsdl-org/SDL_image/releases/tag/release-3.4.0
