### PR TITLE
ethindp-prism: update to 0.5.0

### DIFF
--- a/ports/ethindp-prism/portfile.cmake
+++ b/ports/ethindp-prism/portfile.cmake
@@ -6,8 +6,8 @@ endif()
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO ethindp/prism
-  REF v0.4.7
-  SHA512 c357aa61d81d4bd39464bc30abc89a402f39d18d2c26c51c61e8da83e5b9596d21a0dcff3d85ef2c404b5b883fe0befc710a649990878fa7630e20d0a919a66b
+  REF v0.5.0
+  SHA512 a0c6b774ab4e87c2c2f2c556d78a40a45eaf52d7ddaab4cb7dbc50947e6919958977abdbfc37185263dbe6d3f3cce3a651d7927202596713e2de75c4a42d92a4
   HEAD_REF master
 )
 vcpkg_check_features(

--- a/ports/ethindp-prism/vcpkg.json
+++ b/ports/ethindp-prism/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ethindp-prism",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "description": "The Platform-agnostic Reader Interface for Speech and Messages",
   "license": "MPL-2.0",
   "supports": "!uwp & !(static & staticcrt)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2805,7 +2805,7 @@
       "port-version": 3
     },
     "ethindp-prism": {
-      "baseline": "0.4.7",
+      "baseline": "0.5.0",
       "port-version": 0
     },
     "etl": {

--- a/versions/e-/ethindp-prism.json
+++ b/versions/e-/ethindp-prism.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7572d8bc2799a643fbd3c89d515d2d8d88a34aab",
+      "version": "0.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1ea3aaefe021c5851d9581f387a50e38df197e2f",
       "version": "0.4.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
