### PR TITLE
[doxygen] Add new port

### DIFF
--- a/ports/doxygen/fix-ghc-fs.patch
+++ b/ports/doxygen/fix-ghc-fs.patch
@@ -1,0 +1,39 @@
+diff --git a/src/dir.cpp b/src/dir.cpp
+index d4fc3291b..5610d005d 100644
+--- a/src/dir.cpp
++++ b/src/dir.cpp
+@@ -15,7 +15,7 @@
+ 
+ #define NOMINMAX
+ #define WIN32_LEAN_AND_MEAN
+-#include "filesystem.hpp"
++#include "ghc/filesystem.hpp"
+ #include "dir.h"
+ 
+ #include <utility>
+diff --git a/src/fileinfo.cpp b/src/fileinfo.cpp
+index c52daa728..06da90ab2 100644
+--- a/src/fileinfo.cpp
++++ b/src/fileinfo.cpp
+@@ -15,7 +15,7 @@
+ 
+ #define NOMINMAX
+ #define WIN32_LEAN_AND_MEAN // optional
+-#include "filesystem.hpp"
++#include "ghc/filesystem.hpp"
+ #include "fileinfo.h"
+ 
+ namespace fs = ghc::filesystem;
+diff --git a/src/portable.cpp b/src/portable.cpp
+index 3a289b5ec..fb4b14e45 100644
+--- a/src/portable.cpp
++++ b/src/portable.cpp
+@@ -642,7 +642,7 @@ size_t Portable::recodeUtf8StringToW(const QCString &inputStr,uint16_t **outBuf)
+ // We need to do this part last as including filesystem.hpp earlier
+ // causes the code above to fail to compile on Windows.
+ 
+-#include "filesystem.hpp"
++#include "ghc/filesystem.hpp"
+ 
+ namespace fs = ghc::filesystem;
+ 

