### PR TITLE
[gz-sim] Skip in CI

### DIFF
--- a/ports/gz-sim/portfile.cmake
+++ b/ports/gz-sim/portfile.cmake
@@ -1,3 +1,6 @@
+# This port is not tested in vcpkg's curated registry due to excessive memory consumption
+# that cause reliability problems for other customers.
+# It must be checked manually after updates.
 string(REGEX MATCH "^[0-9]+" VERSION_MAJOR ${VERSION})
 set(PACKAGE_NAME gazebo)
 

--- a/ports/gz-sim/vcpkg.json
+++ b/ports/gz-sim/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gz-sim",
   "version": "9.5.0",
+  "port-version": 1,
   "description": "Gazebo Sim is an open source robotics simulator.",
   "homepage": "https://gazebosim.org/libs/sim",
   "license": "Apache-2.0",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -280,6 +280,7 @@ gsoap:x64-windows-static-md=skip
 gsoap:x64-windows-static=skip
 gsoap:x64-windows=skip
 gsoap:x86-windows=skip
+gz-sim:x64-linux=skip # many parallel links cause memory exhaustion on our 128GB of RAM lab VMs
 gz-tools:arm-neon-android=fail
 gz-tools:arm64-android=fail
 gz-tools:x64-android=fail

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -568,6 +568,7 @@ gz-rendering7:x64-uwp = cascade
 gz-rendering7(arm|android) = cascade
 gz-sensors7:x64-uwp = cascade
 gz-sensors7(arm | android) = cascade
+gz-sim:x64-linux=skip # many parallel links cause memory exhaustion on our 128GB of RAM lab VMs
 gz-transport12:x64-uwp = cascade
 h5py-lzf:arm64-uwp = cascade
 h5py-lzf:x64-uwp = cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3690,7 +3690,7 @@
     },
     "gz-sim": {
       "baseline": "9.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "gz-tools": {
       "baseline": "2.0.3",

--- a/versions/g-/gz-sim.json
+++ b/versions/g-/gz-sim.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e7bcc96d4c43d2abdee0ed9bd207e66995acec3",
+      "version": "9.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "daf4ff25d1f460f4197c55b870e92cf174cd4353",
       "version": "9.5.0",
       "port-version": 0


### PR DESCRIPTION
We are regularly seeing this port cause other folks' PRs to fail. Even when it succeeds we are getting warnings like: https://dev.azure.com/vcpkg/public/_build/results?buildId=126597

```console
Installing 1196/2727 gz-sim:x64-linux@9.5.0...
Building gz-sim:x64-linux@9.5.0...
Trying to download ignitionrobotics-ign-gazebo-gz-sim9_9.5.0-1.tar.gz using asset cache https://vcpkgassetcachewus.blob.core.windows.net/cache/45125f324d65114264bb57afb99b11f3dab6110f95dad673ec992735c1c958b8fff2daefe90465b3b731499adac8a7e8e790c2a8cbf1e1d73a75ad8362ea4d43?*** SECRET ***
Download successful! Asset cache hit, did not try authoritative source https://github.com/ignitionrobotics/ign-gazebo/archive/gz-sim9_9.5.0.tar.gz
-- Extracting source /vcpkg/downloads/ignitionrobotics-ign-gazebo-gz-sim9_9.5.0-1.tar.gz
-- Applying patch dependencies.patch
-- Using source at /mnt/vcpkg-ci/b/gz-sim/src/sim9_9.5.0-89c77b8d6c.clean
-- Configuring x64-linux-dbg
-- Configuring x64-linux-rel
-- Building x64-linux-dbg
##[warning]Free memory is lower than 5%; Currently used: 95.55%
##[warning]Free memory is lower than 5%; Currently used: 95.55%
##[warning]Free memory is lower than 5%; Currently used: 95.55%
##[warning]Free memory is lower than 5%; Currently used: 95.55%
```

Given that there seem to be relatively few users of this port, and the version we have is already substantially out of date anyway, I'm proposing to skip it in CI.