### PR TITLE
[wxwidgets] update to 3.3.2

### DIFF
--- a/ports/wxwidgets/install-layout.patch
+++ b/ports/wxwidgets/install-layout.patch
@@ -1,46 +1,42 @@
 diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
-index f044d22d4d..a78b9aa1e9 100644
+index 418fe12..0726ea2 100644
 --- a/build/cmake/init.cmake
 +++ b/build/cmake/init.cmake
-@@ -200,12 +200,12 @@ endif()
- 
+@@ -201,11 +201,8 @@ endif()
+ wx_get_install_dir(include)
  if(WIN32_MSVC_NAMING)
      if(wxBUILD_SHARED)
 -        set(lib_suffix "_dll")
-+        # set(lib_suffix "_dll")
      else()
 -        set(lib_suffix "_lib")
-+        # set(lib_suffix "_lib")
      endif()
- 
 -    set(wxPLATFORM_LIB_DIR "${wxCOMPILER_PREFIX}${wxARCH_SUFFIX}${lib_suffix}")
-+    # set(wxPLATFORM_LIB_DIR "${wxCOMPILER_PREFIX}${wxARCH_SUFFIX}${lib_suffix}")
- 
-     # Generator expression to not create different Debug and Release directories
-     set(GEN_EXPR_DIR "$<1:/>")
+     set(wxINSTALL_INCLUDE_DIR "${include_dir}")
+ else()
+     wx_get_flavour(lib_flavour "-")
 diff --git a/build/cmake/install.cmake b/build/cmake/install.cmake
-index a373983043..2e1ace7bf9 100644
+index 88591a8..14f88cb 100644
 --- a/build/cmake/install.cmake
 +++ b/build/cmake/install.cmake
