### PR TITLE
[cimg] update to 3.7.0

### DIFF
--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO GreycLab/CImg
     # Using commit id becuase upstream likes to change tags
-    REF a5fb0fd2efff9af9c7482a2c064f82b8da7c3ceb
-    SHA512 c15ccab40400c8b00e8899a08c67cc5f867db1fd01222e420cb2a7f8b3f5cd625573900d8c192e22156e11930953c6e6676d83a97734cd4f1bd46fea47d7d735
+    REF 7d168a8a013ded3c6d5ab7a0a50ec38b3e3d7790
+    SHA512 4c009c29cfa8401ba4249428e92eb82b085d70471bdd3745cf4ffa5aeac0cca7a9f2c902df966b17e3e8223bed3591ea6ab485cb455019d4f05b39671b920da6
     HEAD_REF master
 )
 

--- a/ports/cimg/vcpkg.json
+++ b/ports/cimg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cimg",
-  "version": "3.6.6",
+  "version": "3.7.0",
   "description": "The CImg Library is a small, open-source, and modern C++ toolkit for image processing",
   "homepage": "https://github.com/GreycLab/CImg",
   "license": "CECILL-C AND CECILL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1749,7 +1749,7 @@
       "port-version": 0
     },
     "cimg": {
-      "baseline": "3.6.6",
+      "baseline": "3.7.0",
       "port-version": 0
     },
     "cinatra": {

--- a/versions/c-/cimg.json
+++ b/versions/c-/cimg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c2a4e6245c42fe114b86474a0182fab414032fa3",
+      "version": "3.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fbf6f051b417d2fcd2a5c0992efe4c77c8615be6",
       "version": "3.6.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/GreycLab/CImg/releases/tag/v.3.7.0
