### PR TITLE
[libuv] Update to 1.52.1

### DIFF
--- a/ports/libuv/portfile.cmake
+++ b/ports/libuv/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libuv/libuv
     REF "v${VERSION}"
-    SHA512 920727ebcfae39db665e518d4d90abef0ca838efcddca2b0f5ba0effc38f2d7e60df79fa5e7aa94dba8ea6e8e800d498c89ee01b36e46ed0b455b6c284852fe9
+    SHA512 c23bb26f8fdcf678dbf14bcee9855830927a40b8ae64dfa287ef1e910f37ad30cb868ecdeaad6f7b2bf3f3fccca1a7282a31b22c547206b672f923d0651f5b0c
     HEAD_REF v1.x
     PATCHES
         fix-build-type.patch
@@ -37,4 +37,4 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libuv/vcpkg.json
+++ b/ports/libuv/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libuv",
-  "version-semver": "1.52.0",
+  "version-semver": "1.52.1",
   "description": "libuv is a multi-platform support library with a focus on asynchronous I/O.",
   "homepage": "https://github.com/libuv/libuv",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5713,7 +5713,7 @@
       "port-version": 16
     },
     "libuv": {
-      "baseline": "1.52.0",
+      "baseline": "1.52.1",
       "port-version": 0
     },
     "libuvc": {

--- a/versions/l-/libuv.json
+++ b/versions/l-/libuv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e874b81faf7bef077d029d9dc8a0ab585522a9a1",
+      "version-semver": "1.52.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "45fb5050035e1147c1e617d6654e78e7f12004c0",
       "version-semver": "1.52.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.