### PR TITLE
[libxpresent] Update to 1.0.2

### DIFF
--- a/ports/libxpresent/portfile.cmake
+++ b/ports/libxpresent/portfile.cmake
@@ -1,18 +1,21 @@
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
+    return()
+endif()
 
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libxpresent
-    REF ced59e4373b7ad8f89ba222b3f489fb22050b991 # 1.0.0
-    SHA512  3904af03ff03a5fca84e63ed92b53668b7d3c9b8572dc829016dbdc3176f3813f7731e519c2769ae84c4c105a4f5dec8378165f02f48d89354842c4dd8062328
-    HEAD_REF master
-) 
-file(MAKE_DIRECTORY "${SOURCE_PATH}/m4/")
-file(TOUCH "${SOURCE_PATH}/m4/dummy")
+vcpkg_download_distfile(
+    LIBXPRESENT_ARCHIVE
+    URLS "https://www.x.org/releases/individual/lib/libXpresent-${VERSION}.tar.xz"
+    FILENAME "libXpresent-${VERSION}.tar.xz"
+    SHA512 7e12c386e5d1404db359f8004a141223b4c08a138a5589d087537ca667e9dd5cdc190f170a5fa991c1f8dd022896bb07bff540e262a0d30d542a3faea06d8c93
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBXPRESENT_ARCHIVE}"
+)
+
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 
 vcpkg_configure_make(
@@ -23,9 +26,6 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-endif()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libxpresent/vcpkg.json
+++ b/ports/libxpresent/vcpkg.json
@@ -1,11 +1,10 @@
 {
   "name": "libxpresent",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Xlib-based library for the X Present Extension",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxpresent",
   "license": null,
   "dependencies": [
-    "bzip2",
     "libx11",
     "libxext",
     "libxfixes",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5845,7 +5845,7 @@
       "port-version": 0
     },
     "libxpresent": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.2",
       "port-version": 0
     },
     "libxrandr": {

--- a/versions/l-/libxpresent.json
+++ b/versions/l-/libxpresent.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a0095a8ee02e2950ac7feafa6a9364cc36995d8",
+      "version": "1.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "7008422cbeacd24d14f6e80446bdc734acdf855b",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
