### PR TITLE
[json-glib] Update to 1.10.8

### DIFF
--- a/ports/json-glib/portfile.cmake
+++ b/ports/json-glib/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_download_distfile(ARCHIVE
         "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
-    SHA512 e1c0e33b17333cf94beb381f505c1819090a11b616dcc23a883f231029dff277c2482823278cbf7b8a07e237d45cbfc7b05f132e1234beff609a739fd5704c6e
+    SHA512 f4ba8660b586a4e738803e4dbfdfcd34fa7ceba9189e7bf3f2b50e21f4d4886f99535ceb3453c89b1d1ae8d96bf4168a135b73b7e1a2dbc46b19e9b710ad56a1
 )
 
 vcpkg_extract_source_archive(

--- a/ports/json-glib/vcpkg.json
+++ b/ports/json-glib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "json-glib",
-  "version": "1.10.6",
-  "port-version": 1,
+  "version": "1.10.8",
   "description": "Implements a full JSON parser and generator using GLib and GObject, and integrates JSON with GLib data types.",
   "homepage": "https://wiki.gnome.org/Projects/JsonGlib",
   "license": "LGPL-2.1-or-later AND CC0-1.0 AND MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4141,8 +4141,8 @@
       "port-version": 0
     },
     "json-glib": {
-      "baseline": "1.10.6",
-      "port-version": 1
+      "baseline": "1.10.8",
+      "port-version": 0
     },
     "json-rpc-cxx": {
       "baseline": "0.3.2",

--- a/versions/j-/json-glib.json
+++ b/versions/j-/json-glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a643582cfcabca9b6d1abb46e821d123ddf3dca0",
+      "version": "1.10.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "007e095217ff2924f7081863d423b98d2e84fe27",
       "version": "1.10.6",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
