### PR TITLE
[slick-net] update to v1.2.4

### DIFF
--- a/ports/slick-net/portfile.cmake
+++ b/ports/slick-net/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-net
     REF "v${VERSION}"
-    SHA512 6e7e64ff7ccc9b384ece333a3f3a1f1185743f0f443c3f3b6ff28c15f5790b9efbfaa5f1db5d74058f522072ffc62148874b56628c5ddb9da7776ca3582d9eb1
+    SHA512 d0177beb2fd3721b88529226521001edbf8681b7f3e16e22259423ccfdd337eb2e145bef0ef6c6a88609a6ba49c70103cf9d2c01afc57987bd24da61e728a2e0
     HEAD_REF main
     PATCHES
         slick-queue.patch

--- a/ports/slick-net/slick-queue.patch
+++ b/ports/slick-net/slick-queue.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6bd7e39..f5dab2f 100644
+index cd0e9ea..1e226f0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -22,7 +22,7 @@ if (LINK_STATICALLY)
+@@ -28,7 +28,7 @@ if (slick-shm_FOUND)
+     message(STATUS "slick-shm: ${slick-shm_VERSION}")
  endif()
- find_package(Boost CONFIG REQUIRED COMPONENTS beast context)
- find_package(OpenSSL CONFIG REQUIRED)
+ 
 -find_package(slick-queue 1.2.2 CONFIG QUIET)
 +find_package(slick-queue 1.2.2 CONFIG REQUIRED)
- 
  if (NOT slick-queue_FOUND)
      message(STATUS "Fetching slick-queue...")
+ 

--- a/ports/slick-net/vcpkg.json
+++ b/ports/slick-net/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-net",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A modern C++20 networking library providing HTTP/HTTPS client, WebSocket/WebSocket Secure client, and HTTP streaming support built on Boost.Beast and Boost.Asio",
   "homepage": "https://github.com/SlickQuant/slick-net",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9165,7 +9165,7 @@
       "port-version": 0
     },
     "slick-net": {
-      "baseline": "1.2.3",
+      "baseline": "1.2.4",
       "port-version": 0
     },
     "slick-object-pool": {

--- a/versions/s-/slick-net.json
+++ b/versions/s-/slick-net.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b64646116742b38f1d29f5fde0cfbd9eb31c2705",
+      "version": "1.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "957ebcb3e4a3990775e642bfef9b4bf1e29ccfbd",
       "version": "1.2.3",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
