### PR TITLE
Fixes variables set by Lua wrapper

### DIFF
--- a/ports/lua/vcpkg-cmake-wrapper.cmake.in
+++ b/ports/lua/vcpkg-cmake-wrapper.cmake.in
@@ -23,6 +23,6 @@ endif()
 set(Lua_FOUND TRUE)
 
 # Compatibility with this port's old behavior
-set(Lua_INCLUDE_DIR ${Lua_INCLUDE_DIR})
-set(Lua_LIBRARIES ${Lua_LIBRARIES})
-set(Lua_FOUND ${Lua_FOUND})
+set(LUA_INCLUDE_DIR ${Lua_INCLUDE_DIR})
+set(LUA_LIBRARIES ${Lua_LIBRARIES})
+set(LUA_FOUND ${Lua_FOUND})

--- a/ports/lua/vcpkg-cmake-wrapper.cmake.in
+++ b/ports/lua/vcpkg-cmake-wrapper.cmake.in
@@ -11,13 +11,18 @@ if (@COMPILE_AS_CPP@)
     _find_package(unofficial-lua-cpp CONFIG ${REQUIRES})
 endif()
 
-get_filename_component(LUA_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}" PATH)
-get_filename_component(LUA_INCLUDE_DIR "${LUA_INCLUDE_DIR}" PATH)
-set(LUA_INCLUDE_DIR ${LUA_INCLUDE_DIR}/include)
+get_filename_component(Lua_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(Lua_INCLUDE_DIR "${Lua_INCLUDE_DIR}" PATH)
+set(Lua_INCLUDE_DIR ${Lua_INCLUDE_DIR}/include)
 
-list(APPEND LUA_LIBRARIES lua)
+list(APPEND Lua_LIBRARIES lua)
 if (TARGET lua-cpp)
-    list(APPEND LUA_LIBRARIES lua-cpp)
+    list(APPEND Lua_LIBRARIES lua-cpp)
 endif()
 
-set(LUA_FOUND 1)
+set(Lua_FOUND TRUE)
+
+# Compatibility with this port's old behavior
+set(Lua_INCLUDE_DIR ${Lua_INCLUDE_DIR})
+set(Lua_LIBRARIES ${Lua_LIBRARIES})
+set(Lua_FOUND ${Lua_FOUND})

--- a/ports/lua/vcpkg.json
+++ b/ports/lua/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lua",
   "version": "5.5.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A powerful, fast, lightweight, embeddable scripting language",
   "homepage": "https://www.lua.org",
   "license": null,

--- a/ports/lua/vcpkg.json
+++ b/ports/lua/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "lua",
   "version": "5.5.0",
+  "port-version": 1,
   "description": "A powerful, fast, lightweight, embeddable scripting language",
   "homepage": "https://www.lua.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6074,7 +6074,7 @@
     },
     "lua": {
       "baseline": "5.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "lua-compat53": {
       "baseline": "0.10",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6074,7 +6074,7 @@
     },
     "lua": {
       "baseline": "5.5.0",
-      "port-version": 1
+      "port-version": 2
     },
     "lua-compat53": {
       "baseline": "0.10",

--- a/versions/l-/lua.json
+++ b/versions/l-/lua.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d4eeedc78d4489657f59376900c757c8df05ff5f",
+      "version": "5.5.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "cd357b7cb6448c982038b11a94e109d84edb360e",
       "version": "5.5.0",
       "port-version": 1

--- a/versions/l-/lua.json
+++ b/versions/l-/lua.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cd357b7cb6448c982038b11a94e109d84edb360e",
+      "version": "5.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "68062c242e90605fcdab46f73a6cad3e93eab06b",
       "version": "5.5.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #48972

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.