### PR TITLE
[libfs] Update to 1.0.10

### DIFF
--- a/ports/libfs/portfile.cmake
+++ b/ports/libfs/portfile.cmake
@@ -1,16 +1,20 @@
 if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
     message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-else()
+    return()
+endif()
 
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.freedesktop.org/xorg
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO lib/libfs
-    REF "libFS-${VERSION}"
-    SHA512 8d21f82fb335b3ff2f09875a118e90ab1425ce3456ee5d9cbd319491c8def5b8318860d427e1bbb74eae8fbc8f6f199375d4765b2e409ea91a82ecb852a7bab4
-    HEAD_REF master
-) 
+vcpkg_download_distfile(
+    LIBFS_ARCHIVE
+    URLS "https://www.x.org/releases/individual/lib/libFS-${VERSION}.tar.xz"
+    FILENAME "libFS-${VERSION}.tar.xz"
+    SHA512 f4dc361b7e1dcc1f348ea86e96c5a60ff40c5168b6097f00d8a5db2b86d089cfca12ac13dbde5ce3b53279b7eb8773ed6dcd9c678c2e95363ffa5127ecaacee7
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBFS_ARCHIVE}"
+)
 
 set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
 
@@ -22,9 +26,9 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-endif()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libfs/vcpkg.json
+++ b/ports/libfs/vcpkg.json
@@ -1,12 +1,11 @@
 {
   "name": "libfs",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "X Font Service client library",
   "homepage": "https://gitlab.freedesktop.org/xorg/lib/libfs",
   "license": null,
   "supports": "!windows",
   "dependencies": [
-    "bzip2",
     "xorg-macros",
     "xproto",
     "xtrans"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4897,7 +4897,7 @@
       "port-version": 2
     },
     "libfs": {
-      "baseline": "1.0.9",
+      "baseline": "1.0.10",
       "port-version": 0
     },
     "libftdi": {

--- a/versions/l-/libfs.json
+++ b/versions/l-/libfs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64be308dc13819ba2efb93b2380f172c06b84eab",
+      "version": "1.0.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "a995cbd80fc7904508d36ccf3a46cdadc4f9ce38",
       "version": "1.0.9",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.