### PR TITLE
[half] Fix literal operator syntax, add test port

### DIFF
--- a/ports/half/literal_operator.diff
+++ b/ports/half/literal_operator.diff
@@ -1,0 +1,31 @@
+diff --git a/include/half.hpp b/include/half.hpp
+index cb658f2..5c054c6 100644
+--- a/include/half.hpp
++++ b/include/half.hpp
+@@ -442,7 +442,7 @@ namespace half_float
+ 	/// ~~~~
+ 	namespace literal
+ 	{
+-		half operator "" _h(long double);
++		half operator ""_h(long double);
+ 	}
+ #endif
+ 
+@@ -2261,7 +2261,7 @@ namespace half_float
+ 		friend struct std::hash<half>;
+ 	#endif
+ 	#if HALF_ENABLE_CPP11_USER_LITERALS
+-		friend half literal::operator "" _h(long double);
++		friend half literal::operator ""_h(long double);
+ 	#endif
+ 	#endif
+ 	};
+@@ -2276,7 +2276,7 @@ namespace half_float
+ 		/// \param value literal value
+ 		/// \return half with of given value (possibly rounded)
+ 		/// \exception FE_OVERFLOW, ...UNDERFLOW, ...INEXACT according to rounding
+-		inline half operator "" _h(long double value) { return half(detail::binary, detail::float2half<half::round_style>(value)); }
++		inline half operator ""_h(long double value) { return half(detail::binary, detail::float2half<half::round_style>(value)); }
+ 	}
+ #endif
+ 

--- a/ports/half/portfile.cmake
+++ b/ports/half/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_sourceforge(
     FILENAME "half-${VERSION}.zip"
     NO_REMOVE_ONE_LEVEL
     SHA512 946b1663a736eb486f670ba9dfcc56b43b9e7fb195988174b7dd004bdd2e23aba7a395b8867b4f58c97e73a50edf845b703b8cfc35708a562e6a9d7e1b4f4204
+    PATCHES
+        literal_operator.diff
 )
 
 file(GLOB HEADER_FILES "${SOURCE_PATH}/include/*.hpp")

--- a/ports/half/vcpkg.json
+++ b/ports/half/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "half",
   "version": "2.2.1",
+  "port-version": 1,
   "description": "C++ library for half precision floating point arithmetics.",
   "homepage": "https://sourceforge.net/projects/half/",
   "license": "MIT"

--- a/scripts/test_ports/vcpkg-ci-half/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-half/portfile.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${CURRENT_PORT_DIR}/project"
+)
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-half/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-half/project/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+project(halftest)
+
+find_path(HALF_INCLUDE_DIRS "half.hpp")
+add_executable(main main.cpp)
+target_include_directories(main PRIVATE ${HALF_INCLUDE_DIRS})

--- a/scripts/test_ports/vcpkg-ci-half/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-half/project/main.cpp
@@ -1,0 +1,11 @@
+#include <type_traits>
+
+#include <half.hpp>
+
+int main()
+{
+    using namespace half_float::literal;
+    auto x = 2.4_h;
+    static_assert(std::is_same<decltype(x), half_float::half>::value);
+    half_float::half y = half_float::sqrt(x);
+}

--- a/scripts/test_ports/vcpkg-ci-half/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-half/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-half",
+  "version-string": "ci",
+  "description": "Validation port",
+  "dependencies": [
+    "half",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3694,7 +3694,7 @@
     },
     "half": {
       "baseline": "2.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "halide": {
       "baseline": "18.0.0",

--- a/versions/h-/half.json
+++ b/versions/h-/half.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ec987385fe081fb2fbabe52bbd485ce68ce229f4",
+      "version": "2.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "cb043c76e364be5e48acaf5ae8d158d632d9ec09",
       "version": "2.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

This issue has been reported on SourceForge: https://sourceforge.net/p/half/discussion/general/thread/02d90668a5/ but no new upstream release so far.