### PR TITLE
[tiny-optional] update to 1.5.3

### DIFF
--- a/ports/tiny-optional/portfile.cmake
+++ b/ports/tiny-optional/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Sedeniono/tiny-optional
     REF "v${VERSION}"
-    SHA512 d92394c20a12451c59b30a7bec446dce1be08a6aab2ed8527a6e23f04789be759b6f4eb83666d1985b2716df2031baeb84d5ec83d39ceaf43d7162921cb92d4a
+    SHA512 9457f6d67216c3b12ef5caec7540c9f92ce0a039f21bc81a2b640d9919a8da37fb90647d1bf52aa0adb5f28b65a7766ac8aa6594458566a5d3ae9fc77e8328f8
 )
 
 vcpkg_cmake_configure(

--- a/ports/tiny-optional/vcpkg.json
+++ b/ports/tiny-optional/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-optional",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Drop-in replacement for std::optional that does not waste memory unnecessarily",
   "homepage": "https://github.com/Sedeniono/tiny-optional",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9857,7 +9857,7 @@
       "port-version": 2
     },
     "tiny-optional": {
-      "baseline": "1.5.2",
+      "baseline": "1.5.3",
       "port-version": 0
     },
     "tiny-process-library": {

--- a/versions/t-/tiny-optional.json
+++ b/versions/t-/tiny-optional.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3dc2a9dc3f45a4f51b5d8663ed9e161d1bb21224",
+      "version": "1.5.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "2b587acd9add11f69ade6e9be415d7066bd54c75",
       "version": "1.5.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Sedeniono/tiny-optional/releases/tag/v1.5.3
