### PR TITLE
[slick-shm] Update to v0.1.4

### DIFF
--- a/ports/slick-shm/portfile.cmake
+++ b/ports/slick-shm/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-shm
     REF "v${VERSION}"
-    SHA512 1d0c0cc629ae4996e8566df3f61876bba9b41264b6adc289bd16ef9f083bd1ba0cdd93cb38f3223a209a3b4b17ec161f76eeac56b42f22990dd6c4bcd960fd51 
+    SHA512 2ca3edb663efef81ec5179687305f5081ef1d8ac11c250aa90db5fabf49e445dce74867e9c5ad532edb3c3006dcb4a59dd9692bbed66b2a0cb16e50789f77a52 
     HEAD_REF main
 )
 

--- a/ports/slick-shm/vcpkg.json
+++ b/ports/slick-shm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-shm",
-  "version-semver": "0.1.3",
+  "version-semver": "0.1.4",
   "description": "A modern C++17 header-only, cross-platform shared memory library",
   "homepage": "https://github.com/SlickQuant/slick-shm",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9217,7 +9217,7 @@
       "port-version": 0
     },
     "slick-shm": {
-      "baseline": "0.1.3",
+      "baseline": "0.1.4",
       "port-version": 0
     },
     "slikenet": {

--- a/versions/s-/slick-shm.json
+++ b/versions/s-/slick-shm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a312f79b3bd83622f9bc8065d5a1669a7625f297",
+      "version-semver": "0.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "12ad1da3dfc1d36dd7670088a427b12e9cb73104",
       "version-semver": "0.1.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
