### PR TITLE
[dacap-clip] update to 1.14

### DIFF
--- a/ports/dacap-clip/fix-install-header-and-force-static-compilation.patch
+++ b/ports/dacap-clip/fix-install-header-and-force-static-compilation.patch
@@ -1,20 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 79f7074..775b565 100644
+index d9aa76e..cee1d90 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -25,7 +25,7 @@ if(UNIX AND NOT APPLE)
-   option(CLIP_X11_WITH_PNG "Compile with libpng to support copy/paste image in png format" on)
- endif()
- 
--add_library(clip clip.cpp)
-+add_library(clip STATIC clip.cpp)
- 
- if(CLIP_ENABLE_IMAGE)
-   target_sources(clip PRIVATE image.cpp)
-@@ -109,6 +109,8 @@ endif()
+@@ -132,6 +132,8 @@ endif()
  if(CLIP_INSTALL)
    include(GNUInstallDirs)
- 
+
 +  target_include_directories(clip PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 +
    install(

--- a/ports/dacap-clip/portfile.cmake
+++ b/ports/dacap-clip/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO dacap/clip
   REF v${VERSION}
-  SHA512 c372c18081f2a090e88e04b7253e891589aaa821f660aef603e14f3004aaeb5a4f9540bee1105da5b49f97ee027dd50e374a22cb43e5d7501cf7362661ce0c14
+  SHA512 d245781ae4e290f75195782522190fc4d7645b8718d640fb5e3f6f7a47d1bcbf29fb34407b4368698dfe0039abfc42eac805201a192ab4569a68eca6f6234c76
   PATCHES
     "fix-install-header-and-force-static-compilation.patch")
 

--- a/ports/dacap-clip/vcpkg.json
+++ b/ports/dacap-clip/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dacap-clip",
-  "version": "1.13",
+  "version": "1.14",
   "description": "Cross-platform C++ library to copy/paste clipboard content.",
   "homepage": "https://github.com/dacap/clip",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2345,7 +2345,7 @@
       "port-version": 1
     },
     "dacap-clip": {
-      "baseline": "1.13",
+      "baseline": "1.14",
       "port-version": 0
     },
     "dagir": {

--- a/versions/d-/dacap-clip.json
+++ b/versions/d-/dacap-clip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "caecb666d499ee31770e68de773323a0d872e779",
+      "version": "1.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "2d5a0a4ea4435e3725ba3c1791297c8060613259",
       "version": "1.13",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/dacap/clip/releases/tag/v1.14
