### PR TITLE
[capstone] update to 5.0.7

### DIFF
--- a/ports/capstone/portfile.cmake
+++ b/ports/capstone/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "capstone-engine/capstone"
     REF "${VERSION}"
-    SHA512 d4ed08a2ab4ed8ede51a163e98542129d6441889cf6936ac9e3f8027fb2dfcbb04a7aacba14c2a007e788790bb3939c173b47db3d95f5dd9eafce2f30ff493e1
+    SHA512 e09788d7dfca281f8f3773323d72e1157df777878d59ace6a8996495d505dec10051ce002f473fa5ff8aa60d5e6bb4cff5e55faffb074643cae7c4515e324994
     HEAD_REF next
     PATCHES
         001-silence-windows-crt-secure-warnings.patch

--- a/ports/capstone/vcpkg.json
+++ b/ports/capstone/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "capstone",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "Multi-architecture disassembly framework",
   "homepage": "https://github.com/capstone-engine/capstone",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10096,6 +10096,10 @@
       "baseline": "2023.8",
       "port-version": 2
     },
+    "typecast-ai": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "tvision": {
       "baseline": "2024-05-22",
       "port-version": 1
@@ -10110,10 +10114,6 @@
     },
     "type-safe": {
       "baseline": "0.2.4",
-      "port-version": 0
-    },
-    "typecast-ai": {
-      "baseline": "1.0.1",
       "port-version": 0
     },
     "uchardet": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1601,7 +1601,7 @@
       "port-version": 0
     },
     "capstone": {
-      "baseline": "5.0.6",
+      "baseline": "5.0.7",
       "port-version": 0
     },
     "cargs": {
@@ -10096,10 +10096,6 @@
       "baseline": "2023.8",
       "port-version": 2
     },
-    "typecast-ai": {
-      "baseline": "1.0.1",
-      "port-version": 0
-    },
     "tvision": {
       "baseline": "2024-05-22",
       "port-version": 1
@@ -10114,6 +10110,10 @@
     },
     "type-safe": {
       "baseline": "0.2.4",
+      "port-version": 0
+    },
+    "typecast-ai": {
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "uchardet": {

--- a/versions/c-/capstone.json
+++ b/versions/c-/capstone.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1aa8b5740e1d6d47b0d2fb9f2af708593939f99f",
+      "version": "5.0.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "bcd9fc1db64dc8b7dbf4a63968d25c320c398029",
       "version": "5.0.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/capstone-engine/capstone/releases/tag/5.0.7
