### PR TITLE
[libdwarf] update to 2.3.0

### DIFF
--- a/ports/libdwarf/portfile.cmake
+++ b/ports/libdwarf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO davea42/libdwarf-code
     REF "v${VERSION}"
-    SHA512 9fbf58e04e49816cb1f8e34362dd7c784476422896a88042bebd09778fad4a37cbf3f4c060f491b8d55bec610be37137b24a4910498499d3fcecf9da4aa78254
+    SHA512 66f9c273d272b23b75cb520db8b4c1105f9214e4c5b65187f289090dfa7e889746abf5b4bb9b760c6a0120a7bb3f25b45308acf6c1037742e31946a2023cd804
     HEAD_REF main
     PATCHES
         include-dir.diff # avoid dwarf.h conflict with elfutils
@@ -42,7 +42,7 @@ file(REMOVE_RECURSE
 file(COPY_FILE "${SOURCE_PATH}/src/lib/libdwarf/COPYING" "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libdwarf COPYING")
 file(COPY_FILE "${SOURCE_PATH}/src/bin/dwarfdump/COPYING" "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/dwarfdump COPYING")
 file(COPY_FILE "${SOURCE_PATH}/src/bin/dwarfgen/COPYING" "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/dwarfgen COPYING")
-vcpkg_install_copyright(FILE_LIST 
+vcpkg_install_copyright(FILE_LIST
     "${SOURCE_PATH}/COPYING"
     "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libdwarf COPYING"
     "${SOURCE_PATH}/src/lib/libdwarf/LIBDWARFCOPYRIGHT"

--- a/ports/libdwarf/vcpkg.json
+++ b/ports/libdwarf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdwarf",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A library for reading DWARF2 and later DWARF.",
   "homepage": "https://github.com/davea42/libdwarf-code",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4833,7 +4833,7 @@
       "port-version": 0
     },
     "libdwarf": {
-      "baseline": "2.2.0",
+      "baseline": "2.3.0",
       "port-version": 0
     },
     "libe57": {

--- a/versions/l-/libdwarf.json
+++ b/versions/l-/libdwarf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26d85bb6374fa03de7febf797c5ab6817ad7b426",
+      "version": "2.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "db46d4e35bcf87e87410b99813e07d306fe2e554",
       "version": "2.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/davea42/libdwarf-code/releases/tag/v2.3.0
