### PR TITLE
[mpir] Port to vcpkg-make

### DIFF
--- a/ports/mpir/portfile.cmake
+++ b/ports/mpir/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     PATCHES 
         enable-runtimelibrary-toggle.patch
         fix-static-include-files.patch
+        subdirs.diff
         vcpkg-cross-builds.diff
 )
 

--- a/ports/mpir/portfile.cmake
+++ b/ports/mpir/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     PATCHES 
         enable-runtimelibrary-toggle.patch
         fix-static-include-files.patch
+        vcpkg-cross-build.diff
 )
 
 if(NOT VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_MINGW)

--- a/ports/mpir/portfile.cmake
+++ b/ports/mpir/portfile.cmake
@@ -5,7 +5,7 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wbhart/mpir
-    REF cdd444aedfcbb190f00328526ef278428702d56e # 3.0.0
+    REF cdd444aedfcbb190f00328526ef278428702d56e # tag: mpir-3.0.0
     SHA512 f46e45bdba27c9f89953ba23186b694486fd3010bd370ea2de71a4649a2816e716a6520c9baa96936f1884437ef03f92b21c0b1fb5b757beba5a05fed30b2bfc
     HEAD_REF master
     PATCHES 
@@ -13,30 +13,21 @@ vcpkg_from_github(
         fix-static-include-files.patch
 )
 
-if(NOT VCPKG_TARGET_IS_WINDOWS)
+if(NOT VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_MINGW)
     vcpkg_find_acquire_program(YASM)
 
-    set(SHARED_STATIC --disable-static --enable-shared)
-    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        set(SHARED_STATIC --enable-static --disable-shared --with-pic)
-    endif()
-
-    set(OPTIONS --disable-silent-rules --enable-gmpcompat --enable-cxx ${SHARED_STATIC})
-
-    string(APPEND VCPKG_C_FLAGS " -Wno-implicit-function-declaration")
-    string(APPEND VCPKG_CXX_FLAGS " -Wno-implicit-function-declaration")
-
-    # on Linux, autoconf is required; on macOS, it isn't
-    if(VCPKG_TARGET_IS_LINUX)
-        set(AUTOCONFIG "AUTOCONFIG")
-    endif()
-
-    vcpkg_configure_make(
+    vcpkg_make_configure(
         SOURCE_PATH "${SOURCE_PATH}"
-        ${AUTOCONFIG}
-        OPTIONS ${OPTIONS}
+        AUTORECONF
+        OPTIONS
+            --enable-cxx
+            --enable-gmpcompat
+            --with-pic
+            "--with-yasm=${YASM}"
+            "CFLAGS=\$CFLAGS -Wno-implicit-function-declaration"
+            "CCAS=" # use default $CC -c
     )
-    vcpkg_install_make()
+    vcpkg_make_install()
 else()
     set(MSVC_VERSION 14)
     if(VCPKG_PLATFORM_TOOLSET MATCHES "v14(1|2|3)")
@@ -72,12 +63,9 @@ else()
     file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/COPYING.LIB" "${CURRENT_PACKAGES_DIR}/debug/lib/COPYING.LIB")
 endif()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
 file(REMOVE_RECURSE
-        "${CURRENT_PACKAGES_DIR}/debug/include"
-        "${CURRENT_PACKAGES_DIR}/debug/share"
-    )
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${SOURCE_PATH}/COPYING.LIB")

--- a/ports/mpir/portfile.cmake
+++ b/ports/mpir/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
     PATCHES 
         enable-runtimelibrary-toggle.patch
         fix-static-include-files.patch
-        vcpkg-cross-build.diff
+        vcpkg-cross-builds.diff
 )
 
 if(NOT VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_MINGW)

--- a/ports/mpir/subdirs.diff
+++ b/ports/mpir/subdirs.diff
@@ -1,0 +1,15 @@
+diff --git a/Makefile.am b/Makefile.am
+index 6565654..554ed17 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -100,9 +100,8 @@ LIBGMPXX_LT_CURRENT = 12
+ LIBGMPXX_LT_REVISION = 3
+ LIBGMPXX_LT_AGE = 4
+ 
+-SUBDIRS = tests
+ 
+-SUBDIRS += mpn fft mpz mpq mpf printf scanf cxx tune doc
++SUBDIRS =  mpn fft mpz mpq mpf printf scanf cxx tune
+ 
+ EXTRA_DIST = configfsf.guess configfsf.sub .gdbinit INSTALL.autoconf
+ 

