### PR TITLE
[apache-datasketches] Use official ASF archive URL

### DIFF
--- a/ports/apache-datasketches/portfile.cmake
+++ b/ports/apache-datasketches/portfile.cmake
@@ -1,9 +1,12 @@
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO apache/datasketches-cpp
-    REF "${VERSION}"
-    SHA512 a5b51aa70d07ee14f79ba7220ba2d423e714e5486d549feb5660b91a63ac775ccc0c877d636577414ae8e45bd38f639f0a6d6453efa310550b89631dedcf9b6f
-    HEAD_REF master
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://archive.apache.org/dist/datasketches/cpp/${VERSION}/apache-datasketches-cpp-${VERSION}-src.zip"
+    FILENAME "apache-datasketches-cpp-${VERSION}-src.zip"
+    SHA512 98ce350e63fff02ac1ab39005a808ad0ab0b308f0807464db235fe9e6cb6dd8f5081494bd0aca85eeec5216f6a6a23280b732e714da9ad6f53690dd9da9c430c
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port

--- a/ports/apache-datasketches/vcpkg.json
+++ b/ports/apache-datasketches/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "apache-datasketches",
   "version": "5.2.0",
+  "port-version": 1,
   "description": "Apache DataSketches Core C++ Library Component.",
   "homepage": "https://datasketches.apache.org/",
   "license": "Apache-2.0",

--- a/versions/a-/apache-datasketches.json
+++ b/versions/a-/apache-datasketches.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8942c6b225218c416ae95315d3952592e3e993d3",
+      "version": "5.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4577e1a537f65a2d1696f7b00ca60658e6d0f12f",
       "version": "5.2.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -182,7 +182,7 @@
     },
     "apache-datasketches": {
       "baseline": "5.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "approval-tests-cpp": {
       "baseline": "10.13.0",


### PR DESCRIPTION
Switch the `apache-datasketches` port to download source from the official
Apache Software Foundation archive at `archive.apache.org/dist/`
instead of using `vcpkg_from_github`.

The ASF archive is the canonical, permanent distribution point for
Apache project releases. GitHub-generated tarballs may differ from
official release artifacts.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.