### PR TITLE
[basisu] update to 2.0.3

### DIFF
--- a/ports/basisu/devendor-zstd.diff
+++ b/ports/basisu/devendor-zstd.diff
@@ -1,19 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c4f91bb..c29c411 100644
+index c4f91bb..c48e4f4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -96,6 +96,10 @@ message("Initial BASISU_OPENCL=${BASISU_OPENCL}")
+@@ -96,6 +96,9 @@ message("Initial BASISU_OPENCL=${BASISU_OPENCL}")
  message("Initial BASISU_SAN=${BASISU_SAN}")
  message("Initial BASISU_EXAMPLES=${BASISU_EXAMPLES}")
  
 +if(BASISU_SYSTEM_ZSTD)
 +    find_package(zstd CONFIG REQUIRED)
 +endif()
-+
  if ((NOT MSVC) AND BASISU_OPENCL)
      # With MSVC builds we use the Khronos lib/include files in the project's "OpenCL" directory, to completely avoid requiring fiddly to install vendor SDK's.
      # Otherwise we use the system's (if any).
-@@ -286,13 +290,8 @@ set(ENCODER_LIB_SRC_LIST
+@@ -286,12 +289,8 @@ set(ENCODER_LIB_SRC_LIST
      transcoder/basisu_transcoder.h
      transcoder/basisu_idct.h
      transcoder/basisu.h
@@ -23,11 +22,10 @@ index c4f91bb..c29c411 100644
 -if (BASISU_ZSTD)
 -    set(ENCODER_LIB_SRC_LIST ${ENCODER_LIB_SRC_LIST} zstd/zstd.c)
 -endif()
--
+ 
  # Create the static library
  add_library(basisu_encoder STATIC ${ENCODER_LIB_SRC_LIST})
- target_include_directories(basisu_encoder PUBLIC
-@@ -300,6 +299,14 @@ target_include_directories(basisu_encoder PUBLIC
+@@ -300,6 +299,13 @@ target_include_directories(basisu_encoder PUBLIC
      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/encoder>
      $<INSTALL_INTERFACE:include>)
  
@@ -38,40 +36,47 @@ index c4f91bb..c29c411 100644
 +    target_sources(basisu_encoder PRIVATE zstd/zstd.c zstd/zstd.h)
 +    target_include_directories(basisu_encoder BEFORE PRIVATE zstd)
 +endif()
-+
  # Create the basisu executable and link against the static library
  add_executable(basisu basisu_tool.cpp)
  target_link_libraries(basisu PRIVATE basisu_encoder)
+@@ -347,7 +353,7 @@ if (BASISU_BUILD_WASM)
+         
+     endif()
+ 
+-    # 256 MB initial, 3.5 GB max — safe defaults for BasisU
++    # 256 MB initial, 3.5 GB max ï¿½ safe defaults for BasisU
+     target_link_options(basisu PRIVATE
+         -Wl,--initial-memory=268435456
+         -Wl,--max-memory=3758096384
 diff --git a/basisu-config.cmake.in b/basisu-config.cmake.in
-index 15c0d7e..7acd627 100644
+index 15c0d7e..243c6ea 100644
 --- a/basisu-config.cmake.in
 +++ b/basisu-config.cmake.in
-@@ -1,5 +1,10 @@
+@@ -1,5 +1,9 @@
  @PACKAGE_INIT@
  
 +include(CMakeFindDependencyMacro)
 +if("@BASISU_ZSTD@" AND "@BASISU_SYSTEM_ZSTD@")
 +  find_dependency(zstd CONFIG)
 +endif()
-+
  include("${CMAKE_CURRENT_LIST_DIR}/basisu-targets.cmake")
  
  check_required_components(basisu)
 diff --git a/encoder/basisu_astc_ldr_encode.cpp b/encoder/basisu_astc_ldr_encode.cpp
-index 1710b1b..0739464 100644
+index 66b8e16..06b0754 100644
 --- a/encoder/basisu_astc_ldr_encode.cpp
 +++ b/encoder/basisu_astc_ldr_encode.cpp
-@@ -18,7 +18,7 @@
- #include "3rdparty/android_astc_decomp.h"
- #include <queue>
+@@ -27,7 +27,7 @@
+ #endif
  
+ #if BASISD_SUPPORT_KTX2_ZSTD
 -#include "../zstd/zstd.h"
 +#include <zstd.h>
+ #endif
  
  namespace basisu {
- namespace astc_ldr {
 diff --git a/encoder/basisu_comp.cpp b/encoder/basisu_comp.cpp
-index 617ff30..f2fb95b 100644
+index 1803020..9727b93 100644
 --- a/encoder/basisu_comp.cpp
 +++ b/encoder/basisu_comp.cpp
 @@ -34,7 +34,7 @@
@@ -84,7 +89,7 @@ index 617ff30..f2fb95b 100644
  
  // Set to 1 to disable the mipPadding alignment workaround (which only seems to be needed when no key-values are written at all)
 diff --git a/transcoder/basisu_transcoder.cpp b/transcoder/basisu_transcoder.cpp
-index 347a024..521af5c 100644
+index 1321c7d..c042c8c 100644
 --- a/transcoder/basisu_transcoder.cpp
 +++ b/transcoder/basisu_transcoder.cpp
 @@ -174,7 +174,7 @@

--- a/ports/basisu/portfile.cmake
+++ b/ports/basisu/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BinomialLLC/basis_universal
     REF "${git_ref}"
-    SHA512 5dec1498ba61ca117d554a26463272d0b12547f8bd92fb5e60a37d4bc004c802535ca719a3c8d2968ab0dc8aeeb40760e3598897c87e62aa5f1ab3b5e882e66c
+    SHA512 92f5883333cd76219a5a69141b020faf0285453f98abcaa56f3d57eed36b2c21e9f22d1d265347d48c53f89f02bc2a5881e5df783a97898ec9434c2384ad23e6
     HEAD_REF master
     PATCHES
         export-cmake-config.diff

--- a/ports/basisu/vcpkg.json
+++ b/ports/basisu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "basisu",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Basis Universal is a supercompressed GPU texture and video compression format that outputs a highly compressed intermediate file format (.basis) that can be quickly transcoded to a wide variety of GPU texture compression formats.",
   "homepage": "https://github.com/BinomialLLC/basis_universal",
   "license": null,

--- a/versions/b-/basisu.json
+++ b/versions/b-/basisu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c73f0aa68245d73234e6e6d623ac6f63761165f",
+      "version": "2.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "b301b37105c01693f50151fa04456fc7c3b00c40",
       "version": "2.0.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -645,7 +645,7 @@
       "port-version": 0
     },
     "basisu": {
-      "baseline": "2.0.2",
+      "baseline": "2.0.3",
       "port-version": 0
     },
     "bbalouki-itch": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/BinomialLLC/basis_universal/releases/tag/v2_0_3
