### PR TITLE
Revert "[vcpkg_from_git] Unshallow when fetching FETCH_REF"

### DIFF
--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -55,7 +55,7 @@ function(vcpkg_from_git)
 
         if(DEFINED arg_FETCH_REF)
             set(ref_to_fetch "${arg_FETCH_REF}")
-            vcpkg_list(SET git_fetch_shallow_param --unshallow)
+            vcpkg_list(SET git_fetch_shallow_param)
         else()
             set(ref_to_fetch "${arg_REF}")
         endif()


### PR DESCRIPTION
Reverts microsoft/vcpkg#49293

Example regressions:

* https://github.com/microsoft/vcpkg/pull/49788#issuecomment-3842687577
* https://github.com/microsoft/vcpkg/pull/49791 (I merged through this one)
* https://dev.azure.com/vcpkg/public/_build/results?buildId=126760