### PR TITLE
[slick-queue] Update to v1.3.0

### DIFF
--- a/ports/slick-queue/portfile.cmake
+++ b/ports/slick-queue/portfile.cmake
@@ -2,8 +2,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-queue
     REF "v${VERSION}"
-    SHA512 7a6a10ff5651c956a826e89ee6f92ee92b3bc7d3c20603f6f76ab8e2ca0150ae1db2a269692e6426470e147d61be3ea53bddeeca6b999ab0191807019eda9945
+    SHA512 5162daecd838bb6e6f506617759411d7461550cd2f6d6077a5fd08c74a151e5ee798e8470373f730be551be6abcd6ac56cba17fb7938365754d36ab62f8204a5
     HEAD_REF main
+    PATCHES
+        slick-shm.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/slick-queue/slick-shm.patch
+++ b/ports/slick-queue/slick-shm.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6cbc9ee..b5f3d7a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD 20)
+ # Options:
+ option(BUILD_SLICK_QUEUE_TESTS "Build tests" ON)
+ 
+-find_package(slick-shm CONFIG QUIET)
++find_package(slick-shm CONFIG REQUIRED)
+ 
+ if (NOT slick-shm_FOUND)
+     include(FetchContent)

--- a/ports/slick-queue/vcpkg.json
+++ b/ports/slick-queue/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-queue",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "A C++ Lock-Free MPMC queue - header-only library for high throughput concurrent messaging with optional shared memory support",
   "homepage": "https://github.com/SlickQuant/slick-queue",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
+    "slick-shm",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9209,7 +9209,7 @@
       "port-version": 0
     },
     "slick-queue": {
-      "baseline": "1.2.3",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "slick-shm": {

--- a/versions/s-/slick-queue.json
+++ b/versions/s-/slick-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "979e15cd33a7a8ba364b249185fe4b1edb59a30b",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7589ab1759ee075a3be96061cee5b6a07ca49819",
       "version": "1.2.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
