### PR TITLE
[libdivide] update to 5.3.0

### DIFF
--- a/ports/libdivide/portfile.cmake
+++ b/ports/libdivide/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ridiculousfish/libdivide
     REF "v${VERSION}"
-    SHA512 1a429b436e545360fb898e059ce689f5123d3fce25242d5a54e52588b75c97008918c1dc5e43f537eb8b2e61577339955ca66d9bbb0eb4440a00500a8a146ccf
+    SHA512 0a60d2ab750116faefc7db7a5209599d4fac5bfd74f7ad7377a525a65d4523855f395eb3e62e75a9eb9bf4d564354a40b2a056737bcf6c21cb6b7fb1f5918453
     HEAD_REF master
     PATCHES
         no-werror.patch

--- a/ports/libdivide/vcpkg.json
+++ b/ports/libdivide/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdivide",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "libdivide.h is a header-only C/C++ library for optimizing integer division.",
   "homepage": "https://github.com/ridiculousfish/libdivide",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4769,7 +4769,7 @@
       "port-version": 12
     },
     "libdivide": {
-      "baseline": "5.2.0",
+      "baseline": "5.3.0",
       "port-version": 0
     },
     "libdjinterop": {

--- a/versions/l-/libdivide.json
+++ b/versions/l-/libdivide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ee96d21ae7eb9c87ea8332c73fc39a9cbfe8f05b",
+      "version": "5.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5e81740fc7d610d3c1f30867c8aa127c7db25bcd",
       "version": "5.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/ridiculousfish/libdivide/releases/tag/v5.3.0
