### PR TITLE
[wt] update to 4.12.5

### DIFF
--- a/ports/wt/portfile.cmake
+++ b/ports/wt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO emweb/wt
     REF "${VERSION}"
-    SHA512 120ea51e12fc8e65a26eb3ab6bca04d3db956ca28e945df21c8cb03b0da444bafd742313c8bb713a9d88083956b8c8109c599a254411dcae7da8b9975e7e73c1
+    SHA512 d150d16eb5a464153436efdf970500c57122c7910faae3c35580026f7c78edfa32ac96c21a9e53cac6103b6f54d36f2baea295187f3026c4efe42d4e6fcb0afc
     HEAD_REF master
     PATCHES
         0005-XML_file_path.patch

--- a/ports/wt/vcpkg.json
+++ b/ports/wt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wt",
-  "version": "4.12.3",
+  "version": "4.12.5",
   "description": "Wt is a C++ library for developing web applications",
   "homepage": "https://github.com/emweb/wt",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10753,7 +10753,7 @@
       "port-version": 0
     },
     "wt": {
-      "baseline": "4.12.3",
+      "baseline": "4.12.5",
       "port-version": 0
     },
     "wtl": {

--- a/versions/w-/wt.json
+++ b/versions/w-/wt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "73c8ac1fb32369910f81f6b6a236e5da29027bf6",
+      "version": "4.12.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "e7b748287e0e78a106c535b1323725046bf8d742",
       "version": "4.12.3",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/emweb/wt/releases/tag/4.12.5
https://github.com/emweb/wt/releases/tag/4.12.4
