### PR TITLE
New port: frei0r

### DIFF
--- a/ports/frei0r/install-dlls-to-bin.diff
+++ b/ports/frei0r/install-dlls-to-bin.diff
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9bb5b8c..faac2b1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,6 +30,10 @@ if (NOT CMAKE_BUILD_TYPE)
+       FORCE)
+ endif (NOT CMAKE_BUILD_TYPE)
+ 
+-set (LIBDIR "${CMAKE_INSTALL_LIBDIR}/frei0r-1")
++if(WIN32)
++    set(LIBDIR "${CMAKE_INSTALL_BINDIR}/frei0r-1")
++else()
++    set(LIBDIR "${CMAKE_INSTALL_LIBDIR}/frei0r-1")
++endif()
+ set (FREI0R_DEF "${CMAKE_SOURCE_DIR}/msvc/frei0r_1_0.def")
+ set (FREI0R_1_1_DEF "${CMAKE_SOURCE_DIR}/msvc/frei0r_1_1.def")

--- a/ports/frei0r/portfile.cmake
+++ b/ports/frei0r/portfile.cmake
@@ -1,0 +1,43 @@
+# Frei0r dlls are MODULE librarys that are meant to be loaded at runtime,
+# hence they don't have import libs
+set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
+
+vcpkg_download_distfile(FIX_UPSTREAM_PR_252
+    URLS https://github.com/dyne/frei0r/pull/252.patch?full_index=1
+    SHA512 bdf8c6e64d73495a843c76d08204217002f1108363674633a70574ba05f0f33efafc567b73f604c7c76fd9a9614a64ccadd62c3709454b52efbb8b8d61055532
+    FILENAME fix-sleid0r-symbol-export.patch
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dyne/frei0r
+    REF "v${VERSION}"
+    SHA512 81831ede1d76d0ad8811f6b8116eb71a74e5af47a3249954f2c6f327e71e618d92c31f19566963bd9952363b22c5a6606df3ef8592f97c3bb1cd8ed9abe94c14
+    HEAD_REF master
+    PATCHES
+        "${FIX_UPSTREAM_PR_252}"
+        install-dlls-to-bin.diff
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+        cairo   WITHOUT_CAIRO
+        opencv  WITHOUT_OPENCV
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+      ${FEATURE_OPTIONS}
+      -DWITHOUT_GAVL=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/frei0r/vcpkg.json
+++ b/ports/frei0r/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "frei0r",
+  "version": "2.5.4",
+  "description": "A large collection of free and portable video plugins",
+  "homepage": "https://frei0r.dyne.org/",
+  "license": "GPL-2.0",
+  "supports": "!(static & windows)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "features": {
+    "cairo": {
+      "description": "Enable plugins dependent upon Cairo",
+      "supports": "!arm & !static",
+      "dependencies": [
+        {
+          "name": "cairo",
+          "default-features": false
+        }
+      ]
+    },
+    "opencv": {
+      "description": "Enable plugins dependent upon OpenCV",
+      "dependencies": [
+        "opencv"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3184,6 +3184,10 @@
       "baseline": "2.0.0",
       "port-version": 1
     },
+    "frei0r": {
+      "baseline": "2.5.4",
+      "port-version": 0
+    },
     "fribidi": {
       "baseline": "1.0.16",
       "port-version": 0

--- a/versions/f-/frei0r.json
+++ b/versions/f-/frei0r.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ddfa0c31ead64f21a195cc53c5b5c437f73f9142",
+      "version": "2.5.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #16054

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [x] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
- [x] Only one version is added to each modified port's versions file.

FYI @jaromil
