### PR TITLE
[fastpfor] add new port

### DIFF
--- a/ports/fastpfor/fix-arm-checker.patch
+++ b/ports/fastpfor/fix-arm-checker.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake_modules/environment.cmake b/cmake_modules/environment.cmake
+index 8072ae8..a10aa25 100644
+--- a/cmake_modules/environment.cmake
++++ b/cmake_modules/environment.cmake
+@@ -5,6 +5,6 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "ar
+ endif ()
+ 
+ # Check if the Visual Studio build is targeting ARM
+-if (CMAKE_GENERATOR_PLATFORM MATCHES "ARM64" OR CMAKE_GENERATOR_PLATFORM MATCHES "ARM")
++if (CMAKE_GENERATOR_PLATFORM MATCHES "[Aa][Rr][Mm]64" OR CMAKE_GENERATOR_PLATFORM MATCHES "[Aa][Rr][Mm]")
+     set(SUPPORT_NEON ON)
+-endif ()
+\ No newline at end of file
++endif ()

--- a/ports/fastpfor/fix-arm-checker.patch
+++ b/ports/fastpfor/fix-arm-checker.patch
@@ -16,3 +16,68 @@ index 8072ae8..9d05bcc 100644
      set(SUPPORT_NEON ON)
  endif ()
 \ No newline at end of file
+diff --git a/headers/common.h b/headers/common.h
+index b1c97b5..bbb937f 100644
+--- a/headers/common.h
++++ b/headers/common.h
+@@ -12,7 +12,7 @@
+ #include <fcntl.h>
+ #if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+ #include <immintrin.h>
+-#elif defined(__GNUC__) && defined(__aarch64__)
++#elif defined(__GNUC__) && (defined(__aarch64__) || defined(__arm__))
+ #include <simde/x86/sse4.1.h>
+ #endif
+ 
+@@ -52,7 +52,7 @@
+ 
+ #if (defined(_M_IX86) || defined(_M_AMD64))
+ #include <intrin.h>
+-#elif defined(_M_ARM64)
++#elif defined(_M_ARM64) || defined(_M_ARM)
+ #include <simde/x86/sse4.1.h>
+ #endif
+ 
+diff --git a/src/streamvbyte.c b/src/streamvbyte.c
+index 1f9dc6b..37a6442 100644
+--- a/src/streamvbyte.c
++++ b/src/streamvbyte.c
+@@ -9,7 +9,7 @@
+     /* Microsoft C/C++-compatible compiler */
+     #if (defined(_M_IX86) || defined(_M_AMD64))
+     #include <intrin.h>
+-    #elif defined(_M_ARM64)
++    #elif defined(_M_ARM64) || defined(_M_ARM)
+     #include <simde/x86/sse4.1.h>
+     #endif
+ 
+@@ -19,7 +19,7 @@
+ #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+     /* GCC-compatible compiler, targeting x86/x86-64 */
+     #include <x86intrin.h>
+-#elif defined(__aarch64__)
++#elif defined(__aarch64__) || defined (__arm__)
+     /* GCC-compatible compiler, targeting ARM with NEON */
+     #include <simde/x86/sse4.1.h>
+ #elif defined(__GNUC__) && defined(__IWMMXT__)
+diff --git a/src/varintdecode.c b/src/varintdecode.c
+index 7807e12..c77f117 100644
+--- a/src/varintdecode.c
++++ b/src/varintdecode.c
+@@ -7,14 +7,14 @@
+      /* Microsoft C/C++-compatible compiler */
+     #if (defined(_M_IX86) || defined(_M_AMD64))
+     #include <intrin.h>
+-    #elif defined(_M_ARM64)
++    #elif defined(_M_ARM64) || defined(_M_ARM)
+     #include <simde/x86/sse4.1.h>
+     #endif
+ #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+     /* GCC-compatible compiler, targeting x86/x86-64 */
+     #include <x86intrin.h>
+ 
+-#elif defined(__aarch64__)
++#elif defined(__aarch64__) || defined (__arm__)
+     /* GCC-compatible compiler, targeting ARM with NEON */
+     #include <simde/x86/sse4.1.h>
+ #elif defined(__GNUC__) && defined(__IWMMXT__)

