### PR TITLE
[bde] update to 4.36.0.0

### DIFF
--- a/ports/bde/fix-bdlar-target.patch
+++ b/ports/bde/fix-bdlar-target.patch
@@ -1,12 +1,11 @@
-diff --git a/groups/bdl/CMakeLists.txt b/groups/bdl/CMakeLists.txt
-index 4f23715..8ac3e5b 100644
---- a/groups/bdl/CMakeLists.txt
-+++ b/groups/bdl/CMakeLists.txt
-@@ -26,6 +26,7 @@ target_compile_options(bdlde-iface
- if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-     target_compile_options(bdlf INTERFACE /bigobj)
-     target_compile_options(bdlcc INTERFACE /bigobj)
-+    target_compile_options(bdlar PRIVATE  /bigobj)
-     target_link_libraries(bdlb-iface PRIVATE bcrypt)
- endif()
- 
+diff --git a/groups/CMakeLists.txt b/groups/CMakeLists.txt
+index 7ee0b81..5346c7b 100644
+--- a/groups/CMakeLists.txt
++++ b/groups/CMakeLists.txt
+@@ -1,3 +1,6 @@
++if(MSVC)
++    add_compile_options(/bigobj)
++endif()
+ add_subdirectory(bsl)
+ add_subdirectory(bdl)
+ add_subdirectory(bal)

--- a/ports/bde/fix-bdlar-target.patch
+++ b/ports/bde/fix-bdlar-target.patch
@@ -1,0 +1,12 @@
+diff --git a/groups/bdl/CMakeLists.txt b/groups/bdl/CMakeLists.txt
+index 4f23715..8ac3e5b 100644
+--- a/groups/bdl/CMakeLists.txt
++++ b/groups/bdl/CMakeLists.txt
+@@ -26,6 +26,7 @@ target_compile_options(bdlde-iface
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     target_compile_options(bdlf INTERFACE /bigobj)
+     target_compile_options(bdlcc INTERFACE /bigobj)
++    target_compile_options(bdlar PRIVATE  /bigobj)
+     target_link_libraries(bdlb-iface PRIVATE bcrypt)
+ endif()
+ 

--- a/ports/bde/pcre2_find_package.patch
+++ b/ports/bde/pcre2_find_package.patch
@@ -1,0 +1,40 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 07c22f5e6..277b2379c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,6 +9,12 @@ if(NOT BBS_BUILD_SYSTEM)
+     bbs_build_tests_with_all()
+ endif()
+ 
++if (BDE_USE_EXTERNAL_PCRE2)
++    set(PCRE2_USE_STATIC_LIBS ON)
++    find_package(pcre2 CONFIG REQUIRED)
++    add_library(pcre2 ALIAS pcre2::pcre2-8-static)
++endif()
++
+ add_subdirectory(thirdparty)
+ add_subdirectory(groups)
+ add_subdirectory(standalones)
+diff --git a/groups/bdl/bdlpcre/bdlpcre_regex.h b/groups/bdl/bdlpcre/bdlpcre_regex.h
+index cd1c4a350..e67841c95 100644
+--- a/groups/bdl/bdlpcre/bdlpcre_regex.h
++++ b/groups/bdl/bdlpcre/bdlpcre_regex.h
+@@ -660,7 +660,7 @@ BSLS_IDENT("$Id$ $CSID$")
+ #ifndef _PCRE2_H
+ #define PCRE2_CODE_UNIT_WIDTH 8
+ #define PCRE2_STATIC
+-#include <pcre2/pcre2.h>
++#include <pcre2.h>
+ #endif
+ 
+ #ifndef BDE_DONT_ALLOW_TRANSITIVE_INCLUDES
+diff --git a/groups/bdl/group/bdl.dep b/groups/bdl/group/bdl.dep
+index 91ec53004..c4e3d0e8a 100644
+--- a/groups/bdl/group/bdl.dep
++++ b/groups/bdl/group/bdl.dep
+@@ -1,4 +1,4 @@
+ bsl
+ # third-party
+ inteldfp
+-pcre2
++libpcre2-8

--- a/ports/bde/portfile.cmake
+++ b/ports/bde/portfile.cmake
@@ -25,7 +25,7 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 f9d7433fc3a7ebf1e2a1fddab850b6f10f7ced78aec0e1f1e86c152187fcf2434846102cfb95621e95a22d8977f5d8af46deeef0400b8debba3511c6e6552882
     HEAD_REF main
-    PATCHES fix-bdlar-target.patch
+    PATCHES fix-bdlar-target.patch use-vcpkg-pcre2.patch
 )
 
 vcpkg_cmake_configure(
@@ -36,6 +36,7 @@ vcpkg_cmake_configure(
         -DCMAKE_CXX_STANDARD_REQUIRED=ON
         -DCMAKE_CXX_EXTENSIONS=OFF
         -DBBS_BUILD_SYSTEM=1
+        -DBDE_USE_EXTERNAL_PCRE2=1
         "-DBdeBuildSystem_DIR:PATH=${TOOLS_PATH}/BdeBuildSystem"
     OPTIONS_RELEASE
         -DBDE_BUILD_TARGET_OPT=1
@@ -49,7 +50,7 @@ vcpkg_cmake_build()
 # Install release
 vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-list(APPEND SUBPACKAGES "inteldfp" "pcre2" "s_baltst" "bsl" "bbryu" "bdl" "bbl" "bal")
+list(APPEND SUBPACKAGES "inteldfp" "s_baltst" "bsl" "bbryu" "bdl" "bbl" "bal")
 include(GNUInstallDirs) # needed for CMAKE_INSTALL_LIBDIR
 foreach(subpackage IN LISTS SUBPACKAGES)
     vcpkg_cmake_config_fixup(PACKAGE_NAME ${subpackage} CONFIG_PATH /${CMAKE_INSTALL_LIBDIR}/cmake/${subpackage} DO_NOT_DELETE_PARENT_CONFIG_PATH)

--- a/ports/bde/portfile.cmake
+++ b/ports/bde/portfile.cmake
@@ -25,6 +25,7 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 f9d7433fc3a7ebf1e2a1fddab850b6f10f7ced78aec0e1f1e86c152187fcf2434846102cfb95621e95a22d8977f5d8af46deeef0400b8debba3511c6e6552882
     HEAD_REF main
+    PATCHES fix-bdlar-target.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/bde/portfile.cmake
+++ b/ports/bde/portfile.cmake
@@ -5,12 +5,12 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
 
 # Acquire BDE Tools and add them to PATH
-set (BDE_TOOLS_VER 4.13.0.0)
+set (BDE_TOOLS_VER 4.36.0.0)
 vcpkg_from_github(
     OUT_SOURCE_PATH TOOLS_PATH
     REPO "bloomberg/bde-tools"
     REF "${BDE_TOOLS_VER}"
-    SHA512 6a0eec25889a33fb0302af735ed2fcce38afa5ad2be9202d2589d76509f9fd85f9ddc0a73147df1b6471543f51df3b5b40e8c08d378ab1335d2703d89b5921e6
+    SHA512 c1ec488c6cd4e4859e916aab52d809a3cb292e933dbf3e8cf662d60617956c44eceec1853b2d310d587dcb0fe70eba74271ca2d2a2d06e06393852acae9311ab
     HEAD_REF main
 )
 
@@ -23,7 +23,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "bloomberg/bde"
     REF "${VERSION}"
-    SHA512 d6d7e453cf22f6e28f3513b818ab3f4b597db3e1d109587e0e0a8957338483c475494f55d953dfe86de507a6c292d1492d9cbb3c8be359044ef368fe80595448
+    SHA512 f9d7433fc3a7ebf1e2a1fddab850b6f10f7ced78aec0e1f1e86c152187fcf2434846102cfb95621e95a22d8977f5d8af46deeef0400b8debba3511c6e6552882
     HEAD_REF main
 )
 
@@ -48,7 +48,7 @@ vcpkg_cmake_build()
 # Install release
 vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-list(APPEND SUBPACKAGES "ryu" "inteldfp" "pcre2" "s_baltst" "bsl" "bdl" "bal")
+list(APPEND SUBPACKAGES "inteldfp" "pcre2" "s_baltst" "bsl" "bbryu" "bdl" "bbl" "bal")
 include(GNUInstallDirs) # needed for CMAKE_INSTALL_LIBDIR
 foreach(subpackage IN LISTS SUBPACKAGES)
     vcpkg_cmake_config_fixup(PACKAGE_NAME ${subpackage} CONFIG_PATH /${CMAKE_INSTALL_LIBDIR}/cmake/${subpackage} DO_NOT_DELETE_PARENT_CONFIG_PATH)

--- a/ports/bde/use-vcpkg-pcre2.patch
+++ b/ports/bde/use-vcpkg-pcre2.patch
@@ -1,0 +1,40 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 07c22f5e6..277b2379c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,6 +9,12 @@ if(NOT BBS_BUILD_SYSTEM)
+     bbs_build_tests_with_all()
+ endif()
+ 
++if (BDE_USE_EXTERNAL_PCRE2)
++    set(PCRE2_USE_STATIC_LIBS ON)
++    find_package(pcre2 CONFIG REQUIRED)
++    add_library(pcre2 ALIAS pcre2::pcre2-8-static)
++endif()
++
+ add_subdirectory(thirdparty)
+ add_subdirectory(groups)
+ add_subdirectory(standalones)
+diff --git a/groups/bdl/bdlpcre/bdlpcre_regex.h b/groups/bdl/bdlpcre/bdlpcre_regex.h
+index cd1c4a350..e67841c95 100644
+--- a/groups/bdl/bdlpcre/bdlpcre_regex.h
++++ b/groups/bdl/bdlpcre/bdlpcre_regex.h
+@@ -660,7 +660,7 @@ BSLS_IDENT("$Id$ $CSID$")
+ #ifndef _PCRE2_H
+ #define PCRE2_CODE_UNIT_WIDTH 8
+ #define PCRE2_STATIC
+-#include <pcre2/pcre2.h>
++#include <pcre2.h>
+ #endif
+ 
+ #ifndef BDE_DONT_ALLOW_TRANSITIVE_INCLUDES
+diff --git a/groups/bdl/group/bdl.dep b/groups/bdl/group/bdl.dep
+index 91ec53004..c4e3d0e8a 100644
+--- a/groups/bdl/group/bdl.dep
++++ b/groups/bdl/group/bdl.dep
+@@ -1,4 +1,4 @@
+ bsl
+ # third-party
+ inteldfp
+-pcre2
++libpcre2-8

--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "bde",
-  "version": "4.18.0.0",
+  "version": "4.36.0.0",
   "description": "Basic Development Environment - a set of foundational C++ libraries used at Bloomberg.",
   "homepage": "https://techatbloomberg.com/",
   "documentation": "https://bloomberg.github.io/bde/",

--- a/ports/bde/vcpkg.json
+++ b/ports/bde/vcpkg.json
@@ -15,6 +15,10 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    },
+    {
+      "name": "pcre2",
+      "host": false
     }
   ]
 }

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85cfc15c290f03c91be9a8ee432a71917288c83e",
+      "version": "4.36.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "34499e736823b1b6b2fe34a37d9162ecab8e187c",
       "version": "4.18.0.0",
       "port-version": 0

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4b40088cbcebabfb56a25bc3a27a3a9db229d3e6",
+      "git-tree": "f0a27110dd75bd8e4cb9e46d2a3ce83def636965",
       "version": "4.36.0.0",
       "port-version": 0
     },

--- a/versions/b-/bde.json
+++ b/versions/b-/bde.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "85cfc15c290f03c91be9a8ee432a71917288c83e",
+      "git-tree": "4b40088cbcebabfb56a25bc3a27a3a9db229d3e6",
       "version": "4.36.0.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -665,7 +665,7 @@
       "port-version": 0
     },
     "bde": {
-      "baseline": "4.18.0.0",
+      "baseline": "4.36.0.0",
       "port-version": 0
     },
     "bdwgc": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

