### PR TITLE
[orange-math] update to v4.8.0

### DIFF
--- a/ports/orange-math/portfile.cmake
+++ b/ports/orange-math/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO orange-cpp/omath
     REF "v${VERSION}"
-    SHA512 9c2fd36bb5d3ca2c2bc1a2115c2da53e1441037aebd26c8d60d976422aa427883a1ebf0b594b8e81677da0bfe64b01b48e40344ff53006b7ba8a366891651027
+    SHA512 fdcd4394ff132bc690a2be6ba275da36d037bf3edbe3d6cdeabbbb4a42ee9657f876af9b8e99a9c77bb44a6dce64f0906f9d28bde04c8b608fb2d44dd6ca8134
     HEAD_REF master
 )
 

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "orange-math",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "General purpose math library",
   "homepage": "https://github.com/orange-cpp/omath",
+  "documentation": "https://libomath.org",
   "license": "Zlib",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7337,7 +7337,7 @@
       "port-version": 1
     },
     "orange-math": {
-      "baseline": "4.7.0",
+      "baseline": "4.8.0",
       "port-version": 0
     },
     "orc": {

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8337c73b2e06c092d8b4512ab860a7e0c620c05e",
+      "version": "4.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1f615358d2934d9fc7caa94079ce4c4b25a1661b",
       "version": "4.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
