### PR TITLE
[libuv] update to 1.52.0

### DIFF
--- a/ports/libuv/portfile.cmake
+++ b/ports/libuv/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libuv/libuv
     REF "v${VERSION}"
-    SHA512 cf3ca916fc3a762a194dac86718a5a7fe24f230e34172a48f9b3401ad72fbc1cf21b46ceaba956cdf6783d323e518d40f8632fff965943869819a1c26992a3c1
+    SHA512 920727ebcfae39db665e518d4d90abef0ca838efcddca2b0f5ba0effc38f2d7e60df79fa5e7aa94dba8ea6e8e800d498c89ee01b36e46ed0b455b6c284852fe9
     HEAD_REF v1.x
     PATCHES
         fix-build-type.patch

--- a/ports/libuv/vcpkg.json
+++ b/ports/libuv/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libuv",
-  "version-semver": "1.51.0",
+  "version-semver": "1.52.0",
   "description": "libuv is a multi-platform support library with a focus on asynchronous I/O.",
   "homepage": "https://github.com/libuv/libuv",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5689,7 +5689,7 @@
       "port-version": 16
     },
     "libuv": {
-      "baseline": "1.51.0",
+      "baseline": "1.52.0",
       "port-version": 0
     },
     "libuvc": {

--- a/versions/l-/libuv.json
+++ b/versions/l-/libuv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "45fb5050035e1147c1e617d6654e78e7f12004c0",
+      "version-semver": "1.52.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "eaf94ede185f34dff0625254f6e64261d1c819fc",
       "version-semver": "1.51.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/libuv/libuv/releases/tag/v1.52.0
