### PR TITLE
[aeron] update to 1.50.3

### DIFF
--- a/ports/aeron/portfile.cmake
+++ b/ports/aeron/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aeron-io/aeron
     REF "${VERSION}"
-    SHA512 d1d649964f45f0c016417ded42f4d9fc3d0fb5f7cd085b31dc38c0cbc0c3238c1e905ddf0b1dafc8e3c843c858762e3179f10aacb05cd914160cbd391de61ce6
+    SHA512 994356df46953a21728d84fc9425707603e98ea571d559d15100a14b329f505c36eb7d0ada86551fa7cfc8a4bc08af445e438191cd89cb42e6f11bbe8c00007e
     HEAD_REF master
     PATCHES
         patches/add-libuuid-vcpkg-support.patch

--- a/ports/aeron/vcpkg.json
+++ b/ports/aeron/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "aeron",
-  "version": "1.50.2",
+  "version": "1.50.3",
   "description": "Efficient reliable UDP unicast, UDP multicast, and IPC message transport",
   "homepage": "https://github.com/aeron-io/aeron",
   "license": "Apache-2.0",

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ba695358d7e176a72044321e0fc79bf4c6993755",
+      "version": "1.50.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "2eee19ef32a9ac3d618316045641b2bdaa5ce0fc",
       "version": "1.50.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -61,7 +61,7 @@
       "port-version": 0
     },
     "aeron": {
-      "baseline": "1.50.2",
+      "baseline": "1.50.3",
       "port-version": 0
     },
     "air-ctl": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/aeron-io/aeron/releases/tag/1.50.3
