### PR TITLE
[libgossip] update to 1.2.1.2

### DIFF
--- a/ports/libgossip/fix-dependencies.patch
+++ b/ports/libgossip/fix-dependencies.patch
@@ -1,28 +1,40 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5d6f2f9..fd8d384 100644
+index 0f19760..1eaca89 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -30,7 +30,7 @@ add_library(libgossip ${LIBGOSSIP_CORE_SRC})
- add_library(libgossip::core ALIAS libgossip)
- 
+@@ -66,7 +66,7 @@ add_library(libgossip::core ALIAS libgossip)
+ # ============================================
  # Handle ASIO dependency
+ # ============================================
 -setup_bundled_asio()
 +find_package(asio CONFIG REQUIRED)
  
+ # ============================================
  # Network library
- set(LIBGOSSIP_NET_SRC src/net/udp_transport.cpp src/net/tcp_transport.cpp
-@@ -41,10 +41,10 @@ add_library(libgossip_net ${LIBGOSSIP_NET_SRC})
- add_library(libgossip::network ALIAS libgossip_net)
- 
- # Find and link ASIO
+@@ -82,10 +82,10 @@ add_library(libgossip::network ALIAS libgossip_net)
+ # ============================================
+ # ASIO dependency
+ # ============================================
 -if(ASIO_FOUND)
--  target_include_directories(
--    libgossip_net PUBLIC $<BUILD_INTERFACE:${ASIO_INCLUDE_DIR}>
--                         $<INSTALL_INTERFACE:include>)
+-    target_include_directories(
+-        libgossip_net PUBLIC $<BUILD_INTERFACE:${ASIO_INCLUDE_DIR}>
+-                             $<INSTALL_INTERFACE:include>)
 +if(1)
 +  target_link_libraries(
 +    libgossip_net PUBLIC $<BUILD_INTERFACE:asio::asio>
 +  )
  else()
-   message(FATAL_ERROR "ASIO is required for the network library")
+     message(FATAL_ERROR 
+         "ASIO is required for the network library but was not found.\n"
+@@ -104,9 +104,8 @@ elseif(NOT LIBGOSSIP_VCPKG_MODE)
+         "Please run: cd third_party && git clone --depth 1 --branch v3.11.2 https://github.com/nlohmann/json.git\n"
+         "Or install nlohmann-json via your package manager.")
+ else()
+-    message(FATAL_ERROR 
+-        "nlohmann/json not found.\n"
+-        "In VCPKG mode, please ensure nlohmann-json is installed via vcpkg.")
++    find_package(nlohmann_json CONFIG REQUIRED)
++    target_link_libraries(libgossip_net PUBLIC nlohmann_json::nlohmann_json)
  endif()
+ 
+ target_link_libraries(libgossip_net PUBLIC libgossip)

--- a/ports/libgossip/portfile.cmake
+++ b/ports/libgossip/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO caomengxuan666/libgossip
     REF "v${VERSION}"
-    SHA512 64320a74b1be5270bba2ea213c7a76900626d54afe4b6a0381dfdf0b2d5a64cab0e8e00234f3c75f232a6d1b4579931cbf3bc8b92503fccf7b815973ab2ed010
+    SHA512 971f51f6583d3246a5696b35a419fd30ce8ebbd7940b63bb9731f7ec2f12e0f6d68b3924c0be81de30d4eb33f24a39be4db72d2cee5f2ca5e52081aa7c568699
     HEAD_REF main
     PATCHES
         fix-dependencies.patch

--- a/ports/libgossip/support-uwp.patch
+++ b/ports/libgossip/support-uwp.patch
@@ -1,5 +1,5 @@
 diff --git a/src/net/tcp_transport.cpp b/src/net/tcp_transport.cpp
-index 90c6e31..0ad2b07 100644
+index 4046b03..b675ed3 100644
 --- a/src/net/tcp_transport.cpp
 +++ b/src/net/tcp_transport.cpp
 @@ -1,4 +1,9 @@
@@ -9,15 +9,16 @@ index 90c6e31..0ad2b07 100644
 +#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
 +#define ASIO_WINDOWS_APP
 +#endif
+ #include "core/enum_reflection.inl"
  #include <asio.hpp>
  #include <chrono>
- #include <functional>
 diff --git a/src/net/udp_transport.cpp b/src/net/udp_transport.cpp
-index f958a88..fc56509 100644
+index a2c4bda..9720353 100644
 --- a/src/net/udp_transport.cpp
 +++ b/src/net/udp_transport.cpp
-@@ -1,4 +1,9 @@
+@@ -1,5 +1,10 @@
  #include "net/udp_transport.hpp"
+ #include "core/enum_reflection.inl"
 +
 +// For UWP applications
 +#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)

--- a/ports/libgossip/vcpkg.json
+++ b/ports/libgossip/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "name": "libgossip",
-  "version": "1.1.2.0",
+  "version": "1.2.1.2",
   "description": "A C++17 implementation of the Gossip protocol, designed for decentralized distributed systems.",
   "homepage": "https://github.com/caomengxuan666/libgossip",
   "license": "MIT",
   "dependencies": [
     "asio",
+    "nlohmann-json",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4941,7 +4941,7 @@
       "port-version": 6
     },
     "libgossip": {
-      "baseline": "1.1.2.0",
+      "baseline": "1.2.1.2",
       "port-version": 0
     },
     "libgpg-error": {

--- a/versions/l-/libgossip.json
+++ b/versions/l-/libgossip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "467452e288941bb183f9da7577451b8e954d5424",
+      "version": "1.2.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "dc56e77ec00b1237f49e174def40df353477386b",
       "version": "1.1.2.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

https://github.com/caomengxuan666/libgossip/releases/tag/v1.2.1.2
