### PR TITLE
[cleishm-frequency-cpp] update to 1.1.2

### DIFF
--- a/ports/cleishm-frequency-cpp/portfile.cmake
+++ b/ports/cleishm-frequency-cpp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cleishm/frequency-cpp
     REF "v${VERSION}"
-    SHA512 9535b051bbe57b1586f5df11edb6f41d97dc4b7ab2210e03e7911a21f0f88cc91ff100a5ed1062ab470a870bce9a17b2f6cde30ef918f911ae5d501a5a78ccc7
+    SHA512 afe81f653573fc4222ac96979b949d5714db2aba444d6965ee5e71a015ffdc8008709c0180af7ffe5295920cb99185849ff359d1fe5fdb8ef7f9f8cfcdc504b3
     HEAD_REF main
 )
 

--- a/ports/cleishm-frequency-cpp/vcpkg.json
+++ b/ports/cleishm-frequency-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cleishm-frequency-cpp",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "description": "Type-safe frequency handling library modeled after std::chrono",
   "homepage": "https://github.com/cleishm/frequency-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1797,7 +1797,7 @@
       "port-version": 2
     },
     "cleishm-frequency-cpp": {
-      "baseline": "1.0.0",
+      "baseline": "1.1.2",
       "port-version": 0
     },
     "cleishm-thermo-cpp": {

--- a/versions/c-/cleishm-frequency-cpp.json
+++ b/versions/c-/cleishm-frequency-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d105319506bd27d7c670511b1305eb763aae850",
+      "version": "1.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "a4860db2c83e3f152aa6c2277d9add44250c14a0",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/cleishm/frequency-cpp/releases/tag/v1.1.2
https://github.com/cleishm/frequency-cpp/releases/tag/v1.1.0
