### PR TITLE
[libjxl] update to 0.11.2

### DIFF
--- a/ports/libjxl/portfile.cmake
+++ b/ports/libjxl/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libjxl/libjxl
     REF "v${VERSION}"
-    SHA512 0cfd81d9d3b783f96bd04f244d73ffbc12186c89993d46064a2751bef0a446a5e86be05add5c10f60d4482d39333d9bf3f9a866d6eb84f8fa0d4e8b5828fd74c
+    SHA512 a7e1f7d060b358f4382e84367d66aa2850aef3b4524a0fdfe3f22dd258fb9e35dda7540f859d8bf4c32f31c61a7a03db677f4490a9f472cd25869a9d00797336
     HEAD_REF main
     PATCHES
         fix-dependencies.patch

--- a/ports/libjxl/vcpkg.json
+++ b/ports/libjxl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libjxl",
-  "version-semver": "0.11.1",
-  "port-version": 4,
+  "version-semver": "0.11.2",
   "description": "JPEG XL image format reference implementation",
   "homepage": "https://github.com/libjxl/libjxl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5049,8 +5049,8 @@
       "port-version": 0
     },
     "libjxl": {
-      "baseline": "0.11.1",
-      "port-version": 4
+      "baseline": "0.11.2",
+      "port-version": 0
     },
     "libkeyfinder": {
       "baseline": "2.2.8",

--- a/versions/l-/libjxl.json
+++ b/versions/l-/libjxl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "864e158b0697e23dfa15a1731d089ce62a4b0f53",
+      "version-semver": "0.11.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ac044181841dbaf63e6403aa3931b944574b2bdf",
       "version-semver": "0.11.1",
       "port-version": 4


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/libjxl/libjxl/releases/tag/v0.11.2
