### PR TITLE
[idyntree] Update to 15.0.0

### DIFF
--- a/ports/idyntree/portfile.cmake
+++ b/ports/idyntree/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO robotology/idyntree
     REF "v${VERSION}"
-    SHA512 7aa527e2af743a7aa34023280292c742c756d34dbb51cb03ff5a6fa71e93d308e70788c69bcc321dfbfa6ddad0315bab28b44e8c9b3e64163d36bc3641e892f9
+    SHA512 bfcdddebb2ae3d5b9e75cea799d4dfb6ad745d26eb220419c9795c30397ee400dce7669546fe78aadbab49e29be48b3ecece7bb972c1032d04f6b621a1d5bcf0
     HEAD_REF master
 )
 

--- a/ports/idyntree/vcpkg.json
+++ b/ports/idyntree/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "idyntree",
-  "version": "14.3.0",
+  "version": "15.0.0",
   "description": "Multibody Dynamics Library designed for Free Floating Robots.",
   "homepage": "https://github.com/robotology/idyntree",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3869,7 +3869,7 @@
       "port-version": 0
     },
     "idyntree": {
-      "baseline": "14.3.0",
+      "baseline": "15.0.0",
       "port-version": 0
     },
     "if97": {

--- a/versions/i-/idyntree.json
+++ b/versions/i-/idyntree.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b70b0d455deea770d50782417c9e6dff30d729b",
+      "version": "15.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "70a105f6a5fc8f8994850bdfa22e7e32c13795ca",
       "version": "14.3.0",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
