### PR TITLE
[qpdf] Update to 12.3.2

### DIFF
--- a/ports/qpdf/portfile.cmake
+++ b/ports/qpdf/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO qpdf/qpdf
-    REF v${VERSION}
-    SHA512 19e848295b95863d378955ff6606af37209e2b1698f1b641b820beec122f2eefb6dee28b466c29bcef52c0fb591be739bf016b3497a1fa189bedea6695d1f6f8
+    REF "v${VERSION}"
+    SHA512 1aa9f11dc561e2ddf95a3052f6224269ab73cf1dddc5fefcc4e021351da3472819ed5979fe2073501a04f25a2fcbb126726437dbe8793d89d3f27739d599e6f6
     PATCHES
         cmake-library-only.patch
 )

--- a/ports/qpdf/vcpkg.json
+++ b/ports/qpdf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qpdf",
-  "version": "12.3.1",
+  "version": "12.3.2",
   "description": "A content-preserving PDF document transformer",
   "homepage": "https://qpdf.sourceforge.io/",
   "license": "Apache-2.0 AND MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7997,7 +7997,7 @@
       "port-version": 0
     },
     "qpdf": {
-      "baseline": "12.3.1",
+      "baseline": "12.3.2",
       "port-version": 0
     },
     "qpid-proton": {

--- a/versions/q-/qpdf.json
+++ b/versions/q-/qpdf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "73aa26b167a01911ed5b424e0954eb1ac9aa95c7",
+      "version": "12.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ede036d51491613ab6c9576643f846b09d8d40d0",
       "version": "12.3.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
