### PR TITLE
[duckdb] update to 1.5.0

### DIFF
--- a/ports/duckdb/library-linkage-excel.diff
+++ b/ports/duckdb/library-linkage-excel.diff
@@ -13,3 +13,16 @@ index 981de80..65aa1da 100644
  install(
    TARGETS ${EXTENSION_NAME}
    EXPORT "${DUCKDB_EXPORT_SET}"
+diff --git a/src/excel/xlsx/read_xlsx.cpp b/src/excel/xlsx/read_xlsx.cpp
+index 685f23c..342c5b8 100644
+--- a/src/excel/xlsx/read_xlsx.cpp
++++ b/src/excel/xlsx/read_xlsx.cpp
+@@ -444,7 +444,7 @@ static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindIn
+ 
+ 	// Glob here so that we auto load any required extension filesystems
+ 	auto &fs = FileSystem::GetFileSystem(context);
+-	auto files = fs.GlobFiles(file_path, context, FileGlobOptions::ALLOW_EMPTY);
++	auto files = fs.GlobFiles(file_path, FileGlobOptions::ALLOW_EMPTY);
+ 	if (files.empty()) {
+ 		// Use our own error message to be less confusing
+ 		throw IOException("Cannot open file \"%s\": No such file or directory", file_path);

--- a/ports/duckdb/library-linkage.diff
+++ b/ports/duckdb/library-linkage.diff
@@ -1,41 +1,28 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4e9d498..70414b4 100644
+index 9d3d46d..90a99fa 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -410,7 +410,6 @@ option(EXTENSION_STATIC_BUILD
-         FALSE)
- 
- if(WIN32 OR ZOS)
+@@ -418,11 +418,9 @@ option(EXTENSION_STATIC_BUILD
+         TRUE)
+
+ if(ZOS)
+-  set(EXTENSION_STATIC_BUILD TRUE)
+ endif()
+
+ if(WIN32)
 -  set(EXTENSION_STATIC_BUILD TRUE)
    add_definitions(-D_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS=1)
  endif()
- 
-@@ -857,6 +856,7 @@ if (NOT EXTENSION_CONFIG_BUILD AND NOT ${EXTENSION_TESTS_ONLY} AND NOT CLANG_TID
-     message(STATUS "Extensions will be deployed to: ${LOCAL_EXTENSION_REPO_DIR}")
-   endif()
- endif()
-+set_target_properties(duckdb_local_extension_repo PROPERTIES EXCLUDE_FROM_ALL 1)
- 
- function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTENSION_VERSION CAPI_VERSION PARAMETERS)
-   set(TARGET_NAME ${NAME}_loadable_extension)
-@@ -875,6 +875,8 @@ function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTEN
- 
-   if(EMSCRIPTEN)
-      add_library(${TARGET_NAME} STATIC ${FILES})
-+  elseif(WIN32)
-+     add_library(${TARGET_NAME} MODULE ${FILES})
-   else()
-      add_library(${TARGET_NAME} SHARED ${FILES})
-   endif()
+
 diff --git a/DuckDBConfig.cmake.in b/DuckDBConfig.cmake.in
-index 7c5ce31..bc4f40d 100644
+index 1b039ce..5abf24f 100644
 --- a/DuckDBConfig.cmake.in
 +++ b/DuckDBConfig.cmake.in
-@@ -6,8 +6,24 @@
- 
+@@ -9,8 +9,24 @@ set(DuckDB_EXTENSIONS "@DUCKDB_EXTENSION_NAMES@")
+
  include(CMakeFindDependencyMacro)
  find_dependency(Threads)
--if(NOT @WITH_INTERNAL_ICU@)
+-if("icu" IN_LIST DuckDB_EXTENSIONS AND NOT @WITH_INTERNAL_ICU@)
 -    find_dependency(ICU COMPONENTS i18n uc data)
 +if(NOT "@BUILD_SHARED_LIBS@")
 +    set(z_vcpkg_duckdb_extensions_names "@DUCKDB_EXTENSION_NAMES@")
@@ -56,25 +43,25 @@ index 7c5ce31..bc4f40d 100644
 +    endif()
 +    unset(z_vcpkg_duckdb_extensions_names)
  endif()
- 
+
  # Compute paths
-@@ -18,7 +34,7 @@ if(NOT TARGET duckdb AND NOT DuckDB_BINARY_DIR)
+@@ -21,7 +37,7 @@ if(NOT TARGET duckdb AND NOT DuckDB_BINARY_DIR)
      include("${DuckDB_CMAKE_DIR}/DuckDBExports.cmake")
  endif()
- 
+
 -if(DuckDB_USE_STATIC_LIBS)
 +if(NOT "@BUILD_SHARED_LIBS@")
      set(DuckDB_LIBRARIES duckdb_static)
  else()
      set(DuckDB_LIBRARIES duckdb)
 diff --git a/extension/autocomplete/CMakeLists.txt b/extension/autocomplete/CMakeLists.txt
-index 544e65a..a8e1e43 100644
+index 7419753..dac3e03 100644
 --- a/extension/autocomplete/CMakeLists.txt
 +++ b/extension/autocomplete/CMakeLists.txt
-@@ -13,6 +13,10 @@ set(PARAMETERS "-warnings")
+@@ -16,6 +16,10 @@ set(PARAMETERS "-warnings")
  build_loadable_extension(autocomplete ${PARAMETERS}
                           ${AUTOCOMPLETE_EXTENSION_FILES})
- 
+
 +set_target_properties(autocomplete_loadable_extension PROPERTIES EXCLUDE_FROM_ALL 1)
 +if(BUILD_SHARED_LIBS)
 +  return()
@@ -89,7 +76,7 @@ index c97cd77..0827683 100644
 @@ -14,6 +14,10 @@ set(PARAMETERS "-warnings")
  build_loadable_extension(core_functions ${PARAMETERS} ${CORE_FUNCTION_FILES})
  target_link_libraries(core_functions_loadable_extension duckdb_skiplistlib)
- 
+
 +set_target_properties(core_functions_loadable_extension PROPERTIES EXCLUDE_FROM_ALL 1)
 +if(BUILD_SHARED_LIBS)
 +  return()
@@ -97,8 +84,29 @@ index c97cd77..0827683 100644
  install(
    TARGETS core_functions_extension
    EXPORT "${DUCKDB_EXPORT_SET}"
+diff --git a/extension/extension_build_tools.cmake b/extension/extension_build_tools.cmake
+index 977a4b2..2b9e7f9 100644
+--- a/extension/extension_build_tools.cmake
++++ b/extension/extension_build_tools.cmake
+@@ -96,6 +96,7 @@ if (NOT ${EXTENSION_CONFIG_BUILD} AND NOT ${EXTENSION_TESTS_ONLY} AND NOT CLANG_
+         message(STATUS "Extensions will be deployed to: ${LOCAL_EXTENSION_REPO_DIR}")
+     endif()
+ endif()
++set_target_properties(duckdb_local_extension_repo PROPERTIES EXCLUDE_FROM_ALL 1)
+
+ function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTENSION_VERSION CAPI_VERSION PARAMETERS)
+     set(TARGET_NAME ${NAME}_loadable_extension)
+@@ -114,6 +115,8 @@ function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTEN
+
+     if(EMSCRIPTEN)
+         add_library(${TARGET_NAME} STATIC ${FILES})
++    elseif(WIN32)
++        add_library(${TARGET_NAME} MODULE ${FILES})
+     else()
+         add_library(${TARGET_NAME} SHARED ${FILES})
+     endif()
 diff --git a/extension/icu/CMakeLists.txt b/extension/icu/CMakeLists.txt
-index a5bb58a..8edff2b 100644
+index a5bb58a..fbdffed 100644
 --- a/extension/icu/CMakeLists.txt
 +++ b/extension/icu/CMakeLists.txt
 @@ -42,6 +42,11 @@ build_loadable_extension(icu ${PARAMETERS} ${ICU_EXTENSION_FILES})
@@ -120,7 +128,7 @@ index 38be497..75cb8fb 100644
 @@ -12,6 +12,9 @@ set(JEMALLOC_EXTENSION_FILES jemalloc_extension.cpp ${JEMALLOC_OBJECT_FILES})
  build_static_extension(jemalloc ${JEMALLOC_EXTENSION_FILES})
  # we do not do build_loadable_extension here because jemalloc is static-only
- 
+
 +if(BUILD_SHARED_LIBS)
 +  return()
 +endif()
@@ -134,7 +142,7 @@ index 80b4af4..81055de 100644
 @@ -41,6 +41,10 @@ set(PARAMETERS "-warnings")
  build_loadable_extension(json ${PARAMETERS} ${JSON_EXTENSION_FILES})
  target_link_libraries(json_loadable_extension duckdb_yyjson)
- 
+
 +set_target_properties(json_loadable_extension PROPERTIES EXCLUDE_FROM_ALL 1)
 +if(BUILD_SHARED_LIBS)
 +  return()
@@ -143,13 +151,13 @@ index 80b4af4..81055de 100644
    TARGETS json_extension
    EXPORT "${DUCKDB_EXPORT_SET}"
 diff --git a/extension/parquet/CMakeLists.txt b/extension/parquet/CMakeLists.txt
-index a8335d8..ef2ea3f 100644
+index 047a841..07e9bc2 100644
 --- a/extension/parquet/CMakeLists.txt
 +++ b/extension/parquet/CMakeLists.txt
-@@ -82,6 +82,10 @@ set(PARAMETERS "-warnings")
+@@ -86,6 +86,10 @@ set(PARAMETERS "-warnings")
  build_loadable_extension(parquet ${PARAMETERS} ${PARQUET_EXTENSION_FILES})
  target_link_libraries(parquet_loadable_extension duckdb_mbedtls duckdb_zstd)
- 
+
 +set_target_properties(parquet_loadable_extension PROPERTIES EXCLUDE_FROM_ALL 1)
 +if(BUILD_SHARED_LIBS)
 +  return()
@@ -164,7 +172,7 @@ index 6ec4cb8..db51141 100644
 @@ -11,6 +11,10 @@ set(PARAMETERS "-warnings")
  build_loadable_extension(tpcds ${PARAMETERS} tpcds_extension.cpp
                           ${DSDGEN_OBJECT_FILES})
- 
+
 +set_target_properties(tpcds_loadable_extension PROPERTIES EXCLUDE_FROM_ALL 1)
 +if(BUILD_SHARED_LIBS)
 +  return()
@@ -179,7 +187,7 @@ index 46dcb12..46b9950 100644
 @@ -11,6 +11,10 @@ set(PARAMETERS "-warnings")
  build_loadable_extension(tpch ${PARAMETERS} tpch_extension.cpp
                           ${DBGEN_OBJECT_FILES})
- 
+
 +set_target_properties(tpch_loadable_extension PROPERTIES EXCLUDE_FROM_ALL 1)
 +if(BUILD_SHARED_LIBS)
 +  return()
@@ -188,13 +196,13 @@ index 46dcb12..46b9950 100644
    TARGETS tpch_extension
    EXPORT "${DUCKDB_EXPORT_SET}"
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 1915e92..83da5f4 100644
+index 24afa3d..e1e0310 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -172,8 +172,15 @@ else()
- 
- endif()
- 
+@@ -143,8 +143,15 @@ install(FILES "${PROJECT_SOURCE_DIR}/src/include/duckdb.hpp"
+               "${PROJECT_SOURCE_DIR}/src/include/duckdb.h"
+         DESTINATION "${INSTALL_INCLUDE_DIR}")
+
 +if(BUILD_SHARED_LIBS)
 +  set(INSTALL_TARGET duckdb)
 +  set_target_properties(duckdb_static PROPERTIES EXCLUDE_FROM_ALL 1)

--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO duckdb/duckdb
         REF v${VERSION}
-        SHA512 2287ff1af67808e495ca4da527bd54e9c9f2044ed1bb4749cdaeee7993a7b0edca73cccd476a607442a4bf313b43e2358bf6ca28035e2dbe52b16847f6e5b30a
+        SHA512 c7fabf6e4e0ccf3d1f9bc750c23def714ebe460e82e8c0e06ac157f50c245224807fd717751de65fb51e6203db4e30adb5c7500fb4524696d96d1efab34fb395
         HEAD_REF main
     PATCHES
         library-linkage.diff
@@ -41,8 +41,8 @@ if("httpfs" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH DUCKDB_HTTPFS_SOURCE_PATH
         REPO duckdb/duckdb_httpfs
-        REF 8ff2283fb14b443e673c58e2e9621e3c3215d794
-        SHA512 df2a61667b1fcf0e7a1d455a1805231c61362a135e7a93079b47032246b502b48aafcbae4aeee7b29145c25e3b98afa5ef6e3076ffcb71562acfbae6e2fbc087
+        REF 74f954001f3a740c909181b02259de6c7b942632
+        SHA512 50035a92f87ef4b52cf3c44514923d8e63f2baadbc600ced44bdf3fb50d5ff217e6574bf42b5ff4ef1e6339c721c81e3a1fa305c0f50d9190763bf1151d38ffd
         HEAD_REF main
         PATCHES
             library-linkage-httpfs.diff
@@ -60,8 +60,8 @@ if("iceberg" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH DUCKDB_ICEBERG_SOURCE_PATH
         REPO duckdb/duckdb-iceberg
-        REF 6cec0127c340bc7e83c7e6b2390e27cb555a9d0a
-        SHA512 d49f7e9f0492111ac81f0c34db84ca675c6a39fb66f257d080953a53922243d6cff09ee1c1dbb0f5fefc911b936ed8b03df2b30431cd6e2319c4cbefcf8690b6
+        REF 23c7cc52d84f63e9af47d0831862cfe7da3fb40f
+        SHA512 cec39b3f87d246f76841b65fe2d73016cc82c752a06aec0c8cb282aa8cc7070693ab00e699e1d147a3b1c9356a844d67e8a7c89fea0f1f720addb1f1f3f62075
         HEAD_REF main
     )
     list(APPEND extension_dirs "${DUCKDB_ICEBERG_SOURCE_PATH}")

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "description": "High-performance in-process analytical database system",
   "homepage": "https://duckdb.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2597,7 +2597,7 @@
       "port-version": 0
     },
     "duckdb": {
-      "baseline": "1.4.4",
+      "baseline": "1.5.0",
       "port-version": 0
     },
     "duckx": {

--- a/versions/d-/duckdb.json
+++ b/versions/d-/duckdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b93c3b45ed73bee77701e49b645047b8a9c01e2c",
+      "version": "1.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1d8bae3bb7089ffc184af199c454e7aa704e4eee",
       "version": "1.4.4",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/duckdb/duckdb/releases/tag/v1.5.0
