### PR TITLE
[vincentlaucsb-csv-parser] update to 2.4.0

### DIFF
--- a/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
+++ b/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
@@ -52,11 +52,11 @@ index 1b920b1..c56a142 100644
  if (CSV_DEVELOPER)
      # Allow for performance profiling
 diff --git a/include/internal/CMakeLists.txt b/include/internal/CMakeLists.txt
-index 4cbf58c..e9e65f8 100644
+index 7da751c..45b1bb8 100644
 --- a/include/internal/CMakeLists.txt
 +++ b/include/internal/CMakeLists.txt
-@@ -23,6 +23,9 @@ target_sources(csv
- 		"data_type.hpp"
+@@ -26,6 +26,9 @@ target_sources(csv
+ 		thread_safe_deque.hpp
  		)
  
 -set_target_properties(csv PROPERTIES LINKER_LANGUAGE CXX)

--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 ead00b640569da960f5ec70ca2f85fbe0f116643ac6d69951f15d5a2030f1538bbffa1d27dd487be7fc5b8561f374103dfa115d4918534cf9ccd1143b76713b3
+    SHA512 d6314bbff657904a04bc5e2ccbb1cd07baf0c032f4d6f10cb56f24edda073cb75cd79c1993e690f38407bca73811136dc5837bed70d75d681cfa8200f799f4de
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10421,7 +10421,7 @@
       "port-version": 1
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "2.3.0",
+      "baseline": "2.4.0",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d15f09ac7ba7f28a276acbe6081fe7caa12e59d7",
+      "version": "2.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "61a85adb966f97ad0334f1229309a731589cb189",
       "version": "2.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/vincentlaucsb/csv-parser/releases/tag/2.4.0
