### PR TITLE
[itlib] update to 1.12.1

### DIFF
--- a/ports/itlib/portfile.cmake
+++ b/ports/itlib/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO iboB/itlib
   REF "v${VERSION}"
-  SHA512 9995b083cedde1883acd0f60cb6463dc1af21c0dde0b0c588db9ae311a8929c15c7d1c1853ab15ac79d77035ce3cef568eac1a0358b16b2015acf638c2281054
+  SHA512 30137dffdbb9f708ca8e04c0d04e7af7f4d640cd9cd72ee99a40ca81d3f243c5bc1574aa4ab3cdb6eee8b1f11ada5787ac66aa08cc30e9de0d569d6d43d4cfd4
   HEAD_REF master
 )
 

--- a/ports/itlib/vcpkg.json
+++ b/ports/itlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "itlib",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "A collection of std-like single-header C++ libraries.",
   "homepage": "https://github.com/iboB/itlib",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4021,7 +4021,7 @@
       "port-version": 1
     },
     "itlib": {
-      "baseline": "1.12.0",
+      "baseline": "1.12.1",
       "port-version": 0
     },
     "itpp": {

--- a/versions/i-/itlib.json
+++ b/versions/i-/itlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eaa8120fee6ed412d89d247f359fd59b0981946c",
+      "version": "1.12.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d2a4aa9356ae2e45a5f8901354d3687a44eaeae2",
       "version": "1.12.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/iboB/itlib/releases/tag/v1.12.1
