### PR TITLE
[shaderc] update to 2026.1

### DIFF
--- a/ports/shaderc/build-version.inc
+++ b/ports/shaderc/build-version.inc
@@ -1,1 +1,1 @@
-"shaderc v2023.8 v2023.8\n"
+"shaderc v2026.1 v2026.1\n"

--- a/ports/shaderc/build-version.inc
+++ b/ports/shaderc/build-version.inc
@@ -1,1 +1,1 @@
-"shaderc v2026.1 v2026.1\n"
+"shaderc @VERSION@ @VERSION@\n"

--- a/ports/shaderc/disable-update-version.patch
+++ b/ports/shaderc/disable-update-version.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index bd6b890..0b55f77 100644
+index 06f5395..ae3d1e9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -129,12 +129,6 @@ if(${SHADERC_ENABLE_EXAMPLES})
+@@ -139,12 +139,6 @@ if(${SHADERC_ENABLE_EXAMPLES})
      add_subdirectory(examples)
  endif()
  
@@ -16,14 +16,14 @@ index bd6b890..0b55f77 100644
    add_custom_target(${NAME}-pkg-config ALL
      COMMAND ${CMAKE_COMMAND}
 diff --git a/glslc/CMakeLists.txt b/glslc/CMakeLists.txt
-index 1277d87..e431761 100644
+index 44d5576..e69011f 100644
 --- a/glslc/CMakeLists.txt
 +++ b/glslc/CMakeLists.txt
-@@ -53,7 +53,6 @@ shaderc_default_compile_options(glslc_exe)
- target_include_directories(glslc_exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/.. ${spirv-tools_SOURCE_DIR}/include)
- set_target_properties(glslc_exe PROPERTIES OUTPUT_NAME glslc)
- target_link_libraries(glslc_exe PRIVATE glslc shaderc_util shaderc)
--add_dependencies(glslc_exe build-version)
+@@ -54,7 +54,6 @@ if(SHADERC_ENABLE_EXECUTABLES)
+   target_include_directories(glslc_exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/.. ${spirv-tools_SOURCE_DIR}/include)
+   set_target_properties(glslc_exe PROPERTIES OUTPUT_NAME glslc)
+   target_link_libraries(glslc_exe PRIVATE glslc shaderc_util shaderc)
+-  add_dependencies(glslc_exe build-version)
+ endif(SHADERC_ENABLE_EXECUTABLES)
  
  shaderc_add_tests(
-   TEST_PREFIX glslc

--- a/ports/shaderc/portfile.cmake
+++ b/ports/shaderc/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_github(
         cmake-config-export.patch
 )
 
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/build-version.inc" DESTINATION "${SOURCE_PATH}/glslc/src")
+configure_file(${CMAKE_CURRENT_LIST_DIR}/build-version.inc ${SOURCE_PATH}/glslc/src/build-version.inc)
 
 set(OPTIONS "")
 if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")

--- a/ports/shaderc/portfile.cmake
+++ b/ports/shaderc/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/shaderc
     REF "v${VERSION}"
-    SHA512 6761372591075944fddd926e9f7c2ea9447496566d2d549f523c6c529c3bd753d459b66d499f76d955bdcfb335016daddbeba49b087f4ecabf37d76a46ac14cd
+    SHA512 b8758884d5cd67f5536f30838295e618544df38e3ca3e2b1379757bc57464d333c3263c5fd19e5b4a735284fde7c3d4de9075a414691b2e86ba069bcff2cd616
     HEAD_REF master
     PATCHES 
         disable-update-version.patch

--- a/ports/shaderc/vcpkg.json
+++ b/ports/shaderc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "shaderc",
-  "version": "2025.2",
-  "port-version": 1,
+  "version": "2026.1",
   "description": "A collection of tools, libraries and tests for shader compilation.",
   "homepage": "https://github.com/google/shaderc",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9081,8 +9081,8 @@
       "port-version": 0
     },
     "shaderc": {
-      "baseline": "2025.2",
-      "port-version": 1
+      "baseline": "2026.1",
+      "port-version": 0
     },
     "shaderwriter": {
       "baseline": "2.9.0",

--- a/versions/s-/shaderc.json
+++ b/versions/s-/shaderc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5aa2087e34f40fa9e5e8af0cccd63d60dcb6170e",
+      "version": "2026.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f80716ef5416dbfd00c192c967b74555c7872a01",
       "version": "2025.2",
       "port-version": 1

--- a/versions/s-/shaderc.json
+++ b/versions/s-/shaderc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5aa2087e34f40fa9e5e8af0cccd63d60dcb6170e",
+      "git-tree": "b4ccf9a7a18e625a0e1eee42125157158c3bff0d",
       "version": "2026.1",
       "port-version": 0
     },


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

Fixes #45143 