### PR TITLE
[cpr] update to 1.14.2

### DIFF
--- a/ports/cpr/portfile.cmake
+++ b/ports/cpr/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libcpr/cpr
     REF ${VERSION}
-    SHA512 1ce3f035fe1050eb83fc2920a201adafe7e1b52932974778dc8d201fb33da02a42a2cf7ca9613000537efc6a5bdbbed6887e8f76884ca6cf0784f3344e01613c
+    SHA512 9907d2936f814924e82aaaf652149c119e2d9b94677efde0c80c570bc8cb50e4a36aa2520e2efb3f1fc82cba10ef61b9262705cd6e5cb49757b0c37af071ae22
     HEAD_REF master
     PATCHES
         disable_werror.patch

--- a/ports/cpr/vcpkg.json
+++ b/ports/cpr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpr",
-  "version-semver": "1.14.1",
+  "version-semver": "1.14.2",
   "description": "C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.",
   "homepage": "https://github.com/libcpr/cpr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2161,7 +2161,7 @@
       "port-version": 0
     },
     "cpr": {
-      "baseline": "1.14.1",
+      "baseline": "1.14.2",
       "port-version": 0
     },
     "cpu-features": {

--- a/versions/c-/cpr.json
+++ b/versions/c-/cpr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9831fce6b2847eab6889364642da31eb7a13f02f",
+      "version-semver": "1.14.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e22744d56b6cd9b5a5c13ff02cf078aeb0d62232",
       "version-semver": "1.14.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/libcpr/cpr/releases/tag/1.14.2
