### PR TITLE
[vincentlaucsb-csv-parser] update to 2.5.0

### DIFF
--- a/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
+++ b/ports/vincentlaucsb-csv-parser/001-fix-cmake.patch
@@ -1,21 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 210d0db..0434f73 100644
+index f0b137a..3ff9de7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1,6 +1,12 @@
+@@ -1,5 +1,9 @@
  cmake_minimum_required(VERSION 3.10)
  project(csv)
- 
 +include(GNUInstallDirs)
 +
-+find_path(HEDLEY_INCLUDE_DIRS "hedley.h")
 +find_package(mio CONFIG REQUIRED)
 +find_package(string-view-lite CONFIG REQUIRED)
-+
+ 
  if(CSV_CXX_STANDARD)
  	set(CMAKE_CXX_STANDARD ${CSV_CXX_STANDARD})
- else()
-@@ -45,10 +51,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
+@@ -46,10 +50,7 @@ set(CSV_TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/tests)
  
  include_directories(${CSV_INCLUDE_DIR})
  
@@ -27,7 +24,7 @@ index 210d0db..0434f73 100644
  
  ## Main Library
  add_subdirectory(${CSV_SOURCE_DIR})
-@@ -65,6 +68,23 @@ if (CSV_BUILD_PROGRAMS)
+@@ -66,6 +67,23 @@ if (CSV_BUILD_PROGRAMS)
      add_subdirectory("programs")
  endif()
  
@@ -52,10 +49,10 @@ index 210d0db..0434f73 100644
  if (CSV_DEVELOPER)
      # Allow for performance profiling
 diff --git a/include/internal/CMakeLists.txt b/include/internal/CMakeLists.txt
-index 7da751c..45b1bb8 100644
+index 7da751c..9c80176 100644
 --- a/include/internal/CMakeLists.txt
 +++ b/include/internal/CMakeLists.txt
-@@ -26,6 +26,9 @@ target_sources(csv
+@@ -26,6 +26,8 @@ target_sources(csv
  		thread_safe_deque.hpp
  		)
  
@@ -64,7 +61,6 @@ index 7da751c..45b1bb8 100644
 -target_include_directories(csv INTERFACE ../)
 +set_target_properties(csv PROPERTIES LINKER_LANGUAGE CXX OUTPUT_NAME "vincentlaucsb-csv-parser-csv")
 +target_include_directories(csv
-+	PUBLIC ${HEDLEY_INCLUDE_DIRS}
 +	INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vincentlaucsb-csv-parser>
 +)
 +target_link_libraries(csv PRIVATE Threads::Threads PUBLIC mio::mio mio::mio-headers nonstd::string-view-lite)

--- a/ports/vincentlaucsb-csv-parser/002-fix-include.patch
+++ b/ports/vincentlaucsb-csv-parser/002-fix-include.patch
@@ -1,8 +1,8 @@
 diff --git a/include/internal/basic_csv_parser.hpp b/include/internal/basic_csv_parser.hpp
-index d76b2d9..8dd0110 100644
+index 16c8666..7b4221e 100644
 --- a/include/internal/basic_csv_parser.hpp
 +++ b/include/internal/basic_csv_parser.hpp
-@@ -15,7 +15,7 @@
+@@ -12,7 +12,7 @@
  #include <thread>
  #include <vector>
  
@@ -12,29 +12,23 @@ index d76b2d9..8dd0110 100644
  #include "common.hpp"
  #include "csv_format.hpp"
 diff --git a/include/internal/common.hpp b/include/internal/common.hpp
-index c132bfb..dff4d03 100644
+index 7f8d737..f0ead1a 100644
 --- a/include/internal/common.hpp
 +++ b/include/internal/common.hpp
-@@ -28,12 +28,12 @@
- #pragma once
- #include <type_traits>
- 
+@@ -92,7 +92,7 @@ namespace csv {
+       */
+     using string_view = std::string_view;
+ #else
 -#include "../external/string_view.hpp"
 +#include "nonstd/string_view.hpp"
- 
-   // If there is another version of Hedley, then the newer one 
-   // takes precedence.
-   // See: https://github.com/nemequ/hedley
--#include "../external/hedley.h"
-+#include "hedley.h"
- 
- namespace csv {
- #ifdef _MSC_VER
+      /** @typedef string_view
+       *  The string_view class used by this library.
+       */
 diff --git a/include/internal/csv_reader.hpp b/include/internal/csv_reader.hpp
-index 1cdf6e0..3077395 100644
+index 02e9164..2e93f12 100644
 --- a/include/internal/csv_reader.hpp
 +++ b/include/internal/csv_reader.hpp
-@@ -15,7 +15,7 @@
+@@ -16,7 +16,7 @@
  #include <string>
  #include <vector>
  

--- a/ports/vincentlaucsb-csv-parser/portfile.cmake
+++ b/ports/vincentlaucsb-csv-parser/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vincentlaucsb/csv-parser
     REF "${VERSION}"
-    SHA512 b8d70f27be5f000880df25aa0d457e9a01053b4c851cbfe6c69a2b499fa03d75189ce73d357f28e69b8530a34b40d93e70a720f7441fa16b6dbed1cc502ba88d
+    SHA512 72f67ebe33af9d5e986650c7de3a4b1e9fce50c9dcd51d7c840b6bf3c355f4c17395046183131c1263bc45506092a22801e5a47dee810ac7e591416a4802814a
     HEAD_REF master
     PATCHES
         001-fix-cmake.patch

--- a/ports/vincentlaucsb-csv-parser/vcpkg.json
+++ b/ports/vincentlaucsb-csv-parser/vcpkg.json
@@ -1,12 +1,11 @@
 {
   "name": "vincentlaucsb-csv-parser",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "A modern C++ library for reading, writing, and analyzing CSV (and similar) files.",
   "homepage": "https://github.com/vincentlaucsb/csv-parser",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
-    "hedley",
     "mio",
     "string-view-lite",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10421,7 +10421,7 @@
       "port-version": 1
     },
     "vincentlaucsb-csv-parser": {
-      "baseline": "2.4.2",
+      "baseline": "2.5.0",
       "port-version": 0
     },
     "visit-struct": {

--- a/versions/v-/vincentlaucsb-csv-parser.json
+++ b/versions/v-/vincentlaucsb-csv-parser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d4e2220377a12ea0b1d58998611f77c33409f8f6",
+      "version": "2.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "74f142672f54d026df230440eec2a5102b63246f",
       "version": "2.4.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/vincentlaucsb/csv-parser/releases/tag/2.5.0
