### PR TITLE
[sentry-native] update to 0.12.5

### DIFF
--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 a20a549511fa989c04eb28fc40777c6396d12925eb8a16ec919961dc3d7a8ce7931efc490587513dbe74e2fe5b96659e8bf295d2e457b7dd26a4ff54dfb7635f
+    SHA512 f943e1949e1b6e046ce0e11bb95e71f39d3e61ac2a0f3e93d9a4526a8e1c790e1120ade3b152caafd9739383d07f48439d106255db47aef4b1ffe740670a82b8
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9013,7 +9013,7 @@
       "port-version": 0
     },
     "sentry-native": {
-      "baseline": "0.12.4",
+      "baseline": "0.12.5",
       "port-version": 0
     },
     "septag-dmon": {

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "334418dcb83bb70bb746aef9fc083ac5940e0eb7",
+      "version": "0.12.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "119dce865a5b258603558ffbfdd2142d0ab75df1",
       "version": "0.12.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
