### PR TITLE
[libva] Update to 2.23.0

### DIFF
--- a/ports/libva/portfile.cmake
+++ b/ports/libva/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/libva
     REF "${VERSION}"
-    SHA512 85f4aa6b6e9173d407ca3987745f985d0f898091f14c947a928b6db662a03b5cfe82483901690d81618697fe17a2c41ff6694a611f3654d5ab06840da987e40d
+    SHA512 03e3648b43a0c82c7840203d0b6286879317667ad9d4cf8d7813a29023ffebaf6cd5719a1a9f5fb0f2671738bd675c69a08fd27aa73b7339c8524a8f794150bc
     HEAD_REF master
 )
 
@@ -10,7 +10,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
     x11             WITH_X11
     wayland         WITH_WAYLAND
-    glx            WITH_GLX
+    glx             WITH_GLX
 )
 
 message(WARNING "You will need to install libdrm dependencies to use this port:\nsudo apt install libdrm-dev\n")

--- a/ports/libva/vcpkg.json
+++ b/ports/libva/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libva",
-  "version": "2.20.0",
+  "version": "2.23.0",
   "description": "Libva is an implementation for VA-API (Video Acceleration API)",
   "homepage": "https://github.com/intel/libva",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5721,7 +5721,7 @@
       "port-version": 1
     },
     "libva": {
-      "baseline": "2.20.0",
+      "baseline": "2.23.0",
       "port-version": 0
     },
     "libvault": {

--- a/versions/l-/libva.json
+++ b/versions/l-/libva.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89a5d8f9d5eac612100d1b6d9d38608ac6f162ef",
+      "version": "2.23.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "739fb2042eb20d480f710b1bd73c772753e18523",
       "version": "2.20.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
