### PR TITLE
[cpprestsdk] Update Boost fix-asio-error.patch

### DIFF
--- a/ports/cpprestsdk/fix-asio-error.patch
+++ b/ports/cpprestsdk/fix-asio-error.patch
@@ -1,5 +1,5 @@
 diff --git a/Release/include/pplx/threadpool.h b/Release/include/pplx/threadpool.h
-index b297ff6..56ea475 100644
+index b297ff6b..56ea4751 100644
 --- a/Release/include/pplx/threadpool.h
 +++ b/Release/include/pplx/threadpool.h
 @@ -69,15 +69,15 @@ public:
@@ -22,7 +22,7 @@ index b297ff6..56ea475 100644
  
  } // namespace crossplat
 diff --git a/Release/src/http/client/http_client_asio.cpp b/Release/src/http/client/http_client_asio.cpp
-index 07bb488..f9c7c51 100644
+index 07bb4885..f9c7c51d 100644
 --- a/Release/src/http/client/http_client_asio.cpp
 +++ b/Release/src/http/client/http_client_asio.cpp
 @@ -146,9 +146,9 @@ class asio_connection
@@ -234,7 +234,7 @@ index 07bb488..f9c7c51 100644
                  // The existing handler was canceled so schedule a new one.
                  assert(m_state == started);
 diff --git a/Release/src/http/client/x509_cert_utilities.cpp b/Release/src/http/client/x509_cert_utilities.cpp
-index 67fc5ac..7239f97 100644
+index 67fc5ac4..7239f978 100644
 --- a/Release/src/http/client/x509_cert_utilities.cpp
 +++ b/Release/src/http/client/x509_cert_utilities.cpp
 @@ -95,7 +95,7 @@ bool verify_cert_chain_platform_specific(boost::asio::ssl::verify_context& verif
@@ -247,7 +247,7 @@ index 67fc5ac..7239f97 100644
      }
  #endif
 diff --git a/Release/src/http/listener/http_server_asio.cpp b/Release/src/http/listener/http_server_asio.cpp
-index e83b9ff..14aadfb 100644
+index e83b9ff5..14aadfb4 100644
 --- a/Release/src/http/listener/http_server_asio.cpp
 +++ b/Release/src/http/listener/http_server_asio.cpp
 @@ -520,17 +520,14 @@ void hostport_listener::start()
@@ -318,7 +318,7 @@ index e83b9ff..14aadfb 100644
              size_t actualSize = 0;
              try
 diff --git a/Release/src/pplx/pplxlinux.cpp b/Release/src/pplx/pplxlinux.cpp
-index 630a9e4..65625b6 100644
+index 630a9e47..65625b6f 100644
 --- a/Release/src/pplx/pplxlinux.cpp
 +++ b/Release/src/pplx/pplxlinux.cpp
 @@ -35,7 +35,7 @@ _PPLXIMP void YieldExecution() { std::this_thread::yield(); }
@@ -331,7 +331,7 @@ index 630a9e4..65625b6 100644
  
  } // namespace details
 diff --git a/Release/src/pplx/threadpool.cpp b/Release/src/pplx/threadpool.cpp
-index ba38a1a..e12e48d 100644
+index ba38a1a1..e12e48d8 100644
 --- a/Release/src/pplx/threadpool.cpp
 +++ b/Release/src/pplx/threadpool.cpp
 @@ -37,7 +37,7 @@ static void abort_if_no_jvm()
@@ -353,7 +353,7 @@ index ba38a1a..e12e48d 100644
  
  #if defined(_WIN32)
 diff --git a/Release/src/websockets/client/ws_client_wspp.cpp b/Release/src/websockets/client/ws_client_wspp.cpp
-index d7c31c4..8dfa815 100644
+index d7c31c40..8dfa8156 100644
 --- a/Release/src/websockets/client/ws_client_wspp.cpp
 +++ b/Release/src/websockets/client/ws_client_wspp.cpp
 @@ -225,7 +225,7 @@ public:
@@ -365,3 +365,16 @@ index d7c31c4..8dfa815 100644
                      return rfc2818(preverified, verifyCtx);
                  });
  
+diff --git a/Release/tests/functional/pplx/pplx_test/pplx_op_test.cpp b/Release/tests/functional/pplx/pplx_test/pplx_op_test.cpp
+index 82b10a7b..584b0dee 100644
+--- a/Release/tests/functional/pplx/pplx_test/pplx_op_test.cpp
++++ b/Release/tests/functional/pplx/pplx_test/pplx_op_test.cpp
+@@ -57,7 +57,7 @@ class pplx_dflt_scheduler : public pplx::scheduler_interface
+     virtual void schedule(pplx::TaskProc_t proc, void* param)
+     {
+         pplx::details::atomic_increment(s_flag);
+-        m_pool->service().post([=]() -> void { proc(param); });
++        boost::asio::post(m_pool->service(), [=]() -> void { proc(param); });
+     }
+ 
+ public:

--- a/ports/cpprestsdk/vcpkg.json
+++ b/ports/cpprestsdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cpprestsdk",
   "version": "2.10.19",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "C++11 JSON, REST, and OAuth library",
     "The C++ REST SDK is a Microsoft project for cloud-based client-server communication in native code using a modern asynchronous C++ API design. This project aims to help C++ developers connect to and interact with services."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2114,7 +2114,7 @@
     },
     "cpprestsdk": {
       "baseline": "2.10.19",
-      "port-version": 3
+      "port-version": 4
     },
     "cppslippi": {
       "baseline": "1.4.3.18",

--- a/versions/c-/cpprestsdk.json
+++ b/versions/c-/cpprestsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c85a8c04f8c279996f3108f50fea8be0ca5779cf",
+      "version": "2.10.19",
+      "port-version": 4
+    },
+    {
       "git-tree": "9f5e160191038cbbd2470e534c43f051c80e7d44",
       "version": "2.10.19",
       "port-version": 3


### PR DESCRIPTION
- Fix the following error in
```sh
  cpprestsdk-2.10.19/Release/tests/functional/pplx/pplx_test/pplx_op_test.cpp:60:27:
  error:
  ‘class boost::asio::io_context’ has no member named ‘post’
   60 |         m_pool->service().post([=]() -> void { proc(param); });
      |                           ^~~~
```
- Run `./vcpkg x-add-version --all`

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
