### PR TITLE
[aws-c-auth] Update to 0.9.6

### DIFF
--- a/ports/aws-c-auth/portfile.cmake
+++ b/ports/aws-c-auth/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-auth
     REF "v${VERSION}"
-    SHA512 fecd4cb7f650022fb19be99c76f86690d8a425e885298798f3c1edb5f58580202f8a6c1a1e415e79f7b37dfccb0e43f9baaf87aa75ecaf11286f9e08e6730a72
-    HEAD_REF master
+    SHA512 03d39cf5b03a08478cdce9decf33166ada7235b3ff2eb9ea657724dbadacd08bea2bc6322bbf67136270ce9a8be8010f0bb845f1ed650b2b93f492351805ac34
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/aws-c-auth/vcpkg.json
+++ b/ports/aws-c-auth/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-auth",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "C99 library implementation of AWS client-side authentication: standard credentials providers and signing.",
   "homepage": "https://github.com/awslabs/aws-c-auth",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-auth.json
+++ b/versions/a-/aws-c-auth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cd943ef660eea7d2e2498f11e657a4d72c92cfc8",
+      "version": "0.9.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "69e60a5d5d9642457352cbfbc3239c8386731ba9",
       "version": "0.9.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -453,7 +453,7 @@
       "port-version": 2
     },
     "aws-c-auth": {
-      "baseline": "0.9.5",
+      "baseline": "0.9.6",
       "port-version": 0
     },
     "aws-c-cal": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
