### PR TITLE
[retropak] new port

### DIFF
--- a/ports/retropak/portfile.cmake
+++ b/ports/retropak/portfile.cmake
@@ -1,0 +1,29 @@
+# This portfile is for reference when submitting to the vcpkg registry
+# It should be placed in the vcpkg/ports/retropak directory
+
+# This is a data-only package (schemas and locales)
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO piersroberts/retropak
+    REF v${VERSION}
+    SHA512 e8a709af428222c40f75a5d0b12a9d70a34562ebc717a9702111a33251be57f042a78d5dbd84e1857c890e91426c925bb54e11b5ec275311288a2610e86d4c46
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/packages/vcpkg"
+)
+
+vcpkg_cmake_install()
+
+# Remove empty directories
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+# Install license
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+# Copy usage file
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+

--- a/ports/retropak/usage
+++ b/ports/retropak/usage
@@ -1,0 +1,19 @@
+The package retropak provides JSON schema files for validating Retropak software containers.
+
+Schema files are installed to: ${RETROPAK_SCHEMA_DIR}
+Locale files are installed to: ${RETROPAK_LOCALE_DIR}
+
+In your CMakeLists.txt:
+
+    find_package(retropak CONFIG REQUIRED)
+    
+    # Access schema files
+    message(STATUS "Retropak schemas: ${RETROPAK_SCHEMA_DIR}")
+    message(STATUS "Retropak locales: ${RETROPAK_LOCALE_DIR}")
+    
+    # Example: Copy schema to build directory
+    configure_file(
+        "${RETROPAK_SCHEMA_DIR}/v1/retropak.schema.json"
+        "${CMAKE_BINARY_DIR}/retropak.schema.json"
+        COPYONLY
+    )

--- a/ports/retropak/vcpkg.json
+++ b/ports/retropak/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "retropak",
+  "version": "1.0.0",
+  "description": "A modern container format for retro software preservation. Provides JSON schema and metadata specification for Retropak software containers.",
+  "homepage": "https://retropak.org",
+  "license": "CC0-1.0",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8604,6 +8604,10 @@
       "baseline": "1.0.0",
       "port-version": 0
     },
+    "retropak": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "rewolf-wow64ext": {
       "baseline": "1.0.0.9",
       "port-version": 1

--- a/versions/r-/retropak.json
+++ b/versions/r-/retropak.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4d810cfbe5235eacd176ed78eed932999219d325",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
