### PR TITLE
[webview2] update to 1.0.3800.47

### DIFF
--- a/ports/webview2/portfile.cmake
+++ b/ports/webview2/portfile.cmake
@@ -5,7 +5,7 @@ endif()
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${VERSION}"
     FILENAME "microsoft.web.webview2.${VERSION}.zip"
-    SHA512 0a9abb1068228e208dd258354654d9b99711933ca8fd4494f5c1093123e1e851b83cb8e64c4a49e4d2ae26a434e8e36755501109c4cb7f7d488e3845254ac0a7
+    SHA512 10048ce88c166b7f29a563fcdb9487d71bac5723777cd0a98b5c5a0e71cff344551a0bc27410b0cb0f8482a9ecdec7454a45ad0d2a7ae998fc347ead15598889
 )
 
 vcpkg_extract_source_archive(

--- a/ports/webview2/vcpkg.json
+++ b/ports/webview2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "webview2",
-  "version": "1.0.3719.77",
+  "version": "1.0.3800.47",
   "description": "The WebView2 control allows you to embed web technologies (HTML, CSS, and JavaScript) using Microsoft Edge",
   "homepage": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",
   "documentation": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10621,7 +10621,7 @@
       "port-version": 0
     },
     "webview2": {
-      "baseline": "1.0.3719.77",
+      "baseline": "1.0.3800.47",
       "port-version": 0
     },
     "wepoll": {

--- a/versions/w-/webview2.json
+++ b/versions/w-/webview2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69a9ca71aa36f5a3257a94632fa9555dd333dad7",
+      "version": "1.0.3800.47",
+      "port-version": 0
+    },
+    {
       "git-tree": "c872c42ae75265cdb7bf6ed298d2c8299f29aeca",
       "version": "1.0.3719.77",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
