### PR TITLE
[kissfft] Update to 131.2.0

### DIFF
--- a/ports/kissfft/portfile.cmake
+++ b/ports/kissfft/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mborgerding/kissfft
     REF "${VERSION}"
-    SHA512 bd715868ce0e93a291a0592fb1f8b960e832fc64efe863755e52b67d5addff9bcb444a1bf2570d1914c52b41dad1023d0d86400f5ea30c9fb84cd6b4f7210708
+    SHA512 5d02802a9e191e7cb77c26e9a34659a5d47c4e85bcfdf86a7cffdda66d8b79261f7fe5795ffabd78644b6094c01b32a84841669fbc0009ac9268ae1ba521af9e
     HEAD_REF master
     PATCHES
         fix-install-dirs.patch

--- a/ports/kissfft/vcpkg.json
+++ b/ports/kissfft/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kissfft",
-  "version": "131.1.0",
+  "version": "131.2.0",
   "description": "A Fast Fourier Transform (FFT) library that tries to Keep it Simple, Stupid",
   "homepage": "https://github.com/mborgerding/kissfft",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4437,7 +4437,7 @@
       "port-version": 7
     },
     "kissfft": {
-      "baseline": "131.1.0",
+      "baseline": "131.2.0",
       "port-version": 0
     },
     "kissnet": {

--- a/versions/k-/kissfft.json
+++ b/versions/k-/kissfft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ee92f7b02b4aa654c0bc270a25f9d06d2ac309bb",
+      "version": "131.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a0a9f47bf62471468dd9f73727f03e580fca14c4",
       "version": "131.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
