### PR TITLE
[dispenso] Add new port (v1.5.0)

### DIFF
--- a/ports/dispenso/fix-arm64-platform-define.patch
+++ b/ports/dispenso/fix-arm64-platform-define.patch
@@ -1,0 +1,24 @@
+diff --git a/dispenso/detail/notifier_common.h b/dispenso/detail/notifier_common.h
+--- a/dispenso/detail/notifier_common.h
++++ b/dispenso/detail/notifier_common.h
+@@ -117,12 +117,12 @@
+
+ #elif defined(_WIN32)
+
+-#if (defined(_M_ARM64) || defined(_M_ARM)) && !defined(_ARM_)
+-#define _ARM_
+-#elif _WIN64
+-#define _AMD64_
+-#elif _WIN32
+-#define _X86_
+-#else
+-#error "No valid windows platform"
++#if (defined(_M_ARM64) || defined(__aarch64__)) && !defined(_ARM64_)
++#define _ARM64_
++#elif (defined(_M_ARM) || defined(__arm__)) && !defined(_ARM_)
++#define _ARM_
++#elif (defined(_M_AMD64) || defined(__x86_64__) || defined(_WIN64)) && !defined(_AMD64_)
++#define _AMD64_
++#elif !defined(_X86_)
++#define _X86_
+ #endif // platform

--- a/ports/dispenso/portfile.cmake
+++ b/ports/dispenso/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO facebookincubator/dispenso
+    REF "v${VERSION}"
+    SHA512 2c1da1e5050cdc788af81aeda44cb5e54a1aa40e85149e24835daf37e4a34c26d794d94f7b8539985f2732a1e9ec8d82c89776ed3c7449710ecaff01586bac9e
+    HEAD_REF main
+    PATCHES
+        fix-arm64-platform-define.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DISPENSO_SHARED)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DDISPENSO_BUILD_TESTS=OFF
+        -DDISPENSO_BUILD_BENCHMARKS=OFF
+        -DDISPENSO_SHARED_LIB=${DISPENSO_SHARED}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/Dispenso-${VERSION}")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/dispenso/usage
+++ b/ports/dispenso/usage
@@ -1,0 +1,4 @@
+dispenso provides CMake targets:
+
+  find_package(Dispenso CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE Dispenso::dispenso)

--- a/ports/dispenso/vcpkg.json
+++ b/ports/dispenso/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "dispenso",
+  "version": "1.5.0",
+  "description": "A high-performance C++ library for parallel programming with thread pools, parallel for loops, futures, task graphs, and concurrent containers",
+  "homepage": "https://github.com/facebookincubator/dispenso",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2532,6 +2532,10 @@
       "baseline": "2020-01-29",
       "port-version": 3
     },
+    "dispenso": {
+      "baseline": "1.5.0",
+      "port-version": 0
+    },
     "distorm": {
       "baseline": "3.5.2b",
       "port-version": 0

--- a/versions/d-/dispenso.json
+++ b/versions/d-/dispenso.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ce42fc72355fdaf7505ec8a6634ddf28fe42e721",
+      "version": "1.5.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Add dispenso, a high-performance C++ library for parallel programming from Meta.

Fixes https://github.com/microsoft/vcpkg/issues/50805

## Features
- Work-stealing thread pools
- Parallel for loops
- Futures (std::experimental::future-like API)
- Task graphs and pipelines
- Concurrent containers

## Links
- **Homepage**: https://github.com/facebookincubator/dispenso
- **Documentation**: https://facebookincubator.github.io/dispenso
- **License**: MIT

## Testing
- Tested on x64-linux and arm64-osx
- Builds successfully with vcpkg install
- Usage file provided
- **Version**: 1.5.0

## New Port Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/dispenso/versions
    - [ ] The project is amongst the first web search results for "dispenso" or "dispenso C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.