### PR TITLE
[libxxf86vm] Update to 1.1.7

### DIFF
--- a/ports/libxxf86vm/portfile.cmake
+++ b/ports/libxxf86vm/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_download_distfile(
     LIBXXF86VM_ARCHIVE
     URLS "https://www.x.org/releases/individual/lib/libXxf86vm-${VERSION}.tar.xz"
     FILENAME "libXxf86vm-${VERSION}.tar.xz"
-    SHA512 7fb3ac4302eea43b70d5106f6c7a113e28e2807da22d2bb7f040e0c4afd322cad4b7f258a5bd6da3940b6b6b39065e1acb218a6dc0ba06b9dd86ea3849231266
+    SHA512 d1051c9698a884d86e5beb00d5ee148d2b5ded7fd05168861f722b89643ad9b7f7d220f0cbb64b290a69faf9a6630181533aaddb01c9c68b46f1e5625030f094
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libxxf86vm/vcpkg.json
+++ b/ports/libxxf86vm/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "libxxf86vm",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Xlib-based library for the XFree86-VidMode X extension",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxxf86vm",
   "license": null,
   "dependencies": [
-    "bzip2",
     "libxext",
     "xorg-macros",
     "xproto"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5873,7 +5873,7 @@
       "port-version": 0
     },
     "libxxf86vm": {
-      "baseline": "1.1.6",
+      "baseline": "1.1.7",
       "port-version": 0
     },
     "libyaml": {

--- a/versions/l-/libxxf86vm.json
+++ b/versions/l-/libxxf86vm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a1cda7b9a2294ea01157cd79ba404bd03cc8c17a",
+      "version": "1.1.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "bd1e90abbeb5cb9d3f5dddb22d902f3b474b6e35",
       "version": "1.1.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

v1.1.7 adds meson support, but once again issues with under Windows due to `sed` (and probably missing symbol exports too). Therefore still using autoconf.