--- a/ports/doxygen/fix-sqlite3-link.patch
+++ b/ports/doxygen/fix-sqlite3-link.patch
@@ -1,0 +1,68 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6468e292d..d25791192 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -83,7 +83,7 @@ if(use_sys_spdlog)
+   find_package(spdlog CONFIG REQUIRED)
+ endif()
+ if(use_sys_sqlite3)
+-  find_package(SQLite3 REQUIRED)
++  find_package(unofficial-sqlite3 CONFIG REQUIRED)
+ endif()
+ 
+ if(NOT DEFINED MACOS_VERSION_MIN) # to allow overruling with -DMACOS_VERSION_MIN
+diff --git a/addon/doxyapp/CMakeLists.txt b/addon/doxyapp/CMakeLists.txt
+index 2f901d41a..176f084ef 100644
+--- a/addon/doxyapp/CMakeLists.txt
++++ b/addon/doxyapp/CMakeLists.txt
+@@ -39,7 +39,7 @@ endif()
+ target_link_libraries(doxyapp
+ doxymain
+ md5
+-sqlite3
++unofficial::sqlite3::sqlite3
+ xml
+ lodepng
+ mscgen
+@@ -48,7 +48,6 @@ doxycfg
+ vhdlparser
+ ${Iconv_LIBRARIES}
+ ${CMAKE_THREAD_LIBS_INIT}
+-${SQLITE3_LIBRARIES}
+ ${EXTRA_LIBS}
+ ${CLANG_LIBS}
+ ${COVERAGE_LINKER_FLAGS}
+diff --git a/addon/doxyparse/CMakeLists.txt b/addon/doxyparse/CMakeLists.txt
+index be86b2dc9..8b85160de 100644
+--- a/addon/doxyparse/CMakeLists.txt
++++ b/addon/doxyparse/CMakeLists.txt
+@@ -28,7 +28,7 @@ endif()
+ target_link_libraries(doxyparse
+ doxymain
+ md5
+-sqlite3
++unofficial::sqlite3::sqlite3
+ xml
+ lodepng
+ mscgen
+@@ -37,7 +37,6 @@ doxycfg
+ vhdlparser
+ ${Iconv_LIBRARIES}
+ ${CMAKE_THREAD_LIBS_INIT}
+-${SQLITE3_LIBRARIES}
+ ${EXTRA_LIBS}
+ ${CLANG_LIBS}
+ ${COVERAGE_LINKER_FLAGS}
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index ef0dac53f..d3727dd5f 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -388,7 +388,7 @@ target_link_libraries(doxygen PRIVATE
+     doxymain
+     doxycfg
+     md5
+-    sqlite3
++    unofficial::sqlite3::sqlite3
+     lodepng
+     mscgen
+     xml

--- a/ports/doxygen/portfile.cmake
+++ b/ports/doxygen/portfile.cmake
@@ -8,7 +8,18 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-sqlite3-link.patch
+	remove-deps-testing.patch
+	use-ext-deps.patch
+	fix-ghc-fs.patch
 )
+
+file(REMOVE_RECURSE "${SOURCE_PATH}/deps/TinyDeflate")
+file(REMOVE_RECURSE "${SOURCE_PATH}/deps/filesystem")
+file(REMOVE_RECURSE "${SOURCE_PATH}/deps/liblodepng")
+file(REMOVE_RECURSE "${SOURCE_PATH}/deps/spdlog")
+file(REMOVE_RECURSE "${SOURCE_PATH}/deps/sqlite3")
+file(REMOVE_RECURSE "${SOURCE_PATH}/deps/iconv_winbuild")
+file(REMOVE_RECURSE "${SOURCE_PATH}/deps/fmt")
 
 vcpkg_find_acquire_program(FLEX)
 vcpkg_find_acquire_program(BISON)

--- a/ports/doxygen/portfile.cmake
+++ b/ports/doxygen/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
 
 vcpkg_find_acquire_program(FLEX)
 vcpkg_find_acquire_program(BISON)
+vcpkg_find_acquire_program(PYTHON3)
 
 vcpkg_cmake_configure(
 	SOURCE_PATH "${SOURCE_PATH}"
@@ -21,6 +22,7 @@ vcpkg_cmake_configure(
 	    -Duse_sys_sqlite3=ON
 	    -DFLEX_EXECUTABLE=${FLEX}
 	    -DBISON_EXECUTABLE=${BISON}
+	    -DPython_EXECUTABLE=${PYTHON3}
 )
 
 vcpkg_cmake_install()

--- a/ports/doxygen/portfile.cmake
+++ b/ports/doxygen/portfile.cmake
@@ -25,20 +25,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-set(DOXY_TOOLS "doxygen")
-if("app" IN_LIST FEATURES)
-  list(APPEND DOXY_TOOLS "doxyapp")
-endif()
-if("parse" IN_LIST FEATURES)
-  list(APPEND DOXY_TOOLS "doxyparse")
-endif()
-if("search" IN_LIST FEATURES)
-  list(APPEND DOXY_TOOLS "doxysearch")
-endif()
-if("wizard" IN_LIST FEATURES)
-  list(APPEND DOXY_TOOLS "doxywizard")
-endif()
-vcpkg_copy_tools(TOOL_NAMES ${DOXY_TOOLS} AUTO_CLEAN)
+vcpkg_copy_tools(TOOL_NAMES doxygen AUTO_CLEAN)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/doxygen/portfile.cmake
+++ b/ports/doxygen/portfile.cmake
@@ -1,0 +1,44 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO doxygen/doxygen
+    REF Release_1_16_1
+    SHA512 99db422f65ee32a76f2b9c016b035ccc1297d34b494c947235544bbaf5c44962273b52fa2c728af6ee0b17c5614b8808367fcce1d7dd872557eeb5cb37c34d32
+    HEAD_REF master
+    PATCHES
+        fix-sqlite3-link.patch
+)
+
+vcpkg_find_acquire_program(FLEX)
+vcpkg_find_acquire_program(BISON)
+
+vcpkg_cmake_configure(
+	SOURCE_PATH "${SOURCE_PATH}"
+	OPTIONS
+	    -Duse_sys_spdlog=ON
+	    -Duse_sys_fmt=ON
+	    -Duse_sys_sqlite3=ON
+	    -DFLEX_EXECUTABLE=${FLEX}
+	    -DBISON_EXECUTABLE=${BISON}
+)
+
+vcpkg_cmake_install()
+
+set(DOXY_TOOLS "doxygen")
+if("app" IN_LIST FEATURES)
+  list(APPEND DOXY_TOOLS "doxyapp")
+endif()
+if("parse" IN_LIST FEATURES)
+  list(APPEND DOXY_TOOLS "doxyparse")
+endif()
+if("search" IN_LIST FEATURES)
+  list(APPEND DOXY_TOOLS "doxysearch")
+endif()
+if("wizard" IN_LIST FEATURES)
+  list(APPEND DOXY_TOOLS "doxywizard")
+endif()
+vcpkg_copy_tools(TOOL_NAMES ${DOXY_TOOLS} AUTO_CLEAN)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/doxygen/remove-deps-testing.patch
+++ b/ports/doxygen/remove-deps-testing.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6468e292d..72e05d9a4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -163,15 +163,6 @@ endif()
+ 
+ if(WIN32)
+   if(MSVC)
+-    if(NOT ICONV_DIR)
+-      if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+-        list(APPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/deps/iconv_winbuild/include" "${PROJECT_SOURCE_DIR}/deps/iconv_winbuild/x64")
+-      elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+-        list(APPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/deps/iconv_winbuild/include" "${PROJECT_SOURCE_DIR}/deps/iconv_winbuild/x86")
+-      endif()
+-    else()
+-      list(APPEND CMAKE_PREFIX_PATH ${ICONV_DIR})
+-    endif()
+     set(CMAKE_REQUIRED_DEFINITIONS "-DLIBICONV_STATIC")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj") # needed for language.cpp on 64bit
+     add_definitions(-DLIBICONV_STATIC -D_CRT_SECURE_NO_WARNINGS)
+@@ -306,7 +297,6 @@ include(cmake/CompilerWarnings.cmake)
+ include(cmake/Coverage.cmake)
+ include(cmake/WindowsEncoding.cmake)
+ 
+-add_subdirectory(deps)
+ add_subdirectory(libversion)
+ add_subdirectory(libxml)
+ add_subdirectory(vhdlparser)
+@@ -337,8 +327,5 @@ if(GENERATEDS_FOUND)
+ endif()
+ add_subdirectory(addon)
+ 
+-enable_testing()
+-add_subdirectory(testing)
+-
+ include(cmake/packaging.cmake) # set CPACK_xxxx properties
+ include(CPack)

--- a/ports/doxygen/use-ext-deps.patch
+++ b/ports/doxygen/use-ext-deps.patch
@@ -1,0 +1,36 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index ef0dac53f..9de1a8c70 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,11 +1,8 @@
+ # vim:ts=4:sw=4:expandtab:autoindent:
+ 
+ include_directories(
+-    ${PROJECT_SOURCE_DIR}/deps/TinyDeflate
+-    ${PROJECT_SOURCE_DIR}/deps/filesystem
+-    ${PROJECT_SOURCE_DIR}/deps/libmd5
+-    ${PROJECT_SOURCE_DIR}/deps/liblodepng
+     ${PROJECT_SOURCE_DIR}/deps/libmscgen
++    ${PROJECT_SOURCE_DIR}/deps/libmd5
+     ${PROJECT_SOURCE_DIR}/libversion
+     ${PROJECT_SOURCE_DIR}/libxml
+     ${PROJECT_SOURCE_DIR}/vhdlparser
+@@ -343,6 +340,18 @@ add_executable(doxygen
+     ${PROJECT_SOURCE_DIR}/templates/icon/doxygen.rc
+ )
+ 
++find_package(ghc_filesystem CONFIG REQUIRED)
++link_libraries(doxygen PRIVATE ghcFilesystem::ghc_filesystem)
++
++find_package(Iconv REQUIRED)
++link_libraries(doxygen PRIVATE Iconv::Iconv)
++
++find_package(lodepng-c CONFIG REQUIRED)
++link_libraries(doxygen PRIVATE lodepng-c)
++
++find_path(TINYDEFLATE_INCLUDE_DIRS "gunzip.hh")
++include_directories(doxygen PRIVATE ${TINYDEFLATE_INCLUDE_DIRS})
++
+ # enable to monitor compilation times
+ #set_property(TARGET doxymain PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
+ 

--- a/ports/doxygen/vcpkg.json
+++ b/ports/doxygen/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "doxygen",
+  "version-semver": "1.16.1",
+  "description": "Documentation generator from code",
+  "license": "GPL-2.0-only",
+  "dependencies": [
+    "fmt",
+    "ghc-filesystem",
+    "libiconv",
+    "lodepng",
+    "spdlog",
+    "sqlite3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "features": {
+    "app": {
+      "description": "Build the doxyapp package"
+    },
+    "parse": {
+      "description": "Build the doxyparse package"
+    },
+    "search": {
+      "description": "Build the doxysearch package"
+    },
+    "wizard": {
+      "description": "Build the doxywizard package"
+    }
+  }
+}

--- a/ports/doxygen/vcpkg.json
+++ b/ports/doxygen/vcpkg.json
@@ -5,9 +5,6 @@
   "license": "GPL-2.0-only",
   "dependencies": [
     "fmt",
-    "ghc-filesystem",
-    "libiconv",
-    "lodepng",
     "spdlog",
     "sqlite3",
     {

--- a/ports/doxygen/vcpkg.json
+++ b/ports/doxygen/vcpkg.json
@@ -10,7 +10,11 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    }
+    },
+    "libiconv",
+    "ghc-filesystem",
+    "tinydeflate",
+    "lodepng"
   ],
   "features": {
     "app": {

--- a/ports/tinydeflate/portfile.cmake
+++ b/ports/tinydeflate/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO bisqwit/TinyDeflate
+    REF 68ced8bd5c819264e628d4f063500753b77f613d
+    SHA512 1555adc1caa26383110c680806af5b2011ea192fbe9c45479c5622cf6b4a51685f3bf1bdfa530ff6ca5e55871e8b6781516edb90dad5a5b4265b67bb53966a2d
+    HEAD_REF master
+)
+
+file(COPY "${SOURCE_PATH}/gunzip.hh" DESTINATION "${CURRENT_PACKAGES_DIR}/include/")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/README.md")

--- a/ports/tinydeflate/vcpkg.json
+++ b/ports/tinydeflate/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "name": "tinydeflate",
+  "version-date": "2024-08-09",
+  "description": "A deflate/gzip decompressor that requires minimal amount of memory to work"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2548,6 +2548,10 @@
       "baseline": "3.4.0",
       "port-version": 0
     },
+    "doxygen": {
+      "baseline": "1.16.1",
+      "port-version": 0
+    },
     "dp-thread-pool": {
       "baseline": "0.7.0",
       "port-version": 1
@@ -9863,6 +9867,10 @@
     "tinycthread": {
       "baseline": "2019-08-06",
       "port-version": 3
+    },
+    "tinydeflate": {
+      "baseline": "2024-08-09",
+      "port-version": 0
     },
     "tinydir": {
       "baseline": "1.2.6",

--- a/versions/d-/doxygen.json
+++ b/versions/d-/doxygen.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0f62a3b268e3bc57115b8bd0e3cdec02e7532117",
+      "version-semver": "1.16.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/d-/doxygen.json
+++ b/versions/d-/doxygen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0f62a3b268e3bc57115b8bd0e3cdec02e7532117",
+      "git-tree": "5a175372835771b93b0d656386a6bdfa15e9d0fa",
       "version-semver": "1.16.1",
       "port-version": 0
     }

--- a/versions/d-/doxygen.json
+++ b/versions/d-/doxygen.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5a175372835771b93b0d656386a6bdfa15e9d0fa",
+      "git-tree": "10c7db390e4b12e8e771d870ada4ca0f991ecd0d",
       "version-semver": "1.16.1",
       "port-version": 0
     }

--- a/versions/t-/tinydeflate.json
+++ b/versions/t-/tinydeflate.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "26e220798829b47b2268e8e9e920ddce87d096c8",
+      "version-date": "2024-08-09",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Closes #50154 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

WIP, still need to fix the vendored dependencies in doxygen.