### PR TITLE
[aeron] Update to 1.50.0

### DIFF
--- a/ports/aeron/patches/fix-static-crt-linkage.patch
+++ b/ports/aeron/patches/fix-static-crt-linkage.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1234567..abcdefg 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -178,10 +178,6 @@ elseif (MSVC)
+     endif ()
+
+     add_compile_options(/Oy-)
+-    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:RELEASE>>:/MD>)
+-    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:DEBUG>>:/MDd>)
+     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/MP>)
+     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/wd4251>)
+-    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:RELEASE>>:/MD>)
+-    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:/MDd>)
+     add_compile_options($<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:/Od>)
+     add_compile_options($<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:/Zi>)

--- a/ports/aeron/portfile.cmake
+++ b/ports/aeron/portfile.cmake
@@ -28,7 +28,9 @@ set(AERON_CMAKE_OPTIONS
     -DBUILD_AERON_ARCHIVE_API=${BUILD_ARCHIVE}
 )
 
-if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+# Only set static CRT if triplet explicitly requests it (VCPKG_CRT_LINKAGE=static)
+# Otherwise, respect the triplet's CRT setting (dynamic/MD or static/MT)
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_CRT_LINKAGE STREQUAL "static")
     list(APPEND AERON_CMAKE_OPTIONS
         -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$$<$$<CONFIG:Debug>:Debug>
         -DCMAKE_POLICY_DEFAULT_CMP0091=NEW

--- a/ports/aeron/portfile.cmake
+++ b/ports/aeron/portfile.cmake
@@ -6,10 +6,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aeron-io/aeron
     REF "${VERSION}"
-    SHA512 6302b235285d897bb58d388c1883145c486f931575174b68161e67a04ae2efb48993d8045855d6e04ba378fdb58050c5339561c85fffb6b222abaa1952103d37
+    SHA512 936b3a0d6903cc54246c41b946c8964b5f2957b115364445302764a579bbcc6d3c569c924aa44f96db309c0a90cef06779b608c6fc35c8284a041ff4d266f9db
     HEAD_REF master
     PATCHES
         patches/add-libuuid-vcpkg-support.patch
+        patches/fix-static-crt-linkage.patch
 )
 
 # Set archive option based on feature
@@ -19,13 +20,24 @@ else()
     set(BUILD_ARCHIVE OFF)
 endif()
 
+# Set CRT linkage for Windows static builds
+set(AERON_CMAKE_OPTIONS
+    -DAERON_INSTALL_TARGETS=ON
+    -DAERON_TESTS=OFF
+    -DAERON_BUILD_SAMPLES=OFF
+    -DBUILD_AERON_ARCHIVE_API=${BUILD_ARCHIVE}
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND AERON_CMAKE_OPTIONS
+        -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$$<$$<CONFIG:Debug>:Debug>
+        -DCMAKE_POLICY_DEFAULT_CMP0091=NEW
+    )
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DAERON_INSTALL_TARGETS=ON
-        -DAERON_TESTS=OFF
-        -DAERON_BUILD_SAMPLES=OFF
-        -DBUILD_AERON_ARCHIVE_API=${BUILD_ARCHIVE}
+    OPTIONS ${AERON_CMAKE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/aeron/vcpkg.json
+++ b/ports/aeron/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "aeron",
-  "version": "1.49.3",
-  "port-version": 2,
+  "version": "1.50.0",
   "description": "Efficient reliable UDP unicast, UDP multicast, and IPC message transport",
   "homepage": "https://github.com/aeron-io/aeron",
   "license": "Apache-2.0",

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a0f95b74df05758d1649fd98b42d8f9fc18c4019",
+      "git-tree": "936aefc7566d95f7234b2d57c8878a1253220ee7",
       "version": "1.50.0",
       "port-version": 0
     },

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a0f95b74df05758d1649fd98b42d8f9fc18c4019",
+      "version": "1.50.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "99b549362720ba9d2df482b3e21b9009a4f5f94b",
       "version": "1.49.3",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -57,8 +57,8 @@
       "port-version": 0
     },
     "aeron": {
-      "baseline": "1.49.3",
-      "port-version": 2
+      "baseline": "1.50.0",
+      "port-version": 0
     },
     "air-ctl": {
       "baseline": "1.1.2",


### PR DESCRIPTION
Update aeron from
  version 1.49.3 to 1.50.0.

  Release notes: https://github.com/aeron-io/aeron/releases/tag/1.50.0

  - [x] Changes comply with the maintainer guide.
  - [x] SHA512s are updated for each updated download.
  - [x] The \"supports\" clause reflects platforms that may be fixed by this
   new version.
  - [x] Any fixed CI baseline entries are removed from that file.
  - [x] Any patches that are no longer applied are deleted from the port's
  directory.
  - [x] The version database is fixed by rerunning \`./vcpkg x-add-version
  --all\` and committing the result.
  - [x] Only one version is added to each modified port's versions file.