### PR TITLE
[qpid-proton] Use official ASF archive URL

### DIFF
--- a/ports/qpid-proton/portfile.cmake
+++ b/ports/qpid-proton/portfile.cmake
@@ -1,11 +1,14 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO apache/qpid-proton
-    REF "${VERSION}"
-    SHA512 ce24a92d623c9e56666128e243bc58acdbff8f7dfac1f728fdbd97a2c3ec21135b8c2a79c3e13920ca0d52545819766b90fc6aca35318b754eedf5ae5329ff36 
-    HEAD_REF next
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://archive.apache.org/dist/qpid/proton/${VERSION}/qpid-proton-${VERSION}.tar.gz"
+    FILENAME "qpid-proton-${VERSION}.tar.gz"
+    SHA512 3e7fe56ca1423f45f71d81f5e1d6ec5f21c073cc580628e12a8dbd545a86805b7312834e0d1234dde43797633d575ed639f21a96239b217500cc0a824482aae3
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         early-cxx.diff
         fix-dependencies.patch

--- a/ports/qpid-proton/vcpkg.json
+++ b/ports/qpid-proton/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qpid-proton",
   "version": "0.40.0",
+  "port-version": 1,
   "description": "Qpid Proton is a high-performance, lightweight messaging library.",
   "homepage": "https://github.com/apache/qpid-proton",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7978,7 +7978,7 @@
     },
     "qpid-proton": {
       "baseline": "0.40.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qpoases": {
       "baseline": "3.2.2",

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "91f0848a3d2c3cb00401d40615e98ad202f72419",
+      "version": "0.40.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "fa587ba9e7e884370056a0c9cd66f9a634a3af4a",
       "version": "0.40.0",
       "port-version": 0


### PR DESCRIPTION
Switch the `qpid-proton` port to download source from the official
Apache Software Foundation archive at `archive.apache.org/dist/`
instead of using `vcpkg_from_github`.

The ASF archive is the canonical, permanent distribution point for
Apache project releases. GitHub-generated tarballs may differ from
official release artifacts.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.