### PR TITLE
[webview] add 0.12.0

### DIFF
--- a/ports/webview/001_use_system_webview2.patch
+++ b/ports/webview/001_use_system_webview2.patch
@@ -1,0 +1,47 @@
+diff -Naur webview-0.12.0.orig/cmake/modules/FindMSWebView2.cmake webview-0.12.0/cmake/modules/FindMSWebView2.cmake
+--- webview-0.12.0.orig/cmake/modules/FindMSWebView2.cmake	2024-09-11 19:21:07.000000000 +0300
++++ webview-0.12.0/cmake/modules/FindMSWebView2.cmake	2026-02-12 22:50:33.603749400 +0300
+@@ -1,11 +1,4 @@
+-if(DEFINED MSWebView2_ROOT)
+-    find_path(MSWebView2_INCLUDE_DIR WebView2.h
+-        PATHS
+-            "${MSWebView2_ROOT}/build/native"
+-            "${MSWebView2_ROOT}"
+-        PATH_SUFFIXES include
+-        NO_CMAKE_FIND_ROOT_PATH)
+-endif()
++find_path(MSWebView2_INCLUDE_DIR WebView2.h)
+ 
+ include(FindPackageHandleStandardArgs)
+ find_package_handle_standard_args(MSWebView2 REQUIRED_VARS MSWebView2_INCLUDE_DIR)
+diff -Naur webview-0.12.0.orig/cmake/webview.cmake webview-0.12.0/cmake/webview.cmake
+--- webview-0.12.0.orig/cmake/webview.cmake	2024-09-11 19:21:07.000000000 +0300
++++ webview-0.12.0/cmake/webview.cmake	2026-02-12 22:50:16.042742400 +0300
+@@ -71,10 +71,6 @@
+         list(APPEND WEBVIEW_DEPENDENCIES PkgConfig::WEBVIEW_WEBKITGTK PkgConfig::WEBVIEW_GTK dl)
+     elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+         if(WEBVIEW_USE_BUILTIN_MSWEBVIEW2)
+-            find_package(MSWebView2 QUIET)
+-            if(NOT MSWebView2_FOUND)
+-                webview_fetch_mswebview2(${WEBVIEW_MSWEBVIEW2_VERSION})
+-            endif()
+             find_package(MSWebView2 REQUIRED)
+             if(MSWebView2_FOUND)
+                 list(APPEND WEBVIEW_DEPENDENCIES MSWebView2::headers)
+@@ -83,16 +79,3 @@
+         list(APPEND WEBVIEW_DEPENDENCIES advapi32 ole32 shell32 shlwapi user32 version)
+     endif()
+ endmacro()
+-
+-function(webview_fetch_mswebview2 VERSION)
+-    if(NOT COMMAND FetchContent_Declare)
+-        include(FetchContent)
+-    endif()
+-    set(FC_NAME microsoft_web_webview2)
+-    FetchContent_Declare(${FC_NAME}
+-        URL "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${VERSION}"
+-        CONFIGURE_COMMAND "")
+-    FetchContent_MakeAvailable(${FC_NAME})
+-    set(MSWebView2_ROOT "${${FC_NAME}_SOURCE_DIR}")
+-    set(MSWebView2_ROOT "${MSWebView2_ROOT}" PARENT_SCOPE)
+-endfunction()

--- a/ports/webview/portfile.cmake
+++ b/ports/webview/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO webview/webview
+    REF "${VERSION}"
+    SHA512 f198e414145101693fd2b5724fb017df578770c6edda319ce312cf9e9e1fdc1b1d94beba2e64e75d9746dee16010cc525be8ae7ca0713ee541b75a0a1d9bc791
+    HEAD_REF master
+    PATCHES 001_use_system_webview2.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DWEBVIEW_BUILD_DOCS=OFF
+        -DWEBVIEW_BUILD_TESTS=OFF
+        -DWEBVIEW_BUILD_EXAMPLES=OFF
+        -DWEBVIEW_ENABLE_CHECKS=OFF
+        -DWEBVIEW_ENABLE_PACKAGING=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/webview/vcpkg.json
+++ b/ports/webview/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "webview",
+  "version": "0.12.0",
+  "description": "A tiny cross-platform webview library for C/C++ to build modern cross-platform GUIs",
+  "homepage": "https://github.com/webview/webview",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "webview2",
+      "platform": "windows"
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.
