### PR TITLE
[msolve] new port

### DIFF
--- a/ports/msolve/fix-android.patch
+++ b/ports/msolve/fix-android.patch
@@ -1,0 +1,16 @@
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -73,11 +73,9 @@
+ AX_GCC_BUILTIN([__builtin_clzll])
+ AX_GCC_BUILTIN([__builtin_clzl])
+ 
+ # Checks for library functions.
+-AC_FUNC_MALLOC
+-AC_FUNC_REALLOC
+-AC_CHECK_FUNCS([floor getdelim gettimeofday memmove memset pow sqrt strchr strstr strtol])
++AC_CHECK_FUNCS([floor getdelim gettimeofday memmove memset malloc realloc pow sqrt strchr strstr strtol])
+ 
+ AC_CONFIG_HEADERS([config.h])
+ AC_CONFIG_FILES([
+  Makefile

--- a/ports/msolve/portfile.cmake
+++ b/ports/msolve/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO algebraic-solving/msolve
+    REF "v${VERSION}"
+    SHA512 db6fdae0fafe785618e457c6db787e5b835b5487359fd72fc39ebfa7f64fcae63ea131a2e6fe9f832c64d549c454688306e25ba52a9f2c3fa14a50fabd31b0de
+    HEAD_REF master
+    PATCHES
+        fix-android.patch
+)
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+)
+
+vcpkg_make_install()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/msolve/vcpkg.json
+++ b/ports/msolve/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "msolve",
+  "version": "0.9.4",
+  "description": "Computer algebra algorithms for solving polynomial systems",
+  "homepage": "https://msolve.lip6.fr/",
+  "license": "GPL-2.0-only",
+  "supports": "!windows",
+  "dependencies": [
+    "flint",
+    "gmp",
+    "mpfr",
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6656,6 +6656,10 @@
       "baseline": "10.1.12498.52",
       "port-version": 0
     },
+    "msolve": {
+      "baseline": "0.9.4",
+      "port-version": 0
+    },
     "msquic": {
       "baseline": "2.4.8",
       "port-version": 1

--- a/versions/m-/msolve.json
+++ b/versions/m-/msolve.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "b11858d8408d4b02d664e3bc90bbaeb5858b9438",
+      "version": "0.9.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

