### PR TITLE
[directml] New port: Microsoft.AI.DirectML binaries from NuGet package 1.15.4

### DIFF
--- a/ports/directml/portfile.cmake
+++ b/ports/directml/portfile.cmake
@@ -1,27 +1,22 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
-vcpkg_find_acquire_program(NUGET)
 
 # DirectML provides DirectML.Debug.dll. They will be installed with release DLLs
 set(VCPKG_BUILD_TYPE release)
 set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
 
-set(ENV{NUGET_PACKAGES} "${BUILDTREES_DIR}/nuget")
-
 # see https://www.nuget.org/packages/Microsoft.AI.DirectML/
 # see https://github.com/microsoft/DirectML/blob/master/Releases.md
-set(PACKAGE_NAME    "Microsoft.AI.DirectML")
-set(PACKAGE_VERSION "1.15.4")
-
-file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME}")
-file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}")
-vcpkg_execute_required_process(
-    COMMAND "${NUGET}" install "${PACKAGE_NAME}" -Version "${PACKAGE_VERSION}" -Verbosity detailed
-                -OutputDirectory "${CURRENT_BUILDTREES_DIR}"
-    WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
-    LOGNAME install-nuget
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/${VERSION}"
+         "https://globalcdn.nuget.org/packages/microsoft.ai.directml.${VERSION}.nupkg"
+    FILENAME "Microsoft.AI.DirectML-${VERSION}.zip"
+    SHA512 fde767f56904abc90fd53f65d8729c918ab7f6e3c5e1ecdd479908fc02b4535cf2b0860f7ab2acb9b731d6cb809b72c3d5d4d02853fb8f5ea022a47bc44ef285
+)
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
 )
 
-get_filename_component(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME}.${PACKAGE_VERSION}" ABSOLUTE)
 if(VCPKG_TARGET_IS_WINDOWS)
     if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
         set(TRIPLE "x64-win")

