### PR TITLE
[paho-mqtt] update to 1.3.16

### DIFF
--- a/ports/paho-mqtt/portfile.cmake
+++ b/ports/paho-mqtt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO eclipse/paho.mqtt.c
   REF "v${VERSION}"
-  SHA512 e2c47485624f47a895aeeb4f978dd8d98fefca1c8caf9512a2adc03d0bf3c0c2225ab3f96a6ad3513f6df1976e52645248666308c42f05ce25fc8d0980947d28
+  SHA512 a69cb4fdd9c56d7ed7b2275610b680bd9830d9e5b5d5151edf30db052da234b0ccce93e6b9e687be3f515699b79721d9282b5a77bf7a00e1719e5264e0ad9a4a
   HEAD_REF master
   PATCHES
     fix-unresolvedsymbol-arm.patch

--- a/ports/paho-mqtt/vcpkg.json
+++ b/ports/paho-mqtt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "paho-mqtt",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "description": "Paho project provides open-source client implementations of MQTT and MQTT-SN messaging protocols aimed at new, existing, and emerging applications for the Internet of Things",
   "homepage": "https://github.com/eclipse/paho.mqtt.c",
   "license": "EPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7433,7 +7433,7 @@
       "port-version": 1
     },
     "paho-mqtt": {
-      "baseline": "1.3.15",
+      "baseline": "1.3.16",
       "port-version": 0
     },
     "paho-mqttpp3": {

--- a/versions/p-/paho-mqtt.json
+++ b/versions/p-/paho-mqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e21dc957c32e5cbed2467cc926e856e346b9e66e",
+      "version": "1.3.16",
+      "port-version": 0
+    },
+    {
       "git-tree": "99aed70c33396bcb5b324bc32858f1a56d8e010a",
       "version": "1.3.15",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/eclipse-paho/paho.mqtt.c/releases/tag/v1.3.16
