### PR TITLE
[liblzma] Add sandbox feature

### DIFF
--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -13,6 +13,12 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         tools BUILD_TOOLS
 )
 
+if("tools" IN_LIST FEATURES)
+    set(XZ_SANDBOX "auto")
+else()
+    set(XZ_SANDBOX "no")
+endif()
+
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "wasm32")
     set(WASM_OPTIONS -DCMAKE_C_BYTE_ORDER=LITTLE_ENDIAN -DCMAKE_CXX_BYTE_ORDER=LITTLE_ENDIAN)
 endif()
@@ -28,6 +34,7 @@ vcpkg_cmake_configure(
         -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=   # using flags from (vcpkg) toolchain
         -DENABLE_NLS=OFF # nls is not supported by this port, yet
         -DXZ_NLS=OFF
+        -DXZ_SANDBOX:STRING=${XZ_SANDBOX}
     MAYBE_UNUSED_VARIABLES
         CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
         CREATE_XZ_SYMLINKS

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "liblzma",
   "version": "5.8.2",
+  "port-version": 1,
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5122,7 +5122,7 @@
     },
     "liblzma": {
       "baseline": "5.8.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libmad": {
       "baseline": "0.16.4",

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d161ccfe43a06cdb2a32d7a9e9fcbf92d67eb7ab",
+      "version": "5.8.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "ac8f26dab6f1bda59ca96900cda5c81a1cd0aa48",
       "version": "5.8.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #49986

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [X] Any patches that are no longer applied are deleted from the port's directory.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.
