### PR TITLE
[glew] update to 2.3.1

### DIFF
--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -7,7 +7,7 @@ endif()
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/nigels-com/glew/releases/download/glew-${VERSION}/glew-${VERSION}.tgz"
     FILENAME "glew-${VERSION}.tgz"
-    SHA512 a452874b7e7e5a359593fcd93475cf2c7a484f649947308f8611461df58772e060fe5a305434c22cc2411e34a20775379fcae735477f6ef056b31730ae87426e
+    SHA512 cb4caecf32ec0f180c2691dc7769ffc99571c64f259a2663a2b80e788f1c2fd5362c59e0caaeefed6fb78a4070366d244666a657358049b09071b59fae2377e0
 )
 
 vcpkg_extract_source_archive(

--- a/ports/glew/vcpkg.json
+++ b/ports/glew/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "glew",
-  "version": "2.3.0",
-  "port-version": 1,
+  "version": "2.3.1",
   "description": "The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.",
   "homepage": "https://github.com/nigels-com/glew",
   "supports": "!android",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3373,8 +3373,8 @@
       "port-version": 4
     },
     "glew": {
-      "baseline": "2.3.0",
-      "port-version": 1
+      "baseline": "2.3.1",
+      "port-version": 0
     },
     "glfw3": {
       "baseline": "3.4",

--- a/versions/g-/glew.json
+++ b/versions/g-/glew.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "edfc7053968c85e646897acc2f6f1c94d1690499",
+      "version": "2.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c92564f55b8331fb3b961c96abe4810954f907fb",
       "version": "2.3.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/nigels-com/glew/releases/tag/glew-2.3.1

Small release to fix compilation error on gcc12.