### PR TITLE
[kf6archive] Update to 6.22.0

### DIFF
--- a/ports/kf6archive/portfile.cmake
+++ b/ports/kf6archive/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/karchive
     REF "v${VERSION}"
-    SHA512 f87fd53ba029b05d3c233ea8d8a9dbb7b2aba2aec55a38b26cfd0f6e1c49d8c1297c06d634175ccc5bbbce00261a3387a2da3c705011e9cbae538eae2723fef3
+    SHA512 d6ab327b5c42c3221348d797e575984d50790f46db6f7e92dd442f7792e88804f88054fb4bcaf6b12470f992f0a18065a2aafa67eb4d4784d5caf0082c4d4b0e
     HEAD_REF master
     PATCHES
         zstd.diff

--- a/ports/kf6archive/vcpkg.json
+++ b/ports/kf6archive/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "kf6archive",
-  "version": "6.7.0",
-  "port-version": 1,
+  "version": "6.22.0",
   "description": "File compression",
   "homepage": "https://invent.kde.org/frameworks/karchive",
   "documentation": "https://api.kde.org/karchive-index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4429,8 +4429,8 @@
       "port-version": 0
     },
     "kf6archive": {
-      "baseline": "6.7.0",
-      "port-version": 1
+      "baseline": "6.22.0",
+      "port-version": 0
     },
     "kfr": {
       "baseline": "6.3.1",

--- a/versions/k-/kf6archive.json
+++ b/versions/k-/kf6archive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b08fa1b6a16e2db3474ef63456327409f6bb6f05",
+      "version": "6.22.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "38d377350523b0927cf1a68b8343d901c33081cd",
       "version": "6.7.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
