### PR TITLE
[svt-av1] update to 4.0.0

### DIFF
--- a/ports/svt-av1/no-force-llvm.diff
+++ b/ports/svt-av1/no-force-llvm.diff
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 57100575..65b5b775 100644
+index 9991d67..ba8a982 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -200,7 +200,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_OUTPUT_DIRECTORY})
- set(REQUIRES_PRIVATE "")
+@@ -192,7 +192,7 @@ set(PC_LIBS_PRIVATE)
+ set(PC_REQUIRES_PRIVATE)
  
  #Clang support, required to build static with LTO
 -if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND UNIX AND NOT APPLE)

--- a/ports/svt-av1/portfile.cmake
+++ b/ports/svt-av1/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AOMediaCodec/SVT-AV1
     REF "v${VERSION}"
-    SHA512 4301e923965e3bff30a0fd2f74ae023d19260f91c2361d48ea7bc1718f501dcca73fa17cb8795b23392ca1bfbe1f4d55edcbb5ce06a2fa9e41da36c5166f527d
+    SHA512 e367c1eadea5150362ea1ee17251a16711285a81f0688ba717b77747d77f81b4c5039c29ba6cade1c6b5ba8275004c4ebdb954c961521c6a3b402c7912086b7a
     PATCHES
         no-force-llvm.diff
         no-safestringlib.diff

--- a/ports/svt-av1/portfile.cmake
+++ b/ports/svt-av1/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AOMediaCodec/SVT-AV1
     REF "v${VERSION}"
-    SHA512 e367c1eadea5150362ea1ee17251a16711285a81f0688ba717b77747d77f81b4c5039c29ba6cade1c6b5ba8275004c4ebdb954c961521c6a3b402c7912086b7a
+    SHA512 0a96e46aa602a223dcb3419232e04757b933f0da73ad22232bc8cc2e13ab5ad41c6abe16252b4a7626af3478ed85f9759b601d8ff3ef63fa545dd64a006e0d23
     PATCHES
         no-force-llvm.diff
         no-safestringlib.diff

--- a/ports/svt-av1/unvendor-fastfeat.diff
+++ b/ports/svt-av1/unvendor-fastfeat.diff
@@ -1,37 +1,37 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 58afd52..9f333ef 100644
+index 4edfad6..976305c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -719,4 +719,3 @@ if(BUILD_TESTING)
      add_subdirectory(third_party/googletest)
  endif()
-
+ 
 -add_subdirectory(third_party/fastfeat)
 diff --git a/Source/Lib/CMakeLists.txt b/Source/Lib/CMakeLists.txt
-index ff0116b..8abed8b 100644
+index 6a2c57d..0df3012 100644
 --- a/Source/Lib/CMakeLists.txt
 +++ b/Source/Lib/CMakeLists.txt
-@@ -30,7 +30,7 @@ endif()
+@@ -24,7 +24,7 @@ endif()
  include_directories(${PROJECT_SOURCE_DIR}/Source/API/
      ${PROJECT_SOURCE_DIR}/Source/Lib/Codec/
      ${PROJECT_SOURCE_DIR}/Source/Lib/C_DEFAULT/
 -    ${PROJECT_SOURCE_DIR}/third_party/fastfeat/)
 +)
-
+ 
  add_library(SvtAv1Enc)
  # Required for cmake to be able to tell Xcode how to link all of the object files
-@@ -81,7 +81,6 @@ endif()
-
+@@ -75,7 +75,6 @@ endif()
+ 
  # Encoder Lib Source Files
  target_sources(SvtAv1Enc PRIVATE
 -    $<TARGET_OBJECTS:FASTFEAT>
      $<TARGET_OBJECTS:GLOBALS>
      $<TARGET_OBJECTS:CODEC>
      $<TARGET_OBJECTS:C_DEFAULT>)
-@@ -122,6 +121,14 @@ else()
+@@ -115,6 +114,13 @@ if(BUILD_SHARED_LIBS)
+ else()
      set(SVT_AV1_TARGET SVT-AV1-static)
  endif()
