### PR TITLE
[sentry-native] update to 0.12.8

### DIFF
--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 4f2e7cfd519d37b4b15c97161826e71e796b89cf849597cb37d6515f9913fd216fd5dca3f7d10b32df5a0f9e500b2b3407fb5b2479251c0f3c4dea2861d32aaa
+    SHA512 761ef9a1652d25b416e0921782b66bfdca0ecc40de6b1caadb145e3551d3b0a955f43f942116e627c51959086488919385a1a671072c8b5799589ffcdfd9d4bb
 )
 
 vcpkg_extract_source_archive(

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8989,7 +8989,7 @@
       "port-version": 0
     },
     "sentry-native": {
-      "baseline": "0.12.7",
+      "baseline": "0.12.8",
       "port-version": 0
     },
     "septag-dmon": {

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6daad642d4620aab9124399289c47799d3ac07f1",
+      "version": "0.12.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "a1e9714556385a11845a51dd054be9b28b144762",
       "version": "0.12.7",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version.~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
