### PR TITLE
[openldap] Update to 2.6.12

### DIFF
--- a/ports/openldap/portfile.cmake
+++ b/ports/openldap/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${VERSION}.tgz"
          "https://mirror.eu.oneandone.net/software/openldap/openldap-release/openldap-${VERSION}.tgz"
     FILENAME "openldap-${VERSION}.tgz"
-    SHA512 18129ad9a385457941e3203de5f130fe2571701abf24592c5beffb01361aae3182c196b2cd48ffeecb792b9b0e5f82c8d92445a7ec63819084757bdedba63b20
+    SHA512 951b510393433114939f386d43e202a62803724f395e4e400a556ca451f90ff1e179fe580b3db51f275859257b32814e66a13145d46f68bded4ff61c1fa37f36
 )
 
 vcpkg_extract_source_archive(

--- a/ports/openldap/vcpkg.json
+++ b/ports/openldap/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openldap",
-  "version": "2.6.10",
-  "port-version": 1,
+  "version": "2.6.12",
   "description": "OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.",
   "homepage": "https://www.openldap.org/software/",
   "license": "OLDAP-2.8",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7269,8 +7269,8 @@
       "port-version": 0
     },
     "openldap": {
-      "baseline": "2.6.10",
-      "port-version": 1
+      "baseline": "2.6.12",
+      "port-version": 0
     },
     "openmama": {
       "baseline": "6.3.2",

--- a/versions/o-/openldap.json
+++ b/versions/o-/openldap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "883649e3136904724071a1fc64356fb1ff00d605",
+      "version": "2.6.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "34670de3e7ab65b3802aaab853d1126d67fe576f",
       "version": "2.6.10",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
