### PR TITLE
[gklib, metis] Add support for x64-mingw-dynamic

### DIFF
--- a/ports/gklib/portfile.cmake
+++ b/ports/gklib/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     SHA512 54ba87f2c47e025ada0fe6fe608d9d144df5cd13e97e71892dbba4d50cd96409add309937a540cdf8bd2632cbfbc0e22e080a32d114ba6037008c8676aa8d88d
     PATCHES
         build-fixes.patch
+        regex.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SHARED)

--- a/ports/gklib/regex.patch
+++ b/ports/gklib/regex.patch
@@ -1,0 +1,13 @@
+--- 71aac9f2f8-6ab87cd67d.clean/CMakeLists.txt.old	2026-02-05 23:01:42.685830600 +0100
++++ 71aac9f2f8-6ab87cd67d.clean/CMakeLists.txt	2026-02-05 23:02:00.820495600 +0100
+@@ -109,6 +109,10 @@ if(NOT HAVE_PCREPOSIX_H)
+   check_include_file(regex.h HAVE_REGEX_H)
+   if(NOT HAVE_REGEX_H)
+     set(USE_GKREGEX ON)
++  else()
++    if(MINGW)
++      target_link_libraries(${PROJECT_NAME} PUBLIC regex)
++    endif()
+   endif()
+ endif()
+ 

--- a/ports/gklib/vcpkg.json
+++ b/ports/gklib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gklib",
   "version-date": "2025-07-06",
+  "port-version": 1,
   "description": "General helper libraries for KarypisLab.",
   "homepage": "https://github.com/KarypisLab/GKlib/",
   "license": "Apache-2.0",

--- a/ports/metis/build-fixes-gkregex.patch
+++ b/ports/metis/build-fixes-gkregex.patch
@@ -1,0 +1,14 @@
+--- 3b0b581ab2-3f513bfb0c.clean/conf/gkbuild.cmake.old	2026-02-07 18:50:18.944623000 +0100
++++ 3b0b581ab2-3f513bfb0c.clean/conf/gkbuild.cmake	2026-02-07 18:51:19.086997000 +0100
+@@ -16,9 +16,9 @@ option(GKRAND "enable GKRAND support" OF
+ 
+ # Add compiler flags.
+ if(MSVC)
+-  set(GK_COPTIONS "-DWIN32 -DMSC -D_CRT_SECURE_NO_DEPRECATE -DUSE_GKREGEX")
++  set(GK_COPTIONS "-DWIN32 -DMSC -D_CRT_SECURE_NO_DEPRECATE")
+ elseif(MINGW)
+-  set(GK_COPTS "-DUSE_GKREGEX")
++#  set(GK_COPTS "-DUSE_GKREGEX")
+ else()
+   set(GK_COPTIONS "-DLINUX -D_FILE_OFFSET_BITS=64")
+ endif(MSVC)

--- a/ports/metis/portfile.cmake
+++ b/ports/metis/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     SHA512 c41168788c287ed9baea3c43c1ea8ef7d0bbdaa340a03cbbb5d0ba2d928d8a6dd83e2b77e7d3fabc58ac6d2b59a4be0492940e31460fe5e1807849cb98e80d2e
     PATCHES
         build-fixes.patch
+        build-fixes-gkregex.patch
 )
 file(COPY "${SOURCE_PATH}/include/" DESTINATION "${SOURCE_PATH}/build/xinclude")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/install_config.cmake" DESTINATION "${SOURCE_PATH}")

--- a/ports/metis/vcpkg.json
+++ b/ports/metis/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "metis",
   "version-date": "2025-07-04",
+  "port-version": 1,
   "description": "Serial Graph Partitioning and Fill-reducing Matrix Ordering",
   "homepage": "https://github.com/KarypisLab/METIS",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6326,7 +6326,7 @@
     },
     "metis": {
       "baseline": "2025-07-04",
-      "port-version": 0
+      "port-version": 1
     },
     "metrohash": {
       "baseline": "1.1.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3366,7 +3366,7 @@
     },
     "gklib": {
       "baseline": "2025-07-06",
-      "port-version": 0
+      "port-version": 1
     },
     "gl2ps": {
       "baseline": "1.4.2",

--- a/versions/g-/gklib.json
+++ b/versions/g-/gklib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5fcb778964e119e95b4b30606fcea8a3362d79c1",
+      "version-date": "2025-07-06",
+      "port-version": 1
+    },
+    {
       "git-tree": "c3b9e3dbc3c508699816a7723c720428a478b364",
       "version-date": "2025-07-06",
       "port-version": 0

--- a/versions/m-/metis.json
+++ b/versions/m-/metis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b831f3b20149877e84f9101cc44ebb1ffe0e26f9",
+      "version-date": "2025-07-04",
+      "port-version": 1
+    },
+    {
       "git-tree": "83d3f4ee2d498f9bc5d8f63b562744442c6065f1",
       "version-date": "2025-07-04",
       "port-version": 0


### PR DESCRIPTION
gklib needs regex to avoid undefined symbol about regex_t for target x64-mingw-dynamic

I also noticed that metis decided if `USE_GKREGEX` needs to be defined. It's wrong. [gklib already does it](https://github.com/KarypisLab/GKlib/blob/6e7951358fd896e2abed7887196b6871aac9f2f8/CMakeLists.txt#L159).

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
