### PR TITLE
[xerces-c] Use official ASF archive URL

### DIFF
--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -1,10 +1,13 @@
 vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO apache/xerces-c
-    REF "v${VERSION}"
-    SHA512 228f7b35ca219a2d5202b853983fd2941325413724f9cfbb8d0056bb81669c4530a792323f60736e4f6bf2c4f289fab21d6e2107e9ba65438437ae19b374b4a8
-    HEAD_REF master
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${VERSION}.tar.gz"
+    FILENAME "xerces-c-${VERSION}.tar.gz"
+    SHA512 b93110d2ac2f2198b3afb8854a1999376ac687c2be1e6c1b75c7d848c946c81c78f735f71eb2f824e11a493a58c67b7855c74b422a393d3ecc7c2bda103e5b27
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         dependencies.patch
         disable-tests.patch

--- a/ports/xerces-c/vcpkg.json
+++ b/ports/xerces-c/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "xerces-c",
   "version-semver": "3.3.0",
+  "port-version": 1,
   "description": "Xerces-C++ is a XML parser, for parsing, generating, manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.",
   "homepage": "https://github.com/apache/xerces-c",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10826,7 +10826,7 @@
     },
     "xerces-c": {
       "baseline": "3.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "xeus": {
       "baseline": "0.24.3",

--- a/versions/x-/xerces-c.json
+++ b/versions/x-/xerces-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8cff02f80634e4cf6c3a788a296e0cff49108363",
+      "version-semver": "3.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "47ca04adf7071f0db4fd56a909439110fbe4eae2",
       "version-semver": "3.3.0",
       "port-version": 0


### PR DESCRIPTION
Switch the `xerces-c` port to download source from the official
Apache Software Foundation archive at `archive.apache.org/dist/`
instead of using `vcpkg_from_github`.

The ASF archive is the canonical, permanent distribution point for
Apache project releases. GitHub-generated tarballs may differ from
official release artifacts.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.