### PR TITLE
[gobject-introspection] Fix setuptools 81

### DIFF
--- a/ports/gobject-introspection/portfile.cmake
+++ b/ports/gobject-introspection/portfile.cmake
@@ -13,6 +13,8 @@ vcpkg_extract_source_archive(
     PATCHES
         0001-g-ir-tool-template.in.patch
         gir-scanner-runtime.diff
+        # https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/575
+        setuptools-compat.patch
 )
 
 include("${CURRENT_PORT_DIR}/vcpkg-port-config.cmake")

--- a/ports/gobject-introspection/setuptools-compat.patch
+++ b/ports/gobject-introspection/setuptools-compat.patch
@@ -1,0 +1,14 @@
+diff --git a/giscanner/msvccompiler.py b/giscanner/msvccompiler.py
+index c9f14b5..1cd57df 100644
+--- a/giscanner/msvccompiler.py
++++ b/giscanner/msvccompiler.py
+@@ -40,7 +40,8 @@ class MSVCCompiler(DistutilsMSVCCompiler):
+ 
+     def __init__(self, verbose=0, dry_run=0, force=0):
+         super(DistutilsMSVCCompiler, self).__init__()
+-        CCompiler.__init__(self, verbose, dry_run, force)
++        # dry_run removed in setuptools 81; just ignore it
++        CCompiler.__init__(self, verbose=verbose, force=force)
+         self.__paths = []
+         self.__arch = None  # deprecated name
+         self.initialized = False

--- a/ports/gobject-introspection/vcpkg.json
+++ b/ports/gobject-introspection/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gobject-introspection",
   "version": "1.86.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "A middleware layer between C libraries (using GObject) and language bindings.",
     "Building (with) gobject-introspection is based on dynamic library linkage. Static builds of the core feature set are supported only for CI purposes.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3466,7 +3466,7 @@
     },
     "gobject-introspection": {
       "baseline": "1.86.0",
-      "port-version": 1
+      "port-version": 2
     },
     "godot-cpp": {
       "baseline": "4.4",

--- a/versions/g-/gobject-introspection.json
+++ b/versions/g-/gobject-introspection.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ab81d4194cc3a975fd12793d4ca8893986702f5a",
+      "version": "1.86.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "9fc1dbba428c95f5b53e5839d05c681035ceb1e5",
       "version": "1.86.0",
       "port-version": 1


### PR DESCRIPTION
Fixes #49860

Fixes https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/575

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
