### PR TITLE
[faiss] update to 1.14.1

### DIFF
--- a/ports/faiss/portfile.cmake
+++ b/ports/faiss/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebookresearch/faiss
     REF "v${VERSION}"
-    SHA512 dd90a63a43e4e532ac24af0f51a3dcfd2302dc4d4f742b0d8c38750cf5e94301d7eada9be064be6bbe6e25d57a2755f140ba90e8fb47a67280a86dfbb9e85afa
+    SHA512 f4f1e392a3b25d5523cd1f4a6293f13018703687aeb609fafc93e2d99b3c8bba1d7a2ae300ec9ceea7750d66517c688d1a2b1160f98edfea37b78d218804f9ed
     HEAD_REF master
     PATCHES
         msvc-template.diff

--- a/ports/faiss/vcpkg.json
+++ b/ports/faiss/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "faiss",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Faiss is a library for efficient similarity search and clustering of dense vectors.",
   "homepage": "https://faiss.ai/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2873,7 +2873,7 @@
       "port-version": 3
     },
     "faiss": {
-      "baseline": "1.14.0",
+      "baseline": "1.14.1",
       "port-version": 0
     },
     "fakeit": {

--- a/versions/f-/faiss.json
+++ b/versions/f-/faiss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e0d08130d2f86a9e82fab9c4ad6c9006460816f",
+      "version": "1.14.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "afb20fdb70b0e32473360a67ea91bbde7a21e3f4",
       "version": "1.14.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
