### PR TITLE
[simdutf] update to 8.1.0

### DIFF
--- a/ports/simdutf/portfile.cmake
+++ b/ports/simdutf/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO simdutf/simdutf
     REF "v${VERSION}"
-    SHA512 ee30ac7b7b96dfef2ced3938b1cc8e10cd5ec5b3d35ac9679f30fbb7811bf3f930a31f5b4cf0b4002f27eba84d2e27e7c7bd910d96aa04485588188ad910361d
+    SHA512 8cd088a4b3f7175395b4449a5efc585b1eeb2c3e0cc18661e58b73b2a064ae6789ae456fe39c9574fe5b4e77fc96c4eaaf68452f73132e2aac832888c29abe5a
     HEAD_REF master
 )
 

--- a/ports/simdutf/vcpkg.json
+++ b/ports/simdutf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "simdutf",
-  "version-semver": "8.0.0",
+  "version-semver": "8.1.0",
   "description": "Unicode validation and transcoding at billions of characters per second",
   "homepage": "https://github.com/simdutf/simdutf",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9145,7 +9145,7 @@
       "port-version": 0
     },
     "simdutf": {
-      "baseline": "8.0.0",
+      "baseline": "8.1.0",
       "port-version": 0
     },
     "simonbrunel-qtpromise": {

--- a/versions/s-/simdutf.json
+++ b/versions/s-/simdutf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "951322f8c05aac592b2ad605b56be1d8645cd690",
+      "version-semver": "8.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "505bbe69c0bde49af400c94d21b412bc6d5c7c88",
       "version-semver": "8.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/simdutf/simdutf/releases/tag/v8.1.0
