### PR TITLE
Vcpkg obfuscxx

### DIFF
--- a/ports/obfuscxx/portfile.cmake
+++ b/ports/obfuscxx/portfile.cmake
@@ -1,0 +1,11 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nevergiveupcpp/obfuscxx
+    REF v1.0.0
+	SHA512 78d252714ef84b4897d587842d49af252b33cdd14feff3c1ed57012ab7d0a04b51f301b9b6bb89a2ad5b2089081d3671365ed6bc84f10afbe6d28280b5bea2a7
+)
+
+file(INSTALL "${SOURCE_PATH}/include/obfuscxx/"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/obfuscxx/portfile.cmake
+++ b/ports/obfuscxx/portfile.cmake
@@ -1,11 +1,20 @@
+set(OBFUSCXX_VERSION "v1.3.1")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nevergiveupcpp/obfuscxx
-    REF v1.0.0
-	SHA512 78d252714ef84b4897d587842d49af252b33cdd14feff3c1ed57012ab7d0a04b51f301b9b6bb89a2ad5b2089081d3671365ed6bc84f10afbe6d28280b5bea2a7
+    REF ${OBFUSCXX_VERSION}
+	SHA512 78f12676dce516847650fd06a4f5e745cb02c0877285ec135890c295978726741ba658e4bf543779384b6fa88bd1003b4be3f8290f69dd5cb554da715e6e4972
 )
 
-file(INSTALL "${SOURCE_PATH}/include/obfuscxx/"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+vcpkg_cmake_configure(
+	SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/obfuscxx)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/obfuscxx/vcpkg.json
+++ b/ports/obfuscxx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "obfuscxx",
   "version": "1.3.1",
-  "port-version": 0,
   "description": "Header-only compile-time variables obfuscation library for C++20",
   "homepage": "https://github.com/nevergiveupcpp/obfuscxx",
   "license": "Apache-2.0",

--- a/ports/obfuscxx/vcpkg.json
+++ b/ports/obfuscxx/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "obfuscxx",
+  "version": "1.0.0",
+  "description": "Header-only compile-time variables obfuscation library for C++20",
+  "homepage": "https://github.com/nevergiveupcpp/obfuscxx",
+  "license": "Apache-2.0"
+}

--- a/ports/obfuscxx/vcpkg.json
+++ b/ports/obfuscxx/vcpkg.json
@@ -1,7 +1,18 @@
 {
   "name": "obfuscxx",
-  "version": "1.0.0",
+  "version": "1.3.1",
+  "port-version": 0,
   "description": "Header-only compile-time variables obfuscation library for C++20",
   "homepage": "https://github.com/nevergiveupcpp/obfuscxx",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7072,6 +7072,10 @@
       "baseline": "1.3.0",
       "port-version": 2
     },
+    "obfuscxx": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "oboe": {
       "baseline": "1.10.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7073,7 +7073,7 @@
       "port-version": 2
     },
     "obfuscxx": {
-      "baseline": "1.0.0",
+      "baseline": "1.3.1",
       "port-version": 0
     },
     "oboe": {

--- a/versions/o-/obfuscxx.json
+++ b/versions/o-/obfuscxx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "05cafe2a79371e3314b0fe145cb4a80b490028b6",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/o-/obfuscxx.json
+++ b/versions/o-/obfuscxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a37f5c2132f4d0ab7ca8c87d97bc86e377b0d95",
+      "version": "1.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "05cafe2a79371e3314b0fe145cb4a80b490028b6",
       "version": "1.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/nevergiveupcpp/obfuscxx/releases/tag/v1.3.1