### PR TITLE
[gperftools] update to 2.18

### DIFF
--- a/ports/gperftools/portfile.cmake
+++ b/ports/gperftools/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gperftools/gperftools
     REF gperftools-${VERSION}
-    SHA512 c6f68c307f7ecc5a3ff49b616155cb6d5bcc8e7a14b52f480a4e7e6deed562e988af549cd6b3d6f9150d92561947460a2a97d3355c73b81a4d0414870c0b7d32
+    SHA512 6ac99109d9b02afdaf31fb5ecd0bbd752a2ed59494ac7cc584944a2ebdb3254e25df2cb18a0bc1fc0e9230b967890e550cccaf92b9e59473e538977de6a133bf
     HEAD_REF master
     PATCHES
         libunwind.diff

--- a/ports/gperftools/vcpkg.json
+++ b/ports/gperftools/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gperftools",
-  "version": "2.17.2",
+  "version": "2.18",
   "description": "A high-performance multi-threaded malloc() implementation, plus some performance analysis tools.",
   "homepage": "https://github.com/gperftools/gperftools",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3465,7 +3465,7 @@
       "port-version": 0
     },
     "gperftools": {
-      "baseline": "2.17.2",
+      "baseline": "2.18",
       "port-version": 0
     },
     "gpgme": {

--- a/versions/g-/gperftools.json
+++ b/versions/g-/gperftools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "764aa17c43a4e70bda87cbdcc56435423959c6c9",
+      "version": "2.18",
+      "port-version": 0
+    },
+    {
       "git-tree": "19a4b8ddfb0a2462157b915a18fc8bca61f1d561",
       "version": "2.17.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/gperftools/gperftools/releases/tag/gperftools-2.18
