### PR TITLE
[proj] update to 9.8.0

### DIFF
--- a/ports/proj/portfile.cmake
+++ b/ports/proj/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/PROJ
     REF "${VERSION}"
-    SHA512 c5ca62e34612a764cf5cef15e7313ac9e3dccf698e045ac09f8d24e4c109ebf9ee207bcd9d5d698b3f6ecb35d98ec621672f58d130e0eefce74705c3152f374c
+    SHA512 87070e95be1ddaf816d712ab64b0a3834bb61d7a8be0e578a38f5e3346ec4ebdaf901da4bbd325174fb2379ead97a9fe042ac658ca5a1e096c15db0e9f37c8c7
     HEAD_REF master
     PATCHES
         fix-proj4-targets-cmake.patch

--- a/ports/proj/vcpkg.json
+++ b/ports/proj/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "proj",
-  "version": "9.7.1",
+  "version": "9.8.0",
   "description": "PROJ library for cartographic projections",
   "homepage": "https://proj.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7825,7 +7825,7 @@
       "port-version": 0
     },
     "proj": {
-      "baseline": "9.7.1",
+      "baseline": "9.8.0",
       "port-version": 0
     },
     "projectm": {

--- a/versions/p-/proj.json
+++ b/versions/p-/proj.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c369ff70210210bb59b702e2576c9111dec1b6d",
+      "version": "9.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "efcf327291c6be6908a96814445f995a7f3ba8e2",
       "version": "9.7.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/OSGeo/PROJ/releases/tag/9.8.0
