### PR TITLE
[opencsg] update to 1.8.2

### DIFF
--- a/ports/opencsg/portfile.cmake
+++ b/ports/opencsg/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO floriankirsch/OpenCSG
     REF "opencsg-${VERSION_CSG}-release"
-    SHA512 9c674553ff0bccd35b34475019f53f4dda900c4b26635e6f52871b81e974a9c6319891c1d42e387606ccb0a890dcbb286baa424ce240f78493ef6f920c0bcb3a
+    SHA512 03b33dc1f2b04e94490fdcac2d1dc25ecd8608706f0510dc0c6c3b5e51f031c4f8dae5f29ee72e47c15b67cf13f3f2dd82777686260179b95d83086db44f6aea
     HEAD_REF master
     PATCHES
         illegal_char.patch

--- a/ports/opencsg/vcpkg.json
+++ b/ports/opencsg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "opencsg",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "OpenCSG is a library that does image-based CSG rendering using OpenGL. OpenCSG is written in C++ and supports most modern graphics hardware using Microsoft Windows or the Linux operating system.",
   "homepage": "https://github.com/floriankirsch/OpenCSG",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7165,7 +7165,7 @@
       "port-version": 0
     },
     "opencsg": {
-      "baseline": "1.8.1",
+      "baseline": "1.8.2",
       "port-version": 0
     },
     "openctm": {

--- a/versions/o-/opencsg.json
+++ b/versions/o-/opencsg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6eebafd40e1dfc34b25e896a45a0c9917770f281",
+      "version": "1.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "1407ec9df49f94d7feaef6172b75495e910b6c76",
       "version": "1.8.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/floriankirsch/OpenCSG/releases/tag/opencsg-1-8-2-release
