### PR TITLE
[st-tree] update to 1.4.0

### DIFF
--- a/ports/st-tree/portfile.cmake
+++ b/ports/st-tree/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO erikerlandson/st_tree
     REF "version_${VERSION}"
-    SHA512 354181bf397d92a863fcb46a6c07aec44599720456f61d639b3f0df4b95a6f908d0d44d3b2a430b3ef5a30c5df24ad29f638c4f8f80e51682d3eee800cfeea57
+    SHA512 dd555fce81cde5aa4b30854c856eb7dfd61ee1a7f5874c7538990fa331cfbe85838cb2a547af5e255debf04be3e0f5599701ce64743071f935a97162e48cd59d
     HEAD_REF develop
 )
 

--- a/ports/st-tree/vcpkg.json
+++ b/ports/st-tree/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "st-tree",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A fast and flexible c++ template class for tree data structures",
   "homepage": "https://github.com/erikerlandson/st_tree",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9477,7 +9477,7 @@
       "port-version": 0
     },
     "st-tree": {
-      "baseline": "1.3.0",
+      "baseline": "1.4.0",
       "port-version": 0
     },
     "stackwalker": {

--- a/versions/s-/st-tree.json
+++ b/versions/s-/st-tree.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29a2f889eb9f5b2611b35db6d1ad746b718d5abf",
+      "version": "1.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "526ad9fc8ea20e519c365ff439bd8af976d9d8f6",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/erikerlandson/st_tree/releases/tag/version_1.4.0
