### PR TITLE
add option for using Qt6 with Log4cxx

### DIFF
--- a/ports/log4cxx/vcpkg.json
+++ b/ports/log4cxx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "log4cxx",
   "version": "1.6.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Apache log4cxx is a logging framework for C++ patterned after Apache log4j, which uses Apache Portable Runtime for most platform-specific code and should be usable on any platform supported by APR",
   "homepage": "https://logging.apache.org/log4cxx",
   "license": "Apache-2.0",
@@ -34,6 +34,15 @@
       "dependencies": [
         {
           "name": "qt5-base",
+          "default-features": false
+        }
+      ]
+    },
+    "qt6": {
+      "description": "Allow QString values in the LOG4CXX_WARN, LOG4CXX_INFO, LOG4CXX_DEBUG etc. macros",
+      "dependencies": [
+        {
+          "name": "qtbase",
           "default-features": false
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6022,7 +6022,7 @@
     },
     "log4cxx": {
       "baseline": "1.6.1",
-      "port-version": 1
+      "port-version": 2
     },
     "logme": {
       "baseline": "2.4.4",

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53dcd90b8d1b097565dd4f5f0e2d2a16c87dc5a0",
+      "version": "1.6.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "5c8b00c1fc97b2cd862922240686dc170692226c",
       "version": "1.6.1",
       "port-version": 1


### PR DESCRIPTION
- [ ? ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ n/a ] SHA512s are updated for each updated download.
- [[ n/a ]The "supports" clause reflects platforms that may be fixed by this new version.
-  [ n/a ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ n/a ] Any patches that are no longer applied are deleted from the port's directory.
- [ yes ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ yes ] Only one version is added to each modified port's versions file.


For the first checklist item, this would go against the maintainer guide where it says:

> Features must be treated as additive functionality. If port[featureA] installs and port[featureB] installs, then port[featureA,featureB] must install. 

However, since log4cxx can use either Qt5 or Qt6, one should be selected.  It would be impossible to use both Qt5 and Qt6 at the same time