### PR TITLE
[huira] Add new port version 0.8.0

### DIFF
--- a/ports/huira/portfile.cmake
+++ b/ports/huira/portfile.cmake
@@ -18,7 +18,6 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         -DHUIRA_APPS=ON          # build CLI tools → installed to tools/huira/
         -DHUIRA_TESTS=OFF        # never build tests in a port
-        -DBUILD_SHARED_LIBS=OFF  # vcpkg prefers static by default; flip if needed
 )
 
 vcpkg_cmake_install()

--- a/ports/huira/portfile.cmake
+++ b/ports/huira/portfile.cmake
@@ -1,7 +1,3 @@
-# portfile.cmake for huira
-#
-# vcpkg install huira
-
 set(VCPKG_BUILD_TYPE release) # Only headers and tools
 
 vcpkg_from_github(

--- a/ports/huira/portfile.cmake
+++ b/ports/huira/portfile.cmake
@@ -2,6 +2,8 @@
 #
 # vcpkg install huira
 
+set(VCPKG_BUILD_TYPE release) # Only headers and tools
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO huira-render/huira
@@ -10,29 +12,23 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-set(VCPKG_BUILD_TYPE release)
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools HUIRA_APPS
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
-        -DHUIRA_APPS=ON          # build CLI tools → installed to tools/huira/
-        -DHUIRA_TESTS=OFF        # never build tests in a port
+        -DHUIRA_TESTS=OFF
 )
 
 vcpkg_cmake_install()
 
-# Relocate CLI tools from bin/ to the vcpkg-conventional tools directory.
-# List every executable your project installs.
-set(HUIRA_TOOLS
-    huira
-)
-
-# vcpkg_copy_tools also registers the tools so vcpkg add-path knows about them.
-vcpkg_copy_tools(
-    TOOL_NAMES ${HUIRA_TOOLS}
-    AUTO_CLEAN
-)
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES huira AUTO_CLEAN)
+endif()
 
 # Fix up the installed CMake config so that paths are relocatable.
 vcpkg_cmake_config_fixup(
@@ -50,8 +46,5 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/bin"
 )
 
-# Install usage file
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
-# Install the license. Adjust the filename to match your project.
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/huira/portfile.cmake
+++ b/ports/huira/portfile.cmake
@@ -1,0 +1,58 @@
+# portfile.cmake for huira
+#
+# vcpkg install huira
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO huira-render/huira
+    REF "v${VERSION}"
+    SHA512 7f46d1c514a4a7ba5981dd2224ff4b01b3dc8f30903cf91f3bde25135d338dd7ac375d68eb75502d26264f7c6e54195c6126487cfc51c0a7c87f7c53d49df30f
+    HEAD_REF main
+)
+
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DHUIRA_APPS=ON          # build CLI tools → installed to tools/huira/
+        -DHUIRA_TESTS=OFF        # never build tests in a port
+        -DBUILD_SHARED_LIBS=OFF  # vcpkg prefers static by default; flip if needed
+)
+
+vcpkg_cmake_install()
+
+# Relocate CLI tools from bin/ to the vcpkg-conventional tools directory.
+# List every executable your project installs.
+set(HUIRA_TOOLS
+    huira
+)
+
+# vcpkg_copy_tools also registers the tools so vcpkg add-path knows about them.
+vcpkg_copy_tools(
+    TOOL_NAMES ${HUIRA_TOOLS}
+    AUTO_CLEAN
+)
+
+# Fix up the installed CMake config so that paths are relocatable.
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME huira
+    CONFIG_PATH lib/cmake/huira
+)
+
+# Cleanup
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/bin"
+    "${CURRENT_PACKAGES_DIR}/debug/bin"
+    "${CURRENT_PACKAGES_DIR}/lib"
+    "${CURRENT_PACKAGES_DIR}/bin"
+)
+
+# Install usage file
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+# Install the license. Adjust the filename to match your project.
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/huira/portfile.cmake
+++ b/ports/huira/portfile.cmake
@@ -36,14 +36,10 @@ vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/huira
 )
 
-# Cleanup
 file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug/include"
-    "${CURRENT_PACKAGES_DIR}/debug/share"
     "${CURRENT_PACKAGES_DIR}/bin"
     "${CURRENT_PACKAGES_DIR}/debug/bin"
     "${CURRENT_PACKAGES_DIR}/lib"
-    "${CURRENT_PACKAGES_DIR}/bin"
 )
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/huira/usage
+++ b/ports/huira/usage
@@ -1,0 +1,17 @@
+huira provides CMake integration targets and CLI tools.
+
+--- CMake library usage ---
+
+  find_package(huira CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE huira::huira)
+
+--- CLI tools ---
+
+The following tools are installed to tools/huira/ and can be added to your
+PATH with:
+
+  vcpkg integrate install   # or use the CMAKE_PREFIX_PATH approach
+
+Run `vcpkg x-add-path` or invoke them directly at:
+
+  <vcpkg-root>/installed/<triplet>/tools/huira/<tool-name>

