### PR TITLE
Update libpqxx to version 8

### DIFF
--- a/ports/libpqxx/fix_build_with_vs2017.patch
+++ b/ports/libpqxx/fix_build_with_vs2017.patch
@@ -2,10 +2,10 @@ diff --git a/include/pqxx/internal/header-pre.hxx b/include/pqxx/internal/header
 index 833d583..21b7400 100644
 --- a/include/pqxx/internal/header-pre.hxx
 +++ b/include/pqxx/internal/header-pre.hxx
-@@ -101,6 +101,11 @@
+@@ -152,6 +152,11 @@
  // Workarounds for Microsoft Visual C++
  #  ifdef _MSC_VER
- 
+
 +// Workarounds for deprecated attribute syntax error in Visual Studio 2017.
 +#    if _MSC_VER < 1920
 +#      define PQXX_DEPRECATED(MESSAGE) __declspec(deprecated( #MESSAGE ))
@@ -13,23 +13,23 @@ index 833d583..21b7400 100644
 +
  // Suppress vtables on abstract classes.
  #    define PQXX_NOVTABLE __declspec(novtable)
- 
-@@ -170,6 +175,10 @@
+
+@@ -219,6 +224,10 @@
  #  define PQXX_NOVTABLE /* novtable */
  #endif
- 
+
 +#ifndef PQXX_DEPRECATED
 +#  define PQXX_DEPRECATED(MESSAGE) [[deprecated( #MESSAGE )]]
 +#endif
 +
- // C++20: Assume support.
- #if defined(PQXX_HAVE_LIKELY)
- #  define PQXX_LIKELY [[likely]]
+ // C++23: Assume support.
+ #if defined(PQXX_HAVE_ASSUME)
+ #  define PQXX_ASSUME(condition) [[assume(condition)]]
 diff --git a/include/pqxx/stream_from.hxx b/include/pqxx/stream_from.hxx
 index b275a7f..c63a80f 100644
 --- a/include/pqxx/stream_from.hxx
 +++ b/include/pqxx/stream_from.hxx
-@@ -160,7 +160,7 @@ public:
+@@ -162,7 +162,7 @@
    /** @deprecated Use factories @ref table or @ref raw_table instead.
     */
    template<typename Iter>
@@ -37,8 +37,8 @@ index b275a7f..c63a80f 100644
 +  PQXX_DEPRECATED("Use transaction_base::stream instead.") stream_from(
      transaction_base &, from_table_t, std::string_view table,
      Iter columns_begin, Iter columns_end);
- 
-@@ -168,13 +168,13 @@ public:
+
+@@ -170,13 +170,13 @@
    /** @deprecated Use factory function @ref query instead.
     */
    template<typename Columns>
@@ -46,7 +46,7 @@ index b275a7f..c63a80f 100644
 +  PQXX_DEPRECATED("Use transaction_base::stream() instead.") stream_from(
      transaction_base &tx, from_table_t, std::string_view table,
      Columns const &columns);
- 
+
  #include "pqxx/internal/ignore-deprecated-pre.hxx"
    /// @deprecated Use factories @ref table or @ref raw_table instead.
 -  [[deprecated("Use transaction_base::stream instead.")]] stream_from(
@@ -54,8 +54,8 @@ index b275a7f..c63a80f 100644
      transaction_base &tx, std::string_view table) :
            stream_from{tx, from_table, table}
    {}
-@@ -182,14 +182,14 @@ public:
- 
+@@ -184,14 +184,14 @@
+
    /// @deprecated Use factories @ref table or @ref raw_table instead.
    template<typename Columns>
 -  [[deprecated("Use transaction_base::stream instead.")]] stream_from(
@@ -63,33 +63,11 @@ index b275a7f..c63a80f 100644
      transaction_base &tx, std::string_view table, Columns const &columns) :
            stream_from{tx, from_table, table, columns}
    {}
- 
+
    /// @deprecated Use factories @ref table or @ref raw_table instead.
    template<typename Iter>
 -  [[deprecated("Use transaction_base::stream instead.")]] stream_from(
 +  PQXX_DEPRECATED("Use transaction_base::stream instead.") stream_from(
      transaction_base &, std::string_view table, Iter columns_begin,
      Iter columns_end);
- 
-diff --git a/include/pqxx/stream_to.hxx b/include/pqxx/stream_to.hxx
-index 281af28..838003d 100644
---- a/include/pqxx/stream_to.hxx
-+++ b/include/pqxx/stream_to.hxx
-@@ -248,7 +248,7 @@ public:
-    * your data fields and the table is explicit in your code, and not hidden
-    * in an "implicit contract" between your code and your schema.
-    */
--  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
-+  PQXX_DEPRECATED("Use table() or raw_table() factory.") stream_to(
-     transaction_base &tx, std::string_view table_name) :
-           stream_to{tx, table_name, ""sv}
-   {}
-@@ -257,7 +257,7 @@ public:
-   /** @deprecated Use @ref table or @ref raw_table as a factory.
-    */
-   template<typename Columns>
--  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
-+  PQXX_DEPRECATED("Use table() or raw_table() factory.") stream_to(
-     transaction_base &, std::string_view table_name, Columns const &columns);
- 
- private:
+

--- a/ports/libpqxx/portfile.cmake
+++ b/ports/libpqxx/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jtv/libpqxx
     REF "${VERSION}"
-    SHA512 aedce62ca581de21afb0b5985b52b9f23f1ec467a0097c696367cd16cc158b901805387455cb010fee463e4cffe0abbd56a16cb760776161acb40b9137d30784
+    SHA512 d25aed55f833f75c813fdb34bd8fcb1346313e010e762797b5e6b2548d82ceb9c8a9df2aef020471ac0a67879e69e719afbf1fd987eb56b632d1aadd287221b6
     HEAD_REF master
     PATCHES
         fix_build_with_vs2017.patch

--- a/ports/libpqxx/vcpkg.json
+++ b/ports/libpqxx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libpqxx",
-  "version": "7.10.5",
+  "version": "8.0.0",
   "description": [
     "The official* C++ client API for PostgreSQL.",
     "*) NB https://pqxx.org/libpqxx/faq/"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5377,7 +5377,7 @@
       "port-version": 3
     },
     "libpqxx": {
-      "baseline": "7.10.5",
+      "baseline": "8.0.0",
       "port-version": 0
     },
     "libprotobuf-mutator": {

--- a/versions/l-/libpqxx.json
+++ b/versions/l-/libpqxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e1249048a1e3d14894fb6e71af58e819c94a39d",
+      "version": "8.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4007db2df833f92ce86c2d4744a0f25e39ec536e",
       "version": "7.10.5",
       "port-version": 0


### PR DESCRIPTION
Updates libpqxx to version 8. This has been tested on Mac 26.3.1

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

