### PR TITLE
[webview2] update to 1.0.3719.77

### DIFF
--- a/ports/webview2/portfile.cmake
+++ b/ports/webview2/portfile.cmake
@@ -5,7 +5,7 @@ endif()
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${VERSION}"
     FILENAME "microsoft.web.webview2.${VERSION}.zip"
-    SHA512 583693b9a93bf7c22df2963c63ed831baf2a5992b0a39bb5531f240ef6838947b19ac0e17ea59dc352d1f3b62412a74f6bfd78484cb0559456ce0b4da0a2aaab
+    SHA512 0a9abb1068228e208dd258354654d9b99711933ca8fd4494f5c1093123e1e851b83cb8e64c4a49e4d2ae26a434e8e36755501109c4cb7f7d488e3845254ac0a7
 )
 
 vcpkg_extract_source_archive(

--- a/ports/webview2/vcpkg.json
+++ b/ports/webview2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "webview2",
-  "version": "1.0.3650.58",
+  "version": "1.0.3719.77",
   "description": "The WebView2 control allows you to embed web technologies (HTML, CSS, and JavaScript) using Microsoft Edge",
   "homepage": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",
   "documentation": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10629,7 +10629,7 @@
       "port-version": 0
     },
     "webview2": {
-      "baseline": "1.0.3650.58",
+      "baseline": "1.0.3719.77",
       "port-version": 0
     },
     "wepoll": {

--- a/versions/w-/webview2.json
+++ b/versions/w-/webview2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c872c42ae75265cdb7bf6ed298d2c8299f29aeca",
+      "version": "1.0.3719.77",
+      "port-version": 0
+    },
+    {
       "git-tree": "5110d32a745f8b25568a5f31c448334e3886888c",
       "version": "1.0.3650.58",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
