### PR TITLE
[orderflow-c] add new port

### DIFF
--- a/ports/orderflow-c/copyright
+++ b/ports/orderflow-c/copyright
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gregorian Rayne
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ports/orderflow-c/portfile.cmake
+++ b/ports/orderflow-c/portfile.cmake
@@ -1,0 +1,107 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gregorian-09/orderflow
+    REF v0.1.1
+    SHA512 5f51de19256f252c0f4f59497e6e53b64be04103e4073778a8f57f30245a26463499b7ccb78a70030d217f56e65b529021386fd5fa72b5ff0cc309eb1180dab6
+    HEAD_REF main
+)
+
+find_program(CARGO NAMES cargo REQUIRED)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(RUST_TARGET "x86_64-pc-windows-msvc")
+elseif(VCPKG_TARGET_IS_OSX)
+    set(RUST_TARGET "x86_64-apple-darwin")
+elseif(VCPKG_TARGET_IS_LINUX)
+    set(RUST_TARGET "x86_64-unknown-linux-gnu")
+else()
+    message(FATAL_ERROR "Unsupported platform for orderflow-c")
+endif()
+
+set(ENV{CARGO_TARGET_DIR} "${CURRENT_BUILDTREES_DIR}/cargo-target")
+
+function(orderflow_cargo_build BUILD_KIND)
+    if("${BUILD_KIND}" STREQUAL "debug")
+        set(PROFILE_ARG "")
+    elseif("${BUILD_KIND}" STREQUAL "release")
+        set(PROFILE_ARG "--release")
+    else()
+        message(FATAL_ERROR "Unknown cargo build kind: ${BUILD_KIND}")
+    endif()
+
+    vcpkg_execute_required_process(
+        COMMAND "${CARGO}" build ${PROFILE_ARG} --locked --target "${RUST_TARGET}" --manifest-path "${SOURCE_PATH}/crates/of_ffi_c/Cargo.toml"
+        WORKING_DIRECTORY "${SOURCE_PATH}"
+        LOGNAME "cargo-build-${TARGET_TRIPLET}-${BUILD_KIND}"
+    )
+endfunction()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    orderflow_cargo_build("release")
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    orderflow_cargo_build("debug")
+endif()
+
+file(INSTALL "${SOURCE_PATH}/crates/of_ffi_c/include/orderflow.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+function(orderflow_install_artifacts BUILD_KIND)
+    if("${BUILD_KIND}" STREQUAL "debug")
+        set(PROFILE_DIR "debug")
+        set(LIB_DEST "debug/lib")
+        set(BIN_DEST "debug/bin")
+    else()
+        set(PROFILE_DIR "release")
+        set(LIB_DEST "lib")
+        set(BIN_DEST "bin")
+    endif()
+
+    set(BUILD_OUT "${CURRENT_BUILDTREES_DIR}/cargo-target/${RUST_TARGET}/${PROFILE_DIR}")
+
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        if(VCPKG_TARGET_IS_WINDOWS)
+            file(INSTALL "${BUILD_OUT}/of_ffi_c.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/${LIB_DEST}")
+        else()
+            file(INSTALL "${BUILD_OUT}/libof_ffi_c.a" DESTINATION "${CURRENT_PACKAGES_DIR}/${LIB_DEST}")
+        endif()
+    else()
+        if(VCPKG_TARGET_IS_WINDOWS)
+            file(INSTALL "${BUILD_OUT}/of_ffi_c.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/${BIN_DEST}")
+            if(EXISTS "${BUILD_OUT}/of_ffi_c.dll.lib")
+                file(INSTALL "${BUILD_OUT}/of_ffi_c.dll.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/${LIB_DEST}")
+            else()
+                file(INSTALL "${BUILD_OUT}/of_ffi_c.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/${LIB_DEST}")
+            endif()
+        elseif(VCPKG_TARGET_IS_OSX)
+            file(INSTALL "${BUILD_OUT}/libof_ffi_c.dylib" DESTINATION "${CURRENT_PACKAGES_DIR}/${LIB_DEST}")
+        else()
+            file(INSTALL "${BUILD_OUT}/libof_ffi_c.so" DESTINATION "${CURRENT_PACKAGES_DIR}/${LIB_DEST}")
+        endif()
+    endif()
+endfunction()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    orderflow_install_artifacts("release")
+endif()
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    orderflow_install_artifacts("debug")
+endif()
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+file(WRITE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/orderflow.pc"
+"prefix=\${pcfiledir}/../..\n\
+exec_prefix=\${prefix}\n\
+libdir=\${prefix}/lib\n\
+includedir=\${prefix}/include\n\
+\n\
+Name: orderflow\n\
+Description: Orderflow C ABI runtime\n\
+Version: 0.1.1\n\
+Libs: -L\${libdir} -lof_ffi_c\n\
+Cflags: -I\${includedir}\n")
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${CURRENT_PORT_DIR}/copyright")

--- a/ports/orderflow-c/portfile.cmake
+++ b/ports/orderflow-c/portfile.cmake
@@ -6,7 +6,56 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-find_program(CARGO NAMES cargo REQUIRED)
+set(RUSTUP_HOME "${CURRENT_BUILDTREES_DIR}/rustup-home")
+set(CARGO_HOME "${CURRENT_BUILDTREES_DIR}/cargo-home")
+file(MAKE_DIRECTORY "${RUSTUP_HOME}" "${CARGO_HOME}")
+set(ENV{RUSTUP_HOME} "${RUSTUP_HOME}")
+set(ENV{CARGO_HOME} "${CARGO_HOME}")
+
+if(VCPKG_HOST_IS_WINDOWS)
+    set(RUSTUP_INIT_URL "https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe")
+    set(RUSTUP_INIT_SHA512 "20c8eeecb2bbd7132b418b415d860d1df4ae8711a303de66f15a050d0c58db7d7868ac8f0389fb03d1078688173de94bcd13e07377e971caa1b6cfde9c50d75e")
+    set(RUSTUP_INIT_FILENAME "rustup-init-x86_64-pc-windows-msvc.exe")
+    set(CARGO "${CARGO_HOME}/bin/cargo.exe")
+elseif(VCPKG_HOST_IS_OSX)
+    set(RUSTUP_INIT_URL "https://static.rust-lang.org/rustup/dist/x86_64-apple-darwin/rustup-init")
+    set(RUSTUP_INIT_SHA512 "14c0d8491cae3b556978ec7c93886db943eccf0f65e24187478308b42aaea3174821c65be0ae8a50b1c70b5ea54a8c009d4af248a07a127bb45ea531a7602b0c")
+    set(RUSTUP_INIT_FILENAME "rustup-init-x86_64-apple-darwin")
+    set(CARGO "${CARGO_HOME}/bin/cargo")
+elseif(VCPKG_HOST_IS_LINUX)
+    set(RUSTUP_INIT_URL "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init")
+    set(RUSTUP_INIT_SHA512 "245e554e5203df236a4794e595f647bb9019b8664efb1ba1c7faef8f362f9dcc31c7b1475d54e75425962341180612db32ee94cc45256977ea631d75628f43db")
+    set(RUSTUP_INIT_FILENAME "rustup-init-x86_64-unknown-linux-gnu")
+    set(CARGO "${CARGO_HOME}/bin/cargo")
+else()
+    message(FATAL_ERROR "Unsupported host platform for Rust toolchain bootstrap")
+endif()
+
+if(NOT EXISTS "${CARGO}")
+    vcpkg_download_distfile(RUSTUP_INIT_PATH
+        URLS "${RUSTUP_INIT_URL}"
+        SHA512 "${RUSTUP_INIT_SHA512}"
+        FILENAME "${RUSTUP_INIT_FILENAME}"
+    )
+
+    if(VCPKG_HOST_IS_WINDOWS)
+        set(RUSTUP_INIT_CMD "${RUSTUP_INIT_PATH}")
+    else()
+        file(CHMOD "${RUSTUP_INIT_PATH}"
+            PERMISSIONS
+                OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                GROUP_READ GROUP_EXECUTE
+                WORLD_READ WORLD_EXECUTE
+        )
+        set(RUSTUP_INIT_CMD "${RUSTUP_INIT_PATH}")
+    endif()
+
+    vcpkg_execute_required_process(
+        COMMAND "${RUSTUP_INIT_CMD}" -y --profile minimal --default-toolchain 1.85.0 --no-modify-path
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
+        LOGNAME "rustup-init-${TARGET_TRIPLET}"
+    )
+endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)
     set(RUST_TARGET "x86_64-pc-windows-msvc")

