### PR TITLE
[libbson, mongo-c-driver] update to 2.2.2; [mongo-cxx-driver] update to 4.1.4

### DIFF
--- a/ports/libbson/fix-include-directory.patch
+++ b/ports/libbson/fix-include-directory.patch
@@ -1,13 +1,13 @@
 diff --git a/src/libbson/CMakeLists.txt b/src/libbson/CMakeLists.txt
-index e3eaca4..ef3644b 100644
+index 47bb0bd72f..ea76b75425 100644
 --- a/src/libbson/CMakeLists.txt
 +++ b/src/libbson/CMakeLists.txt
-@@ -302,7 +302,7 @@ endif () # ENABLE_EXAMPLES
- # 8888888 888  888  88888P'  "Y888 "Y888888 888 888
+@@ -300,7 +300,7 @@ endif () # ENABLE_EXAMPLES
  
- set (BSON_HEADER_INSTALL_DIR
--   "${CMAKE_INSTALL_INCLUDEDIR}/libbson-${BSON_API_VERSION}"
-+   "${CMAKE_INSTALL_INCLUDEDIR}"
- )
- function(install_export_target target)
-    # Tell pkg-config where the headers are going:
+ # Infix directory for all libbson headers.
+ if(NOT DEFINED BSON_INSTALL_INCLUDEDIR)
+-   set(BSON_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/bson-${PROJECT_VERSION}")
++   set(BSON_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+ endif()
+ # Infix directory for all libbson CMake package files
+ if(NOT DEFINED BSON_INSTALL_CMAKEDIR)

--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 2b4c1b1ff414f4a33abea4f032fdeb90e63b5bc279b5b9dac98132892d8922c81146279934e6e872926109a0639fa6a2b3a0a021e2f70683e99c56a5ffd66c4d
+    SHA512 1f1346a52db7241af832d7d5db107512a73af75546818e6600e420505f48c613b08cc332e76337670fe4b19ca057a2b04385b05279e76385adcf42276190123a
     HEAD_REF master
     PATCHES
         fix-include-directory.patch # vcpkg legacy decision
@@ -43,15 +43,10 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME bson-1.0 CONFIG_PATH "lib/cmake/bson-1.0" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_cmake_config_fixup(PACKAGE_NAME "bson-${VERSION}" CONFIG_PATH "lib/cmake/bson-${VERSION}")
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/bson/bson-macros.h"
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/bson/macros.h"
         "#define BSON_MACROS_H" "#define BSON_MACROS_H\n#ifndef BSON_STATIC\n#define BSON_STATIC\n#endif")
-    vcpkg_cmake_config_fixup(PACKAGE_NAME libbson-static-1.0 CONFIG_PATH "lib/cmake/libbson-static-1.0")
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/libbson-1.0")
-    file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/libbson-1.0-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libbson-1.0")
-else()
-    vcpkg_cmake_config_fixup(PACKAGE_NAME libbson-1.0 CONFIG_PATH "lib/cmake/libbson-1.0")
 endif()
 
 file(REMOVE_RECURSE

--- a/ports/libbson/usage
+++ b/ports/libbson/usage
@@ -1,4 +1,4 @@
 libbson provides CMake targets:
 
-    find_package(bson-1.0 CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:mongo::bson_static>,mongo::bson_static,mongo::bson_shared>)
+    find_package(bson CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:bson::static>,bson::static,bson::shared>)

--- a/ports/libbson/vcpkg.json
+++ b/ports/libbson/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libbson",
-  "version": "1.30.7",
+  "version": "2.2.2",
   "description": "libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.",
   "homepage": "https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson",
   "license": null,

--- a/ports/mongo-c-driver/disable-dynamic-when-static.patch
+++ b/ports/mongo-c-driver/disable-dynamic-when-static.patch
@@ -1,35 +1,34 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3a40f52..d080479 100644
+index 773f1ebb92..56fc94794f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -358,11 +358,11 @@ if (USE_SYSTEM_LIBBSON)
+@@ -321,10 +321,10 @@ if (USE_SYSTEM_LIBBSON)
  
     set (USING_SYSTEM_BSON TRUE)
-    if (NOT TARGET mongo::bson_shared)
--           message (FATAL_ERROR "System libbson built without shared library target")
+    if (NOT TARGET bson::shared)
+-      message (FATAL_ERROR "System libbson built without shared library target")
 +
     endif ()
-    set (BSON_LIBRARIES mongo::bson_shared)
-    if (NOT TARGET mongo::bson_static)
--           message (FATAL_ERROR "System libbson built without static library target")
+    if (NOT TARGET bson::static)
+-      message (FATAL_ERROR "System libbson built without static library target")
 +
     endif ()
-    set (BSON_STATIC_LIBRARIES mongo::bson_static)
  endif ()
+ 
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index fcab819..be0bfb2 100644
+index 9b2c2f845d..65617c1736 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -889,7 +889,7 @@ set (
+@@ -862,7 +862,7 @@ set (
     "${mongo-c-driver_SOURCE_DIR}/src/uthash"
  )
  
 -if (ENABLE_SHARED)
 +if (NOT MONGOC_ENABLE_STATIC_BUILD)
-    add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
-    if(WIN32)
-       # Add resource-definition script for Windows shared library (.dll).
-@@ -966,7 +966,7 @@ if (ENABLE_SHARED)
+    add_library (mongoc_shared SHARED ${SOURCES} ${HEADERS})
+    add_library(mongoc::shared ALIAS mongoc_shared)
+    set_property(TARGET mongoc_shared PROPERTY EXPORT_NAME mongoc::shared)
+@@ -929,7 +929,7 @@ if (ENABLE_SHARED)
                 RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
     endif () # ENABLE_SHM_COUNTERS
  
@@ -37,8 +36,8 @@ index fcab819..be0bfb2 100644
 +endif () # NOT MONGOC_ENABLE_STATIC_BUILD
  
  if (MONGOC_ENABLE_STATIC_BUILD)
-    add_library (mongoc_static STATIC ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
-@@ -1364,7 +1364,7 @@ if (MONGOC_ENABLE_STATIC_INSTALL)
+    add_library (mongoc_static STATIC ${SOURCES} ${HEADERS})
+@@ -1338,7 +1338,7 @@ if (MONGOC_ENABLE_STATIC_INSTALL)
     list (APPEND TARGETS_TO_INSTALL mongoc_static)
  endif ()
  
@@ -46,20 +45,4 @@ index fcab819..be0bfb2 100644
 +if (NOT MONGOC_ENABLE_STATIC_BUILD)
     list (APPEND TARGETS_TO_INSTALL mongoc_shared)
  endif ()
- 
-@@ -1419,6 +1419,7 @@ endif()
- set_property(TARGET ${TARGETS_TO_INSTALL} APPEND PROPERTY pkg_config_INCLUDE_DIRECTORIES "${MONGOC_HEADER_INSTALL_DIR}")
- 
- # Deprecated alias for libmongoc-1.0.pc, see CDRIVER-2086.
-+if (NOT MONGOC_ENABLE_STATIC_BUILD)
- if (MONGOC_ENABLE_SSL)
-    configure_file (
-       ${CMAKE_CURRENT_SOURCE_DIR}/src/libmongoc-ssl-1.0.pc.in
-@@ -1429,6 +1430,7 @@ if (MONGOC_ENABLE_SSL)
-       DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-    )
- endif ()
-+endif ()
- 
- include (CMakePackageConfigHelpers)
  

--- a/ports/mongo-c-driver/fix-dependencies.patch
+++ b/ports/mongo-c-driver/fix-dependencies.patch
@@ -1,22 +1,8 @@
-diff --git a/build/cmake/libmongoc-static-1.0-config.cmake.in b/build/cmake/libmongoc-static-1.0-config.cmake.in
-index bec3163..a32d5f3 100644
---- a/build/cmake/libmongoc-static-1.0-config.cmake.in
-+++ b/build/cmake/libmongoc-static-1.0-config.cmake.in
-@@ -24,6 +24,9 @@ set (MONGOC_STATIC_VERSION_FULL @libmongoc_VERSION_FULL@)
- 
- include(CMakeFindDependencyMacro)
- find_dependency (mongoc-1.0)
-+if("@ENABLE_SNAPPY@" STREQUAL "ON")
-+    find_dependency(Snappy CONFIG)
-+endif()
- 
- set(MONGOC_STATIC_LIBRARY mongo::mongoc_static)
- set(MONGOC_STATIC_LIBRARIES mongo::mongoc_static)
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index 0a18f5a..5346a9d 100644
+index 9b2c2f845d..9cb6397d2e 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -50,7 +50,7 @@ endif ()
+@@ -52,7 +52,7 @@ endif ()
  set (ZLIB_INCLUDE_DIRS "")
  if (ENABLE_ZLIB MATCHES "SYSTEM|AUTO")
     message (STATUS "Searching for zlib CMake packages")
@@ -25,13 +11,13 @@ index 0a18f5a..5346a9d 100644
     if (ZLIB_FOUND)
        message (STATUS "   zlib found version \"${ZLIB_VERSION_STRING}\"")
        message (STATUS "   zlib include path \"${ZLIB_INCLUDE_DIRS}\"")
-@@ -468,10 +468,10 @@ else ()
+@@ -460,10 +460,10 @@ else ()
  endif ()
  
  # Sets SNAPPY_LIBRARIES and SNAPPY_INCLUDE_DIRS.
 -include (FindSnappy)
 -if (SNAPPY_INCLUDE_DIRS)
-+if(ENABLE_SNAPPY)
++if (ENABLE_SNAPPY)
 +   find_package(Snappy CONFIG REQUIRED)
 +   set(SNAPPY_LIBRARIES Snappy::snappy)
     set (MONGOC_ENABLE_COMPRESSION 1)
@@ -39,7 +25,7 @@ index 0a18f5a..5346a9d 100644
  endif ()
  
  mongo_bool01 (MONGOC_ENABLE_SHM_COUNTERS ENABLE_SHM_COUNTERS)
-@@ -759,7 +759,7 @@ set (STATIC_LIBRARIES
+@@ -780,7 +780,7 @@ set (STATIC_LIBRARIES
  )
  
  # utf8proc configuration
@@ -48,51 +34,50 @@ index 0a18f5a..5346a9d 100644
  set(UTF8PROC_INCLUDE_DIRS, "")
  if (USE_BUNDLED_UTF8PROC)
     set (
-@@ -955,7 +955,7 @@ if (MONGOC_ENABLE_STATIC_BUILD)
-    set_target_properties (mongoc_static PROPERTIES
-       VERSION 0.0.0
-       OUTPUT_NAME "${MONGOC_OUTPUT_BASENAME}-static-${MONGOC_API_VERSION}"
--      pkg_config_REQUIRES "libbson-static-1.0"
-+      pkg_config_REQUIRES "libbson-static-1.0 libutf8proc"
+@@ -913,7 +913,7 @@ if (ENABLE_SHARED)
+       OUTPUT_NAME "${MONGOC_OUTPUT_BASENAME}${PROJECT_VERSION_MAJOR}"
+       VERSION "${PROJECT_VERSION}"
+       SOVERSION "${PROJECT_VERSION_MAJOR}"
+-      pkg_config_REQUIRES "bson${PROJECT_VERSION_MAJOR}"
++      pkg_config_REQUIRES "bson${PROJECT_VERSION_MAJOR} libutf8proc"
        )
-    if(MONGOC_ENABLE_STATIC_INSTALL)
-       mongo_generate_pkg_config (mongoc_static FILENAME libmongoc-static-${MONGOC_API_VERSION}.pc INSTALL)
-diff --git a/src/libmongoc/src/mongoc-config.cmake b/src/libmongoc/src/mongoc-config.cmake
-index 31e6cbc..cdbb756 100644
---- a/src/libmongoc/src/mongoc-config.cmake
-+++ b/src/libmongoc/src/mongoc-config.cmake
-@@ -1,5 +1,8 @@
- include(CMakeFindDependencyMacro)
- find_dependency(bson-1.0 @libmongoc_VERSION@)
+    mongo_generate_pkg_config(mongoc_shared INSTALL RENAME mongoc${PROJECT_VERSION_MAJOR}.pc)
+ 
+diff --git a/src/libmongoc/etc/mongocConfig.cmake.in b/src/libmongoc/etc/mongocConfig.cmake.in
+index 14d7e4c7ed..1597473cee 100644
+--- a/src/libmongoc/etc/mongocConfig.cmake.in
++++ b/src/libmongoc/etc/mongocConfig.cmake.in
+@@ -48,6 +48,9 @@ include(CMakeFindDependencyMacro)
+ get_filename_component(__parent_dir "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
+ # Also import the `bson` package, to ensure its targets are also available
+ find_dependency(bson "${__mongoc_package_version}" HINTS ${__parent_dir})
 +if("@ENABLE_SNAPPY@")
 +    find_dependency(Snappy CONFIG)
 +endif()
  
- # If we need to import a TLS package for our imported targets, do that now:
- set(MONGOC_TLS_BACKEND [[@TLS_BACKEND@]])
-@@ -13,8 +16,6 @@ if(_tls_package)
-   set(CMAKE_MODULE_PATH "${_prev_path}")
- endif()
- 
--include("${CMAKE_CURRENT_LIST_DIR}/mongoc-targets.cmake")
--
- unset(_required)
- unset(_quiet)
- if(${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)
-@@ -29,9 +30,8 @@ if(NOT _mongoc_built_with_bundled_utf8proc AND NOT TARGET PkgConfig::PC_UTF8PROC
-   # libmongoc was compiled against an external utf8proc and links against a
-   # FindPkgConfig-generated IMPORTED target. Find that package and generate that
-   # imported target here:
--  find_dependency(PkgConfig)
--  pkg_check_modules(PC_UTF8PROC ${_required} ${_quiet} libutf8proc IMPORTED_TARGET GLOBAL)
+ # QUIET arg for finding dependencies:
+ unset(__quiet)
+@@ -60,16 +63,8 @@ if(NOT __mongoc_uses_bundled_utf8proc AND NOT TARGET PkgConfig::PC_UTF8PROC)
+     # libmongoc was compiled against an external utf8proc and links against a
+     # FindPkgConfig-generated IMPORTED target. Find that package and generate that
+     # imported target here:
+-    find_dependency(PkgConfig)
+-    pkg_check_modules(PC_UTF8PROC ${__quiet} libutf8proc IMPORTED_TARGET GLOBAL)
+-    if(NOT PC_UTF8PROC_FOUND)
+-        # Handle if it wasn't found (find_dependency would usually do this for us,
+-        # but pkg_check_modules() does not)
+-        set(mongoc_FOUND FALSE)
+-        set(mongoc_NOT_FOUND_MESSAGE "We were unable to find the required libutf8proc package with pkg-config")
+-        return()
+-    endif()
  endif()
 +find_dependency(unofficial-utf8proc CONFIG)
  
- # Find dependencies for SASL
- set(_sasl_backend [[@SASL_BACKEND@]])
-@@ -43,3 +43,5 @@ if(_sasl_backend STREQUAL "Cyrus")
-   find_dependency(SASL2 2.0)
-   set(CMAKE_MODULE_PATH "${_prev_path}")
+ # If we need to import a TLS package for our imported targets, do that now:
+ if(__mongoc_tls_package)
+@@ -110,3 +105,5 @@ if(NOT TARGET mongoc::mongoc)  # Don't redefine the target if we were already in
+     add_library(mongoc::mongoc IMPORTED INTERFACE)
+     set_property(TARGET mongoc::mongoc APPEND PROPERTY INTERFACE_LINK_LIBRARIES mongoc::${__type})
  endif()
 +
 +include("${CMAKE_CURRENT_LIST_DIR}/mongoc-targets.cmake")

--- a/ports/mongo-c-driver/fix-include-directory.patch
+++ b/ports/mongo-c-driver/fix-include-directory.patch
@@ -1,13 +1,13 @@
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index 4675313..847e073 100644
+index 9b2c2f845d..2231d76edc 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -1255,7 +1255,7 @@ else ()
- endif ()
+@@ -28,7 +28,7 @@ set (MONGOC_ENABLE_COMPRESSION_ZLIB 0)
+ set (MONGOC_ENABLE_COMPRESSION_ZSTD 0)
  
- set (MONGOC_HEADER_INSTALL_DIR
--   "${CMAKE_INSTALL_INCLUDEDIR}/libmongoc-${MONGOC_API_VERSION}"
-+   "${CMAKE_INSTALL_INCLUDEDIR}"
- )
- 
- install (
+ if(NOT DEFINED MONGOC_INSTALL_INCLUDEDIR)
+-   set(MONGOC_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/mongoc-${PROJECT_VERSION}")
++   set(MONGOC_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+ endif()
+ if(NOT DEFINED MONGOC_INSTALL_CMAKEDIR)
+    set(MONGOC_INSTALL_CMAKEDIR "${MONGO_C_DRIVER_INSTALL_CMAKEDIR}/mongoc-${PROJECT_VERSION}")

--- a/ports/mongo-c-driver/fix-mingw.patch
+++ b/ports/mongo-c-driver/fix-mingw.patch
@@ -1,17 +1,17 @@
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index 5be5265..b2bc27d 100644
+index 9b2c2f845d..64bdc251bb 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -209,7 +209,7 @@ endfunction()
+@@ -204,7 +204,7 @@ endfunction()
  # Per-backend link libs/options:
  set(SecureTransport/LINK_LIBRARIES "-framework CoreFoundation" "-framework Security")
  set(SecureTransport/pkg_config_LIBS -framework Corefoundation -framework Security)
--set(SecureChannel/LINK_LIBRARIES secur32.lib crypt32.lib Bcrypt.lib)
-+set(SecureChannel/LINK_LIBRARIES secur32.lib crypt32.lib bcrypt.lib)
+-set(SecureChannel/LINK_LIBRARIES secur32.lib crypt32.lib Bcrypt.lib ncrypt.lib)
++set(SecureChannel/LINK_LIBRARIES secur32.lib crypt32.lib bcrypt.lib ncrypt.lib)
  set(SecureChannel/pkg_config_LIBS ${SecureChannel/LINK_LIBRARIES})
- set(LibreSSL/LINK_LIBRARIES LibreSSL::TLS LibreSSL::Crypto)
- set(LibreSSL/pkg_config_LIBS -ltls -lcrypto)
-@@ -360,7 +360,7 @@ function(_use_sasl libname)
+ set(OpenSSL/LINK_LIBRARIES OpenSSL::SSL OpenSSL::Crypto $<$<PLATFORM_ID:Windows>:crypt32.lib>)
+ set(OpenSSL/pkg_config_LIBS -lssl -lcrypto $<$<PLATFORM_ID:Windows>:crypt32.lib>)
+@@ -338,7 +338,7 @@ function(_use_sasl libname)
     target_link_libraries(_mongoc-dependencies INTERFACE _mongoc-sasl_backend)
     install(TARGETS _mongoc-sasl_backend EXPORT mongoc-targets)
     if(libname STREQUAL "SSPI")
@@ -21,43 +21,44 @@ index 5be5265..b2bc27d 100644
     elseif(libname STREQUAL "CYRUS")
        find_package(SASL2 2.0 REQUIRED)
 diff --git a/src/libmongoc/src/mongoc/mongoc-client.c b/src/libmongoc/src/mongoc/mongoc-client.c
-index 096e0f9..62eca88 100644
+index f4322798c0..cf01aa86c2 100644
 --- a/src/libmongoc/src/mongoc/mongoc-client.c
 +++ b/src/libmongoc/src/mongoc/mongoc-client.c
-@@ -18,8 +18,8 @@
- #include <mongoc/mongoc-config.h>
+@@ -20,8 +20,8 @@
+ 
  #ifdef MONGOC_HAVE_DNSAPI
  /* for DnsQuery_UTF8 */
--#include <Windows.h>
 -#include <WinDNS.h>
-+#include <windows.h>
+-#include <Windows.h>
 +#include <winDNS.h>
++#include <windows.h>
  #include <ws2tcpip.h>
  #else
  #if defined(MONGOC_HAVE_RES_NSEARCH) || defined(MONGOC_HAVE_RES_SEARCH)
 diff --git a/src/libmongoc/src/mongoc/mongoc-socket.c b/src/libmongoc/src/mongoc/mongoc-socket.c
-index df48fd0..3231035 100644
+index 9231df1a12..440c109af2 100644
 --- a/src/libmongoc/src/mongoc/mongoc-socket.c
 +++ b/src/libmongoc/src/mongoc/mongoc-socket.c
-@@ -25,7 +25,7 @@
- #include <mongoc/mongoc-socket-private.h>
- #include <mongoc/mongoc-trace-private.h>
+@@ -23,7 +23,7 @@
+ #include <mongoc/mongoc-host-list.h>
+ 
  #ifdef _WIN32
 -#include <Mstcpip.h>
 +#include <mstcpip.h>
  #include <process.h>
  #endif
- #include <common-cmp-private.h>
+ #include <mlib/cmp.h>
 diff --git a/src/libmongoc/src/mongoc/mongoc-sspi-private.h b/src/libmongoc/src/mongoc/mongoc-sspi-private.h
-index 381c417..3c7689c 100644
+index e5c8c970bd..83185cc50d 100644
 --- a/src/libmongoc/src/mongoc/mongoc-sspi-private.h
 +++ b/src/libmongoc/src/mongoc/mongoc-sspi-private.h
-@@ -28,7 +28,7 @@ BSON_BEGIN_DECLS
+@@ -29,8 +29,8 @@ BSON_BEGIN_DECLS
  
  #define SECURITY_WIN32 1 /* Required for SSPI */
  
 -#include <Windows.h>
-+#include <windows.h>
- #include <limits.h>
  #include <sspi.h>
++#include <windows.h>
+ 
+ #include <limits.h>
  #include <string.h>

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
     REF "${VERSION}"
-    SHA512 2b4c1b1ff414f4a33abea4f032fdeb90e63b5bc279b5b9dac98132892d8922c81146279934e6e872926109a0639fa6a2b3a0a021e2f70683e99c56a5ffd66c4d
+    SHA512 1f1346a52db7241af832d7d5db107512a73af75546818e6600e420505f48c613b08cc332e76337670fe4b19ca057a2b04385b05279e76385adcf42276190123a
     HEAD_REF master
     PATCHES
         disable-dynamic-when-static.patch
@@ -71,25 +71,20 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 if("snappy" IN_LIST FEATURES AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libmongoc-static-1.0.pc" " -lSnappy::snappy" "")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libmongoc-static-1.0.pc" "Requires: " "Requires: snappy ")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/mongoc2-static.pc" " -lSnappy::snappy" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/mongoc2-static.pc" "Requires: " "Requires: snappy ")
     if(NOT VCPKG_BUILD_TYPE)
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libmongoc-static-1.0.pc" " -lSnappy::snappy" "")
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libmongoc-static-1.0.pc" "Requires: " "Requires: snappy ")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/mongoc2-static.pc" " -lSnappy::snappy" "")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/mongoc2-static.pc" "Requires: " "Requires: snappy ")
     endif()
 endif()
 vcpkg_fixup_pkgconfig()
 
-# deprecated
-vcpkg_cmake_config_fixup(PACKAGE_NAME libmongoc-1.0 CONFIG_PATH "lib/cmake/libmongoc-1.0" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_cmake_config_fixup(PACKAGE_NAME "mongoc-${VERSION}" CONFIG_PATH "lib/cmake/mongoc-${VERSION}")
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    vcpkg_cmake_config_fixup(PACKAGE_NAME libmongoc-static-1.0 CONFIG_PATH "lib/cmake/libmongoc-static-1.0" DO_NOT_DELETE_PARENT_CONFIG_PATH)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mongoc/mongoc-macros.h"
         "#define MONGOC_MACROS_H" "#define MONGOC_MACROS_H\n#ifndef MONGOC_STATIC\n#define MONGOC_STATIC\n#endif")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/libmongoc-1.0/libmongoc-1.0-config.cmake" "mongoc_shared" "mongoc_static")
 endif()
-# recommended
-vcpkg_cmake_config_fixup(PACKAGE_NAME mongoc-1.0 CONFIG_PATH "lib/cmake/mongoc-1.0")
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/mongo-c-driver/remove_abs_patch.cmake
+++ b/ports/mongo-c-driver/remove_abs_patch.cmake
@@ -1,8 +1,8 @@
 diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index 6e295d68fb..54ab225ba7 100644
+index 9b2c2f845d..e4357d98a2 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
-@@ -474,7 +474,7 @@ if (NOT WIN32)
+@@ -449,7 +449,7 @@ if (NOT WIN32)
     mongoc_get_accept_args (MONGOC_SOCKET_ARG2 MONGOC_SOCKET_ARG3)
  endif ()
  

--- a/ports/mongo-c-driver/usage
+++ b/ports/mongo-c-driver/usage
@@ -1,4 +1,4 @@
 mongo-c-driver provides CMake targets:
 
-  find_package(mongoc-1.0 CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:mongo::mongoc_shared>,mongo::mongoc_shared,mongo::mongoc_static>)
+  find_package(mongoc CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:mongo::shared>,mongo::shared,mongo::static>)

--- a/ports/mongo-c-driver/vcpkg.json
+++ b/ports/mongo-c-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-c-driver",
-  "version": "1.30.7",
+  "version": "2.2.2",
   "description": "Client library written in C for MongoDB.",
   "homepage": "https://github.com/mongodb/mongo-c-driver",
   "license": "Apache-2.0",

--- a/ports/mongo-cxx-driver/fix-dependencies.patch
+++ b/ports/mongo-cxx-driver/fix-dependencies.patch
@@ -1,35 +1,26 @@
 diff --git a/src/bsoncxx/CMakeLists.txt b/src/bsoncxx/CMakeLists.txt
-index 1e241f5..adf9a27 100644
+index 10e090c1d1..0759b8af2a 100644
 --- a/src/bsoncxx/CMakeLists.txt
 +++ b/src/bsoncxx/CMakeLists.txt
-@@ -105,7 +105,7 @@ else()
-     else()
-         # Require package of old libbson name (with lib).
-         if(NOT BSONCXX_LINK_WITH_STATIC_MONGOC)
--            find_package(libbson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} REQUIRED)
-+            find_package(libbson-${LIBBSON_REQUIRED_ABI_VERSION} REQUIRED)
-             message(STATUS "found libbson version ${BSON_VERSION}")
-             set(libbson_target ${BSON_LIBRARIES})
-             set(libbson_include_directories ${BSON_INCLUDE_DIRS})
+@@ -65,7 +65,7 @@ if(TARGET bson_shared OR TARGET bson_static)
+         set(bson_target bson::shared)
+     endif()
+ else()
+-    find_package(bson ${BSON_REQUIRED_VERSION} REQUIRED)
++    find_package(bson REQUIRED)
+ 
+     message(STATUS "Found bson: ${bson_DIR} (found version \"${bson_VERSION}\")")
+ 
 diff --git a/src/mongocxx/CMakeLists.txt b/src/mongocxx/CMakeLists.txt
-index 4fe323f..2e27410 100644
+index 8b40ce7b72..4c75fb114f 100644
 --- a/src/mongocxx/CMakeLists.txt
 +++ b/src/mongocxx/CMakeLists.txt
-@@ -41,7 +41,7 @@ if(TARGET mongoc_shared OR TARGET mongoc_static)
-     set(MONGOCXX_PKG_DEP "find_dependency(mongoc-${LIBMONGOC_REQUIRED_ABI_VERSION} REQUIRED)")
+@@ -40,7 +40,7 @@ if(TARGET mongoc_shared OR TARGET mongoc_static)
+         set(mongoc_target mongoc::shared)
+     endif()
  else()
-     # Attempt to find libmongoc by new package name (without lib).
--    find_package(mongoc-${LIBMONGOC_REQUIRED_ABI_VERSION} ${LIBMONGOC_REQUIRED_VERSION} QUIET)
-+    find_package(mongoc-${LIBMONGOC_REQUIRED_ABI_VERSION} CONFIG REQUIRED)
+-    find_package(mongoc ${MONGOC_REQUIRED_VERSION} REQUIRED)
++    find_package(mongoc REQUIRED)
  
-     if(mongoc-${LIBMONGOC_REQUIRED_ABI_VERSION}_FOUND)
-         message(STATUS "found libmongoc version ${mongoc-${LIBMONGOC_REQUIRED_ABI_VERSION}_VERSION}")
-@@ -56,7 +56,7 @@ else()
-     else()
-         # Require package of old libmongoc name (with lib).
-         if(NOT MONGOCXX_LINK_WITH_STATIC_MONGOC)
--            find_package(libmongoc-${LIBMONGOC_REQUIRED_ABI_VERSION} ${LIBMONGOC_REQUIRED_VERSION} REQUIRED)
-+            find_package(libmongoc-${LIBMONGOC_REQUIRED_ABI_VERSION} REQUIRED)
-             message(STATUS "found libmongoc version ${MONGOC_VERSION}")
-             set(libmongoc_target ${MONGOC_LIBRARIES})
-             set(libmongoc_definitions ${MONGOC_DEFINITIONS})
+     message(STATUS "Found mongoc: ${mongoc_DIR} (found version \"${mongoc_VERSION}\")")
+ 

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-cxx-driver
     REF "r${VERSION}"
-    SHA512 7b6564cb5087b03886f3c99aa5da9e87a898b1bd1098393a7668e39d673d6203a39f7fa95e5bef995f5e53c18654ef1806823cf643a994a8c19a1df75b9eb306
+    SHA512 8a7c7d37120e97a8aafca5fea986b4e98e062466df7006ee311bb79bf0b16016a3d6070e18beffc236b145dfa86d5968aa66f5c4b8e6f0ba5683d960c695006f
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/mongo-cxx-driver/vcpkg.json
+++ b/ports/mongo-cxx-driver/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-cxx-driver",
-  "version": "4.0.0",
+  "version": "4.1.4",
   "description": "MongoDB C++ Driver.",
   "homepage": "https://github.com/mongodb/mongo-cxx-driver",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4649,7 +4649,7 @@
       "port-version": 0
     },
     "libbson": {
-      "baseline": "1.30.7",
+      "baseline": "2.2.2",
       "port-version": 0
     },
     "libcaer": {
@@ -6489,7 +6489,7 @@
       "port-version": 2
     },
     "mongo-c-driver": {
-      "baseline": "1.30.7",
+      "baseline": "2.2.2",
       "port-version": 0
     },
     "mongo-cxx-driver": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6493,7 +6493,7 @@
       "port-version": 0
     },
     "mongo-cxx-driver": {
-      "baseline": "4.0.0",
+      "baseline": "4.1.4",
       "port-version": 0
     },
     "mongoose": {

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "515d00bc48bc4c4cc51adec258860c2bd2c89d2f",
+      "version": "2.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "7572b0991afb09a501fbc59dfbaa6b595396bb83",
       "version": "1.30.7",
       "port-version": 0

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3de41371126f51a965f709c14f35cebc8954c32b",
+      "version": "2.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "df7b485cc084abbe525768778f95d98746f45e2d",
       "version": "1.30.7",
       "port-version": 0

--- a/versions/m-/mongo-cxx-driver.json
+++ b/versions/m-/mongo-cxx-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43b553ec9e4eae1fd19f699dc73670a8de205514",
+      "version": "4.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "6189b50c8af944ed1231b6e30672b49a1a988c85",
       "version": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
Fixes #45394
Fixes #45314

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

> [!NOTE]
> Since mongo-cxx-driver 4.0.0 is not compatible with mongo-c-driver 2.x, it seems I also needed to update the mongo-cxx-driver package to the latest version (4.1.4) which is compatible with mongo-c-driver 2.x.