### PR TITLE
[libmariadb] Update to 3.4.8

### DIFF
--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -6,17 +6,11 @@ if(VCPKG_TARGET_IS_WINDOWS AND "openssl" IN_LIST FEATURES)
     message(WARNING "Using OpenSSL instead of schannel.")
 endif()
 
-vcpkg_download_distfile(fp_is_not_const_patch
-    URLS https://github.com/mariadb-corporation/mariadb-connector-c/commit/0ca807a210befe9c159d6b9a2c1d5de8f26869ad.diff?full_index=1
-    FILENAME mariadb-corporation-mariadb-connector-c-fp_is_not_const-0ca807a.diff
-    SHA512 1695ae5408fd54b148315aaa47806371e7db5f0001fc98bc480914aeaa41d48c0841ff64e99266b6c0ea1262ac65983507faf46306d98292c87926f74900fee2
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mariadb-corporation/mariadb-connector-c
-    REF v${VERSION}
-    SHA512 0e06452539fcea4e21c3922b58b7079aa5d467e2ac704fe586fcd83563f69c4e0536d40e0020170f7670320cc71cd9de2a110f3f4c6ed52233aa329c3e495fd5
+    REF "v${VERSION}"
+    SHA512 7283ade71a80fb577558e36405621c51caf268ea96b501c9d98c1bb40c474e037a66fccca61a274b358ee2dbb5133e2458cb12dda3a349a3390ef40eb9f3c4b1
     HEAD_REF 3.4
     PATCHES
         compiler-flags.diff
@@ -25,7 +19,6 @@ vcpkg_from_github(
         library-linkage.diff
         cmake-export.diff
         no-abs-path.diff
-        ${fp_is_not_const_patch}
 )
 file(REMOVE_RECURSE
     "${SOURCE_PATH}/cmake/FindIconv.cmake"

--- a/ports/libmariadb/vcpkg.json
+++ b/ports/libmariadb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libmariadb",
-  "version-semver": "3.4.7",
+  "version-semver": "3.4.8",
   "description": "MariaDB Connector/C is used to connect C/C++ applications to MariaDB and MySQL databases",
   "homepage": "https://github.com/mariadb-corporation/mariadb-connector-c",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5113,7 +5113,7 @@
       "port-version": 2
     },
     "libmariadb": {
-      "baseline": "3.4.7",
+      "baseline": "3.4.8",
       "port-version": 0
     },
     "libmatio-cpp": {

--- a/versions/l-/libmariadb.json
+++ b/versions/l-/libmariadb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17b008dfbe6f91f57f8c667906afa67b17d04cc3",
+      "version-semver": "3.4.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "f17c21d25e6448236a978a35d9a430144de13c9e",
       "version-semver": "3.4.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.