### PR TITLE
[liblttng-ust] Update to 2.14.0

### DIFF
--- a/ports/liblttng-ust/portfile.cmake
+++ b/ports/liblttng-ust/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lttng/lttng-ust
     REF "v${VERSION}"
-    SHA512 4b41e4b80465f1e94178054430246b552f6b04e65682b1c943ac2e33d5e2c6eb24707fdaec8165855fd0f11ebc60a3afa9117fbaddd2d634d03cc76e74ee6381
+    SHA512 543c76bebc7a93368f14d427a545ecb455eba7fd4bf037a96109414362033ebae247684f2c83ef8588a12ca759fdf970f930dfdf640b4bd6a41514b40ea78b86
     HEAD_REF master
 )
 
@@ -15,7 +15,6 @@ vcpkg_make_configure(
         --disable-man-pages
         --disable-examples
         --disable-numa
-
 )
 
 vcpkg_make_install()

--- a/ports/liblttng-ust/vcpkg.json
+++ b/ports/liblttng-ust/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "liblttng-ust",
-  "version": "2.14.0-rc1",
+  "version": "2.14.0",
   "description": "LTTng-UST, the Linux Trace Toolkit Next Generation Userspace Tracer, is port of the low-overhead tracing capabilities of the LTTng kernel tracer to user-space. The library 'liblttng-ust' enables tracing of applications and libraries.",
   "homepage": "https://lttng.org/",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5141,7 +5141,7 @@
       "port-version": 0
     },
     "liblttng-ust": {
-      "baseline": "2.14.0-rc1",
+      "baseline": "2.14.0",
       "port-version": 0
     },
     "liblzf": {

--- a/versions/l-/liblttng-ust.json
+++ b/versions/l-/liblttng-ust.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "42bb060c76d2d8d3831e7a25da24eaafc4d6eb5d",
+      "version": "2.14.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3ff7fb427ef88c1f7a7f91015a0bb2cfa3b2e8f3",
       "version": "2.14.0-rc1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
