### PR TITLE
[zxc] update rapidhash dependency

### DIFF
--- a/ports/zxc/vcpkg.json
+++ b/ports/zxc/vcpkg.json
@@ -5,7 +5,10 @@
   "homepage": "https://github.com/hellobertrand/zxc",
   "license": "BSD-3-Clause AND MIT",
   "dependencies": [
-    "rapidhash",
+    {
+      "name": "rapidhash",
+      "version>=": "3"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/z-/zxc.json
+++ b/versions/z-/zxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4888d001c59f35c4fc1bdc4c34be5c38f60e0dfd",
+      "git-tree": "20840031ab7fe7bd820d205079b015902cf6e253",
       "version": "0.8.3",
       "port-version": 0
     },


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.