### PR TITLE
[jsonfusion]:update to 0.710.0

### DIFF
--- a/ports/jsonfusion/portfile.cmake
+++ b/ports/jsonfusion/portfile.cmake
@@ -2,13 +2,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tucher/JsonFusion
     REF "v${VERSION}"
-    SHA512 4f9068ae571b140b67499a8bc5e10a0af5aed7cf8a1fc53b77c36f73e60f2546c3a6585ad903d0169e4e57ab8d2914905f62419f27218b94ebaf2235de02ce8f
+    SHA512 fe8cb3068fc5ce7f5bacb708eb4c9947fa241b7cf29d50b1d285f5df243a164e063701de9bf1e486d6a38be0c9d0677d0ed0450b70e3878cdad1dbbae363bc36
     HEAD_REF master
 )
 
 # Install JsonFusion headers, excluding experimental 3party directory
 # (3party is only used with JSONFUSION_FP_BACKEND=1, default is 0 with in-house implementation)
-file(INSTALL "${SOURCE_PATH}/include/JsonFusion" 
+file(INSTALL "${SOURCE_PATH}/include/JsonFusion"
      DESTINATION "${CURRENT_PACKAGES_DIR}/include"
      PATTERN "3party" EXCLUDE)
 

--- a/ports/jsonfusion/vcpkg.json
+++ b/ports/jsonfusion/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonfusion",
-  "version": "0.707.0",
+  "version": "0.710.0",
   "description": "Type-driven JSON/CBOR parser with declarative validation. Header-only C++23 library.",
   "homepage": "https://github.com/tucher/JsonFusion",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4161,7 +4161,7 @@
       "port-version": 0
     },
     "jsonfusion": {
-      "baseline": "0.707.0",
+      "baseline": "0.710.0",
       "port-version": 0
     },
     "jsonifier": {

--- a/versions/j-/jsonfusion.json
+++ b/versions/j-/jsonfusion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2aa8233f622d88be661160cca7166053b371b181",
+      "version": "0.710.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3f390340968218a3c482f0fc3c6db90c80184725",
       "version": "0.707.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/tucher/JsonFusion/releases/tag/v0.710.0