-
 +find_library(FASTFEAT REQUIRED
 +    NAMES fastfeat
 +    PATHS "${FASTFEAT_LIB_DIR}"
@@ -39,12 +39,11 @@ index ff0116b..8abed8b 100644
 +)
 +list(APPEND PLATFORM_LIBS ${FASTFEAT})
 +set(LIBS_PRIVATE "${LIBS_PRIVATE} -lfastfeat")
-+
- set_target_properties(SvtAv1Enc PROPERTIES VERSION ${ENC_VERSION})
- set_target_properties(SvtAv1Enc PROPERTIES SOVERSION ${ENC_VERSION_MAJOR})
- set_target_properties(SvtAv1Enc PROPERTIES C_VISIBILITY_PRESET hidden)
+ 
+ set_target_properties(SvtAv1Enc PROPERTIES VERSION ${PROJECT_VERSION})
+ set_target_properties(SvtAv1Enc PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
 diff --git a/Source/Lib/Codec/CMakeLists.txt b/Source/Lib/Codec/CMakeLists.txt
-index 0fe036f..5e2c595 100644
+index 0fe036f..9ca2a7c 100644
 --- a/Source/Lib/Codec/CMakeLists.txt
 +++ b/Source/Lib/Codec/CMakeLists.txt
 @@ -39,7 +39,7 @@ include_directories(${PROJECT_SOURCE_DIR}/Source/API/
@@ -71,27 +70,26 @@ index 0fe036f..5e2c595 100644
 -    ${PROJECT_SOURCE_DIR}/third_party/fastfeat/)
 +)
  endif ()
