### PR TITLE
[pdal] update to 2.10.0

### DIFF
--- a/ports/pdal/dependencies.diff
+++ b/ports/pdal/dependencies.diff
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ca5a692..e0651b4 100644
+index f653190..7281a51 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -161,12 +161,9 @@ if (WITH_TESTS)
@@ -15,10 +15,12 @@ index ca5a692..e0651b4 100644
  add_subdirectory(tools)
  add_subdirectory(apps)
  
-@@ -230,12 +227,13 @@ add_library(PDAL::PDAL ALIAS ${PDAL_LIB_NAME})
+@@ -228,14 +225,13 @@ add_library(PDAL::PDAL ALIAS ${PDAL_LIB_NAME})
+ # without specification.
+ #
  
- 
- 
+-
+-
 +find_package(Eigen3 CONFIG REQUIRED)
 +target_link_libraries(${PDAL_LIB_NAME} PRIVATE Eigen3::Eigen)
  target_include_directories(${PDAL_LIB_NAME}
@@ -31,25 +33,27 @@ index ca5a692..e0651b4 100644
  target_include_directories(${PDAL_LIB_NAME}
      PRIVATE
          ${ROOT_DIR}
-@@ -269,6 +267,8 @@ target_link_libraries(${PDAL_LIB_NAME}
+@@ -269,7 +265,8 @@ target_link_libraries(${PDAL_LIB_NAME}
          ${PDAL_LIBDIR}
          ${WINSOCK_LIBRARY}
  )
+-
 +find_package(nanoflann CONFIG REQUIRED)
 +target_link_libraries(${PDAL_LIB_NAME} PRIVATE nanoflann::nanoflann)
- 
  if (ZSTD_FOUND)
      target_link_libraries(${PDAL_LIB_NAME}
-@@ -304,9 +304,6 @@ target_include_directories(${PDAL_LIB_NAME}
+         PRIVATE
+@@ -304,10 +301,6 @@ target_include_directories(${PDAL_LIB_NAME}
      INTERFACE
          $<INSTALL_INTERFACE:include>)
  
 -target_compile_definitions(${PDAL_LIB_NAME}
 -    PRIVATE
 -    H3_PREFIX=PDALH3)
- 
+-
  if(WIN32)
      target_compile_definitions(${PDAL_LIB_NAME}
+         PUBLIC
 diff --git a/cmake/h3.cmake b/cmake/h3.cmake
 index 398ad6d..fb3c9ad 100644
 --- a/cmake/h3.cmake
@@ -88,16 +92,49 @@ index 6543ff6..dc6fac8 100644
  set(UTFCPP_LIB_NAME utf8::cpp)
  
 diff --git a/pdal/JsonFwd.hpp b/pdal/JsonFwd.hpp
-index 507c456..6b502d0 100644
+index 507c456..dea017f 100644
 --- a/pdal/JsonFwd.hpp
 +++ b/pdal/JsonFwd.hpp
-@@ -1,3 +1,4 @@
+@@ -1,6 +1,6 @@
 +#include <nlohmann/json_fwd.hpp>
  #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
  #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+-
+ // PDAL no longer exposes nlohmann in its public
+ // headers due to it changing its type definitions. See
+ // https://github.com/PDAL/PDAL/pull/4706 for more details. If you have
+diff --git a/pdal/KDIndex.hpp b/pdal/KDIndex.hpp
+index 8cfcf50..7c1a7ba 100644
+--- a/pdal/KDIndex.hpp
++++ b/pdal/KDIndex.hpp
+@@ -35,6 +35,7 @@
+ #pragma once
  
+ #include <pdal/PointView.hpp>
++#include <nanoflann.hpp>
+ 
+ namespace pdal
+ {
+@@ -46,7 +47,7 @@ class KDFlexImpl;
+ class PDAL_EXPORT KD2Index
+ {
+ public:
+-    using RadiusResult = std::pair<size_t, double>;
++    using RadiusResult = nanoflann::ResultItem<size_t, double>;
+     using RadiusResults = std::vector<RadiusResult>;
+ 
+     KD2Index(const PointView& buf);
+@@ -79,7 +80,7 @@ private:
+ class PDAL_EXPORT KD3Index
+ {
+ public:
+-    using RadiusResult = std::pair<size_t, double>;
++    using RadiusResult = nanoflann::ResultItem<size_t, double>;
+     using RadiusResults = std::vector<RadiusResult>;
+ 
+     KD3Index(const PointView& buf);
 diff --git a/pdal/private/KDImpl.hpp b/pdal/private/KDImpl.hpp
-index 473ffba..a69431f 100644
+index a328f34..bedb367 100644
 --- a/pdal/private/KDImpl.hpp
 +++ b/pdal/private/KDImpl.hpp
 @@ -34,7 +34,8 @@
@@ -110,8 +147,17 @@ index 473ffba..a69431f 100644
  
  namespace pdal
  {
-@@ -116,7 +117,7 @@ public:
-     PointIdList radius(double const& x, double const& y, double const& r) const
+@@ -42,7 +43,7 @@ namespace pdal
+ class KD2Impl
+ {
+ public:
+-    using RadiusResults = std::vector<std::pair<size_t, double>>;
++    using RadiusResults = std::vector<nanoflann::ResultItem<std::size_t, double>>;
+ 
+     KD2Impl(const PointView& buf) : m_buf(buf),
+         m_index(2, *this, nanoflann::KDTreeSingleIndexAdaptorParams(100))
+@@ -118,7 +119,7 @@ public:
+     PointIdList radius(double x, double y, double r) const
      {
          PointIdList output;
 -        std::vector<std::pair<std::size_t, double>> ret_matches;
@@ -119,7 +165,16 @@ index 473ffba..a69431f 100644
          nanoflann::SearchParams params;
          params.sorted = true;
  
-@@ -247,7 +248,7 @@ public:
+@@ -157,7 +158,7 @@ private:
+ class KD3Impl
+ {
+ public:
+-    using RadiusResults = std::vector<std::pair<size_t, double>>;
++    using RadiusResults = std::vector<nanoflann::ResultItem<std::size_t, double>>;
+ 
+     KD3Impl(const PointView& buf) : m_buf(buf),
+         m_index(3, *this, nanoflann::KDTreeSingleIndexAdaptorParams(100))
+@@ -262,7 +263,7 @@ public:
      PointIdList radius(double x, double y, double z, double r) const
      {
          PointIdList output;
@@ -128,7 +183,7 @@ index 473ffba..a69431f 100644
          nanoflann::SearchParams params;
          params.sorted = true;
  
-@@ -330,7 +331,7 @@ public:
+@@ -356,7 +357,7 @@ public:
      PointIdList radius(PointId idx, double r) const
      {
          PointIdList output;
@@ -138,12 +193,12 @@ index 473ffba..a69431f 100644
          params.sorted = true;
  
 diff --git a/tools/lasdump/CMakeLists.txt b/tools/lasdump/CMakeLists.txt
-index d0d4d64..595d724 100644
+index fa842d1..a9f4e7a 100644
 --- a/tools/lasdump/CMakeLists.txt
 +++ b/tools/lasdump/CMakeLists.txt
-@@ -11,6 +11,7 @@ add_executable(lasdump
- )
+@@ -15,6 +15,7 @@ add_executable(lasdump
  
+ # Explicitly link and tell CMake to link libstdc++
  target_link_libraries(lasdump PRIVATE
 +    ${UTFCPP_LIB_NAME}
      ${PDAL_LAZPERF_LIB_NAME}

--- a/ports/pdal/portfile.cmake
+++ b/ports/pdal/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     #[[
         Attention: pdal-dimbuilder must be updated together with pdal
     #]]
-    SHA512 7ed8300bf700abf79314aa3f9867d05a0ae077e4a8d4940a19f91c89869cfe2dfbe0d1ba5679d8457e64adcf1f924dec46686d022bfd6046657ab829795059a7
+    SHA512 1139a7ad312768ed2555c5c585923316bd7b1d13f56d2af0bec4c626a4e3cda5cadf668fe1d6a3e64be3ffd3ac9bb5b3675ebace23e6c5e233151894d8dbe4aa
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/pdal/vcpkg.json
+++ b/ports/pdal/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pdal",
-  "version": "2.9.3",
+  "version": "2.10.0",
   "description": "PDAL - Point Data Abstraction Library is a library for manipulating point cloud data.",
   "homepage": "https://pdal.org/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7513,7 +7513,7 @@
       "port-version": 0
     },
     "pdal": {
-      "baseline": "2.9.3",
+      "baseline": "2.10.0",
       "port-version": 0
     },
     "pdal-c": {

--- a/versions/p-/pdal.json
+++ b/versions/p-/pdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41c37366ea648e7e846435aff1762fd2f8eca9cd",
+      "version": "2.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8efcd67d1e86d4e04f46deb12a799fdb35dddbd7",
       "version": "2.9.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/PDAL/PDAL/releases/tag/2.10.0
