### PR TITLE
[pybind11] update to 3.0.3

### DIFF
--- a/ports/pybind11/android.diff
+++ b/ports/pybind11/android.diff
@@ -1,16 +1,16 @@
 diff --git a/tools/pybind11NewTools.cmake b/tools/pybind11NewTools.cmake
-index e881ca7..c012e2d 100644
+index 5ab3142..de0e63b 100644
 --- a/tools/pybind11NewTools.cmake
 +++ b/tools/pybind11NewTools.cmake
-@@ -248,10 +248,7 @@ if(TARGET ${_Python}::Module)
-   # files.
-   get_target_property(module_target_type ${_Python}::Module TYPE)
-   if(ANDROID AND module_target_type STREQUAL INTERFACE_LIBRARY)
--    set_property(
--      TARGET ${_Python}::Module
--      APPEND
--      PROPERTY INTERFACE_LINK_LIBRARIES "${${_Python}_LIBRARIES}")
-+    target_link_libraries(${_Python}::Module INTERFACE ${${_Python}_LIBRARIES})
-   endif()
+@@ -245,10 +245,7 @@ if(TARGET ${_Python}::Module)
+     APPEND
+     PROPERTY INTERFACE_LINK_LIBRARIES ${_Python}::Module)
+ else()
+-  set_property(
+-    TARGET pybind11::module
+-    APPEND
+-    PROPERTY INTERFACE_LINK_LIBRARIES pybind11::python_link_helper)
++  target_link_libraries(${_Python}::Module INTERFACE ${${_Python}_LIBRARIES})
+ endif()
  
-   set_property(
+ # WITHOUT_SOABI and WITH_SOABI will disable the custom extension handling used by pybind11.

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pybind/pybind11
     REF "v${VERSION}"
-    SHA512 c17e6d6a78c38e760864b390ac2aa7df6a94ca53acb2e8be71f0d63d611b738fa20a16946c98a93fbfcad56cb0346ebf247bbe41c6f5171c6ce68397b1e5c4db
+    SHA512 19bee2c76320e25202ee078b5680ff8a7acfb33494dec29dad984ab04de8bcb01340d9fec37c8cc5ac9015dfc367e60312dcd8506e66ce8f0af4c49db562ddef
     HEAD_REF master
     PATCHES
         android.diff

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pybind/pybind11
     REF "v${VERSION}"
-    SHA512 d6846dc88234a355f9ff312cfd0ecb8d3c7bb0e446ea5fcfc931ed7f18d56206e2b02662cdbd8d8d940a9f67b195dabfa13585f4bb1d57cb1af8a9c39a447a79
+    SHA512 40b40ec9fdde7b377222fa329162638be5e66bee75918d78369f741dc14b52f058fb50bb33159d099fc40f43aca39234092ce884cccc3258f34274c7dde807f0
     HEAD_REF master
     PATCHES
         android.diff

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pybind/pybind11
     REF "v${VERSION}"
-    SHA512 19bee2c76320e25202ee078b5680ff8a7acfb33494dec29dad984ab04de8bcb01340d9fec37c8cc5ac9015dfc367e60312dcd8506e66ce8f0af4c49db562ddef
+    SHA512 d6846dc88234a355f9ff312cfd0ecb8d3c7bb0e446ea5fcfc931ed7f18d56206e2b02662cdbd8d8d940a9f67b195dabfa13585f4bb1d57cb1af8a9c39a447a79
     HEAD_REF master
     PATCHES
         android.diff

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pybind11",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "documentation": "https://pybind11.readthedocs.io/",

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pybind11",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "documentation": "https://pybind11.readthedocs.io/",

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pybind11",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "documentation": "https://pybind11.readthedocs.io/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7901,7 +7901,7 @@
       "port-version": 0
     },
     "pybind11": {
-      "baseline": "3.0.1",
+      "baseline": "3.0.2",
       "port-version": 0
     },
     "pystring": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7901,7 +7901,7 @@
       "port-version": 0
     },
     "pybind11": {
-      "baseline": "3.0.3",
+      "baseline": "3.0.4",
       "port-version": 0
     },
     "pystring": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7901,7 +7901,7 @@
       "port-version": 0
     },
     "pybind11": {
-      "baseline": "3.0.2",
+      "baseline": "3.0.3",
       "port-version": 0
     },
     "pystring": {

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "95b6ea24ef8968359b14079b2a57d66afe1d7309",
+      "version": "3.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2c5d74751c919edb2c3c7a183ee633df69c45c15",
       "version": "3.0.1",
       "port-version": 0

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "95b6ea24ef8968359b14079b2a57d66afe1d7309",
-      "version": "3.0.2",
+      "git-tree": "2a3762571fbaf7be1355f02d4bf934e642abfa62",
+      "version": "3.0.3",
       "port-version": 0
     },
     {

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "2a3762571fbaf7be1355f02d4bf934e642abfa62",
-      "version": "3.0.3",
+      "git-tree": "d3653220bb9f1d47e6a8751f922786a9dda55e00",
+      "version": "3.0.4",
       "port-version": 0
     },
     {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/pybind/pybind11/releases/tag/v3.0.3

