### PR TITLE
[arrow-adbc] Use official ASF archive URL

### DIFF
--- a/ports/arrow-adbc/portfile.cmake
+++ b/ports/arrow-adbc/portfile.cmake
@@ -1,9 +1,12 @@
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO apache/arrow-adbc
-    REF apache-arrow-adbc-${VERSION}
-    SHA512 59cccbeeefa295d69cacfa8851b621376106aca57ebd94291523fcca314c0bd10c1d296801d1eacce9edddd46a8c87deaf3d8367e32ba5fd5b322b34c6af8625
-    HEAD_REF main
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://archive.apache.org/dist/arrow/apache-arrow-adbc-${VERSION}/apache-arrow-adbc-${VERSION}.tar.gz"
+    FILENAME "apache-arrow-adbc-${VERSION}.tar.gz"
+    SHA512 86bc77b5e1fba2a8616614e9f7077e2e966165e28ff6fd4c7e96f4538ce3ac7f705da2e528515384870565ebbd0ec8ce27d45234446d2985d357111a25e51d13
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         fix_static_build.patch
         fix_windows_build.patch

--- a/ports/arrow-adbc/vcpkg.json
+++ b/ports/arrow-adbc/vcpkg.json
@@ -49,5 +49,6 @@
         "sqlite3"
       ]
     }
-  }
+  },
+  "port-version": 1
 }

--- a/versions/a-/arrow-adbc.json
+++ b/versions/a-/arrow-adbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1cc11a24b15146b904b2c244c8915709cce71c67",
+      "version": "16",
+      "port-version": 1
+    },
+    {
       "git-tree": "a74b6472fa61b1a1d88ff337b26150642bcdf68f",
       "version": "16",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -294,7 +294,7 @@
     },
     "arrow-adbc": {
       "baseline": "16",
-      "port-version": 0
+      "port-version": 1
     },
     "arsenalgear": {
       "baseline": "2.1.1",


### PR DESCRIPTION
## Summary
- Use official ASF archive URL for the `arrow-adbc` port
- Source is now downloaded from `archive.apache.org/dist/` instead of GitHub
- This ensures downloads use the canonical Apache Software Foundation distribution point

## Details
The Apache Software Foundation distributes official releases through
`https://archive.apache.org/dist/`. Using GitHub as a download source
is discouraged because:
1. GitHub tarballs are not the official ASF releases
2. GitHub-generated tarballs may differ from official release artifacts
3. The ASF archive is the canonical, permanent source for releases

## Checklist
- [x] SHA512 hash verified against downloaded tarball
- [x] Port-version bumped
- [x] Version database updated