### PR TITLE
[assimp] update to 6.0.4

### DIFF
--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO assimp/assimp
     REF "v${VERSION}"
-    SHA512 182c4ef0feca7c37d4c7d6fae801a77e6efd93d86ea4a3ff2f32fac98bd5f83c04df6e5a667036a070450f5811cd91a5d23bcd4d4a1d00ded3b1c5cc14bd0363
+    SHA512 f3639e3964ea8ef41ce684eb1b764ece79f64a15ecae068846c5bc0853780e39f600776027d8843e6a3f47988daf067a164161a58f76ec6de13027ae1e473bfb
     HEAD_REF master
     PATCHES
         build_fixes.patch

--- a/ports/assimp/vcpkg.json
+++ b/ports/assimp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "assimp",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "The Open Asset import library",
   "homepage": "https://github.com/assimp/assimp",
   "license": "BSD-3-Clause",

--- a/versions/a-/assimp.json
+++ b/versions/a-/assimp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "844278e86f9a397d023eec5b4395f81f5739c3ad",
+      "version": "6.0.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "cc82b4fe481f060fd2525c8b83a00e91856b2183",
       "version": "6.0.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -325,7 +325,7 @@
       "port-version": 0
     },
     "assimp": {
-      "baseline": "6.0.3",
+      "baseline": "6.0.4",
       "port-version": 0
     },
     "astr": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/assimp/assimp/releases/tag/v6.0.4
