### PR TITLE
[scintilla] Update to 5.5.8

### DIFF
--- a/ports/scintilla/portfile.cmake
+++ b/ports/scintilla/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-  URLS "https://www.scintilla.org/scintilla556.zip"
-  FILENAME "scintilla556.zip"
-  SHA512 8e845a94379fff88222fa9e4e5f534f62595420dd933166e4d9cc67b197c79f578405cb020892142ead1afd85bd42f1dc4361a339134a087e14760ff33d0a1cf
+  URLS "https://www.scintilla.org/scintilla558.zip"
+  FILENAME "scintilla558.zip"
+  SHA512 b1cb0249426331c9fa14e3d3908be629814b10cba552f40ee7e7fe93957994a49550dd0ecb5a3d21d44f91ae9ba91f5fc3c1248700ddebcc7cd41334dc41adaf
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
@@ -15,7 +15,7 @@ endif()
 vcpkg_extract_source_archive(
   SOURCE_PATH
   ARCHIVE ${ARCHIVE}
-  SOURCE_BASE 5.5.6
+  SOURCE_BASE 5.5.8
   PATCHES ${PATCHES}
 )
 

--- a/ports/scintilla/vcpkg.json
+++ b/ports/scintilla/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "scintilla",
-  "version": "5.5.6",
+  "version": "5.5.8",
   "description": "A free source code editing component for Win32, GTK+, and OS X",
   "homepage": "https://www.scintilla.org/",
   "supports": "windows & !uwp & !mingw",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8857,7 +8857,7 @@
       "port-version": 1
     },
     "scintilla": {
-      "baseline": "5.5.6",
+      "baseline": "5.5.8",
       "port-version": 0
     },
     "sciplot": {

--- a/versions/s-/scintilla.json
+++ b/versions/s-/scintilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4017343a552021fd0147ce1cbc78e4a1cc9bbd30",
+      "version": "5.5.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "a82db6d9c0d2eaf3fe2e54810820a76c0948d3cd",
       "version": "5.5.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
