### PR TITLE
[coin-or-cbc, coin-or-clp, coin-or-osi, coinutils] update coin ports

### DIFF
--- a/ports/coin-or-cbc/disable_glpk.patch
+++ b/ports/coin-or-cbc/disable_glpk.patch
@@ -1,14 +1,14 @@
-diff --git a/src/CbcSolver.cpp b/src/CbcSolver.cpp
-index 93da884..1c9d463 100644
---- a/src/CbcSolver.cpp
-+++ b/src/CbcSolver.cpp
-@@ -32,6 +32,9 @@
- void CbcCrashHandler(int sig);
- #endif
+diff --git a/Cbc/src/CbcSolver.cpp b/Cbc/src/CbcSolver.cpp
+--- a/Cbc/src/CbcSolver.cpp
++++ b/Cbc/src/CbcSolver.cpp
+@@ -61,6 +61,9 @@
+ #define CLP_QUOTE(s) CLP_STRING(s)
+ #define CLP_STRING(s) #s
  
+ #include "CbcSolverHeuristics.hpp"
 +// glpk currently not supported
-+#undef COINUTILS_HAS_GLPK
++#undef COIN_HAS_GLPK
 +
- #ifdef COINUTILS_HAS_GLPK
+ #ifdef COIN_HAS_GLPK
  #include "glpk.h"
- #endif
+ extern glp_tran *cbc_glp_tran;

--- a/ports/coin-or-cbc/portfile.cmake
+++ b/ports/coin-or-cbc/portfile.cmake
@@ -1,19 +1,21 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO coin-or/Cbc
-    REF ca088df34881ef0d58124e53b3d70bfa73e92713
-    SHA512 9df1242910a42a9b942fd25dbf8a80b6278d75641c93e1218b39695224cf88bdf9d1a2d27e637ebb068b1e8733267a0f16c69b4db9a480e3f6b9cd732afb2d7a
+    REF releases/2.10.13
+    SHA512 31a35e4b30181892c34065606b036702cfa5f9ba31589aa092a2da7293ba1c528ead3fa9aa9752470103b4cbe3609ef6fa1b89b1890534f1be10ad2bb60ac6e9
     PATCHES
-        pkgconf_win.patch
         disable_glpk.patch
 )
+
+set(CBC_SOURCE_PATH "${SOURCE_PATH}/Cbc")
 
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SOURCE_PATH}")
 
 set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
 
 vcpkg_make_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
+    SOURCE_PATH "${CBC_SOURCE_PATH}"
+    DEFAULT_OPTIONS_EXCLUDE "(--docdir=.*|--datarootdir=.*)"
     OPTIONS
         --with-coinutils
         --with-clp
@@ -34,4 +36,4 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(FILE_LIST "${CBC_SOURCE_PATH}/LICENSE")

--- a/ports/coin-or-cbc/portfile.cmake
+++ b/ports/coin-or-cbc/portfile.cmake
@@ -13,14 +13,6 @@ file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SO
 
 set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    # Seed autoconf cache to skip GNU-compiler-specific probes when
