### PR TITLE
[slick-queue] update to v1.4.1

### DIFF
--- a/ports/slick-queue/portfile.cmake
+++ b/ports/slick-queue/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SlickQuant/slick-queue
     REF "v${VERSION}"
-    SHA512 f68aefa611905e4f425741e7854caaed6746a4f9a8d9399ef6795881d62308acf758eaecc622ec6e34e942d5cd5a6ddf290975ccb42e0fb2889b1c576cc73559
+    SHA512 216300e638d0cf6bf5775f66d0466446c1fd5b63da7506cc4dec00c520435feb0bb564c99170e786cbd6361a781d1de63b609f82aeb83a722e325f4e9d99503c
     HEAD_REF main
     PATCHES
         slick-shm.patch

--- a/ports/slick-queue/slick-shm.patch
+++ b/ports/slick-queue/slick-shm.patch
@@ -4,7 +4,7 @@ index 6cbc9ee..b5f3d7a 100644
 +++ b/CMakeLists.txt
 @@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD 20)
  # Options:
- option(BUILD_SLICK_QUEUE_TESTS "Build tests" ON)
+ option(BUILD_SLICK_QUEUE_TESTS "Build tests" ${PROJECT_IS_TOP_LEVEL})
  
 -find_package(slick-shm CONFIG QUIET)
 +find_package(slick-shm CONFIG REQUIRED)

--- a/ports/slick-queue/vcpkg.json
+++ b/ports/slick-queue/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "slick-queue",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A C++ Lock-Free MPMC queue - header-only library for high throughput concurrent messaging with optional shared memory support",
   "homepage": "https://github.com/SlickQuant/slick-queue",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9189,7 +9189,7 @@
       "port-version": 0
     },
     "slick-queue": {
-      "baseline": "1.4.0",
+      "baseline": "1.4.1",
       "port-version": 0
     },
     "slick-shm": {

--- a/versions/s-/slick-queue.json
+++ b/versions/s-/slick-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e748ce9fa5d5334dbbb5271ef562588592cc642b",
+      "version": "1.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6df69108c75422771ad4da90994cc9fff291d555",
       "version": "1.4.0",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.



<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
