### PR TITLE
[vcpkg-make] Add a NO_CONFIGURE option

### DIFF
--- a/ports/vcpkg-make/vcpkg.json
+++ b/ports/vcpkg-make/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-make",
-  "version-date": "2026-01-01",
+  "version-date": "2026-02-23",
   "documentation": "https://learn.microsoft.com/vcpkg/maintainers/functions/vcpkg_make_configure",
   "license": null,
   "supports": "native",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10341,7 +10341,7 @@
       "port-version": 0
     },
     "vcpkg-make": {
-      "baseline": "2026-01-01",
+      "baseline": "2026-02-23",
       "port-version": 0
     },
     "vcpkg-msbuild": {

--- a/versions/v-/vcpkg-make.json
+++ b/versions/v-/vcpkg-make.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c50bb4e57de68b0ec9daae95de41a7a45b95878",
+      "version-date": "2026-02-23",
+      "port-version": 0
+    },
+    {
       "git-tree": "c1c80d7a4b56ff925cb9d6691e6baa4c44f4e179",
       "version-date": "2026-01-01",
       "port-version": 0


### PR DESCRIPTION
Experimenting with NO_CONFIGURE option for vcpkg-make port. If upstream doesn't supply a configure script than user have to add an empty stub. Motivation -> https://github.com/microsoft/vcpkg/pull/49542/changes#diff-acd6c2d36d562deab8fa57e5842b1423c3fa533140245ece6360247d4c8e3f0a