### PR TITLE
[pixman] Add test port

### DIFF
--- a/ports/pixman/vcpkg.json
+++ b/ports/pixman/vcpkg.json
@@ -1,11 +1,16 @@
 {
   "name": "pixman",
   "version": "0.46.4",
+  "port-version": 1,
   "description": "Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.",
   "homepage": "https://www.cairographics.org/releases",
   "license": "MIT AND BSD-2-Clause",
   "dependencies": [
     "libpng",
+    {
+      "name": "pthreads",
+      "platform": "windows & !mingw"
+    },
     {
       "name": "vcpkg-tool-meson",
       "host": true

--- a/scripts/test_ports/vcpkg-ci-pixman/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-pixman/portfile.cmake
@@ -1,0 +1,7 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+
+vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-pixman/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-pixman/project/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+project(pixman-test CXX)
+
+find_package(PkgConfig REQUIRED)
+
+pkg_search_module(pixman REQUIRED pixman-1 IMPORTED_TARGET)
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE PkgConfig::pixman)

--- a/scripts/test_ports/vcpkg-ci-pixman/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-pixman/project/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+#include <pixman.h>
+
+int main() {
+    const char* version = pixman_version_string();
+    std::cout << "Pixman version: " << version << "\n";
+
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-pixman/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-pixman/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-pixman",
+  "version-string": "ci",
+  "description": "Validates pixman",
+  "dependencies": [
+    "pixman",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7606,7 +7606,7 @@
     },
     "pixman": {
       "baseline": "0.46.4",
-      "port-version": 0
+      "port-version": 1
     },
     "pkgconf": {
       "baseline": "2.5.1",

--- a/versions/p-/pixman.json
+++ b/versions/p-/pixman.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3613ae3c8119964f0d7f1caeff82801d10c7135c",
+      "version": "0.46.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "e921b489ab8ee9972223eef2158259cbb7829938",
       "version": "0.46.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

#49475 is currently failing as `pixman` requires `-lpthreadVC3`. Compared to this my local machine doesn't require this for pixman (not requested in the created pixman.pc file), so I cannot reproduce the issue locally. The dependency can differ due to [this](https://gitlab.freedesktop.org/pixman/pixman/-/blob/pixman-0.46.4/meson.build?ref_type=tags#L473-491). Therefore adding a test port to check whether the pixman definton is really okay or not (`pkg_search_module(... IMPORTED_TARGET)` resolves dependencies recursive).