### PR TITLE
[libwebsockets] update to 4.5.4

### DIFF
--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO warmcat/libwebsockets
     REF "v${VERSION}"
-    SHA512 1dcf2bf6704ee1a6cc0a102c9175cc743d432508f05488329019cf20c3bfc8dca00e2d22e4d085b03a9a1e9697e786545b600be68d45c941951f8ffd585d0048
+    SHA512 825cd7a9497b48cb50f7570fcc83a8fcaa8afad2b9653e72cb3eeb58583e4a724024fc06fe9f7a9035bdf233f5741bd8e4e0e5da89c5a0bf37b88515af62ab22
     HEAD_REF master
     PATCHES
         fix-dependency-libuv.patch

--- a/ports/libwebsockets/vcpkg.json
+++ b/ports/libwebsockets/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libwebsockets",
-  "version-semver": "4.5.3",
+  "version-semver": "4.5.4",
   "description": "Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.",
   "homepage": "https://libwebsockets.org/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5761,7 +5761,7 @@
       "port-version": 2
     },
     "libwebsockets": {
-      "baseline": "4.5.3",
+      "baseline": "4.5.4",
       "port-version": 0
     },
     "libx11": {

--- a/versions/l-/libwebsockets.json
+++ b/versions/l-/libwebsockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a6d41952b9398a450344fe4d7748cc0175728887",
+      "version-semver": "4.5.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "f6201033ace6be5b8e3dd8f94c88601cd37edf6b",
       "version-semver": "4.5.3",
       "port-version": 0


### PR DESCRIPTION
Fixes #50319

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/warmcat/libwebsockets/releases/tag/v4.5.4
