### PR TITLE
[freerdp] Update to 3.23.0

### DIFF
--- a/ports/freerdp/portfile.cmake
+++ b/ports/freerdp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FreeRDP/FreeRDP
     REF "${VERSION}"
-    SHA512 "cc52f70be7ce34989be4fbdf172ed90b65978986de2e8b97c77d3a04bfc4fa79738b15a7adb71c1fa980e1f1ab8336022594a1032e91d9102bcb66d36ced62a9"
+    SHA512 15895ce80a7e8fc0300d1129d2f4092162cbfee92efba26d7e570197bfb37821d9e92b835ca1589a1b876df3246d3eba9a2225e1c63519fb9fc4d93a8f3e5e88
     HEAD_REF master
     PATCHES
         dependencies.patch
@@ -124,7 +124,6 @@ if("server" IN_LIST FEATURES)
         vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/FreeRDP-Shadow3 PACKAGE_NAME freerdp-shadow3 DO_NOT_DELETE_PARENT_CONFIG_PATH)
         list(APPEND tools freerdp-shadow-cli)
     endif()
-    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/rdtk0 PACKAGE_NAME rdtk0 DO_NOT_DELETE_PARENT_CONFIG_PATH)
 endif()
 if("winpr-tools" IN_LIST FEATURES)
     list(APPEND tools winpr-hash winpr-makecert)
@@ -142,9 +141,6 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/winpr3/winpr/build-config.
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     # They build static with dllexport, so it must be used with dllexport. Proper fix needs invasive patching.
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/freerdp3/freerdp/api.h" "#ifdef FREERDP_EXPORTS" "#if 1")
-    if(WITH_SERVER)
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/rdtk0/rdtk/api.h" "#ifdef RDTK_EXPORTS" "#if 1")
-    endif()
 endif()
 
 file(GLOB cmakefiles  "${CURRENT_PACKAGES_DIR}/include/*/CMakeFiles")

--- a/ports/freerdp/vcpkg.json
+++ b/ports/freerdp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "freerdp",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "description": "A free implementation of the Remote Desktop Protocol (RDP)",
   "homepage": "https://github.com/FreeRDP/FreeRDP",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3165,7 +3165,7 @@
       "port-version": 9
     },
     "freerdp": {
-      "baseline": "3.22.0",
+      "baseline": "3.23.0",
       "port-version": 0
     },
     "freetds": {

--- a/versions/f-/freerdp.json
+++ b/versions/f-/freerdp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7de104ad56361578095fabbea348985134987637",
+      "version": "3.23.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c61b6375e0e2b63946d903d35abeb38731efe630",
       "version": "3.22.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

`rdtk` is not be built anymore, because it was first made [optionally](https://github.com/FreeRDP/FreeRDP/commit/69200a72177aa06e7335ccd1bd6f84011bd10d7f) and then marked as [unmaintained](https://github.com/FreeRDP/FreeRDP/commit/a97afe0067b8d44ba80618acb17fd848c763ba27). We could still enable it, but as it is unmaintained I think it i better to to not add an option until someone really misses sth.