### PR TITLE
[dlfcn-win32] Add support for VCPKG_LIBRARY_LINKAGE

### DIFF
--- a/ports/dlfcn-win32/portfile.cmake
+++ b/ports/dlfcn-win32/portfile.cmake
@@ -7,8 +7,12 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED}
 )
 
 vcpkg_cmake_install()

--- a/ports/dlfcn-win32/vcpkg.json
+++ b/ports/dlfcn-win32/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dlfcn-win32",
   "version": "1.4.2",
+  "port-version": 1,
   "description": "dlfcn-win32 is an implementation of dlfcn for Windows.",
   "homepage": "https://github.com/dlfcn-win32/dlfcn-win32",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2534,7 +2534,7 @@
     },
     "dlfcn-win32": {
       "baseline": "1.4.2",
-      "port-version": 0
+      "port-version": 1
     },
     "dlib": {
       "baseline": "20.0",

--- a/versions/d-/dlfcn-win32.json
+++ b/versions/d-/dlfcn-win32.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e29d24bbfb608518553e340a6f246694b2071ed7",
+      "version": "1.4.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "80f2c52f546e5ba65c29921cddcc2ce48ab93fe8",
       "version": "1.4.2",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
[dlfcn-win32]  Add support for VCPKG_LIBRARY_LINKAGE
<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
