### PR TITLE
[jwsung91-unilink] update to 0.4.2

### DIFF
--- a/ports/jwsung91-unilink/portfile.cmake
+++ b/ports/jwsung91-unilink/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jwsung91/unilink
     REF v${VERSION}
-    SHA512 922a3029a4fdde4c9da895b06b56cea2d2b8002825b1c8514fb0d39d61e52dad9ba2ef1cf6a4f8ee99d82d652ad0f0d6146edb8adaa60362cc18e67d41e2040f
+    SHA512 e653eddf9a4623fa4cacbbb924a5b2cf5fc01177e246a29833eda70d1ae62b3e784a7c8ac912185c70c767dd238aa4445b050b15c8fc2b4a356e92927453efc0
     PATCHES
         include-cstdint.patch
 )

--- a/ports/jwsung91-unilink/vcpkg.json
+++ b/ports/jwsung91-unilink/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jwsung91-unilink",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Simple, cross-platform async C++ communication library for Serial, TCP, and UDP",
   "homepage": "https://github.com/jwsung91/unilink",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4173,7 +4173,7 @@
       "port-version": 0
     },
     "jwsung91-unilink": {
-      "baseline": "0.4.1",
+      "baseline": "0.4.2",
       "port-version": 0
     },
     "jwt-cpp": {

--- a/versions/j-/jwsung91-unilink.json
+++ b/versions/j-/jwsung91-unilink.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "faaf9ed9c72d9e22aa1dafe21347c351eb4a01a3",
+      "version": "0.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2dd3571ddc015c85f52f31bebe319c873f71b4a1",
       "version": "0.4.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/jwsung91/unilink/releases/tag/v0.4.2
