### PR TITLE
[kaitai-struct-cpp-stl-runtime] Switch homepage URL to https

### DIFF
--- a/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
+++ b/ports/kaitai-struct-cpp-stl-runtime/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kaitai-io/kaitai_struct_cpp_stl_runtime
-    REF ${VERSION}
+    REF "${VERSION}"
     SHA512 fd537c5d45d4c53de54c31b9286ff1100f74d62458fa2bbfd0d10d9cfedeb638e20c8d89a683b934310244de1de1093dbf79a06ac56a4918032ee31f0b49cbd7
     HEAD_REF master
     PATCHES
@@ -24,4 +24,4 @@ vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/kaitai-struct-cpp-stl-runtime/vcpkg.json
+++ b/ports/kaitai-struct-cpp-stl-runtime/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "kaitai-struct-cpp-stl-runtime",
   "version": "0.11",
+  "port-version": 1,
   "description": "Kaitai Struct is a declarative language used for describe various binary data structures, laid out in files or in memory. This library implements Kaitai Struct API for C++ using STL",
-  "homepage": "http://kaitai.io/",
+  "homepage": "https://kaitai.io",
   "documentation": "https://doc.kaitai.io/lang_cpp_stl.html",
   "license": "MIT",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4210,7 +4210,7 @@
     },
     "kaitai-struct-cpp-stl-runtime": {
       "baseline": "0.11",
-      "port-version": 0
+      "port-version": 1
     },
     "kangaru": {
       "baseline": "4.3.2",

--- a/versions/k-/kaitai-struct-cpp-stl-runtime.json
+++ b/versions/k-/kaitai-struct-cpp-stl-runtime.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "33e78fe7401fd9e0c9dd794a0cc95b9b984769a0",
+      "version": "0.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "c24e4f3de328fd608e8e828c063d66eeac2eb13b",
       "version": "0.11",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Fixes Repology warning:
```
Homepage link http://kaitai.io/ is a permanent redirect to its HTTPS counterpart https://kaitai.io/ and should be updated.
```

As this projects does not have often new tags, updating it via a new port-version instead of waiting for next tag.