### PR TITLE
[workflow] update to 1.0.0

### DIFF
--- a/ports/workflow/portfile.cmake
+++ b/ports/workflow/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sogou/workflow
     REF "v${VERSION}"
-    SHA512 78996029efd23ca7843f4089d801729174bf8e6bcb1babbe6f557db0c0b4094069dce38328332ddcddffec6710e77cfd03110264d0c670b8cd42b23dda5061ed
+    SHA512 ed38ce31c39d5f51497379f4184c7890d30b1e683973cd363f7921e628cf1d731bbbbe77f8cece1195cea2199e64d503ea4ed2bfb350d09fc22c862abd497577
     HEAD_REF master
     PATCHES
         cmake.diff

--- a/ports/workflow/vcpkg.json
+++ b/ports/workflow/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.11.11",
-  "port-version": 2,
+  "version": "1.0.0",
   "description": "C++ Parallel Computing and Asynchronous Networking Engine",
   "homepage": "https://github.com/sogou/workflow",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10709,8 +10709,8 @@
       "port-version": 3
     },
     "workflow": {
-      "baseline": "0.11.11",
-      "port-version": 2
+      "baseline": "1.0.0",
+      "port-version": 0
     },
     "workflow-win": {
       "baseline": "2026-01-09",

--- a/versions/w-/workflow.json
+++ b/versions/w-/workflow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1cef31dac1e04135b5ea3b54fcd3cfe974c3a193",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fbf9964982f5cfc53b5c588d4b6e201cdbeabd02",
       "version": "0.11.11",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/sogou/workflow/releases/tag/v1.0.0
