### PR TITLE
[orefkov-simstr] update to 1.6.2

### DIFF
--- a/ports/orefkov-simstr/portfile.cmake
+++ b/ports/orefkov-simstr/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO orefkov/simstr
-	SHA512 57923844fe5add71d8434dfbe014266c6465bcf33aadc19b5f7c21f1fdee30edb6231c6b6daf007a812f3688aa63e6bfa6eeae73fe0fdb52fb3d09080c069bd0
+	SHA512 5e9e9dd5cf98416d10c768782be6ddae78e3ebdd5d587aeb1186cee7dd49a503c2bd01166438d0be3caf0b36796aa639b80d08366eff8eb7716700e2073bc0ba
     REF "rel${VERSION}"
     HEAD_REF main
 )

--- a/ports/orefkov-simstr/vcpkg.json
+++ b/ports/orefkov-simstr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "orefkov-simstr",
-  "version-semver": "1.6.0",
+  "version-semver": "1.6.2",
   "description": "Yet another C++ strings library implementation",
   "homepage": "https://github.com/orefkov/simstr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7389,7 +7389,7 @@
       "port-version": 0
     },
     "orefkov-simstr": {
-      "baseline": "1.6.0",
+      "baseline": "1.6.2",
       "port-version": 0
     },
     "ormpp": {

--- a/versions/o-/orefkov-simstr.json
+++ b/versions/o-/orefkov-simstr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a264a804147f8e5afe382a050a77e4a22a88aca",
+      "version-semver": "1.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "55cf099753afba6358c8efbf09e5fb3da28e5135",
       "version-semver": "1.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/orefkov/simstr/releases/tag/rel1.6.2
