### PR TITLE
[qlementine] Update to 1.4.2

### DIFF
--- a/ports/qlementine/portfile.cmake
+++ b/ports/qlementine/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oclero/qlementine
     REF "v${VERSION}"
-    SHA512 036098cb07c0e15a68ab310efd06da2120745fcbd8ed6ff8351f6088d9ae4bbadbdbc5c6d690be64108a2ae99a51d3e203c5576af90a85d6775471b9b71c7684
+    SHA512 7c80b11f938b3e2ea23083e8394470b8cfa95bbe07d5bc89720c46e5ec0a004839860094044eecfe830a080d5e8b2e62cafc883c66ceeae84a2e8aadf8acbaed
 )
 
 vcpkg_cmake_configure(

--- a/ports/qlementine/vcpkg.json
+++ b/ports/qlementine/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qlementine",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Modern QStyle for desktop Qt6 applications.",
   "homepage": "https://github.com/oclero/qlementine/",
   "documentation": "https://oclero.github.io/qlementine/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7973,7 +7973,7 @@
       "port-version": 6
     },
     "qlementine": {
-      "baseline": "1.4.1",
+      "baseline": "1.4.2",
       "port-version": 0
     },
     "qlementine-icons": {

--- a/versions/q-/qlementine.json
+++ b/versions/q-/qlementine.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6988f1492dd96a293558e22f1cc52a43c2c899f4",
+      "version": "1.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d95a386404311d3e16f9ba418687b6a923c15b22",
       "version": "1.4.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
