### PR TITLE
[orange-math] updated to 5.0.0

### DIFF
--- a/ports/orange-math/portfile.cmake
+++ b/ports/orange-math/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO orange-cpp/omath
     REF "v${VERSION}"
-    SHA512 fdcd4394ff132bc690a2be6ba275da36d037bf3edbe3d6cdeabbbb4a42ee9657f876af9b8e99a9c77bb44a6dce64f0906f9d28bde04c8b608fb2d44dd6ca8134
+    SHA512 bd9e3ebe993267b035a5659cb3984f7254c46ea7893475a871d80853726cf053587d0b6008a24a423c8bae89d23fb18d3498f03b89b601f22128deed1a442cb4
     HEAD_REF master
 )
 

--- a/ports/orange-math/vcpkg.json
+++ b/ports/orange-math/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "orange-math",
-  "version": "4.8.0",
+  "version": "5.0.0",
   "description": "General purpose math library",
   "homepage": "https://github.com/orange-cpp/omath",
   "documentation": "https://libomath.org",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7353,7 +7353,7 @@
       "port-version": 1
     },
     "orange-math": {
-      "baseline": "4.8.0",
+      "baseline": "5.0.0",
       "port-version": 0
     },
     "orc": {

--- a/versions/o-/orange-math.json
+++ b/versions/o-/orange-math.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3d59ac33cdc67503b81524516e477c9cf01f1871",
+      "version": "5.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8337c73b2e06c092d8b4512ab860a7e0c620c05e",
       "version": "4.8.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

