### PR TITLE
[mqtt-cpp] Update to 13.2.3

### DIFF
--- a/ports/mqtt-cpp/portfile.cmake
+++ b/ports/mqtt-cpp/portfile.cmake
@@ -1,9 +1,11 @@
+set(VCPKG_BUILD_TYPE release) # header-only port
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO redboltz/mqtt_cpp
-    REF v${VERSION}
+    REF "v${VERSION}"
     SHA512
-    a237c08ff741c9b85e30f476f0a6d4d67d6720f66d68ac49253ff463e4675f89d0d6b69038a9dfd5814694e48f24af735dee57aa66215c5e0d3279c688878b2f
+    81e2b6a1d070bb57a212fb95abe3f36f8b41131058675528b67e41a2076a19f30f488619b9e3a5dbc0fe53db4efa5c9959111f06c241ebe616b78a70f9dfcad1
     HEAD_REF master
 )
 
@@ -19,6 +21,6 @@ vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME mqtt_cpp_iface CONFIG_PATH lib/cmake/mqtt_cpp_iface)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE_1_0.txt")

--- a/ports/mqtt-cpp/vcpkg.json
+++ b/ports/mqtt-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mqtt-cpp",
-  "version-semver": "13.2.2",
+  "version-semver": "13.2.3",
   "description": "Header-only MQTT client/server for C++14 based on Boost.Asio.",
   "homepage": "https://github.com/redboltz/mqtt_cpp",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6585,7 +6585,7 @@
       "port-version": 0
     },
     "mqtt-cpp": {
-      "baseline": "13.2.2",
+      "baseline": "13.2.3",
       "port-version": 0
     },
     "ms-gdk": {

--- a/versions/m-/mqtt-cpp.json
+++ b/versions/m-/mqtt-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bfebc5f78e307eccf891f2c17548815d7909108e",
+      "version-semver": "13.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "74588fb1fa49bc522009fdd0e80dca527e24d2c7",
       "version-semver": "13.2.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