-@@ -63,7 +63,7 @@ else()
- 
-     install(DIRECTORY DESTINATION "bin")
+@@ -68,7 +68,7 @@ else()
+     wx_get_install_platform_dir(runtime)
+     install(DIRECTORY DESTINATION "${runtime_dir}")
      install(CODE "execute_process( \
 -        COMMAND ${CMAKE_COMMAND} -E create_symlink \
 +        COMMAND ${CMAKE_COMMAND} -E copy \
-         \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/lib/wx/config/${wxBUILD_FILE_ID}\" \
-         \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/wx-config\" \
+         \"${CMAKE_INSTALL_PREFIX}/${library_dir}/wx/config/${wxBUILD_FILE_ID}\" \
+         \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${runtime_dir}/wx-config\" \
          )"
 diff --git a/build/cmake/utils/CMakeLists.txt b/build/cmake/utils/CMakeLists.txt
-index 15f4339ef9..f93849e025 100644
+index 608351a..d8110f9 100644
 --- a/build/cmake/utils/CMakeLists.txt
 +++ b/build/cmake/utils/CMakeLists.txt
-@@ -39,7 +39,7 @@ if(wxUSE_XRC)
+@@ -40,7 +40,7 @@ if(wxUSE_XRC)
  
          # Don't use wx_install() here to preserve escaping.
          install(CODE "execute_process( \
 -            COMMAND ${CMAKE_COMMAND} -E create_symlink \
 +            COMMAND ${CMAKE_COMMAND} -E copy \
-             \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/${wxrc_output_name}${EXE_SUFFIX}\" \
-             \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/wxrc${EXE_SUFFIX}\" \
+             \"${CMAKE_INSTALL_PREFIX}/${runtime_dir}/${wxrc_output_name}${EXE_SUFFIX}\" \
+             \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${runtime_dir}/wxrc${EXE_SUFFIX}\" \
              )"

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wxWidgets/wxWidgets
     REF "v${VERSION}"
-    SHA512 8ad17582c4ba721ffe76ada4bb8bd7bc4b050491220aca335fd0506a51354fb789d5bc3d965f0f459dc81784d6427c88272e2acc2099cddf73730231b5a16f62
+    SHA512 c47460c8bc150445e7774a287a79bd70b6d96b91ea46b51f238a317f068e466d570c5a94e2204d112e42da781a5cef98236718efff4b7f539d61a12ceaf65eb7
     HEAD_REF master
     PATCHES
         install-layout.patch
@@ -18,8 +18,8 @@ vcpkg_from_github(
 vcpkg_from_github(
     OUT_SOURCE_PATH lexilla_SOURCE_PATH
     REPO wxWidgets/lexilla
-    REF "27c20a6ae5eebf418debeac0166052ed6fb653bc"
-    SHA512 7e5de7f664509473b691af8261fca34c2687772faca7260eeba5f2984516e6f8edf88c27192e056c9dda996e2ad2c20f6d1dff1c4bd2f3c0d74852cb50ca424a
+    REF "0dbce0b418b8b3d2ef30304d0bf53ff58c07ed84"
+    SHA512 61f7b0217f4518121ecad32f015b53600e565bdd499d4020468cf6c8a533d516c6881115aa5e640afca5ea428535f47680cde426fa3dbabe9e4423b4526853fd
     HEAD_REF wx
 )
 file(COPY "${lexilla_SOURCE_PATH}/" DESTINATION "${SOURCE_PATH}/src/stc/lexilla")
@@ -127,7 +127,9 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/wxWidgets)
+
+string(REGEX MATCH "^[0-9]+\\.[0-9]+" VERSION_MAJOR_MINOR "${VERSION}")
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/wxWidgets-${VERSION_MAJOR_MINOR})
 
 # The CMake export is not ready for use: It lacks a config file.
 file(REMOVE_RECURSE

--- a/ports/wxwidgets/sdl2.patch
+++ b/ports/wxwidgets/sdl2.patch
@@ -1,8 +1,8 @@
 diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
-index 5447d33..f5440b4 100644
+index 0726ea2..2f8652d 100644
 --- a/build/cmake/init.cmake
 +++ b/build/cmake/init.cmake
-@@ -530,7 +530,9 @@ if(wxUSE_GUI)
+@@ -684,7 +684,9 @@ if(wxUSE_GUI)
      endif()
  
      if(wxUSE_SOUND AND wxUSE_LIBSDL AND UNIX AND NOT APPLE)
@@ -12,9 +12,9 @@ index 5447d33..f5440b4 100644
 +        set(SDL2_LIBRARY SDL2::SDL2 CACHE INTERNAL "")
          if(NOT SDL2_FOUND)
              find_package(SDL)
-         endif()
+             mark_as_advanced(SDL_INCLUDE_DIR SDLMAIN_LIBRARY)
 diff --git a/build/cmake/wxWidgetsConfig.cmake.in b/build/cmake/wxWidgetsConfig.cmake.in
-index 60cf762..202a8c3 100644
+index 8e4e2be..9a3cad2 100644
 --- a/build/cmake/wxWidgetsConfig.cmake.in
 +++ b/build/cmake/wxWidgetsConfig.cmake.in
 @@ -2,6 +2,9 @@

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -23,6 +23,9 @@
     "expat",
     {
       "name": "gtk3",
+      "features": [
+        "wayland"
+      ],
       "platform": "!windows & !osx & !ios"
     },
     {

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "wxwidgets",
-  "version": "3.3.1",
-  "port-version": 1,
+  "version": "3.3.2",
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10769,8 +10769,8 @@
       "port-version": 0
     },
     "wxwidgets": {
-      "baseline": "3.3.1",
-      "port-version": 1
+      "baseline": "3.3.2",
+      "port-version": 0
     },
     "wyhash": {
       "baseline": "2023-12-03",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1cf0ae9c5c60519bcb9d5c326fb7268008f85d6d",
+      "version": "3.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c3b7a128822dda9b567ad7efaa48fbcdf889e7d0",
       "version": "3.3.1",
       "port-version": 1

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1cf0ae9c5c60519bcb9d5c326fb7268008f85d6d",
+      "git-tree": "824d58236f416841814ed7b1942c43de873c0f62",
       "version": "3.3.2",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/wxWidgets/wxWidgets/releases/tag/v3.3.2
