### PR TITLE
[miniz] Update to 3.1.1

### DIFF
--- a/ports/miniz/portfile.cmake
+++ b/ports/miniz/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO richgel999/miniz
-    REF c883286f1a6443720e7705450f59e579a4bbb8e2
-    SHA512 56f8ad02ba695bcc469f0711423f7027faeb49515aac6ecd7bc4f86d6f40f6816f2c2fc893ec39379e39abfb7a2dbe2c53da38202f04a22e357eb0e5f6f375ff
+    REF "${VERSION}"
+    SHA512 b2116d01161e6ba978541da3b1040338158a2da0d4559ae2817c1bd19a56472476b6984d438e7b8451aa0142d0405858342d719a76bd3bd6fd2df3ff6edc0700
     HEAD_REF master
 )
 
@@ -17,10 +17,13 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_copy_pdbs(BUILD_PATHS "${CURRENT_PACKAGES_DIR}/bin/*.dll")
+vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/miniz)
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/miniz/vcpkg.json
+++ b/ports/miniz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "miniz",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Single C source file zlib-replacement library",
   "homepage": "https://github.com/richgel999/miniz",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6425,7 +6425,7 @@
       "port-version": 0
     },
     "miniz": {
-      "baseline": "3.1.0",
+      "baseline": "3.1.1",
       "port-version": 0
     },
     "minizip": {

--- a/versions/m-/miniz.json
+++ b/versions/m-/miniz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44b2ff8aa21c4b2d578087c1b2337ca9c19a981d",
+      "version": "3.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d598c340f6c87c8c7f2e63bd15664e627a22a511",
       "version": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.