### PR TITLE
[simsimd] update to 6.5.15

### DIFF
--- a/ports/simsimd/portfile.cmake
+++ b/ports/simsimd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/SimSIMD
     REF "v${VERSION}"
-    SHA512 4774141df1f70e455ca09b2b9d3adffe6b8b9fbecd3ae28c65170fd006ff38622b1fd8b3716012d883a9cf8625e1bfbf5209c35a0b2f6ee39a9feb442582635c
+    SHA512 90a5263cc71f8cacd7d3039b6ea2bb42ac06192a1106e37e6e7e03a390436d692dc75bb3ecf83d0e4134e548dd5c736db75459a2ec2f20f36f1de894353ece82
     HEAD_REF main
     PATCHES
         export-target.patch

--- a/ports/simsimd/vcpkg.json
+++ b/ports/simsimd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simsimd",
-  "version": "6.5.13",
+  "version": "6.5.15",
   "description": "Fastest similarity-measures and distance functions on the Wild West – vectors, strings, short molecules, and even DNA sequences. All with a pinch of SIMD for both x86 and ARM.",
   "homepage": "https://github.com/ashvardanian/SimSIMD",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9169,7 +9169,7 @@
       "port-version": 0
     },
     "simsimd": {
-      "baseline": "6.5.13",
+      "baseline": "6.5.15",
       "port-version": 0
     },
     "sintra": {

--- a/versions/s-/simsimd.json
+++ b/versions/s-/simsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "07e6699254a2d1da5a5a3f27baef6e688a6f35d7",
+      "version": "6.5.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "68a4668cb569dd0757f858da19631804a9640539",
       "version": "6.5.13",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/ashvardanian/SimSIMD/releases/tag/v6.5.15
