### PR TITLE
Install libspeechd-dev package on AZP for ethindp-prism speech-dispatcher feature

### DIFF
--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -166,6 +166,9 @@ APT_PACKAGES="$APT_PACKAGES cuda-cccl-12-9 cuda-compat-12-9 cuda-compiler-12-9 c
 ## PowerShell + Azure
 APT_PACKAGES="$APT_PACKAGES powershell azcopy azure-cli"
 
+## Required for speech-dispatcher feature for ethindp-prism
+APT_PACKAGES="$APT_PACKAGES libspeechd-dev"
+
 ## Additionally required/installed by Azure DevOps Scale Set Agents, skip on WSL
 if [[ $(grep microsoft /proc/version) ]]; then
 echo "Skipping install of ADO prerequisites on WSL."


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

This PR fixes the speech-dispatcher feature from failing to build on x64-linux triplets, discovered in PR #49486.