### PR TITLE
[libupnp] update to 1.14.29

### DIFF
--- a/ports/libupnp/make-static-func.patch
+++ b/ports/libupnp/make-static-func.patch
@@ -1,0 +1,13 @@
+diff --git a/upnp/src/genlib/miniserver/miniserver.c b/upnp/src/genlib/miniserver/miniserver.c
+index 822e281..1f0fef2 100644
+--- a/upnp/src/genlib/miniserver/miniserver.c
++++ b/upnp/src/genlib/miniserver/miniserver.c
+@@ -458,7 +458,7 @@ static void remove_active_connection(SOCKET sock)
+ /*!
+  * \brief Shutdown all active socket connections
+  */
+-void shutdown_all_active_connections(void)
++static void shutdown_all_active_connections(void)
+ {
+ 	ListNode *node;
+ 	int count;

--- a/ports/libupnp/make-static-func.patch
+++ b/ports/libupnp/make-static-func.patch
@@ -11,3 +11,20 @@ index 822e281..1f0fef2 100644
  {
  	ListNode *node;
  	int count;
+diff --git a/upnp/src/inc/miniserver.h b/upnp/src/inc/miniserver.h
+index c28382d..e902b37 100644
+--- a/upnp/src/inc/miniserver.h
++++ b/upnp/src/inc/miniserver.h
+@@ -148,12 +148,6 @@ int StartMiniServer(
+  */
+ int StopMiniServer(void);
+ 
+-/*!
+- * \brief Shutdown all active socket connections to interrupt blocking
+- * operations.
+- */
+-void shutdown_all_active_connections(void);
+-
+ #ifdef __cplusplus
+ } /* extern C */
+ #endif

--- a/ports/libupnp/portfile.cmake
+++ b/ports/libupnp/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 48e56099013e6ad73f39a96d53c54d11af61f11daf289089c9286d09525b2d33c40f97e199cb03593847e231ec09a47ab559aa7c29817d217f4469830b0a84d7
     PATCHES
         fix-pthreads4w-targets.patch
+        make-static-func.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LIBUPNP_BUILD_STATIC)

--- a/ports/libupnp/portfile.cmake
+++ b/ports/libupnp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pupnp/pupnp
     REF "release-${VERSION}"
-    SHA512 2aed5c72cb8e33b89d85e6755b99e7bd4e82ffb58d03ef58c2cdd790d4dc6c33b3a9f91168595930be53f0bb803e266e2bb02ea5fcc5cda8edada9453bf56492
+    SHA512 48e56099013e6ad73f39a96d53c54d11af61f11daf289089c9286d09525b2d33c40f97e199cb03593847e231ec09a47ab559aa7c29817d217f4469830b0a84d7
     PATCHES
         fix-pthreads4w-targets.patch
 )

--- a/ports/libupnp/vcpkg.json
+++ b/ports/libupnp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libupnp",
-  "version": "1.14.25",
+  "version": "1.14.29",
   "description": "libupnp: Build UPnP-compliant control points, devices, and bridges on several operating systems.",
   "homepage": "https://github.com/pupnp/pupnp/",
   "documentation": "https://github.com/pupnp/pupnp/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5653,7 +5653,7 @@
       "port-version": 0
     },
     "libupnp": {
-      "baseline": "1.14.25",
+      "baseline": "1.14.29",
       "port-version": 0
     },
     "liburcu": {

--- a/versions/l-/libupnp.json
+++ b/versions/l-/libupnp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "da7f524d86fb11d50cbd6ccf119a67873a82bf6f",
+      "git-tree": "9838ba607c2ffd0b44368080f33affc22734939c",
       "version": "1.14.29",
       "port-version": 0
     },

--- a/versions/l-/libupnp.json
+++ b/versions/l-/libupnp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9838ba607c2ffd0b44368080f33affc22734939c",
+      "git-tree": "ff3e60ca8525829f69ce23e74003e1634f68a4c9",
       "version": "1.14.29",
       "port-version": 0
     },

--- a/versions/l-/libupnp.json
+++ b/versions/l-/libupnp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "da7f524d86fb11d50cbd6ccf119a67873a82bf6f",
+      "version": "1.14.29",
+      "port-version": 0
+    },
+    {
       "git-tree": "49cc2e5824590583f7277390e1e74512cfa56889",
       "version": "1.14.25",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/pupnp/pupnp/releases/tag/release-1.14.29
