### PR TITLE
[arrow] Update to 23.0.1

### DIFF
--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     ARCHIVE_PATH
     URLS "https://archive.apache.org/dist/arrow/arrow-${VERSION}/apache-arrow-${VERSION}.tar.gz"
     FILENAME apache-arrow-${VERSION}.tar.gz
-    SHA512 ddaaf31e7f3f8246ce3aa6e77c812c55a7993d037aaebc8ca9d79d54c701717a135eebfede731a3239becfaed2fa2395fcb3d68b14c32b9de72b3f5598d9df4a
+    SHA512 c687e50dfcdbf7e0e39710224360d35d9aa734452b3a47adc8c101f3019b6b4116310c05b9f3cd0a5ed4ad9b7bd8fb88edb70e79b3cbd413a57e5e35e4554a6c
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "arrow",
-  "version": "23.0.0",
+  "version": "23.0.1",
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50e30671c1cdb1475e1dd054ca3e6d01a418d90e",
+      "version": "23.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "1e41ecff4d2696961e337f7219bb73c30c1fbccd",
       "version": "23.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -289,7 +289,7 @@
       "port-version": 10
     },
     "arrow": {
-      "baseline": "23.0.0",
+      "baseline": "23.0.1",
       "port-version": 0
     },
     "arrow-adbc": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
