### PR TITLE
[vcpkg scripts] Add PowerShell Core tool support for cross-platform builds

### DIFF
--- a/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
+++ b/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
@@ -26,10 +26,8 @@ function(vcpkg_copy_tool_dependencies tool_dir)
     endif()
 
     if(VCPKG_TARGET_IS_WINDOWS)
-        find_program(Z_VCPKG_POWERSHELL_CORE pwsh)
-        if (NOT Z_VCPKG_POWERSHELL_CORE)
-            message(FATAL_ERROR "Could not find PowerShell Core; please open an issue to report this.")
-        endif()
+        vcpkg_find_acquire_program(PWSH)
+        set(Z_VCPKG_POWERSHELL_CORE "${PWSH}")
         cmake_path(RELATIVE_PATH tool_dir
             BASE_DIRECTORY "${CURRENT_PACKAGES_DIR}"
             OUTPUT_VARIABLE relative_tool_dir

--- a/scripts/cmake/vcpkg_find_acquire_program(PWSH).cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program(PWSH).cmake
@@ -1,0 +1,1 @@
+z_use_vcpkg_fetch(PWSH FETCH_NAME powershell-core)

--- a/scripts/vcpkg-tools.json
+++ b/scripts/vcpkg-tools.json
@@ -335,6 +335,56 @@
       "archive": "PowerShell-7.5.4-win-arm64.zip"
     },
     {
+      "name": "powershell-core",
+      "os": "windows",
+      "arch":"x86",
+      "version": "7.5.4",
+      "executable": "pwsh.exe",
+      "url": "https://github.com/PowerShell/PowerShell/releases/download/v7.5.4/PowerShell-7.5.4-win-x86.zip",
+      "sha512": "221ddfc685ccb497d26fbdbc6a2d198460e082934a683cade961057282616b85a1f1e9e91e9e01e4a0b36fb3c523fd9983884c62f5c917ea70fd2dd9dfa4a85e",
+      "archive": "PowerShell-7.5.4-win-x86.zip"
+    },
+    {
+      "name": "powershell-core",
+      "os": "linux",
+      "arch":"x64",
+      "version": "7.5.4",
+      "executable": "pwsh",
+      "url": "https://github.com/PowerShell/PowerShell/releases/download/v7.5.4/powershell-7.5.4-linux-x64.tar.gz",
+      "sha512": "6ff028cee3b23c71136de736ae5a93beb7b625215db3398b034fbdb0dd7b034ebf53da32cc47880982f7506054514e9af3cc5defcb4d69a7dd4a08a766469f0b",
+      "archive": "powershell-7.5.4-linux-x64.tar.gz"
+    },
+    {
+      "name": "powershell-core",
+      "os": "linux",
+      "arch":"arm64",
+      "version": "7.5.4",
+      "executable": "pwsh",
+      "url": "https://github.com/PowerShell/PowerShell/releases/download/v7.5.4/powershell-7.5.4-linux-arm64.tar.gz",
+      "sha512": "ef721f209842f13a560a21373744ab953ee8af41a60a0ed2f434131f85f4cd1b11565e3615df538a7d78cb5dd2096e9e2ccb42f4ffda79208c80f5206bb40cad",
+      "archive": "powershell-7.5.4-linux-arm64.tar.gz"
+    },
+    {
+      "name": "powershell-core",
+      "os": "osx",
+      "arch":"x64",
+      "version": "7.5.4",
+      "executable": "pwsh",
+      "url": "https://github.com/PowerShell/PowerShell/releases/download/v7.5.4/powershell-7.5.4-osx-x64.tar.gz",
+      "sha512": "350fef6fe9f18a7d85a5ea09374eb64c6198d389a24080984c0909601490decf21b0ec65b74248ad56c22bfea95bc745a7c9d1edd20bdeb276a905278a09c2c0",
+      "archive": "powershell-7.5.4-osx-x64.tar.gz"
+    },
+    {
+      "name": "powershell-core",
+      "os": "osx",
+      "arch":"arm64",
+      "version": "7.5.4",
+      "executable": "pwsh",
+      "url": "https://github.com/PowerShell/PowerShell/releases/download/v7.5.4/powershell-7.5.4-osx-arm64.tar.gz",
+      "sha512": "c93ffabdd01fa967bce32201dd9053409967d784f6bea6ce8edd19fb02ecaab15ad697518ff2202f19ee2c62781e17eb8b52bd970498554f931b0f23eb3226dc",
+      "archive": "powershell-7.5.4-osx-arm64.tar.gz"
+    },
+    {
       "name": "node",
       "os": "windows",
       "arch":"x64",


### PR DESCRIPTION
## Summary

Split from #49890 — this PR extracts the PowerShell Core tool acquisition portion as an independent change.

- Add `vcpkg_find_acquire_program(PWSH)` module for standardized PowerShell Core acquisition via vcpkg's tool infrastructure
- Replace hardcoded `find_program(pwsh)` in `vcpkg_copy_tool_dependencies.cmake` with `vcpkg_find_acquire_program(PWSH)`, eliminating build failures when PowerShell is not pre-installed on the host
- Add PowerShell Core 7.5.4 platform definitions in `vcpkg-tools.json` for Windows x86, Linux x64/arm64, and macOS x64/arm64 (Windows x64/arm64 entries already existed)

## Problem

When cross-compiling Windows targets from macOS or Linux, `vcpkg_copy_tool_dependencies` fails with:

```
Could not find PowerShell Core; please open an issue to report this.
```

PowerShell is required for dependency deployment scripts but the previous code assumed `pwsh` was already available on the host system via `find_program()`.

## Solution

Use vcpkg's existing tool acquisition infrastructure (`vcpkg_find_acquire_program` / `z_use_vcpkg_fetch`) to automatically download and configure PowerShell Core 7.5.4 when needed. This follows the same pattern used by other vcpkg tools (cmake, ninja, git, etc.) and ensures PowerShell is available on any supported platform without requiring manual installation.

## Changes

| File | Description |
|------|-------------|
| `scripts/cmake/vcpkg_find_acquire_program(PWSH).cmake` | New module: maps `PWSH` to `powershell-core` tool fetch |
| `scripts/cmake/vcpkg_copy_tool_dependencies.cmake` | Replace `find_program(pwsh)` + `FATAL_ERROR` with `vcpkg_find_acquire_program(PWSH)` |
| `scripts/vcpkg-tools.json` | Add 5 new `powershell-core` entries (win-x86, linux-x64, linux-arm64, osx-x64, osx-arm64) |

## Test plan

Tested on macOS ARM64 and Linux x64. SHA-512 hashes verified locally against official GitHub release archives for both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)