### PR TITLE
[libmysofa] Update to 1.3.4

### DIFF
--- a/ports/libmysofa/portfile.cmake
+++ b/ports/libmysofa/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hoene/libmysofa
     REF "v${VERSION}"
-    SHA512 83800ce29ae5c98f302ca574fd9a28de4ec0f85f5bc217c5497b690f12abdf72809e60e36412d6457181303ba7d082cb050050cd1164e7cfc9446e8e0783dda0
+    SHA512 58bd056678503491292a8a9b6b3f43451995a2c0a16735e4ae474d2d3e49bd7b3d6ef3dbfd0ce78e30d9f70887dd9cac60a8fae05ece0c167414f8ac4d3d5514
     HEAD_REF main
     PATCHES
       use-vcpkg-zlib.patch

--- a/ports/libmysofa/vcpkg.json
+++ b/ports/libmysofa/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmysofa",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Reader for AES SOFA files to get better HRTFs (Head-Relative Transfer Functions)",
   "homepage": "https://github.com/hoene/libmysofa",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5201,7 +5201,7 @@
       "port-version": 2
     },
     "libmysofa": {
-      "baseline": "1.3.3",
+      "baseline": "1.3.4",
       "port-version": 0
     },
     "libmysql": {

--- a/versions/l-/libmysofa.json
+++ b/versions/l-/libmysofa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e80ab6bc6a75bb1b2ff6d3cd339ae0e82f148c0",
+      "version": "1.3.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "e0c19c902473a0c3b91cecf038a5f499ab1b2326",
       "version": "1.3.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.