### PR TITLE
[xatlas] added new port

### DIFF
--- a/ports/xatlas/portfile.cmake
+++ b/ports/xatlas/portfile.cmake
@@ -1,0 +1,43 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jpcy/xatlas
+    REF f700c7790aaa030e794b52ba7791a05c085faf0c
+    SHA512 1f7afcc9056ab636abef017033aaf63d219cdec95e871beade2c694f8e8b4a58563cf506c5afb6d0d5536233f791e11adbcf3f6f26548105b31d381289892dea
+    HEAD_REF master
+)
+
+file(WRITE "${SOURCE_PATH}/CMakeLists.txt" [=[
+cmake_minimum_required(VERSION 3.10)
+project(xatlas LANGUAGES CXX)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) 
+
+add_library(xatlas source/xatlas/xatlas.cpp)
+add_library(xatlas::xatlas ALIAS xatlas)
+
+target_include_directories(xatlas PUBLIC 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/source/xatlas>
+    $<INSTALL_INTERFACE:include>
+)
+
+install(TARGETS xatlas EXPORT xatlas-config 
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+install(EXPORT xatlas-config NAMESPACE xatlas:: DESTINATION share/xatlas)
+install(FILES source/xatlas/xatlas.h DESTINATION include)
+]=])
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/xatlas/portfile.cmake
+++ b/ports/xatlas/portfile.cmake
@@ -6,11 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 file(WRITE "${SOURCE_PATH}/CMakeLists.txt" [=[
 cmake_minimum_required(VERSION 3.10)
 project(xatlas LANGUAGES CXX)
-
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) 
 
 add_library(xatlas source/xatlas/xatlas.cpp)
 add_library(xatlas::xatlas ALIAS xatlas)

--- a/ports/xatlas/vcpkg.json
+++ b/ports/xatlas/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "xatlas",
+  "version-date": "2022-07-22",
+  "description": "Mesh parameterization / UV unwrapping library",
+  "homepage": "https://github.com/jpcy/xatlas",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10776,6 +10776,10 @@
       "baseline": "1.4.22",
       "port-version": 2
     },
+    "xatlas": {
+      "baseline": "2022-07-22",
+      "port-version": 0
+    },
     "xaudio2redist": {
       "baseline": "1.2.13",
       "port-version": 0

--- a/versions/x-/xatlas.json
+++ b/versions/x-/xatlas.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "385fbe4b6eb4c1410b00cdbe55e0ca209bb52d2c",
+      "version-date": "2022-07-22",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/x-/xatlas.json
+++ b/versions/x-/xatlas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "385fbe4b6eb4c1410b00cdbe55e0ca209bb52d2c",
+      "git-tree": "a9b22eca50ee8282ddb80666ca08732cf8a01671",
       "version-date": "2022-07-22",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #49976

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->
## Description:
Adds `xatlas`, a mesh parameterization / UV unwrapping library.
Since the upstream repository does not provide a build system, this port injects a `CMakeLists.txt` to build the library correctly on all platforms.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

