### PR TITLE
[arrayfire] Fix fmt library compile error in OpenCL backend

### DIFF
--- a/ports/arrayfire/fix-fmt-error.patch
+++ b/ports/arrayfire/fix-fmt-error.patch
@@ -6,18 +6,4 @@ index 35f992f..8cfc83e 100644
  #include <traits.hpp>
 +#include <fmt/format.h>
 +#include <fmt/ranges.h>
- 
-@@ -33,3 +35,2 @@
- using common::loggerFactory;
--using fmt::format;
- using opencl::getActiveDeviceId;
-@@ -65,3 +66,3 @@
-             build_error +=
--                format("OpenCL Device: {}\n\tOptions: {}\n\tLog:\n{}\n",
-+                fmt::format("OpenCL Device: {}\n\tOptions: {}\n\tLog:\n{}\n",
-                        device.getInfo<CL_DEVICE_NAME>(),
-@@ -71,3 +72,3 @@
-     } catch (const cl::Error &e) {
--        build_error = format("Failed to fetch build log: {}", e.what());
-+        build_error = fmt::format("Failed to fetch build log: {}", e.what());
-     }
+

--- a/ports/arrayfire/fix-fmt-error.patch
+++ b/ports/arrayfire/fix-fmt-error.patch
@@ -1,0 +1,23 @@
+diff --git a/src/backend/opencl/compile_module.cpp b/src/backend/opencl/compile_module.cpp
+index 35f992f..8cfc83e 100644
+--- a/src/backend/opencl/compile_module.cpp
++++ b/src/backend/opencl/compile_module.cpp
+@@ -21,2 +21,4 @@
+ #include <traits.hpp>
++#include <fmt/format.h>
++#include <fmt/ranges.h>
+ 
+@@ -33,3 +35,2 @@
+ using common::loggerFactory;
+-using fmt::format;
+ using opencl::getActiveDeviceId;
+@@ -65,3 +66,3 @@
+             build_error +=
+-                format("OpenCL Device: {}\n\tOptions: {}\n\tLog:\n{}\n",
++                fmt::format("OpenCL Device: {}\n\tOptions: {}\n\tLog:\n{}\n",
+                        device.getInfo<CL_DEVICE_NAME>(),
+@@ -71,3 +72,3 @@
+     } catch (const cl::Error &e) {
+-        build_error = format("Failed to fetch build log: {}", e.what());
++        build_error = fmt::format("Failed to fetch build log: {}", e.what());
+     }

--- a/ports/arrayfire/portfile.cmake
+++ b/ports/arrayfire/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_from_github(
     Fix-constexpr-error-with-vs2019-with-half.patch
     fix-dependency-clfft.patch
     fix-miss-header-file.patch
+    fix-fmt-error.patch
     remove-cl2hpp-download.diff
     "${CUDA_PATCHES}"
 )

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrayfire",
   "version-semver": "3.8.0",
-  "port-version": 9,
+  "port-version": 10,
   "description": "ArrayFire is a general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.",
   "homepage": "https://github.com/arrayfire/arrayfire",
   "license": "BSD-3-Clause",

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrayfire",
   "version-semver": "3.8.0",
-  "port-version": 10,
+  "port-version": 11,
   "description": "ArrayFire is a general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.",
   "homepage": "https://github.com/arrayfire/arrayfire",
   "license": "BSD-3-Clause",

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrayfire",
   "version-semver": "3.8.0",
-  "port-version": 11,
+  "port-version": 10,
   "description": "ArrayFire is a general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.",
   "homepage": "https://github.com/arrayfire/arrayfire",
   "license": "BSD-3-Clause",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -645,7 +645,6 @@ adios2[cuda]:x64-windows-static = feature-fails # try_run() invoked in cross-com
 adios2[mpi]:x86-windows = feature-fails
 adios2[python] = feature-fails # Could NOT find Python (missing: Python_NumPy_INCLUDE_DIRS NumPy)
 adios2[zfp](android | (arm & windows)) = feature-fails # try_run() invoked in cross-compiling mode
-arrayfire[opencl](windows) = feature-fails # build errror: See https://github.com/microsoft/vcpkg/issues/33464
 ashes[core](windows) = combination-fails # CMake Error: INSTALL(EXPORT) given unknown export "AshesRenderers". One render backend must be selected
 awlib[graphics](osx) = feature-fails # Broken code. See https://github.com/microsoft/vcpkg/issues/39849
 cgns[core,fortran,hdf5,legacy,lfs,mpi,tests](osx | linux) = combination-fails # ["fortran","hdf5","mpi"]: Could NOT find MPI (missing: MPI_Fortran_FOUND) (found version "3.1")

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "25faf9c700f23f676b2a75653de1de7d1a3802b5",
+      "version-semver": "3.8.0",
+      "port-version": 10
+    },
+    {
       "git-tree": "c0aef37891aafcb73d45f1e18bba8c581085b099",
       "version-semver": "3.8.0",
       "port-version": 9

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e7d6fc4cf7ba8cd983b3f70db579865cd49ae38",
+      "version-semver": "3.8.0",
+      "port-version": 11
+    },
+    {
       "git-tree": "25faf9c700f23f676b2a75653de1de7d1a3802b5",
       "version-semver": "3.8.0",
       "port-version": 10

--- a/versions/a-/arrayfire.json
+++ b/versions/a-/arrayfire.json
@@ -1,12 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0e7d6fc4cf7ba8cd983b3f70db579865cd49ae38",
-      "version-semver": "3.8.0",
-      "port-version": 11
-    },
-    {
-      "git-tree": "25faf9c700f23f676b2a75653de1de7d1a3802b5",
+      "git-tree": "c977914f0cfe2c181c1feea7a21e67ca3cefa45c",
       "version-semver": "3.8.0",
       "port-version": 10
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -278,7 +278,7 @@
     },
     "arrayfire": {
       "baseline": "3.8.0",
-      "port-version": 10
+      "port-version": 11
     },
     "arrow": {
       "baseline": "23.0.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -278,7 +278,7 @@
     },
     "arrayfire": {
       "baseline": "3.8.0",
-      "port-version": 11
+      "port-version": 10
     },
     "arrow": {
       "baseline": "23.0.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -278,7 +278,7 @@
     },
     "arrayfire": {
       "baseline": "3.8.0",
-      "port-version": 9
+      "port-version": 10
     },
     "arrow": {
       "baseline": "23.0.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.


## Description
Fix compile error `'join' is not a member of 'fmt'` caused by incorrect fmt library usage in the OpenCL backend compile_module.cpp file:
- Add missing fmt header includes (<fmt/format.h>, <fmt/ranges.h>)

## Tested
- Environment: Windows 11 + MSVC 16.11. 53 (VS 2019)
- Command: `vcpkg install arrayfire[cpu,opencl]`
- Result: Compiles successfully without fmt-related errors