### PR TITLE
[libxcvt] Update to 0.1.3

### DIFF
--- a/ports/libxcvt/portfile.cmake
+++ b/ports/libxcvt/portfile.cmake
@@ -1,18 +1,25 @@
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxcvt
-    REF db5ff12110994dc9010d44f981399e796917a845
-    SHA512 a69c4d163ab7a5f71dd4940e9b1f7ac2c5b5f282cbe9e1af26dcb677d061ff5187aa17f9acf9f913d3b05afac44f44b962ca4290ad2f5ae7f104ec870d8b515f
-    HEAD_REF master
+vcpkg_download_distfile(
+    LIBXCVT_ARCHIVE
+    URLS "https://www.x.org/releases/individual/lib/libxcvt-${VERSION}.tar.xz"
+    FILENAME "libxcvt-${VERSION}.tar.xz"
+    SHA512 2fecc784375e69b6e8e46608618a5f5a8ad20ecd5229fd093883fe401dd6ea231d8b77c6753756fff01f3040bef2db60a042d40fc349769ef5348e5cd9ed1f28
 )
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBXCVT_ARCHIVE}"
+)
+
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
 )
 vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_tools(TOOL_NAMES cvt AUTO_CLEAN)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libxcvt/vcpkg.json
+++ b/ports/libxcvt/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libxcvt",
-  "version": "0.1.2",
-  "port-version": 1,
+  "version": "0.1.3",
   "description": "A library providing a standalone version of the X server implementation of the VESA CVT standard timing modelines generator.",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxcvt",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5761,8 +5761,8 @@
       "port-version": 0
     },
     "libxcvt": {
-      "baseline": "0.1.2",
-      "port-version": 1
+      "baseline": "0.1.3",
+      "port-version": 0
     },
     "libxdamage": {
       "baseline": "1.1.5",
@@ -10096,10 +10096,6 @@
       "baseline": "2023.8",
       "port-version": 2
     },
-    "typecast-ai": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "tvision": {
       "baseline": "2024-05-22",
       "port-version": 1
@@ -10114,6 +10110,10 @@
     },
     "type-safe": {
       "baseline": "0.2.4",
+      "port-version": 0
+    },
+    "typecast-ai": {
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "uchardet": {

--- a/versions/l-/libxcvt.json
+++ b/versions/l-/libxcvt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6cbf827f94d380694ac6f355d9d35545cd7c2dbf",
+      "version": "0.1.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "2d0f2580b3ae5c31631891387f581c241da5410d",
       "version": "0.1.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.