### PR TITLE
[nss] Fix cross-compilation from macOS

### DIFF
--- a/ports/nss/macos-cross-compile.patch
+++ b/ports/nss/macos-cross-compile.patch
@@ -1,0 +1,34 @@
+--- a/nss/build.sh
++++ b/nss/build.sh
+@@ -66,6 +66,7 @@
+ sslkeylogfile=1
+ 
+ gyp_params=(--depth="$cwd" --generator-output=".")
++gyp_flavor=
+ ninja_params=()
+ 
+ # Assume that MSVC is wanted if this is running on windows.
+@@ -134,6 +135,7 @@
+         --mozilla-central) gyp_params+=(-Dmozilla_central=1) ;;
+ 	--python) python="$2"; shift ;;
+ 	--python=*) python="${1#*=}" ;;
++        -DOS=*) gyp_params+=("$1"); gyp_flavor="${1#-DOS=}" ;;
+         -D*) gyp_params+=("$1") ;;
+         *) show_help; exit 2 ;;
+     esac
+@@ -275,7 +277,14 @@
+         set_nspr_path "$obj_dir/include/nspr:$obj_dir/lib"
+     fi
+ 
+-    run_verbose run_scanbuild ${GYP} -f ninja "${gyp_params[@]}" "$cwd/nss.gyp"
++    # On macOS, gyp defaults to "mac" flavor which emits Xcode-specific flags
++    # and tools (libtool, -arch, etc.) incompatible with cross-compilation targets.
++    gyp_format=ninja
++    if [ "$(uname -s)" = "Darwin" ] && [ -n "$gyp_flavor" ] && [ "$gyp_flavor" != "mac" ]; then
++        gyp_format="ninja-${gyp_flavor}"
++        export GYP_CROSSCOMPILE=1
++    fi
++    run_verbose run_scanbuild ${GYP} -f "$gyp_format" "${gyp_params[@]}" "$cwd/nss.gyp"
+ 
+     mv -f "$gyp_config.new" "$gyp_config"
+ fi

--- a/ports/nss/portfile.cmake
+++ b/ports/nss/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_extract_source_archive(
         "02-gen-debug-info-for-release.patch"
         "03-use-debug-crt-for-debug.patch" # See https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.vcprojectengine.runtimelibraryoption
         include-dirs.diff
+        macos-cross-compile.patch
 )
 file(GLOB devendor "${SOURCE_PATH}/nss/lib/sqlite/*.?" "${SOURCE_PATH}/nss/lib/zlib/*.?")
 file(REMOVE ${devendor})

--- a/ports/nss/vcpkg.json
+++ b/ports/nss/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nss",
   "version": "3.113.1",
+  "port-version": 1,
   "description": "Network Security Services from Mozilla",
   "homepage": "https://ftp.mozilla.org/pub/security/nss/releases/",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6990,7 +6990,7 @@
     },
     "nss": {
       "baseline": "3.113.1",
-      "port-version": 0
+      "port-version": 1
     },
     "nsync": {
       "baseline": "1.30.0",

--- a/versions/n-/nss.json
+++ b/versions/n-/nss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1cdf7d0e3caf9b7910f89c5b0ab9d8b41adaad46",
+      "version": "3.113.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "9ebeab29c2c5137eafaafbd20bde91f40a2faba1",
       "version": "3.113.1",
       "port-version": 0


### PR DESCRIPTION
## Summary
- On macOS, gyp-next defaults to "mac" flavor, emitting Xcode-specific flags (`-arch x86_64`, `-fasm-blocks`, `-mpascal-strings`) and using macOS `libtool` instead of `ar`, even when targeting other platforms (e.g. `arm64-android`).
- This patch makes NSS's `build.sh` detect the target OS from `-DOS=` and use `ninja-<os>` format with `GYP_CROSSCOMPILE=1` when cross-compiling on macOS, so gyp generates correct toolchain rules for the target.

## Test plan
- [x] `vcpkg install nss:arm64-android` succeeds on macOS host
- [ ] Native macOS build (`nss:arm64-osx`) is unaffected
- [ ] Linux host builds are unaffected (patch only activates on Darwin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)