### PR TITLE
Add xnpp port

### DIFF
--- a/ports/xnpp/portfile.cmake
+++ b/ports/xnpp/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO borgesdan/xnpp

--- a/ports/xnpp/portfile.cmake
+++ b/ports/xnpp/portfile.cmake
@@ -2,24 +2,20 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO borgesdan/xnpp
     REF v0.1.0
-    SHA512 14c483b1856d1645356948adccd42cea6ccc91a97041637e1f4751ac8b329034127359d2c87b768485c6b41825aa28764be72583551d20c2832054fcd6af298c
+    SHA512 399fc3189e8fb40ab9c66ffe4417840ef08e5cae22085585ad55bd3e38409b030b00e95a5569c37cee0f56dd35ae824d1bdc9e80dc9a9dec2b1a9418b7c9166e
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DXNPP_BUILD_LIB=ON
-        -DXNPP_BUILD_APP=OFF
+        -DXNPP_BUILD_CONTENTPIPELINE=OFF
 )
 
 vcpkg_cmake_install()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
-endif()
-
 vcpkg_cmake_config_fixup(
-    CONFIG_PATH lib/cmake/Xnpp
+    CONFIG_PATH lib/cmake/xnpp
 )
 
 vcpkg_install_copyright(

--- a/ports/xnpp/portfile.cmake
+++ b/ports/xnpp/portfile.cmake
@@ -14,6 +14,10 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/bin")
+endif()
+
 vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/Xnpp
 )

--- a/ports/xnpp/portfile.cmake
+++ b/ports/xnpp/portfile.cmake
@@ -12,15 +12,14 @@ vcpkg_cmake_configure(
         -DXNPP_BUILD_APP=OFF
 )
 
-if(NOT VCPKG_TARGET_IS_WINDOWS)
-    message(FATAL_ERROR "xnpp is supported only on Windows.")
-endif()
-
-
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/Xnpp
+)
+
+vcpkg_install_copyright(
+    FILE_LIST "${SOURCE_PATH}/LICENSE.md"
 )
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/xnpp/portfile.cmake
+++ b/ports/xnpp/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO borgesdan/xnpp
+    REF v0.1.0
+    SHA512 14c483b1856d1645356948adccd42cea6ccc91a97041637e1f4751ac8b329034127359d2c87b768485c6b41825aa28764be72583551d20c2832054fcd6af298c
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DXNPP_BUILD_LIB=ON
+        -DXNPP_BUILD_APP=OFF
+)
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    message(FATAL_ERROR "xnpp is supported only on Windows.")
+endif()
+
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH lib/cmake/Xnpp
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/xnpp/portfile.cmake
+++ b/ports/xnpp/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO borgesdan/xnpp

--- a/ports/xnpp/vcpkg.json
+++ b/ports/xnpp/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "A port of Microsoft XNA in C++",
   "homepage": "https://github.com/borgesdan/xnpp",
   "license": "MIT",
-  "supports": ""windows & !uwp"",
+  "supports": "windows & !uwp",
   "dependencies": [
     {
       "name": "directxtk",

--- a/ports/xnpp/vcpkg.json
+++ b/ports/xnpp/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "A port of Microsoft XNA in C++",
   "homepage": "https://github.com/borgesdan/xnpp",
   "license": "MIT",
-  "supports": "windows & !x86 & !uwp",
+  "supports": "windows & !uwp",
   "dependencies": [
     {
       "name": "directxtk",

--- a/ports/xnpp/vcpkg.json
+++ b/ports/xnpp/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "A port of Microsoft XNA in C++",
   "homepage": "https://github.com/borgesdan/xnpp",
   "license": "MIT",
-  "supports": "windows",
+  "supports": ""windows & !uwp"",
   "dependencies": [
     {
       "name": "directxtk",

--- a/ports/xnpp/vcpkg.json
+++ b/ports/xnpp/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "A port of Microsoft XNA in C++",
   "homepage": "https://github.com/borgesdan/xnpp",
   "license": "MIT",
-  "supports": "windows & !uwp",
+  "supports": "windows & !x86 & !uwp",
   "dependencies": [
     {
       "name": "directxtk",

--- a/ports/xnpp/vcpkg.json
+++ b/ports/xnpp/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "xnpp",
+  "version": "0.1.0",
+  "description": "A port of Microsoft XNA in C++",
+  "homepage": "https://github.com/borgesdan/xnpp",
+  "license": "MIT",
+  "supports": "windows",
+  "dependencies": [
+    {
+      "name": "directxtk",
+      "features": [
+        "xaudio2-9"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10820,6 +10820,10 @@
       "baseline": "2024-08-20",
       "port-version": 0
     },
+    "xnpp": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "xorg-macros": {
       "baseline": "1.20.2",
       "port-version": 0

--- a/versions/x-/xnpp.json
+++ b/versions/x-/xnpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "00a6e59ece7a08ea5ae28c272e661233be679760",
+      "git-tree": "b4c8f954352e3da582ac397c2f0adaed4461397c",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/x-/xnpp.json
+++ b/versions/x-/xnpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d1e049e97bfea2665afc93ed488ac43aa39efbd3",
+      "git-tree": "00a6e59ece7a08ea5ae28c272e661233be679760",
       "version": "0.1.0",
       "port-version": 0
     }

--- a/versions/x-/xnpp.json
+++ b/versions/x-/xnpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d1e049e97bfea2665afc93ed488ac43aa39efbd3",
+      "version": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- Package: xnpp
- Version: 0.1.0
- Homepage: https://github.com/borgesdan/xnpp
- License: MIT


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.