--- a/ports/orderflow-c/usage
+++ b/ports/orderflow-c/usage
@@ -1,0 +1,16 @@
+orderflow-c provides the C ABI runtime library and header.
+
+Installed files:
+  include/orderflow.h
+  lib/libof_ffi_c.* (or Windows equivalent)
+
+pkg-config:
+  pkg-config --cflags --libs orderflow
+
+Manual compile example:
+  cc app.c -o app $(pkg-config --cflags --libs orderflow)
+
+If using dynamic linkage, ensure the runtime loader can find the shared library:
+  Linux:   LD_LIBRARY_PATH
+  macOS:   DYLD_LIBRARY_PATH
+  Windows: PATH

--- a/ports/orderflow-c/vcpkg.json
+++ b/ports/orderflow-c/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "orderflow-c",
   "version-semver": "0.1.1",
+  "port-version": 1,
   "description": "Orderflow C ABI runtime library (header + native lib)",
   "homepage": "https://github.com/gregorian-09/orderflow",
   "license": "MIT",

--- a/ports/orderflow-c/vcpkg.json
+++ b/ports/orderflow-c/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "orderflow-c",
+  "version-semver": "0.1.1",
+  "description": "Orderflow C ABI runtime library (header + native lib)",
+  "homepage": "https://github.com/gregorian-09/orderflow",
+  "license": "MIT",
+  "supports": "(windows | linux | osx) & x64"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7396,6 +7396,10 @@
       "baseline": "2.2.2",
       "port-version": 1
     },
