### PR TITLE
[nanoarrow] Use official ASF archive URL

### DIFF
--- a/ports/nanoarrow/portfile.cmake
+++ b/ports/nanoarrow/portfile.cmake
@@ -1,10 +1,13 @@
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO apache/arrow-nanoarrow
-    REF "a579fbf5d192e85b6249935e117de7d02a6dc4e9"
-    SHA512 9e08268c73a1743e964c58038fbc9b175705dc1a83e3436d468dc66571f4cad8d31d55ffa0c2b9d7a9c340a93f225e34bdd13d259571cfd8809b8add448e5624
-    HEAD_REF main
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://archive.apache.org/dist/arrow/apache-arrow-nanoarrow-${VERSION}/apache-arrow-nanoarrow-${VERSION}.tar.gz"
+    FILENAME "apache-arrow-nanoarrow-${VERSION}.tar.gz"
+    SHA512 98f9f4c8dada0175e39e02d2baa01d0f63ad94636925cd289cbffa423de26bf0ede437aaa1ec10ff91e7d375e72cfddd950d040602520ab7891ab4c6337ce4f7
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/thirdparty")

--- a/ports/nanoarrow/vcpkg.json
+++ b/ports/nanoarrow/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nanoarrow",
   "version": "0.8.0",
+  "port-version": 1,
   "description": "Helpers for Arrow C Data & Arrow C Stream interfaces",
   "homepage": "https://arrow.apache.org/nanoarrow",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6710,7 +6710,7 @@
     },
     "nanoarrow": {
       "baseline": "0.8.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nanobench": {
       "baseline": "4.3.11",

--- a/versions/n-/nanoarrow.json
+++ b/versions/n-/nanoarrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9c1146b9c9360cc05905f6ecd1bff7ba0fb9cf73",
+      "version": "0.8.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5e1df005c16a740f30674ee940e55add69c7896b",
       "version": "0.8.0",
       "port-version": 0


### PR DESCRIPTION
Switch the `nanoarrow` port to download source from the official
Apache Software Foundation archive at `archive.apache.org/dist/`
instead of using `vcpkg_from_github`.

The ASF archive is the canonical, permanent distribution point for
Apache project releases. GitHub-generated tarballs may differ from
official release artifacts.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.