### PR TITLE
[openal-soft] update to 1.25.1

### DIFF
--- a/ports/openal-soft/portfile.cmake
+++ b/ports/openal-soft/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcat/openal-soft
     REF ${VERSION}
-    SHA512 33cdc03198c4fdbd6c67bae460328d8f910baf0a522891735590df140ef727a5d7a1acc64826128994700e7d75c75c938b20483858575ff4e0ebc3f120a9e206
+    SHA512 47eccb317ed6040c549f2b51d2d45afcdcd03d56d8cb0ea9ef8a98d2c61c9629ffad39596cffa2ad848dd3b65a227a6591406dc483ebd3a3e03bb0a4d0f112b1
     HEAD_REF master
     PATCHES
         pkgconfig-cxx.diff

--- a/ports/openal-soft/vcpkg.json
+++ b/ports/openal-soft/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openal-soft",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.",
   "homepage": "https://github.com/kcat/openal-soft",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7153,7 +7153,7 @@
       "port-version": 0
     },
     "openal-soft": {
-      "baseline": "1.25.0",
+      "baseline": "1.25.1",
       "port-version": 0
     },
     "openblas": {

--- a/versions/o-/openal-soft.json
+++ b/versions/o-/openal-soft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6aef35d27ec2119c280b9a60324226cba2ddea27",
+      "version": "1.25.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b9ddf9723bc350b0b106d0d4f11b75181798dcde",
       "version": "1.25.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/kcat/openal-soft/releases/tag/1.25.1
