### PR TITLE
[arcticdb-sparrow-extensions] Update sparrow extensions to 1.1

### DIFF
--- a/ports/arcticdb-sparrow-extensions/vcpkg.json
+++ b/ports/arcticdb-sparrow-extensions/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arcticdb-sparrow-extensions",
-  "version": "0.2.0",
+  "version": "1.1.0",
   "description": "Apache Arrow canonical extensions for Sparrow",
   "homepage": "https://github.com/QuantStack/sparrow-extensions",
   "license": "Apache-2.0",

--- a/versions/a-/arcticdb-sparrow-extensions.json
+++ b/versions/a-/arcticdb-sparrow-extensions.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "95d265dea45af6e03be34db9ce996e934244134b",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "156842526f80a1cca5b001a9e9298457464f481e",
       "version": "0.2.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -217,7 +217,7 @@
       "port-version": 0
     },
     "arcticdb-sparrow-extensions": {
-      "baseline": "0.2.0",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "arcus": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.