### PR TITLE
[exiv2] update to 0.28.8

### DIFF
--- a/ports/exiv2/portfile.cmake
+++ b/ports/exiv2/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Exiv2/exiv2
     REF "v${VERSION}"
-    SHA512 b53f4989abcd5d346f2a9c726a06707c47e1990ecb2e5e193c963e01d452fefe4dddd14e25eb08ef35e2f8288b8ec4bdee60725aa7dcd6b1c0348ed56c803fc0
+    SHA512 e322438b565fe373e65baceeb4fd5173f538063b12b3d5a93d6e707da5020c818b1b9cc116f7bf0709635aa72b941dacb7a2bcfe6d946e2eaf7d9e55736dec5b
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/exiv2/vcpkg.json
+++ b/ports/exiv2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "exiv2",
-  "version": "0.28.7",
-  "port-version": 1,
+  "version": "0.28.8",
   "description": "Image metadata library and tools",
   "homepage": "https://exiv2.org",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2837,8 +2837,8 @@
       "port-version": 9
     },
     "exiv2": {
-      "baseline": "0.28.7",
-      "port-version": 1
+      "baseline": "0.28.8",
+      "port-version": 0
     },
     "expat": {
       "baseline": "2.7.4",

--- a/versions/e-/exiv2.json
+++ b/versions/e-/exiv2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77d6e07a13b02b2aff14996e1edf201a7da32af9",
+      "version": "0.28.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "cedee9b50efea8688a242e81109bf6d14181e724",
       "version": "0.28.7",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/Exiv2/exiv2/releases/tag/v0.28.8
