### PR TITLE
jbcoe-value-types: Add v1.0.1

### DIFF
--- a/ports/jbcoe-value-types/fix-install.patch
+++ b/ports/jbcoe-value-types/fix-install.patch
@@ -1,34 +1,15 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 552698a..5e595a5 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -126,9 +126,6 @@ target_sources(polymorphic_cxx17
+diff --git i/CMakeLists.txt w/CMakeLists.txt
+index ca05777..c47bce3 100644
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -144,10 +144,6 @@ xyz_add_object_library(
  
  if (${XYZ_VALUE_TYPES_IS_NOT_SUBPROJECT})
  
 -    add_subdirectory(benchmarks)
 -    add_subdirectory(compile_checks)
 -    add_subdirectory(exploration)
- 
+-
      if (${BUILD_TESTING})
          FetchContent_Declare(
-diff --git a/cmake/coverage.cmake b/cmake/coverage.cmake
-index 28022d6..1527f92 100644
---- a/cmake/coverage.cmake
-+++ b/cmake/coverage.cmake
-@@ -16,7 +16,6 @@ set(COVERAGE_SUPPORTED_FLAGS
-     "--coverage"
- )
- 
--find_package(Python3 REQUIRED COMPONENTS Interpreter)
- 
- #[=======================================================================[.rst:
- virtualenv_create
-@@ -84,6 +83,7 @@ function(virtualenv_create)
-         message(FATAL_ERROR "REQUIREMENTS must exist, invalid path: ${PYTHON_VENV_REQUIREMENTS}")
-     endif()
- 
-+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
-     set(PYTHON_VENV_INTERPRETER ${PYTHON_VENV_DESTINATION}/bin/python)
- 
-     add_custom_command(
+           googletest

--- a/ports/jbcoe-value-types/portfile.cmake
+++ b/ports/jbcoe-value-types/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jbcoe/value_types
-    REF 0f3f7275bb374c6a2581fe65c0f158bfcc8cefa3 #v1.0.0
-    SHA512 821cd420f79b3fb8eede18fde50beef49c1ce910476a4ac5aa71cd2cbb7ad89063f0a8f66cd8de2ea778ad302bee068ebc774e35b4ee456196e687748d82986f
+    REF 6f50aff4d406f35dd427654184ea20263712ccfe #v1.0.1
+    SHA512 97c200314313d2a76503fbe046d210e4402a8436abdaadb894f0d0f0207489f0347952ee9afb1fa3b82b97fce22fa67567298f956ce9ef80a56f8393fa002bfe
     HEAD_REF main
     PATCHES
         fix-install.patch

--- a/ports/jbcoe-value-types/vcpkg.json
+++ b/ports/jbcoe-value-types/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jbcoe-value-types",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Value-type for composite class design for C++26 (reference implementation of std::indirect and std::polymorphic from p3019r14)",
   "homepage": "https://github.com/jbcoe/value_types",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4065,7 +4065,7 @@
       "port-version": 0
     },
     "jbcoe-value-types": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "jbig2dec": {

--- a/versions/j-/jbcoe-value-types.json
+++ b/versions/j-/jbcoe-value-types.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "156b8f78d285d0a1aa4b8c04e99324946792d8ff",
+      "version": "1.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a6e450439907bf9e0837fa1decf156ebd324c2b",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

