### PR TITLE
[obfuscxx] Add new port

### DIFF
--- a/ports/obfuscxx/portfile.cmake
+++ b/ports/obfuscxx/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nevergiveupcpp/obfuscxx
+    REF v1.0.0
+	SHA512 78d252714ef84b4897d587842d49af252b33cdd14feff3c1ed57012ab7d0a04b51f301b9b6bb89a2ad5b2089081d3671365ed6bc84f10afbe6d28280b5bea2a7
+)
+
+file(INSTALL "${SOURCE_PATH}/include/obfuscxx/"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/obfuscxx/vcpkg.json
+++ b/ports/obfuscxx/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "obfuscxx",
+  "version": "1.0.0",
+  "description": "Header-only compile-time variables obfuscation library for C++20",
+  "homepage": "https://github.com/nevergiveupcpp/obfuscxx",
+  "license": "Apache-2.0"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7072,6 +7072,10 @@
       "baseline": "1.3.0",
       "port-version": 2
     },
+    "obfuscxx": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "oboe": {
       "baseline": "1.10.0",
       "port-version": 0

--- a/versions/o-/obfuscxx.json
+++ b/versions/o-/obfuscxx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "05cafe2a79371e3314b0fe145cb4a80b490028b6",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add new header-only port for obfuscxx - compile-time variables obfuscation library for C++20.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name.
    - [x] The project is amongst the first web search results for "obfuscxx" or "obfuscxx C++".
- [x] Optional dependencies of the build are all controlled by the port.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.