### PR TITLE
[gmsh] Update to 4.15.1

### DIFF
--- a/ports/gmsh/portfile.cmake
+++ b/ports/gmsh/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://gmsh.info/src/gmsh-${VERSION}-source.tgz"
     FILENAME "gmsh-${VERSION}-source.tgz"
-    SHA512 f757688ed08b0c37ad3ebcf98b7661c385a434f83672fcad9c7f406afecc00fb1df6ef955a7ac76e54662ef95bcf2ca8a5d133c02603122ba5507f2d5359674e
+    SHA512 dc3ba00c2788d95f30d0cedac490b72cdf6805ef67d81f8636e4ff45510640991cc85e950b3953335f1ba73f9458b980949469844f65d6d5fb09b51936ddef12
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/gmsh/vcpkg.json
+++ b/ports/gmsh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gmsh",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "description": "Gmsh is an open source 3D finite element mesh generator with a built-in CAD engine and post-processor.",
   "homepage": "https://gmsh.info",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3469,7 +3469,7 @@
       "port-version": 3
     },
     "gmsh": {
-      "baseline": "4.15.0",
+      "baseline": "4.15.1",
       "port-version": 0
     },
     "gobject-introspection": {

--- a/versions/g-/gmsh.json
+++ b/versions/g-/gmsh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "33c365b0696bb024d512cfc0ddfa2f5cb8ef7922",
+      "version": "4.15.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f2baa4aa7b9650c272142760980c24f08ac0b915",
       "version": "4.15.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
