### PR TITLE
[taocpp-json] Update to 1.0.0-beta.14

### DIFF
--- a/ports/taocpp-json/portfile.cmake
+++ b/ports/taocpp-json/portfile.cmake
@@ -3,9 +3,9 @@ set(VCPKG_BUILD_TYPE release) # header-only
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO taocpp/json
-    REF f357d7269b7503eed21d0c3b98b9075c28a98f56 # accessed on 2020-09-14
-    SHA512 4a4be970779ed0c6044c7ad40918ad6b3908ca10dbfb3738cbebb62154d437ad13ca27947119a6b1a6c8d92b22a9282477c73ddc5721ca30b8b355b77d7ce729
-    HEAD_REF master
+    REF "${VERSION}"
+    SHA512 07909e824c8c0a3c4568a50e941dde2507ddffbd1456816e3a85d5ec9e119655604011554be8b05c0c94d19a16abd3f030d2bbebe96d65d639184aad0c720bc9
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/taocpp-json/vcpkg.json
+++ b/ports/taocpp-json/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "taocpp-json",
-  "version-date": "2020-09-14",
-  "port-version": 4,
+  "version-semver": "1.0.0-beta.14",
   "description": "C++ header-only JSON library",
   "dependencies": [
+    "pegtl",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9745,8 +9745,8 @@
       "port-version": 0
     },
     "taocpp-json": {
-      "baseline": "2020-09-14",
-      "port-version": 4
+      "baseline": "1.0.0-beta.14",
+      "port-version": 0
     },
     "tap-windows6": {
       "baseline": "9.21.2-0e30f5c",

--- a/versions/t-/taocpp-json.json
+++ b/versions/t-/taocpp-json.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52bfef0440b04ebd2b4f36116ea8762d7a3e7a7f",
+      "version-semver": "1.0.0-beta.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "0f65d42ce52c1a7c42635e90f51af98f786ae9b2",
       "version-date": "2020-09-14",
       "port-version": 4


### PR DESCRIPTION
No releases are available yet, so I just picked the latest beta.

This notably fixes the following a GCC>=15 warning caused by `tao/json/external/pegtl/demangle.hpp:7`:
```cpp
/usr/include/c++/15/ciso646:49:6: warning: #warning "<ciso646> is not a standard header since C++20, use <version> to detect implementation-specific macros" [-Wcpp]
   49 | #    warning "<ciso646> is not a standard header since C++20, use <version> to detect implementation-specific macros"
      |      ^~~~~~~
```

Followed advice from https://github.com/microsoft/vcpkg/issues/27004#issuecomment-1259228079 to include the new submodule, PEGTL was previously vendored.

Tested on Linux x64 with a small example.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.