### PR TITLE
[libmem] update to 5.1.5

### DIFF
--- a/ports/libmem/portfile.cmake
+++ b/ports/libmem/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rdbo/libmem
     REF "${VERSION}"
-    SHA512 0
+    SHA512 1accb68bf0af12079c273f88af451e0eebd1550ba166b2821ea63fb810bf0debb95cef406d6624605b831a7e7adb7523ae2c267a0b67c5a6bdfff45f4c6221f4
     HEAD_REF master
     PATCHES
         0001-CMakeLists.patch

--- a/ports/libmem/portfile.cmake
+++ b/ports/libmem/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rdbo/libmem
     REF "${VERSION}"
-    SHA512 7b291fac0d12be6734cdf2be9705b787c0419aa45d3ce41a968f9e2a009eba739eadbf6ba1ea1663134b97eb20a97992af62fdb5157235d2b21ea76cc1f7f7fd
+    SHA512 58a1db4f4b01e452c91c307d4486d5e4e39887ee3b3b2ad930b6718d8daeb509
     HEAD_REF master
     PATCHES
         0001-CMakeLists.patch

--- a/ports/libmem/portfile.cmake
+++ b/ports/libmem/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rdbo/libmem
     REF "${VERSION}"
-    SHA512 58a1db4f4b01e452c91c307d4486d5e4e39887ee3b3b2ad930b6718d8daeb509
+    SHA512 0
     HEAD_REF master
     PATCHES
         0001-CMakeLists.patch

--- a/ports/libmem/vcpkg.json
+++ b/ports/libmem/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmem",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "Advanced Game Hacking Library for C, Modern C++, Rust and Python (Windows/Linux/FreeBSD) (Process/Memory Hacking) (Hooking/Detouring) (Cross Platform) (x86/x64/ARM/ARM64) (DLL/SO Injection) (Internal/External) (Assembler/Disassembler)",
   "homepage": "https://github.com/rdbo/libmem",
   "license": "AGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5177,7 +5177,7 @@
       "port-version": 0
     },
     "libmem": {
-      "baseline": "5.1.4",
+      "baseline": "5.1.5",
       "port-version": 0
     },
     "libmemcached-awesome": {

--- a/versions/l-/libmem.json
+++ b/versions/l-/libmem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c9c6dc38333ed4fbb237c3cb0a17fb639c9679be",
+      "version": "5.1.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "633b6a7430c0ee386e958e20b1fbaa3e511c1887",
       "version": "5.1.4",
       "port-version": 0

--- a/versions/l-/libmem.json
+++ b/versions/l-/libmem.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d8af7b0178f3988b829d595e639d7f33ac59a867",
+      "git-tree": "ce18d4dbcc9ceb28a0a5b8e61ae5e745025b1685",
       "version": "5.1.5",
       "port-version": 0
     },

--- a/versions/l-/libmem.json
+++ b/versions/l-/libmem.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c9c6dc38333ed4fbb237c3cb0a17fb639c9679be",
+      "git-tree": "d8af7b0178f3988b829d595e639d7f33ac59a867",
       "version": "5.1.5",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.