### PR TITLE
[valijson] Update to 1.0.6

### DIFF
--- a/ports/valijson/portfile.cmake
+++ b/ports/valijson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tristanpenman/valijson
     REF "v${VERSION}"
-    SHA512 2b3a3f6f29d576bfdd7460f69bb8efceee886ab352d2b09c60ced24e1707bbf3e05329d6ec36758905a424f7d615f18cdb874fe9d9a5d1b2efd9cc4a2cbf9a29
+    SHA512 d62fd57c10ef5343f2ba16c23f0c327ead21dabe637a9100c3a4ab88920b7feb55b53f6abc966da37e3cebbb44c19bc2588470dd036f0ff6e58054b41b71758a
     HEAD_REF master
 )
 

--- a/ports/valijson/vcpkg.json
+++ b/ports/valijson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "valijson",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Header-only C++ library for JSON Schema validation",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10245,7 +10245,7 @@
       "port-version": 8
     },
     "valijson": {
-      "baseline": "1.0.5",
+      "baseline": "1.0.6",
       "port-version": 0
     },
     "value-ptr-lite": {

--- a/versions/v-/valijson.json
+++ b/versions/v-/valijson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de3f430dc5bc0b7d918b7e6e9bfdfd5d72bb38c8",
+      "version": "1.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "4c7074ff89474d9eed103026e6ef789d76a88598",
       "version": "1.0.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
