### PR TITLE
[libmagic] update to 5.47

### DIFF
--- a/ports/libmagic/portfile.cmake
+++ b/ports/libmagic/portfile.cmake
@@ -21,8 +21,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO file/file
-    REF FILE5_46
-    SHA512 fb8157ee8065feaf57412ccdeee57cd8fc853b54ac49b0ddc818eeb1ca3555a7cfd25dea08996503f7c565dcba8c57fd7e4dc5fe3452872c617f5612a94a8f0e
+    REF FILE5_47
+    SHA512 9ef8d1efd744115b0f28a7bef1a6b3e25c6feb71f6e37590bc18fe49e77d55adddb712527fd3c4080e0b70f13c5f33cdce3ce932e99a751e6de6a0e8b381c30a
     HEAD_REF master
     PATCHES ${PATCHES}
 )

--- a/ports/libmagic/vcpkg.json
+++ b/ports/libmagic/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmagic",
-  "version": "5.46",
-  "port-version": 2,
+  "version": "5.47",
   "description": "This library can be used to classify files according to magic number tests.",
   "homepage": "https://github.com/file/file",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5129,8 +5129,8 @@
       "port-version": 4
     },
     "libmagic": {
-      "baseline": "5.46",
-      "port-version": 2
+      "baseline": "5.47",
+      "port-version": 0
     },
     "libmariadb": {
       "baseline": "3.4.8",

--- a/versions/l-/libmagic.json
+++ b/versions/l-/libmagic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b28f78340e941bccfa7f0130e1baf5ef6c123bda",
+      "version": "5.47",
+      "port-version": 0
+    },
+    {
       "git-tree": "41586f5bc835926bf3a4ba4bfc79be735ca581d3",
       "version": "5.46",
       "port-version": 2


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/file/file/releases/tag/FILE5_47
