### PR TITLE
 [libmediainfo] update to 26.01

### DIFF
--- a/ports/libmediainfo/portfile.cmake
+++ b/ports/libmediainfo/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MediaArea/MediaInfoLib
     REF "v${MEDIAINFO_VERSION}"
-    SHA512 90151a43cb8c2882f0e4529960fae2ed585982b6d36711e0fe435dbca6fbdd234dc130e2fd7dc7546902959247f730618a4baccd6f8ede66c04ed06b4a4975ad
+    SHA512 fec7b3107b34b2d2235e85fb610e9f6d7f51065cc3c07eb2bd22df8a8b8476ced13ef050b0ecd5dadd7997a740b4402d97367ab06031e540ca09bece6165430d
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/libmediainfo/vcpkg.json
+++ b/ports/libmediainfo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmediainfo",
-  "version": "25.10",
+  "version": "26.1",
   "description": "Get most relevant technical and tag data from video and audio files",
   "homepage": "https://github.com/MediaArea/MediaInfoLib",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5125,7 +5125,7 @@
       "port-version": 0
     },
     "libmediainfo": {
-      "baseline": "25.10",
+      "baseline": "26.1",
       "port-version": 0
     },
     "libmem": {

--- a/versions/l-/libmediainfo.json
+++ b/versions/l-/libmediainfo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c90cb5fc6fc4a447ac78cfc28974e185ab76d624",
+      "version": "26.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "edc8522c0b4b47f7b031542f5242f0bf4001133b",
       "version": "25.10",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.