### PR TITLE
[valijson] update to 1.1.0

### DIFF
--- a/ports/valijson/portfile.cmake
+++ b/ports/valijson/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tristanpenman/valijson
     REF "v${VERSION}"
-    SHA512 d62fd57c10ef5343f2ba16c23f0c327ead21dabe637a9100c3a4ab88920b7feb55b53f6abc966da37e3cebbb44c19bc2588470dd036f0ff6e58054b41b71758a
+    SHA512 4916e12dc45312462a7abbc2707f5c1edfe129feb03e73afebf11a80ac6fb2f4469fdb4d83174d1c0565f8553ff958b1dc0ea78132d7063bbf640de0ade1676b
     HEAD_REF master
 )
 

--- a/ports/valijson/vcpkg.json
+++ b/ports/valijson/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "name": "valijson",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Header-only C++ library for JSON Schema validation",
+  "homepage": "https://github.com/tristanpenman/valijson",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10273,7 +10273,7 @@
       "port-version": 8
     },
     "valijson": {
-      "baseline": "1.0.6",
+      "baseline": "1.1.0",
       "port-version": 0
     },
     "value-ptr-lite": {

--- a/versions/v-/valijson.json
+++ b/versions/v-/valijson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7fce2196da7dbf7ea93f35953165da8bf96f9485",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "de3f430dc5bc0b7d918b7e6e9bfdfd5d72bb38c8",
       "version": "1.0.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/tristanpenman/valijson/releases/tag/v1.1.0