--- a/ports/fastpfor/fix-arm-checker.patch
+++ b/ports/fastpfor/fix-arm-checker.patch
@@ -4,80 +4,15 @@ index 8072ae8..9d05bcc 100644
 +++ b/cmake_modules/environment.cmake
 @@ -1,10 +1,10 @@
  include(CheckCXXCompilerFlag)
- 
+
 -if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm" OR CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
 +if (CMAKE_SYSTEM_PROCESSOR MATCHES "[Aa][Rr][Mm]64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "[Aa][Rr][Mm]" OR CMAKE_SYSTEM_PROCESSOR MATCHES "[Aa][Rr][Cc][Hh]64")
      set(SUPPORT_NEON ON)
  endif ()
- 
+
  # Check if the Visual Studio build is targeting ARM
 -if (CMAKE_GENERATOR_PLATFORM MATCHES "ARM64" OR CMAKE_GENERATOR_PLATFORM MATCHES "ARM")
 +if (CMAKE_GENERATOR_PLATFORM MATCHES "[Aa][Rr][Mm]64" OR CMAKE_GENERATOR_PLATFORM MATCHES "[Aa][Rr][Mm]")
      set(SUPPORT_NEON ON)
  endif ()
 \ No newline at end of file
-diff --git a/headers/common.h b/headers/common.h
-index b1c97b5..bbb937f 100644
---- a/headers/common.h
-+++ b/headers/common.h
-@@ -12,7 +12,7 @@
- #include <fcntl.h>
- #if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
- #include <immintrin.h>
--#elif defined(__GNUC__) && defined(__aarch64__)
-+#elif defined(__GNUC__) && (defined(__aarch64__) || defined(__arm__))
- #include <simde/x86/sse4.1.h>
- #endif
- 
-@@ -52,7 +52,7 @@
- 
- #if (defined(_M_IX86) || defined(_M_AMD64))
- #include <intrin.h>
--#elif defined(_M_ARM64)
-+#elif defined(_M_ARM64) || defined(_M_ARM)
- #include <simde/x86/sse4.1.h>
- #endif
- 
-diff --git a/src/streamvbyte.c b/src/streamvbyte.c
-index 1f9dc6b..37a6442 100644
---- a/src/streamvbyte.c
-+++ b/src/streamvbyte.c
-@@ -9,7 +9,7 @@
-     /* Microsoft C/C++-compatible compiler */
-     #if (defined(_M_IX86) || defined(_M_AMD64))
-     #include <intrin.h>
--    #elif defined(_M_ARM64)
-+    #elif defined(_M_ARM64) || defined(_M_ARM)
-     #include <simde/x86/sse4.1.h>
-     #endif
- 
-@@ -19,7 +19,7 @@
- #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
-     /* GCC-compatible compiler, targeting x86/x86-64 */
-     #include <x86intrin.h>
--#elif defined(__aarch64__)
-+#elif defined(__aarch64__) || defined (__arm__)
-     /* GCC-compatible compiler, targeting ARM with NEON */
-     #include <simde/x86/sse4.1.h>
- #elif defined(__GNUC__) && defined(__IWMMXT__)
-diff --git a/src/varintdecode.c b/src/varintdecode.c
-index 7807e12..c77f117 100644
---- a/src/varintdecode.c
-+++ b/src/varintdecode.c
-@@ -7,14 +7,14 @@
-      /* Microsoft C/C++-compatible compiler */
-     #if (defined(_M_IX86) || defined(_M_AMD64))
-     #include <intrin.h>
--    #elif defined(_M_ARM64)
-+    #elif defined(_M_ARM64) || defined(_M_ARM)
-     #include <simde/x86/sse4.1.h>
-     #endif
- #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
-     /* GCC-compatible compiler, targeting x86/x86-64 */
-     #include <x86intrin.h>
- 
--#elif defined(__aarch64__)
-+#elif defined(__aarch64__) || defined (__arm__)
-     /* GCC-compatible compiler, targeting ARM with NEON */
-     #include <simde/x86/sse4.1.h>
- #elif defined(__GNUC__) && defined(__IWMMXT__)

--- a/ports/fastpfor/fix-arm-checker.patch
+++ b/ports/fastpfor/fix-arm-checker.patch
@@ -1,14 +1,18 @@
 diff --git a/cmake_modules/environment.cmake b/cmake_modules/environment.cmake
-index 8072ae8..a10aa25 100644
+index 8072ae8..9d05bcc 100644
 --- a/cmake_modules/environment.cmake
 +++ b/cmake_modules/environment.cmake
-@@ -5,6 +5,6 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "ar
+@@ -1,10 +1,10 @@
+ include(CheckCXXCompilerFlag)
+ 
+-if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm" OR CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
++if (CMAKE_SYSTEM_PROCESSOR MATCHES "[Aa][Rr][Mm]64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "[Aa][Rr][Mm]" OR CMAKE_SYSTEM_PROCESSOR MATCHES "[Aa][Rr][Cc][Hh]64")
+     set(SUPPORT_NEON ON)
  endif ()
  
  # Check if the Visual Studio build is targeting ARM
 -if (CMAKE_GENERATOR_PLATFORM MATCHES "ARM64" OR CMAKE_GENERATOR_PLATFORM MATCHES "ARM")
 +if (CMAKE_GENERATOR_PLATFORM MATCHES "[Aa][Rr][Mm]64" OR CMAKE_GENERATOR_PLATFORM MATCHES "[Aa][Rr][Mm]")
      set(SUPPORT_NEON ON)
--endif ()
+ endif ()
 \ No newline at end of file
-+endif ()

--- a/ports/fastpfor/portfile.cmake
+++ b/ports/fastpfor/portfile.cmake
@@ -6,6 +6,14 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 63eae397540e901e6b60420a92a165bbc16f35d97238221dac5d9d8819f40886a12edc17087d0aa2eeef706b8f411d1d19b77d6833d8bf34ad8340fa59f4cccf
     HEAD_REF master
+    PATCHES
+        remove-cpm.patch
+)
+
+file(REMOVE
+    ${SOURCE_PATH}/cmake_modules/CPM.cmake
+    ${SOURCE_PATH}/cmake_modules/Findsnappy.cmake
+    ${SOURCE_PATH}/cmake_modules/simde.cmake
 )
 
 vcpkg_cmake_configure(
@@ -15,7 +23,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/FastPFOR" PACKAGE_NAME "FastPFOR")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/FastPFOR")
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/fastpfor/portfile.cmake
+++ b/ports/fastpfor/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO fast-pack/FastPFOR
+    REF "v${VERSION}"
+    SHA512 63eae397540e901e6b60420a92a165bbc16f35d97238221dac5d9d8819f40886a12edc17087d0aa2eeef706b8f411d1d19b77d6833d8bf34ad8340fa59f4cccf
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DFASTPFOR_WITH_TEST=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/FastPFOR" PACKAGE_NAME "FastPFOR")
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/doc"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/fastpfor/portfile.cmake
+++ b/ports/fastpfor/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         remove-cpm.patch
+        fix-arm-checker.patch
 )
 
 file(REMOVE

--- a/ports/fastpfor/remove-cpm.patch
+++ b/ports/fastpfor/remove-cpm.patch
@@ -1,0 +1,63 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c32c332..fcb9324 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,7 +13,6 @@ set(CMAKE_C_STANDARD_REQUIRED True)
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
+ include(AppendCompilerFlags)
+ 
+-include(cmake/CPM.cmake)
+ 
+ project(FastPFOR CXX C)
+ set(PROJECT_URL "https://github.com/fast-pack/FastPFOR")
+@@ -40,7 +39,6 @@ if( SUPPORT_SSE42 )
+     MESSAGE( STATUS "SSE 4.2 support detected" )
+ else()
+     if (SUPPORT_NEON)
+-        include(simde)
+         MESSAGE(STATUS "USING SIMDE FOR SIMD OPERATIONS")
+     else ()
+         MESSAGE(STATUS "SIMDE and SSE 4.2 support not detected")
+@@ -112,10 +110,11 @@ add_executable(csv2maropu src/csv2maropu.cpp)
+ target_link_libraries(csv2maropu PRIVATE FastPFOR)
+ 
+ if (SUPPORT_NEON)
+-    target_link_libraries(FastPFOR PUBLIC simde)
+-    target_link_libraries(gapstats PUBLIC simde)
+-    target_link_libraries(partitionbylength PUBLIC simde)
+-    target_link_libraries(csv2maropu PUBLIC simde)
++    find_path(SIMDE_INCLUDE_DIRS "simde/arm/neon.h")
++    target_include_directories(FastPFOR PRIVATE ${SIMDE_INCLUDE_DIRS})
++    target_include_directories(gapstats PRIVATE ${SIMDE_INCLUDE_DIRS})
++    target_include_directories(partitionbylength PRIVATE ${SIMDE_INCLUDE_DIRS})
++    target_include_directories(csv2maropu PRIVATE ${SIMDE_INCLUDE_DIRS})
+ else()
+     message(STATUS "SIMDE not used")
+ endif()
+@@ -128,21 +127,21 @@ if( SUPPORT_SSE42 )
+     target_link_libraries(benchbitpacking FastPFOR)
+ endif()
+ 
+-find_package(snappy)
+-if(NOT ${snappy_FOUND})
++find_package(Snappy CONFIG)
++if(NOT ${Snappy_FOUND})
+     message(STATUS "Snappy was not found. codecssnappy and "
+                    "inmemorybenchmarksnappy targets are not available.")
+ else()
+     message(STATUS "Snappy was found. Building additional targets "
+                    "codecssnappy and inmemorybenchmarksnappy.")
+-    include_directories(${snappy_INCLUDE_DIRS})
++    include_directories(${Snappy_INCLUDE_DIRS})
+     add_executable(codecssnappy src/codecs.cpp)
+     set_target_properties(codecssnappy PROPERTIES DEFINE_SYMBOL USESNAPPY)
+-    target_link_libraries(codecssnappy FastPFOR ${snappy_LIBRARIES})
++    target_link_libraries(codecssnappy FastPFOR ${Snappy_LIBRARIES})
+ 
+     add_executable(inmemorybenchmarksnappy src/inmemorybenchmark.cpp)
+     set_target_properties(inmemorybenchmarksnappy PROPERTIES DEFINE_SYMBOL USESNAPPY)
+-    target_link_libraries(inmemorybenchmarksnappy FastPFOR ${snappy_LIBRARIES})
++    target_link_libraries(inmemorybenchmarksnappy FastPFOR ${Snappy_LIBRARIES})
+ endif()
+ 
+ option(FASTPFOR_WITH_TEST "Build with Google Test" ON)

--- a/ports/fastpfor/remove-cpm.patch
+++ b/ports/fastpfor/remove-cpm.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c32c332..fcb9324 100644
+index c32c332..a72eada 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -13,7 +13,6 @@ set(CMAKE_C_STANDARD_REQUIRED True)
@@ -18,7 +18,7 @@ index c32c332..fcb9324 100644
          MESSAGE(STATUS "USING SIMDE FOR SIMD OPERATIONS")
      else ()
          MESSAGE(STATUS "SIMDE and SSE 4.2 support not detected")
-@@ -112,10 +110,11 @@ add_executable(csv2maropu src/csv2maropu.cpp)
+@@ -112,10 +110,9 @@ add_executable(csv2maropu src/csv2maropu.cpp)
  target_link_libraries(csv2maropu PRIVATE FastPFOR)
  
  if (SUPPORT_NEON)
@@ -27,14 +27,12 @@ index c32c332..fcb9324 100644
 -    target_link_libraries(partitionbylength PUBLIC simde)
 -    target_link_libraries(csv2maropu PUBLIC simde)
 +    find_path(SIMDE_INCLUDE_DIRS "simde/arm/neon.h")
-+    target_include_directories(FastPFOR PRIVATE ${SIMDE_INCLUDE_DIRS})
-+    target_include_directories(gapstats PRIVATE ${SIMDE_INCLUDE_DIRS})
-+    target_include_directories(partitionbylength PRIVATE ${SIMDE_INCLUDE_DIRS})
-+    target_include_directories(csv2maropu PRIVATE ${SIMDE_INCLUDE_DIRS})
++    target_include_directories(FastPFOR PUBLIC ${SIMDE_INCLUDE_DIRS})
++    target_compile_definitions(FastPFOR PUBLIC SIMDE_ENABLE_NATIVE_ALIASES)
  else()
      message(STATUS "SIMDE not used")
  endif()
-@@ -128,21 +127,21 @@ if( SUPPORT_SSE42 )
+@@ -128,21 +125,21 @@ if( SUPPORT_SSE42 )
      target_link_libraries(benchbitpacking FastPFOR)
  endif()
  

--- a/ports/fastpfor/vcpkg.json
+++ b/ports/fastpfor/vcpkg.json
@@ -6,6 +6,10 @@
   "license": "Apache-2.0",
   "supports": "x64 | x86",
   "dependencies": [
+    {
+      "name": "simde",
+      "platform": "arm64 | arm"
+    },
     "snappy",
     {
       "name": "vcpkg-cmake",

--- a/ports/fastpfor/vcpkg.json
+++ b/ports/fastpfor/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Fast integer compression",
   "homepage": "https://github.com/fast-pack/FastPFOR",
   "license": "Apache-2.0",
+  "supports": "x64 | x86",
   "dependencies": [
     "snappy",
     {

--- a/ports/fastpfor/vcpkg.json
+++ b/ports/fastpfor/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Fast integer compression",
   "homepage": "https://github.com/fast-pack/FastPFOR",
   "license": "Apache-2.0",
+  "supports": "!(arm & !arm64)",
   "dependencies": [
     {
       "name": "simde",

--- a/ports/fastpfor/vcpkg.json
+++ b/ports/fastpfor/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "fastpfor",
+  "version": "0.3.1",
+  "description": "Fast integer compression",
+  "homepage": "https://github.com/fast-pack/FastPFOR",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "snappy",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/fastpfor/vcpkg.json
+++ b/ports/fastpfor/vcpkg.json
@@ -4,11 +4,10 @@
   "description": "Fast integer compression",
   "homepage": "https://github.com/fast-pack/FastPFOR",
   "license": "Apache-2.0",
-  "supports": "x64 | x86",
   "dependencies": [
     {
       "name": "simde",
-      "platform": "arm64 | arm"
+      "platform": "arm"
     },
     "snappy",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2928,6 +2928,10 @@
       "baseline": "0.6.4",
       "port-version": 0
     },
+    "fastpfor": {
+      "baseline": "0.3.1",
+      "port-version": 0
+    },
     "faudio": {
       "baseline": "26.1",
       "port-version": 0

--- a/versions/f-/fastpfor.json
+++ b/versions/f-/fastpfor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "27abbf1be96e54c20d042e47f8b4ac7634a9ea3a",
+      "git-tree": "d10632b7292e5f1c537d4337640b9b182f548b1d",
       "version": "0.3.1",
       "port-version": 0
     }

--- a/versions/f-/fastpfor.json
+++ b/versions/f-/fastpfor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "25097e68c41302913adad98df5e731b5904d94c6",
+      "git-tree": "27abbf1be96e54c20d042e47f8b4ac7634a9ea3a",
       "version": "0.3.1",
       "port-version": 0
     }

--- a/versions/f-/fastpfor.json
+++ b/versions/f-/fastpfor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6b9cf443f2948764d216187cacb6ae6603d37d75",
+      "git-tree": "f4b149a80080dd67bbf789592dc82121a248707e",
       "version": "0.3.1",
       "port-version": 0
     }

--- a/versions/f-/fastpfor.json
+++ b/versions/f-/fastpfor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f4b149a80080dd67bbf789592dc82121a248707e",
+      "git-tree": "417c35830ac307216e557045de87a3fc148a29b9",
       "version": "0.3.1",
       "port-version": 0
     }

--- a/versions/f-/fastpfor.json
+++ b/versions/f-/fastpfor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e8da279e95db5f88e4d657dbaf74fc1c20b41db3",
+      "git-tree": "e9241b565fa01089f72ad03ebfc04af84c247977",
       "version": "0.3.1",
       "port-version": 0
     }

--- a/versions/f-/fastpfor.json
+++ b/versions/f-/fastpfor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "417c35830ac307216e557045de87a3fc148a29b9",
+      "git-tree": "25097e68c41302913adad98df5e731b5904d94c6",
       "version": "0.3.1",
       "port-version": 0
     }

--- a/versions/f-/fastpfor.json
+++ b/versions/f-/fastpfor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d10632b7292e5f1c537d4337640b9b182f548b1d",
+      "git-tree": "5523cd12d720511b1b0d6d56ddfffce5c591f73b",
       "version": "0.3.1",
       "port-version": 0
     }

--- a/versions/f-/fastpfor.json
+++ b/versions/f-/fastpfor.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6b9cf443f2948764d216187cacb6ae6603d37d75",
+      "version": "0.3.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/f-/fastpfor.json
+++ b/versions/f-/fastpfor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5523cd12d720511b1b0d6d56ddfffce5c591f73b",
+      "git-tree": "e8da279e95db5f88e4d657dbaf74fc1c20b41db3",
       "version": "0.3.1",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

https://github.com/fast-pack/FastPFOR

