### PR TITLE
[arrow-adbc] Use official ASF archive URL

### DIFF
--- a/ports/arrow-adbc/portfile.cmake
+++ b/ports/arrow-adbc/portfile.cmake
@@ -26,6 +26,21 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" ADBC_BUILD_SHARED)
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "static" ADBC_BUILD_STATIC)
 
+set(ADBC_NEEDS_GO OFF)
+if("flightsql" IN_LIST FEATURES OR "snowflake" IN_LIST FEATURES OR "bigquery" IN_LIST FEATURES)
+    set(ADBC_NEEDS_GO ON)
+endif()
+
+if(ADBC_NEEDS_GO)
+    vcpkg_find_acquire_program(GO)
+    get_filename_component(GO_EXE_PATH "${GO}" DIRECTORY)
+    vcpkg_add_to_path("${GO_EXE_PATH}")
+    # Ensure GOMODCACHE is writable (needed in containerized CI environments)
+    if(NOT DEFINED ENV{GOMODCACHE})
+        set(ENV{GOMODCACHE} "${CURRENT_BUILDTREES_DIR}/go-cache")
+    endif()
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/c
     OPTIONS

--- a/ports/arrow-adbc/portfile.cmake
+++ b/ports/arrow-adbc/portfile.cmake
@@ -1,9 +1,12 @@
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO apache/arrow-adbc
-    REF apache-arrow-adbc-${VERSION}
-    SHA512 59cccbeeefa295d69cacfa8851b621376106aca57ebd94291523fcca314c0bd10c1d296801d1eacce9edddd46a8c87deaf3d8367e32ba5fd5b322b34c6af8625
-    HEAD_REF main
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://archive.apache.org/dist/arrow/apache-arrow-adbc-${VERSION}/apache-arrow-adbc-${VERSION}.tar.gz"
+    FILENAME "apache-arrow-adbc-${VERSION}.tar.gz"
+    SHA512 86bc77b5e1fba2a8616614e9f7077e2e966165e28ff6fd4c7e96f4538ce3ac7f705da2e528515384870565ebbd0ec8ce27d45234446d2985d357111a25e51d13
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         fix_static_build.patch
         fix_windows_build.patch

--- a/ports/arrow-adbc/vcpkg.json
+++ b/ports/arrow-adbc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "arrow-adbc",
   "version": "16",
+  "port-version": 1,
   "description": "Apache Arrow ADBC: Database Connectivity API for Arrow-based data systems",
   "homepage": "https://arrow.apache.org/adbc/",
   "license": "Apache-2.0",

--- a/versions/a-/arrow-adbc.json
+++ b/versions/a-/arrow-adbc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8613b6b373e9cb1a9b889f9f061e8a5351bd0dfd",
+      "git-tree": "629876ab58aae94be54b47bb1238d11acaf45a58",
       "version": "16",
       "port-version": 1
     },

--- a/versions/a-/arrow-adbc.json
+++ b/versions/a-/arrow-adbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8613b6b373e9cb1a9b889f9f061e8a5351bd0dfd",
+      "version": "16",
+      "port-version": 1
+    },
+    {
       "git-tree": "a74b6472fa61b1a1d88ff337b26150642bcdf68f",
       "version": "16",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -294,7 +294,7 @@
     },
     "arrow-adbc": {
       "baseline": "16",
-      "port-version": 0
+      "port-version": 1
     },
     "arsenalgear": {
       "baseline": "2.1.1",


### PR DESCRIPTION
Switch the `arrow-adbc` port to download source from the official
Apache Software Foundation archive at `archive.apache.org/dist/`
instead of using `vcpkg_from_github`.

The ASF archive is the canonical, permanent distribution point for
Apache project releases. GitHub-generated tarballs may differ from
official release artifacts.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.