### PR TITLE
[slang] Add new port (version 10.0)

### DIFF
--- a/ports/slang/fix-get-target-property.patch
+++ b/ports/slang/fix-get-target-property.patch
@@ -1,0 +1,35 @@
+diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
+index 1234567..abcdefg 100644
+--- a/external/CMakeLists.txt
++++ b/external/CMakeLists.txt
+@@ -44,7 +44,8 @@ endif()
+
+ if(fmt_FOUND)
+   get_target_property(FMT_CFG fmt::fmt IMPORTED_CONFIGURATIONS)
+-  get_target_property(FMT_LIB fmt::fmt IMPORTED_LOCATION_${FMT_CFG})
++  list(GET FMT_CFG 0 FMT_CFG_FIRST)
++  get_target_property(FMT_LIB fmt::fmt IMPORTED_LOCATION_${FMT_CFG_FIRST})
+   get_target_property(FMT_INC fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
+   message(STATUS "Found system fmt library: ${FMT_LIB}")
+   message(STATUS "Using system fmt include: ${FMT_INC}")
+@@ -76,7 +77,7 @@ if(SLANG_USE_MIMALLOC)
+
+   set(find_pkg_args "")
+   if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
+-    set(find_pkg_args "FIND_PACKAGE_ARGS" "${mimalloc_min_version}")
++    set(find_pkg_args "FIND_PACKAGE_ARGS")
+   endif()
+
+   set(MI_OVERRIDE
+@@ -116,8 +117,9 @@ if(SLANG_USE_MIMALLOC)
+     endif()
+
+     get_target_property(MIMALLOC_CFG ${mimalloc_target} IMPORTED_CONFIGURATIONS)
+-    get_target_property(MIMALLOC_LIB ${mimalloc_target}
+-                        IMPORTED_LOCATION_${MIMALLOC_CFG})
++    list(GET MIMALLOC_CFG 0 MIMALLOC_CFG_FIRST)
++    get_target_property(MIMALLOC_LIB ${mimalloc_target}
++                        IMPORTED_LOCATION_${MIMALLOC_CFG_FIRST})
+     get_target_property(MIMALLOC_INC ${mimalloc_target}
+                         INTERFACE_INCLUDE_DIRECTORIES)
+     message(STATUS "Found system mimalloc library: ${MIMALLOC_LIB}")

--- a/ports/slang/portfile.cmake
+++ b/ports/slang/portfile.cmake
@@ -1,0 +1,60 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO MikePopoloski/slang
+    REF "v${VERSION}"
+    SHA512 f8402e422e8278be363d4630f264885230f11dcf969ffeafefc88c0ac5d0761dd81e7ee5d50bab1d4363d0783600bb974181db78609c021bde4406d8fcf1dbc5
+    HEAD_REF master
+    PATCHES
+        fix-get-target-property.patch
+        use-expected-lite.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        mimalloc     SLANG_USE_MIMALLOC
+        tools        SLANG_INCLUDE_TOOLS
+)
+
+vcpkg_find_acquire_program(PYTHON3)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        "-DPython_EXECUTABLE=${PYTHON3}"
+        -DSLANG_INCLUDE_TESTS=OFF
+        -DSLANG_INCLUDE_DOCS=OFF
+        -DSLANG_INCLUDE_PYLIB=OFF
+        -DSLANG_INCLUDE_INSTALL=ON
+        -DSLANG_INCLUDE_COVERAGE=OFF
+        -DSLANG_USE_CPPTRACE=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/slang")
+
+# Move misplaced pkgconfig files to the correct directory
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig/sv-lang.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/sv-lang.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/sv-lang.pc")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/sv-lang.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/sv-lang.pc" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sv-lang.pc")
+endif()
+
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES slang slang-hier slang-reflect slang-tidy AUTO_CLEAN)
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/slang/usage
+++ b/ports/slang/usage
@@ -1,0 +1,4 @@
+slang provides CMake targets:
+
+    find_package(slang CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE slang::slang_slang)

--- a/ports/slang/use-expected-lite.patch
+++ b/ports/slang/use-expected-lite.patch
@@ -1,0 +1,41 @@
+diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
+index 1a54f7a24..bcc698bd0 100644
+--- a/external/CMakeLists.txt
++++ b/external/CMakeLists.txt
+@@ -217,10 +217,6 @@ if(SLANG_INCLUDE_INSTALL)
+     DIRECTORY ${PROJECT_SOURCE_DIR}/external/ieee1800/
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ieee1800
+     COMPONENT slang_Development)
+-  install(
+-    FILES ${PROJECT_SOURCE_DIR}/external/expected.hpp
+-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+-    COMPONENT slang_Development)
+ 
+   if(NOT fmt_FOUND)
+     install(
+diff --git a/include/slang/syntax/SyntaxTree.h b/include/slang/syntax/SyntaxTree.h
+index 5a9030bc8..32d93de93 100644
+--- a/include/slang/syntax/SyntaxTree.h
++++ b/include/slang/syntax/SyntaxTree.h
+@@ -7,7 +7,7 @@
+ //------------------------------------------------------------------------------
+ #pragma once
+ 
+-#include <expected.hpp>
++#include <nonstd/expected.hpp>
+ #include <memory>
+ #include <vector>
+ 
+diff --git a/include/slang/text/SourceManager.h b/include/slang/text/SourceManager.h
+index 0bbdf05bc..a06c8c5b8 100644
+--- a/include/slang/text/SourceManager.h
++++ b/include/slang/text/SourceManager.h
+@@ -8,7 +8,7 @@
+ #pragma once
+ 
+ #include <atomic>
+-#include <expected.hpp>
++#include <nonstd/expected.hpp>
+ #include <filesystem>
+ #include <memory>
+ #include <mutex>

--- a/ports/slang/vcpkg.json
+++ b/ports/slang/vcpkg.json
@@ -1,0 +1,33 @@
+{
+  "name": "slang",
+  "version": "10.0",
+  "description": "SystemVerilog compiler and language services",
+  "homepage": "https://github.com/MikePopoloski/slang",
+  "license": "MIT",
+  "supports": "!arm32 & !(windows & !x64)",
+  "dependencies": [
+    "boost-unordered",
+    "expected-lite",
+    "fmt",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "mimalloc": {
+      "description": "Use the mimalloc allocator",
+      "supports": "!(windows & !static)",
+      "dependencies": [
+        "mimalloc"
+      ]
+    },
+    "tools": {
+      "description": "Build the slang command-line tool"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9168,6 +9168,10 @@
       "baseline": "3.0.0",
       "port-version": 0
     },
+    "slang": {
+      "baseline": "10.0",
+      "port-version": 0
+    },
     "sleef": {
       "baseline": "3.9.0",
       "port-version": 1

--- a/versions/s-/slang.json
+++ b/versions/s-/slang.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "882ab2ac3a544d40d80994db1c083afc5871222a",
+      "version": "10.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
