### PR TITLE
[patternia] add new port

### DIFF
--- a/ports/patternia/portfile.cmake
+++ b/ports/patternia/portfile.cmake
@@ -1,4 +1,4 @@
-# Header-only library
+set(VCPKG_BUILD_TYPE release) # Header-only library
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sentomk/patternia
@@ -17,6 +17,6 @@ vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}"
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/patternia/portfile.cmake
+++ b/ports/patternia/portfile.cmake
@@ -1,0 +1,22 @@
+# Header-only library
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO sentomk/patternia
+    REF "v${VERSION}"
+    SHA512 d96ba11737f1183ac8758bc933be8c1d6f496c28bed767e27c3af1f9bd079c84d5939edc77b55172fb31e5338a6cc7b637138a30e4cb679c0f38cf3f390a5544
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DPTN_INSTALL=ON
+        -DPTN_BUILD_TESTS=OFF
+        -DPTN_BUILD_BENCHMARKS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/patternia/vcpkg.json
+++ b/ports/patternia/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "patternia",
+  "version": "0.6.3",
+  "description": "Providing pattern matching for modern c++.",
+  "homepage": "https://github.com/sentomk/patternia",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7500,6 +7500,10 @@
       "baseline": "1.5.3",
       "port-version": 0
     },
+    "patternia": {
+      "baseline": "0.6.3",
+      "port-version": 0
+    },
     "pbc": {
       "baseline": "0.5.14",
       "port-version": 9

--- a/versions/p-/patternia.json
+++ b/versions/p-/patternia.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4329b5cbdd706dc5c9453766f2f7922665bf0705",
+      "git-tree": "4a04dd6e5965cce0471ac3d596fb8117452f27fe",
       "version": "0.6.3",
       "port-version": 0
     }

--- a/versions/p-/patternia.json
+++ b/versions/p-/patternia.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4329b5cbdd706dc5c9453766f2f7922665bf0705",
+      "version": "0.6.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/sentomk/patternia
