### PR TITLE
Cpptotp port

### DIFF
--- a/ports/cpptotp/cpptotp-config.cmake.in
+++ b/ports/cpptotp/cpptotp-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/cpptotp-targets.cmake" )
+
+check_required_components(cpptotp)

--- a/ports/cpptotp/cpptotp-config.cmake.in
+++ b/ports/cpptotp/cpptotp-config.cmake.in
@@ -1,5 +1,0 @@
-@PACKAGE_INIT@
-
-include ( "${CMAKE_CURRENT_LIST_DIR}/cpptotp-targets.cmake" )
-
-check_required_components(cpptotp)

--- a/ports/cpptotp/fix-cmake-for-vcpkg.patch
+++ b/ports/cpptotp/fix-cmake-for-vcpkg.patch
@@ -40,10 +40,10 @@ index 556a4ab..7e23e7c 100644
 +
 +set_property(TARGET cpptotp PROPERTY CXX_STANDARD 11)
 +target_include_directories(cpptotp PRIVATE src)
-+add_library(cpptotp::cpptotp ALIAS cpptotp)
++add_library(unofficial::cpptotp::cpptotp ALIAS cpptotp)
 +
 +install(TARGETS cpptotp
-+  EXPORT cpptotp-targets
++  EXPORT unofficial-cpptotp-targets
 +  RUNTIME DESTINATION bin
 +  LIBRARY DESTINATION lib
 +  ARCHIVE DESTINATION lib
@@ -57,18 +57,18 @@ index 556a4ab..7e23e7c 100644
 +include(CMakePackageConfigHelpers)
 +
 +configure_package_config_file(
-+  "${CMAKE_CURRENT_SOURCE_DIR}/cpptotp-config.cmake.in"
-+  "${CMAKE_CURRENT_BINARY_DIR}/cpptotp-config.cmake"
-+  INSTALL_DESTINATION "share/cpptotp"
++  "${CMAKE_CURRENT_SOURCE_DIR}/unofficial-cpptotp-config.cmake.in"
++  "${CMAKE_CURRENT_BINARY_DIR}/unofficial-cpptotp-config.cmake"
++  INSTALL_DESTINATION "share/unofficial-cpptotp"
 +)
 +
 +install(FILES
-+  "${CMAKE_CURRENT_BINARY_DIR}/cpptotp-config.cmake"
-+  DESTINATION "share/cpptotp"
++  "${CMAKE_CURRENT_BINARY_DIR}/unofficial-cpptotp-config.cmake"
++  DESTINATION "share/unofficial-cpptotp"
 +)
 +
 +install(
-+  EXPORT cpptotp-targets
-+  DESTINATION "share/cpptotp"
-+  NAMESPACE cpptotp::
++  EXPORT unofficial-cpptotp-targets
++  DESTINATION "share/unofficial-cpptotp"
++  NAMESPACE unofficial::cpptotp::
  )

--- a/ports/cpptotp/fix-cmake-for-vcpkg.patch
+++ b/ports/cpptotp/fix-cmake-for-vcpkg.patch
@@ -1,0 +1,74 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 556a4ab..7e23e7c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,25 +1,54 @@
+-# The contents of this file have been placed into the public domain; see the
+-# file COPYING for more details.
++cmake_minimum_required (VERSION 3.18)
+ 
+-cmake_minimum_required (VERSION 2.6)
+-project (CppOtp)
++project (
++  cpptotp
++  LANGUAGES C CXX
++  VERSION 2013.11.19
++)
+ 
+-# activate C++11 mode
+-if(CMAKE_COMPILER_IS_GNUCXX)
+-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+-endif(CMAKE_COMPILER_IS_GNUCXX)
++add_library(cpptotp STATIC)
+ 
+-# the static library
+-add_library(cppotp STATIC
++target_sources(cpptotp PRIVATE
+ 	src/libcppotp/bytes.cpp
+ 	src/libcppotp/otp.cpp
+ 	src/libcppotp/sha1.cpp
+ )
+ 
+-# the binary
+-add_executable(gauche
+-	src/gauche.cpp
++set(CPPTOTP_HEADERS
++	src/libcppotp/bytes.h
++	src/libcppotp/otp.h
++	src/libcppotp/sha1.h
++)
++
++set_property(TARGET cpptotp PROPERTY CXX_STANDARD 11)
++target_include_directories(cpptotp PRIVATE src)
++add_library(cpptotp::cpptotp ALIAS cpptotp)
++
++install(TARGETS cpptotp
++  EXPORT cpptotp-targets
++  RUNTIME DESTINATION bin
++  LIBRARY DESTINATION lib
++  ARCHIVE DESTINATION lib
++  INCLUDES DESTINATION include
+ )
+-target_link_libraries(gauche
+-	cppotp
++
++install(FILES ${CPPTOTP_HEADERS} DESTINATION "include/cpptotp")
++
++include(CMakePackageConfigHelpers)
++
++configure_package_config_file(
++  "${CMAKE_CURRENT_SOURCE_DIR}/cpptotp-config.cmake.in"
++  "${CMAKE_CURRENT_BINARY_DIR}/cpptotp-config.cmake"
++  INSTALL_DESTINATION "share/cpptotp"
++)
++
++install(FILES
++  "${CMAKE_CURRENT_BINARY_DIR}/cpptotp-config.cmake"
++  DESTINATION "share/cpptotp"
++)
++
++install(
++  EXPORT cpptotp-targets
++  DESTINATION "share/cpptotp"
++  NAMESPACE cpptotp::
+ )

--- a/ports/cpptotp/portfile.cmake
+++ b/ports/cpptotp/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     PATCHES fix-cmake-for-vcpkg.patch
 )
 
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/cpptotp-config.cmake.in" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-cpptotp-config.cmake.in" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -15,7 +15,7 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-vcpkg_cmake_config_fixup()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-cpptotp)
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 

--- a/ports/cpptotp/portfile.cmake
+++ b/ports/cpptotp/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO RavuAlHemio/cpptotp
+    REF "696f618aec5c97970dd0948fef11cf46f7dfa255"
+    SHA512 02fa5f4c555be1a4a64ac3546ff3a5ec47af5ea78893f65a6e2ee2f41cf64e1081a7fc438398e8fdc967ce50800ca8910a0a299fff6687c7c3e6d6dd861778f0
+    PATCHES fix-cmake-for-vcpkg.patch
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/cpptotp-config.cmake.in" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup()
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+

--- a/ports/cpptotp/unofficial-cpptotp-config.cmake.in
+++ b/ports/cpptotp/unofficial-cpptotp-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/unofficial-cpptotp-targets.cmake" )
+
+check_required_components(unofficial-cpptotp)

--- a/ports/cpptotp/usage
+++ b/ports/cpptotp/usage
@@ -1,0 +1,4 @@
+The package cpptotp provides CMake targets:
+
+    find_package(cpptotp REQUIRED)
+    target_link_libraries(main PRIVATE cpptotp::cpptotp)

--- a/ports/cpptotp/usage
+++ b/ports/cpptotp/usage
@@ -1,4 +1,4 @@
 The package cpptotp provides CMake targets:
 
-    find_package(cpptotp REQUIRED)
-    target_link_libraries(main PRIVATE cpptotp::cpptotp)
+    find_package(unofficial-cpptotp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::cpptotp::cpptotp)

--- a/ports/cpptotp/vcpkg.json
+++ b/ports/cpptotp/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "C++ implementation of TOTP (time-based one-time password) authentication",
   "homepage": "https://github.com/RavuAlHemio/cpptotp",
   "license": "CC0-1.0",
+  "supports": "!android",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/cpptotp/vcpkg.json
+++ b/ports/cpptotp/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "cpptotp",
+  "version": "2013.11.19",
+  "description": "C++ implementation of TOTP (time-based one-time password) authentication",
+  "homepage": "https://github.com/RavuAlHemio/cpptotp",
+  "license": "CC0-1.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2128,6 +2128,10 @@
       "baseline": "0.1.2",
       "port-version": 0
     },
+    "cpptotp": {
+      "baseline": "2013.11.19",
+      "port-version": 0
+    },
     "cpptrace": {
       "baseline": "1.0.4",
       "port-version": 0

--- a/versions/c-/cpptotp.json
+++ b/versions/c-/cpptotp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "39527da252d6c574ffa2268e94bfaab0c0f74377",
+      "version": "2013.11.19",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/cpptotp.json
+++ b/versions/c-/cpptotp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4ee46a2b3fcbe513df2030a98cf1dcb805116cc6",
+      "git-tree": "e9d296d17a3fb084cee5ba840b1ea7781358f936",
       "version": "2013.11.19",
       "port-version": 0
     }

--- a/versions/c-/cpptotp.json
+++ b/versions/c-/cpptotp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "485e50f746963f2abc00fee1ce8ca92c0a7ba304",
+      "git-tree": "4ee46a2b3fcbe513df2030a98cf1dcb805116cc6",
       "version": "2013.11.19",
       "port-version": 0
     }

--- a/versions/c-/cpptotp.json
+++ b/versions/c-/cpptotp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39527da252d6c574ffa2268e94bfaab0c0f74377",
+      "git-tree": "485e50f746963f2abc00fee1ce8ca92c0a7ba304",
       "version": "2013.11.19",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<img width="1885" height="875" alt="GoogleResults" src="https://github.com/user-attachments/assets/93ccb3e4-4208-4fab-a30c-604ef36f7dee" />


