### PR TITLE
[libadwaita] Update to 1.8.4 

### DIFF
--- a/ports/libadwaita/portfile.cmake
+++ b/ports/libadwaita/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(ARCHIVE
         "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
-    SHA512 86591af2a699931518e211a41844a23d5aaaccb6196d39b28f4768129852c33267e9a66a91dc274711a31df38b84f39feb7c7d22ae54b946a16cea4865ac83e8
+    SHA512 eb4808592c8578c7541291d6528af688224eaa80ae543a68ab8a8d081d2751e44dc80b980673e412580d80d3fd4f2ff10c23dfcb63fa54b581151a7cce7f233d
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")

--- a/ports/libadwaita/vcpkg.json
+++ b/ports/libadwaita/vcpkg.json
@@ -1,12 +1,12 @@
 {
   "name": "libadwaita",
-  "version": "1.3.2",
-  "port-version": 3,
+  "version": "1.8.4",
   "description": "Building blocks for modern GNOME applications",
   "homepage": "https://gnome.pages.gitlab.gnome.org/libadwaita",
   "license": "LGPL-2.1-or-later",
   "supports": "!xbox",
   "dependencies": [
+    "appstream",
     {
       "name": "glib",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4593,8 +4593,8 @@
       "port-version": 0
     },
     "libadwaita": {
-      "baseline": "1.3.2",
-      "port-version": 3
+      "baseline": "1.8.4",
+      "port-version": 0
     },
     "libaec": {
       "baseline": "1.1.6",

--- a/versions/l-/libadwaita.json
+++ b/versions/l-/libadwaita.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ae59ad8a9edfdc1781ddee7dd039cc68a4870b8",
+      "version": "1.8.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "65b49e4fa18bd8467db73e2587f2bd562f288517",
       "version": "1.3.2",
       "port-version": 3


### PR DESCRIPTION
Appstream was added as a dependency in 1.4.x, via
https://gitlab.gnome.org/GNOME/libadwaita/-/merge_requests/772

Resolves https://github.com/microsoft/vcpkg/issues/36328

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.