### PR TITLE
[intx] update to 0.15.0

### DIFF
--- a/ports/intx/portfile.cmake
+++ b/ports/intx/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO chfast/intx
     REF "v${VERSION}"
-    SHA512 f8b86f53052577965bac480ac6b222aee29ec005e151e596139c7e98e1410c8f9ed27beffa23e58307fa96815af2af9b8dcfbf076d9ea259f609d7d3784f9896
+    SHA512 8d3ab7f8492bc409f075118ed2a85b2efffe1ab9eaf36d93c5532f30d5e80b6eadbd3d5f5dd1e8dc5760f45b0236c633afdc492ad125ffdf9dcdea1ba9c382d9
     HEAD_REF master
 )
 

--- a/ports/intx/vcpkg.json
+++ b/ports/intx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "intx",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Extended precision integer C++ library ",
   "homepage": "https://github.com/chfast/intx",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4029,7 +4029,7 @@
       "port-version": 0
     },
     "intx": {
-      "baseline": "0.14.0",
+      "baseline": "0.15.0",
       "port-version": 0
     },
     "iowa-hills-dsp": {

--- a/versions/i-/intx.json
+++ b/versions/i-/intx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e51d8dbd5d460ecfb37f355a090c269d5d1c1b25",
+      "version": "0.15.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "934adb0d6cafe33e669c4f2bbe495ac0bc6b21f0",
       "version": "0.14.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/chfast/intx/releases/tag/v0.15.0
