### PR TITLE
[7zip] Update to 26.00

### DIFF
--- a/ports/7zip/portfile.cmake
+++ b/ports/7zip/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ip7z/7zip
     REF "${upstream_version}"
-    SHA512 eb5ed600f82aca52f6dc8d2be3e4da4380670308dff2bcbfc96255d9d23bb5ca35dea073bd97070f0a1891b2f329d88a06b304f48e30f4ad89256c7664e9c1ea
+    SHA512 5f4922efd94e12776e531f77053981978a0d9f8c6da50f51bdb750a54436b07ddccafa6a1180fd234a7fcaf4d2a5b0ab7c2a9267da2ea8e68407bf432ff0f76c
     HEAD_REF main
     PATCHES
         sort-asm.diff

--- a/ports/7zip/vcpkg.json
+++ b/ports/7zip/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "7zip",
-  "version": "25.1",
-  "port-version": 1,
+  "version": "26.0",
   "description": "Library for archiving file with a high compression ratio.",
   "homepage": "https://www.7-zip.org",
   "license": "LGPL-2.1-or-later",

--- a/versions/7-/7zip.json
+++ b/versions/7-/7zip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e6c2908a7497a1d8e71ed3813f5533d2314956a8",
+      "version": "26.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "181bb1c243122a292eef7567aa94476888b18465",
       "version": "25.1",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5,8 +5,8 @@
       "port-version": 5
     },
     "7zip": {
-      "baseline": "25.1",
-      "port-version": 1
+      "baseline": "26.0",
+      "port-version": 0
     },
     "abcmake": {
       "baseline": "6.4.0",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.