### PR TITLE
[openssl] fix mingw build

### DIFF
--- a/ports/openssl/fix-mingw-build.patch
+++ b/ports/openssl/fix-mingw-build.patch
@@ -1,0 +1,17 @@
+diff --git a/ssl/quic/quic_reactor.c b/ssl/quic/quic_reactor.c
+index a754f285bbe2b..d8ac969d02a69 100644
+--- a/ssl/quic/quic_reactor.c
++++ b/ssl/quic/quic_reactor.c
+@@ -76,6 +76,12 @@ void ossl_quic_reactor_cleanup(QUIC_REACTOR *rtor)
+ }
+ 
+ #if defined(OPENSSL_SYS_WINDOWS)
++
++/* Work around for MinGW builds. */
++#if defined(__MINGW32__) && !defined(SIO_UDP_NETRESET)
++#  define SIO_UDP_NETRESET _WSAIOW(IOC_VENDOR, 15)
++#endif
++
+ /*
+  * On Windows recvfrom() may return WSAECONNRESET when destination port
+  * used in preceding call to sendto() is no longer reachable. The reset

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_from_github(
         unix/move-openssldir.patch
         unix/no-empty-dirs.patch
         unix/no-static-libs-for-shared.patch
+        fix-mingw-build.patch
 )
 
 vcpkg_list(SET CONFIGURE_OPTIONS

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openssl",
   "version": "3.6.1",
+  "port-version": 1,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7314,7 +7314,7 @@
     },
     "openssl": {
       "baseline": "3.6.1",
-      "port-version": 0
+      "port-version": 1
     },
     "opensubdiv": {
       "baseline": "3.5.0",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e21dbecc6f01203cf4c0bf0f02f390ef38aaf25b",
+      "version": "3.6.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "395e812a5600e3022a77354ba3f2ead250a8c5cf",
       "version": "3.6.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
