### PR TITLE
[quill] Update to 11.1.0

### DIFF
--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
     REF "v${VERSION}"
-    SHA512 8e53c0e3256cb95ca18151ce2093d0565a347b38e335619f2cb0c8563ad811ded91c9837cb11def9bcbe48dd3e019d3efadbb5626efeeb6c291c84ae0e7e262e
+    SHA512 13ace8810e01bbd89ae467d27e0972ec272b7a8dcb219951babc9e66b891719a2ad446dab449e3dacff31b2f4937c17cbaf0fd37b3e9a1b5ac64d11e5c433876
     HEAD_REF master
 )
 

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "quill",
-  "version": "11.0.2",
+  "version": "11.1.0",
   "description": "Asynchronous Low Latency C++ Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
+  "documentation": "https://quillcpp.readthedocs.io/en/latest/",
   "license": "MIT",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8421,7 +8421,7 @@
       "port-version": 0
     },
     "quill": {
-      "baseline": "11.0.2",
+      "baseline": "11.1.0",
       "port-version": 0
     },
     "quirc": {

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0eacc5e77152f05f63a09f4e287548517c5375c7",
+      "version": "11.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "64c9920e9e0eb68132fd09d6785dadf3ea6beba1",
       "version": "11.0.2",
       "port-version": 0


### PR DESCRIPTION
Update the quill port from 11.0.2 to 11.1.0: https://github.com/odygrd/quill/releases/tag/v11.1.0

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.