### PR TITLE
[nss] Fix cross-compilation from macOS (e.g. arm64-android)

### DIFF
--- a/ports/nss/macos-cross-compile.patch
+++ b/ports/nss/macos-cross-compile.patch
@@ -1,0 +1,34 @@
+--- a/nss/build.sh
++++ b/nss/build.sh
+@@ -66,6 +66,7 @@
+ sslkeylogfile=1
+ 
+ gyp_params=(--depth="$cwd" --generator-output=".")
++gyp_flavor=
+ ninja_params=()
+ 
+ # Assume that MSVC is wanted if this is running on windows.
+@@ -134,6 +135,7 @@
+         --mozilla-central) gyp_params+=(-Dmozilla_central=1) ;;
+ 	--python) python="$2"; shift ;;
+ 	--python=*) python="${1#*=}" ;;
++        -DOS=*) gyp_params+=("$1"); gyp_flavor="${1#-DOS=}" ;;
+         -D*) gyp_params+=("$1") ;;
+         *) show_help; exit 2 ;;
+     esac
+@@ -275,7 +277,14 @@
+         set_nspr_path "$obj_dir/include/nspr:$obj_dir/lib"
+     fi
+ 
+-    run_verbose run_scanbuild ${GYP} -f ninja "${gyp_params[@]}" "$cwd/nss.gyp"
++    # On macOS, gyp defaults to "mac" flavor which emits Xcode-specific flags
++    # and tools (libtool, -arch, etc.) incompatible with cross-compilation targets.
++    gyp_format=ninja
++    if [ "$(uname -s)" = "Darwin" ] && [ -n "$gyp_flavor" ] && [ "$gyp_flavor" != "mac" ]; then
++        gyp_format="ninja-${gyp_flavor}"
++        export GYP_CROSSCOMPILE=1
++    fi
++    run_verbose run_scanbuild ${GYP} -f "$gyp_format" "${gyp_params[@]}" "$cwd/nss.gyp"
+ 
+     mv -f "$gyp_config.new" "$gyp_config"
+ fi

--- a/ports/nss/portfile.cmake
+++ b/ports/nss/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_extract_source_archive(
         "02-gen-debug-info-for-release.patch"
         "03-use-debug-crt-for-debug.patch" # See https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.vcprojectengine.runtimelibraryoption
         include-dirs.diff
+        macos-cross-compile.patch
 )
 file(GLOB devendor "${SOURCE_PATH}/nss/lib/sqlite/*.?" "${SOURCE_PATH}/nss/lib/zlib/*.?")
 file(REMOVE ${devendor})

--- a/ports/nss/vcpkg.json
+++ b/ports/nss/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nss",
   "version": "3.113.1",
+  "port-version": 1,
   "description": "Network Security Services from Mozilla",
   "homepage": "https://ftp.mozilla.org/pub/security/nss/releases/",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6990,7 +6990,7 @@
     },
     "nss": {
       "baseline": "3.113.1",
-      "port-version": 0
+      "port-version": 1
     },
     "nsync": {
       "baseline": "1.30.0",

--- a/versions/n-/nss.json
+++ b/versions/n-/nss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1cdf7d0e3caf9b7910f89c5b0ab9d8b41adaad46",
+      "version": "3.113.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "9ebeab29c2c5137eafaafbd20bde91f40a2faba1",
       "version": "3.113.1",
       "port-version": 0


### PR DESCRIPTION
gyp-next defaults to "mac" flavor on macOS, emitting Xcode-specific
flags (-arch, -fasm-blocks, libtool) even when targeting other platforms.
This patch makes build.sh use ninja-<os> format and GYP_CROSSCOMPILE=1
when the target OS differs from the host.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.