### PR TITLE
[onednn] Update to 3.11

### DIFF
--- a/ports/onednn/portfile.cmake
+++ b/ports/onednn/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oneapi-src/oneDNN
     REF "v${VERSION}"
-    SHA512 2a7505cd06a379a2050f99fac990dcaa65a80b8bd864b00712304379383ac02603cec1d956c5178b5c1dc075fdcf52b3043acf766c2d8a714ac2b927b7dc5e06
+    SHA512 de60ecd881b97e9942441e0eb5c53e2caa2a0a1a1c78ab9211ab103244b66b62c0f3dfa5b322bb2c39dfe13f85a9aebf82b899dde1ccdc01ba8ff9deed832787
     HEAD_REF master
 )
 
@@ -12,10 +12,11 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${DNNL_OPTIONS}
+    OPTIONS
         -DDNNL_BUILD_DOC=OFF
         -DDNNL_BUILD_EXAMPLES=OFF
         -DDNNL_BUILD_TESTS=OFF
+        ${DNNL_OPTIONS}
 )
 vcpkg_cmake_install()
 

--- a/ports/onednn/vcpkg.json
+++ b/ports/onednn/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "onednn",
-  "version": "3.7",
+  "version": "3.11",
   "description": "oneAPI Deep Neural Network Library (oneDNN)",
   "homepage": "https://github.com/oneapi-src/oneDNN",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7113,7 +7113,7 @@
       "port-version": 0
     },
     "onednn": {
-      "baseline": "3.7",
+      "baseline": "3.11",
       "port-version": 0
     },
     "oniguruma": {

--- a/versions/o-/onednn.json
+++ b/versions/o-/onednn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4cf82b6c624515a6044809dc76136cb9271613b1",
+      "version": "3.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "21894fd2829583297a01535fb83a09f77afa5ff2",
       "version": "3.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
