### PR TITLE
[cmark] update to 0.31.2

### DIFF
--- a/ports/cmark/portfile.cmake
+++ b/ports/cmark/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO commonmark/cmark
     REF "${VERSION}"
-    SHA512 3b4f8b47d8ea270078ab986aa22fc32b227786459bd33c7225aac578d8dd014e3d8788a6add60ea10571fdb4c7dc6a1ece960815a02f04f153b1775c73ccff8f
+    SHA512 8dcf4f25b53e84a16afa506214f17c3d2d7b0cc78d9d289b469ad8d1e481c4b355263eca3fb1e2b595c30734bc2d617fd38e00d17a14dcfa9de8c71580916265
     HEAD_REF master
     PATCHES
         add-feature-tools.patch

--- a/ports/cmark/vcpkg.json
+++ b/ports/cmark/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cmark",
-  "version-semver": "0.31.1",
+  "version-semver": "0.31.2",
   "description": "CommonMark parsing and rendering library",
   "homepage": "https://github.com/commonmark/cmark",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1857,7 +1857,7 @@
       "port-version": 0
     },
     "cmark": {
-      "baseline": "0.31.1",
+      "baseline": "0.31.2",
       "port-version": 0
     },
     "cmark-gfm": {

--- a/versions/c-/cmark.json
+++ b/versions/c-/cmark.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b6350748e7b5de2385b99e46c229bea52e7b20c9",
+      "version-semver": "0.31.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "159e4cc034614fb2158e373eb2d992a4fa29a343",
       "version-semver": "0.31.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/commonmark/cmark/releases/tag/0.31.2
