### PR TITLE
[nanovg] Update to 2023-08-26

### DIFF
--- a/ports/nanovg/portfile.cmake
+++ b/ports/nanovg/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO memononen/nanovg
-    REF 1f9c8864fc556a1be4d4bf1d6bfe20cde25734b4
-    SHA512 99a44f01114ee653a966d4695596886240752f5a06d540c408b5aeaebdcc5360fc2043276515695580d048649a20dc50409107f89c4ce506d2ccb83a0635d29f
+    REF f93799c078fa11ed61c078c65a53914c8782c00b
+    SHA512 06f55e574ac3f73f2abe6cc614e13f29d27f2e05b2a035a19084fbf69f73cc0571d808a323cd07d25f0f1cb3097bef83d10d4315999ff21d6d3c8eee494dd7fb
     HEAD_REF master
 )
 
@@ -21,7 +21,9 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
-                    "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/nanovg/vcpkg.json
+++ b/ports/nanovg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nanovg",
-  "version-date": "2019-08-30",
-  "port-version": 6,
+  "version-date": "2023-08-26",
   "description": "NanoVG is small antialiased vector graphics rendering library for OpenGL.",
   "homepage": "https://github.com/memononen/nanovg",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6757,8 +6757,8 @@
       "port-version": 0
     },
     "nanovg": {
-      "baseline": "2019-08-30",
-      "port-version": 6
+      "baseline": "2023-08-26",
+      "port-version": 0
     },
     "nativefiledialog-extended": {
       "baseline": "1.3.0",

--- a/versions/n-/nanovg.json
+++ b/versions/n-/nanovg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a33041d78528c4573881c3b494d41c939d16c3a",
+      "version-date": "2023-08-26",
+      "port-version": 0
+    },
+    {
       "git-tree": "be98decc778a823aedeec9c8c74ff6a3398f7642",
       "version-date": "2019-08-30",
       "port-version": 6


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.