### PR TITLE
[mpir] Fix compile error for Linux x86 (Error: invalid instruction su…

### DIFF
--- a/ports/mpir/portfile.cmake
+++ b/ports/mpir/portfile.cmake
@@ -23,6 +23,10 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
 
     set(OPTIONS --disable-silent-rules --enable-gmpcompat --enable-cxx ${SHARED_STATIC})
 
+    if(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+        vcpkg_list(APPEND OPTIONS "--host=x86-linux")
+    endif()
+
     string(APPEND VCPKG_C_FLAGS " -Wno-implicit-function-declaration")
     string(APPEND VCPKG_CXX_FLAGS " -Wno-implicit-function-declaration")
 

--- a/ports/mpir/vcpkg.json
+++ b/ports/mpir/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mpir",
   "version-date": "2022-03-02",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Multiple Precision Integers and Rationals",
   "homepage": "https://github.com/wbhart/mpir",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6594,7 +6594,7 @@
     },
     "mpir": {
       "baseline": "2022-03-02",
-      "port-version": 3
+      "port-version": 4
     },
     "mpmcqueue": {
       "baseline": "2021-12-01",

--- a/versions/m-/mpir.json
+++ b/versions/m-/mpir.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc3493fa293493b27f85851899ac40db7b1b7dc2",
+      "version-date": "2022-03-02",
+      "port-version": 4
+    },
+    {
       "git-tree": "66630c57080280e1089146536f7d5d21c7504600",
       "version-date": "2022-03-02",
       "port-version": 3


### PR DESCRIPTION
Fixes compile errors on linux x86:
```
addmul_1.c: In function ‘__gmpn_addmul_1’:
addmul_1.c:58:1: warning: unsupported size for integer register
   58 | }
      | ^
submul_1.c: In function ‘__gmpn_submul_1’:
submul_1.c:58:1: warning: unsupported size for integer register
   58 | }
      | ^
mul_1.c: In function ‘__gmpn_mul_1’:
mul_1.c:53:1: warning: unsupported size for integer register
   53 | }
      | ^
addmul_1.c: Assembler messages:
addmul_1.c:45: Error: invalid instruction suffix for `mul'
make[2]: *** [Makefile:463: addmul_1.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
mul_1.c: Assembler messages:
mul_1.c:43: Error: invalid instruction suffix for `mul'
submul_1.c: Assembler messages:
submul_1.c:45: Error: invalid instruction suffix for `mul'
make[2]: *** [Makefile:463: submul_1.lo] Error 1
make[2]: *** [Makefile:463: mul_1.lo] Error 1
make[1]: *** [Makefile:953: all-recursive] Error 1
make: *** [Makefile:756: all] Error 2
```
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
