### PR TITLE
[avro-cpp] Use official ASF archive URL

### DIFF
--- a/ports/avro-cpp/portfile.cmake
+++ b/ports/avro-cpp/portfile.cmake
@@ -1,9 +1,12 @@
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO apache/avro
-    REF "release-${VERSION}"
-    SHA512 4e7fd7ebb41f6149a499d0d38babd99d07f936143b47a60f7c568a589fb0e6369301c7230bde518b554eaeaa9ded1ed1fae2661cbd5ebc49fb5f22d97c066f05
-    HEAD_REF master
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://archive.apache.org/dist/avro/avro-${VERSION}/avro-src-${VERSION}.tar.gz"
+    FILENAME "avro-src-${VERSION}.tar.gz"
+    SHA512 0d86bfece0f12f8bc424e27e71e3e6b828c4280fa1a6d7dc7e0d58bff2351f2c1fd3ccb98c1291dfc6c67d9cb5a0bdb7bb9f36ba5bd6b26fa9545f358db42663
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         fix-cmake.patch
 )

--- a/ports/avro-cpp/vcpkg.json
+++ b/ports/avro-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "avro-cpp",
   "version": "1.12.1",
+  "port-version": 1,
   "description": "Apache Avro is a data serialization system",
   "homepage": "https://github.com/apache/avro",
   "license": "Apache-2.0",

--- a/versions/a-/avro-cpp.json
+++ b/versions/a-/avro-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f85aad132aa9fd6a464be359fa7359b9633c780",
+      "version": "1.12.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "05e75f00bd2a82451f3c9853885676592eef023f",
       "version": "1.12.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -446,7 +446,7 @@
     },
     "avro-cpp": {
       "baseline": "1.12.1",
-      "port-version": 0
+      "port-version": 1
     },
     "awlib": {
       "baseline": "2024-04-06",


### PR DESCRIPTION
Switch the `avro-cpp` port to download source from the official
Apache Software Foundation archive at `archive.apache.org/dist/`
instead of using `vcpkg_from_github`.

The ASF archive is the canonical, permanent distribution point for
Apache project releases. GitHub-generated tarballs may differ from
official release artifacts.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.