### PR TITLE
[ncnn] Set NCNN_VERSION for invariant platform.h

### DIFF
--- a/ports/ncnn/portfile.cmake
+++ b/ports/ncnn/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_cmake_configure(
         -DNCNN_BUILD_EXAMPLES=OFF
         -DNCNN_BUILD_BENCHMARK=OFF
         -DNCNN_SHARED_LIB=${BUILD_SHARED}
+        -DNCNN_VERSION=${VERSION}
 )
 
 vcpkg_cmake_install()

--- a/ports/ncnn/vcpkg.json
+++ b/ports/ncnn/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ncnn",
   "version": "20250916",
+  "port-version": 1,
   "description": "ncnn is a high-performance neural network inference computing framework.",
   "homepage": "https://github.com/Tencent/ncnn",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6810,7 +6810,7 @@
     },
     "ncnn": {
       "baseline": "20250916",
-      "port-version": 0
+      "port-version": 1
     },
     "ncurses": {
       "baseline": "6.5",

--- a/versions/n-/ncnn.json
+++ b/versions/n-/ncnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8dfdf5896a05b6d935026bb30963ce0875436f0a",
+      "version": "20250916",
+      "port-version": 1
+    },
+    {
       "git-tree": "279f3db36dbce2acd9a68108270c4ff0980d7638",
       "version": "20250916",
       "port-version": 0


### PR DESCRIPTION
In build of ncnn, CMake generates platform.h and it includes the value of NCNN_VERSION [1]. According to CMakeLists.txt [2], NCNN_VERSION is set to be the current date unless NCNN_VERSION is provided. This would break consistency because the content of platform.h varies each time we build this port. Providing NCNN_VERSION explicitly in portfile.cmake will resolve this problem.

---

[1] https://github.com/Tencent/ncnn/blob/20250916/src/platform.h.in#L61
[2] https://github.com/Tencent/ncnn/blob/20250916/CMakeLists.txt#L15

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
