### PR TITLE
[ecaludp] new port

### DIFF
--- a/ports/ecaludp/find-recycle.patch
+++ b/ports/ecaludp/find-recycle.patch
@@ -1,0 +1,27 @@
+diff --git a/ecaludp/CMakeLists.txt b/ecaludp/CMakeLists.txt
+index c6fc47a..df7073d 100644
+--- a/ecaludp/CMakeLists.txt
++++ b/ecaludp/CMakeLists.txt
+@@ -26,7 +26,8 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+ 
+ find_package(asio    REQUIRED)
+-find_package(recycle REQUIRED)
++
++find_path(RECYCLE_INCLUDE_DIRS "recycle/no_locking_policy.hpp")
+ 
+ message(STATUS "ECALUDP_ENABLE_NPCAP: ${ECALUDP_ENABLE_NPCAP}")
+ if(ECALUDP_ENABLE_NPCAP)
+@@ -99,11 +100,11 @@ target_link_libraries(${PROJECT_NAME}
+     PRIVATE
+         # Link header-only libs (recycle) as described in this workaround:
+         # https://gitlab.kitware.com/cmake/cmake/-/issues/15415#note_633938
+-        $<BUILD_INTERFACE:steinwurf::recycle>
+         $<$<BOOL:${WIN32}>:ws2_32>
+         $<$<BOOL:${WIN32}>:wsock32>
+         $<$<BOOL:${ECALUDP_ENABLE_NPCAP}>:udpcap::udpcap>
+ )
++target_include_directories(${PROJECT_NAME} PRIVATE ${RECYCLE_INCLUDE_DIRS})
+ 
+ target_compile_definitions(${PROJECT_NAME}
+     PRIVATE

--- a/ports/ecaludp/portfile.cmake
+++ b/ports/ecaludp/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO eclipse-ecal/ecaludp
+    REF "v${VERSION}"
+    SHA512 4f9d8c67777a63b569bd7069ca2a43eaaaa898a429c206bccfd5e90b10a733aa5f138be059cef2fcebda53987fdf0583b1d1859ecd154b9a48b5d39afd21c637
+    HEAD_REF master
+    PATCHES
+        find-recycle.patch
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(ECALUDP_LIBRARY_TYPE "SHARED")
+else()
+    set(ECALUDP_LIBRARY_TYPE "STATIC")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DECALUDP_LIBRARY_TYPE=${ECALUDP_LIBRARY_TYPE}
+        -DECALUDP_BUILD_SAMPLES=OFF
+        -DECALUDP_BUILD_TESTS=OFF
+        -DECALUDP_ENABLE_NPCAP=OFF
+        -DECALUDP_USE_BUILTIN_ASIO=OFF
+        -DECALUDP_USE_BUILTIN_RECYCLE=OFF
+        -DECALUDP_USE_BUILTIN_UDPCAP=OFF
+        -DECALUDP_USE_BUILTIN_GTEST=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ecaludp)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ecaludp/vcpkg.json
+++ b/ports/ecaludp/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "UDP transport library for eCAL with fragmentation/reassembly support.",
   "homepage": "https://github.com/eclipse-ecal/ecaludp",
   "license": "Apache-2.0",
+  "supports": "!uwp",
   "dependencies": [
     "asio",
     "recycle",

--- a/ports/ecaludp/vcpkg.json
+++ b/ports/ecaludp/vcpkg.json
@@ -7,7 +7,13 @@
   "dependencies": [
     "asio",
     "recycle",
-    "vcpkg-cmake",
-    "vcpkg-cmake-config"
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/ecaludp/vcpkg.json
+++ b/ports/ecaludp/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "ecaludp",
+  "version": "0.1.2",
+  "description": "UDP transport library for eCAL with fragmentation/reassembly support.",
+  "homepage": "https://github.com/eclipse-ecal/ecaludp",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "asio",
+    "recycle",
+    "vcpkg-cmake",
+    "vcpkg-cmake-config"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2680,6 +2680,10 @@
       "baseline": "5.13.4",
       "port-version": 0
     },
+    "ecaludp": {
+      "baseline": "0.1.2",
+      "port-version": 0
+    },
     "ecm": {
       "baseline": "6.7.0",
       "port-version": 1

--- a/versions/e-/ecaludp.json
+++ b/versions/e-/ecaludp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9532af3cee1a79508db33734a1f60499191a2984",
+      "version": "0.1.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/e-/ecaludp.json
+++ b/versions/e-/ecaludp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9532af3cee1a79508db33734a1f60499191a2984",
+      "git-tree": "149144822832bdc7ea5d0f430914a8f0c01c5096",
       "version": "0.1.2",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

