### PR TITLE
[libid3tag] Update to 0.16.4

### DIFF
--- a/ports/libid3tag/portfile.cmake
+++ b/ports/libid3tag/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(
-    ARCHIVE URLS "https://codeberg.org/tenacityteam/libid3tag/archive/${VERSION}.tar.gz"
-    FILENAME "${VERSION}.tar.gz"
-    SHA512 d49bc637899e4251ed66b5b56aa4c910dcdecd6b03ed197866d74175fc4eadff40f40f336606b23e2505b0e11834c4212a1314feeeaa2c0e9713051fdb56cb45
+    ARCHIVE URLS "https://codeberg.org/tenacityteam/libid3tag/releases/download/${VERSION}/id3tag-${VERSION}-source.tar.gz"
+    FILENAME "id3tag-${VERSION}-source.tar.gz"
+    SHA512 14f51b0c01ce931f563029976fa76f4a30e6fac7d5ad2ef9beff53bd6d1d0f7a3f9a9266a06dcf9018f306d5d3eb8467ced8d6f3aa5160a637873eb02e330c87
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")

--- a/ports/libid3tag/vcpkg.json
+++ b/ports/libid3tag/vcpkg.json
@@ -1,9 +1,13 @@
 {
   "name": "libid3tag",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "ID3 tag manipulation library",
   "homepage": "https://codeberg.org/tenacityteam/libid3tag",
   "dependencies": [
+    {
+      "name": "gperf",
+      "host": true
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5193,7 +5193,7 @@
       "port-version": 0
     },
     "libid3tag": {
-      "baseline": "0.16.3",
+      "baseline": "0.16.4",
       "port-version": 0
     },
     "libideviceactivation": {

--- a/versions/l-/libid3tag.json
+++ b/versions/l-/libid3tag.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa020d1960327e4956fba8a577ed7c4cf4cf57cd",
+      "version": "0.16.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "a30c7af82d01be2c3bd973012681915cf394d464",
       "version": "0.16.3",
       "port-version": 0


### PR DESCRIPTION
This PR updates libid3tag to 0.16.4, which includes quite a few fixes and other changes. Part of these changes include the requirement that gperf now be present at build time, of which I have reflected that in this PR to the best of my ability (it's been a while since I last updated a vcpkg port, so please try to bear with me here :sweat_smile:).

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] ~~The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.~~ **N/A**
- [ ] ~~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.~~ **N/A**
- [ ] ~~All patch files in the port are applied and succeed.~~ **N/A**
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
