### PR TITLE
[babl] Update to 0.1.122

### DIFF
--- a/ports/babl/portfile.cmake
+++ b/ports/babl/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.gimp.org/pub/babl/${VERSION_MAJOR_MINOR}/babl-${VERSION}.tar.xz"
     FILENAME "babl-${VERSION}.tar.xz"
-    SHA512 9134586cc43c6e8596e7518b35a5fec99ab5d9e64270f12d77ebb04f08c4926bba84e068c08006858791334a4e3df063485419394876a76618cfdf3abded29da
+    SHA512 061b8d62a618129c9f08fc04ca1e86145873cf15fcde643be60b52393316275ca6d98bb44ac86b7b26264bc3a9b2fd54db39d78b2b56fe069daf678b28ded59f
 )
 
 vcpkg_extract_source_archive(

--- a/ports/babl/vcpkg.json
+++ b/ports/babl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "babl",
-  "version": "0.1.120",
+  "version": "0.1.122",
   "description": "A pixel encoding and color space conversion engine.",
   "homepage": "https://gegl.org/babl/",
   "license": "LGPL-3.0-or-later",

--- a/versions/b-/babl.json
+++ b/versions/b-/babl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2584be584510eda360e0266975ee110be259a2a3",
+      "version": "0.1.122",
+      "port-version": 0
+    },
+    {
       "git-tree": "3c1409be45a461d0fb090f1e89759ad6f347d616",
       "version": "0.1.120",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -617,7 +617,7 @@
       "port-version": 2
     },
     "babl": {
-      "baseline": "0.1.120",
+      "baseline": "0.1.122",
       "port-version": 0
     },
     "backward-cpp": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
