### PR TITLE
[python3] Add libb2 as a dependency when the extensions feature is enabled

### DIFF
--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -67,8 +67,7 @@
           "default-features": false
         },
         {
-          "name": "libb2",
-          "default-features": false
+          "name": "libb2"
         },
         {
           "name": "libffi",

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.12.9",
-  "port-version": 8,
+  "port-version": 9,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",
@@ -64,6 +64,10 @@
         },
         {
           "name": "expat",
+          "default-features": false
+        },
+        {
+          "name": "libb2",
           "default-features": false
         },
         {

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -66,9 +66,7 @@
           "name": "expat",
           "default-features": false
         },
-        {
-          "name": "libb2"
-        },
+        "libb2",
         {
           "name": "libffi",
           "default-features": false

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7906,7 +7906,7 @@
     },
     "python3": {
       "baseline": "3.12.9",
-      "port-version": 8
+      "port-version": 9
     },
     "qca": {
       "baseline": "2.3.7",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14cafa1ccb9853a25bbe2f0a7a7070bcb569c58b",
+      "version": "3.12.9",
+      "port-version": 9
+    },
+    {
       "git-tree": "8d3b3ef309a4fd7c53561374aa746e6eafed6517",
       "version": "3.12.9",
       "port-version": 8


### PR DESCRIPTION
Fixes #49916 - Provide libb2 through VCPKG and prevent builds from discovering and linking to a locally installed copies of libb2 when building the blake2 extension.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
