### PR TITLE
[abcmake] Add new port

### DIFF
--- a/ports/abcmake/portfile.cmake
+++ b/ports/abcmake/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 85724b25e158f41f0aa0e5f01ea0530a46f6b4397606b1af115c8aec1c29d317aaaf40a6161795687d713b6f00f66b13a1ab3982f351a139dc79a7d4ac42b7da
 )
 
+set(VCPKG_BUILD_TYPE release) # CMake support file only port
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
 vcpkg_cmake_configure(
@@ -13,6 +14,5 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/abcmake/portfile.cmake
+++ b/ports/abcmake/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO an-dr/abcmake
+    REF "v6.4.0"
+    SHA512 85724b25e158f41f0aa0e5f01ea0530a46f6b4397606b1af115c8aec1c29d317aaaf40a6161795687d713b6f00f66b13a1ab3982f351a139dc79a7d4ac42b7da
+)
+
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/abcmake/usage
+++ b/ports/abcmake/usage
@@ -1,0 +1,4 @@
+abcmake provides CMake configs:
+
+    find_package(abcmake CONFIG REQUIRED)
+    add_main_component(${PROJECT_NAME})

--- a/ports/abcmake/vcpkg.json
+++ b/ports/abcmake/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "abcmake",
+  "version": "6.4.0",
+  "description": "Simple, component-first CMake helper for small & medium C/C++ projects",
+  "homepage": "https://github.com/an-dr/abcmake",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/scripts/test_ports/vcpkg-ci-abcmake/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-abcmake/portfile.cmake
@@ -1,0 +1,3 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-abcmake/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-abcmake/project/CMakeLists.txt
@@ -1,0 +1,6 @@
+# from:
+# https://github.com/an-dr/abcmake/tree/4a45dea784dd98473195132a29a2980ed29b3c75/examples/hello_with_find_package
+cmake_minimum_required(VERSION 3.15)
+project(HelloWorld)
+find_package(abcmake CONFIG REQUIRED)
+add_main_component(${PROJECT_NAME})

--- a/scripts/test_ports/vcpkg-ci-abcmake/project/src/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-abcmake/project/src/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello from abcmake using find_package()!" << std::endl;
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-abcmake/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-abcmake/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-abcmake",
+  "version": "1.0.0",
+  "description": "Test port for abcmake",
+  "dependencies": [
+    "abcmake",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/abcmake.json
+++ b/versions/a-/abcmake.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8141193b1821729e3e9c86888eda042bd6154714",
+      "version": "6.4.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/a-/abcmake.json
+++ b/versions/a-/abcmake.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8141193b1821729e3e9c86888eda042bd6154714",
+      "git-tree": "ee7b2ca269c0bbca7802c6750bc3555d750506a7",
       "version": "6.4.0",
       "port-version": 0
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8,6 +8,10 @@
       "baseline": "25.1",
       "port-version": 1
     },
+    "abcmake": {
+      "baseline": "6.4.0",
+      "port-version": 0
+    },
     "ableton-link": {
       "baseline": "3.1.5",
       "port-version": 0


### PR DESCRIPTION
Add [abcmake](https://github.com/an-dr/abcmake) - a simple, component-first CMake helper for small & medium C/C++ projects. It provides convention-over-configuration functions like add_component() for automatic target creation, include paths, and linking.

Version: 6.4.0
License: MIT
Homepage: https://github.com/an-dr/abcmake
abcmake is a pure CMake module (no compilation), so VCPKG_POLICY_EMPTY_INCLUDE_FOLDER is set and the debug directory is removed.


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

