### PR TITLE
[kddockwidgets] Remove qtwidgets from default features

### DIFF
--- a/ports/kddockwidgets/portfile.cmake
+++ b/ports/kddockwidgets/portfile.cmake
@@ -15,7 +15,7 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDAB/KDDockWidgets
-    REF "v${VERSION}" 
+    REF "v${VERSION}"
     SHA512 1e220c5cf608c5bb9242b530eb1e45a15dae462b126c12d253483a1213e72374baa75943d8734c5dc79e34b03b480d1a87cd59cb945996abc0ab20b5d649a5cb
     HEAD_REF master
 )

--- a/ports/kddockwidgets/vcpkg.json
+++ b/ports/kddockwidgets/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kddockwidgets",
   "version": "2.4.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "KDAB's Dock Widget Framework for Qt",
   "homepage": "https://www.kdab.com/development-resources/qt-tools/kddockwidgets/",
   "license": "GPL-2.0-only OR GPL-3.0-only",
@@ -17,9 +17,6 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "default-features": [
-    "qtwidgets"
   ],
   "features": {
     "qtquick": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4206,7 +4206,7 @@
     },
     "kddockwidgets": {
       "baseline": "2.4.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kdiagram": {
       "baseline": "2.8.0",

--- a/versions/k-/kddockwidgets.json
+++ b/versions/k-/kddockwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "afac9f9f59db522a22d27c22c7ca22a68ff18bc5",
+      "version": "2.4.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "fa803ca9bd420a6f6ffa59abd092011ee8ec88c5",
       "version": "2.4.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Per the maintainer guide, default features must not add APIs. Therefore I think specifying qtwidgets as a default feature isn't a good idea: it also makes it more difficult to build only the qtquick API for projects that don't use widgets.

On the other hand, this would cause breakages (in particular, this port used to only have the qtwidgets API) so no worries if you don't want to merge this.