### PR TITLE
[huira] Update port to v0.8.2

### DIFF
--- a/ports/huira/portfile.cmake
+++ b/ports/huira/portfile.cmake
@@ -4,13 +4,13 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO huira-render/huira
     REF "v${VERSION}"
-    SHA512 7f46d1c514a4a7ba5981dd2224ff4b01b3dc8f30903cf91f3bde25135d338dd7ac375d68eb75502d26264f7c6e54195c6126487cfc51c0a7c87f7c53d49df30f
+    SHA512 acbe259332e59eadf84f588a8e9bc5c5c717469fec2be5098ffeecaa6f5c2557dc3c0ad2d968c2803e289b75714fc7a87021b6960be5b321ce1dfd9f029db3fe
     HEAD_REF main
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        tools HUIRA_APPS
+        tools HUIRA_TOOLS
 )
 
 vcpkg_cmake_configure(

--- a/ports/huira/vcpkg.json
+++ b/ports/huira/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "huira",
-  "version": "0.8.0",
-  "description": "A ray tracing library for space engineering and planetary science.",
-  "homepage": "https://github.com/YOUR_ORG/huira",
+  "version": "0.8.2",
+  "description": "A library for space rendering, LiDAR simulation, and solar radiation pressure modeling.",
+  "homepage": "https://github.com/huira-render/huira",
+  "documentation": "https://docs.huira.space",
   "license": "MIT",
   "supports": "!android & !uwp & !xbox",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3825,7 +3825,7 @@
       "port-version": 3
     },
     "huira": {
-      "baseline": "0.8.0",
+      "baseline": "0.8.2",
       "port-version": 0
     },
     "hungarian": {

--- a/versions/h-/huira.json
+++ b/versions/h-/huira.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c801d017ac4f495113735844d988534ec5ec26c",
+      "version": "0.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "be75eeb6d538a3111c8b64cffde8f044763827c2",
       "version": "0.8.0",
       "port-version": 0


### PR DESCRIPTION
Update Huira port to v0.8.2 to fix bugs

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.