### PR TITLE
[avcpp] update to 2.90.1

### DIFF
--- a/ports/avcpp/0003-fix-minmax.patch
+++ b/ports/avcpp/0003-fix-minmax.patch
@@ -1,0 +1,31 @@
+diff --git a/src/avutils.h b/src/avutils.h
+index ad8ca49..178e8d5 100644
+--- a/src/avutils.h
++++ b/src/avutils.h
+@@ -510,10 +510,10 @@ T guessValue(const T& value, L list)
+         return value;
+ 
+     T best = value;
+-    T bestDistance = std::numeric_limits<T>::max();
++    T bestDistance = (std::numeric_limits<T>::max)();
+ 
+     for (auto&& cur : list) {
+-        auto const distance = std::max(cur, value) - std::min(cur, value);
++        auto const distance = (std::max)(cur, value) - (std::min)(cur, value);
+         if (distance < bestDistance) {
+             bestDistance = distance;
+             best = cur;
+@@ -565,11 +565,11 @@ T guessValue(const T& value, const L * list, C endListComparator)
+         return value;
+ 
+     T best = value;
+-    T bestDistance = std::numeric_limits<T>::max();
++    T bestDistance = (std::numeric_limits<T>::max)();
+ 
+     for (const L * ptr = list; !endListComparator(*ptr); ++ptr) {
+         auto const cur = *ptr;
+-        auto const distance = std::max(cur, value) - std::min(cur, value);
++        auto const distance = (std::max)(cur, value) - (std::min)(cur, value);
+         if (distance < bestDistance) {
+             bestDistance = distance;
+             best = cur;

--- a/ports/avcpp/portfile.cmake
+++ b/ports/avcpp/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         0002-av_init_packet_deprecation.patch
+        0003-fix-minmax.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" AVCPP_ENABLE_STATIC)

--- a/ports/avcpp/portfile.cmake
+++ b/ports/avcpp/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO h4tr3d/avcpp
     REF "v${VERSION}"
-    SHA512 b1f6b5a501e7807e70850bba6da35526911d15916b37f3a0e6f10d471f84727adfe1679ad9ece3c2ddb355090448aa7850dc796f5c626cb6bc82c9428856c38e
+    SHA512 a0f4a6577ab9586cd9f8b5bc4ea4329a74857918099473fb366d57dc01d90be6653f81e0a4dd83cb1b35370c99bb34313f2d015d27fac26689feff97a97ff18b
     HEAD_REF master
     PATCHES
         0002-av_init_packet_deprecation.patch

--- a/ports/avcpp/vcpkg.json
+++ b/ports/avcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "avcpp",
-  "version": "2.8.0",
+  "version": "2.90.1",
   "description": "Wrapper for the FFmpeg that simplify usage it from C++ projects.",
   "homepage": "https://github.com/h4tr3d/avcpp",
   "license": "LGPL-2.1-only OR BSD-3-Clause",

--- a/versions/a-/avcpp.json
+++ b/versions/a-/avcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c21f9c43a40f3d1b8a508a47e2bb7cb26f34e75f",
+      "version": "2.90.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "90c3ece0f2c58eb8134acebca17036464184a0b5",
       "version": "2.8.0",
       "port-version": 0

--- a/versions/a-/avcpp.json
+++ b/versions/a-/avcpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c21f9c43a40f3d1b8a508a47e2bb7cb26f34e75f",
+      "git-tree": "bfc7b9ad3262b1757d1c5e8acccae0d21e2224cc",
       "version": "2.90.1",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -429,7 +429,7 @@
       "port-version": 0
     },
     "avcpp": {
-      "baseline": "2.8.0",
+      "baseline": "2.90.1",
       "port-version": 0
     },
     "avir": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/h4tr3d/avcpp/releases/tag/v2.90.1
