### PR TITLE
[libvpx] Update to version 1.16.0

### DIFF
--- a/ports/libvpx/0003-add-uwp-v142-and-v143-support.patch
+++ b/ports/libvpx/0003-add-uwp-v142-and-v143-support.patch
@@ -1,5 +1,5 @@
 diff --git a/build/make/configure.sh b/build/make/configure.sh
-index cc5bf6ce4..9380e87a7 100644
+index ebaec96a5..c80c14984 100644
 --- a/build/make/configure.sh
 +++ b/build/make/configure.sh
 @@ -1092,7 +1092,7 @@ EOF
@@ -11,7 +11,7 @@ index cc5bf6ce4..9380e87a7 100644
              asm_conversion_cmd="${source_path_mk}/build/make/ads2armasm_ms.pl"
              AS_SFX=.S
              msvs_arch_dir=arm-msvs
-@@ -1366,6 +1366,9 @@ EOF
+@@ -1368,6 +1368,9 @@ EOF
          android)
            soft_enable realtime_only
            ;;
@@ -21,7 +21,7 @@ index cc5bf6ce4..9380e87a7 100644
          win*)
            enabled gcc && add_cflags -fno-common
            ;;
-@@ -1484,14 +1487,26 @@ EOF
+@@ -1490,14 +1493,26 @@ EOF
        fi
        AS_SFX=.asm
        case  ${tgt_os} in
@@ -50,7 +50,7 @@ index cc5bf6ce4..9380e87a7 100644
            EXE_SFX=.exe
            ;;
          linux*|solaris*|android*)
-@@ -1622,6 +1637,8 @@ EOF
+@@ -1625,6 +1640,8 @@ EOF
    # Almost every platform uses pthreads.
    if enabled multithread; then
      case ${toolchain} in
@@ -97,19 +97,19 @@ index 1e1db05bb..543eb37b2 100755
                  fi
              fi
 diff --git a/configure b/configure
-index 457bd6b38..fa4bce71b 100755
+index f7225f061..a372a9ae5 100755
 --- a/configure
 +++ b/configure
-@@ -105,6 +105,8 @@ all_platforms="${all_platforms} arm64-darwin22-gcc"
- all_platforms="${all_platforms} arm64-darwin23-gcc"
+@@ -106,6 +106,8 @@ all_platforms="${all_platforms} arm64-darwin23-gcc"
  all_platforms="${all_platforms} arm64-darwin24-gcc"
+ all_platforms="${all_platforms} arm64-darwin25-gcc"
  all_platforms="${all_platforms} arm64-linux-gcc"
 +all_platforms="${all_platforms} arm64-uwp-vs16"
 +all_platforms="${all_platforms} arm64-uwp-vs17"
  all_platforms="${all_platforms} arm64-win64-gcc"
  all_platforms="${all_platforms} arm64-win64-vs15"
  all_platforms="${all_platforms} arm64-win64-vs16"
-@@ -116,6 +118,8 @@ all_platforms="${all_platforms} armv7-darwin-gcc"    #neon Cortex-A8
+@@ -117,6 +119,8 @@ all_platforms="${all_platforms} armv7-darwin-gcc"    #neon Cortex-A8
  all_platforms="${all_platforms} armv7-linux-rvct"    #neon Cortex-A8
  all_platforms="${all_platforms} armv7-linux-gcc"     #neon Cortex-A8
  all_platforms="${all_platforms} armv7-none-rvct"     #neon Cortex-A8
@@ -118,7 +118,7 @@ index 457bd6b38..fa4bce71b 100755
  all_platforms="${all_platforms} armv7-win32-gcc"
  all_platforms="${all_platforms} armv7-win32-vs14"
  all_platforms="${all_platforms} armv7-win32-vs15"
-@@ -147,6 +151,8 @@ all_platforms="${all_platforms} x86-linux-gcc"
+@@ -148,6 +152,8 @@ all_platforms="${all_platforms} x86-linux-gcc"
  all_platforms="${all_platforms} x86-linux-icc"
  all_platforms="${all_platforms} x86-os2-gcc"
  all_platforms="${all_platforms} x86-solaris-gcc"
@@ -127,7 +127,7 @@ index 457bd6b38..fa4bce71b 100755
  all_platforms="${all_platforms} x86-win32-gcc"
  all_platforms="${all_platforms} x86-win32-vs14"
  all_platforms="${all_platforms} x86-win32-vs15"
