### PR TITLE
[vc] Update to 1.4.5

### DIFF
--- a/ports/vc/portfile.cmake
+++ b/ports/vc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  VcDevel/Vc
-    REF 1.4.4
-    SHA512 b8aa0a45637dd1e0cc23f074d023b677aab570dd4a78cff94e4c2d832afb841c1b421077ae9c848a40aa4beb50ed2e31fdf075738496856ff8fe3ea1d0acba07
+    REF "${VERSION}"
+    SHA512 6525a72beae5270e31fe288b6b61cb2c3e431354bda3965b5fea5d743a3a76b33baaa28ef6f024353970a5b9e877fdc27a76754201f97cf21284ee1abdf16665
     HEAD_REF 1.4
     PATCHES 
        correct_cmake_config_path.patch
@@ -21,4 +21,4 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/vc/vcpkg.json
+++ b/ports/vc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vc",
-  "version": "1.4.4",
-  "description": "SIMD Vector Classes for C++ .",
+  "version": "1.4.5",
+  "description": "SIMD Vector Classes for C++",
   "homepage": "https://github.com/VcDevel/Vc",
   "license": "BSD-3-Clause",
   "supports": "!arm64",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10269,7 +10269,7 @@
       "port-version": 0
     },
     "vc": {
-      "baseline": "1.4.4",
+      "baseline": "1.4.5",
       "port-version": 0
     },
     "vcglib": {

--- a/versions/v-/vc.json
+++ b/versions/v-/vc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14b2e932faa680b1d4b7c7599232e968f71f5b58",
+      "version": "1.4.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "219677dca49bb75959b61537111daca726e52a86",
       "version": "1.4.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.