### PR TITLE
[cpp-httplib] Remove restrictions on architecture

### DIFF
--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "cpp-httplib",
   "version": "0.30.2",
+  "port-version": 1,
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",
-  "supports": "!x86 & !arm32",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2014,7 +2014,7 @@
     },
     "cpp-httplib": {
       "baseline": "0.30.2",
-      "port-version": 0
+      "port-version": 1
     },
     "cpp-ipc": {
       "baseline": "1.4.1",

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "46bec4e7cbe694979a19062f7a25ebb9bb100a0d",
+      "version": "0.30.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "e6ff3e7473123e38723a124faa43d29e1e0663ee",
       "version": "0.30.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #49836

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
