### PR TITLE
[ncnn] update to 20260113

### DIFF
--- a/ports/ncnn/portfile.cmake
+++ b/ports/ncnn/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Tencent/ncnn
     REF "${VERSION}"
-    SHA512 bb20d8ece3dcddf49530e1ca44eaad1045702b5fb7a7c9cfd6754eb158c7349bba7d63a3ef1e1a4a6e30ed59622367b802f98bf8343bd30ff0cb6def734757c4
+    SHA512 53de1d8c7b6ea3bdc01eeb1c742fecbf53ba1ec975087814197a270c8a2c104c3f48c81849631ca4460f9d875c45bba7e5e52ff572d0a86131c792867ee0a1f3
     HEAD_REF master
 )
 
@@ -13,6 +13,10 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         vulkan NCNN_VULKAN
         vulkan NCNN_SYSTEM_GLSLANG
 )
+
+if(vulkan IN_LIST FEATURES AND VCPKG_TARGET_IS_OSX)
+    list(APPEND FEATURE_OPTIONS -DNCNN_SIMPLEVK=OFF)
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/ncnn/vcpkg.json
+++ b/ports/ncnn/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ncnn",
-  "version": "20250916",
-  "port-version": 1,
+  "version": "20260113",
   "description": "ncnn is a high-performance neural network inference computing framework.",
   "homepage": "https://github.com/Tencent/ncnn",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6805,8 +6805,8 @@
       "port-version": 2
     },
     "ncnn": {
-      "baseline": "20250916",
-      "port-version": 1
+      "baseline": "20260113",
+      "port-version": 0
     },
     "ncurses": {
       "baseline": "6.5",

--- a/versions/n-/ncnn.json
+++ b/versions/n-/ncnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e4a7d2b3212557f0ee3968e6c22b1d6495c2489",
+      "version": "20260113",
+      "port-version": 0
+    },
+    {
       "git-tree": "8dfdf5896a05b6d935026bb30963ce0875436f0a",
       "version": "20250916",
       "port-version": 1


### PR DESCRIPTION
Supercedes #49953
Closes #49953

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.