### PR TITLE
[livepp] Update to 2.11.2

### DIFF
--- a/ports/livepp/portfile.cmake
+++ b/ports/livepp/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_download_distfile(
     ARCHIVE
     URLS https://liveplusplus.tech/downloads/${LIVEPP_FILE}
     FILENAME "${LIVEPP_FILE}"
-    SHA512 5beb5eabe95982b721a502b57b7210d247a355fe10d0a727cb0e7635203762c1e3bab09a21eab284edd2194bf4e1dd79742e1ef7167546c005d35af20f5f0249
+    SHA512 1b75d9922a46dc6e4176c6581a5c457e3f7f00d5a1a26e3976cab619c45c834730088169fe8dfd5f95d543851db7467f3dd0d92733d4bc00f8da5bfdef55af3d
 )
 
 vcpkg_extract_source_archive(

--- a/ports/livepp/vcpkg.json
+++ b/ports/livepp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "livepp",
-  "version-semver": "2.11.1",
+  "version-semver": "2.11.2",
   "description": "Hot-reload for C & C++ transforms workflows and decreases iteration times.",
   "homepage": "https://liveplusplus.tech/",
   "documentation": "https://liveplusplus.tech/docs/documentation.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5985,7 +5985,7 @@
       "port-version": 0
     },
     "livepp": {
-      "baseline": "2.11.1",
+      "baseline": "2.11.2",
       "port-version": 0
     },
     "llama-cpp": {

--- a/versions/l-/livepp.json
+++ b/versions/l-/livepp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "95f6017c139b140d8b7f57f1f8510a091499693a",
+      "version-semver": "2.11.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "b51e42515801a7dcae87d325dc75b9ad7d89b22b",
       "version-semver": "2.11.1",
       "port-version": 0


### PR DESCRIPTION
Update livepp port from 2.11.1 to 2.11.2: https://liveplusplus.tech/releases.html

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.