### PR TITLE
[libxscrnsaver] Update to 1.2.5

### DIFF
--- a/ports/libxscrnsaver/portfile.cmake
+++ b/ports/libxscrnsaver/portfile.cmake
@@ -1,16 +1,20 @@
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
+    return()
+endif()
 
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxscrnsaver
-    REF 96fffcd9dcaf2ba37ec56aa798677de9ad58ae81 # 1.2.3 
-    SHA512  56ae74721db0c9970001b74227eadfe116d6cbfbb8dc318a4799f5034e0028572d5cc7acedbfb1b812a37bfc8cf21d35b62b264be08b17c695878c37d56bf9a2
-    HEAD_REF master
-) 
+vcpkg_download_distfile(
+    LIBXSCRNSAVER_ARCHIVE
+    URLS "https://www.x.org/releases/individual/lib/libXScrnSaver-${VERSION}.tar.xz"
+    FILENAME "libXScrnSaver-${VERSION}.tar.xz"
+    SHA512 1c0be0d15c5e7b50a3eb4a239e2c833c44b693b111c7f64c409f9abf8051356572acadebc8b295555683ff6bd4895acdbe32b15a538c971f15d8aa4e6b7fd51b
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBXSCRNSAVER_ARCHIVE}"
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 
@@ -30,6 +34,4 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-endif()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libxscrnsaver/vcpkg.json
+++ b/ports/libxscrnsaver/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "libxscrnsaver",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "Xlib-based X11 Screen Saver extension client library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxscrnsaver",
   "license": null,
   "dependencies": [
-    "bzip2",
     "libx11",
     "libxext",
     "xorg-macros",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5901,7 +5901,7 @@
       "port-version": 0
     },
     "libxscrnsaver": {
-      "baseline": "1.2.3",
+      "baseline": "1.2.5",
       "port-version": 0
     },
     "libxslt": {

--- a/versions/l-/libxscrnsaver.json
+++ b/versions/l-/libxscrnsaver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1157371e5ce7f0afda57eb960f76280ab7d22e50",
+      "version": "1.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "534142ab44347318ba7f1f39f4000aa2645beecd",
       "version": "1.2.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Note:
- meson files are now available for this, but requires the Unix tool `sed`. The old autoconf script doesn't need it and therefore builds still under Windows.
- Switching to download archive, to avoid SHA issues again with GitLab.