### PR TITLE
[atomic-queue] Export cmake config

### DIFF
--- a/ports/atomic-queue/001_install.patch
+++ b/ports/atomic-queue/001_install.patch
@@ -1,0 +1,67 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c9dc427..456c99b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,6 +12,11 @@ OPTION( ATOMIC_QUEUE_BUILD_EXAMPLES
+     OFF
+ )
+ 
++OPTION( ATOMIC_QUEUE_ENABLE_INSTALL
++    "If the install target should be enabled."
++    OFF
++)
++
+ if ( PROJECT_IS_TOP_LEVEL )
+     set(CMAKE_CXX_STANDARD 14)
+     set(CMAKE_CXX_STANDARD_REQUIRED)
+@@ -26,5 +31,3 @@ endif()
+ if ( ATOMIC_QUEUE_BUILD_TESTS OR ATOMIC_QUEUE_BUILD_EXAMPLES)
+     add_subdirectory( src )
+ endif()
+-
+-add_library(max0x7ba::atomic_queue ALIAS atomic_queue)
+\ No newline at end of file
+diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
+index 7ca376d..504d3cf 100644
+--- a/include/CMakeLists.txt
++++ b/include/CMakeLists.txt
+@@ -1,17 +1,25 @@
+ CMAKE_MINIMUM_REQUIRED( VERSION 3.25 )
+ 
+-add_library(
+-    atomic_queue
+-    INTERFACE
+-    ${CMAKE_CURRENT_SOURCE_DIR}/atomic_queue/atomic_queue.h
+-    ${CMAKE_CURRENT_SOURCE_DIR}/atomic_queue/atomic_queue_mutex.h
+-    ${CMAKE_CURRENT_SOURCE_DIR}/atomic_queue/barrier.h
+-    ${CMAKE_CURRENT_SOURCE_DIR}/atomic_queue/defs.h
+-    ${CMAKE_CURRENT_SOURCE_DIR}/atomic_queue/spinlock.h
++include(GNUInstallDirs)
++
++add_library(atomic_queue INTERFACE)
++target_include_directories(atomic_queue INTERFACE
++    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>"
++    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+ )
+ 
+-target_include_directories(
+-    atomic_queue
+-    INTERFACE
+-    ${CMAKE_CURRENT_SOURCE_DIR}
+-)
+\ No newline at end of file
++add_library(max0x7ba::atomic_queue ALIAS atomic_queue)
++
++if ( ATOMIC_QUEUE_ENABLE_INSTALL )
++    install(TARGETS atomic_queue EXPORT atomic_queue)
++    install(
++        DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/atomic_queue"
++        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++    )
++    install(
++        EXPORT atomic_queue
++        FILE atomic_queue-config.cmake
++        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/atomic_queue"
++        NAMESPACE max0x7ba::
++    )
++endif ()

--- a/ports/atomic-queue/001_install.patch
+++ b/ports/atomic-queue/001_install.patch
@@ -22,7 +22,7 @@ index c9dc427..456c99b 100644
 -add_library(max0x7ba::atomic_queue ALIAS atomic_queue)
 \ No newline at end of file
 diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
-index 7ca376d..504d3cf 100644
+index 7ca376d..4d44523 100644
 --- a/include/CMakeLists.txt
 +++ b/include/CMakeLists.txt
 @@ -1,17 +1,25 @@
@@ -50,7 +50,7 @@ index 7ca376d..504d3cf 100644
 -    ${CMAKE_CURRENT_SOURCE_DIR}
 -)
 \ No newline at end of file
-+add_library(max0x7ba::atomic_queue ALIAS atomic_queue)
++add_library(atomic_queue::atomic_queue ALIAS atomic_queue)
 +
 +if ( ATOMIC_QUEUE_ENABLE_INSTALL )
 +    install(TARGETS atomic_queue EXPORT atomic_queue)
@@ -62,6 +62,6 @@ index 7ca376d..504d3cf 100644
 +        EXPORT atomic_queue
 +        FILE atomic_queue-config.cmake
 +        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/atomic_queue"
-+        NAMESPACE max0x7ba::
++        NAMESPACE atomic_queue::
 +    )
 +endif ()

