### PR TITLE
[thrift] Use official ASF archive URL

### DIFF
--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -9,15 +9,18 @@ endif()
 vcpkg_find_acquire_program(FLEX)
 vcpkg_find_acquire_program(BISON)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO apache/thrift
-    REF "v${VERSION}"
-    SHA512 6dedcf48a8900e3a1dabfa73a4577a4d2482527b45ad8b77fec3fa7fdd8ea21b9249b3602c1e3e54bcee98143a9bb325b59e345423dc6dd8c9365889095615e2
-    HEAD_REF master
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://archive.apache.org/dist/thrift/${VERSION}/thrift-${VERSION}.tar.gz"
+    FILENAME "thrift-${VERSION}.tar.gz"
+    SHA512 beb37ee2a295fae7df12cce6449c92799076771bae515fafcc790a62ac6e76ac5584f102315d466b8f5f98e236c9dc4a244695bdcd9f1392d6e9a13d365ddadc
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
-      "pc-suffix.patch"
-      "fix_missing_quotes_in_config_and_bin_path.patch"
+        pc-suffix.patch
+        fix_missing_quotes_in_config_and_bin_path.patch
 )
 
 if (VCPKG_TARGET_IS_OSX)

--- a/ports/thrift/vcpkg.json
+++ b/ports/thrift/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "thrift",
   "version": "0.22.0",
+  "port-version": 1,
   "description": "Apache Thrift is a software project spanning a variety of programming languages and use cases. Our goal is to make reliable, performant communication and data serialization across languages as efficient and seamless as possible.",
   "homepage": "https://github.com/apache/thrift",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9830,7 +9830,7 @@
     },
     "thrift": {
       "baseline": "0.22.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tidy-html5": {
       "baseline": "5.8.0",

--- a/versions/t-/thrift.json
+++ b/versions/t-/thrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "37ecae27a996313cbd6862b3c33aa026eda52692",
+      "version": "0.22.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4c4faad4f1e351534a8114aa84d5ab1dee2e025f",
       "version": "0.22.0",
       "port-version": 0


### PR DESCRIPTION
Switch the `thrift` port to download source from the official
Apache Software Foundation archive at `archive.apache.org/dist/`
instead of using `vcpkg_from_github`.

The ASF archive is the canonical, permanent distribution point for
Apache project releases. GitHub-generated tarballs may differ from
official release artifacts.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.