### PR TITLE
[viskores] Add new port

### DIFF
--- a/ports/viskores/portfile.cmake
+++ b/ports/viskores/portfile.cmake
@@ -10,7 +10,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 	FEATURES
 	cuda Viskores_ENABLE_CUDA
         kokkos Viskores_ENABLE_KOKKOS
-        openmp Viskores_ENABLE_OPENMP
         tbb Viskores_ENABLE_TBB
         rendering Viskores_ENABLE_RENDERING
         double     Viskores_USE_DOUBLE_PRECISION
@@ -27,6 +26,7 @@ vcpkg_cmake_configure(
 	-DViskores_ENABLE_TUTORIALS=ON
 	-DViskores_ENABLE_TESTING=OFF
 	-DViskores_ENABLE_TESTING_LIBRARY=OFF
+	-DViskores_ENABLE_OPENMP=OFF
 )
 
 vcpkg_cmake_install()
@@ -36,5 +36,6 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME viskores-1.1)
 vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/viskores/portfile.cmake
+++ b/ports/viskores/portfile.cmake
@@ -1,0 +1,40 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO viskores/viskores
+    REF "v${VERSION}"
+    SHA512 6b3e048b4af791b6a182b590c1b64835f86c3d4f9e786c9ed06dda1fccb053d03c9ef3334e424e03d1c0e617a849417abdab97c651296cf58724c7e2e37e3660
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+	FEATURES
+	cuda Viskores_ENABLE_CUDA
+        kokkos Viskores_ENABLE_KOKKOS
+        openmp Viskores_ENABLE_OPENMP
+        tbb Viskores_ENABLE_TBB
+        rendering Viskores_ENABLE_RENDERING
+        double     Viskores_USE_DOUBLE_PRECISION
+        hdf5       Viskores_ENABLE_HDF5_IO
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+	-DViskores_ENABLE_RENDERING=OFF
+	-DViskores_ENABLE_DOCUMENTATION=OFF
+	-DViskores_ENABLE_EXAMPLES=OFF
+	-DViskores_ENABLE_TUTORIALS=ON
+	-DViskores_ENABLE_TESTING=OFF
+	-DViskores_ENABLE_TESTING_LIBRARY=OFF
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_cmake_config_fixup(PACKAGE_NAME viskores-1.1)
+vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/viskores/vcpkg.json
+++ b/ports/viskores/vcpkg.json
@@ -1,0 +1,38 @@
+{
+  "name": "viskores",
+  "version-semver": "1.1.0",
+  "description": "A visualization library for many-threaded devices.",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA support"
+    },
+    "double": {
+      "description": "Use double precision for floating point calculations"
+    },
+    "hdf5": {
+      "description": "Enable HDF5 support"
+    },
+    "kokkos": {
+      "description": "Enable Kokkos support"
+    },
+    "openmp": {
+      "description": "Enable OpenMP support"
+    },
+    "rendering": {
+      "description": "Enable rendering library"
+    },
+    "tbb": {
+      "description": "Enable TBB support"
+    }
+  }
+}

--- a/ports/viskores/vcpkg.json
+++ b/ports/viskores/vcpkg.json
@@ -25,14 +25,14 @@
     "kokkos": {
       "description": "Enable Kokkos support"
     },
-    "openmp": {
-      "description": "Enable OpenMP support"
-    },
     "rendering": {
       "description": "Enable rendering library"
     },
     "tbb": {
-      "description": "Enable TBB support"
+      "description": "Enable TBB support",
+      "dependencies": [
+        "tbb"
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10400,6 +10400,10 @@
       "baseline": "1.1.0",
       "port-version": 0
     },
+    "viskores": {
+      "baseline": "1.1.0",
+      "port-version": 0
+    },
     "vit-vit-ctpl": {
       "baseline": "0.0.2",
       "port-version": 0

--- a/versions/v-/viskores.json
+++ b/versions/v-/viskores.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "20e02a020eae370b45bb1dd79da4445ee0ce7667",
+      "git-tree": "5a67c7062e62a97e4047d6deade426d78355827e",
       "version-semver": "1.1.0",
       "port-version": 0
     }

--- a/versions/v-/viskores.json
+++ b/versions/v-/viskores.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "20e02a020eae370b45bb1dd79da4445ee0ce7667",
+      "version-semver": "1.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Closes #50172 
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    
<img width="2015" height="1112" alt="image" src="https://github.com/user-attachments/assets/c29548c0-e2f7-49ac-9dca-7cb47f0731f9" />

    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
