### PR TITLE
[libupnp] update to 1.18.2

### DIFF
--- a/ports/libupnp/portfile.cmake
+++ b/ports/libupnp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pupnp/pupnp
     REF "release-${VERSION}"
-    SHA512 2aed5c72cb8e33b89d85e6755b99e7bd4e82ffb58d03ef58c2cdd790d4dc6c33b3a9f91168595930be53f0bb803e266e2bb02ea5fcc5cda8edada9453bf56492
+    SHA512 a2d6ae2539f14b13c1765febee7f865c0932fb7cdf3960eaa6559a93d18158ba2eb17afa3ad2a397de33f1e9890818fc2cfa6415ec67583b80c7939d3c27d8a7
     PATCHES
         fix-pthreads4w-targets.patch
 )

--- a/ports/libupnp/vcpkg.json
+++ b/ports/libupnp/vcpkg.json
@@ -1,9 +1,8 @@
 {
   "name": "libupnp",
-  "version": "1.14.25",
+  "version": "1.18.2",
   "description": "libupnp: Build UPnP-compliant control points, devices, and bridges on several operating systems.",
-  "homepage": "https://github.com/pupnp/pupnp/",
-  "documentation": "https://github.com/pupnp/pupnp/",
+  "homepage": "https://pupnp.github.io/pupnp/",
   "license": "BSD-3-Clause",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5685,7 +5685,7 @@
       "port-version": 0
     },
     "libupnp": {
-      "baseline": "1.14.25",
+      "baseline": "1.18.2",
       "port-version": 0
     },
     "liburcu": {

--- a/versions/l-/libupnp.json
+++ b/versions/l-/libupnp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "305bc87ca6d826b59847e0c54c1c261e5a22677a",
+      "version": "1.18.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "49cc2e5824590583f7277390e1e74512cfa56889",
       "version": "1.14.25",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/pupnp/pupnp/releases/tag/release-1.18.2
