### PR TITLE
[vincentlaucsb-csv-parser] update to 2.4.2

### DIFF
--- a/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
+++ b/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1b920b1..c56a142 100644
+index 210d0db..0434f73 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,6 +1,12 @@
- cmake_minimum_required(VERSION 3.9)
+ cmake_minimum_required(VERSION 3.10)
  project(csv)
  
 +include(GNUInstallDirs)
@@ -15,7 +15,7 @@ index 1b920b1..c56a142 100644
  if(CSV_CXX_STANDARD)
  	set(CMAKE_CXX_STANDARD ${CSV_CXX_STANDARD})
  else()
-@@ -40,10 +46,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
+@@ -45,10 +51,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
  
  include_directories(${CSV_INCLUDE_DIR})
  
@@ -27,7 +27,7 @@ index 1b920b1..c56a142 100644
  
  ## Main Library
  add_subdirectory(${CSV_SOURCE_DIR})
-@@ -60,6 +63,23 @@ if (CSV_BUILD_PROGRAMS)
+@@ -65,6 +68,23 @@ if (CSV_BUILD_PROGRAMS)
      add_subdirectory("programs")
  endif()
  

--- a/ports/vincentlaucsb-csv-parser/003-disable-coverage.patch
+++ b/ports/vincentlaucsb-csv-parser/003-disable-coverage.patch
@@ -1,11 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0434f73..12b2d90 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -29,7 +29,6 @@ if(MSVC)
- else()
- 	# Ignore Visual Studio pragma regions
- 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
--  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} --coverage -Og")
+@@ -39,7 +39,6 @@ else()
+ 	
+ 	if(ENABLE_CODE_COVERAGE)
+ 		message("Code coverage instrumentation enabled")
+-		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} --coverage -Og")
+ 	endif()
  endif(MSVC)
  
- set(CSV_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})

--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 d6314bbff657904a04bc5e2ccbb1cd07baf0c032f4d6f10cb56f24edda073cb75cd79c1993e690f38407bca73811136dc5837bed70d75d681cfa8200f799f4de
+    SHA512 b8d70f27be5f000880df25aa0d457e9a01053b4c851cbfe6c69a2b499fa03d75189ce73d357f28e69b8530a34b40d93e70a720f7441fa16b6dbed1cc502ba88d
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "2.4.0",
+  "version": "2.4.2",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10417,7 +10417,7 @@
       "port-version": 1
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "2.4.0",
+      "baseline": "2.4.2",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "74f142672f54d026df230440eec2a5102b63246f",
+      "version": "2.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "d15f09ac7ba7f28a276acbe6081fe7caa12e59d7",
       "version": "2.4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/vincentlaucsb/csv-parser/releases/tag/2.4.2
https://github.com/vincentlaucsb/csv-parser/releases/tag/2.4.1

