### PR TITLE
[libu2f-server] Replace outdated website and small further improvement

### DIFF
--- a/ports/libu2f-server/CMakeLists.txt
+++ b/ports/libu2f-server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 project(libu2f-server C)
 
@@ -25,7 +25,7 @@ install(TARGETS libu2f-server
 INSTALL(FILES ${LIBU2F_SERVER_HEADERS} DESTINATION "include/libu2f-server")
 
 install(EXPORT libu2f-serverConfig
-  FILE libu2f-serverConfig.cmake
-  NAMESPACE libu2f-server::
-  DESTINATION "share/libu2f-server"
+    FILE libu2f-serverConfig.cmake
+    NAMESPACE libu2f-server::
+    DESTINATION "share/libu2f-server"
 )

--- a/ports/libu2f-server/portfile.cmake
+++ b/ports/libu2f-server/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Yubico/libu2f-server
-    REF libu2f-server-1.1.0
+    REF "libu2f-server-${VERSION}"
     SHA512 085f8e7d74c1efb347747b8930386f18ba870f668f82e9bd479c9f8431585c5dc7f95b2f6b82bdd3a6de0c06f8cb2fbf51c363ced54255a936ab96536158ee59
     HEAD_REF master
     PATCHES
@@ -26,9 +26,10 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libu2f-server/u2f-server.h
     "#include <libu2f-server/u2f-server-version.h>"
 )
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
 vcpkg_copy_pdbs()
 
-# Handle copyright
-configure_file("${SOURCE_PATH}/COPYING" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libu2f-server/vcpkg.json
+++ b/ports/libu2f-server/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "libu2f-server",
   "version": "1.1.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Yubico Universal 2nd Factor (U2F) Server C Library",
-  "homepage": "https://developers.yubico.com/libu2f-server/",
+  "homepage": "https://github.com/Yubico/libu2f-server",
   "supports": "(x86 | x64) & windows",
   "dependencies": [
     "json-c",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5642,7 +5642,7 @@
     },
     "libu2f-server": {
       "baseline": "1.1.0",
-      "port-version": 5
+      "port-version": 6
     },
     "libudfread": {
       "baseline": "1.2.0",

--- a/versions/l-/libu2f-server.json
+++ b/versions/l-/libu2f-server.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f0c5db5722cc2d707d355f6e35519d847fd0d927",
+      "version": "1.1.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "5d1eea42e71fe87d9270b391a2297326e698fdef",
       "version": "1.1.0",
       "port-version": 5


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Changes:
- Website doesn't exists anymore
- Prefer CMake 3.16 for own CMakeLists to suppress CMake deprecation warning
- Unify indentation in CMakeList (sometimes 2 spaces were used, sometimes 4)
- Use `vcpkg_install_copyright`