### PR TITLE
gtk3: move Wayland support to default feature

### DIFF
--- a/ports/gtk3/portfile.cmake
+++ b/ports/gtk3/portfile.cmake
@@ -38,7 +38,7 @@ else()
     list(APPEND OPTIONS_RELEASE -Dintrospection=false)
 endif()
 
-if(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_FREEBSD OR VCPKG_TARGET_IS_OPENBSD)
+if("wayland" IN_LIST FEATURES)
     list(APPEND OPTIONS -Dwayland_backend=true)
 else()
     list(APPEND OPTIONS -Dwayland_backend=false)

--- a/ports/gtk3/vcpkg.json
+++ b/ports/gtk3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk3",
   "version": "3.24.51",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": null,
@@ -53,14 +53,6 @@
     {
       "name": "vcpkg-tool-meson",
       "host": true
-    },
-    {
-      "name": "wayland",
-      "platform": "linux | freebsd | openbsd"
-    },
-    {
-      "name": "wayland-protocols",
-      "platform": "linux | freebsd | openbsd"
     }
   ],
   "features": {
@@ -90,6 +82,14 @@
             "introspection"
           ]
         }
+      ]
+    },
+    "wayland": {
+      "description": "Build with Wayland support",
+      "supports": "linux | freebsd | openbsd",
+      "dependencies": [
+        "wayland",
+        "wayland-protocols"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3554,7 +3554,7 @@
     },
     "gtk3": {
       "baseline": "3.24.51",
-      "port-version": 1
+      "port-version": 2
     },
     "gtkmm": {
       "baseline": "4.14.0",

--- a/versions/g-/gtk3.json
+++ b/versions/g-/gtk3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a829ae7e34f4a45e44afea6cb9fac96ea074274",
+      "version": "3.24.51",
+      "port-version": 2
+    },
+    {
       "git-tree": "13503599f7ef571b58ef8a9897a2aabd972945be",
       "version": "3.24.51",
       "port-version": 1


### PR DESCRIPTION
Make the Linux Wayland support a default feature instead of a hard dependency so that it can be disabled if wanted.
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.