### PR TITLE
[qt5-declarative] Reduce memory pressure while linking tools

### DIFF
--- a/ports/qt5-declarative/linker-oom.diff
+++ b/ports/qt5-declarative/linker-oom.diff
@@ -1,0 +1,14 @@
+diff --git a/tools/tools.pro b/tools/tools.pro
+index 2e04f933..319faeae 100644
+--- a/tools/tools.pro
++++ b/tools/tools.pro
+@@ -1,6 +1,9 @@
+ TEMPLATE = subdirs
+ QT_FOR_CONFIG += qml-private
+ 
++# Reduce memory pressure during linking
++CONFIG += ordered
++
+ qtConfig(qml-devtools) {
+     SUBDIRS += \
+         qmllint \

--- a/ports/qt5-declarative/portfile.cmake
+++ b/ports/qt5-declarative/portfile.cmake
@@ -6,7 +6,13 @@ else()
     list(APPEND CORE_OPTIONS -no-d3d12)
 endif()
 
-qt_submodule_installation(OUT_SOURCE_PATH SOURCE_PATH BUILD_OPTIONS ${CORE_OPTIONS})
+qt_submodule_installation(
+    OUT_SOURCE_PATH SOURCE_PATH
+    PATCHES
+        linker-oom.diff
+    BUILD_OPTIONS
+        ${CORE_OPTIONS}
+)
 
 if(NOT QT_UPDATE_VERSION)
   vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/qt5/QtQml/${QT_MAJOR_MINOR_VER}.${QT_PATCH_VER}/QtQml/private/qqmljsparser_p.h" "${SOURCE_PATH}" "")

--- a/ports/qt5-declarative/vcpkg.json
+++ b/ports/qt5-declarative/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5-declarative",
   "version": "5.15.18",
+  "port-version": 1,
   "description": "Qt Declarative (Quick 2)",
   "license": null,
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8058,7 +8058,7 @@
     },
     "qt5-declarative": {
       "baseline": "5.15.18",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-doc": {
       "baseline": "5.15.18",

--- a/versions/q-/qt5-declarative.json
+++ b/versions/q-/qt5-declarative.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3e5e184c2f19e06bf02d51c993894126072bc52a",
+      "version": "5.15.18",
+      "port-version": 1
+    },
+    {
       "git-tree": "25e69d1575c17727384a03b8a85ce3e437893198",
       "version": "5.15.18",
       "port-version": 0


### PR DESCRIPTION
This port has teared down the whole IDE much too often: Simply do not link multiple tools at once.