### PR TITLE
[foonathan-memory] Backport operator literal syntax fix

### DIFF
--- a/ports/foonathan-memory/backport-0f5ebe9f.diff
+++ b/ports/foonathan-memory/backport-0f5ebe9f.diff
@@ -1,0 +1,43 @@
+diff --git a/include/foonathan/memory/memory_arena.hpp b/include/foonathan/memory/memory_arena.hpp
+index 30ddd68..be2de58 100644
+--- a/include/foonathan/memory/memory_arena.hpp
++++ b/include/foonathan/memory/memory_arena.hpp
+@@ -656,32 +656,32 @@ namespace foonathan
+             /// \returns The number of bytes `value` is in the given unit.
+             /// \ingroup core
+             /// @{
+-            constexpr std::size_t operator"" _KiB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_KiB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1024);
+             }
+ 
+-            constexpr std::size_t operator"" _KB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_KB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1000);
+             }
+ 
+-            constexpr std::size_t operator"" _MiB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_MiB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1024 * 1024);
+             }
+ 
+-            constexpr std::size_t operator"" _MB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_MB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1000 * 1000);
+             }
+ 
+-            constexpr std::size_t operator"" _GiB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_GiB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1024 * 1024 * 1024);
+             }
+ 
+-            constexpr std::size_t operator"" _GB(unsigned long long value) noexcept
++            constexpr std::size_t operator""_GB(unsigned long long value) noexcept
+             {
+                 return std::size_t(value * 1000 * 1000 * 1000);
+             }

--- a/ports/foonathan-memory/portfile.cmake
+++ b/ports/foonathan-memory/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         config-debug.diff
+        backport-0f5ebe9f.diff # Fix deprecated literal operator syntax
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS FEATURES

--- a/ports/foonathan-memory/vcpkg.json
+++ b/ports/foonathan-memory/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "foonathan-memory",
   "version": "0.7.4",
+  "port-version": 1,
   "description": "STL compatible C++ memory allocator library",
   "homepage": "https://foonathan.net/doc/memory/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3138,7 +3138,7 @@
     },
     "foonathan-memory": {
       "baseline": "0.7.4",
-      "port-version": 0
+      "port-version": 1
     },
     "forge": {
       "baseline": "1.0.8",

--- a/versions/f-/foonathan-memory.json
+++ b/versions/f-/foonathan-memory.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d2f4d8463335bfe034de2bc766360292aa198856",
+      "version": "0.7.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "b7f3ed99ac6090ee83925ba9a5da9582e84ffc25",
       "version": "0.7.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

Change was merged into upstream in https://github.com/foonathan/memory/pull/192 but this has not yet been included in any released version.