### PR TITLE
[libxdamage] Update to 1.1.7

### DIFF
--- a/ports/libxdamage/portfile.cmake
+++ b/ports/libxdamage/portfile.cmake
@@ -1,16 +1,20 @@
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
+    return()
+endif()
 
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxdamage
-    REF 977b04cd69738806e0b48fcf5c725763d065f06d # 1.1.5
-    SHA512  79c3a4c63f6c50c39d324183b98ad7e70235aed1c8385acf2f593739c71e7929119448be3e15dffd276b32e4fbb056508deeb35f450f74b85c101047f68d4339
-    HEAD_REF master # branch name
-) 
+vcpkg_download_distfile(
+    LIBXDAMAGE_ARCHIVE
+    URLS "https://www.x.org/releases/individual/lib/libXdamage-${VERSION}.tar.xz"
+    FILENAME "libXdamage-${VERSION}.tar.xz"
+    SHA512 9406e39cbc426d7fa3c66bf1eec202fdb5af5db99a0ff49c2be995b1ff7326a6c1fb395c46391e1c32f5a6569a5d6e02bdd5b79fc79dd468fc3ebd698496bbc2
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBXDAMAGE_ARCHIVE}"
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 
@@ -22,9 +26,6 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-endif()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libxdamage/vcpkg.json
+++ b/ports/libxdamage/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "libxdamage",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "description": "X Damage Extension library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxdamage",
   "license": null,
   "dependencies": [
-    "bzip2",
     "libx11",
     "libxfixes",
     "xorg-macros",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5765,7 +5765,7 @@
       "port-version": 0
     },
     "libxdamage": {
-      "baseline": "1.1.5",
+      "baseline": "1.1.7",
       "port-version": 0
     },
     "libxdf": {

--- a/versions/l-/libxdamage.json
+++ b/versions/l-/libxdamage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "55278a4035f62eb02f27af52d66af66fc2155611",
+      "version": "1.1.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "87138386fc68780b661be1216e8bb2e334071702",
       "version": "1.1.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
