### PR TITLE
[Live555] Update to 2026.01.12

### DIFF
--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -2,17 +2,14 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 string(REPLACE "-" "." format_version ${VERSION})
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://live555.com/liveMedia/public/live.${format_version}.tar.gz"
+    URLS "https://download.live555.com/live.${format_version}.tar.gz"
     FILENAME "live.${format_version}.tar.gz"
-    SHA512 ee2bf17d2803c4bb6f49408a123de9238273749b9c110113facbf78eb01b9961bbd04178335f40d36425c9f96a26ee3da57e970f86d4912b4ec42ab6f4b2c7e9
+    SHA512 59adac68e7906e784a19b2d0c90bfa665a5094e8ef17691bc7f6b0b385c02201d017e6a92e3cc2140ed8496928647cb1186298d2c7ff718a2b0572f1b79a50a2
 )
 
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
-    PATCHES
-        fix-RTSPClient.patch
-        fix_operator_overload.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/live555/vcpkg.json
+++ b/ports/live555/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "live555",
-  "version-date": "2024-11-28",
+  "version-date": "2026-01-12",
   "description": "A complete RTSP server application",
   "homepage": "http://www.live555.com/liveMedia",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5989,7 +5989,7 @@
       "port-version": 0
     },
     "live555": {
-      "baseline": "2024-11-28",
+      "baseline": "2026-01-12",
       "port-version": 0
     },
     "livepp": {

--- a/versions/l-/live555.json
+++ b/versions/l-/live555.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7508c71d426ff4d864d66bac4c77b0d195fa1eb9",
+      "version-date": "2026-01-12",
+      "port-version": 0
+    },
+    {
       "git-tree": "b83d9a10d5b979381dad2b345d934243ee5f507a",
       "version-date": "2024-11-28",
       "port-version": 0


### PR DESCRIPTION
The download link for the Live555 source code has been changed, and the old version is no longer available for download. As of February 1, 2026, the only version I found on the official website is 2026.01.12.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


