### PR TITLE
Fixed SHA512 checksums for Node.js 24.13.0 for windows

### DIFF
--- a/scripts/vcpkg-tools.json
+++ b/scripts/vcpkg-tools.json
@@ -341,7 +341,7 @@
       "version": "24.13.0",
       "executable": "node-v24.13.0-win-x64/node.exe",
       "url": "https://nodejs.org/dist/v24.13.0/node-v24.13.0-win-x64.7z",
-      "sha512": "48a502b242f55ca7e05dcca49be64cfccc50be150227131e742a0b8bf9823b82cf71977d6e9d919ee05a84ed2985c7e670f3fb830e929b5fb16b6c2459d7e119",
+      "sha512": "bf5de907f21b1076ff0c87b199a6d1d6ed94e2bee8101e21b942121e589f49345d3d0667bc12ca10dc84d34e82b3dda194658b4872de8f038de261f2ad5544e6",
       "archive": "node-v24.13.0-win-x64.7z"
     },
     {
@@ -351,7 +351,7 @@
       "version": "24.13.0",
       "executable": "node-v24.13.0-win-arm64/node.exe",
       "url": "https://nodejs.org/dist/v24.13.0/node-v24.13.0-win-arm64.7z",
-      "sha512": "26c1b63d9e11c4b7c9d46101728ad5829fdfc7eee7ffe36fa7f8e3e3143ebce59a60baf8bc150869461ee7fcb96d1b815b2c89cc0df8d8b01b32bf4478f7f942",
+      "sha512": "0ddfd162be940b21eac08b35494540ca73f151828bf4dcc980bb984ee0181f1c9b889da030cf9cde6405191ded97bcd7a696d412c4988b0c1e108a0410cbe491",
       "archive": "node-v24.13.0-win-arm64.7z"
     },
     {


### PR DESCRIPTION
Addressing issue: https://github.com/microsoft/vcpkg/issues/49662

Updated SHA512 checksums for Node.js version 24.13.0 for both x64 and arm64 architectures.

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
