### PR TITLE
[aeron] update to 1.50.1

### DIFF
--- a/ports/aeron/portfile.cmake
+++ b/ports/aeron/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aeron-io/aeron
     REF "${VERSION}"
-    SHA512 936b3a0d6903cc54246c41b946c8964b5f2957b115364445302764a579bbcc6d3c569c924aa44f96db309c0a90cef06779b608c6fc35c8284a041ff4d266f9db
+    SHA512 9d2e862eb8b5c17716d8c913640271d932ebc7129f000d58266b4144b20da502abaad45c603b37ed4ddfff8a12cb0f7d41d4631148fb7ca28f1bbdcead95bd42
     HEAD_REF master
     PATCHES
         patches/add-libuuid-vcpkg-support.patch

--- a/ports/aeron/vcpkg.json
+++ b/ports/aeron/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "aeron",
-  "version": "1.50.0",
-  "port-version": 1,
+  "version": "1.50.1",
   "description": "Efficient reliable UDP unicast, UDP multicast, and IPC message transport",
   "homepage": "https://github.com/aeron-io/aeron",
   "license": "Apache-2.0",

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "260a9c8e2961db374a535bbb3533b909f12fb615",
+      "version": "1.50.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c97b0811df0fb92977a80ee98b10da0777bee14e",
       "version": "1.50.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2664,10 +2664,6 @@
       "baseline": "3.27.1",
       "port-version": 0
     },
-    "easy-profiler": {
-      "baseline": "2.1.0",
-      "port-version": 0
-    },
     "easycl": {
       "baseline": "0.3",
       "port-version": 2
@@ -2683,6 +2679,10 @@
     "easyloggingpp": {
       "baseline": "9.97.1",
       "port-version": 1
+    },
+    "easy-profiler": {
+      "baseline": "2.1.0",
+      "port-version": 0
     },
     "eathread": {
       "baseline": "1.32.09",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -57,8 +57,8 @@
       "port-version": 0
     },
     "aeron": {
-      "baseline": "1.50.0",
-      "port-version": 1
+      "baseline": "1.50.1",
+      "port-version": 0
     },
     "air-ctl": {
       "baseline": "1.1.2",
@@ -2664,6 +2664,10 @@
       "baseline": "3.27.1",
       "port-version": 0
     },
+    "easy-profiler": {
+      "baseline": "2.1.0",
+      "port-version": 0
+    },
     "easycl": {
       "baseline": "0.3",
       "port-version": 2
@@ -2679,10 +2683,6 @@
     "easyloggingpp": {
       "baseline": "9.97.1",
       "port-version": 1
-    },
-    "easy-profiler": {
-      "baseline": "2.1.0",
-      "port-version": 0
     },
     "eathread": {
       "baseline": "1.32.09",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/aeron-io/aeron/releases/tag/1.50.1
