### PR TITLE
[tclap] update to 1.4.0 rc2

### DIFF
--- a/ports/tclap/disable-test.patch
+++ b/ports/tclap/disable-test.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7196785..4cb6a60 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -74,7 +74,7 @@ endif()
+ if(BUILD_EXAMPLES)
+ 	add_subdirectory(examples)
+ endif()
+-add_subdirectory(tests)
++# add_subdirectory(tests)
+ if(BUILD_UNITTESTS)
+ 	add_subdirectory(unittests)
+ endif()

--- a/ports/tclap/portfile.cmake
+++ b/ports/tclap/portfile.cmake
@@ -3,6 +3,8 @@ vcpkg_from_github(
     REPO DAarno/tclap
     REF "${VERSION}"
     SHA512 e698e5a973f48cafce03f2b9dd41b9f507a7a728fbd35050b4aaedc80b39ff898bb7ca515f8a054f39b5277d29c430e238015ed4fd97ae2f40c194269036a83c
+    PATCHES
+        disable-test.patch 
 )
 
 vcpkg_cmake_configure(

--- a/ports/tclap/portfile.cmake
+++ b/ports/tclap/portfile.cmake
@@ -15,6 +15,8 @@ vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/tclap")
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 file(COPY "${SOURCE_PATH}/include/tclap" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/tclap/portfile.cmake
+++ b/ports/tclap/portfile.cmake
@@ -15,7 +15,9 @@ vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/tclap")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
 file(COPY "${SOURCE_PATH}/include/tclap" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
 

--- a/ports/tclap/portfile.cmake
+++ b/ports/tclap/portfile.cmake
@@ -1,9 +1,17 @@
-vcpkg_from_sourceforge(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO tclap
-    FILENAME "tclap-1.2.5.tar.gz"
-    SHA512 3b5b3d76e8ff21133001f5f9589fa6ec143729909bf0b9cc9934377bce178360c161fb5c1f4c4d9e9c74b09cff3d65f1d5100e61d4a732283524a78b6f236b10
+    REPO DAarno/tclap
+    REF "${VERSION}"
+    SHA512 e698e5a973f48cafce03f2b9dd41b9f507a7a728fbd35050b4aaedc80b39ff898bb7ca515f8a054f39b5277d29c430e238015ed4fd97ae2f40c194269036a83c
 )
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/tclap")
 
 file(COPY "${SOURCE_PATH}/include/tclap" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
 

--- a/ports/tclap/vcpkg.json
+++ b/ports/tclap/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "tclap",
-  "version": "1.2.5",
+  "version": "1.4.0-rc2",
   "description": "Templatized command-line argument parser for C++",
-  "homepage": "https://sourceforge.net/projects/tclap/",
-  "license": "MIT"
+  "homepage": "https://github.com/DAarno/tclap",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9757,7 +9757,7 @@
       "port-version": 8
     },
     "tclap": {
-      "baseline": "1.2.5",
+      "baseline": "1.4.0-rc2",
       "port-version": 0
     },
     "tcp-pubsub": {

--- a/versions/t-/tclap.json
+++ b/versions/t-/tclap.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "12a68656027567ba5d90ec4e069a9e8b4f462ed3",
+      "git-tree": "affe9440eee25df45eeac41c09c01c4b9b9af7d5",
       "version": "1.4.0-rc2",
       "port-version": 0
     },

--- a/versions/t-/tclap.json
+++ b/versions/t-/tclap.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0539b6df45e219a631d0e0a19020b0b1c9c3a6f7",
+      "git-tree": "12a68656027567ba5d90ec4e069a9e8b4f462ed3",
       "version": "1.4.0-rc2",
       "port-version": 0
     },

--- a/versions/t-/tclap.json
+++ b/versions/t-/tclap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0539b6df45e219a631d0e0a19020b0b1c9c3a6f7",
+      "version": "1.4.0-rc2",
+      "port-version": 0
+    },
+    {
       "git-tree": "f02ffdbe328a2df58a554ba83269ec09bd47a6ad",
       "version": "1.2.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

tclap 1.4.0 rc2 exports cmake targets now , this will solve the tclap problems in https://github.com/microsoft/vcpkg/pull/49552