### PR TITLE
[libxinerama] Update to 1.1.6

### DIFF
--- a/ports/libxinerama/portfile.cmake
+++ b/ports/libxinerama/portfile.cmake
@@ -1,35 +1,31 @@
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
+    return()
+endif()
 
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxinerama
-    REF  c3ab2361f13154921df2992f9eacc1ea1b3f946b #1.1.4
-    SHA512  c65ed77d370e063f861ff9ed3abee5ad89be9ba452de987263da702985b1aa5be2ddd464e67b7978155e072e67f03ef49192a87fa707fcead408434e1771cbc0
-    HEAD_REF master
-) 
+vcpkg_download_distfile(
+    LIBXINERAMA_ARCHIVE
+    URLS "https://www.x.org/releases/individual/lib/libXinerama-${VERSION}.tar.xz"
+    FILENAME "libXinerama-${VERSION}.tar.xz"
+    SHA512 64bff837941625120da43b8876db4204bc5740bcf3147997fc4df1475f90d6d9e3f9caa8748c7ebbf69d681be8e5ab4bc40f82c56c367dddcec3ab27d1c71573
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBXINERAMA_ARCHIVE}"
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
-
-if (VCPKG_CROSSCOMPILING)
-    list(APPEND OPTIONS --enable-malloc0returnsnull)
-endif()
 
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
-    OPTIONS ${OPTIONS}
 )
 
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-endif()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libxinerama/vcpkg.json
+++ b/ports/libxinerama/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libxinerama",
-  "version": "1.1.4",
+  "version": "1.1.6",
   "description": "Xlib API for Xinerama extension to X11 Protocol",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxinerama",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5801,7 +5801,7 @@
       "port-version": 0
     },
     "libxinerama": {
-      "baseline": "1.1.4",
+      "baseline": "1.1.6",
       "port-version": 0
     },
     "libxkbcommon": {

--- a/versions/l-/libxinerama.json
+++ b/versions/l-/libxinerama.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d28c5c6f6d10e97c18cf79565d687e2bd641472f",
+      "version": "1.1.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "74d2b10e157a97b5358f4bcb17806e6242216395",
       "version": "1.1.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.