### PR TITLE
[gettext] Fix wrong variable type

### DIFF
--- a/ports/gettext/env.patch
+++ b/ports/gettext/env.patch
@@ -1,0 +1,28 @@
+--- a/gettext-tools/gnulib-lib/localtime.c.old	2024-02-21 11:44:25.000000000 +0100
++++ b/gettext-tools/gnulib-lib/localtime.c	2026-02-05 14:32:39.392247000 +0100
+@@ -63,13 +63,19 @@ rpl_localtime (const time_t *tp)
+       char **env = _environ;
+       wchar_t **wenv = _wenviron;
+       if (env != NULL)
+-        for (char *s = env; *s != NULL; s++)
+-          if (s[0] == 'T' && s[1] == 'Z' && s[2] == '=')
+-            s[0] = '$';
++        for (char **ep = env; *ep != NULL; ep++)
++          {
++            char *s = *ep;
++            if (s[0] == 'T' && s[1] == 'Z' && s[2] == '=')
++              s[0] = '$';
++          }
+       if (wenv != NULL)
+-        for (wchar_t *ws = wenv; *ws != NULL; ws++)
+-          if (ws[0] == L'T' && ws[1] == L'Z' && ws[2] == L'=')
+-            ws[0] = L'$';
++        for (wchar_t **wep = wenv; *wep != NULL; wep++)
++          {
++            wchar_t *ws = *wep;
++            if (ws[0] == L'T' && ws[1] == L'Z' && ws[2] == L'=')
++              ws[0] = L'$';
++          }
+     }
+ #endif
+ 

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -30,7 +30,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
         parallel-gettext-tools.patch
         config-step-order.patch
         0001-xgettext-Fix-some-test-failures-on-MSVC.patch
-        env.patch
+        env.patch # https://cgit.git.savannah.gnu.org/cgit/gnulib.git/commit/lib/localtime.c?id=92cdf62b56462b914193c7770440e505a37c2526
 )
 
 set(subdirs "")

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -30,6 +30,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
         parallel-gettext-tools.patch
         config-step-order.patch
         0001-xgettext-Fix-some-test-failures-on-MSVC.patch
+        env.patch
 )
 
 set(subdirs "")

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gettext",
   "version": "0.22.5",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A GNU framework to help produce multi-lingual messages.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "license": "GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3326,7 +3326,7 @@
     },
     "gettext": {
       "baseline": "0.22.5",
-      "port-version": 3
+      "port-version": 4
     },
     "gettext-libintl": {
       "baseline": "0.22.5",

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "635e7dc0794427c798120dc8cec532866aebf82e",
+      "git-tree": "e8581f71d357844e6869e4c79fae472de8012150",
       "version": "0.22.5",
       "port-version": 4
     },

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "635e7dc0794427c798120dc8cec532866aebf82e",
+      "version": "0.22.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "6308f030041019677efe2ef49cc2d7a42b9cf632",
       "version": "0.22.5",
       "port-version": 3


### PR DESCRIPTION
Fixes #40134 

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
