### PR TITLE
[flatbuffers] update to 25.12.19

### DIFF
--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/flatbuffers
     REF "v${VERSION}"
-    SHA512 259ae6c0b024c19c882d87c93d6ba156c15f14a61b11846170ac1b9e9c051cd3e80ae93cfe20ccb1aa30f2085cdbd4127ffa229b42cabbfed6b035ca4851c127
+    SHA512 808c77536fbfb1c8a1145506873a2b4e5cb508e48bf35f8502a2d1349b64e7581bfe7ff2f587b3edb2642cc885c60c0170a8875fad245240a1288057f4c07a42
     HEAD_REF master
     PATCHES
         fix-uwp-build.patch

--- a/ports/flatbuffers/vcpkg.json
+++ b/ports/flatbuffers/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "flatbuffers",
-  "version": "25.9.23",
-  "port-version": 1,
+  "version": "25.12.19",
   "description": "FlatBuffers is a cross platform serialization library architected for maximum memory efficiency. It allows you to directly access serialized data without parsing/unpacking it first, while still having great forwards/backwards compatibility.",
   "homepage": "https://google.github.io/flatbuffers/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3049,8 +3049,8 @@
       "port-version": 0
     },
     "flatbuffers": {
-      "baseline": "25.9.23",
-      "port-version": 1
+      "baseline": "25.12.19",
+      "port-version": 0
     },
     "flatbush": {
       "baseline": "1.3.2",

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3bdc699c0f7c5a58787697e74e345610d454ccf",
+      "version": "25.12.19",
+      "port-version": 0
+    },
+    {
       "git-tree": "cf3ccaa4a8abd4a9dcc02a2006d3387e13e3a94c",
       "version": "25.9.23",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/google/flatbuffers/releases/tag/v25.12.19-2026-02-06-03fffb2