--- a/ports/mpir/vcpkg-cross-builds.diff
+++ b/ports/mpir/vcpkg-cross-builds.diff
@@ -1,0 +1,26 @@
+diff --git a/configure.ac b/configure.ac
+index 5b363fb..cf8fdc5 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1718,11 +1718,21 @@ GMP_H_ANSI
+ 
+ 
+ # The C compiler on the build system, and associated tests.
++if test "$cross_compiling" == "no" ; then
++# native build, native tools
+ GMP_PROG_CC_FOR_BUILD
+ GMP_PROG_CPP_FOR_BUILD
+ GMP_PROG_EXEEXT_FOR_BUILD
+ GMP_C_FOR_BUILD_ANSI
+ GMP_CHECK_LIBM_FOR_BUILD
++else
++# cross build, <TOOL>_FOR_BUILD disabled by vcpkg
++AC_SUBST(CC_FOR_BUILD,"false")
++AC_SUBST(CPP_FOR_BUILD,"false")
++AC_SUBST(EXEEXT_FOR_BUILD,"")
++AC_SUBST(U_FOR_BUILD,"")
++AC_SUBST(LIBM_FOR_BUILD,"")
++fi
+ 
+ # How to assemble, used with CFLAGS etc, see mpn/Makeasm.am.
+ # Using the compiler is a lot easier than figuring out how to invoke the

--- a/ports/mpir/vcpkg.json
+++ b/ports/mpir/vcpkg.json
@@ -1,16 +1,21 @@
 {
   "name": "mpir",
-  "version-date": "2022-03-02",
-  "port-version": 3,
+  "version": "3.0.0",
+  "port-version": 12,
   "description": "Multiple Precision Integers and Rationals",
   "homepage": "https://github.com/wbhart/mpir",
   "license": null,
   "supports": "!(uwp | arm)",
   "dependencies": [
     {
+      "name": "vcpkg-make",
+      "host": true,
+      "platform": "!windows | mingw"
+    },
+    {
       "name": "vcpkg-msbuild",
       "host": true,
-      "platform": "windows"
+      "platform": "windows & !mingw"
     }
   ]
 }

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -164,6 +164,7 @@ moos-essential:arm64-windows=fail
 moos-essential:x64-windows-static-md=fail
 moos-essential:x64-windows=fail
 moos-essential:x86-windows=fail
+mpir:x64-android=fail
 msquic(android)=fail
 nana:x64-linux=fail
 nana:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6593,8 +6593,8 @@
       "port-version": 5
     },
     "mpir": {
-      "baseline": "2022-03-02",
-      "port-version": 3
+      "baseline": "3.0.0",
+      "port-version": 12
     },
     "mpmcqueue": {
       "baseline": "2021-12-01",

--- a/versions/m-/mpir.json
+++ b/versions/m-/mpir.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "10d3b62fd597a553ca1def76a20d4cf411398cd7",
+      "git-tree": "53da93096a39be9d87f27887fedfcbe1fe0197ad",
       "version": "3.0.0",
       "port-version": 12
     },

--- a/versions/m-/mpir.json
+++ b/versions/m-/mpir.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "53da93096a39be9d87f27887fedfcbe1fe0197ad",
+      "git-tree": "98a1517ae08fd1018bd66b5dd90b926e1f96e0f0",
       "version": "3.0.0",
       "port-version": 12
     },

--- a/versions/m-/mpir.json
+++ b/versions/m-/mpir.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "98a1517ae08fd1018bd66b5dd90b926e1f96e0f0",
+      "git-tree": "71d08b7432c6eb9631acbddb9debf3c1a0ec9be4",
       "version": "3.0.0",
       "port-version": 12
     },

--- a/versions/m-/mpir.json
+++ b/versions/m-/mpir.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "10d3b62fd597a553ca1def76a20d4cf411398cd7",
+      "version": "3.0.0",
+      "port-version": 12
+    },
+    {
       "git-tree": "66630c57080280e1089146536f7d5d21c7504600",
       "version-date": "2022-03-02",
       "port-version": 3


### PR DESCRIPTION
For https://github.com/microsoft/vcpkg/pull/49703.
Works for me for x86-linux cross builds with prefixed tools (`CC=i686-linux-gnu-gcc CXX=i686-linux-gnu-g++`).

Remarks:
- Returning to version scheme `version`. #23330 switched to `version-date`, but the source code is still from 3.0.0. (I didn't change the REF in order to not change the asset.)
  cf. https://repology.org/project/mpir/versions
- CI does feature testing of this port, but otherwise skips the port. (Conflict with gmp.)
- mpir.org is gone, the mailing list is dormant. It is more or less inactive.
  (There are 163 commits and > 1400 changed files since 3.0.0, but most distributions still offer 3.0.0.)