### PR TITLE
[luacxx] new port for 4.0.0

### DIFF
--- a/ports/luacxx/portfile.cmake
+++ b/ports/luacxx/portfile.cmake
@@ -1,0 +1,28 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dafrito/luacxx
+    REF "v${VERSION}"
+    SHA512 6072803b82550c6b9c28c6c2ced1f6ca14358d3c61d358b9c80c75bff554a0242e102065f3f269d53352930ae812cb6f9e6471f8a989f3da15dbbb60ad2c9105
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "luacxx" CONFIG_PATH "lib/cmake/luacxx")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+# Upstream Lua does not provide pkgconfig, only repos do, so no need for this
+# vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")

--- a/ports/luacxx/usage
+++ b/ports/luacxx/usage
@@ -1,0 +1,4 @@
+luacxx provides CMake targets:
+
+  find_package(luacxx CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE luacxx::luacxx)

--- a/ports/luacxx/vcpkg.json
+++ b/ports/luacxx/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "luacxx",
+  "version": "4.0.0",
+  "port-version": 1,
+  "description": "Luacxx is a Lua binding library for modern C++",
+  "homepage": "https://github.com/dafrito/luacxx",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "lua",
+      "features": [
+        "cpp"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6076,6 +6076,10 @@
       "baseline": "3.0-rc3",
       "port-version": 0
     },
+    "luacxx": {
+      "baseline": "4.0.0",
+      "port-version": 1
+    },
     "luafilesystem": {
       "baseline": "1.9.0",
       "port-version": 0

--- a/versions/l-/luacxx.json
+++ b/versions/l-/luacxx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "70121e3676578603906da88e5f460b9a520da59a",
+      "version": "4.0.0",
+      "port-version": 1
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.
