### PR TITLE
[jasper] update to 4.2.9

### DIFF
--- a/ports/jasper/portfile.cmake
+++ b/ports/jasper/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jasper-software/jasper
     REF "version-${VERSION}"
-    SHA512 57d33b988f92a0aa2b30af983280c2210f4ed9548dc8a38ed34fce76698489ed37d05b11b1aa92d9c4d0223deb306fbbb11900b696ba080926d4aaf2b62b2740
+    SHA512 5c74521150f49a1055b909e01629ced3b97f222d0d81b0f5b42dcca4915fff11a11e247cc1ec37bcb669b819812892c950ec980275cbebe9897a2aec8b52ab3d
     HEAD_REF master
     PATCHES
         no_stdc_check.patch

--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jasper",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "description": "Open source implementation of the JPEG-2000 Part-1 standard",
   "homepage": "https://github.com/jasper-software/jasper",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4069,7 +4069,7 @@
       "port-version": 0
     },
     "jasper": {
-      "baseline": "4.2.8",
+      "baseline": "4.2.9",
       "port-version": 0
     },
     "jbcoe-value-types": {

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de48578d1bc3a3080e3ae12c75fcbd785bcecce3",
+      "version": "4.2.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "63419e881eced5c0d8d125ab9f888561a1415ec5",
       "version": "4.2.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/jasper-software/jasper/releases/tag/version-4.2.9
