### PR TITLE
[c4core] Update to 0.2.8

### DIFF
--- a/ports/c4core/portfile.cmake
+++ b/ports/c4core/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/c4core
     REF "v${VERSION}"
-    SHA512 c9264bc404a60c9eb926f53998bdf87338792a1c5c687cee9034620965abbe383ac413cfc9dc57bc571596d60c46df99df292229a26dbee232fb43fe40750092
+    SHA512 b2e9a77d5d7a1c4b4bc8b316e258582e849a6a387bcb75e8d472da58f5a24ab348b202c3d94b067fcd920ca80feddb58faa0a2c1509309664dc59137d3c1bc63
     HEAD_REF master
     PATCHES
         disable-cpack.patch

--- a/ports/c4core/vcpkg.json
+++ b/ports/c4core/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "c4core",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Library of low-level C++ utilities",
   "homepage": "https://github.com/biojppm/c4core",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1553,7 +1553,7 @@
       "port-version": 1
     },
     "c4core": {
-      "baseline": "0.2.7",
+      "baseline": "0.2.8",
       "port-version": 0
     },
     "c89stringutils": {

--- a/versions/c-/c4core.json
+++ b/versions/c-/c4core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ba03fc16b036a722c7955a48a1d96ed5d27a30a4",
+      "version": "0.2.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "f21a4b12cc5df173553ef817ae11245a3463773e",
       "version": "0.2.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