--- a/ports/directml/portfile.cmake
+++ b/ports/directml/portfile.cmake
@@ -1,0 +1,81 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
+vcpkg_find_acquire_program(NUGET)
+
+# DirectML provides DirectML.Debug.dll. They will be installed with release DLLs
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+set(ENV{NUGET_PACKAGES} "${BUILDTREES_DIR}/nuget")
+
+# see https://www.nuget.org/packages/Microsoft.AI.DirectML/
+# see https://github.com/microsoft/DirectML/blob/master/Releases.md
+set(PACKAGE_NAME    "Microsoft.AI.DirectML")
+set(PACKAGE_VERSION "1.15.4")
+
+file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME}")
+vcpkg_execute_required_process(
+    COMMAND "${NUGET}" install "${PACKAGE_NAME}" -Version "${PACKAGE_VERSION}" -Verbosity detailed
+                -OutputDirectory "${CURRENT_BUILDTREES_DIR}"
+    WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
+    LOGNAME install-nuget
+)
+
+get_filename_component(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME}.${PACKAGE_VERSION}" ABSOLUTE)
+if(VCPKG_TARGET_IS_WINDOWS)
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        set(TRIPLE "x64-win")
+        # check community triplets...
+        if(DEFINED VCPKG_XBOX_CONSOLE_TARGET AND (VCPKG_XBOX_CONSOLE_TARGET MATCHES "scarlett"))
+            set(TRIPLE "x64-xbox-scarlett-231000")
+        endif()
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+        set(TRIPLE "x86-win")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64ec")
+        set(TRIPLE "arm64ec-win")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        set(TRIPLE "arm64-win")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+        set(TRIPLE "arm-win")
+    else()
+        message(FATAL_ERROR "The architecture '${VCPKG_TARGET_ARCHITECTURE}' is not supported")
+    endif()
+elseif(VCPKG_TARGET_IS_LINUX)
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        set(TRIPLE "x64-linux")
+    else()
+        message(FATAL_ERROR "The architecture '${VCPKG_TARGET_ARCHITECTURE}' is not supported")
+    endif()
+else()
+    message(FATAL_ERROR "The triplet '${TARGET_TRIPLET}' is not supported")
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(INSTALL "${SOURCE_PATH}/bin/${TRIPLE}/DirectML.lib"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/lib"
+    )
+    file(INSTALL "${SOURCE_PATH}/bin/${TRIPLE}/DirectML.dll"
+                 "${SOURCE_PATH}/bin/${TRIPLE}/DirectML.pdb"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/bin"
+    )
+    # Install debug artifacts only if they exist upstream to avoid mismatched debug/release
+    if(EXISTS "${SOURCE_PATH}/bin/${TRIPLE}/DirectML.Debug.dll")
+        file(INSTALL "${SOURCE_PATH}/bin/${TRIPLE}/DirectML.Debug.dll"  DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    endif()
+    if(EXISTS "${SOURCE_PATH}/bin/${TRIPLE}/DirectML.Debug.pdb")
+        file(INSTALL "${SOURCE_PATH}/bin/${TRIPLE}/DirectML.Debug.pdb"  DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    endif()
+elseif(VCPKG_TARGET_IS_LINUX)
+    file(INSTALL "${SOURCE_PATH}/bin/${TRIPLE}/libdirectml.so"  DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+else()
+    message(FATAL_ERROR "The target platform is not supported")
+endif()
+
+file(INSTALL "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE-CODE.txt"
+             "${SOURCE_PATH}/README.md"
+             "${SOURCE_PATH}/ThirdPartyNotices.txt"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/directml/portfile.cmake
+++ b/ports/directml/portfile.cmake
@@ -13,6 +13,7 @@ set(PACKAGE_NAME    "Microsoft.AI.DirectML")
 set(PACKAGE_VERSION "1.15.4")
 
 file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${PACKAGE_NAME}")
+file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}")
 vcpkg_execute_required_process(
     COMMAND "${NUGET}" install "${PACKAGE_NAME}" -Version "${PACKAGE_VERSION}" -Verbosity detailed
                 -OutputDirectory "${CURRENT_BUILDTREES_DIR}"

--- a/ports/directml/vcpkg.json
+++ b/ports/directml/vcpkg.json
@@ -8,5 +8,5 @@
   ],
   "homepage": "https://github.com/microsoft/DirectML",
   "license": "MIT",
-  "supports": "(windows & !static & !uwp) | (x64 & linux)"
+  "supports": "windows & !static & !uwp"
 }

--- a/ports/directml/vcpkg.json
+++ b/ports/directml/vcpkg.json
@@ -3,10 +3,9 @@
   "version-semver": "1.15.4",
   "description": [
     "DirectML is a high-performance, hardware-accelerated DirectX 12 library for machine learning.",
-    "DirectML provides GPU acceleration for common machine learning tasks across a broad range of supported hardware and drivers, ",
-    "including all DirectX 12-capable GPUs from vendors such as AMD, Intel, NVIDIA, and Qualcomm."
+    "DirectML provides GPU acceleration for common machine learning tasks across a broad range of supported hardware and drivers, including all DirectX 12-capable GPUs from vendors such as AMD, Intel, NVIDIA, and Qualcomm."
   ],
   "homepage": "https://github.com/microsoft/DirectML",
   "license": "MIT",
-  "supports": "windows & !static & !uwp"
+  "supports": "((windows & !uwp) | (x64 & linux)) & !(static & staticcrt)"
 }

--- a/ports/directml/vcpkg.json
+++ b/ports/directml/vcpkg.json
@@ -8,5 +8,5 @@
   ],
   "homepage": "https://github.com/microsoft/DirectML",
   "license": "MIT",
-  "supports": "windows | (x64 & linux)"
+  "supports": "(windows & !static & !uwp) | (x64 & linux)"
 }

