### PR TITLE
[libgcrypt] Update to 1.12.1

### DIFF
--- a/ports/libgcrypt/portfile.cmake
+++ b/ports/libgcrypt/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/libgcrypt/libgcrypt-${VERSION}.tar.bz2"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-${VERSION}.tar.bz2"
     FILENAME "libgcrypt-${VERSION}.tar.bz2"
-    SHA512 9421461297bd79b14f94d1ab275c3ed93b5d433531915c5cc7a718a94d32978a46feccb7a33fe63a60780ff00d465fbe1fe9ada5c250cf6d10a525c246c63d1c
+    SHA512 e4be1f9d32bb672663499a1203454b9c646b7f237d9acb64303b991798fe3f4c3366793b0564b94c6687885353f6e7fef6ae6e74a57ccb5eb5606e77c81b3738
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/libgcrypt/vcpkg.json
+++ b/ports/libgcrypt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgcrypt",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "A general purpose cryptographic library",
   "homepage": "https://gnupg.org/software/libgcrypt/index.html",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4913,7 +4913,7 @@
       "port-version": 0
     },
     "libgcrypt": {
-      "baseline": "1.12.0",
+      "baseline": "1.12.1",
       "port-version": 0
     },
     "libgd": {

--- a/versions/l-/libgcrypt.json
+++ b/versions/l-/libgcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66077e955c684716f27e60e6f3885ba9b8e3e0d5",
+      "version": "1.12.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d4cfa851f26d60d89423129b2bd8c279e1516084",
       "version": "1.12.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.