### PR TITLE
[ecm] Update to 6.22.0

### DIFF
--- a/ports/ecm/fix-wrong-version.patch
+++ b/ports/ecm/fix-wrong-version.patch
@@ -1,11 +1,11 @@
 diff --git a/modules/ECMSetupVersion.cmake b/modules/ECMSetupVersion.cmake
-index 7164c9a0bd..408ef33638 100644
+index a40c4484..785c58dd 100644
 --- a/modules/ECMSetupVersion.cmake
 +++ b/modules/ECMSetupVersion.cmake
-@@ -112,7 +112,6 @@ function(ecm_setup_version _version)
+@@ -118,7 +118,6 @@ function(ecm_setup_version _version)
+     set(project_manages_version FALSE)
      set(use_project_version FALSE)
-     cmake_policy(GET CMP0048 project_version_policy)
-     if(project_version_policy STREQUAL "NEW")
+     if(CMAKE_MAJOR_VERSION VERSION_GREATER_EQUAL 4)
 -        set(project_manages_version TRUE)
          if(_version STREQUAL "PROJECT")
              set(use_project_version TRUE)

--- a/ports/ecm/portfile.cmake
+++ b/ports/ecm/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/extra-cmake-modules
     REF "v${VERSION}"
-    SHA512 d62091185c26c4eec83f7b2e06468c3c3691ae0e71f4d60aafaf32be262677affc686a4e54159f487005854bdf46c4c3a2214775daf850039b733ad02edc3936
+    SHA512 317300082441ee01d447fd89dc43e858b270d7d645a1286ed9d85dd669eb11c9e66fe44513ce7f0ee4c9ca5bd803d5f168a8847cbe6ad241b3008068679868b0
     HEAD_REF master
     PATCHES
         fix_generateqmltypes.patch # https://invent.kde.org/frameworks/extra-cmake-modules/-/merge_requests/201

--- a/ports/ecm/vcpkg.json
+++ b/ports/ecm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ecm",
-  "version": "6.7.0",
-  "port-version": 2,
+  "version": "6.22.0",
   "description": "Extra CMake Modules (ECM), extra modules and scripts for CMake",
   "homepage": "https://invent.kde.org/frameworks/extra-cmake-modules",
   "documentation": "https://api.kde.org/ecm/",

--- a/ports/kf5kio/libmount.patch
+++ b/ports/kf5kio/libmount.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/kmountpoint.cpp b/src/core/kmountpoint.cpp
+index dac7a68aa..7d760158a 100644
+--- a/src/core/kmountpoint.cpp
++++ b/src/core/kmountpoint.cpp
+@@ -47,7 +47,7 @@ static const Qt::CaseSensitivity cs = Qt::CaseSensitive;
+ 
+ // Linux
+ #if HAVE_LIB_MOUNT
+-#include <libmount/libmount.h>
++#include <libmount.h>
+ #endif
+ 
+ static bool isNetfs(const QString &mountType)

--- a/ports/kf5kio/portfile.cmake
+++ b/ports/kf5kio/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 085eaf467cb70630b1a2fe5024bd45aebe47f15c397388ebd562d0c0fbfd6700c8cc50d2ec136988d9575173aa01a5a73a1550c1b7cbb93d6909941909a31db7
     HEAD_REF master
+    PATCHES
+        libmount.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/kf5kio/vcpkg.json
+++ b/ports/kf5kio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5kio",
   "version": "5.116.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Network transparent access to files and data",
   "homepage": "https://invent.kde.org/frameworks/kio",
   "documentation": "https://api.kde.org/kio-index.html ",

--- a/ports/kf5solid/003_libmount.patch
+++ b/ports/kf5solid/003_libmount.patch
@@ -1,0 +1,13 @@
+diff --git a/src/solid/devices/backends/udisks2/udisksstorageaccess.cpp b/src/solid/devices/backends/udisks2/udisksstorageaccess.cpp
+index 1c513ab8..beb41140 100644
+--- a/src/solid/devices/backends/udisks2/udisksstorageaccess.cpp
++++ b/src/solid/devices/backends/udisks2/udisksstorageaccess.cpp
+@@ -18,7 +18,7 @@
+ 
+ #include <config-solid.h>
+ #if HAVE_LIBMOUNT
+-#include <libmount/libmount.h>
++#include <libmount.h>
+ #endif
+ 
+ using namespace Solid::Backends::UDisks2;

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         001_fix_libmount.patch
         002_fix_imobile.patch
+        003_libmount.patch
 )
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")

--- a/ports/kf5solid/vcpkg.json
+++ b/ports/kf5solid/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5solid",
   "version": "5.116.0",
+  "port-version": 1,
   "description": "Desktop hardware abstraction",
   "homepage": "https://api.kde.org/solid-index.html",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2693,8 +2693,8 @@
       "port-version": 0
     },
     "ecm": {
-      "baseline": "6.7.0",
-      "port-version": 2
+      "baseline": "6.22.0",
+      "port-version": 0
     },
     "ecos": {
       "baseline": "2.0.10",
@@ -4366,7 +4366,7 @@
     },
     "kf5kio": {
       "baseline": "5.116.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5newstuff": {
       "baseline": "5.116.0",
@@ -4394,7 +4394,7 @@
     },
     "kf5solid": {
       "baseline": "5.116.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5sonnet": {
       "baseline": "5.116.0",

--- a/versions/e-/ecm.json
+++ b/versions/e-/ecm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "351eab3f7d5db50bb7f25dbdf92f22654fddf63c",
+      "version": "6.22.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ea471b038a6572abea9cd7f343468ee026409f2",
       "version": "6.7.0",
       "port-version": 2

--- a/versions/k-/kf5kio.json
+++ b/versions/k-/kf5kio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ed07fb07b270ebc348fc80b8d33eb889a545bef",
+      "version": "5.116.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "a2d1045be719bfbe445c7bcaae85222bd4ceeb21",
       "version": "5.116.0",
       "port-version": 1

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d212c96ef366eb4cc196cc43f9a63b18f7ee979f",
+      "version": "5.116.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1bdd951c06ebafac039965c108befdad8af1ce57",
       "version": "5.116.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Note:
- Removing the patch, as they adjusted the Code there to check for CMake 4 instead of the policy and I have CMake 4.3-nightly and don't have any issue wth builing this lib and there is no hint, what this fixed (patch was cherry picked by @BillyONeal from [here](https://github.com/Neumann-A/vcpkg/blob/b5de39d0d647ecd4f25d3c9cc22ad2e27c88501b/ports/ecm/fix-wrong-version.patch) and the commit message doesn't give any hint why this was necessary) // Edit: Ok necessary for arm64_osx. Maybe can be removed after updating `kdiagram`
- Patch was necessary due to [this](https://github.com/KDE/extra-cmake-modules/commit/1cc17521fefd7adb0631d24a03497bcf63b9512d)
