### PR TITLE
[reactiveplusplus] Update to 2.2.2

### DIFF
--- a/ports/reactiveplusplus/portfile.cmake
+++ b/ports/reactiveplusplus/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO victimsnino/ReactivePlusPlus
     REF "v${VERSION}"
-    SHA512 d48e7e0d397c9fea2eef7c7f27f48f80738e814e2418437c367bcb35830baaaef73f570adf8408153bba2736c1f74769bd37ab41e7afbcea81b280112eb5e6b3
-    HEAD_REF master
+    SHA512 426cd5dea6e3a380b86043c2765c74049bff6b1267ed5eb065f766c2e6dee373d6e431e7cf6584c8a9f3109f6ea17a05a03e2a34257695074f0b5daecdb17fbe
+    HEAD_REF v2
 )
 
 vcpkg_cmake_configure(

--- a/ports/reactiveplusplus/vcpkg.json
+++ b/ports/reactiveplusplus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "reactiveplusplus",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "description": "ReactivePlusPlus is reactive programming library for C++ language",
   "homepage": "https://github.com/victimsnino/ReactivePlusPlus",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8525,7 +8525,7 @@
       "port-version": 0
     },
     "reactiveplusplus": {
-      "baseline": "2.1.1",
+      "baseline": "2.2.2",
       "port-version": 0
     },
     "reactphysics3d": {

--- a/versions/r-/reactiveplusplus.json
+++ b/versions/r-/reactiveplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd293058269a9a1fc2b64d42f73e2c2676aa42f9",
+      "version": "2.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1407c20d8866c628e6e3b6b3723b349e7804403b",
       "version": "2.1.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.