--- a/ports/directml/vcpkg.json
+++ b/ports/directml/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "directml",
+  "version-semver": "1.15.4",
+  "description": [
+    "DirectML is a high-performance, hardware-accelerated DirectX 12 library for machine learning.",
+    "DirectML provides GPU acceleration for common machine learning tasks across a broad range of supported hardware and drivers, ",
+    "including all DirectX 12-capable GPUs from vendors such as AMD, Intel, NVIDIA, and Qualcomm."
+  ],
+  "homepage": "https://github.com/microsoft/DirectML",
+  "license": "MIT",
+  "supports": "windows | (x64 & linux)"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2456,6 +2456,10 @@
       "baseline": "2025-11-25",
       "port-version": 0
     },
+    "directml": {
+      "baseline": "1.15.4",
+      "port-version": 0
+    },
     "directx-dxc": {
       "baseline": "2025-10-10",
       "port-version": 0

--- a/versions/d-/directml.json
+++ b/versions/d-/directml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "516d9aa8e311f737288511628ce0ea14b777e191",
+      "git-tree": "a7a45987f7cc0bdccc42591ef0bd245bdef2437e",
       "version-semver": "1.15.4",
       "port-version": 0
     }

--- a/versions/d-/directml.json
+++ b/versions/d-/directml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "745b80fc9142c829833a385ea3b2fad3be440044",
+      "git-tree": "dc7213506562fec77207433fa54501557aa016ca",
       "version-semver": "1.15.4",
       "port-version": 0
     }

--- a/versions/d-/directml.json
+++ b/versions/d-/directml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a7a45987f7cc0bdccc42591ef0bd245bdef2437e",
+      "git-tree": "93ea348d7289dfdca0ece073ea262dfd4ad32f97",
       "version-semver": "1.15.4",
       "port-version": 0
     }

--- a/versions/d-/directml.json
+++ b/versions/d-/directml.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "745b80fc9142c829833a385ea3b2fad3be440044",
+      "version-semver": "1.15.4",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/d-/directml.json
+++ b/versions/d-/directml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dc7213506562fec77207433fa54501557aa016ca",
+      "git-tree": "516d9aa8e311f737288511628ce0ea14b777e191",
       "version-semver": "1.15.4",
       "port-version": 0
     }


### PR DESCRIPTION

Create new port `directml` which download/install binarry files in the NuGet package.

- https://github.com/luncliff/vcpkg-registry/pull/502

## Description

The onnxruntime project supports DirectML provider feature.
- https://onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html

By default, it uses NuGet to acquire required headers and DLL binaries, but we can also extract the part as isolated port installation.

- https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/dml
- https://github.com/microsoft/onnxruntime/blob/v1.23.2/packages.config#L3
- https://github.com/microsoft/onnxruntime/blob/v1.23.2/cmake/onnxruntime_providers_dml.cmake#L28
- https://github.com/microsoft/onnxruntime/blob/v1.23.2/winml/adapter/winml_adapter_dml.cpp#L40-L42
- https://github.com/microsoft/onnxruntime/blob/v1.23.2/tools/ci_build/build_args.py#L666-L670

### 📍 Known Issues

I once found the provider requires specific Flatbuffers version. Not sure it can be used in vcpkg CI.

- https://github.com/luncliff/vcpkg-registry/blob/2.2603.0/test/self-hosted.json#L130-L133
- https://github.com/microsoft/onnxruntime/blob/v1.23.2/cmake/vcpkg.json#L103-L110

## References

- https://www.nuget.org/packages/Microsoft.AI.DirectML/1.15.4
- https://github.com/luncliff/vcpkg-registry/blob/2.2603.0/ports/onnxruntime/vcpkg.json#L84-L91
- https://github.com/luncliff/vcpkg-registry/blob/2.2603.0/ports/onnxruntime/portfile.cmake#L52-L53
- https://github.com/luncliff/vcpkg-registry/pull/237

## Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

