### PR TITLE
[bit7z] update to 4.0.11

### DIFF
--- a/ports/bit7z/portfile.cmake
+++ b/ports/bit7z/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rikyoz/bit7z
     REF "v${VERSION}"
-    SHA512 18bd18bc7186c04d9c2e731c76f23ab97a796a0ec027dc7163626f30ca807ba98733dbcd96bbca9af0cd0497cede4561c84560bf4e28030f59e1e34c1d98204d
+    SHA512 63683be54d3c8b4b328501f55de49584ad7913f41f9b5f20cfc825bac45fe079efac4aaedb16a0fecc21d045e3a33dbc9a9b53a1ce43da541a2ae8042c91095f
     HEAD_REF master
     PATCHES
       fix_install.patch

--- a/ports/bit7z/vcpkg.json
+++ b/ports/bit7z/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "bit7z",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "description": "A C++ static library offering a clean and simple interface to the 7-zip shared libraries.",
   "homepage": "https://github.com/rikyoz/bit7z",
   "license": "MPL-2.0",

--- a/versions/b-/bit7z.json
+++ b/versions/b-/bit7z.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c981943b56e0bf3cdd005a500c8c5d7cb7acd40c",
+      "version": "4.0.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "d1aa6e09fb69b63f1fe62bb4dc2a6e6768fad7aa",
       "version": "4.0.10",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -741,7 +741,7 @@
       "port-version": 3
     },
     "bit7z": {
-      "baseline": "4.0.10",
+      "baseline": "4.0.11",
       "port-version": 0
     },
     "bitmagic": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
