### PR TITLE
[protobuf] update to 6.34.0

### DIFF
--- a/ports/protobuf/fix-constinit-with-clang-cl.patch
+++ b/ports/protobuf/fix-constinit-with-clang-cl.patch
@@ -1,14 +1,13 @@
 diff --git a/src/google/protobuf/port_def.inc b/src/google/protobuf/port_def.inc
-index a512b4843..31f1f5a12 100644
+index 1b6b41f..0c2808e 100644
 --- a/src/google/protobuf/port_def.inc
 +++ b/src/google/protobuf/port_def.inc
-@@ -678,6 +678,9 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
- #  define PROTOBUF_CONSTINIT
- #  define PROTOBUF_CONSTEXPR constexpr
- # endif
+@@ -431,6 +431,8 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
+ // so we can't enforce constinit. This limitation does not apply to constexpr.
+ // See https://godbolt.org/z/hsT9e3zs4
+ #define PROTOBUF_CONSTINIT
 +#elif defined(_MSC_VER)  && defined(__clang__)
-+#  define PROTOBUF_CONSTINIT
-+#  define PROTOBUF_CONSTEXPR constexpr
- #else
- # if defined(__cpp_constinit) && !defined(__CYGWIN__)
- #  define PROTOBUF_CONSTINIT constinit
++#define PROTOBUF_CONSTINIT
+ #elif defined(__GNUC__) && !defined(__clang__)
+ // GCC doesn't support constinit aggregate initialization of absl::Cord.
+ #define PROTOBUF_CONSTINIT

--- a/ports/protobuf/fix-static-build.patch
+++ b/ports/protobuf/fix-static-build.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/install.cmake b/cmake/install.cmake
-index 65765ca29..f5ad69102 100644
+index 0a31ead..3959980 100644
 --- a/cmake/install.cmake
 +++ b/cmake/install.cmake
-@@ -65,7 +65,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
+@@ -69,7 +69,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
      endforeach ()
    endif ()
    foreach (binary IN LISTS _protobuf_binaries)
@@ -11,10 +11,10 @@ index 65765ca29..f5ad69102 100644
        set_property(TARGET ${binary}
          PROPERTY INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
      elseif (APPLE)
-@@ -85,7 +85,5 @@ set(protobuf_HEADERS
-   ${cpp_features_proto_proto_srcs}
+@@ -93,8 +93,5 @@ set(protobuf_HEADERS
    ${descriptor_proto_proto_srcs}
    ${plugin_proto_proto_srcs}
+-  ${c_sharp_features_proto_proto_srcs}
 -  ${java_features_proto_proto_srcs}
 -  ${go_features_proto_proto_srcs}
  )

--- a/ports/protobuf/fix-upb.patch
+++ b/ports/protobuf/fix-upb.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/install.cmake b/cmake/install.cmake
-index 5e816b311..84211495b 100644
+index 3959980..e22f214 100644
 --- a/cmake/install.cmake
 +++ b/cmake/install.cmake
 @@ -60,7 +60,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
@@ -11,8 +11,7 @@ index 5e816b311..84211495b 100644
      foreach (generator upb upbdefs upb_minitable)
        list(APPEND _protobuf_binaries protoc-gen-${generator})
        install(TARGETS protoc-gen-${generator} EXPORT protobuf-targets
-@@ -93,7 +93,7 @@ set(protobuf_HEADERS
-   ${descriptor_proto_proto_srcs}
+@@ -94,6 +94,6 @@ set(protobuf_HEADERS
    ${plugin_proto_proto_srcs}
  )
 -if (protobuf_BUILD_LIBUPB)

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
-    REF "v33.4"
-    SHA512 540059a93721447cf4723bcca06e91c43a4399cb366c05bf84e9d8e2c439f3107ba17803f9d912549b54c471f2dcc4c9fc834145ec441dff31ca24f9a3543aa9
+    REF "v34.0"
+    SHA512 ba7fb01479c169003d8258896092a217f9781f51dcd59ebe7f5cc9b274f7f242bab2963f8eacb7ae6e1250db6fe8c2099ab54a9a9f399ef2aaeb44455f9afb98
     HEAD_REF master
     PATCHES
         fix-static-build.patch

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
-    REF "v34.0"
-    SHA512 ba7fb01479c169003d8258896092a217f9781f51dcd59ebe7f5cc9b274f7f242bab2963f8eacb7ae6e1250db6fe8c2099ab54a9a9f399ef2aaeb44455f9afb98
+    REF "v35.0"
+    SHA512 0d97b06f4e40b631cf5498bdb895846fd98943eeb97abe7993ee23a200c4956d34bc3c8c1436e5ac8413d217b49ba8689b3a58908a8e4ab5283864d678950aaf
     HEAD_REF master
     PATCHES
         fix-static-build.patch

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "protobuf",
-  "version": "6.33.4",
-  "port-version": 1,
+  "version": "6.34.0",
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protobuf",
-  "version": "6.34.0",
+  "version": "7.35.0",
   "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7833,8 +7833,8 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "6.33.4",
-      "port-version": 1
+      "baseline": "6.34.0",
+      "port-version": 0
     },
     "protobuf-c": {
       "baseline": "1.5.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7833,7 +7833,7 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "6.34.0",
+      "baseline": "7.35.0",
       "port-version": 0
     },
     "protobuf-c": {

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06d9d8423c0ad750de2433b73ac50b3c83a90a7d",
+      "version": "6.34.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "82a850caf35034a45596845a1d6e734b82f6a79a",
       "version": "6.33.4",
       "port-version": 1

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "06d9d8423c0ad750de2433b73ac50b3c83a90a7d",
-      "version": "6.34.0",
+      "git-tree": "07d8ad3c60cc93cc47ed20f041d604390af78f4b",
+      "version": "7.35.0",
       "port-version": 0
     },
     {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/protocolbuffers/protobuf/releases/tag/v34.0
