### PR TITLE
[asio] Add wolfSSL feature

### DIFF
--- a/ports/asio/vcpkg.json
+++ b/ports/asio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "asio",
   "version": "1.32.0",
+  "port-version": 1,
   "description": "Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a consistent asynchronous model using a modern C++ approach.",
   "homepage": "https://think-async.com/Asio/",
   "documentation": "https://think-async.com/Asio/Documentation.html",
@@ -32,6 +33,17 @@
       "description": "Boost.Regex (optional) if you use any of the read_until() or async_read_until() overloads that take a boost::regex parameter.",
       "dependencies": [
         "boost-regex"
+      ]
+    },
+    "wolfssl": {
+      "description": "WolfSSL (optional) if you use Asio's SSL support.",
+      "dependencies": [
+        {
+          "name": "wolfssl",
+          "features": [
+            "asio"
+          ]
+        }
       ]
     }
   }

--- a/versions/a-/asio.json
+++ b/versions/a-/asio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "834d3e0f600aa8cfa2303a7e29f8b938aff6c894",
+      "version": "1.32.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d1b402afe0e4c5b8efb08dcc8be6b0c90900a55e",
       "version": "1.32.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -310,7 +310,7 @@
     },
     "asio": {
       "baseline": "1.32.0",
-      "port-version": 0
+      "port-version": 1
     },
     "asio-grpc": {
       "baseline": "3.6.0",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

Motivation: #40967 added the support to build wolfSSL as asio's backend, but currently there is no way to build asio with wolfSSL as its backend.

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