+    "orderflow-c": {
+      "baseline": "0.1.1",
+      "port-version": 0
+    },
     "orefkov-simstr": {
       "baseline": "1.7.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7398,7 +7398,7 @@
     },
     "orderflow-c": {
       "baseline": "0.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "orefkov-simstr": {
       "baseline": "1.7.3",

--- a/versions/o-/orderflow-c.json
+++ b/versions/o-/orderflow-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ff6c84656a4d2cf2410183eae678057d1f7601c",
+      "version-semver": "0.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "dced3e12de5f53b9cdd32616ccb0b64dd0322077",
       "version-semver": "0.1.1",
       "port-version": 0

--- a/versions/o-/orderflow-c.json
+++ b/versions/o-/orderflow-c.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "dced3e12de5f53b9cdd32616ccb0b64dd0322077",
+      "version-semver": "0.1.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### What does your PR fix?
Adds a new official orderflow-c port to vcpkg for the Orderflow C ABI runtime library.

### Which triplets are supported/not supported? Have you updated the CI baseline?
Supported: (windows | linux | osx) & x64
Baseline updated via ./vcpkg x-add-version orderflow-c.

### Does your port depend on any new vcpkg tools?
No.

### How did you test this PR?
- ./vcpkg install orderflow-c:x64-linux

### Notes
- Source tag: v0.1.1 from gregorian-09/orderflow
- SHA512 is pinned in ports/orderflow-c/portfile.cmake.