### PR TITLE
[mongo-c-driver, libbson] update to 1.30.7

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 2f751bf33410f084e083fc73d8ebb138e40c956e9bccb2ca460d33ab5e6b75793e1910defb1d5faad849a9668e0afc5024179ad323beacd75a12538f2abda270
+    SHA512 2b4c1b1ff414f4a33abea4f032fdeb90e63b5bc279b5b9dac98132892d8922c81146279934e6e872926109a0639fa6a2b3a0a021e2f70683e99c56a5ffd66c4d
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "1.30.6",
+  "version": "1.30.7",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 2f751bf33410f084e083fc73d8ebb138e40c956e9bccb2ca460d33ab5e6b75793e1910defb1d5faad849a9668e0afc5024179ad323beacd75a12538f2abda270
+    SHA512 2b4c1b1ff414f4a33abea4f032fdeb90e63b5bc279b5b9dac98132892d8922c81146279934e6e872926109a0639fa6a2b3a0a021e2f70683e99c56a5ffd66c4d
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.30.6",
+  "version": "1.30.7",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4633,7 +4633,7 @@
       "port-version": 0
     },
     "libbson": {
-      "baseline": "1.30.6",
+      "baseline": "1.30.7",
       "port-version": 0
     },
     "libcaer": {
@@ -6469,7 +6469,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.30.6",
+      "baseline": "1.30.7",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7572b0991afb09a501fbc59dfbaa6b595396bb83",
+      "version": "1.30.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "6e5b99277913120bc8cb8b79c3b559a9f433c590",
       "version": "1.30.6",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "df7b485cc084abbe525768778f95d98746f45e2d",
+      "version": "1.30.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "8c812a808d00c11693d72c86bc15a3272a58407d",
       "version": "1.30.6",
       "port-version": 0


### PR DESCRIPTION
Fixes #49785

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.