### PR TITLE
[charls] update to 2.4.3

### DIFF
--- a/ports/charls/portfile.cmake
+++ b/ports/charls/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO team-charls/charls
     REF "${VERSION}"
-    SHA512 4f1b587f008956ab6fb9d2473c37a7b1a842633113245be7f8bb29b8c64304a6d580a29fcfca97ba1ac75adedbaf89e29adc4ac9e4117e1af1aa5949dbd34df9
+    SHA512 b266b3f56f099419e75b301607db36475ffd4a76142431c74f94c60d2d2f1b1f278625dfd141bf986dcc60d5be4ec86f0ddc7cadd2eafaa7db201f9c0796bfda
     HEAD_REF master
 )
 

--- a/ports/charls/vcpkg.json
+++ b/ports/charls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "charls",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "CharLS, a C++ JPEG-LS library implementation.",
   "homepage": "https://github.com/team-charls/charls",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1709,7 +1709,7 @@
       "port-version": 7
     },
     "charls": {
-      "baseline": "2.4.2",
+      "baseline": "2.4.3",
       "port-version": 0
     },
     "chartdir": {

--- a/versions/c-/charls.json
+++ b/versions/c-/charls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ebadd4c73d279fbddcd91050442d271b3a18ca3",
+      "version": "2.4.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "f9909aaef0219e8727c8f7e22ab93cf3aabbc685",
       "version": "2.4.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/team-charls/charls/releases/tag/2.4.3
