### PR TITLE
[terrakuh-base64] Add new port

### DIFF
--- a/ports/terrakuh-base64/portfile.cmake
+++ b/ports/terrakuh-base64/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO terrakuh/base64
+    REF 412f1645f7aeeb55b78377eefc65e6d7b36ec25b
+    SHA512 d31b3a450583c2deaa8da1e8a18206075d07d5a58302e1e7720bbe6e61de082e7a7f2cf1f15d1c61ce3962d6089410c784dbc1f81993c940d3cadbeaa91c1e4b
+    HEAD_REF master
+)
+
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME base64 CONFIG_PATH lib/cmake/base64)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/terrakuh-base64/vcpkg.json
+++ b/ports/terrakuh-base64/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "terrakuh-base64",
+  "version-date": "2026-02-06",
+  "description": "Simple, open source, header-only base64 encoder",
+  "homepage": "https://github.com/terrakuh/base64",
+  "license": "Unlicense",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9772,6 +9772,10 @@
       "baseline": "2.1.0",
       "port-version": 0
     },
+    "terrakuh-base64": {
+      "baseline": "2026-02-06",
+      "port-version": 0
+    },
     "tesseract": {
       "baseline": "5.5.2",
       "port-version": 0

--- a/versions/t-/terrakuh-base64.json
+++ b/versions/t-/terrakuh-base64.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "bc1fdfbe41c81ec686e17daf742d5e737a4391f8",
+      "version-date": "2026-02-06",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

While this library might seem insignificant, it's used by some huge projects, like llama.cpp: https://github.com/ggml-org/llama.cpp/blob/master/common/base64.hpp

Most use this library by copying the header file so the original repo isn't very popular on github.

I don't like to put external code in my repos so I made a port.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.
