### PR TITLE
[cddlib] switch to vcpkg-make

### DIFF
--- a/ports/cddlib/portfile.cmake
+++ b/ports/cddlib/portfile.cmake
@@ -16,12 +16,12 @@ vcpkg_from_github(
         0002-disable-dd-log.patch  # windows does not export global variables
         ${MSVC_PATCH}
 )
-vcpkg_configure_make(
+vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    AUTOCONFIG
+    AUTORECONF
     COPY_SOURCE  # ensure generated files are found
 )
-vcpkg_install_make()
+vcpkg_make_install()
 vcpkg_fixup_pkgconfig()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${SOURCE_PATH}/COPYING")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/cddlib/vcpkg.json
+++ b/ports/cddlib/vcpkg.json
@@ -1,10 +1,15 @@
 {
   "name": "cddlib",
   "version-string": "0.94n",
+  "port-version": 1,
   "description": "C implementation of the Double Description Method",
   "homepage": "https://github.com/cddlib/cddlib",
   "license": "GPL-2.0-or-later",
   "dependencies": [
-    "gmp"
+    "gmp",
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1650,7 +1650,7 @@
     },
     "cddlib": {
       "baseline": "0.94n",
-      "port-version": 0
+      "port-version": 1
     },
     "cdt": {
       "baseline": "1.4.4",

--- a/versions/c-/cddlib.json
+++ b/versions/c-/cddlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f3c13b34328c8bfb917cac49ee1467b8619bcc7",
+      "version-string": "0.94n",
+      "port-version": 1
+    },
+    {
       "git-tree": "50b8720eab35c7a9f1cbf62cd6eab00850bbe001",
       "version-string": "0.94n",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

switch to vcpkg-make

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
