### PR TITLE
[bddisasm] Update to 3.0.1

### DIFF
--- a/ports/bddisasm/portfile.cmake
+++ b/ports/bddisasm/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bitdefender/bddisasm
     REF "v${VERSION}"
-    SHA512 584e7640ee1964c6ddca9c8653eeb07836adaa48b99ec1bf62b7fc7e8f094ec75f14f82ac1cb227e1b48352add24841fb2b7f6c53f975d7421e4fd9bdf99cb7c
+    SHA512 a0a3fab35acacd7a6cfc96fed867a7c242ecdfe75867c3dcbf66fc9747452f09cc44c5a5038fe15d146eb597c1712f59b89b86961a48f738483794fde9ec0ecc
     HEAD_REF master
 )
 

--- a/ports/bddisasm/vcpkg.json
+++ b/ports/bddisasm/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bddisasm",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "maintainers": "Cristi Anichitei <ianichitei@bitdefender.com>",
   "description": "bddisasm is a fast, lightweight, x86/x64 instruction decoder and emulator.",
   "homepage": "https://github.com/bitdefender/bddisasm",

--- a/versions/b-/bddisasm.json
+++ b/versions/b-/bddisasm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "03ad37b889270ac8fb21cd90c55bed7f536bbe0d",
+      "version": "3.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8462a1ae4b00ccf36adf0a7532221b306a56ecd9",
       "version": "3.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -661,7 +661,7 @@
       "port-version": 4
     },
     "bddisasm": {
-      "baseline": "3.0.0",
+      "baseline": "3.0.1",
       "port-version": 0
     },
     "bde": {


### PR DESCRIPTION

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

The current version of bddisasm available on vcpkg, v3.0.0, has a bug: not all of the required interface headers are listed in CMakeLists.txt:

```
set(BDDISASM_PUBLIC_HEADERS
    "inc/bddisasm.h"
    "inc/bddisasm_status.h"
    "inc/bddisasm_types.h"
    "inc/bddisasm_version.h"
    "inc/bdx86_constants.h"
    "inc/bdx86_core.h"
    "inc/bdx86_cpuidflags.h"
    "inc/bdx86_registers.h")
```

this list is missing `"inc/bdx86_api_legacy.h"` and `"inc/bdx86_api_mini.h"`, which are referenced in bdx86_core.h. As a result these files are not copied when installing the package, which results in compilation errors when you try to use the library:

```
L:\test\build\win-msvc-debug\vcpkg_installed\x64-windows-static\include\bddisasm\bdx86_core.h(1945): fatal error C1083: Cannot open include file: 'bdx86_api_legacy.h': No such file or directory
```

This effectively makes the current vcpkg port for bddisasm unusable.

Version 3.0.1 contains the required fix for this issue.
See: https://github.com/bitdefender/bddisasm/issues/115

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
