### PR TITLE
[starlink-ast] Add test port

### DIFF
--- a/scripts/test_ports/vcpkg-ci-starlink-ast/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-starlink-ast/portfile.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-starlink-ast/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-starlink-ast/project/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+project(starlink-ast-test CXX)
+
+find_path(AST_INCLUDE_DIR ast.h REQUIRED)
+find_library(AST_LIBRARY ast REQUIRED)
+
+add_executable(main main.cpp)
+target_include_directories(main PRIVATE ${AST_INCLUDE_DIR})
+target_link_libraries(main PRIVATE ${AST_LIBRARY})

--- a/scripts/test_ports/vcpkg-ci-starlink-ast/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-starlink-ast/project/main.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+#include <ast.h>
+
+int main() {
+    // Initialize AST for the current thread
+    astBegin;
+
+    std::cout << "AST has been initialized successfully." << std::endl;
+
+    // End the AST context
+    astEnd;
+
+    return 0;
+}

--- a/scripts/test_ports/vcpkg-ci-starlink-ast/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-starlink-ast/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "vcpkg-ci-starlink-ast",
+  "version-string": "ci",
+  "description": "Validates threads support of starlink-ast",
+  "dependencies": [
+    {
+      "name": "starlink-ast",
+      "features": [ "pthreads" ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Test port already mentioned in #50077