-
+ 
  set(all_files
-@@ -292,3 +292,4 @@ set(all_files
+@@ -295,3 +295,4 @@ set(all_files
          )
-
+ 
  add_library(CODEC OBJECT ${all_files})
 +target_include_directories(CODEC PRIVATE "${FASTFEAT_INCLUDE_DIR}")
 diff --git a/Source/Lib/Codec/corner_detect.c b/Source/Lib/Codec/corner_detect.c
-index 793919b..7c7b25d 100644
+index 793919b..ca7e853 100644
 --- a/Source/Lib/Codec/corner_detect.c
 +++ b/Source/Lib/Codec/corner_detect.c
-@@ -18,8 +18,7 @@
+@@ -18,7 +18,7 @@
  #define FAST_BARRIER 18
  int svt_av1_fast_corner_detect(unsigned char *buf, int width, int height, int stride, int *points, int max_points) {
      int       num_points;
 -    xy *const frm_corners_xy = svt_aom_fast9_detect_nonmax(buf, width, height, stride, FAST_BARRIER, &num_points);
--    num_points               = (num_points <= max_points ? num_points : max_points);
-+    xy *const frm_corners_xy = fast9_detect_nonmax(buf, width, height, stride, FAST_BARRIER, &num_points);    num_points               = (num_points <= max_points ? num_points : max_points);
++    xy *const frm_corners_xy = fast9_detect_nonmax(buf, width, height, stride, FAST_BARRIER, &num_points);
+     num_points               = (num_points <= max_points ? num_points : max_points);
      if (num_points > 0 && frm_corners_xy) {
          svt_memcpy(points, frm_corners_xy, sizeof(*frm_corners_xy) * num_points);
-         free(frm_corners_xy);
 diff --git a/Source/Lib/Globals/CMakeLists.txt b/Source/Lib/Globals/CMakeLists.txt
 index 5d1c2da..854cace 100644
 --- a/Source/Lib/Globals/CMakeLists.txt
@@ -102,5 +100,5 @@ index 5d1c2da..854cace 100644
          ${PROJECT_SOURCE_DIR}/Source/Lib/C_DEFAULT/
 -        ${PROJECT_SOURCE_DIR}/third_party/fastfeat/
          )
-
+ 
  if(NOT COMPILE_C_ONLY AND HAVE_X86_PLATFORM)

--- a/ports/svt-av1/unvendor-fastfeat.diff
+++ b/ports/svt-av1/unvendor-fastfeat.diff
@@ -1,39 +1,37 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 57100575..47a9e709 100644
+index 58afd52..9f333ef 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -721,6 +721,5 @@ if(BUILD_TESTING)
+@@ -719,4 +719,3 @@ if(BUILD_TESTING)
      add_subdirectory(third_party/googletest)
  endif()
- 
+
 -add_subdirectory(third_party/fastfeat)
- 
- install(DIRECTORY ${PROJECT_SOURCE_DIR}/Source/API/ DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/svt-av1" FILES_MATCHING PATTERN "*.h")
 diff --git a/Source/Lib/CMakeLists.txt b/Source/Lib/CMakeLists.txt
-index 03ffe4e2..43325e91 100644
+index ff0116b..8abed8b 100644
 --- a/Source/Lib/CMakeLists.txt
 +++ b/Source/Lib/CMakeLists.txt
-@@ -47,7 +47,7 @@ endif()
+@@ -30,7 +30,7 @@ endif()
  include_directories(${PROJECT_SOURCE_DIR}/Source/API/
      ${PROJECT_SOURCE_DIR}/Source/Lib/Codec/
      ${PROJECT_SOURCE_DIR}/Source/Lib/C_DEFAULT/
 -    ${PROJECT_SOURCE_DIR}/third_party/fastfeat/)
 +)
- 
+
  add_library(SvtAv1Enc)
  # Required for cmake to be able to tell Xcode how to link all of the object files
-@@ -98,7 +98,6 @@ endif()
- 
+@@ -81,7 +81,6 @@ endif()
+
  # Encoder Lib Source Files
  target_sources(SvtAv1Enc PRIVATE
 -    $<TARGET_OBJECTS:FASTFEAT>
      $<TARGET_OBJECTS:GLOBALS>
      $<TARGET_OBJECTS:CODEC>
      $<TARGET_OBJECTS:C_DEFAULT>)
-@@ -133,6 +132,14 @@ if(common_lib_source)
-     target_sources(SvtAv1Enc PRIVATE ${common_lib_source})
+@@ -122,6 +121,14 @@ else()
+     set(SVT_AV1_TARGET SVT-AV1-static)
  endif()
- 
+
 +find_library(FASTFEAT REQUIRED
 +    NAMES fastfeat
 +    PATHS "${FASTFEAT_LIB_DIR}"
@@ -46,7 +44,7 @@ index 03ffe4e2..43325e91 100644
  set_target_properties(SvtAv1Enc PROPERTIES SOVERSION ${ENC_VERSION_MAJOR})
  set_target_properties(SvtAv1Enc PROPERTIES C_VISIBILITY_PRESET hidden)
 diff --git a/Source/Lib/Codec/CMakeLists.txt b/Source/Lib/Codec/CMakeLists.txt
-index d3e95e4f..63b32eda 100644
+index 0fe036f..5e2c595 100644
 --- a/Source/Lib/Codec/CMakeLists.txt
 +++ b/Source/Lib/Codec/CMakeLists.txt
 @@ -39,7 +39,7 @@ include_directories(${PROJECT_SOURCE_DIR}/Source/API/
@@ -73,35 +71,36 @@ index d3e95e4f..63b32eda 100644
 -    ${PROJECT_SOURCE_DIR}/third_party/fastfeat/)
 +)
  endif ()
- 
+
  set(all_files
 @@ -292,3 +292,4 @@ set(all_files
          )
- 
+
  add_library(CODEC OBJECT ${all_files})
 +target_include_directories(CODEC PRIVATE "${FASTFEAT_INCLUDE_DIR}")
 diff --git a/Source/Lib/Codec/corner_detect.c b/Source/Lib/Codec/corner_detect.c
-index 793919be..ca7e8537 100644
+index 793919b..7c7b25d 100644
 --- a/Source/Lib/Codec/corner_detect.c
 +++ b/Source/Lib/Codec/corner_detect.c
-@@ -18,7 +18,7 @@
+@@ -18,8 +18,7 @@
  #define FAST_BARRIER 18
  int svt_av1_fast_corner_detect(unsigned char *buf, int width, int height, int stride, int *points, int max_points) {
      int       num_points;
 -    xy *const frm_corners_xy = svt_aom_fast9_detect_nonmax(buf, width, height, stride, FAST_BARRIER, &num_points);
-+    xy *const frm_corners_xy = fast9_detect_nonmax(buf, width, height, stride, FAST_BARRIER, &num_points);
-     num_points               = (num_points <= max_points ? num_points : max_points);
+-    num_points               = (num_points <= max_points ? num_points : max_points);
++    xy *const frm_corners_xy = fast9_detect_nonmax(buf, width, height, stride, FAST_BARRIER, &num_points);    num_points               = (num_points <= max_points ? num_points : max_points);
      if (num_points > 0 && frm_corners_xy) {
          svt_memcpy(points, frm_corners_xy, sizeof(*frm_corners_xy) * num_points);
+         free(frm_corners_xy);
 diff --git a/Source/Lib/Globals/CMakeLists.txt b/Source/Lib/Globals/CMakeLists.txt
-index 47e20736..0d8e99e1 100644
+index 5d1c2da..854cace 100644
 --- a/Source/Lib/Globals/CMakeLists.txt
 +++ b/Source/Lib/Globals/CMakeLists.txt
 @@ -15,7 +15,6 @@
- include_directories(../../../API
+ include_directories(${PROJECT_SOURCE_DIR}/Source/Lib/API
          ${PROJECT_BINARY_DIR}/Source/Lib/Codec/
          ${PROJECT_SOURCE_DIR}/Source/Lib/C_DEFAULT/
 -        ${PROJECT_SOURCE_DIR}/third_party/fastfeat/
          )
- 
+
  if(NOT COMPILE_C_ONLY AND HAVE_X86_PLATFORM)

--- a/ports/svt-av1/vcpkg.json
+++ b/ports/svt-av1/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "svt-av1",
-  "version-semver": "4.0.0",
+  "version-semver": "4.0.1",
   "description": "AV1 software video encoder library",
   "homepage": "https://gitlab.com/AOMediaCodec/SVT-AV1",
   "license": "BSD-3-Clause",

--- a/ports/svt-av1/vcpkg.json
+++ b/ports/svt-av1/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "svt-av1",
-  "version-semver": "3.1.2",
+  "version-semver": "4.0.0",
   "description": "AV1 software video encoder library",
   "homepage": "https://gitlab.com/AOMediaCodec/SVT-AV1",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9657,7 +9657,7 @@
       "port-version": 0
     },
     "svt-av1": {
-      "baseline": "4.0.0",
+      "baseline": "4.0.1",
       "port-version": 0
     },
     "swenson-sort": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9657,7 +9657,7 @@
       "port-version": 0
     },
     "svt-av1": {
-      "baseline": "3.1.2",
+      "baseline": "4.0.0",
       "port-version": 0
     },
     "swenson-sort": {

--- a/versions/s-/svt-av1.json
+++ b/versions/s-/svt-av1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fc760b6c53f2489a779d7eca0f5a7801674d6410",
+      "version-semver": "4.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "dfc35e8860de9551f35b4cb0eb5c10898c2edfdb",
       "version-semver": "3.1.2",
       "port-version": 0

--- a/versions/s-/svt-av1.json
+++ b/versions/s-/svt-av1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a431fc28fc661ef80aae4393612478975cd7f674",
+      "version-semver": "4.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "fc760b6c53f2489a779d7eca0f5a7801674d6410",
       "version-semver": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://gitlab.com/AOMediaCodec/SVT-AV1/-/releases#400---2026-1-23