### PR TITLE
[lunarlog] Add new port (1.29.1)

### DIFF
--- a/ports/lunarlog/portfile.cmake
+++ b/ports/lunarlog/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO LunarECL/LunarLog
+    REF "v1.29.1"
+    SHA512 07e479734568ebf7dd00f3e7d9dbc3d359fa3c1fe7270440aa719f7ee48904a5556e97397195398ada3375b1c7e0e5b289dccabb0ec82e362e7010fd441450a9
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLUNARLOG_BUILD_TESTS=OFF
+        -DLUNARLOG_BUILD_EXAMPLES=OFF
+        -DLUNARLOG_BUILD_BENCHMARKS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/LunarLog)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/lunarlog/usage
+++ b/ports/lunarlog/usage
@@ -1,0 +1,4 @@
+lunarlog provides CMake targets:
+
+    find_package(LunarLog CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE LunarLog::LunarLog)

--- a/ports/lunarlog/vcpkg.json
+++ b/ports/lunarlog/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "lunarlog",
+  "version": "1.29.1",
+  "description": "Header-only C++11 structured logging library with message templates. Inspired by Serilog.",
+  "homepage": "https://github.com/LunarECL/LunarLog",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6108,6 +6108,10 @@
       "baseline": "1.4.335.0",
       "port-version": 0
     },
+    "lunarlog": {
+      "baseline": "1.29.1",
+      "port-version": 0
+    },
     "lunasvg": {
       "baseline": "3.5.0",
       "port-version": 0

--- a/versions/l-/lunarlog.json
+++ b/versions/l-/lunarlog.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "704262c8a149e6bd847f2e2cbd2772aa2b97a226",
+      "version": "1.29.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Add new port: lunarlog

Header-only C++11 structured logging library with message templates, inspired by Serilog.

### Package Information

- **Package name:** lunarlog
- **Version:** 1.29.1
- **Homepage:** https://github.com/LunarECL/LunarLog
- **License:** MIT
- **Supports:** Windows, Linux, macOS (C++11 and later)

### Dependencies

None — header-only with no external dependencies.

### Description

LunarLog provides Serilog-style structured logging for C++11 and above. It supports message templates with named placeholders, multiple sink types (console, file, rolling file, async, batched), runtime log-level control, enrichers, filters, and a fluent builder API.

Key features:
- Message templates with named/positional parameters
- Console, file, rolling file, async, and batched sinks
- Structured properties preserved through the pipeline
- Thread-safe by default
- Sub-loggers with independent pipelines
- Dynamic log-level and config hot-reload
- Single-header distribution available

### Testing

Verified locally on:
- ✅ macOS (Apple Clang, arm64)
- ✅ The upstream project runs CI on Ubuntu (GCC/Clang), macOS (AppleClang), and Windows (MSVC) with 1150+ tests

### Checklist

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The port name follows the project name on GitHub (`LunarLog` → `lunarlog`).
    - [x] The project is amongst the first web search results for "LunarLog C++".
- [x] Optional dependencies are not applicable (no external dependencies).
- [x] The versioning scheme in vcpkg.json matches upstream (semver tags like `v1.29.1`).
- [x] The license declaration in vcpkg.json matches upstream (`MIT`).
- [x] The installed copyright file matches upstream.
- [x] The source code comes from the authoritative GitHub repository.
- [x] The generated usage text is accurate.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is in the new port's versions file.
