### PR TITLE
[polyclipping] Also copy pdb files

### DIFF
--- a/ports/polyclipping/portfile.cmake
+++ b/ports/polyclipping/portfile.cmake
@@ -12,8 +12,9 @@ vcpkg_from_sourceforge(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/cpp"
+    OPTIONS
+    -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT="Embedded"
 )
-
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()

--- a/ports/polyclipping/vcpkg.json
+++ b/ports/polyclipping/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "polyclipping",
   "version": "6.4.2",
-  "port-version": 13,
+  "port-version": 14,
   "description": "The Clipper library performs clipping and offsetting for both lines and polygons. All four boolean clipping operations are supported - intersection, union, difference and exclusive-or. Polygons can be of any shape including self-intersecting polygons.",
   "homepage": "https://sourceforge.net/projects/polyclipping/",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7722,7 +7722,7 @@
     },
     "polyclipping": {
       "baseline": "6.4.2",
-      "port-version": 13
+      "port-version": 14
     },
     "polyhook2": {
       "baseline": "2025-06-21",

--- a/versions/p-/polyclipping.json
+++ b/versions/p-/polyclipping.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f7cc84dafa6bf92127f2aa55b0f2fcb0b09f5bb",
+      "version": "6.4.2",
+      "port-version": 14
+    },
+    {
       "git-tree": "2388298c7ad673550c7492454666dd3a34ada895",
       "version": "6.4.2",
       "port-version": 13


### PR DESCRIPTION
Same problem and same solution as in the Catch2 port: https://github.com/microsoft/vcpkg/pull/49707

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.