-@@ -173,6 +179,8 @@ all_platforms="${all_platforms} x86_64-iphonesimulator-gcc"
+@@ -175,6 +181,8 @@ all_platforms="${all_platforms} x86_64-iphonesimulator-gcc"
  all_platforms="${all_platforms} x86_64-linux-gcc"
  all_platforms="${all_platforms} x86_64-linux-icc"
  all_platforms="${all_platforms} x86_64-solaris-gcc"
@@ -136,7 +136,7 @@ index 457bd6b38..fa4bce71b 100755
  all_platforms="${all_platforms} x86_64-win64-gcc"
  all_platforms="${all_platforms} x86_64-win64-vs14"
  all_platforms="${all_platforms} x86_64-win64-vs15"
-@@ -507,11 +515,10 @@ process_targets() {
+@@ -510,11 +518,10 @@ process_targets() {
      ! enabled multithread && DIST_DIR="${DIST_DIR}-nomt"
      ! enabled install_docs && DIST_DIR="${DIST_DIR}-nodocs"
      DIST_DIR="${DIST_DIR}-${tgt_isa}-${tgt_os}"
@@ -152,7 +152,7 @@ index 457bd6b38..fa4bce71b 100755
      if [ -f "${source_path}/build/make/version.sh" ]; then
          ver=`"$source_path/build/make/version.sh" --bare "$source_path"`
          DIST_DIR="${DIST_DIR}-${ver}"
-@@ -600,6 +607,10 @@ process_detect() {
+@@ -603,6 +610,10 @@ process_detect() {
  
              # Specialize windows and POSIX environments.
              case $toolchain in

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -1,10 +1,8 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/libvpx
     REF "v${VERSION}"
-    SHA512 824fe8719e4115ec359ae0642f5e1cea051d458f09eb8c24d60858cf082f66e411215e23228173ab154044bafbdfbb2d93b589bb726f55b233939b91f928aae0
+    SHA512 07f5e352411d6c0be331706d1835ac89bafbeddcbbac5542b473323766e9e974f4f68b33590f2aa50a7d8d69468a642b508cbb0a7c49a82c9933b07820f9c9d9
     HEAD_REF master
     PATCHES
         0003-add-uwp-v142-and-v143-support.patch

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libvpx",
-  "version": "1.15.2",
-  "port-version": 3,
+  "version": "1.16.0",
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5733,8 +5733,8 @@
       "port-version": 4
     },
     "libvpx": {
-      "baseline": "1.15.2",
-      "port-version": 3
+      "baseline": "1.16.0",
+      "port-version": 0
     },
     "libwandio": {
       "baseline": "4.2.6-1",

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e31aea790e1fca0a9de59250d67c0af4f48a001",
+      "version": "1.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "236f37cfc2554c561459979b338dde6b2aac9d8f",
       "version": "1.15.2",
       "port-version": 3


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

```
2026-01-06 v1.16.0 "Xenonetta Duck"
  This release includes Arm SVE2 and Neon optimizations for 12-tap filters,
  AVX512 implementations for SAD, support for per-frame and per-spatial-layer
  PSNR calculation, and numerous bug fixes.
  - Upgrading:
    This release is ABI incompatible with the previous release.
    Unit tests require C++17 to build.
    Support for 32-bit iOS targets (armv7, armv7s, and i386) has been removed.
  - Enhancement:
    Optimized Arm SVE2 and Neon implementations for 12-tap convolution filters.
    Optimized Neon High Bitdepth (HBD) SAD and sad_avg functions.
    Added Arm Neon DotProd and I8MM implementations for vpx_convolve12.
    Added AVX512 implementations for SAD64 and sad_skip functions.
    Added SSSE3 and AVX2 implementations for 12-tap temporal filter prediction.
    Added support for per-frame and per-spatial-layer PSNR calculation.
    Adjusted temporal filter strength to improve visual quality and reduce block
    artifacts.
    Added support for darwin24 (macOS 15) and darwin25 (macOS 26).
    libwebm is upgraded to commit b4f01ea.
  - Bug fixes:
    Fix to heap buffer overflow in vp9_deblock, vp9_post_proc_frame, and
    vp9_pack_bitstream.
    Fix to integer overflow in vp9_highbd_post_proc, vp9_rc_regulate_q,
    tiny_ssim, and vp9_calc_pframe_target_size_one_pass_cbr.
    Fix to use-of-uninitialized-value in vp9_highbd_post_proc, mfqe, and
    vp8_datarate_test.
    Fix to out-of-bounds in log_tile_cols_from_picsize_level.
    Fix to double free on initialization failure in vpx_codec_enc_init_multi.
    Fix to division-by-zero crash in vpxenc with 0 FPS numerator input.
    Fix to various build failures for Arm/SVE2, macOS cross-compilation, and
    Xcode 16.
```

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
