### PR TITLE
[lexilla] Update to 5.4.6

### DIFF
--- a/ports/lexilla/0003-fix-include-path.patch
+++ b/ports/lexilla/0003-fix-include-path.patch
@@ -1,14 +1,13 @@
 diff --git a/src/Lexilla.vcxproj b/src/Lexilla.vcxproj
-index 82aa9b7..5eac42f 100644
+index 5eedf5cf..c35b62e7 100644
 --- a/src/Lexilla.vcxproj
 +++ b/src/Lexilla.vcxproj
 @@ -75,7 +75,7 @@
-   <ItemDefinitionGroup>
-    <ClCompile>
-      <WarningLevel>Level4</WarningLevel>
--      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+     <ClCompile>
+       <WarningLevel>Level4</WarningLevel>
+       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 -      <AdditionalIncludeDirectories>..\include;..\..\scintilla\include;..\lexlib;</AdditionalIncludeDirectories>
-+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 +      <AdditionalIncludeDirectories>..\include;$(VcpkgInstalledDir)\$(VcpkgTriplet)\include\scintilla;..\lexlib;</AdditionalIncludeDirectories>
-       <BrowseInformation>true</BrowseInformation>
+       <BrowseInformation>false</BrowseInformation>
        <MultiProcessorCompilation>true</MultiProcessorCompilation>
+       <MinimalRebuild>false</MinimalRebuild>

--- a/ports/lexilla/portfile.cmake
+++ b/ports/lexilla/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-  URLS "https://www.scintilla.org/lexilla545.zip"
-  FILENAME "lexilla545.zip"
-  SHA512 03e590a883e31135abc7eccdd089fbe3fe074955db70cbd546b58f32a77109f252c2283519e43f6a6e4c69fae9a99912c2bd828a771ceebeabf67655dde45877
+  URLS "https://www.scintilla.org/lexilla546.zip"
+  FILENAME "lexilla546.zip"
+  SHA512 7290de2acbe9e52cac31aa3bf89dae66faa2040b45e715a2e18d2dd5804b2486dac8ae1cec68d8dc9215fc953628d492dbf57e61751011d17c3d70899a47dec0
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/lexilla/vcpkg.json
+++ b/ports/lexilla/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "lexilla",
-  "version": "5.4.5",
-  "port-version": 1,
+  "version": "5.4.6",
   "description": "Lexilla is a free library of language lexers that can be used with the Scintilla editing component. It comes with complete source code and a license that permits use in any free project or commercial product.",
   "homepage": "https://www.scintilla.org/Lexilla.html",
   "supports": "windows & !uwp & !mingw",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4585,8 +4585,8 @@
       "port-version": 0
     },
     "lexilla": {
-      "baseline": "5.4.5",
-      "port-version": 1
+      "baseline": "5.4.6",
+      "port-version": 0
     },
     "lfreist-hwinfo": {
       "baseline": "2025-07-10",

--- a/versions/l-/lexilla.json
+++ b/versions/l-/lexilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fafceabc075655cf37118434547afeeb71be2864",
+      "version": "5.4.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "15eba30d29c32623b2194b96fe4e283e27a0675f",
       "version": "5.4.5",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.