### PR TITLE
[sord] Fix shared library linkage on macOS

### DIFF
--- a/ports/sord/portfile.cmake
+++ b/ports/sord/portfile.cmake
@@ -7,17 +7,20 @@ vcpkg_from_gitlab(
     HEAD_REF master
 )
 
-# Fix: force shared library linkage on macOS if requested
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    set(MESON_LIB_TYPE "shared")
-else()
-    set(MESON_LIB_TYPE "static")
+# Fix: force shared library linkage ONLY on macOS to solve build issues
+set(ADDITIONAL_OPTIONS "")
+if(VCPKG_TARGET_IS_OSX)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        list(APPEND ADDITIONAL_OPTIONS "-Ddefault_library=shared")
+    else()
+        list(APPEND ADDITIONAL_OPTIONS "-Ddefault_library=static")
+    endif()
 endif()
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -Ddefault_library=${MESON_LIB_TYPE}
+        ${ADDITIONAL_OPTIONS}
 )
 
 vcpkg_install_meson()

--- a/ports/sord/portfile.cmake
+++ b/ports/sord/portfile.cmake
@@ -7,8 +7,17 @@ vcpkg_from_gitlab(
     HEAD_REF master
 )
 
+# Fix: force shared library linkage on macOS if requested
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(MESON_LIB_TYPE "shared")
+else()
+    set(MESON_LIB_TYPE "static")
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Ddefault_library=${MESON_LIB_TYPE}
 )
 
 vcpkg_install_meson()


### PR DESCRIPTION
## Description
Fixes an issue where `sord` would default to building a static library on macOS, even when `VCPKG_LIBRARY_LINKAGE` is set to `dynamic`. This behavior was inconsistent with Linux and Windows builds and caused linkage errors in downstream projects.

### Changes
- Explicitly force `-Ddefault_library=shared` in Meson options when `VCPKG_LIBRARY_LINKAGE` is `dynamic` inside `portfile.cmake`.

### Note
This acts as a fix to enforce consistency across platforms. The root cause of why Meson defaults to static specifically on macOS in this environment is under investigation (logs show conflicting default_library values), but this ensures the correct artifact is produced.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/vcpkg/blob/master/CONTRIBUTING.md) guide
- [x] I have tested this on at least one environment
- [ ] I have updated the `port-version` in `vcpkg.json` (if applicable)
- [ ] I have added a new port (if applicable)