--- a/ports/huira/usage
+++ b/ports/huira/usage
@@ -1,17 +1,4 @@
-huira provides CMake integration targets and CLI tools.
-
---- CMake library usage ---
+huira provides CMake integration:
 
   find_package(huira CONFIG REQUIRED)
   target_link_libraries(main PRIVATE huira::huira)
-
---- CLI tools ---
-
-The following tools are installed to tools/huira/ and can be added to your
-PATH with:
-
-  vcpkg integrate install   # or use the CMAKE_PREFIX_PATH approach
-
-Run `vcpkg x-add-path` or invoke them directly at:
-
-  <vcpkg-root>/installed/<triplet>/tools/huira/<tool-name>

--- a/ports/huira/vcpkg.json
+++ b/ports/huira/vcpkg.json
@@ -8,27 +8,14 @@
     "assimp",
     "cfitsio",
     "cspice",
-    "curl",
-    {
-      "name": "embree",
-      "default-features": false,
-      "features": [
-        "geometry-instance",
-        "geometry-triangle",
-        "tasking-tbb"
-      ]
-    },
-    "fftw3",
-    {
-      "name": "gdal",
-      "default-features": false
-    },
     "glm",
-    "indicators",
     "libjpeg-turbo",
     "libpng",
     "tbb",
-    "tiff",
+    {
+      "name": "tiff",
+      "default-features": false
+    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -37,5 +24,17 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build huira applications",
+      "dependencies": [
+        {
+          "name": "curl",
+          "default-features": false
+        },
+        "indicators"
+      ]
+    }
+  }
 }

--- a/ports/huira/vcpkg.json
+++ b/ports/huira/vcpkg.json
@@ -27,7 +27,8 @@
   ],
   "features": {
     "tools": {
-      "description": "Build huira applications",
+      "description": "Build huira command line tools",
+      "supports": "!android & !uwp & !xbox",
       "dependencies": [
         {
           "name": "curl",

--- a/ports/huira/vcpkg.json
+++ b/ports/huira/vcpkg.json
@@ -1,0 +1,41 @@
+{
+  "name": "huira",
+  "version": "0.8.0",
+  "description": "A ray tracing library for space engineering and planetary science.",
+  "homepage": "https://github.com/YOUR_ORG/huira",
+  "license": "MIT",
+  "dependencies": [
+    "assimp",
+    "cfitsio",
+    "cspice",
+    "curl",
+    {
+      "name": "embree",
+      "default-features": false,
+      "features": [
+        "geometry-instance",
+        "geometry-triangle",
+        "tasking-tbb"
+      ]
+    },
+    "fftw3",
+    {
+      "name": "gdal",
+      "default-features": false
+    },
+    "glm",
+    "indicators",
+    "libjpeg-turbo",
+    "libpng",
+    "tbb",
+    "tiff",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/huira/vcpkg.json
+++ b/ports/huira/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "A ray tracing library for space engineering and planetary science.",
   "homepage": "https://github.com/YOUR_ORG/huira",
   "license": "MIT",
+  "supports": "!android & !uwp & !xbox",
   "dependencies": [
     "assimp",
     "cfitsio",
@@ -28,7 +29,6 @@
   "features": {
     "tools": {
       "description": "Build huira command line tools",
-      "supports": "!android & !uwp & !xbox",
       "dependencies": [
         {
           "name": "curl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3824,6 +3824,10 @@
       "baseline": "2.9.4",
       "port-version": 3
     },
+    "huira": {
+      "baseline": "0.8.0",
+      "port-version": 0
+    },
     "hungarian": {
       "baseline": "0.1.3",
       "port-version": 3

--- a/versions/h-/huira.json
+++ b/versions/h-/huira.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7a42d03a9e961f613a35fe4f45324cffc293682e",
+      "git-tree": "be75eeb6d538a3111c8b64cffde8f044763827c2",
       "version": "0.8.0",
       "port-version": 0
     }

--- a/versions/h-/huira.json
+++ b/versions/h-/huira.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c2177bec5a2e0c3517e044f37adbab68137de180",
+      "version": "0.8.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/h-/huira.json
+++ b/versions/h-/huira.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c2177bec5a2e0c3517e044f37adbab68137de180",
+      "git-tree": "7a42d03a9e961f613a35fe4f45324cffc293682e",
       "version": "0.8.0",
       "port-version": 0
     }


### PR DESCRIPTION
Add new port: huira

huira is a header-only C++ ray tracing library for space engineering and planetary science. It provides an `INTERFACE` CMake target (`huira::huira`) and a CLI tool (`huira`) built via `HUIRA_APPS=ON`.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The file installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.