### PR TITLE
[vulkan-headers] Fix C++ module build issue caused by module name mismatch between vulkan and vulkan_video

### DIFF
--- a/ports/vulkan-headers/fix-vulkan-video-module-name.patch
+++ b/ports/vulkan-headers/fix-vulkan-video-module-name.patch
@@ -1,0 +1,13 @@
+diff --git a/include/vulkan/vulkan_video.cppm b/include/vulkan/vulkan_video.cppm
+index bcf3e54..a530816 100644
+--- a/include/vulkan/vulkan_video.cppm
++++ b/include/vulkan/vulkan_video.cppm
+@@ -21,7 +21,7 @@ VULKAN_HPP_COMPILE_WARNING( VULKAN_HPP_CXX_MODULE_EXPERIMENTAL_WARNING )
+ 
+ #include <vulkan/vulkan_video.hpp>
+ 
+-export module vulkan_hpp:video;
++export module vulkan:video;
+ 
+ export namespace VULKAN_HPP_NAMESPACE::VULKAN_HPP_VIDEO_NAMESPACE
+ {

--- a/ports/vulkan-headers/portfile.cmake
+++ b/ports/vulkan-headers/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF "vulkan-sdk-${VERSION}"
     SHA512 1ec6aabf2267137dfe661fdc36bc25cc44b7c3ac3c6f0bbd8a1a1f5da30619e244ebfb905620c30002b914525d37ac7933f5a7dfd10117888f66d7c1b129612f
     HEAD_REF main
+    PATCHES fix-vulkan-video-module-name.patch
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port

--- a/ports/vulkan-headers/vcpkg.json
+++ b/ports/vulkan-headers/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "vulkan-headers",
   "version": "1.4.335.0",
+  "port-version": 1,
   "description": "Vulkan header files and API registry",
   "homepage": "https://github.com/KhronosGroup/Vulkan-Headers",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10518,7 +10518,7 @@
     },
     "vulkan-headers": {
       "baseline": "1.4.335.0",
-      "port-version": 0
+      "port-version": 1
     },
     "vulkan-hpp": {
       "baseline": "deprecated",

--- a/versions/v-/vulkan-headers.json
+++ b/versions/v-/vulkan-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9cad4056147e0354a30e03a7352356daccf2500",
+      "version": "1.4.335.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9023e9ea5f97f5db51e49d7d16575f0f7fe91956",
       "version": "1.4.335.0",
       "port-version": 0


### PR DESCRIPTION
Vulkan SDK v1.4.335 is released with the Vulkan-Hpp module name changed from `vulkan_hpp` to `vulkan`, but the subsequent changes for `vulkan_video` is missed from the release. It fixes the C++ module build issue by manually applying the patch for it.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
