### PR TITLE
[protobuf] Fix BUILTIN_ATOMICS detection

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -51,6 +51,7 @@ file(REMOVE_RECURSE
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        -DCMAKE_CXX_STANDARD=17
         -Dprotobuf_BUILD_SHARED_LIBS=${protobuf_BUILD_SHARED_LIBS}
         -Dprotobuf_MSVC_STATIC_RUNTIME=${protobuf_MSVC_STATIC_RUNTIME}
         -Dprotobuf_BUILD_TESTS=OFF

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "protobuf",
   "version": "6.33.4",
+  "port-version": 1,
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7850,7 +7850,7 @@
     },
     "protobuf": {
       "baseline": "6.33.4",
-      "port-version": 0
+      "port-version": 1
     },
     "protobuf-c": {
       "baseline": "1.5.2",

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82a850caf35034a45596845a1d6e734b82f6a79a",
+      "version": "6.33.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "276478aca53e8691c716e67a0e6172db1b391299",
       "version": "6.33.4",
       "port-version": 0


### PR DESCRIPTION
protobuf's CMakeList.txt includes a [check for builtin atomics](https://github.com/protocolbuffers/protobuf/blob/edaa823d8b36a8656d7b2b9241b7d0bfe50af878/CMakeLists.txt#L187-L201) which can incorrectly fail when `CMAKE_CXX_STANDARD` isn't defined (depending on platform and toolchain defaults)

protobuf's top-level CMakeList.txt does not, itself, define `CMAKE_CXX_STANDARD` before this check.

Resolve this by explicitly defining `CMAKE_CXX_STANDARD` for the `vcpkg_cmake_configure` call.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
