### PR TITLE
[webcraft] update to 1.0.5

### DIFF
--- a/ports/webcraft/fix-concurrentqueue.patch
+++ b/ports/webcraft/fix-concurrentqueue.patch
@@ -1,26 +1,19 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 619e8f2..be8a743 100644
+index 619e8f2..f3f325a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -23,12 +23,17 @@ endif()
- file(GLOB_RECURSE WebCraft_SOURCES CONFIGURE_DEPENDS src/webcraft/*.cpp)
- add_library(WebCraft STATIC ${WebCraft_SOURCES})
+@@ -30,6 +30,11 @@ target_include_directories(WebCraft PUBLIC
  
-+find_package(concurrentqueue REQUIRED)
+ target_link_libraries(WebCraft PUBLIC ${WEBCRAFT_PLATFORM_LIBS})
+ 
++if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
++    find_package(concurrentqueue REQUIRED)
++    target_link_libraries(WebCraft PUBLIC concurrentqueue::concurrentqueue)
++endif()
 +
- target_include_directories(WebCraft PUBLIC 
-     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-     $<INSTALL_INTERFACE:include>
- )
- 
--target_link_libraries(WebCraft PUBLIC ${WEBCRAFT_PLATFORM_LIBS})
-+target_link_libraries(WebCraft PUBLIC
-+    ${WEBCRAFT_PLATFORM_LIBS} 
-+    concurrentqueue::concurrentqueue
-+)
- 
  # --- 3. Install Rules ---
  
+ # A. Install the Library and Headers
 diff --git a/src/webcraft/runtime.provider.cpp b/src/webcraft/runtime.provider.cpp
 index 0e1300e..8edfe75 100644
 --- a/src/webcraft/runtime.provider.cpp

--- a/ports/webcraft/fix-concurrentqueue.patch
+++ b/ports/webcraft/fix-concurrentqueue.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 619e8f2..be8a743 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,12 +23,17 @@ endif()
+ file(GLOB_RECURSE WebCraft_SOURCES CONFIGURE_DEPENDS src/webcraft/*.cpp)
+ add_library(WebCraft STATIC ${WebCraft_SOURCES})
+ 
++find_package(concurrentqueue REQUIRED)
++
+ target_include_directories(WebCraft PUBLIC 
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+     $<INSTALL_INTERFACE:include>
+ )
+ 
+-target_link_libraries(WebCraft PUBLIC ${WEBCRAFT_PLATFORM_LIBS})
++target_link_libraries(WebCraft PUBLIC
++    ${WEBCRAFT_PLATFORM_LIBS} 
++    concurrentqueue::concurrentqueue
++)
+ 
+ # --- 3. Install Rules ---
+ 
+diff --git a/src/webcraft/runtime.provider.cpp b/src/webcraft/runtime.provider.cpp
+index 0e1300e..8edfe75 100644
+--- a/src/webcraft/runtime.provider.cpp
++++ b/src/webcraft/runtime.provider.cpp
+@@ -47,7 +47,7 @@ void webcraft::async::detail::initialize_runtime() noexcept
+ // to avoid collision with concurrentqueue's BLOCK_SIZE constant
+ #pragma push_macro("BLOCK_SIZE")
+ #undef BLOCK_SIZE
+-#include <concurrentqueue/concurrentqueue.h>
++#include <concurrentqueue/moodycamel/concurrentqueue.h>
+ #pragma pop_macro("BLOCK_SIZE")
+ 
+ #include <liburing.h>

--- a/ports/webcraft/fix-concurrentqueue.patch
+++ b/ports/webcraft/fix-concurrentqueue.patch
@@ -3,16 +3,16 @@ index 619e8f2..f3f325a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -30,6 +30,11 @@ target_include_directories(WebCraft PUBLIC
- 
+
  target_link_libraries(WebCraft PUBLIC ${WEBCRAFT_PLATFORM_LIBS})
- 
+
 +if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 +    find_package(concurrentqueue REQUIRED)
-+    target_link_libraries(WebCraft PUBLIC concurrentqueue::concurrentqueue)
++    target_link_libraries(WebCraft PRIVATE concurrentqueue::concurrentqueue)
 +endif()
 +
  # --- 3. Install Rules ---
- 
+
  # A. Install the Library and Headers
 diff --git a/src/webcraft/runtime.provider.cpp b/src/webcraft/runtime.provider.cpp
 index 0e1300e..8edfe75 100644
@@ -23,7 +23,7 @@ index 0e1300e..8edfe75 100644
  #pragma push_macro("BLOCK_SIZE")
  #undef BLOCK_SIZE
 -#include <concurrentqueue/concurrentqueue.h>
-+#include <concurrentqueue/moodycamel/concurrentqueue.h>
++#include <moodycamel/concurrentqueue.h>
  #pragma pop_macro("BLOCK_SIZE")
- 
+
  #include <liburing.h>

--- a/ports/webcraft/portfile.cmake
+++ b/ports/webcraft/portfile.cmake
@@ -4,8 +4,10 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO adityarao2005/WebCraft
     REF v${VERSION}
-    SHA512 1c0c5de6a6a42b9a6366a633c6dd00008fc1c631da6cda146ae952c499b8a11028af0f8dad2a1c6c3a51119a6bec44ad5087b6128c015910957c661ea52bee7c
+    SHA512 d598d6303fefa1b18e7effb57da99e353a898817bde917588d103aabe0662eea07a3647dc9338c3cd6ba2d048423b7640cbb396f5fd42dd4f7997136b4bcb236
     HEAD_REF main
+    PATCHES
+        fix-concurrentqueue.patch
 )
 
 if (VCPKG_TARGET_IS_LINUX)
@@ -26,6 +28,11 @@ vcpkg_cmake_config_fixup(
 	CONFIG_PATH share/WebCraft
 )
 
+file(REMOVE
+    "${CURRENT_PACKAGES_DIR}/include/webcraft/async/README.md"
+    "${CURRENT_PACKAGES_DIR}/include/webcraft/async/asyncruntime.drawio.svg"
+    "${CURRENT_PACKAGES_DIR}/include/webcraft/async/io/README.md"
+)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/webcraft/vcpkg.json
+++ b/ports/webcraft/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "webcraft",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "An async first C++ networking library leveraging powerful features of C++23 built for scale, speed, and ease.",
   "homepage": "https://github.com/adityarao2005/WebCraft/",
   "license": "MIT",
   "supports": "!(uwp | android | emscripten)",
   "dependencies": [
+    {
+      "name": "concurrentqueue",
+      "platform": "linux"
+    },
     {
       "name": "liburing",
       "platform": "linux"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10609,7 +10609,7 @@
       "port-version": 0
     },
     "webcraft": {
-      "baseline": "1.0.3",
+      "baseline": "1.0.5",
       "port-version": 0
     },
     "websocketpp": {

--- a/versions/w-/webcraft.json
+++ b/versions/w-/webcraft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e61f67c8eda8e62b77235f3e263f10b0e957d5f3",
+      "version": "1.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "0bd4b2b58ab47c6ad57df01cd33023c2115bb0a4",
       "version": "1.0.3",
       "port-version": 0

--- a/versions/w-/webcraft.json
+++ b/versions/w-/webcraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e61f67c8eda8e62b77235f3e263f10b0e957d5f3",
+      "git-tree": "f04b460f4e541065c93c1aad369385b5586ea049",
       "version": "1.0.5",
       "port-version": 0
     },

--- a/versions/w-/webcraft.json
+++ b/versions/w-/webcraft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f04b460f4e541065c93c1aad369385b5586ea049",
+      "git-tree": "b429333a40cc15bd838183ef0fd725ba994a0eb5",
       "version": "1.0.5",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/adityarao2005/WebCraft/releases/tag/v1.0.5

Try to close https://github.com/microsoft/vcpkg/issues/49236.
