### PR TITLE
[openldap] fix emscripten build

### DIFF
--- a/ports/openldap/portfile.cmake
+++ b/ports/openldap/portfile.cmake
@@ -28,6 +28,8 @@ endif()
 
 if(VCPKG_TARGET_IS_ANDROID)
     vcpkg_list(APPEND FEATURE_OPTIONS -with-yielding_select=yes)
+elseif(VCPKG_TARGET_IS_EMSCRIPTEN)
+    vcpkg_list(APPEND FEATURE_OPTIONS --with-yielding_select=no)
 endif()
 
 # Disable build environment details in binaries

--- a/ports/openldap/vcpkg.json
+++ b/ports/openldap/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openldap",
   "version": "2.6.10",
+  "port-version": 1,
   "description": "OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.",
   "homepage": "https://www.openldap.org/software/",
   "license": "OLDAP-2.8",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7250,7 +7250,7 @@
     },
     "openldap": {
       "baseline": "2.6.10",
-      "port-version": 0
+      "port-version": 1
     },
     "openmama": {
       "baseline": "6.3.2",

--- a/versions/o-/openldap.json
+++ b/versions/o-/openldap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34670de3e7ab65b3802aaab853d1126d67fe576f",
+      "version": "2.6.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "b49c6475c57f176ace4dc3f4b2a62caf893025d3",
       "version": "2.6.10",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
