### PR TITLE
gtk3: support Wayland on UNIX

### DIFF
--- a/ports/gtk3/portfile.cmake
+++ b/ports/gtk3/portfile.cmake
@@ -38,11 +38,16 @@ else()
     list(APPEND OPTIONS_RELEASE -Dintrospection=false)
 endif()
 
+if(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_FREEBSD OR VCPKG_TARGET_IS_OPENBSD)
+    list(APPEND OPTIONS -Dwayland_backend=true)
+else()
+    list(APPEND OPTIONS -Dwayland_backend=false)
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${OPTIONS}
-        -Dwayland_backend=false
         -Ddemos=false
         -Dexamples=false
         -Dtests=false

--- a/ports/gtk3/vcpkg.json
+++ b/ports/gtk3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gtk3",
   "version": "3.24.51",
+  "port-version": 1,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": null,
@@ -24,13 +25,13 @@
       "features": [
         "x11"
       ],
-      "platform": "linux"
+      "platform": "linux | freebsd | openbsd"
     },
-    "gdk-pixbuf",
     {
       "name": "gdk-pixbuf",
       "host": true
     },
+    "gdk-pixbuf",
     {
       "name": "gettext",
       "host": true,
@@ -52,6 +53,14 @@
     {
       "name": "vcpkg-tool-meson",
       "host": true
+    },
+    {
+      "name": "wayland",
+      "platform": "linux | freebsd | openbsd"
+    },
+    {
+      "name": "wayland-protocols",
+      "platform": "linux | freebsd | openbsd"
     }
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3546,7 +3546,7 @@
     },
     "gtk3": {
       "baseline": "3.24.51",
-      "port-version": 0
+      "port-version": 1
     },
     "gtkmm": {
       "baseline": "4.14.0",

--- a/versions/g-/gtk3.json
+++ b/versions/g-/gtk3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13503599f7ef571b58ef8a9897a2aabd972945be",
+      "version": "3.24.51",
+      "port-version": 1
+    },
+    {
       "git-tree": "e402c71794edbc5b68ad7926350bb8a068306d78",
       "version": "3.24.51",
       "port-version": 0


### PR DESCRIPTION
Pass `-Dwayland_backend=true` to Meson for Linux, FreeBSD and OpenBSD, and `false` otherwise.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.