### PR TITLE
[bgfx] remove spirv-remapper following glslang port update

### DIFF
--- a/ports/bgfx/fix-dependencies.patch
+++ b/ports/bgfx/fix-dependencies.patch
@@ -100,7 +100,7 @@ diff --git a/bgfx/tools/shaderc/shaderc_metal.cpp b/bgfx/tools/shaderc/shaderc_m
 index 9f073b9..e8fd208 100644
 --- a/bgfx/tools/shaderc/shaderc_metal.cpp
 +++ b/bgfx/tools/shaderc/shaderc_metal.cpp
-@@ -20,11 +20,11 @@ BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wshadow") // warning: declaration of 'u
+@@ -20,11 +20,10 @@ BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wshadow") // warning: declaration of 'u
  #include <spirv_reflect.hpp>
  
  #define ENABLE_OPT 1
@@ -112,7 +112,6 @@ index 9f073b9..e8fd208 100644
 +#include <glslang/Public/ShaderLang.h>
 +#include <glslang/Include/ResourceLimits.h>
 +#include <glslang/SPIRV/GlslangToSpv.h>
-+#include <glslang/SPIRV/SPVRemapper.h>
 +#include <glslang/SPIRV/SpvTools.h>
  #include <spirv-tools/optimizer.hpp>
  BX_PRAGMA_DIAGNOSTIC_POP()
@@ -121,7 +120,7 @@ diff --git a/bgfx/tools/shaderc/shaderc_spirv.cpp b/bgfx/tools/shaderc/shaderc_s
 index f7910de..a844cc0 100644
 --- a/bgfx/tools/shaderc/shaderc_spirv.cpp
 +++ b/bgfx/tools/shaderc/shaderc_spirv.cpp
-@@ -20,11 +20,11 @@ BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wshadow") // warning: declaration of 'u
+@@ -20,11 +20,10 @@ BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wshadow") // warning: declaration of 'u
  #include <spirv_reflect.hpp>
  
  #define ENABLE_OPT 1
@@ -132,7 +131,6 @@ index f7910de..a844cc0 100644
 -#include <SPIRV/SpvTools.h>
 +#include <glslang/Public/ShaderLang.h>
 +#include <glslang/Include/ResourceLimits.h>
-+#include <glslang/SPIRV/SPVRemapper.h>
 +#include <glslang/SPIRV/GlslangToSpv.h>
 +#include <glslang/SPIRV/SpvTools.h>
  #include <spirv-tools/optimizer.hpp>
@@ -335,7 +333,7 @@ index 0f50eab..8b13b28 100644
 -			bgfx-vertexlayout
 -			fcpp
 -			glslang
-+			glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV glslang::SPVRemapper
++			glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV
  			glsl-optimizer
 -			spirv-opt
 -			spirv-cross

--- a/ports/bgfx/vcpkg.json
+++ b/ports/bgfx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "bgfx",
   "version": "1.129.8940-496",
+  "port-version": 1,
   "maintainers": "Sandy Carter <bwrsandman@users.noreply.github.com>",
   "description": "Cross-platform, graphics API agnostic, Bring Your Own Engine/Framework style rendering library.",
   "homepage": "https://bkaradzic.github.io/bgfx/overview.html",

--- a/versions/b-/bgfx.json
+++ b/versions/b-/bgfx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4bf01fdbfc053cd0a55f0794ac38c28ddb37d04a",
+      "version": "1.129.8940-496",
+      "port-version": 1
+    },
+    {
       "git-tree": "0649ad4eb640389c105dbac3a302e9c27e0a04b0",
       "version": "1.129.8940-496",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -718,7 +718,7 @@
     },
     "bgfx": {
       "baseline": "1.129.8940-496",
-      "port-version": 0
+      "port-version": 1
     },
     "bigint": {
       "baseline": "2010.04.30",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #49752
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
