### PR TITLE
[websocketpp] Remove broken version database entry

### DIFF
--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10600,10 +10600,6 @@
       "baseline": "1.0.5",
       "port-version": 0
     },
-    "websocketpp": {
-      "baseline": "0.8.2",
-      "port-version": 4
-    },
     "webthing-cpp": {
       "baseline": "1.2.0",
       "port-version": 0

--- a/versions/w-/websocketpp.json
+++ b/versions/w-/websocketpp.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "4cca0dda87286e4d7f84ece919a4a60de04252e3",
-      "version": "0.8.2",
-      "port-version": 4
-    },
-    {
       "git-tree": "eb46cff6f9a23caefbc56ac8089d1fbee523e13e",
       "version": "0.8.2",
       "port-version": 3


### PR DESCRIPTION
websocketpp was removed from vcpkg master branch. The baseline file contains a websocketpp entry pointing to a version that does not exist.