### PR TITLE
[c-ares] Update license to MIT

### DIFF
--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "c-ares",
   "version-semver": "1.34.6",
+  "port-version": 1,
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
-  "license": "MIT-CMU",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1546,7 +1546,7 @@
     },
     "c-ares": {
       "baseline": "1.34.6",
-      "port-version": 0
+      "port-version": 1
     },
     "c4core": {
       "baseline": "0.2.7",

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ea3dc034c137265c85a72a715613fe858a49df6",
+      "version-semver": "1.34.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "6ee80f35bece6f1dbf2d767833aa117d718df752",
       "version-semver": "1.34.6",
       "port-version": 0


### PR DESCRIPTION
Fixes #49551

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.