### PR TITLE
[sciter-js] Update to 6.0.3.5

### DIFF
--- a/ports/sciter-js/portfile.cmake
+++ b/ports/sciter-js/portfile.cmake
@@ -60,8 +60,11 @@ if(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     file(INSTALL ${SCITER_BIN}/libsciter-gtk.so DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
     file(INSTALL ${SCITER_BIN}/libsciter-gtk.so DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
 
-    file(INSTALL ${SCITER_BIN}/sciter-sqlite.so DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
-    file(INSTALL ${SCITER_BIN}/sciter-sqlite.so DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+    if ("sqlite" IN_LIST FEATURES)
+        file(INSTALL ${SCITER_BIN}/sciter-sqlite.so DESTINATION ${SCITER_TOOLS})
+        file(INSTALL ${SCITER_BIN}/sciter-sqlite.so DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+        file(INSTALL ${SCITER_BIN}/sciter-sqlite.so DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+    endif()
 
 elseif(VCPKG_TARGET_IS_OSX)
     set(SCITER_BIN ${SOURCE_PATH}/bin/macosx)

--- a/ports/sciter-js/portfile.cmake
+++ b/ports/sciter-js/portfile.cmake
@@ -6,8 +6,8 @@ endif()
 
 set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
 
-set(SCITER_REVISION 1a35354adaef9a9940ceac7c209f2aa8157c7fb0)
-set(SCITER_SHA 9d7bc33a5aefb6759ca380cc690ea8a92fe707846045ab5f4d3fd178d4b5c2a43de1a1be8fad97e1c3b4f2c763b5f95f8089a9006de706fa87ef8b1930eb7ad3)
+set(SCITER_REVISION 48d4680f01482539281ec7b51d80c4c3608cfe49)
+set(SCITER_SHA 407bc9674c8f387980ea496d5946b853d126874a7f11545030ea2e15eb801655023fc95d231e63e020cd4bdd0b28b71522c4d0503129be958f1e8fabfa7dbf3a)
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
     set(SCITER_ARCH x64)
@@ -77,6 +77,18 @@ elseif(VCPKG_TARGET_IS_OSX)
     execute_process(COMMAND sh -c "chmod +x usciterjs.app/Contents/MacOS/usciterjs" WORKING_DIRECTORY ${SCITER_TOOLS})
     execute_process(COMMAND sh -c "chmod +x inspector.app/Contents/MacOS/inspector" WORKING_DIRECTORY ${SCITER_TOOLS})
 
+    if ("sqlite" IN_LIST FEATURES)
+        file(INSTALL ${SCITER_BIN}/sciter-sqlite.dylib DESTINATION ${SCITER_TOOLS})
+        file(INSTALL ${SCITER_BIN}/sciter-sqlite.dylib DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+        file(INSTALL ${SCITER_BIN}/sciter-sqlite.dylib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+    endif()
+
+    if ("webview" IN_LIST FEATURES)
+        file(INSTALL ${SCITER_BIN}/sciter-webview.dylib DESTINATION ${SCITER_TOOLS})
+        file(INSTALL ${SCITER_BIN}/sciter-webview.dylib DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+        file(INSTALL ${SCITER_BIN}/sciter-webview.dylib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+    endif()
+
     file(INSTALL ${SCITER_BIN}/libsciter.dylib DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
     file(INSTALL ${SCITER_BIN}/libsciter.dylib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
 
@@ -93,6 +105,18 @@ elseif(VCPKG_TARGET_IS_WINDOWS)
     file(INSTALL ${SCITER_BIN}/inspector.exe DESTINATION ${SCITER_TOOLS})
     file(INSTALL ${SCITER_BIN}/window-mixin.exe DESTINATION ${SCITER_TOOLS})
     file(INSTALL ${SCITER_BIN}/sciter.dll DESTINATION ${SCITER_TOOLS})
+
+    if ("sqlite" IN_LIST FEATURES)
+        file(INSTALL ${SCITER_BIN}/sciter-sqlite.dll DESTINATION ${SCITER_TOOLS})
+        file(INSTALL ${SCITER_BIN}/sciter-sqlite.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+        file(INSTALL ${SCITER_BIN}/sciter-sqlite.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+    endif()
+
+    if ("webview" IN_LIST FEATURES)
+        file(INSTALL ${SCITER_BIN}/sciter-webview.dll DESTINATION ${SCITER_TOOLS})
+        file(INSTALL ${SCITER_BIN}/sciter-webview.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+        file(INSTALL ${SCITER_BIN}/sciter-webview.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+    endif()
 
     file(INSTALL ${SCITER_BIN}/sciter.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
     file(INSTALL ${SCITER_BIN}/sciter.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)

--- a/ports/sciter-js/vcpkg.json
+++ b/ports/sciter-js/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "6.0.3.5",
   "description": "Sciter.JS - Sciter but with QuickJS on board instead of TIScript. Sciter is an embeddable HTML/CSS/scripting engine.",
   "homepage": "https://gitlab.com/sciter-engine/sciter-js-sdk",
-  "supports": "!uwp & !arm & !static",
+  "supports": "!uwp & !arm & !static & !android & !freebsd & !openbsd & !netbsd",
   "features": {
     "sqlite": {
       "description": "Add sciter-sqlite support"

--- a/ports/sciter-js/vcpkg.json
+++ b/ports/sciter-js/vcpkg.json
@@ -1,7 +1,15 @@
 {
   "name": "sciter-js",
-  "version": "6.0.1.3",
+  "version": "6.0.3.5",
   "description": "Sciter.JS - Sciter but with QuickJS on board instead of TIScript. Sciter is an embeddable HTML/CSS/scripting engine.",
   "homepage": "https://gitlab.com/sciter-engine/sciter-js-sdk",
-  "supports": "!uwp & !arm & !static"
+  "supports": "!uwp & !arm & !static",
+  "features": {
+    "sqlite": {
+      "description": "Add sciter-sqlite support"
+    },
+    "webview": {
+      "description": "Add sciter-webview support"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8853,7 +8853,7 @@
       "port-version": 1
     },
     "sciter-js": {
-      "baseline": "6.0.1.3",
+      "baseline": "6.0.3.5",
       "port-version": 0
     },
     "scnlib": {

--- a/versions/s-/sciter-js.json
+++ b/versions/s-/sciter-js.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dfd0acaca01c260e34143443d9aa287a225a1c75",
+      "version": "6.0.3.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "9375e307bde74f809a43a0e42a3f7f85c698edc5",
       "version": "6.0.1.3",
       "port-version": 0

--- a/versions/s-/sciter-js.json
+++ b/versions/s-/sciter-js.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dfd0acaca01c260e34143443d9aa287a225a1c75",
+      "git-tree": "595eb544a35829366839f32200a4c2dbebba4594",
       "version": "6.0.3.5",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

I have added features for libs which are now separate dlls for win/mac.