### PR TITLE
[aeron] Simplify portfile and remove manual CRT configuration

### DIFF
--- a/ports/aeron/portfile.cmake
+++ b/ports/aeron/portfile.cmake
@@ -20,26 +20,13 @@ else()
     set(BUILD_ARCHIVE OFF)
 endif()
 
-# Set CRT linkage for Windows static builds
-set(AERON_CMAKE_OPTIONS
-    -DAERON_INSTALL_TARGETS=ON
-    -DAERON_TESTS=OFF
-    -DAERON_BUILD_SAMPLES=OFF
-    -DBUILD_AERON_ARCHIVE_API=${BUILD_ARCHIVE}
-)
-
-# Only set static CRT if triplet explicitly requests it (VCPKG_CRT_LINKAGE=static)
-# Otherwise, respect the triplet's CRT setting (dynamic/MD or static/MT)
-if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_CRT_LINKAGE STREQUAL "static")
-    list(APPEND AERON_CMAKE_OPTIONS
-        -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$$<$$<CONFIG:Debug>:Debug>
-        -DCMAKE_POLICY_DEFAULT_CMP0091=NEW
-    )
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${AERON_CMAKE_OPTIONS}
+    OPTIONS
+        -DAERON_INSTALL_TARGETS=ON
+        -DAERON_TESTS=OFF
+        -DAERON_BUILD_SAMPLES=OFF
+        -DBUILD_AERON_ARCHIVE_API=${BUILD_ARCHIVE}
 )
 
 vcpkg_cmake_install()

--- a/ports/aeron/vcpkg.json
+++ b/ports/aeron/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "aeron",
   "version": "1.50.0",
+  "port-version": 1,
   "description": "Efficient reliable UDP unicast, UDP multicast, and IPC message transport",
   "homepage": "https://github.com/aeron-io/aeron",
   "license": "Apache-2.0",

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "a0d3b6168fb047f201651af41665255607b568f9",
+      "git-tree": "c97b0811df0fb92977a80ee98b10da0777bee14e",
+      "version": "1.50.0",
+      "port-version": 1
+    },
+    {
+      "git-tree": "936aefc7566d95f7234b2d57c8878a1253220ee7",
       "version": "1.50.0",
       "port-version": 0
     },

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "936aefc7566d95f7234b2d57c8878a1253220ee7",
+      "git-tree": "a0d3b6168fb047f201651af41665255607b568f9",
       "version": "1.50.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -58,7 +58,7 @@
     },
     "aeron": {
       "baseline": "1.50.0",
-      "port-version": 0
+      "port-version": 1
     },
     "air-ctl": {
       "baseline": "1.1.2",


### PR DESCRIPTION
### Description
This PR simplifies the aeron portfile by removing manual CRT linkage configuration, as suggested by @dg0yt in #49581.

### Changes
- Removed manual `CMAKE_MSVC_RUNTIME_LIBRARY` and `CMAKE_POLICY_DEFAULT_CMP0091` settings
- Simplified OPTIONS configuration in `vcpkg_cmake_configure`
- Let vcpkg's toolchain handle CRT linkage automatically based on triplet settings

### Rationale
vcpkg's toolchain file already manages compiler flags and CRT linkage based on triplet configuration. Manual override can cause conflicts and is unnecessary.

Fixes feedback from #49581

---

**Port Update Checklist:**
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.