### PR TITLE
Improve PR instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 - [ ] SHA512s are updated for each updated download.
 - [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
 - [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
-- [ ] If any patches are no longer applied, they are deleted from the port's directory. Check this if no patches were removed.
+- [ ] All patch files in the port are applied and succeed.
 - [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
 - [ ] Exactly one version is added in each modified versions file.
 
@@ -17,16 +17,16 @@ END OF PORT UPDATE CHECKLIST (delete this line) -->
 <!-- If this PR adds a new port, please uncomment and fill out this checklist:
 
 - [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
-- [ ] The name of the port meets one of the following alternatives:
-    - [ ] This component on https://repology.org/ is REPLACE-WITH-MATCHING-LINK
-    - [ ] This component is strongly associated with that name in web searches of the name, or "name c++". Include a screenshot of the search engine results in the PR.
-    - [ ] This component follows the 'GitHubOrg-GitHubRepo' form
+- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
+    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
+    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
+    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
 - [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or controlled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg).
 - [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
 - [ ] The license declaration in `vcpkg.json` matches what upstream says.
 - [ ] The installed as the "copyright" file matches what upstream says.
 - [ ] The source code of the component installed comes from an authoritative source.
-- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the default generated usage is correct.
+- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
 - [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
 - [ ] Exactly one version is added in each modified versions file.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ END OF PORT UPDATE CHECKLIST (delete this line) -->
     - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
     - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
     - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
-- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or controlled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg).
+- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
 - [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
 - [ ] The license declaration in `vcpkg.json` matches what upstream says.
 - [ ] The installed as the "copyright" file matches what upstream says.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,26 +6,28 @@
 
 - [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
 - [ ] SHA512s are updated for each updated download.
-- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
-- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
-- [ ] Any patches that are no longer applied are deleted from the port's directory.
+- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
+- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
+- [ ] If any patches are no longer applied, they are deleted from the port's directory. Check this if no patches were removed.
 - [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
-- [ ] Only one version is added to each modified port's versions file.
+- [ ] Exactly one version is added in each modified versions file.
 
 END OF PORT UPDATE CHECKLIST (delete this line) -->
 
 <!-- If this PR adds a new port, please uncomment and fill out this checklist:
 
 - [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
-- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
-- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
+- [ ] The name of the port meets one of the following alternatives:
+    - [ ] This component on https://repology.org/ is REPLACE-WITH-MATCHING-LINK
+    - [ ] This component is strongly associated with that name in web searches of the name, or "name c++". Include a screenshot of the search engine results in the PR.
+    - [ ] This component follows the 'GitHubOrg-GitHubRepo' form
+- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or controlled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg).
 - [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
 - [ ] The license declaration in `vcpkg.json` matches what upstream says.
 - [ ] The installed as the "copyright" file matches what upstream says.
 - [ ] The source code of the component installed comes from an authoritative source.
-- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
+- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the default generated usage is correct.
 - [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
-- [ ] Only one version is in the new port's versions file.
-- [ ] Only one version is added to each modified port's versions file.
+- [ ] Exactly one version is added in each modified versions file.
 
 END OF NEW PORT CHECKLIST (delete this line) -->


### PR DESCRIPTION
* Get update contributors to check boxes they actually did because they were vacuous.
* Get people claiming that they comply with the naming policy to prove it. There have been WAY too many people checking this box without actually doing it recently.
* Suggest `VCPKG_LOCK_FIND_PACKAGE`. Thanks @dg0yt !
* Acknowledge the existence of `ci.feature.baseline.txt`.
* Note that a usage file should not be added if the automatic one works.
