### PR TITLE
[libice] Fix hash issue

### DIFF
--- a/ports/libice/portfile.cmake
+++ b/ports/libice/portfile.cmake
@@ -4,17 +4,20 @@ if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     return()
 endif()
 
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libice
-    REF "libICE-${VERSION}"
-    SHA512  0892ee9210302e787297763bcf0c7788bcd5f5572d5fd86472e8104dc291e7e190effc0100bbca98c6b048b445bd9e8bdf490287e1dbf2a64693aa1895950610
-    HEAD_REF master
+vcpkg_download_distfile(
+    LIBICE_ARCHIVE
+    URLS "https://www.x.org/releases/individual/lib/libICE-${VERSION}.tar.xz"
+    FILENAME "libICE-${VERSION}.tar.xz"
+    SHA512 340f51ffa1f14ed442ab8bcea92dd63df147c48242e232e818cafe02f43de7ab6e99c5430b9cb8d0dc661295239d2b3f6bdb6a092ce51a98afa06235257e9b1f
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBICE_ARCHIVE}"
     PATCHES
         fix_build.patch
         replace_macros.patch
-) 
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 

--- a/ports/libice/vcpkg.json
+++ b/ports/libice/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libice",
   "version": "1.1.2",
+  "port-version": 1,
   "description": "Inter-Client Exchange Library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libice",
   "license": "MIT-open-group",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5038,7 +5038,7 @@
     },
     "libice": {
       "baseline": "1.1.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libiconv": {
       "baseline": "1.18",

--- a/versions/l-/libice.json
+++ b/versions/l-/libice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "afcdd953a9120e0a40202889f64245e3e73a9f74",
+      "version": "1.1.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "16385399a461bc7d4d4e4bc012c0f397a448a93f",
       "version": "1.1.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

It seems that #49394 didn't last long. Currently getting:
```
Downloading https://gitlab.freedesktop.org/xorg/lib/libice/-/archive/libICE-1.1.2/libice-libICE-1.1.2.tar.gz -> lib-libice-libICE-1.1.2.tar.gz
lib-libice-libICE-1.1.2.tar.gz.26612.part: error: download from https://gitlab.freedesktop.org/xorg/lib/libice/-/archive/libICE-1.1.2/libice-libICE-1.1.2.tar.gz had an unexpected hash
note: Expected: 0892ee9210302e787297763bcf0c7788bcd5f5572d5fd86472e8104dc291e7e190effc0100bbca98c6b048b445bd9e8bdf490287e1dbf2a64693aa1895950610
note: Actual  : 96174671b587d8fdfda4a04e1fb35ec756164e97c0221b7b2d675ef901d7329a19f5be774ce08b130e2b31982674a3701666fda7a2f2304e35ffe963e852850e
```