### PR TITLE
[krb5] Update to 1.22.2

### DIFF
--- a/ports/krb5/portfile.cmake
+++ b/ports/krb5/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO krb5/krb5
-    REF krb5-${VERSION}-final
-    SHA512 4abfc37679483727fdad827afcf53729e6316febdf985a70133ee1dabaf8516e7fa771c1cfbc8fd557fed868c50f16b26bb59939ec091c2dd7019d0b2234ef1f
+    REF "krb5-${VERSION}-final"
+    SHA512 ca1e22a0aced71c004a51716a3237c83d683f81ead2456752079a50cd3406c665822f69bbdfd4999d2ff73ffda0922e4e8330c6c02bdb48ca2745f0ff33a88f1
     HEAD_REF master
     PATCHES
         static-deps.diff

--- a/ports/krb5/vcpkg.json
+++ b/ports/krb5/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "krb5",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": [
     "Kerberos is a network authentication protocol.",
     "It is designed to provide strong authentication for client/server applications by using secret-key cryptography.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4441,7 +4441,7 @@
       "port-version": 0
     },
     "krb5": {
-      "baseline": "1.22.1",
+      "baseline": "1.22.2",
       "port-version": 0
     },
     "ktx": {

--- a/versions/k-/krb5.json
+++ b/versions/k-/krb5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5420d395be8a889db192c014e5194947caf091e5",
+      "version": "1.22.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "20994b6f6cc0b70580c74fdc4e2e468a6840049a",
       "version": "1.22.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.