### PR TITLE
[quickjs-ng] Add a feature for quickjs standard library

### DIFF
--- a/ports/quickjs-ng/portfile.cmake
+++ b/ports/quickjs-ng/portfile.cmake
@@ -12,8 +12,15 @@ vcpkg_from_github(
         pdb_name_conflict.patch
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        libc          QJS_BUILD_LIBC
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/quickjs-ng/vcpkg.json
+++ b/ports/quickjs-ng/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "quickjs-ng",
   "version": "0.11.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "QuickJS, the Next Generation: a mighty JavaScript engine. A small and embeddable JavaScript engine supporting the latest ECMAScript specification.",
   "homepage": "https://github.com/quickjs-ng/quickjs",
   "license": "MIT",
@@ -14,5 +14,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "libc": {
+      "description": "Support for the quickjs standard library"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8386,7 +8386,7 @@
     },
     "quickjs-ng": {
       "baseline": "0.11.0",
-      "port-version": 1
+      "port-version": 2
     },
     "quill": {
       "baseline": "11.0.2",

--- a/versions/q-/quickjs-ng.json
+++ b/versions/q-/quickjs-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca65516cc49dde7b064641847abf979f44a56ef3",
+      "version": "0.11.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "5c4169e09b13642be14ccbecc0cf253367fee229",
       "version": "0.11.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download. (no updates)
- [X] The "supports" clause reflects platforms that may be fixed by this new version. (no changes)
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file. (no changes)
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

This change adds a feature [libc] to the quickjs-ng package to build the optional quickjs standard library component.
