### PR TITLE
[vmaware-vm-detection] update to 2.6.0

### DIFF
--- a/ports/vmaware-vm-detection/portfile.cmake
+++ b/ports/vmaware-vm-detection/portfile.cmake
@@ -2,12 +2,12 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kernelwernel/VMAware
     REF v${VERSION}
-    SHA512 be149227b9a06980c737248077726ab2157265304cf840773cdf84c3bcaba8d0fd922a5a2ada5dbf73646a0d02888933b21a8aa9c5c18158525d09d89688097f
+    SHA512 ff6bdb4c34a08df59ccedb1714ce2ade7656c3f664ed4e11b2e05f9ed4d94f608a566a93aa16784000ed0fd2cca6f34c624db27f2e3fe2f06cb48df6ec161ac3
     HEAD_REF master
 )
 
 # Header only
 set(VCPKG_BUILD_TYPE release)
-file(INSTALL "${SOURCE_PATH}/src/vmaware_MIT.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include/vmaware" RENAME "vmaware.hpp")
+file(INSTALL "${SOURCE_PATH}/src/vmaware.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include/vmaware")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/vmaware-vm-detection/vcpkg.json
+++ b/ports/vmaware-vm-detection/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vmaware-vm-detection",
-  "version": "2.2.0",
+  "version": "2.6.0",
   "description": "VM detection library",
   "homepage": "https://github.com/kernelwernel/VMAware",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10441,7 +10441,7 @@
       "port-version": 0
     },
     "vmaware-vm-detection": {
-      "baseline": "2.2.0",
+      "baseline": "2.6.0",
       "port-version": 0
     },
     "volk": {

--- a/versions/v-/vmaware-vm-detection.json
+++ b/versions/v-/vmaware-vm-detection.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4fd80f043c234f7a063654f1b9086f66f39f1de2",
+      "version": "2.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "86e938926a6c9a25d76e4915ba86ae54b77dafdc",
       "version": "2.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/kernelwernel/VMAware/releases/tag/v2.6.0
