### PR TITLE
[zxc] new port

### DIFF
--- a/ports/zxc/portfile.cmake
+++ b/ports/zxc/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO hellobertrand/zxc
+    REF v${VERSION}
+    SHA512 012cc905268b1eaf04adff5615e796b2d130a5c4d6b7cb356195b0e94a34a3e7ad360d56bb8debdfdb8001a0321d77b5b499611463ec21047ca74f25ae022459
+    HEAD_REF main
+)
+
+# Remove vendored rapidhash to use the rapidhash port instead
+file(REMOVE "${SOURCE_PATH}/src/lib/vendors/rapidhash.h")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DZXC_NATIVE_ARCH=OFF
+        -DZXC_ENABLE_LTO=OFF
+        -DZXC_BUILD_CLI=OFF
+        -DZXC_BUILD_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/zxc)
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/zxc/vcpkg.json
+++ b/ports/zxc/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "zxc",
+  "version": "0.7.3",
+  "description": "High-performance asymmetric lossless compression library",
+  "homepage": "https://github.com/hellobertrand/zxc",
+  "license": "BSD-3-Clause AND MIT",
+  "dependencies": [
+    "rapidhash",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11068,6 +11068,10 @@
       "baseline": "0.1.2",
       "port-version": 0
     },
+    "zxc": {
+      "baseline": "0.7.3",
+      "port-version": 0
+    },
     "zycore": {
       "baseline": "1.5.2",
       "port-version": 0

--- a/versions/z-/zxc.json
+++ b/versions/z-/zxc.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a099a90d13c01059b3ad62b6e2df180a2320091f",
+      "version": "0.7.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Add [zxc](https://github.com/hellobertrand/zxc), a high-performance asymmetric lossless compression library optimized for Content Delivery. Decodes 40% faster than LZ4 on ARM64. (Cross-platform: x86_64, ARM64, ARM32, RISC-V, s390x)

## Checklist
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches the upstream project name.
- [x] Optional dependencies are resolved in exactly one way. The only `find_package` call is `find_package(Threads REQUIRED)`, resolved by CMake.
- [x] The versioning scheme in [vcpkg.json] matches upstream (`0.7.3`).
- [x] The license declaration in [vcpkg.json] matches upstream (`BSD-3-Clause AND MIT`).
- [x] The installed copyright file matches upstream LICENSE (BSD-3-Clause for zxc + MIT for vendored rapidhash).
- [x] The source code comes from the authoritative GitHub repository (`hellobertrand/zxc`).
- [x] The generated usage text is accurate.
- [x] The version database is fixed by running `./vcpkg x-add-version --all`.
- [x] Only one version is in the new port's versions file.