### PR TITLE
[cpp-httplib] update to 0.37.1

### DIFF
--- a/ports/cpp-httplib/portfile.cmake
+++ b/ports/cpp-httplib/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO yhirose/cpp-httplib
     REF "v${VERSION}"
-    SHA512 5efa8140aadffe105dcf39935b732476e95755f6c7473ada3d0b64df2bc02c557633ae3948a25b45e1cf67e89a3ff6329fb30362e4ac033b9a1d1e453aa2eded
+    SHA512 d17f6c7494d9794ccc91c38f79958bd0ca0a1ab5ed78b140a5ed73f1227956e36e3c56318ecb80be381c83c6f570df19cdd4f87bc14559b53c0c5cf32748e306
     HEAD_REF master
     PATCHES
         fix-find-brotli.patch

--- a/ports/cpp-httplib/vcpkg.json
+++ b/ports/cpp-httplib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-httplib",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "A single file C++11 header-only HTTP/HTTPS server and client library",
   "homepage": "https://github.com/yhirose/cpp-httplib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2017,7 +2017,7 @@
       "port-version": 0
     },
     "cpp-httplib": {
-      "baseline": "0.37.0",
+      "baseline": "0.37.1",
       "port-version": 0
     },
     "cpp-ipc": {

--- a/versions/c-/cpp-httplib.json
+++ b/versions/c-/cpp-httplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "679653b0542cc005598aaf7cc70b0a46c8d1f498",
+      "version": "0.37.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "f715c3a2c267acbf539d4fbbfbcc30268db74a3f",
       "version": "0.37.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/yhirose/cpp-httplib/releases/tag/v0.37.1
