### PR TITLE
[spine-runtimes] Fix header overwrite between spine-c and spine-cpp

### DIFF
--- a/ports/spine-runtimes/fix-cmake.patch
+++ b/ports/spine-runtimes/fix-cmake.patch
@@ -42,7 +42,7 @@ index 906f7b0..c5e1f18 100644
 \ No newline at end of file
 +target_include_directories(spine-c PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/spine-c/include>)
 +install(TARGETS spine-c DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+install(FILES ${INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spine)
++install(FILES ${INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spine-c/spine)
 \ No newline at end of file
 diff --git a/spine-cpp/CMakeLists.txt b/spine-cpp/CMakeLists.txt
 index e008c33..805aba8 100644
@@ -58,7 +58,7 @@ index e008c33..805aba8 100644
 \ No newline at end of file
 +target_include_directories(spine-cpp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/spine-cpp/include>)
 +install(TARGETS spine-cpp DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+install(FILES ${INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spine)
++install(FILES ${INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spine-cpp/spine)
 \ No newline at end of file
 diff --git a/spine-sfml/c/CMakeLists.txt b/spine-sfml/c/CMakeLists.txt
 index 68dcc75..2ccfb2d 100644

--- a/ports/spine-runtimes/vcpkg.json
+++ b/ports/spine-runtimes/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "spine-runtimes",
   "version": "4.1.0",
+  "port-version": 1,
   "description": "2D skeletal animation runtimes for Spine",
   "homepage": "https://github.com/EsotericSoftware/spine-runtimes",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9366,7 +9366,7 @@
     },
     "spine-runtimes": {
       "baseline": "4.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "spirit-po": {
       "baseline": "1.1.2",

--- a/versions/s-/spine-runtimes.json
+++ b/versions/s-/spine-runtimes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6e1872905f719ff3b90406cecf86ed4409a258d",
+      "version": "4.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2f07c033a802713abd304b4a9680786cdf53ea74",
       "version": "4.1.0",
       "port-version": 0


### PR DESCRIPTION
The current spine-runtimes port installs both spine-c and spine-cpp headers into include/spine, causing them to overwrite each other. This commit resolves the issue by installing the headers into separate subdirectories.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
