### PR TITLE
[glib-networking] Update to 2.80.1

### DIFF
--- a/ports/glib-networking/portfile.cmake
+++ b/ports/glib-networking/portfile.cmake
@@ -1,12 +1,12 @@
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
-string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
+string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(ARCHIVE
     URLS
         "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
-    SHA512 7574e82aa018332edf99dd284c7fd74b5935bca4a6a70e950ae4b22bbe7be188433fea69e35c742cae120e7ff7d1a6b4f5bf3957fc31f220f50189d3958a3f58
+    SHA512 0f1b3807635fcae143ad1a89731a8f7e1b6f4b8f6cc2dd1b7b5eea3d77c796ee5a55ea330901bfd22927d07795f39450d30f0f1029595761e659f96a8415c263
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")

--- a/ports/glib-networking/vcpkg.json
+++ b/ports/glib-networking/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "glib-networking",
-  "version": "2.78.0",
-  "port-version": 1,
+  "version": "2.80.1",
   "description": "Network extensions for GLib",
   "homepage": "https://gitlab.gnome.org/GNOME/glib-networking",
   "license": "LGPL-2.1-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3405,8 +3405,8 @@
       "port-version": 0
     },
     "glib-networking": {
-      "baseline": "2.78.0",
-      "port-version": 1
+      "baseline": "2.80.1",
+      "port-version": 0
     },
     "glibmm": {
       "baseline": "2.80.1",

--- a/versions/g-/glib-networking.json
+++ b/versions/g-/glib-networking.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cda251ff0d6e92cc3aae3ae09710c26b748a34ef",
+      "version": "2.80.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "cf7bbe3e51215869aa69942f90c1a96b1c6e1318",
       "version": "2.78.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

