### PR TITLE
[libaec] Update to 1.1.5

### DIFF
--- a/ports/libaec/fix_export_target.patch
+++ b/ports/libaec/fix_export_target.patch
@@ -1,0 +1,13 @@
+diff --git a/packaging/CMakeLists.txt b/packaging/CMakeLists.txt
+index 16cace7..c2e7571 100644
+--- a/packaging/CMakeLists.txt
++++ b/packaging/CMakeLists.txt
+@@ -35,7 +35,7 @@ if(BUILD_STATIC_LIBS)
+     EXPORT libaec_static_targets
+     PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+ 
+-  install(EXPORT libaec_shared_targets
++  install(EXPORT libaec_static_targets
+     DESTINATION "${libaec_INSTALL_CMAKEDIR}"
+     NAMESPACE libaec::
+     FILE libaec_static-targets.cmake)

--- a/ports/libaec/vcpkg.json
+++ b/ports/libaec/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libaec",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Adaptive Entropy Coding library",
   "homepage": "https://gitlab.dkrz.de/k202009/libaec",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4577,7 +4577,7 @@
       "port-version": 3
     },
     "libaec": {
-      "baseline": "1.1.4",
+      "baseline": "1.1.5",
       "port-version": 0
     },
     "libaes-siv": {

--- a/versions/l-/libaec.json
+++ b/versions/l-/libaec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6281781decab1fe8a7f85a958a0e316df368e4e1",
+      "version": "1.1.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "f1e6ec945caf3975d531619c91b3ccedfd48200b",
       "version": "1.1.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
