### PR TITLE
[h3] Set `ENABLE_{DOCS,FORMAT,LINTING}=OFF` in portfile

### DIFF
--- a/ports/h3/portfile.cmake
+++ b/ports/h3/portfile.cmake
@@ -16,6 +16,10 @@ vcpkg_cmake_configure(
         -DBUILD_FILTERS=OFF
         -DBUILD_GENERATORS=OFF
         -DBUILD_TESTING=OFF
+
+        -DENABLE_DOCS=OFF
+        -DENABLE_FORMAT=OFF
+        -DENABLE_LINTING=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/h3/vcpkg.json
+++ b/ports/h3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "h3",
   "version-semver": "4.4.1",
+  "port-version": 1,
   "description": "A Hexagonal Hierarchical Geospatial Indexing System",
   "homepage": "https://github.com/uber/h3",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3690,7 +3690,7 @@
     },
     "h3": {
       "baseline": "4.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "h5py-lzf": {
       "baseline": "3.15.1",

--- a/versions/h-/h3.json
+++ b/versions/h-/h3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b7a13926003f83b9c13c75564684e58842c97479",
+      "version-semver": "4.4.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "53c6e7764ef0ad4f33491e8f5f5d55d7dd430c54",
       "version-semver": "4.4.1",
       "port-version": 0


### PR DESCRIPTION
H3's CMakeLists.txt automatically enables [formatting] and [linting]
based on the available programs, and always enables [documentation].
These increase the build surface and, in the cases of
`ENABLE_{FORMAT,LINTING}`, cause spurious program failures polluting the
build log with newer Clang versions since the `.clang-{format,tidy}`
files are currently outdated[^1].

- [x] Changes comply with the maintainer guide.
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this
  new version, or no changes were necessary.
- [x] Any fixed CI baseline and CI feature baseline entries are removed
  from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning
  `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

[formatting]: <https://github.com/uber/h3/blob/1d5346bb30082e10b8da60a6d288bc1998295d61/CMakeLists.txt#L429-L433>
[linting]: <https://github.com/uber/h3/blob/1d5346bb30082e10b8da60a6d288bc1998295d61/CMakeLists.txt#L448-L453>
[documentation]: <https://github.com/uber/h3/blob/1d5346bb30082e10b8da60a6d288bc1998295d61/CMakeLists.txt#L461-L463>
[v16]: <https://releases.llvm.org/16.0.0/tools/clang/tools/extra/docs/ReleaseNotes.html#improvements-to-clang-tidy>
[v18]: <https://releases.llvm.org/18.1.0/tools/clang/tools/extra/docs/ReleaseNotes.html#improvements-to-clang-tidy>
[here]: <https://github.com/uber/h3/blob/1d5346bb30082e10b8da60a6d288bc1998295d61/.clang-tidy#L5>
[^1]: For example, `clang-tidy` option `AnalyzeTemporaryDtors` (used
  [here]) was deprecated in [v16], and removed in [v18].  Using it causes
  invocation to fail.
