### PR TITLE
[libnpy] Add new port (version 2.1.1)

### DIFF
--- a/ports/libnpy/portfile.cmake
+++ b/ports/libnpy/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO matajoh/libnpy
+    REF "v${VERSION}"
+    SHA512 f01e4621899b1ad80507df485b9bd4ec65b0ae1a8f4e32fd6f34d52ce567b158926337117119e62e3a1ad78665d95d1edebaf549b0c73e9049b2d4deafdf31cd
+    HEAD_REF main
+)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLIBNPY_BUILD_TESTS=OFF
+        -DLIBNPY_BUILD_DOCUMENTATION=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME npy)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libnpy/usage
+++ b/ports/libnpy/usage
@@ -1,0 +1,4 @@
+The package libnpy provides CMake targets:
+
+    find_package(npy CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE npy::npy)

--- a/ports/libnpy/vcpkg.json
+++ b/ports/libnpy/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libnpy",
+  "version": "2.1.1",
+  "description": "A C++17 library for reading and writing NumPy NPY and NPZ array files",
+  "homepage": "https://github.com/matajoh/libnpy",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5268,6 +5268,10 @@
       "baseline": "0.8.8",
       "port-version": 0
     },
+    "libnpy": {
+      "baseline": "2.1.1",
+      "port-version": 0
+    },
     "libobfuscate": {
       "baseline": "2024-07-10",
       "port-version": 0

--- a/versions/l-/libnpy.json
+++ b/versions/l-/libnpy.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7e0bcfb7ffa11023cc1c38f0c154e4c866e7a13d",
+      "version": "2.1.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Hi, I've noticed that my library appears to already have been added to vcpkg (matajoh-libnpy). In 2.1.1 I added a port in the repo itself. What is the correct way to update the port to reflect this? I don't want to step on anyone's toes, but I wasn't sure how to proceed in this case.