--- a/ports/atomic-queue/002_fix_nil_conflict.patch
+++ b/ports/atomic-queue/002_fix_nil_conflict.patch
@@ -1,0 +1,31 @@
+diff --git a/include/atomic_queue/atomic_queue.h b/include/atomic_queue/atomic_queue.h
+index 05540d3..9010b62 100644
+--- a/include/atomic_queue/atomic_queue.h
++++ b/include/atomic_queue/atomic_queue.h
+@@ -117,7 +117,7 @@ ATOMIC_QUEUE_INLINE static constexpr uint64_t round_up_to_power_of_2(uint64_t a)
+ ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ 
+ template<class T>
+-constexpr T nil() noexcept {
++constexpr T nil_value() noexcept {
+ #if __cpp_lib_atomic_is_always_lock_free // Better compile-time error message requires C++17.
+     static_assert(std::atomic<T>::is_always_lock_free, "Queue element type T is not atomic. Use AtomicQueue2/AtomicQueueB2 for such element types.");
+ #endif
+@@ -359,7 +359,7 @@ public:
+ 
+ ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ 
+-template<class T, unsigned SIZE, T NIL = details::nil<T>(), bool MINIMIZE_CONTENTION = true, bool MAXIMIZE_THROUGHPUT = true, bool TOTAL_ORDER = false, bool SPSC = false>
++template<class T, unsigned SIZE, T NIL = details::nil_value<T>(), bool MINIMIZE_CONTENTION = true, bool MAXIMIZE_THROUGHPUT = true, bool TOTAL_ORDER = false, bool SPSC = false>
+ class AtomicQueue : public AtomicQueueCommon<AtomicQueue<T, SIZE, NIL, MINIMIZE_CONTENTION, MAXIMIZE_THROUGHPUT, TOTAL_ORDER, SPSC>> {
+     using Base = AtomicQueueCommon<AtomicQueue<T, SIZE, NIL, MINIMIZE_CONTENTION, MAXIMIZE_THROUGHPUT, TOTAL_ORDER, SPSC>>;
+     friend Base;
+@@ -433,7 +433,7 @@ public:
+ 
+ ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ 
+-template<class T, class A = std::allocator<T>, T NIL = details::nil<T>(), bool MAXIMIZE_THROUGHPUT = true, bool TOTAL_ORDER = false, bool SPSC = false>
++template<class T, class A = std::allocator<T>, T NIL = details::nil_value<T>(), bool MAXIMIZE_THROUGHPUT = true, bool TOTAL_ORDER = false, bool SPSC = false>
+ class AtomicQueueB : private std::allocator_traits<A>::template rebind_alloc<std::atomic<T>>,
+                      public AtomicQueueCommon<AtomicQueueB<T, A, NIL, MAXIMIZE_THROUGHPUT, TOTAL_ORDER, SPSC>> {
+     using AllocatorElements = typename std::allocator_traits<A>::template rebind_alloc<std::atomic<T>>;

--- a/ports/atomic-queue/portfile.cmake
+++ b/ports/atomic-queue/portfile.cmake
@@ -4,19 +4,20 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 94dcb32fa812b684e1d713b860e5f22f053a3e9f39aa619ca217cfbc0b88643b0ccf87c0a6016eb929f5766d3bf2d046c6d4dbeb128d96f7e29437a95331301c
     HEAD_REF master
+    PATCHES
+        001_install.patch
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port
 
-file(
-    COPY
-        "${SOURCE_PATH}/include/atomic_queue/atomic_queue.h"
-        "${SOURCE_PATH}/include/atomic_queue/atomic_queue_mutex.h"
-        "${SOURCE_PATH}/include/atomic_queue/barrier.h"
-        "${SOURCE_PATH}/include/atomic_queue/defs.h"
-        "${SOURCE_PATH}/include/atomic_queue/spinlock.h"
-    DESTINATION
-        "${CURRENT_PACKAGES_DIR}/include/atomic_queue"
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DATOMIC_QUEUE_ENABLE_INSTALL=ON
 )
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME atomic_queue)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/atomic-queue/portfile.cmake
+++ b/ports/atomic-queue/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         001_install.patch
+        002_fix_nil_conflict.patch
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port

--- a/ports/atomic-queue/vcpkg.json
+++ b/ports/atomic-queue/vcpkg.json
@@ -1,7 +1,18 @@
 {
   "name": "atomic-queue",
   "version": "1.7.1",
+  "port-version": 1,
   "description": "Minimalistic header-only thread-safe ultra-low-latency multiple-producer-multiple-consumer lockless queues based on circular buffer with std::atomic.",
   "homepage": "https://github.com/max0x7ba/atomic_queue",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/a-/atomic-queue.json
+++ b/versions/a-/atomic-queue.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "08d1ed86840328720a4c1c829ba35d3790010ea5",
+      "git-tree": "af05ff651972c08c33a71fb03688871e7394048a",
       "version": "1.7.1",
       "port-version": 1
     },

--- a/versions/a-/atomic-queue.json
+++ b/versions/a-/atomic-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08d1ed86840328720a4c1c829ba35d3790010ea5",
+      "version": "1.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e97b5dcafeb90882b25f52ab4c8bef1ae97d7c43",
       "version": "1.7.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -390,7 +390,7 @@
     },
     "atomic-queue": {
       "baseline": "1.7.1",
-      "port-version": 0
+      "port-version": 1
     },
     "attr": {
       "baseline": "2.5.2",


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

