### PR TITLE
[netcdf-c] x64-mingw-dynamic - Fix wrong variable type

### DIFF
--- a/ports/netcdf-c/portfile.cmake
+++ b/ports/netcdf-c/portfile.cmake
@@ -1,3 +1,19 @@
+vcpkg_download_distfile(WINDOWS_STAT1_PATCH
+    URLS https://github.com/Unidata/netcdf-c/commit/02ba4e90a8b7683277e353c92a6b1627bb8e3dfd.patch?full_index=1
+    FILENAME windows-stat1-02ba4e90a8b7683277e353c92a6b1627bb8e3dfd.patch
+    SHA512 a4b74b3f93c12696aaeb500ed27e65676f06cc14f0e1cd43664af344ce5b294409e26d68190a1c6ce9050f231902901d7afba2a5718b9759beaf069cb3d91bf0
+)
+vcpkg_download_distfile(WINDOWS_STAT2_PATCH
+    URLS https://github.com/Unidata/netcdf-c/commit/d97667994ecc8ac30d4f5ea59b440b4187ab5328.patch?full_index=1
+    FILENAME windows-stat2-d97667994ecc8ac30d4f5ea59b440b4187ab5328.patch
+    SHA512 dc1f4370ea65a35a2e99bdeed721b584fca9440733fed4b7a618e12b8338422bbd1fe586acd44623da7b686de17b7c2103735cc14be38ae332a13187f6855474
+)
+vcpkg_download_distfile(WINDOWS_STAT3_PATCH
+    URLS https://github.com/Unidata/netcdf-c/commit/22a370fcf1332674f718395c889524b50ddb836a.patch?full_index=1
+    FILENAME windows-stat3-22a370fcf1332674f718395c889524b50ddb836a.patch
+    SHA512 de289c0d7afd2c0463d6719b2fadb2ecaddbcea4b94ea0d255d4c41cc3efc9cd30af92a56ae693a65465a9e98b59ca830d51994e30f71179ef50f61c61efd41d
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Unidata/netcdf-c
@@ -12,6 +28,9 @@ vcpkg_from_github(
         plugin-install-dir.diff
         fstat.patch
         backport-d7895f6.diff  # cf. https://github.com/Unidata/netcdf-c/pull/3237
+        "${WINDOWS_STAT1_PATCH}"
+        "${WINDOWS_STAT2_PATCH}"
+        "${WINDOWS_STAT3_PATCH}"
 )
 file(GLOB_RECURSE modules "${SOURCE_PATH}/cmake/modules/Find*.cmake")
 set(vendored_bzip2 blocksort.c huffman.c crctable.c randtable.c compress.c decompress.c bzlib.c bzlib.h bzlib_private.h)

--- a/ports/netcdf-c/vcpkg.json
+++ b/ports/netcdf-c/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "netcdf-c",
   "version": "4.9.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A set of self-describing, machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data.",
   "homepage": "https://github.com/Unidata/netcdf-c",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6814,7 +6814,7 @@
     },
     "netcdf-c": {
       "baseline": "4.9.3",
-      "port-version": 2
+      "port-version": 3
     },
     "netcdf-cxx4": {
       "baseline": "4.3.1",

--- a/versions/n-/netcdf-c.json
+++ b/versions/n-/netcdf-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c975887ccc47e534bdd79ddb29d7a11506f2d712",
+      "version": "4.9.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "e9ba4f966238415db77982c8fb15f45d35cfa520",
       "version": "4.9.3",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
