### PR TITLE
[atomic-queue] Bump to v1.7.2 and export cmake config

### DIFF
--- a/ports/atomic-queue/portfile.cmake
+++ b/ports/atomic-queue/portfile.cmake
@@ -2,21 +2,20 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO max0x7ba/atomic_queue
     REF "v${VERSION}"
-    SHA512 94dcb32fa812b684e1d713b860e5f22f053a3e9f39aa619ca217cfbc0b88643b0ccf87c0a6016eb929f5766d3bf2d046c6d4dbeb128d96f7e29437a95331301c
+    SHA512 af61f91929d469a11325920815bbd73696f53553272c5d0a5352c3414aacc785a21bb3fc18907eaef59d656785293e8c2b3b48ef359778edf2b6dc191f8673c7
     HEAD_REF master
 )
 
 set(VCPKG_BUILD_TYPE release) # header-only port
 
-file(
-    COPY
-        "${SOURCE_PATH}/include/atomic_queue/atomic_queue.h"
-        "${SOURCE_PATH}/include/atomic_queue/atomic_queue_mutex.h"
-        "${SOURCE_PATH}/include/atomic_queue/barrier.h"
-        "${SOURCE_PATH}/include/atomic_queue/defs.h"
-        "${SOURCE_PATH}/include/atomic_queue/spinlock.h"
-    DESTINATION
-        "${CURRENT_PACKAGES_DIR}/include/atomic_queue"
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DATOMIC_QUEUE_ENABLE_INSTALL=ON
 )
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME atomic_queue)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/atomic-queue/vcpkg.json
+++ b/ports/atomic-queue/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "atomic-queue",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Minimalistic header-only thread-safe ultra-low-latency multiple-producer-multiple-consumer lockless queues based on circular buffer with std::atomic.",
   "homepage": "https://github.com/max0x7ba/atomic_queue",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/a-/atomic-queue.json
+++ b/versions/a-/atomic-queue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f44a161216e9d3e47cd77cb90ebb646c50d5af71",
+      "version": "1.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e97b5dcafeb90882b25f52ab4c8bef1ae97d7c43",
       "version": "1.7.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -385,7 +385,7 @@
       "port-version": 4
     },
     "atomic-queue": {
-      "baseline": "1.7.1",
+      "baseline": "1.7.2",
       "port-version": 0
     },
     "attr": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Origin pr https://github.com/microsoft/vcpkg/pull/50329
