### PR TITLE
[libdjinterop] Devendor libraries

### DIFF
--- a/ports/libdjinterop/devendor_libs.diff
+++ b/ports/libdjinterop/devendor_libs.diff
@@ -1,0 +1,45 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7ca2d6f..f317c4d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -226,6 +226,9 @@ configure_file(
+ include(GNUInstallDirs)
+ set(DJINTEROP_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/djinterop")
+ 
++find_package(date CONFIG REQUIRED)
++find_path(SQLITE_MODERN_CPP_INCLUDE_DIRS "sqlite_modern_cpp.h")
++
+ target_include_directories(
+         DjInterop PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+@@ -234,13 +237,13 @@ target_include_directories(
+ target_include_directories(
+         DjInterop PRIVATE SYSTEM
+         ${ZLIB_INCLUDE_DIRS}
+-        ext/sqlite_modern_cpp
+-        ext/date)
++        ${SQLITE_MODERN_CPP_INCLUDE_DIRS})
+ 
+ target_link_libraries(
+     DjInterop PUBLIC
+-    ${ZLIB_LIBRARIES})
+-
++    ${ZLIB_LIBRARIES}
++    PRIVATE
++    date::date)
+ 
+ if(SYSTEM_SQLITE)
+     # Search for system installation of SQLite and use that.
+diff --git a/src/djinterop/util/chrono.cpp b/src/djinterop/util/chrono.cpp
+index 0d551dd..475aece 100644
+--- a/src/djinterop/util/chrono.cpp
++++ b/src/djinterop/util/chrono.cpp
+@@ -22,7 +22,7 @@
+ #include <stdexcept>
+ #include <string>
+ 
+-#include <date.h>
++#include <date/date.h>
+ 
+ namespace djinterop::util
+ {

--- a/ports/libdjinterop/portfile.cmake
+++ b/ports/libdjinterop/portfile.cmake
@@ -4,7 +4,11 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 45969510c2a2c863bd9627ddc73f404c84d12cc0eea922c23a04dc3486420188936ef556e6a5372e3cc390b3b12d748d64d0cae82a845d6306a4da18227bb435
     HEAD_REF master
+    PATCHES
+        devendor_libs.diff
 )
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/ext")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libdjinterop/vcpkg.json
+++ b/ports/libdjinterop/vcpkg.json
@@ -1,11 +1,14 @@
 {
   "name": "libdjinterop",
   "version": "0.27.0",
+  "port-version": 1,
   "description": "C++ library for access to DJ record libraries. Currently only supports Denon Engine Prime databases",
   "homepage": "https://github.com/xsco/libdjinterop",
   "license": "LGPL-3.0-or-later",
   "supports": "!xbox",
   "dependencies": [
+    "date",
+    "sqlite-modern-cpp",
     "sqlite3",
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4774,7 +4774,7 @@
     },
     "libdjinterop": {
       "baseline": "0.27.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libdmtx": {
       "baseline": "0.7.7",

--- a/versions/l-/libdjinterop.json
+++ b/versions/l-/libdjinterop.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb88b6ff11d18e737c84eafdf99e4c555d8d7056",
+      "version": "0.27.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d49a24f19dcdfc7403bb37d41e30b9f7d96141e8",
       "version": "0.27.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
