### PR TITLE
[gettext, netcdf-c, gklib] Add support to x64-mingw-dynamic

### DIFF
--- a/ports/gettext/env.patch
+++ b/ports/gettext/env.patch
@@ -1,0 +1,28 @@
+--- a/gettext-tools/gnulib-lib/localtime.c.old	2024-02-21 11:44:25.000000000 +0100
++++ b/gettext-tools/gnulib-lib/localtime.c	2026-02-05 14:32:39.392247000 +0100
+@@ -63,13 +63,19 @@ rpl_localtime (const time_t *tp)
+       char **env = _environ;
+       wchar_t **wenv = _wenviron;
+       if (env != NULL)
+-        for (char *s = env; *s != NULL; s++)
+-          if (s[0] == 'T' && s[1] == 'Z' && s[2] == '=')
+-            s[0] = '$';
++        for (char **ep = env; *ep != NULL; ep++)
++          {
++            char *s = *ep;
++            if (s[0] == 'T' && s[1] == 'Z' && s[2] == '=')
++              s[0] = '$';
++          }
+       if (wenv != NULL)
+-        for (wchar_t *ws = wenv; *ws != NULL; ws++)
+-          if (ws[0] == L'T' && ws[1] == L'Z' && ws[2] == L'=')
+-            ws[0] = L'$';
++        for (wchar_t **wep = wenv; *wep != NULL; wep++)
++          {
++            wchar_t *ws = *wep;
++            if (ws[0] == L'T' && ws[1] == L'Z' && ws[2] == L'=')
++              ws[0] = L'$';
++          }
+     }
+ #endif
+ 

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -30,6 +30,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
         parallel-gettext-tools.patch
         config-step-order.patch
         0001-xgettext-Fix-some-test-failures-on-MSVC.patch
+        env.patch
 )
 
 set(subdirs "")

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gettext",
   "version": "0.22.5",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A GNU framework to help produce multi-lingual messages.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "license": "GPL-3.0-only",

--- a/ports/gklib/portfile.cmake
+++ b/ports/gklib/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     SHA512 54ba87f2c47e025ada0fe6fe608d9d144df5cd13e97e71892dbba4d50cd96409add309937a540cdf8bd2632cbfbc0e22e080a32d114ba6037008c8676aa8d88d
     PATCHES
         build-fixes.patch
+        regex.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SHARED)

--- a/ports/gklib/regex.patch
+++ b/ports/gklib/regex.patch
@@ -1,0 +1,12 @@
+--- 71aac9f2f8-6ab87cd67d.clean/CMakeLists.txt.old	2026-02-05 23:01:42.685830600 +0100
++++ 71aac9f2f8-6ab87cd67d.clean/CMakeLists.txt	2026-02-05 23:02:00.820495600 +0100
+@@ -109,6 +109,9 @@ if(NOT HAVE_PCREPOSIX_H)
+   check_include_file(regex.h HAVE_REGEX_H)
+   if(NOT HAVE_REGEX_H)
+     set(USE_GKREGEX ON)
++  else()
++    target_link_libraries(${PROJECT_NAME}
++      PUBLIC regex)
+   endif()
+ endif()
+ 

--- a/ports/gklib/vcpkg.json
+++ b/ports/gklib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gklib",
   "version-date": "2025-07-06",
+  "port-version": 1,
   "description": "General helper libraries for KarypisLab.",
   "homepage": "https://github.com/KarypisLab/GKlib/",
   "license": "Apache-2.0",

--- a/ports/netcdf-c/portfile.cmake
+++ b/ports/netcdf-c/portfile.cmake
@@ -1,3 +1,9 @@
+vcpkg_download_distfile(WINDOWS_STAT_PATCH
+    URLS https://github.com/Unidata/netcdf-c/commit/02ba4e90a8b7683277e353c92a6b1627bb8e3dfd.patch?full_index=1
+    FILENAME windows-stat-02ba4e90a8b7683277e353c92a6b1627bb8e3dfd.patch
+    SHA512 a4b74b3f93c12696aaeb500ed27e65676f06cc14f0e1cd43664af344ce5b294409e26d68190a1c6ce9050f231902901d7afba2a5718b9759beaf069cb3d91bf0
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Unidata/netcdf-c
@@ -12,6 +18,7 @@ vcpkg_from_github(
         plugin-install-dir.diff
         fstat.patch
         backport-d7895f6.diff  # cf. https://github.com/Unidata/netcdf-c/pull/3237
+        "${WINDOWS_STAT_PATCH}"
 )
 file(GLOB_RECURSE modules "${SOURCE_PATH}/cmake/modules/Find*.cmake")
 set(vendored_bzip2 blocksort.c huffman.c crctable.c randtable.c compress.c decompress.c bzlib.c bzlib.h bzlib_private.h)

--- a/ports/netcdf-c/vcpkg.json
+++ b/ports/netcdf-c/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "netcdf-c",
   "version": "4.9.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A set of self-describing, machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data.",
   "homepage": "https://github.com/Unidata/netcdf-c",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6814,7 +6814,7 @@
     },
     "netcdf-c": {
       "baseline": "4.9.3",
-      "port-version": 2
+      "port-version": 3
     },
     "netcdf-cxx4": {
       "baseline": "4.3.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3366,7 +3366,7 @@
     },
     "gklib": {
       "baseline": "2025-07-06",
-      "port-version": 0
+      "port-version": 1
     },
     "gl2ps": {
       "baseline": "1.4.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3326,7 +3326,7 @@
     },
     "gettext": {
       "baseline": "0.22.5",
-      "port-version": 3
+      "port-version": 4
     },
     "gettext-libintl": {
       "baseline": "0.22.5",

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "635e7dc0794427c798120dc8cec532866aebf82e",
+      "version": "0.22.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "6308f030041019677efe2ef49cc2d7a42b9cf632",
       "version": "0.22.5",
       "port-version": 3

--- a/versions/g-/gklib.json
+++ b/versions/g-/gklib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de94c45e5a1b6d306e5b11ebd79afaf2ad8f119d",
+      "version-date": "2025-07-06",
+      "port-version": 1
+    },
+    {
       "git-tree": "c3b9e3dbc3c508699816a7723c720428a478b364",
       "version-date": "2025-07-06",
       "port-version": 0

--- a/versions/n-/netcdf-c.json
+++ b/versions/n-/netcdf-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4023467060d0531fac7f6290174a102e964a731",
+      "version": "4.9.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "e9ba4f966238415db77982c8fb15f45d35cfa520",
       "version": "4.9.3",
       "port-version": 2


### PR DESCRIPTION
Fixes #40134 (gettext) and fix netcdf-c and gklib/metis.

Patches for gettext and netcdf-c comes from upstream. The patch for gklib is mine.

I needed to update gklib to build metis to avoid missing symbol from regex library.

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
