### PR TITLE
[brpc] Update to 1.16.0

### DIFF
--- a/ports/braft/fix-bvar-detail-sample.patch
+++ b/ports/braft/fix-bvar-detail-sample.patch
@@ -1,0 +1,13 @@
+diff --git a/src/braft/util.cpp b/src/braft/util.cpp
+index 9770b75..3a12819 100644
+--- a/src/braft/util.cpp
++++ b/src/braft/util.cpp
+@@ -47,7 +47,7 @@ namespace detail {
+ typedef PercentileSamples<1022> CombinedPercentileSamples;
+ 
+ static int64_t get_window_recorder_qps(void* arg) {
+-    detail::Sample<Stat> s;
++    Sample<Stat> s;
+     static_cast<RecorderWindow*>(arg)->get_span(1, &s);
+     // Use floating point to avoid overflow.
+     if (s.time_us <= 0) {

--- a/ports/braft/portfile.cmake
+++ b/ports/braft/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_from_github(
         fix-glog.patch
         protobuf.patch
         protobuf-6.patch
+        fix-bvar-detail-sample.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/braft/vcpkg.json
+++ b/ports/braft/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "braft",
   "version-date": "2021-26-04",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Consensus algorithm library",
   "homepage": "https://github.com/baidu/braft",
   "license": "Apache-2.0",

--- a/ports/brpc/fix-build.patch
+++ b/ports/brpc/fix-build.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 92f7114..f60e395 100644
+index b10991f..a507685 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -77,7 +77,8 @@ endif()
@@ -24,7 +24,7 @@ index 92f7114..f60e395 100644
  
  include_directories(
      ${PROJECT_SOURCE_DIR}/src
-@@ -177,12 +181,17 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+@@ -180,12 +184,17 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
  endif()
  
  find_package(Protobuf REQUIRED)
@@ -42,7 +42,7 @@ index 92f7114..f60e395 100644
          absl::absl_check
          absl::absl_log
          absl::algorithm
-@@ -222,29 +231,21 @@ else()
+@@ -225,29 +234,21 @@ else()
      use_cxx11()
  endif()
  find_package(Threads REQUIRED)
@@ -81,7 +81,7 @@ index 92f7114..f60e395 100644
  endif()
  
  if(WITH_MESALINK)
-@@ -267,7 +268,7 @@ if(WITH_RDMA)
+@@ -270,7 +271,7 @@ if(WITH_RDMA)
      endif()
  endif()
  
@@ -90,7 +90,7 @@ index 92f7114..f60e395 100644
  if(NOT PROTOC_LIB)
      message(FATAL_ERROR "Fail to find protoc lib")
  endif()
-@@ -277,9 +278,6 @@ if(WITH_BORINGSSL)
+@@ -280,9 +281,6 @@ if(WITH_BORINGSSL)
      include_directories(${BORINGSSL_INCLUDE_DIR})
  else()
      if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
@@ -100,16 +100,16 @@ index 92f7114..f60e395 100644
      endif()
  
      find_package(OpenSSL)
-@@ -305,6 +303,8 @@ set(DYNAMIC_LIB
+@@ -308,6 +306,8 @@ set(DYNAMIC_LIB
  if(WITH_BORINGSSL)
      list(APPEND DYNAMIC_LIB ${BORINGSSL_SSL_LIBRARY})
      list(APPEND DYNAMIC_LIB ${BORINGSSL_CRYPTO_LIBRARY})
 +elseif(1)
 +    list(APPEND DYNAMIC_LIB OpenSSL::SSL)
  else()
-     list(APPEND DYNAMIC_LIB ${OPENSSL_CRYPTO_LIBRARY})
      if(WITH_MESALINK)
-@@ -318,7 +318,8 @@ if(WITH_RDMA)
+         list(APPEND DYNAMIC_LIB ${OPENSSL_CRYPTO_LIBRARY})
+@@ -322,7 +322,8 @@ if(WITH_RDMA)
      list(APPEND DYNAMIC_LIB ${RDMA_LIB})
  endif()
  
@@ -119,7 +119,7 @@ index 92f7114..f60e395 100644
  
  if(WITH_GLOG)
      set(DYNAMIC_LIB ${GLOG_LIB} ${DYNAMIC_LIB})
-@@ -327,7 +328,7 @@ endif()
+@@ -331,7 +332,7 @@ endif()
  
  if(WITH_SNAPPY)
      set(DYNAMIC_LIB ${DYNAMIC_LIB} ${SNAPPY_LIB})
@@ -128,7 +128,7 @@ index 92f7114..f60e395 100644
  endif()
  
  if (WITH_BTHREAD_TRACER)
-@@ -551,6 +552,7 @@ compile_proto(PROTO_HDRS PROTO_SRCS ${PROJECT_BINARY_DIR}
+@@ -556,6 +557,7 @@ compile_proto(PROTO_HDRS PROTO_SRCS ${PROJECT_BINARY_DIR}
                                      ${PROJECT_SOURCE_DIR}/src
                                      "${PROTO_FILES}")
  add_library(PROTO_LIB OBJECT ${PROTO_SRCS} ${PROTO_HDRS})
@@ -146,7 +146,7 @@ index 723dab4..36277cd 100644
  Libs.private: @BRPC_PRIVATE_LIBS@
 +Requires.private: @BRPC_PRIVATE_REQUIRES@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 1b4b233..e0bdb64 100644
+index 1b4b233..f14d024 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -26,6 +26,10 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
@@ -160,19 +160,19 @@ index 1b4b233..e0bdb64 100644
  
  # shared library needs POSITION_INDEPENDENT_CODE
  set_property(TARGET ${SOURCES_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)
-@@ -58,10 +62,9 @@ function(check_thrift_version target_arg)
-     endif()
+@@ -59,9 +63,9 @@ function(check_thrift_version target_arg)
  endfunction()
  
-+target_link_libraries(brpc-static PUBLIC ${DYNAMIC_LIB})
  
++target_link_libraries(brpc-static PUBLIC ${DYNAMIC_LIB})
++
  if(WITH_THRIFT)
 -   target_link_libraries(brpc-static ${THRIFT_LIB})
 -   check_thrift_version(brpc-static)
  endif()
  
  SET_TARGET_PROPERTIES(brpc-static PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
-@@ -74,24 +77,25 @@ set(protoc_gen_mcpack_SOURCES
+@@ -74,24 +78,25 @@ set(protoc_gen_mcpack_SOURCES
   )
      
  add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
@@ -196,18 +196,18 @@ index 1b4b233..e0bdb64 100644
  
      target_link_libraries(protoc-gen-mcpack brpc-shared ${DYNAMIC_LIB} pthread)
  
-+    target_include_directories(brpc-shared PUBLIC $<INSTALL_INTERFACE:include>)
++    target_include_directories(brpc-shared PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
      install(TARGETS brpc-shared
 +            EXPORT unofficial-brpc-targets
              RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
              LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
              ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-@@ -102,8 +106,38 @@ endif()
+@@ -102,8 +107,38 @@ endif()
  
  
  
 +if(NOT BUILD_SHARED_LIBS)
-+target_include_directories(brpc-static PUBLIC $<INSTALL_INTERFACE:include>)
++target_include_directories(brpc-static PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
  install(TARGETS brpc-static
 +        EXPORT unofficial-brpc-targets
          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/ports/brpc/portfile.cmake
+++ b/ports/brpc/portfile.cmake
@@ -1,20 +1,12 @@
-vcpkg_download_distfile(
-    PROTOBUF_V6_PATCH
-    URLS https://github.com/apache/brpc/commit/8d87814330d9ebbfe5b95774fdb71056fcb3170c.patch?full_index=1
-    SHA512 d8787b11f91b50377869713f9f9159a36659c8f4ca43e77105968b3918c95cb13dbcaef6170329bd2eaa5e7455d00636cfa6db2fd99e8aace293a0e7e1b3df75
-    FILENAME 8d87814330d9ebbfe5b95774fdb71056fcb3170c.patch
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/brpc
     REF "${VERSION}"
-    SHA512 93366c2b073de8a1af5ededa9ef5a6803ccd393bbb5fe1f9872c230e4997995759517fa4dd1a51ffd120a5c9040dcb00b1c580c5ccf032dd70561c0c3283f990
+    SHA512 ffcd624550c060fdff01fad0fb752b4aa113dd1dea5ad6d688cb3d3964ded5a120df07f01bbc4a9b15aee226634fc6a851ab4c24fbed6ea07f31c305f6fef71f
     HEAD_REF master
     PATCHES
         fix-build.patch
         fix-warnings.patch
-        ${PROTOBUF_V6_PATCH}
 )
 
 vcpkg_cmake_configure(

--- a/ports/brpc/vcpkg.json
+++ b/ports/brpc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "brpc",
-  "version": "1.15.0",
-  "port-version": 1,
+  "version": "1.16.0",
   "description": "Industrial-grade RPC framework used throughout Baidu, with 1,000,000+ instances and thousands kinds of services, called \"baidu-rpc\" inside Baidu.",
   "homepage": "https://github.com/apache/brpc",
   "license": "Apache-2.0",

--- a/versions/b-/braft.json
+++ b/versions/b-/braft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b440e9e2bb821fea49c1e62ea5f8e306d2706bd3",
+      "version-date": "2021-26-04",
+      "port-version": 7
+    },
+    {
       "git-tree": "8e216ee57fd2f228d5172bc6605aeb6d3d912433",
       "version-date": "2021-26-04",
       "port-version": 6

--- a/versions/b-/brpc.json
+++ b/versions/b-/brpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d30e0402aea62dba456d47bf1b0c66f8f948021",
+      "version": "1.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "89120d70f29486c1ce7bf96454649b85d895fcdf",
       "version": "1.15.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1489,8 +1489,8 @@
       "port-version": 0
     },
     "brpc": {
-      "baseline": "1.15.0",
-      "port-version": 1
+      "baseline": "1.16.0",
+      "port-version": 0
     },
     "brunocodutra-metal": {
       "baseline": "2.1.4",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1474,7 +1474,7 @@
     },
     "braft": {
       "baseline": "2021-26-04",
-      "port-version": 6
+      "port-version": 7
     },
     "breakpad": {
       "baseline": "2024-02-16",


### PR DESCRIPTION
## Summary

Update brpc port from 1.15.0 to 1.16.0 (Apache bRPC 1.16.0), and fix downstream braft port compatibility.

### Changes (brpc)

- Updated version from 1.15.0 to 1.16.0
- Removed the separate protobuf v6 patch as it is now included upstream in 1.16.0
- Updated fix-build.patch to accommodate upstream CMakeLists.txt changes
- Updated SHA512 hash for the new source tarball
- Updated versions database and baseline

### Changes (braft)

- Added fix-bvar-detail-sample.patch to fix name resolution issue with brpc 1.16.0
- Bumped port-version from 6 to 7

### Release highlights (brpc 1.16.0)

- Support protobuf v30+ compatibility
- Add RISC-V architecture support
- Support tag for selective channel
- Enable TLS key logging via SSLKEYLOGFILE
- Support more SSL verify modes