### PR TITLE
[pipewire] Update to 1.4.10

### DIFF
--- a/ports/pipewire/portfile.cmake
+++ b/ports/pipewire/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pipewire/pipewire
     REF "${VERSION}"
-    SHA512 15d5383b307c6a33e221a1f3b13e1a6b182e1826f419420654e25c5db2daf3793b094f816604bda9fa03abe6dff66c12dad98637edab67ca5966bbb8c57ea4ad
-    HEAD_REF master # branch name
+    SHA512 aa5a01fe812bfb439147885fdef89edfcd9f97943eb3fb209b698896d0092a9bdba02de3df4c39d14f5c1792b69927c36eb7af134e9a85e7a794bcbf9def3986
+    HEAD_REF master
 )
 
 vcpkg_configure_meson(

--- a/ports/pipewire/vcpkg.json
+++ b/ports/pipewire/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pipewire",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "Low-latency audio/video router and processor. This port only builds the client library, not the server.",
   "homepage": "https://pipewire.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7569,7 +7569,7 @@
       "port-version": 2
     },
     "pipewire": {
-      "baseline": "1.4.9",
+      "baseline": "1.4.10",
       "port-version": 0
     },
     "pistache": {

--- a/versions/p-/pipewire.json
+++ b/versions/p-/pipewire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9543fa1c15b170abb3ce44f4f33e174cc45ec1c0",
+      "version": "1.4.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "1bb8b571d1fdf9e94019f379161b0e3390348da0",
       "version": "1.4.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.