### PR TITLE
[basisu] : Added ctype.h include as recent MSVC seems to require it explicitly 

### DIFF
--- a/ports/basisu/add_ctype.diff
+++ b/ports/basisu/add_ctype.diff
@@ -1,0 +1,13 @@
+diff --git a/transcoder/basisu_containers_impl.h b/transcoder/basisu_containers_impl.h
+index d4d3eb2..3d7aadd 100644
+--- a/transcoder/basisu_containers_impl.h
++++ b/transcoder/basisu_containers_impl.h
+@@ -1,6 +1,8 @@
+ // basisu_containers_impl.h
+ // Do not include directly
+ 
++#include <ctype.h>
++
+ #ifdef _MSC_VER
+ #pragma warning (disable:4127) // warning C4127: conditional expression is constant
+ #endif

--- a/ports/basisu/portfile.cmake
+++ b/ports/basisu/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_github(
         export-cmake-config.diff
         skip-strip.diff
         devendor-zstd.diff
+		add_ctype.diff
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/zstd")
 

--- a/ports/basisu/vcpkg.json
+++ b/ports/basisu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "basisu",
   "version": "1.60",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Basis Universal is a supercompressed GPU texture and video compression format that outputs a highly compressed intermediate file format (.basis) that can be quickly transcoded to a wide variety of GPU texture compression formats.",
   "homepage": "https://github.com/BinomialLLC/basis_universal",
   "license": null,

--- a/versions/b-/basisu.json
+++ b/versions/b-/basisu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "df3b41875494dda742bc268c648edb99c0a39828",
+      "version": "1.60",
+      "port-version": 3
+    },
+    {
       "git-tree": "4fdb1c26742dee24aa7aff9f38cc3bac34c37473",
       "version": "1.60",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -634,7 +634,7 @@
     },
     "basisu": {
       "baseline": "1.60",
-      "port-version": 2
+      "port-version": 3
     },
     "bbalouki-itch": {
       "baseline": "1.1.0",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #49366 
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR updates an existing port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