-    # configure runs under MSYS with MSVC. This avoids failing conftests
-    # that are incompatible with cl.exe.
-    set(ENV{ac_cv_c_compiler_gnu} "no")
-    set(ENV{ac_cv_cxx_compiler_gnu} "no")
-endif()
-
 vcpkg_make_configure(
     SOURCE_PATH "${CBC_SOURCE_PATH}"
     AUTOCONFIG

--- a/ports/coin-or-cbc/portfile.cmake
+++ b/ports/coin-or-cbc/portfile.cmake
@@ -23,6 +23,7 @@ endif()
 
 vcpkg_make_configure(
     SOURCE_PATH "${CBC_SOURCE_PATH}"
+    AUTOCONFIG
     DEFAULT_OPTIONS_EXCLUDE "(--docdir=.*|--datarootdir=.*)"
     OPTIONS
         --with-coinutils

--- a/ports/coin-or-cbc/portfile.cmake
+++ b/ports/coin-or-cbc/portfile.cmake
@@ -13,6 +13,14 @@ file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SO
 
 set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    # Seed autoconf cache to skip GNU-compiler-specific probes when
+    # configure runs under MSYS with MSVC. This avoids failing conftests
+    # that are incompatible with cl.exe.
+    set(ENV{ac_cv_c_compiler_gnu} "no")
+    set(ENV{ac_cv_cxx_compiler_gnu} "no")
+endif()
+
 vcpkg_make_configure(
     SOURCE_PATH "${CBC_SOURCE_PATH}"
     DEFAULT_OPTIONS_EXCLUDE "(--docdir=.*|--datarootdir=.*)"

--- a/ports/coin-or-cbc/vcpkg.json
+++ b/ports/coin-or-cbc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "coin-or-cbc",
-  "version-date": "2024-06-04",
-  "port-version": 1,
+  "version-date": "2026-03-11",
+  "port-version": 0,
   "description": "Cbc (Coin-or branch and cut) is an open-source mixed integer linear programming solver written in C++.",
   "homepage": "https://github.com/coin-or/Cbc",
   "license": "EPL-2.0",

--- a/ports/coin-or-cbc/vcpkg.json
+++ b/ports/coin-or-cbc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "coin-or-cbc",
   "version-date": "2026-03-11",
-  "port-version": 0,
   "description": "Cbc (Coin-or branch and cut) is an open-source mixed integer linear programming solver written in C++.",
   "homepage": "https://github.com/coin-or/Cbc",
   "license": "EPL-2.0",

--- a/ports/coin-or-cgl/portfile.cmake
+++ b/ports/coin-or-cgl/portfile.cmake
@@ -20,6 +20,7 @@ endif()
 
 vcpkg_configure_make(
     SOURCE_PATH "${CGL_SOURCE_PATH}"
+    AUTOCONFIG
     NO_ADDITIONAL_PATHS
     OPTIONS
       --with-coinutils

--- a/ports/coin-or-cgl/portfile.cmake
+++ b/ports/coin-or-cgl/portfile.cmake
@@ -11,13 +11,6 @@ file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${CG
 
 set(ENV{ACLOCAL} "aclocal -I \"${CGL_SOURCE_PATH}/BuildTools\"")
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    # Prevent autoconf GCC-specific detection which can emit tests that
-    # don't compile with MSVC under MSYS. Seed cache variables accordingly.
-    set(ENV{ac_cv_c_compiler_gnu} "no")
-    set(ENV{ac_cv_cxx_compiler_gnu} "no")
-endif()
-
 vcpkg_configure_make(
     SOURCE_PATH "${CGL_SOURCE_PATH}"
     AUTOCONFIG

--- a/ports/coin-or-cgl/portfile.cmake
+++ b/ports/coin-or-cgl/portfile.cmake
@@ -1,17 +1,19 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO coin-or/Cgl
-    REF 3d7daa62b37e7b3504a372f2c93236052952d0f8
-    SHA512 48014a5e5bec23ebda34d97f1c3aeb511271e17dac203258668a94a8004c01b7460ddfd7086b6db911d4e8800b61cf2bdc5a11b597cc22317cfef45364cf20fd
+    REF releases/0.60.10
+    SHA512 b422e9ad00d647602fa122a650264e77cefc25106a99cf4e101f117f9ee72c4256728faa9fa7d81f1ad9fd2461d147b9e771827b6121562e274812a13d5988b1
 )
 
-file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SOURCE_PATH}")
+set(CGL_SOURCE_PATH "${SOURCE_PATH}/Cgl")
 
-set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
+file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${CGL_SOURCE_PATH}")
+
+set(ENV{ACLOCAL} "aclocal -I \"${CGL_SOURCE_PATH}/BuildTools\"")
 
 vcpkg_configure_make(
-    SOURCE_PATH "${SOURCE_PATH}"
-    AUTOCONFIG
+    SOURCE_PATH "${CGL_SOURCE_PATH}"
+    NO_ADDITIONAL_PATHS
     OPTIONS
       --with-coinutils
       --with-osi
@@ -31,4 +33,4 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${CGL_SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/coin-or-cgl/portfile.cmake
+++ b/ports/coin-or-cgl/portfile.cmake
@@ -11,6 +11,13 @@ file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${CG
 
 set(ENV{ACLOCAL} "aclocal -I \"${CGL_SOURCE_PATH}/BuildTools\"")
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    # Prevent autoconf GCC-specific detection which can emit tests that
+    # don't compile with MSVC under MSYS. Seed cache variables accordingly.
+    set(ENV{ac_cv_c_compiler_gnu} "no")
+    set(ENV{ac_cv_cxx_compiler_gnu} "no")
+endif()
+
 vcpkg_configure_make(
     SOURCE_PATH "${CGL_SOURCE_PATH}"
     NO_ADDITIONAL_PATHS

--- a/ports/coin-or-cgl/vcpkg.json
+++ b/ports/coin-or-cgl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "coin-or-cgl",
-  "version-date": "2023-02-01",
+  "version-date": "2026-03-11",
   "description": "The COIN-OR Cut Generation Library (Cgl) is a collection of cut generators that can be used with other COIN-OR packages that make use of cuts, such as, among others, the linear solver Clp or the mixed integer linear programming solvers Cbc or BCP.",
   "homepage": "https://github.com/coin-or/Cgl",
   "license": "EPL-2.0",

--- a/ports/coin-or-clp/portfile.cmake
+++ b/ports/coin-or-clp/portfile.cmake
@@ -11,6 +11,15 @@ file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${CL
 
 set(ENV{ACLOCAL} "aclocal -I \"${CLP_SOURCE_PATH}/BuildTools\"")
 
+# When building on Windows under MSYS with MSVC, avoid GCC-specific
+# autoconf probe paths by presetting the autoconf cache to indicate the
+# compiler is not GNU. This prevents conftest probes that embed
+# 'choke me' and fail with cl.exe.
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(ENV{ac_cv_c_compiler_gnu} "no")
+    set(ENV{ac_cv_cxx_compiler_gnu} "no")
+endif()
+
 vcpkg_configure_make(
     SOURCE_PATH "${CLP_SOURCE_PATH}"
     NO_ADDITIONAL_PATHS

--- a/ports/coin-or-clp/portfile.cmake
+++ b/ports/coin-or-clp/portfile.cmake
@@ -11,15 +11,6 @@ file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${CL
 
 set(ENV{ACLOCAL} "aclocal -I \"${CLP_SOURCE_PATH}/BuildTools\"")
 
-# When building on Windows under MSYS with MSVC, avoid GCC-specific
-# autoconf probe paths by presetting the autoconf cache to indicate the
-# compiler is not GNU. This prevents conftest probes that embed
-# 'choke me' and fail with cl.exe.
-if(VCPKG_TARGET_IS_WINDOWS)
-    set(ENV{ac_cv_c_compiler_gnu} "no")
-    set(ENV{ac_cv_cxx_compiler_gnu} "no")
-endif()
-
 vcpkg_configure_make(
     SOURCE_PATH "${CLP_SOURCE_PATH}"
     AUTOCONFIG

--- a/ports/coin-or-clp/portfile.cmake
+++ b/ports/coin-or-clp/portfile.cmake
@@ -35,8 +35,4 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-if(EXISTS "${CURRENT_PACKAGES_DIR}/include/coin/ClpModel.hpp")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/coin/ClpModel.hpp" "\"glpk.h\"" "\"../glpk.h\"")
-endif()
-
 file(INSTALL "${CLP_SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/coin-or-clp/portfile.cmake
+++ b/ports/coin-or-clp/portfile.cmake
@@ -22,6 +22,7 @@ endif()
 
 vcpkg_configure_make(
     SOURCE_PATH "${CLP_SOURCE_PATH}"
+    AUTOCONFIG
     NO_ADDITIONAL_PATHS
     OPTIONS
       --with-coinutils

--- a/ports/coin-or-clp/portfile.cmake
+++ b/ports/coin-or-clp/portfile.cmake
@@ -1,18 +1,19 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO coin-or/Clp
-    REF 5315ef2e93f5f532a600e16ab604ac439a416e59
-    SHA512 78dc8f562e7c1bff3e86c81eda4eda9780a4075921bcdd2338191f37820699baee94eec86b6f63b1b27e5bca7346a2611d669a7cdf3e47e1c032b072ca10bdab
-    PATCHES dep.patch
+    REF releases/1.17.11
+    SHA512 212b5a928db66130d7c844c01e40bbecc4f9267944137ec9cfd3efb089f2c91c2113a0a593d4cf66ab3957df8c4cf6a701e10b33a637a7568deaef2253a746d9
 )
 
-file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SOURCE_PATH}")
+set(CLP_SOURCE_PATH "${SOURCE_PATH}/Clp")
 
-set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
+file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${CLP_SOURCE_PATH}")
+
+set(ENV{ACLOCAL} "aclocal -I \"${CLP_SOURCE_PATH}/BuildTools\"")
 
 vcpkg_configure_make(
-    SOURCE_PATH "${SOURCE_PATH}"
-    AUTOCONFIG
+    SOURCE_PATH "${CLP_SOURCE_PATH}"
+    NO_ADDITIONAL_PATHS
     OPTIONS
       --with-coinutils
       --with-glpk
@@ -34,6 +35,8 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/coin-or/ClpModel.hpp" "\"glpk.h\"" "\"../glpk.h\"")
+if(EXISTS "${CURRENT_PACKAGES_DIR}/include/coin/ClpModel.hpp")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/coin/ClpModel.hpp" "\"glpk.h\"" "\"../glpk.h\"")
+endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${CLP_SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/coin-or-clp/vcpkg.json
+++ b/ports/coin-or-clp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "coin-or-clp",
-  "version-date": "2023-02-01",
+  "version-date": "2026-03-11",
   "description": "Clp (Coin-or linear programming) is an open-source linear programming solver written in C++. It is primarily meant to be used as a callable library, but a basic, stand-alone executable version is also available.",
   "license": "EPL-2.0",
   "dependencies": [

--- a/ports/coin-or-ipopt/portfile.cmake
+++ b/ports/coin-or-ipopt/portfile.cmake
@@ -13,6 +13,13 @@ file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SO
 
 set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    # Avoid GNU-specific autoconf checks on Windows/MSVC by predefining
+    # autoconf cache variables so configure won't try GCC-only probes.
+    set(ENV{ac_cv_c_compiler_gnu} "no")
+    set(ENV{ac_cv_cxx_compiler_gnu} "no")
+endif()
+
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG

--- a/ports/coin-or-ipopt/portfile.cmake
+++ b/ports/coin-or-ipopt/portfile.cmake
@@ -13,13 +13,6 @@ file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SO
 
 set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    # Avoid GNU-specific autoconf checks on Windows/MSVC by predefining
-    # autoconf cache variables so configure won't try GCC-only probes.
-    set(ENV{ac_cv_c_compiler_gnu} "no")
-    set(ENV{ac_cv_cxx_compiler_gnu} "no")
-endif()
-
 vcpkg_configure_make(
     SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG

--- a/ports/coin-or-osi/portfile.cmake
+++ b/ports/coin-or-osi/portfile.cmake
@@ -13,11 +13,6 @@ if(VCPKG_TARGET_IS_WINDOWS)
         "PKG_CONFIG_PATH=@COIN_PKG_CONFIG_PATH@:$(DESTDIR)$(pkgconfiglibdir)"
         "PKG_CONFIG_PATH=$(DESTDIR)$(pkgconfiglibdir)"
     )
-    # Avoid GCC-specific autoconf probes that assume a GNU compiler when
-    # running configure under MSYS with MSVC. Preseed autoconf cache to
-    # prevent detection paths that emit 'choke me' probes and fail on cl.exe.
-    set(ENV{ac_cv_c_compiler_gnu} "no")
-    set(ENV{ac_cv_cxx_compiler_gnu} "no")
 endif()
 
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${OSI_SOURCE_PATH}")
@@ -26,6 +21,7 @@ set(ENV{ACLOCAL} "aclocal -I \"${OSI_SOURCE_PATH}/BuildTools\"")
 
 vcpkg_configure_make(
     SOURCE_PATH "${OSI_SOURCE_PATH}"
+    AUTOCONFIG
     NO_ADDITIONAL_PATHS
     OPTIONS
         --with-glpk

--- a/ports/coin-or-osi/portfile.cmake
+++ b/ports/coin-or-osi/portfile.cmake
@@ -13,6 +13,11 @@ if(VCPKG_TARGET_IS_WINDOWS)
         "PKG_CONFIG_PATH=@COIN_PKG_CONFIG_PATH@:$(DESTDIR)$(pkgconfiglibdir)"
         "PKG_CONFIG_PATH=$(DESTDIR)$(pkgconfiglibdir)"
     )
+    # Avoid GCC-specific autoconf probes that assume a GNU compiler when
+    # running configure under MSYS with MSVC. Preseed autoconf cache to
+    # prevent detection paths that emit 'choke me' probes and fail on cl.exe.
+    set(ENV{ac_cv_c_compiler_gnu} "no")
+    set(ENV{ac_cv_cxx_compiler_gnu} "no")
 endif()
 
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${OSI_SOURCE_PATH}")

--- a/ports/coin-or-osi/portfile.cmake
+++ b/ports/coin-or-osi/portfile.cmake
@@ -13,12 +13,6 @@ if(VCPKG_TARGET_IS_WINDOWS)
         "PKG_CONFIG_PATH=@COIN_PKG_CONFIG_PATH@:$(DESTDIR)$(pkgconfiglibdir)"
         "PKG_CONFIG_PATH=$(DESTDIR)$(pkgconfiglibdir)"
     )
-
-    vcpkg_replace_string(
-        "${OSI_SOURCE_PATH}/Makefile.in"
-        "$(PKG_CONFIG) --libs osi > $(addlibsdir)/osi_addlibs.txt"
-        "$(PKG_CONFIG) --libs osi > \"$(addlibsdir)/osi_addlibs.txt\""
-    )
 endif()
 
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${OSI_SOURCE_PATH}")

--- a/ports/coin-or-osi/portfile.cmake
+++ b/ports/coin-or-osi/portfile.cmake
@@ -7,6 +7,20 @@ vcpkg_from_github(
 
 set(OSI_SOURCE_PATH "${SOURCE_PATH}/Osi")
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_replace_string(
+        "${OSI_SOURCE_PATH}/Makefile.in"
+        "PKG_CONFIG_PATH=@COIN_PKG_CONFIG_PATH@:$(DESTDIR)$(pkgconfiglibdir)"
+        "PKG_CONFIG_PATH=$(DESTDIR)$(pkgconfiglibdir)"
+    )
+
+    vcpkg_replace_string(
+        "${OSI_SOURCE_PATH}/Makefile.in"
+        "$(PKG_CONFIG) --libs osi > $(addlibsdir)/osi_addlibs.txt"
+        "$(PKG_CONFIG) --libs osi > \"$(addlibsdir)/osi_addlibs.txt\""
+    )
+endif()
+
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${OSI_SOURCE_PATH}")
 
 set(ENV{ACLOCAL} "aclocal -I \"${OSI_SOURCE_PATH}/BuildTools\"")

--- a/ports/coin-or-osi/portfile.cmake
+++ b/ports/coin-or-osi/portfile.cmake
@@ -1,18 +1,19 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO coin-or/Osi
-    REF 2420bb864d039a03e11c579b0c9087adbdaa26db
-    SHA512 27d501cb513a0570ad83247b6a8e7fc69cdbcd2cbec6c11aea0b5982627e76efa7ea6403e6d97419f6c984553434f088a748a7d8d54c1bf73cdbdfd5bef1f2b0
-    PATCHES glpk.patch
+    REF releases/0.108.12
+    SHA512 9f8f9da4d6e309530219d1b077a08d0f7e24f2bc36286667a412967f4f54d2df66b7dd7322328ed821ff1ab5211efc8eafaf29ef78293a7f8e6fab7cca09f870
 )
 
-file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SOURCE_PATH}")
+set(OSI_SOURCE_PATH "${SOURCE_PATH}/Osi")
 
-set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
+file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${OSI_SOURCE_PATH}")
+
+set(ENV{ACLOCAL} "aclocal -I \"${OSI_SOURCE_PATH}/BuildTools\"")
 
 vcpkg_configure_make(
-    SOURCE_PATH "${SOURCE_PATH}"
-    AUTOCONFIG
+    SOURCE_PATH "${OSI_SOURCE_PATH}"
+    NO_ADDITIONAL_PATHS
     OPTIONS
         --with-glpk
         --with-lapack
@@ -34,4 +35,4 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${OSI_SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/coin-or-osi/vcpkg.json
+++ b/ports/coin-or-osi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "coin-or-osi",
-  "version-date": "2024-04-16",
+  "version-date": "2026-03-11",
   "description": "Osi (Open Solver Interface) provides an abstract base class to a generic linear programming (LP) solver, along with derived classes for specific solvers. Many applications may be able to use the Osi to insulate themselves from a specific LP solver.",
   "license": "EPL-2.0",
   "dependencies": [

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -1,14 +1,15 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO coin-or/CoinUtils
-    REF 014be1f1724c074401d9d9c27bcce35baa9dca45 # I don't trust the release tags. They seem to point to a different fork with an outdates file structure?
-    SHA512 c5b706ca070b9f0997f9cdf532eb97c4d6ef6c6219d5d247c486048daf94a31151711ad96a32a0f0e701024d7759f07abc867591249d6c19b2b1c153257b794a
-    PATCHES coinutils.patch coinutils2.patch
+    REF releases/2.11.13
+    SHA512 4f31a22bb70c51d2a607dd685b9e804a5718d1ab67993dff86da25f4f6fe2e4173810522252703a439a0e1e7828b8ad42c5ca5ef97030d1760453f8f3155b7f5
 )
 
-file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${SOURCE_PATH}")
+set(COINUTILS_SOURCE_PATH "${SOURCE_PATH}/CoinUtils")
 
-set(ENV{ACLOCAL} "aclocal -I \"${SOURCE_PATH}/BuildTools\"")
+file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${COINUTILS_SOURCE_PATH}")
+
+set(ENV{ACLOCAL} "aclocal -I \"${COINUTILS_SOURCE_PATH}/BuildTools\"")
 
 #--enable-msvc
 set(options "")
@@ -19,11 +20,10 @@ else()
 endif()
 
 vcpkg_configure_make(
-    SOURCE_PATH "${SOURCE_PATH}"
-    AUTOCONFIG
+    SOURCE_PATH "${COINUTILS_SOURCE_PATH}"
+    NO_ADDITIONAL_PATHS
     OPTIONS
         ${options}
-        --with-lapack
         --without-netlib
         --without-sample
         --without-asl
@@ -40,8 +40,12 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/coin-or/CoinMpsIO.hpp" "\"glpk.h\"" "\"../glpk.h\"")
+if(EXISTS "${CURRENT_PACKAGES_DIR}/include/coin/CoinMpsIO.hpp")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/coin/CoinMpsIO.hpp" "\"glpk.h\"" "\"../glpk.h\"")
+endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/coinutils" RENAME copyright)
+file(INSTALL "${COINUTILS_SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/coinutils" RENAME copyright)
 
-file(COPY "${SOURCE_PATH}/m4" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+if(EXISTS "${COINUTILS_SOURCE_PATH}/m4")
+    file(COPY "${COINUTILS_SOURCE_PATH}/m4" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+endif()

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -9,6 +9,12 @@ set(COINUTILS_SOURCE_PATH "${SOURCE_PATH}/CoinUtils")
 
 vcpkg_replace_string(
     "${COINUTILS_SOURCE_PATH}/Makefile.in"
+    "PKG_CONFIG_PATH=@COIN_PKG_CONFIG_PATH@:$(DESTDIR)$(pkgconfiglibdir)"
+    "PKG_CONFIG_PATH=$(DESTDIR)$(pkgconfiglibdir)"
+)
+
+vcpkg_replace_string(
+    "${COINUTILS_SOURCE_PATH}/Makefile.in"
     "\"$(PKG_CONFIG)\" --libs coinutils > $(addlibsdir)/coinutils_addlibs.txt"
     "\"$(PKG_CONFIG)\" --libs coinutils > \"$(addlibsdir)/coinutils_addlibs.txt\""
 )

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -7,17 +7,19 @@ vcpkg_from_github(
 
 set(COINUTILS_SOURCE_PATH "${SOURCE_PATH}/CoinUtils")
 
-vcpkg_replace_string(
-    "${COINUTILS_SOURCE_PATH}/Makefile.in"
-    "PKG_CONFIG_PATH=@COIN_PKG_CONFIG_PATH@:$(DESTDIR)$(pkgconfiglibdir)"
-    "PKG_CONFIG_PATH=$(DESTDIR)$(pkgconfiglibdir)"
-)
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_replace_string(
+        "${COINUTILS_SOURCE_PATH}/Makefile.in"
+        "PKG_CONFIG_PATH=@COIN_PKG_CONFIG_PATH@:$(DESTDIR)$(pkgconfiglibdir)"
+        "PKG_CONFIG_PATH=$(DESTDIR)$(pkgconfiglibdir)"
+    )
 
-vcpkg_replace_string(
-    "${COINUTILS_SOURCE_PATH}/Makefile.in"
-    "\"$(PKG_CONFIG)\" --libs coinutils > $(addlibsdir)/coinutils_addlibs.txt"
-    "\"$(PKG_CONFIG)\" --libs coinutils > \"$(addlibsdir)/coinutils_addlibs.txt\""
-)
+    vcpkg_replace_string(
+        "${COINUTILS_SOURCE_PATH}/Makefile.in"
+        "\"$(PKG_CONFIG)\" --libs coinutils > $(addlibsdir)/coinutils_addlibs.txt"
+        "\"$(PKG_CONFIG)\" --libs coinutils > \"$(addlibsdir)/coinutils_addlibs.txt\""
+    )
+endif()
 
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${COINUTILS_SOURCE_PATH}")
 

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -29,7 +29,6 @@ endif()
 
 vcpkg_configure_make(
     SOURCE_PATH "${COINUTILS_SOURCE_PATH}"
-    AUTOCONFIG
     NO_ADDITIONAL_PATHS
     OPTIONS
         ${options}
@@ -45,6 +44,16 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    # Some upstream autoreconf runs for CoinUtils trigger macros that
+    # expect C++ to be set as the current language. Running autoreconf
+    # can fail in our MSYS image. Fall back to seeding autoconf cache on
+    # Windows so configure avoids GCC-specific probes that later fail
+    # against cl.exe.
+    set(ENV{ac_cv_c_compiler_gnu} "no")
+    set(ENV{ac_cv_cxx_compiler_gnu} "no")
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -13,6 +13,11 @@ if(VCPKG_TARGET_IS_WINDOWS)
         "PKG_CONFIG_PATH=@COIN_PKG_CONFIG_PATH@:$(DESTDIR)$(pkgconfiglibdir)"
         "PKG_CONFIG_PATH=$(DESTDIR)$(pkgconfiglibdir)"
     )
+    # Prevent autoconf from performing GCC-specific probes when running
+    # under MSYS with MSVC. Seed autoconf cache to avoid 'choke me' test
+    # code paths that don't compile with cl.exe.
+    set(ENV{ac_cv_c_compiler_gnu} "no")
+    set(ENV{ac_cv_cxx_compiler_gnu} "no")
 endif()
 
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${COINUTILS_SOURCE_PATH}")

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -27,6 +27,16 @@ else()
     list(APPEND options "--without-glpk")
 endif()
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    # Some upstream autoreconf runs for CoinUtils trigger macros that
+    # expect C++ to be set as the current language. Running autoreconf
+    # can fail in our MSYS image. Fall back to seeding autoconf cache on
+    # Windows so configure avoids GCC-specific probes that later fail
+    # against cl.exe.
+    set(ENV{ac_cv_c_compiler_gnu} "no")
+    set(ENV{ac_cv_cxx_compiler_gnu} "no")
+endif()
+
 vcpkg_configure_make(
     SOURCE_PATH "${COINUTILS_SOURCE_PATH}"
     NO_ADDITIONAL_PATHS
@@ -44,16 +54,6 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
-
-if(VCPKG_TARGET_IS_WINDOWS)
-    # Some upstream autoreconf runs for CoinUtils trigger macros that
-    # expect C++ to be set as the current language. Running autoreconf
-    # can fail in our MSYS image. Fall back to seeding autoconf cache on
-    # Windows so configure avoids GCC-specific probes that later fail
-    # against cl.exe.
-    set(ENV{ac_cv_c_compiler_gnu} "no")
-    set(ENV{ac_cv_cxx_compiler_gnu} "no")
-endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -13,12 +13,6 @@ if(VCPKG_TARGET_IS_WINDOWS)
         "PKG_CONFIG_PATH=@COIN_PKG_CONFIG_PATH@:$(DESTDIR)$(pkgconfiglibdir)"
         "PKG_CONFIG_PATH=$(DESTDIR)$(pkgconfiglibdir)"
     )
-
-    vcpkg_replace_string(
-        "${COINUTILS_SOURCE_PATH}/Makefile.in"
-        "\"$(PKG_CONFIG)\" --libs coinutils > $(addlibsdir)/coinutils_addlibs.txt"
-        "\"$(PKG_CONFIG)\" --libs coinutils > \"$(addlibsdir)/coinutils_addlibs.txt\""
-    )
 endif()
 
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${COINUTILS_SOURCE_PATH}")

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -7,6 +7,12 @@ vcpkg_from_github(
 
 set(COINUTILS_SOURCE_PATH "${SOURCE_PATH}/CoinUtils")
 
+vcpkg_replace_string(
+    "${COINUTILS_SOURCE_PATH}/Makefile.in"
+    "\"$(PKG_CONFIG)\" --libs coinutils > $(addlibsdir)/coinutils_addlibs.txt"
+    "\"$(PKG_CONFIG)\" --libs coinutils > \"$(addlibsdir)/coinutils_addlibs.txt\""
+)
+
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${COINUTILS_SOURCE_PATH}")
 
 set(ENV{ACLOCAL} "aclocal -I \"${COINUTILS_SOURCE_PATH}/BuildTools\"")

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -52,10 +52,6 @@ vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-if(EXISTS "${CURRENT_PACKAGES_DIR}/include/coin/CoinMpsIO.hpp")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/coin/CoinMpsIO.hpp" "\"glpk.h\"" "\"../glpk.h\"")
-endif()
-
 file(INSTALL "${COINUTILS_SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/coinutils" RENAME copyright)
 
 if(EXISTS "${COINUTILS_SOURCE_PATH}/m4")

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -34,6 +34,7 @@ endif()
 
 vcpkg_configure_make(
     SOURCE_PATH "${COINUTILS_SOURCE_PATH}"
+    AUTOCONFIG
     NO_ADDITIONAL_PATHS
     OPTIONS
         ${options}

--- a/ports/coinutils/portfile.cmake
+++ b/ports/coinutils/portfile.cmake
@@ -13,11 +13,6 @@ if(VCPKG_TARGET_IS_WINDOWS)
         "PKG_CONFIG_PATH=@COIN_PKG_CONFIG_PATH@:$(DESTDIR)$(pkgconfiglibdir)"
         "PKG_CONFIG_PATH=$(DESTDIR)$(pkgconfiglibdir)"
     )
-    # Prevent autoconf from performing GCC-specific probes when running
-    # under MSYS with MSVC. Seed autoconf cache to avoid 'choke me' test
-    # code paths that don't compile with cl.exe.
-    set(ENV{ac_cv_c_compiler_gnu} "no")
-    set(ENV{ac_cv_cxx_compiler_gnu} "no")
 endif()
 
 file(COPY "${CURRENT_INSTALLED_DIR}/share/coin-or-buildtools/" DESTINATION "${COINUTILS_SOURCE_PATH}")

--- a/ports/coinutils/vcpkg.json
+++ b/ports/coinutils/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "coinutils",
-  "version-date": "2024-04-08",
+  "version-date": "2026-03-11",
   "description": "CoinUtils (Coin-or Utilities) is an open-source collection of classes and functions that are generally useful to more than one COIN-OR project",
   "homepage": "https://www.coin-or.org/",
   "license": "EPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1885,15 +1885,15 @@
       "port-version": 1
     },
     "coin-or-cbc": {
-      "baseline": "2024-06-04",
-      "port-version": 1
+      "baseline": "2026-03-11",
+      "port-version": 0
     },
     "coin-or-cgl": {
-      "baseline": "2023-02-01",
+      "baseline": "2026-03-11",
       "port-version": 0
     },
     "coin-or-clp": {
-      "baseline": "2023-02-01",
+      "baseline": "2026-03-11",
       "port-version": 0
     },
     "coin-or-ipopt": {
@@ -1901,11 +1901,11 @@
       "port-version": 0
     },
     "coin-or-osi": {
-      "baseline": "2024-04-16",
+      "baseline": "2026-03-11",
       "port-version": 0
     },
     "coinutils": {
-      "baseline": "2024-04-08",
+      "baseline": "2026-03-11",
       "port-version": 0
     },
     "collada-dom": {

--- a/versions/c-/coin-or-cbc.json
+++ b/versions/c-/coin-or-cbc.json
@@ -1,12 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "87eba0c7a705d0ee83b7a1e6f8e46b84d100cbea",
-      "version-date": "2026-03-11",
-      "port-version": 0
-    },
-    {
-      "git-tree": "ae78e39435813db254ab0b54cc2454dee59cf150",
+      "git-tree": "c8ed41f94e780fa1b8e351dcbc805d5c7a7926a4",
       "version-date": "2026-03-11",
       "port-version": 0
     },

--- a/versions/c-/coin-or-cbc.json
+++ b/versions/c-/coin-or-cbc.json
@@ -1,6 +1,16 @@
 {
   "versions": [
     {
+      "git-tree": "87eba0c7a705d0ee83b7a1e6f8e46b84d100cbea",
+      "version-date": "2026-03-11",
+      "port-version": 0
+    },
+    {
+      "git-tree": "ae78e39435813db254ab0b54cc2454dee59cf150",
+      "version-date": "2026-03-11",
+      "port-version": 0
+    },
+    {
       "git-tree": "b0c13a7eef211d2564992a9c2f50f2b7ba0b5659",
       "version-date": "2024-06-04",
       "port-version": 1

--- a/versions/c-/coin-or-cgl.json
+++ b/versions/c-/coin-or-cgl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a3f5d0d36ad30028cad4d7494be011ab1c45ab2",
+      "version-date": "2026-03-11",
+      "port-version": 0
+    },
+    {
       "git-tree": "3272f90811fbc680b219072ed319082b025a4788",
       "version-date": "2023-02-01",
       "port-version": 0

--- a/versions/c-/coin-or-clp.json
+++ b/versions/c-/coin-or-clp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a63187b8cc34ddbdcc2ccfb7d08545849d2f0de2",
+      "version-date": "2026-03-11",
+      "port-version": 0
+    },
+    {
       "git-tree": "35592c499a237bd46e45a9016aaa82ac06f3d2b6",
       "version-date": "2023-02-01",
       "port-version": 0

--- a/versions/c-/coin-or-clp.json
+++ b/versions/c-/coin-or-clp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a63187b8cc34ddbdcc2ccfb7d08545849d2f0de2",
+      "git-tree": "f2832c22650137991b2ef50bdc2acf8a5db8bc5d",
       "version-date": "2026-03-11",
       "port-version": 0
     },

--- a/versions/c-/coin-or-osi.json
+++ b/versions/c-/coin-or-osi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca35d9522929ebd158c423ed870f8a9275d5700c",
+      "version-date": "2026-03-11",
+      "port-version": 0
+    },
+    {
       "git-tree": "697c758cc9c54919a8e15682ec846a1a9cfe0b88",
       "version-date": "2024-04-16",
       "port-version": 0

--- a/versions/c-/coinutils.json
+++ b/versions/c-/coinutils.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc9221722137aee786c26e0abe246870f8c447ab",
+      "version-date": "2026-03-11",
+      "port-version": 0
+    },
+    {
       "git-tree": "f5fe4624a0175bbe05b4a5c67db6c1e0df3e3666",
       "version-date": "2024-04-08",
       "port-version": 0

--- a/versions/c-/coinutils.json
+++ b/versions/c-/coinutils.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc9221722137aee786c26e0abe246870f8c447ab",
+      "git-tree": "9ae8c60b4bcf5ecb88027c632de0f262100b943e",
       "version-date": "2026-03-11",
       "port-version": 0
     },


### PR DESCRIPTION
# Port update checklist

    [X] Maintainer guide compliance: mostly good (ports build/install, metadata present).
    [X] SHA512 updated for each updated download.
    [X] supports clause: no changes needed for these updates.
    [~] CI baseline / feature baseline cleanup: scripts/ci.feature.baseline.txt still has cascade entries for arm64-linux (coinutils, coin-or-osi, coin-or-clp, coin-or-cgl, coin-or-cbc). Not necessarily wrong, but not removed.
    [X] Patch files apply: verified during full rebuild.
    [X] Version DB fixed by x-add-version: fails currently.
    [X] Exactly one version added per modified versions file
