### PR TITLE
[soundtouch] update to 2.4.0

### DIFF
--- a/ports/soundtouch/portfile.cmake
+++ b/ports/soundtouch/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     GITHUB_HOST https://codeberg.org
     REPO soundtouch/soundtouch
     REF ${VERSION}
-    SHA512 9cc507e15be065fe404e3f9ac71cdc596474c4a86b04a4b969c6c3ed4aff865cdf6aee24929046818a7d3791f005778aea112d74ef4d8f60b05460755a08dbe3
+    SHA512 8bd199c6363104ba6c9af1abbd3c4da3567ccda5fe3a68298917817fc9312ecb0914609afba1abd864307b0a596becf450bc7073eeec17b1de5a7c5086fbc45e
     HEAD_REF master
 )
 

--- a/ports/soundtouch/vcpkg.json
+++ b/ports/soundtouch/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "soundtouch",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "SoundTouch is an open-source audio processing library for changing the Tempo, Pitch and Playback Rates of audio streams or audio files.",
   "homepage": "https://www.surina.net/soundtouch",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9317,7 +9317,7 @@
       "port-version": 0
     },
     "soundtouch": {
-      "baseline": "2.3.3",
+      "baseline": "2.4.0",
       "port-version": 0
     },
     "soxr": {

--- a/versions/s-/soundtouch.json
+++ b/versions/s-/soundtouch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc13dd17e35d60c64e0af1b3ee27cbe3b816e7d5",
+      "version": "2.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d0278d07d154448d3466b034bf90b111be54e521",
       "version": "2.3.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://codeberg.org/soundtouch/soundtouch/releases/tag/2.4.0

try to close https://github.com/microsoft/vcpkg/issues/49594.
