### PR TITLE
[qtmultimedia] Devendor signalsmith-stretch and use the latest version from the VCPKG port instead

### DIFF
--- a/ports/qtmultimedia/ffmpeg-compile-def-and-devendor-signalsmith-stretch.patch
+++ b/ports/qtmultimedia/ffmpeg-compile-def-and-devendor-signalsmith-stretch.patch
@@ -2,6 +2,21 @@ diff --git a/src/plugins/multimedia/ffmpeg/CMakeLists.txt b/src/plugins/multimed
 index 77c459a..af5229e 100644
 --- a/src/plugins/multimedia/ffmpeg/CMakeLists.txt
 +++ b/src/plugins/multimedia/ffmpeg/CMakeLists.txt
+@@ -85,11 +85,9 @@ qt_internal_add_module(FFmpegMediaPluginImplPrivate
+         # compiled with different compiler options:
+         # not used because `__NO_INLINE__' not defined [-Werror=invalid-pch]
+         playbackengine/qffmpegaudioframeconverter.cpp
+-
+-    SYSTEM_INCLUDE_DIRECTORIES
+-        ../../../3rdparty/signalsmith-stretch/
+-    ATTRIBUTION_FILE_DIR_PATHS
+-        ../../../3rdparty/signalsmith-stretch
++
++    SYSTEM_INCLUDE_DIRECTORIES
++        "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/signalsmith-stretch"
+ )
+ 
+ if (LINUX OR ANDROID)
 @@ -285,7 +285,7 @@ else()
      # applications need to link against the ffmpeg libs via qt_add_ios_ffmpeg_libraries
      foreach(ffmpeg_lib IN LISTS ffmpeg_libs)

--- a/ports/qtmultimedia/portfile.cmake
+++ b/ports/qtmultimedia/portfile.cmake
@@ -4,7 +4,7 @@ include("${SCRIPT_PATH}/qt_install_submodule.cmake")
 set(${PORT}_PATCHES
     static_find_modules.patch
     remove-static-ssl-stub.patch
-    ffmpeg-compile-def.patch
+    ffmpeg-compile-def-and-devendor-signalsmith-stretch.patch
     ffmpeg.patch
     ae41d3e-ffmpeg8.diff
 )

--- a/ports/qtmultimedia/vcpkg.json
+++ b/ports/qtmultimedia/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtmultimedia",
   "version": "6.10.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qt Multimedia is an add-on module that provides a rich set of QML types and C++ classes to handle multimedia content.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -59,7 +59,8 @@
             "qml"
           ],
           "platform": "linux"
-        }
+        },
+        "signalsmith-stretch"
       ]
     },
     "gstreamer": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8266,7 +8266,7 @@
     },
     "qtmultimedia": {
       "baseline": "6.10.0",
-      "port-version": 2
+      "port-version": 3
     },
     "qtnetworkauth": {
       "baseline": "6.10.0",

--- a/versions/q-/qtmultimedia.json
+++ b/versions/q-/qtmultimedia.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "42023495025a526dfa6b36628c5040fd1165bf40",
+      "version": "6.10.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "ef340d7d5816023205cf368e3c6ec5f5e1451e36",
       "version": "6.10.0",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.