### PR TITLE
[bark] update to 0.5.0

### DIFF
--- a/ports/bark/portfile.cmake
+++ b/ports/bark/portfile.cmake
@@ -3,11 +3,11 @@ vcpkg_from_github(
   REPO twig-energy/bark
   REF "${VERSION}"
   HEAD_REF main
-  SHA512 d6d23cb1bfe4010768bb3bd574db790992a0cef95477c4e56c0d4cb9da93fe0e59b0de54fbb60d4320ace2ab9d4e0ae1438c89e4f29cf3fc920e5afb0ba2df33
+  SHA512 d63957b37c4ac81058c2368d8c64a7d9d83a054b7d78045b8962b98ac47b17980199d868029d762d24f6d13c687c57b92cb6de9c556943fa0403351409fb9702
 )
 
-if(VCPKG_TARGET_IS_WINDOWS)  
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)  
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
 vcpkg_cmake_configure(
@@ -24,6 +24,6 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}") 
+file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/bark/vcpkg.json
+++ b/ports/bark/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bark",
-  "version-semver": "0.4.0",
+  "version-semver": "0.5.0",
   "description": "A modern, low latency datadog client for C++",
   "homepage": "https://github.com/twig-energy/bark",
   "license": "MIT",

--- a/versions/b-/bark.json
+++ b/versions/b-/bark.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2824cc5e8e71aa976ae1192f34827e993772ae98",
+      "version-semver": "0.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d0223b7a7be3e7c964ef2ac76a0e07566ce5cab8",
       "version-semver": "0.4.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -625,7 +625,7 @@
       "port-version": 0
     },
     "bark": {
-      "baseline": "0.4.0",
+      "baseline": "0.5.0",
       "port-version": 0
     },
     "barkeep": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/twig-energy/bark/releases/tag/0.5.0
