### PR TITLE
[yoctolib]  2.1.11723 Update

### DIFF
--- a/ports/yoctolib/portfile.cmake
+++ b/ports/yoctolib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yoctopuce/yoctolib_cpp
     REF "v${VERSION}"
-    SHA512 c57baae00289dc2bbcabe278d9ff5667077bd3b93fadd20fd9de4428050af0bb6a659849b52e5c93b3e51c6d71764839c0d299e775d4133f85fa31990242077e
+    SHA512 2c1188b1b1d120500d0152a81da799ca0d7c03dced502f60a1553ce95c7c404c93c913fe2fd12d5c569f3f45b7632a1480edaa8ed87cbae258097bc30413e164
     HEAD_REF master
     PATCHES
         001-cmake_config.patch

--- a/ports/yoctolib/vcpkg.json
+++ b/ports/yoctolib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "yoctolib",
-  "version": "2.1.6320",
+  "version": "2.1.11723",
   "description": "Official Yoctopuce Library for C++",
   "homepage": "https://github.com/yoctopuce/yoctolib_cpp",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10957,7 +10957,7 @@
       "port-version": 0
     },
     "yoctolib": {
-      "baseline": "2.1.6320",
+      "baseline": "2.1.11723",
       "port-version": 0
     },
     "yoga": {

--- a/versions/y-/yoctolib.json
+++ b/versions/y-/yoctolib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "840a3cdaa069043e30f584aaccd9edfa5a8969eb",
+      "version": "2.1.11723",
+      "port-version": 0
+    },
+    {
       "git-tree": "a068fe63550863e24dc9cfd6e55ebd8e8fd7c742",
       "version": "2.1.6320",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
