### PR TITLE
[libdvdcss] Update to 1.5.0

### DIFF
--- a/ports/libdvdcss/portfile.cmake
+++ b/ports/libdvdcss/portfile.cmake
@@ -2,31 +2,21 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     GITLAB_URL https://code.videolan.org/
     REPO videolan/libdvdcss
-    REF ${VERSION}
-    SHA512 b4265ea7c31ca863569b6b20caf158d7ecf9ef6ca8ea3fb372ab7a730e2cb0fdfc2331e6b7aba102faa7751301e063f466dc5dc50a467dd659e008ee7c73383a
+    REF "${VERSION}"
+    SHA512 276ab26a7295bb45dd852c8d8ad262dfb6f8bc4dae347b1f83ac6949aaea4cabf4cf84f79dabf2442d207c1f9bffca07793748794aa338a4694327672326799b
     HEAD_REF master
 )
-file(WRITE "${SOURCE_PATH}/ChangeLog" "Cf. https://code.videolan.org/videolan/libdvdcss/-/commits/${VERSION}/") # not in git
 
-set(cppflags "")
-if(VCPKG_TARGET_IS_WINDOWS)
-    # PATH_MAX from msvc/libdvdcss.vcxproj
-    set(cppflags "CPPFLAGS=\$CPPFLAGS -DPATH_MAX=2048 -DWIN32_LEAN_AND_MEAN")
-endif()
-
-vcpkg_configure_make(
+vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
-    AUTOCONFIG
-    OPTIONS
-        --disable-doc
-        ${cppflags}
 )
-vcpkg_install_make()
+
+vcpkg_install_meson()
+
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 

--- a/ports/libdvdcss/vcpkg.json
+++ b/ports/libdvdcss/vcpkg.json
@@ -1,8 +1,14 @@
 {
   "name": "libdvdcss",
-  "version-semver": "1.4.3",
+  "version-semver": "1.5.0",
   "description": "Accessing DVDs like a block device library",
   "homepage": "https://www.videolan.org/developers/libdvdcss.html",
   "license": "GPL-2.0-or-later",
-  "supports": "!uwp & !xbox"
+  "supports": "!uwp & !xbox",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4825,7 +4825,7 @@
       "port-version": 0
     },
     "libdvdcss": {
-      "baseline": "1.4.3",
+      "baseline": "1.5.0",
       "port-version": 0
     },
     "libdvdnav": {

--- a/versions/l-/libdvdcss.json
+++ b/versions/l-/libdvdcss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef5409a54c842eb19d5f231ef9c43edb390df768",
+      "version-semver": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "879280b3353aac493a996c9ed8da98699734d12d",
       "version-semver": "1.4.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Note: The Windows specific values are now [added by default](https://code.videolan.org/videolan/libdvdcss/-/blob/1.5.0/meson.build?ref_type=tags#L36).