### PR TITLE
Update libvhdi to version 20251119

### DIFF
--- a/ports/libvhdi/macos_fixes.patch
+++ b/ports/libvhdi/macos_fixes.patch
@@ -1,5 +1,5 @@
 diff --git a/libcfile/libcfile_file.c b/libcfile/libcfile_file.c
-index 45e3fc8..5195b7a 100755
+index 417417c..abf49a0 100644
 --- a/libcfile/libcfile_file.c
 +++ b/libcfile/libcfile_file.c
 @@ -56,7 +56,7 @@
@@ -11,7 +11,7 @@ index 45e3fc8..5195b7a 100755
  /* Required for Linux platforms that use a sizeof( u64 )
   * in linux/fs.h but have no typedef of it
   */
-@@ -4194,6 +4194,12 @@ ssize_t libcfile_file_io_control_read(
+@@ -4194,6 +4194,11 @@ ssize_t libcfile_file_io_control_read(
  	return( read_count );
  }
  
@@ -20,25 +20,24 @@ index 45e3fc8..5195b7a 100755
 +#undef HAVE_POSIX_FADVISE
 +#endif
 +
-+
  /* Read data from a device file using IO control
   * Returns the number of bytes read if successful or -1 on error
   */
 diff --git a/libclocale/libclocale_support.c b/libclocale/libclocale_support.c
-index f5e29c2..56c4724 100755
+index b5f3d7b..d914c46 100644
 --- a/libclocale/libclocale_support.c
 +++ b/libclocale/libclocale_support.c
 @@ -68,7 +68,7 @@ int libclocale_initialize(
  
  		return( -1 );
  	}
--#if defined( HAVE_BINDTEXTDOMAIN ) && defined( HAVE_TEXTDOMAIN )
-+#if !defined( __APPLE__) && defined( HAVE_BINDTEXTDOMAIN ) && defined( HAVE_TEXTDOMAIN )
+-#if defined( HAVE_BINDTEXTDOMAIN ) && defined( HAVE_TEXTDOMAIN ) && defined( LOCALEDIR )
++#if !defined( __APPLE__ ) && defined( HAVE_BINDTEXTDOMAIN ) && defined( HAVE_TEXTDOMAIN ) && defined( LOCALEDIR )
  	if( bindtextdomain(
  	     domain_name,
  	     LOCALEDIR ) == NULL )
 diff --git a/libvhdi/libvhdi_i18n.c b/libvhdi/libvhdi_i18n.c
-index fb33e05..13e8c39 100755
+index 66e0651..bb5a356 100644
 --- a/libvhdi/libvhdi_i18n.c
 +++ b/libvhdi/libvhdi_i18n.c
 @@ -40,7 +40,7 @@ int libvhdi_i18n_initialize(

--- a/ports/libvhdi/portfile.cmake
+++ b/ports/libvhdi/portfile.cmake
@@ -3,7 +3,7 @@ set(LIB_FILENAME libvhdi-alpha-${VERSION}.tar.gz)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/libyal/libvhdi/releases/download/${VERSION}/${LIB_FILENAME}"
     FILENAME "${LIB_FILENAME}"
-    SHA512 5eddbb2ea5800f4427a9763b904b74d1b4a876844f0fb00a8e758c73424171ff7b52a821b1618ea575e9553e6ab357ce80884fab8503dcfc36343a32f80ecd02
+    SHA512 982ce91da22f174285aab00c26c4b26375f4d87afb08551a9c5a4d678e15010f066c624e1a0db87ae62a26d30d692a7f1c883dcbe748ebc3cf0e5817dbaa467f
 )
 
 vcpkg_extract_source_archive(

--- a/ports/libvhdi/vcpkg.json
+++ b/ports/libvhdi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libvhdi",
-  "version": "20231127",
+  "version": "20251119",
   "description": "Library and tools to access the Virtual Hard Disk (VHD) image format ",
   "homepage": "https://github.com/libyal/libvhdi",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5725,7 +5725,7 @@
       "port-version": 1
     },
     "libvhdi": {
-      "baseline": "20231127",
+      "baseline": "20251119",
       "port-version": 0
     },
     "libvmaf": {

--- a/versions/l-/libvhdi.json
+++ b/versions/l-/libvhdi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "687f61e3babbb2366dfa01a5ab9f77dd31c78270",
+      "version": "20251119",
+      "port-version": 0
+    },
+    {
       "git-tree": "60ba1f9b6d3e8d3a5543c8f7b85cd42939bb1960",
       "version": "20231127",
       "port-version": 0


### PR DESCRIPTION

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/libyal/libvhdi/releases

Hi, Update libvhdi to 2025 since the source of 2023 version is unavailable for download.

Closes #50095 