### PR TITLE
[z3] update to 4.16.0

### DIFF
--- a/ports/z3/portfile.cmake
+++ b/ports/z3/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO Z3Prover/z3
   REF z3-${VERSION}
-  SHA512 e31df90b0edb3fd4a49a1069d78135d03c6b196c2bc8359a67273e02eba7214a7ff8654488f076ce7a0cf6edffdff9afc403799db3a6e5a1585a6d4c99c4df2a
+  SHA512 7dbcdd04a72f46bc3b6cbac2453b2a43f5ae126287b878ffe37f0573f910a1130c474c5edfa622dab09957f106cf425ab0f7cdfd34d41658599ad50a81ae39dd
   HEAD_REF master
   PATCHES
       fix-install-path.patch

--- a/ports/z3/vcpkg.json
+++ b/ports/z3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "z3",
-  "version": "4.15.8",
+  "version": "4.16.0",
   "description": "Z3 is a theorem prover from Microsoft Research",
   "homepage": "https://github.com/Z3Prover/z3",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10965,7 +10965,7 @@
       "port-version": 0
     },
     "z3": {
-      "baseline": "4.15.8",
+      "baseline": "4.16.0",
       "port-version": 0
     },
     "z4kn4fein-semver": {

--- a/versions/z-/z3.json
+++ b/versions/z-/z3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92417c223aa55b84d0eb5633c242736f18838bcc",
+      "version": "4.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "72ef33c9ebb7e24fbbddfbe13d8c075339d2a145",
       "version": "4.15.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/Z3Prover/z3/blob/z3-4.16.0/RELEASE_NOTES.md#version-4160
