### PR TITLE
[vulkan-memory-allocator-hpp] update to v3.3.0

### DIFF
--- a/ports/vulkan-memory-allocator-hpp/portfile.cmake
+++ b/ports/vulkan-memory-allocator-hpp/portfile.cmake
@@ -1,14 +1,17 @@
+
+# The git tag is in the format "v3.3.0+2". So do some regex magic for the git ref.
+string(REGEX REPLACE "^([0-9.]+)\$" "\\1\+2" git_ref "${VERSION}")
+message(STATUS "Using git ref v${git_ref} for version ${VERSION}")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO YaaZ/VulkanMemoryAllocator-Hpp
-    REF "v${VERSION}"
-    SHA512 95f5a8930431c18683d7e768ce1363b4edcb2fa7ca527054c77dbc8b34355308f621eed8cd018a574a928ac93e8689d4a8991802e3d601f5c0d1204a9155aee6
+    REF "v${git_ref}"
+    SHA512 72fccbba9ad422baa0f9e9389a72ccf4aa760ea1f15ecdf6d08604d60c25969938a300db6350363841ba66a40ca7804265477faeb601e142de9d7211da08ada2
     HEAD_REF master
 )
 
 file(COPY "${SOURCE_PATH}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
-
-file(COPY "${SOURCE_PATH}/src/vk_mem_alloc.cppm" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-vulkan-memory-allocator-hpp-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}")
 

--- a/ports/vulkan-memory-allocator-hpp/portfile.cmake
+++ b/ports/vulkan-memory-allocator-hpp/portfile.cmake
@@ -1,6 +1,6 @@
 
-# The git tag is in the format "v3.3.0+2". So do some regex magic for the git ref.
-string(REGEX REPLACE "^([0-9.]+)\$" "\\1\+2" git_ref "${VERSION}")
+# The git tag is in the format "v3.3.0+2".
+set(git_ref "${VERSION}+2")
 message(STATUS "Using git ref v${git_ref} for version ${VERSION}")
 
 vcpkg_from_github(

--- a/ports/vulkan-memory-allocator-hpp/portfile.cmake
+++ b/ports/vulkan-memory-allocator-hpp/portfile.cmake
@@ -1,12 +1,9 @@
-
-# The git tag is in the format "v3.3.0+2".
-set(git_ref "${VERSION}+2")
-message(STATUS "Using git ref v${git_ref} for version ${VERSION}")
+set(GIT_TAG v3.3.0+2)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO YaaZ/VulkanMemoryAllocator-Hpp
-    REF "v${git_ref}"
+    REF "${GIT_TAG}"
     SHA512 72fccbba9ad422baa0f9e9389a72ccf4aa760ea1f15ecdf6d08604d60c25969938a300db6350363841ba66a40ca7804265477faeb601e142de9d7211da08ada2
     HEAD_REF master
 )

--- a/ports/vulkan-memory-allocator-hpp/portfile.cmake
+++ b/ports/vulkan-memory-allocator-hpp/portfile.cmake
@@ -1,9 +1,7 @@
-set(GIT_TAG v3.3.0+2)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO YaaZ/VulkanMemoryAllocator-Hpp
-    REF "${GIT_TAG}"
+    REF "v${VERSION}+2"
     SHA512 72fccbba9ad422baa0f9e9389a72ccf4aa760ea1f15ecdf6d08604d60c25969938a300db6350363841ba66a40ca7804265477faeb601e142de9d7211da08ada2
     HEAD_REF master
 )

--- a/ports/vulkan-memory-allocator-hpp/vcpkg.json
+++ b/ports/vulkan-memory-allocator-hpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vulkan-memory-allocator-hpp",
-  "version": "3.1.0",
-  "port-version": 1,
+  "version": "3.3.0",
   "description": "C++ bindings for VulkanMemoryAllocator (Development branch)",
   "homepage": "https://github.com/YaaZ/VulkanMemoryAllocator-Hpp",
   "license": "CC0-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10513,8 +10513,8 @@
       "port-version": 0
     },
     "vulkan-memory-allocator-hpp": {
-      "baseline": "3.1.0",
-      "port-version": 1
+      "baseline": "3.3.0",
+      "port-version": 0
     },
     "vulkan-sdk-components": {
       "baseline": "1.4.335.0",

--- a/versions/v-/vulkan-memory-allocator-hpp.json
+++ b/versions/v-/vulkan-memory-allocator-hpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "603db325435a9470668c2dc7637d367c3e80e4df",
+      "git-tree": "511c9cff2bf339f7bf95d988661214ddc1acbc4c",
       "version": "3.3.0",
       "port-version": 0
     },

--- a/versions/v-/vulkan-memory-allocator-hpp.json
+++ b/versions/v-/vulkan-memory-allocator-hpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "603db325435a9470668c2dc7637d367c3e80e4df",
+      "version": "3.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "46c30259ccc070ffefcb8c2a95908ccfe9d4dada",
       "version": "3.1.0",
       "port-version": 1

--- a/versions/v-/vulkan-memory-allocator-hpp.json
+++ b/versions/v-/vulkan-memory-allocator-hpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e2341623173b8823e2a4be8eee7bd7493edbd6f9",
+      "git-tree": "0e228b9fac7763ade067a5eb6d461682b7e8dbe2",
       "version": "3.3.0",
       "port-version": 0
     },

--- a/versions/v-/vulkan-memory-allocator-hpp.json
+++ b/versions/v-/vulkan-memory-allocator-hpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "511c9cff2bf339f7bf95d988661214ddc1acbc4c",
+      "git-tree": "e2341623173b8823e2a4be8eee7bd7493edbd6f9",
       "version": "3.3.0",
       "port-version": 0
     },


### PR DESCRIPTION
Fixes #49489 
Fixes #48036 

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
