### PR TITLE
[xtl] Update to 0.8.2

### DIFF
--- a/ports/xtl/portfile.cmake
+++ b/ports/xtl/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xtensor-stack/xtl
     REF "${VERSION}"
-    SHA512 cb032d27b2f7dff135c442fd92e3924eb108355769354c9eee9ec2d3ec7ebd867ee89ee2e10f41352447e08f185637f338fdc40e37d60d85cf2fffdcaac1ce6c
+    SHA512 d7155d5fbaaeb54caf799823e2020f1bcbb6eaeaa2be3b22625f9056faf001847c6ef749bc14f68feccec924a1faf551f27c4ee7f6f33da5d2dcfbc112824069
     HEAD_REF master
     PATCHES
         fix-fixup-cmake.patch

--- a/ports/xtl/vcpkg.json
+++ b/ports/xtl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xtl",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The x template library",
   "homepage": "https://github.com/xtensor-stack/xtl",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10925,7 +10925,7 @@
       "port-version": 1
     },
     "xtl": {
-      "baseline": "0.8.1",
+      "baseline": "0.8.2",
       "port-version": 0
     },
     "xtrans": {

--- a/versions/x-/xtl.json
+++ b/versions/x-/xtl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89d8f773ab4c559909140acaaf72ab31895ece66",
+      "version": "0.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "7100cb1e4fe6c3037f7b8cab064fff462575839f",
       "version": "0.8.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
