### PR TITLE
[crashpad] Update vswhere arguments to include MSVC Build Tools in mini_chromium

### DIFF
--- a/ports/crashpad/fix-msvc-autofind-build-tools.patch
+++ b/ports/crashpad/fix-msvc-autofind-build-tools.patch
@@ -1,0 +1,13 @@
+diff --git a/build/win_helper.py b/build/win_helper.py
+index be977c8..829343a 100644
+--- a/build/win_helper.py
++++ b/build/win_helper.py
+@@ -186,7 +186,7 @@ class WinTool(object):
+           'Microsoft Visual Studio', 'Installer', 'vswhere.exe')
+       if os.path.exists(vswhere_path):
+         installation_path = subprocess.check_output(
+-            [vswhere_path, '-latest', '-property', 'installationPath']).strip()
++            [vswhere_path, '-products', '*', '-latest', '-property', 'installationPath']).strip()
+         if installation_path:
+           return (installation_path.decode("utf-8"),
+                   os.path.join('VC', 'Auxiliary', 'Build', 'vcvarsall.bat'))

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -26,6 +26,7 @@ if(NOT EXISTS "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium/BUILD.gn")
             fix-std-20.patch
             ndk-toolchain.diff
             fix-lib-name-conflict-1.patch
+            fix-msvc-autofind-build-tools.patch
     )
     file(REMOVE_RECURSE "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium")
     file(RENAME "${mini_chromium}" "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium")

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2024-04-11",
-  "port-version": 9,
+  "port-version": 10,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2166,7 +2166,7 @@
     },
     "crashpad": {
       "baseline": "2024-04-11",
-      "port-version": 9
+      "port-version": 10
     },
     "crashrpt": {
       "baseline": "1.4.3",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea6b66006133eb96ab03957bdc8940ba5465f8a3",
+      "version-date": "2024-04-11",
+      "port-version": 10
+    },
+    {
       "git-tree": "3db57798ca8f3d8309c3564cc7a8a1ed8955bf63",
       "version-date": "2024-04-11",
       "port-version": 9


### PR DESCRIPTION
When mini_chromium searches for an MSVC installation via vswhere.exe, it currently defaults to searching for standard IDE installations (like Community or Professional). This causes the search to fail if only the Visual Studio Build Tools are installed.

By adding the -products * flag to the vswhere invocation, all compatible products—including Build Tools—are correctly identified. This ensures crashpad can be compiled in environments without a full IDE installation.