### PR TITLE
[cimg] update to 3.7.2

### DIFF
--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -3,8 +3,8 @@ set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO GreycLab/CImg
     # Using commit id becuase upstream likes to change tags
-    REF 7d168a8a013ded3c6d5ab7a0a50ec38b3e3d7790
-    SHA512 4c009c29cfa8401ba4249428e92eb82b085d70471bdd3745cf4ffa5aeac0cca7a9f2c902df966b17e3e8223bed3591ea6ab485cb455019d4f05b39671b920da6
+    REF adc0075060e600f79bff9a6455daf53ff5968905
+    SHA512 59b7388238d73e7c56a029bc7f372085f9e2a167ff138f0f2671ad59d3c988ca512e0b3df4892688b665baff3f327da429e94d60e0ee75c29b8367f7f3537de1
     HEAD_REF master
 )
 

--- a/ports/cimg/vcpkg.json
+++ b/ports/cimg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cimg",
-  "version": "3.7.0",
+  "version": "3.7.2",
   "description": "The CImg Library is a small, open-source, and modern C++ toolkit for image processing",
   "homepage": "https://github.com/GreycLab/CImg",
   "license": "CECILL-C AND CECILL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1745,7 +1745,7 @@
       "port-version": 0
     },
     "cimg": {
-      "baseline": "3.7.0",
+      "baseline": "3.7.2",
       "port-version": 0
     },
     "cinatra": {

--- a/versions/c-/cimg.json
+++ b/versions/c-/cimg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8cab180cf18909a34c138e728ab11d817da48efb",
+      "version": "3.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c2a4e6245c42fe114b86474a0182fab414032fa3",
       "version": "3.7.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/GreycLab/CImg/releases/tag/v.3.7.2
