### PR TITLE
[brpc] Use official ASF archive URL

### DIFF
--- a/ports/brpc/portfile.cmake
+++ b/ports/brpc/portfile.cmake
@@ -5,12 +5,15 @@ vcpkg_download_distfile(
     FILENAME 8d87814330d9ebbfe5b95774fdb71056fcb3170c.patch
 )
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO apache/brpc
-    REF "${VERSION}"
-    SHA512 93366c2b073de8a1af5ededa9ef5a6803ccd393bbb5fe1f9872c230e4997995759517fa4dd1a51ffd120a5c9040dcb00b1c580c5ccf032dd70561c0c3283f990
-    HEAD_REF master
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://archive.apache.org/dist/brpc/${VERSION}/apache-brpc-${VERSION}-src.tar.gz"
+    FILENAME "apache-brpc-${VERSION}-src.tar.gz"
+    SHA512 cf7e252b2132f134bc881aa3fa2faef274811900a1cfb72c48f1488b40fa1d3214b2ba1def0681a7b177f6e87b4534b9a15337f90f9119e6a483f71cdd6cd826
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         fix-build.patch
         fix-warnings.patch

--- a/ports/brpc/vcpkg.json
+++ b/ports/brpc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "brpc",
   "version": "1.15.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Industrial-grade RPC framework used throughout Baidu, with 1,000,000+ instances and thousands kinds of services, called \"baidu-rpc\" inside Baidu.",
   "homepage": "https://github.com/apache/brpc",
   "license": "Apache-2.0",

--- a/versions/b-/brpc.json
+++ b/versions/b-/brpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8b35ed11d075c696cfab16282a900f422ebf725",
+      "version": "1.15.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "89120d70f29486c1ce7bf96454649b85d895fcdf",
       "version": "1.15.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1494,7 +1494,7 @@
     },
     "brpc": {
       "baseline": "1.15.0",
-      "port-version": 1
+      "port-version": 2
     },
     "brunocodutra-metal": {
       "baseline": "2.1.4",


### PR DESCRIPTION
Switch the `brpc` port to download source from the official
Apache Software Foundation archive at `archive.apache.org/dist/`
instead of using `vcpkg_from_github`.

The ASF archive is the canonical, permanent distribution point for
Apache project releases. GitHub-generated tarballs may differ from
official release artifacts.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.