### PR TITLE
[sol2] Fix build with lua 5.5

### DIFF
--- a/ports/sol2/lua-5.5.diff
+++ b/ports/sol2/lua-5.5.diff
@@ -1,0 +1,42 @@
+diff --git a/include/sol/compatibility/compat-5.3.h b/include/sol/compatibility/compat-5.3.h
+index 8d32d2d7..bd9dad99 100644
+--- a/include/sol/compatibility/compat-5.3.h
++++ b/include/sol/compatibility/compat-5.3.h
+@@ -405,7 +405,7 @@ COMPAT53_API void luaL_requiref(lua_State *L, const char *modname,
+ 
+ 
+ /* other Lua versions */
+-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 504
++#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 505
+ 
+ #  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, or 5.4)"
+
+diff --git a/include/sol/compatibility/compat-5.4.h b/include/sol/compatibility/compat-5.4.h
+index ae747c64..b5238579 100644
+--- a/include/sol/compatibility/compat-5.4.h
++++ b/include/sol/compatibility/compat-5.4.h
+@@ -17,7 +17,7 @@ extern "C" {
+ }
+ #endif
+ 
+-#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM == 504
++#if defined(LUA_VERSION_NUM) && (LUA_VERSION_NUM == 504 || LUA_VERSION_NUM == 505)
+ 
+ #if !defined(LUA_ERRGCMM)
+ /* So Lua 5.4 actually removes this, which breaks sol2...
+diff --git a/include/sol/state.hpp b/include/sol/state.hpp
+index ed2412ed..b05e9741 100644
+--- a/include/sol/state.hpp
++++ b/include/sol/state.hpp
+@@ -39,7 +39,11 @@ namespace sol {
+ 		}
+ 
+ 		state(lua_CFunction panic, lua_Alloc alfunc, void* alpointer = nullptr)
++#if LUA_VERSION_NUM < 505
+ 		: unique_base(lua_newstate(alfunc, alpointer)), state_view(unique_base::get()) {
++#else
++		: unique_base(lua_newstate(alfunc, alpointer, 0)), state_view(unique_base::get()) {
++#endif
+ 			set_default_state(unique_base::get(), panic);
+ 		}
+ 

--- a/ports/sol2/pkgconfig.diff
+++ b/ports/sol2/pkgconfig.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b54f71a..a3c569b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -148,7 +148,7 @@ endif()
+ 
+ if(SOL2_ENABLE_INSTALL)
+ 	# pkg-config support, except on Windows
+-	if(NOT WIN32 OR NOT CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
++	if(1)
+ 		set(PKGCONFIG_INSTALL_DIR
+ 			"${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig"
+ 			CACHE PATH "Path where sol2.pc is installed")

--- a/ports/sol2/portfile.cmake
+++ b/ports/sol2/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
 set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sol2)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/sol2)
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/sol2/portfile.cmake
+++ b/ports/sol2/portfile.cmake
@@ -1,3 +1,5 @@
+set(VCPKG_BUILD_TYPE release) # header-only
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ThePhD/sol2
@@ -6,9 +8,9 @@ vcpkg_from_github(
     HEAD_REF develop
     PATCHES
         header-only.patch
+        lua-5.5.diff # variation of https://github.com/ThePhD/sol2/pull/1723
 )
 
-set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/sol2)

--- a/ports/sol2/portfile.cmake
+++ b/ports/sol2/portfile.cmake
@@ -9,13 +9,12 @@ vcpkg_from_github(
     PATCHES
         header-only.patch
         lua-5.5.diff # variation of https://github.com/ThePhD/sol2/pull/1723
+        pkgconfig.diff
 )
 
 vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/sol2)
 vcpkg_fixup_pkgconfig()
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/sol2/vcpkg.json
+++ b/ports/sol2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sol2",
   "version": "3.5.0",
+  "port-version": 1,
   "description": "Sol3 (sol2 v3.0) - a C++ <-> Lua API wrapper with advanced features and top notch performance",
   "homepage": "https://github.com/ThePhD/sol2",
   "license": "MIT",

--- a/scripts/test_ports/vcpkg-ci-sol2/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-sol2/portfile.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-sol2/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-sol2/project/CMakeLists.txt
@@ -1,13 +1,17 @@
 cmake_minimum_required(VERSION 3.16)
 project(sol2-test C CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+
+# Select a Lua implementation
+find_package(Lua REQUIRED)
+
 
 find_package(sol2 CONFIG REQUIRED)
 
 add_executable(main-cmake main.cpp)
 target_link_libraries(main-cmake PRIVATE sol2::sol2)
 
-find_package(Lua REQUIRED)
 target_link_libraries(sol2::sol2 INTERFACE ${LUA_LIBRARIES})
 
 

--- a/scripts/test_ports/vcpkg-ci-sol2/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-sol2/project/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+project(sol2-test C CXX)
+
+
+find_package(sol2 CONFIG REQUIRED)
+
+add_executable(main-cmake main.cpp)
+target_link_libraries(main-cmake PRIVATE sol2::sol2)
+
+find_package(Lua REQUIRED)
+target_link_libraries(sol2::sol2 INTERFACE ${LUA_LIBRARIES})
+
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PC_SOL2 sol2 REQUIRED)
+
+add_executable(main-pkgconfig main.cpp)
+target_include_directories(main-pkgconfig PRIVATE ${PC_SOL2_INCLUDE_DIRS})
+target_link_libraries(main-pkgconfig PRIVATE ${PC_SOL2_LUA_LIBRARIES})
+
+target_link_libraries(main-pkgconfig PRIVATE ${LUA_LIBRARIES})

--- a/scripts/test_ports/vcpkg-ci-sol2/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-sol2/project/main.cpp
@@ -1,0 +1,11 @@
+// From README
+#include <sol/sol.hpp>
+#include <cassert>
+
+int main() {
+    sol::state lua;
+    int x = 0;
+    lua.set_function("beep", [&x]{ ++x; });
+    lua.script("beep()");
+    assert(x == 1);
+}

--- a/scripts/test_ports/vcpkg-ci-sol2/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-sol2/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "vcpkg-ci-sol2",
+  "version-string": "ci",
+  "description": "Validate port sol2",
+  "dependencies": [
+    {
+      "name": "lua",
+      "default-features": false
+    },
+    {
+      "name": "sol2",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9274,7 +9274,7 @@
     },
     "sol2": {
       "baseline": "3.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "solid3": {
       "baseline": "3.5.8",

--- a/versions/s-/sol2.json
+++ b/versions/s-/sol2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e96155c1c9ff455a1bed96e3d66ef6171181ec08",
+      "version": "3.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1335e18b0ecb699219ed36d3cad23309181d34a7",
       "version": "3.5.0",
       "port-version": 0

--- a/versions/s-/sol2.json
+++ b/versions/s-/sol2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e96155c1c9ff455a1bed96e3d66ef6171181ec08",
+      "git-tree": "b3089bcbf6e652b82348192c6289d0ba2d0d9fe7",
       "version": "3.5.0",
       "port-version": 1
     },


### PR DESCRIPTION
Resolves #49587.

NB: `sol2` is header-only. It deliberately does not export a direct dependency to a particular Lua implementation (`lua`, `luajit`). This is not changed by this PR. However, the test port establish a build combining `sol2` and `lua`.