### PR TITLE
[ncnn] Update to 20260113

### DIFF
--- a/ports/ncnn/portfile.cmake
+++ b/ports/ncnn/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Tencent/ncnn
     REF "${VERSION}"
-    SHA512 bb20d8ece3dcddf49530e1ca44eaad1045702b5fb7a7c9cfd6754eb158c7349bba7d63a3ef1e1a4a6e30ed59622367b802f98bf8343bd30ff0cb6def734757c4
+    SHA512 53de1d8c7b6ea3bdc01eeb1c742fecbf53ba1ec975087814197a270c8a2c104c3f48c81849631ca4460f9d875c45bba7e5e52ff572d0a86131c792867ee0a1f3
     HEAD_REF master
 )
 
@@ -22,6 +22,7 @@ vcpkg_cmake_configure(
         -DNCNN_BUILD_EXAMPLES=OFF
         -DNCNN_BUILD_BENCHMARK=OFF
         -DNCNN_SHARED_LIB=${BUILD_SHARED}
+        --trace-expand
 )
 
 vcpkg_cmake_install()

--- a/ports/ncnn/vcpkg.json
+++ b/ports/ncnn/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ncnn",
-  "version": "20250916",
+  "version": "20260113",
   "description": "ncnn is a high-performance neural network inference computing framework.",
   "homepage": "https://github.com/Tencent/ncnn",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6773,7 +6773,7 @@
       "port-version": 2
     },
     "ncnn": {
-      "baseline": "20250916",
+      "baseline": "20260113",
       "port-version": 0
     },
     "ncurses": {

--- a/versions/n-/ncnn.json
+++ b/versions/n-/ncnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e5ad152f805f8bf87a95fe279c77d721f51a83f",
+      "version": "20260113",
+      "port-version": 0
+    },
+    {
       "git-tree": "279f3db36dbce2acd9a68108270c4ff0980d7638",
       "version": "20250916",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.