### PR TITLE
[orc] Use official ASF archive URL

### DIFF
--- a/ports/orc/portfile.cmake
+++ b/ports/orc/portfile.cmake
@@ -1,11 +1,14 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO apache/orc
-    REF "v${VERSION}"
-    SHA512 43353b3c2ac752b388518de017ae9363f45088b9abe995ec0d740575c2b8514b14e0aca36454aab7cbb9d8adf7c93be188317a5997d8931b8ecf9f0a81a59553
-    HEAD_REF main
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://archive.apache.org/dist/orc/orc-${VERSION}/orc-${VERSION}.tar.gz"
+    FILENAME "orc-${VERSION}.tar.gz"
+    SHA512 6be97bf80ca89765bfecdb7d24b7f2967af79f2cbf659ce835ab9345e2a356400942143f4c6b3c25e6ded1f5df811bd6be6d1005e8b99716d842b43072f61786
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         external-project.diff
         tools-build.diff

--- a/ports/orc/vcpkg.json
+++ b/ports/orc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "orc",
   "version": "2.2.2",
+  "port-version": 1,
   "description": "The smallest, fastest columnar storage for Hadoop workloads.",
   "homepage": "https://orc.apache.org/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7358,7 +7358,7 @@
     },
     "orc": {
       "baseline": "2.2.2",
-      "port-version": 0
+      "port-version": 1
     },
     "orefkov-simstr": {
       "baseline": "1.6.6",

--- a/versions/o-/orc.json
+++ b/versions/o-/orc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b2e0ea633827bba3347f9e976a10028d6e0442da",
+      "version": "2.2.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "7e8ef729096ecae101ac7f536c3f83394f3de4b3",
       "version": "2.2.2",
       "port-version": 0


### PR DESCRIPTION
Switch the `orc` port to download source from the official
Apache Software Foundation archive at `archive.apache.org/dist/`
instead of using `vcpkg_from_github`.

The ASF archive is the canonical, permanent distribution point for
Apache project releases. GitHub-generated tarballs may differ from
official release artifacts.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.