### PR TITLE
[qtmultimedia] Change the default backend to ffmpeg and declare hard dependencies

### DIFF
--- a/ports/qtmultimedia/portfile.cmake
+++ b/ports/qtmultimedia/portfile.cmake
@@ -27,10 +27,7 @@ if("gstreamer" IN_LIST FEATURES)
     list(APPEND FEATURE_OPTIONS "-DINPUT_gstreamer='yes'")
 else()
     list(APPEND FEATURE_OPTIONS "-DINPUT_gstreamer='no'")
-    list(APPEND unused INPUT_gstreamer_gl INPUT_gstreamer_photography)
 endif()
-list(APPEND FEATURE_OPTIONS "-DINPUT_gstreamer_gl='no'")
-list(APPEND FEATURE_OPTIONS "-DINPUT_gstreamer_photography='no'")
 
 if("ffmpeg" IN_LIST FEATURES)
     # Note: Requires pulsadio on linux and wmfsdk on windows

--- a/ports/qtmultimedia/portfile.cmake
+++ b/ports/qtmultimedia/portfile.cmake
@@ -32,22 +32,8 @@ endif()
 if("ffmpeg" IN_LIST FEATURES)
     # Note: Requires pulsadio on linux and wmfsdk on windows
     list(APPEND FEATURE_OPTIONS "-DINPUT_ffmpeg='yes'")
-    if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_ANDROID)
-        list(APPEND FEATURE_OPTIONS "-DINPUT_pulseaudio='no'")
-    else()
-        list(APPEND FEATURE_OPTIONS "-DINPUT_pulseaudio='yes'")
-    endif()
 else()
     list(APPEND FEATURE_OPTIONS "-DINPUT_ffmpeg='no'")
-    list(APPEND FEATURE_OPTIONS "-DINPUT_pulseaudio='no'")
-endif()
-
-# alsa is not ready
-if(NOT "ffmpeg" IN_LIST FEATURES AND NOT "gstreamer" IN_LIST FEATURES AND VCPKG_TARGET_IS_LINUX)
-  #list(APPEND FEATURE_OPTIONS "-DFEATURE_alsa=ON") # alsa is experimental so don't activate it (also missing the dep on it.)
-  message(FATAL_ERROR "You need to activate at least one backend.")
-else()
-  list(APPEND FEATURE_OPTIONS "-DFEATURE_alsa=OFF")
 endif()
 
 qt_install_submodule(PATCHES    ${${PORT}_PATCHES}

--- a/ports/qtmultimedia/vcpkg.json
+++ b/ports/qtmultimedia/vcpkg.json
@@ -19,6 +19,14 @@
     {
       "name": "qtshadertools",
       "default-features": false
+    },
+    {
+      "name": "pipewire",
+      "platform": "linux"
+    },
+    {
+      "name": "pulseaudio",
+      "platform": "linux"
     }
   ],
   "default-features": [
@@ -39,10 +47,6 @@
             "swresample",
             "swscale"
           ]
-        },
-        {
-          "name": "pulseaudio",
-          "platform": "linux"
         },
         {
           "name": "qtdeclarative",

--- a/ports/qtmultimedia/vcpkg.json
+++ b/ports/qtmultimedia/vcpkg.json
@@ -1,11 +1,19 @@
 {
   "name": "qtmultimedia",
   "version": "6.10.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Multimedia is an add-on module that provides a rich set of QML types and C++ classes to handle multimedia content.",
   "homepage": "https://www.qt.io/",
   "license": null,
   "dependencies": [
+    {
+      "name": "pipewire",
+      "platform": "linux"
+    },
+    {
+      "name": "pulseaudio",
+      "platform": "linux"
+    },
     {
       "name": "qtbase",
       "default-features": false,
@@ -19,14 +27,6 @@
     {
       "name": "qtshadertools",
       "default-features": false
-    },
-    {
-      "name": "pipewire",
-      "platform": "linux"
-    },
-    {
-      "name": "pulseaudio",
-      "platform": "linux"
     }
   ],
   "default-features": [

--- a/ports/qtmultimedia/vcpkg.json
+++ b/ports/qtmultimedia/vcpkg.json
@@ -22,6 +22,7 @@
     }
   ],
   "default-features": [
+    "ffmpeg",
     "widgets"
   ],
   "features": {

--- a/ports/qtmultimedia/vcpkg.json
+++ b/ports/qtmultimedia/vcpkg.json
@@ -22,10 +22,6 @@
     }
   ],
   "default-features": [
-    {
-      "name": "gstreamer",
-      "platform": "linux"
-    },
     "widgets"
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8290,7 +8290,7 @@
     },
     "qtmultimedia": {
       "baseline": "6.10.0",
-      "port-version": 1
+      "port-version": 2
     },
     "qtnetworkauth": {
       "baseline": "6.10.0",

--- a/versions/q-/qtmultimedia.json
+++ b/versions/q-/qtmultimedia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef340d7d5816023205cf368e3c6ec5f5e1451e36",
+      "version": "6.10.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "922e7f06ecabc206f34437cd11aea8e972f5850b",
       "version": "6.10.0",
       "port-version": 1


### PR DESCRIPTION
working for qt on qtmultimedia, i found a few configuration issues in the qtmultimedia recipe

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
