### PR TITLE
[zpp-bits] update to 4.6

### DIFF
--- a/ports/zpp-bits/portfile.cmake
+++ b/ports/zpp-bits/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eyalz800/zpp_bits
     REF "v${VERSION}"
-    SHA512 db3e036a1452b551155ee204ce7e3e6b6a7ab7116142fe434004cdb8d4c910afc9aaed4c3d1d4c831e0c4183a5d9a989d3e538b496d4ef68d1a15684f347c645
+    SHA512 faa96f9702a96fae10ba9dec01d0eda0e708a8bda2ee9febbcca89dfe78cf4947edbff941fe51c5529ad4c76a344ea187069ba3ed79daa36140cf39acfb522b8
     HEAD_REF master
 )
 

--- a/ports/zpp-bits/vcpkg.json
+++ b/ports/zpp-bits/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zpp-bits",
-  "version": "4.5",
+  "version": "4.6",
   "description": "A lightweight C++20 serialization and RPC library",
   "homepage": "https://github.com/eyalz800/zpp_bits",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10993,7 +10993,7 @@
       "port-version": 4
     },
     "zpp-bits": {
-      "baseline": "4.5",
+      "baseline": "4.6",
       "port-version": 0
     },
     "zserge-webview": {

--- a/versions/z-/zpp-bits.json
+++ b/versions/z-/zpp-bits.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "20c031ff57d9281538bd8f878fdf8affcaf1c182",
+      "version": "4.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "24290e718eb0a3da5119029ece494a689be4a822",
       "version": "4.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/eyalz800/zpp_bits/releases/tag/v4.6
