### PR TITLE
[fastcdr] Update to 2.3.5

### DIFF
--- a/ports/fastcdr/portfile.cmake
+++ b/ports/fastcdr/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eProsima/Fast-CDR
     REF "v${VERSION}"
-    SHA512 49ffa82bca0db4968ba2baecbf46c020ac1b072226486678cfe26ab7c023ab6cbcb1b48c48d9ac2e7254ef6ce0c61f717c3cbbc5f546a13d8dff299ce382580c
+    SHA512 cdf13b4801ec9a5dcc7f5b30963db75645f6e0287d4dbac46dbc2eb8e3881a5cdd4318f71178e3903b40fcddcc2b6d70a4a66ac2b5cf8a2e29161e1e0b1a5a94
     HEAD_REF master
     PATCHES
         pdb-file.patch

--- a/ports/fastcdr/vcpkg.json
+++ b/ports/fastcdr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastcdr",
-  "version-semver": "2.3.4",
+  "version-semver": "2.3.5",
   "description": "eProsima FastCDR is a C++ library that provides two serialization mechanisms. One is the standard CDR serialization mechanism, while the other is a faster implementation that modifies the standard.",
   "homepage": "https://github.com/eProsima/Fast-CDR",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2901,7 +2901,7 @@
       "port-version": 0
     },
     "fastcdr": {
-      "baseline": "2.3.4",
+      "baseline": "2.3.5",
       "port-version": 0
     },
     "fastcgi": {

--- a/versions/f-/fastcdr.json
+++ b/versions/f-/fastcdr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b099bffa7914cb2510f23cbfc2f6958d8f272137",
+      "version-semver": "2.3.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "aee4d40e657f6a79ca4b04d080aafc4c4f226237",
       "version-semver": "2.3.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.