### PR TITLE
[libgpg-error] Update to 1.59

### DIFF
--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(tarball
         "https://mirrors.dotsrc.org/gcrypt/libgpg-error/libgpg-error-${VERSION}.tar.bz2"
         "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-${VERSION}.tar.bz2"
     FILENAME "libgpg-error-${VERSION}.tar.bz2"
-    SHA512 4f4cb7f24e6cf4266c30da3985b9e62d4ab6012d8f43e9969d6edfd344d2a08f6277ab10610627597f6c58d064b3127fd286ae678381b84610d611645db5bbb4
+    SHA512 86a2b4f94928e88aab23c84e0febb702453617edf3cddf45d0ed9ea817007085a6d132214fd2c855d816ec296514401157e89dab2790aea1edf5c376ea7e1f56
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/libgpg-error/vcpkg.json
+++ b/ports/libgpg-error/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgpg-error",
-  "version": "1.58",
+  "version": "1.59",
   "description": "A runtime library for GnuPG and other software which likes to use it.",
   "homepage": "https://gnupg.org/software/libgpg-error/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4949,7 +4949,7 @@
       "port-version": 0
     },
     "libgpg-error": {
-      "baseline": "1.58",
+      "baseline": "1.59",
       "port-version": 0
     },
     "libgpiod": {

--- a/versions/l-/libgpg-error.json
+++ b/versions/l-/libgpg-error.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69108598d197866362cbddb894a2cf9c0fad1ec7",
+      "version": "1.59",
+      "port-version": 0
+    },
+    {
       "git-tree": "e44e69b2c8b8c8dce5a8c3888f1159b137081300",
       "version": "1.58",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
