### PR TITLE
[orefkov-simstr] update to 1.4.0

### DIFF
--- a/ports/orefkov-simstr/portfile.cmake
+++ b/ports/orefkov-simstr/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO orefkov/simstr
-	SHA512 faae3caf8bf342d26b0ff6c4ddf6b3f69279d04dcf1cde1c4dbf78057870833fdc85a4bec072fa0ca617e6b60eace72f898cb831b7b9506341d593b3edc99a98
+	SHA512 63592a9a006ed969b5adf290c25f395aa9b3be36a8bb8162fd1318badeeab9730e5a6dcac75874a60547de4411b973487e80c352f1815defdd64992e0c3d61de
     REF "rel${VERSION}"
     HEAD_REF main
 )

--- a/ports/orefkov-simstr/vcpkg.json
+++ b/ports/orefkov-simstr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "orefkov-simstr",
-  "version-semver": "1.3.1",
+  "version-semver": "1.4.0",
   "description": "Yet another C++ strings library implementation",
   "homepage": "https://github.com/orefkov/simstr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7373,7 +7373,7 @@
       "port-version": 0
     },
     "orefkov-simstr": {
-      "baseline": "1.3.1",
+      "baseline": "1.4.0",
       "port-version": 0
     },
     "ormpp": {

--- a/versions/o-/orefkov-simstr.json
+++ b/versions/o-/orefkov-simstr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5c6aa5c0e91eb89b562ecd596f14b14794907f63",
+      "version-semver": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "354367b048669f4b659fbad7daa15a6f30b1797e",
       "version-semver": "1.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/orefkov/simstr/releases/tag/rel1.4.0
