### PR TITLE
[vcpkg.targets] Allow specifying the root for the installed directory

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg-general.xml
+++ b/scripts/buildsystems/msbuild/vcpkg-general.xml
@@ -73,6 +73,10 @@
                   Description="The location where headers and binaries will be consumed from. In manifest mode, this directory will be created and populated based on vcpkg.json.">
   </StringProperty>
 
+  <StringProperty Name="VcpkgInstalledDirRoot" DisplayName="Installed Directory Root" Category="General" Subtype="folder" Visible="true"
+                  Description="In manifest mode and when Installed Directory is not defined, the root to derive Installed Directory from for each triplet.">
+  </StringProperty>
+
   <BoolProperty Name="VcpkgUseStatic" DisplayName="Use Static Libraries" Category="Conditional" Default="false"
                 Description="Vcpkg can build static libraries (e.g. x64-windows-static). This options changes the default triplet to use these static libraries by appending -static to $(VcpkgTriplet). This will not be shown in the evaluation of the Triplet within the UI." />
 

--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -17,11 +17,17 @@
     <_ZVcpkgInstalledDir>$(VcpkgInstalledDir)</_ZVcpkgInstalledDir>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(VcpkgEnableManifest)' == 'true'">
+    <_ZVcpkgInstalledDirRoot>$(VcpkgInstalledDirRoot)</_ZVcpkgInstalledDirRoot>
+    <_ZVcpkgInstalledDirRoot Condition="'$(_ZVcpkgInstalledDirRoot)' == ''">$(_ZVcpkgManifestRoot)vcpkg_installed\</_ZVcpkgInstalledDirRoot>
+  </PropertyGroup>
+
   <!-- Add trailing slashes to inputs that must have them to conform with msbuild conventions. -->
   <PropertyGroup>
     <_ZVcpkgRoot Condition="!$(_ZVcpkgRoot.EndsWith('\'))">$(_ZVcpkgRoot)\</_ZVcpkgRoot>
     <_ZVcpkgManifestRoot Condition="'$(_ZVcpkgManifestRoot)' != '' and !$(_ZVcpkgManifestRoot.EndsWith('\'))">$(_ZVcpkgManifestRoot)\</_ZVcpkgManifestRoot>
     <_ZVcpkgInstalledDir Condition="'$(_ZVcpkgInstalledDir)' != '' and !$(_ZVcpkgInstalledDir.EndsWith('\'))">$(_ZVcpkgInstalledDir)\</_ZVcpkgInstalledDir>
+    <_ZVcpkgInstalledDirRoot Condition="'$(_ZVcpkgInstalledDirRoot)' != '' and !$(_ZVcpkgInstalledDirRoot.EndsWith('\'))">$(_ZVcpkgInstalledDirRoot)\</_ZVcpkgInstalledDirRoot>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -76,7 +82,7 @@
   <Choose>
     <When Condition="'$(VcpkgEnableManifest)' == 'true'">
       <PropertyGroup>
-        <_ZVcpkgInstalledDir Condition="'$(_ZVcpkgInstalledDir)' == ''">$(_ZVcpkgManifestRoot)vcpkg_installed\$(VcpkgTriplet)\</_ZVcpkgInstalledDir>
+        <_ZVcpkgInstalledDir Condition="'$(_ZVcpkgInstalledDir)' == ''">$(_ZVcpkgInstalledDirRoot)$(VcpkgTriplet)\</_ZVcpkgInstalledDir>
       </PropertyGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
In manifest mode overriding VcPkgInstalledDir leads to each triplet being put in that directory so if VcPkgInstalledDir isn't unique per triplet, each ends up in the same directory. That isn't intended vcpkg usage and hence causes various build issues.

The user could circumvent that by crafting a unique VcPkgInstalledDir for each triplet - which is exactly what vcpkg.targets does already when deriving the VcPkgTriplet value - but the user would need to do that manually since they don't have access to VcPkgTriplet before importing vcpkg.targets, and afterwards it is too late.

So introduce a new property VcpkgInstalledDirRoot which allows the user to specify where they want the installed directory, but append the VcPkgTriplet subdirectory to it. This is fully backwards compatible since this root defaults to $(VcpkgManifestRoot)/vcpkg_installed and that is what was used already.

Note: the alternative (which is the behavior I assumed vcpkg would have) would be that when the user specifies VcPkgInstalledDir in manifest mode, vcpkg.targets appends VcpkgTriplet to it then uses that as actual installed directory, but that's not backwards compatible.