### PR TITLE
libstatgrab port

### DIFF
--- a/ports/libstatgrab/configure.ac.patch
+++ b/ports/libstatgrab/configure.ac.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 9516870..f8345c6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -127,7 +127,7 @@ AS_IF([test "x$ac_cv_need_minus_d_hpux_source" = "xyes"],
+       [CPPFLAGS="$CPPFLAGS -D_HPUX_SOURCE"])
+ 
+ dnl check language / compatibility environment
+-AX_CHECK_XOPEN_SOURCE
++AX_WIN32([],[AX_CHECK_XOPEN_SOURCE])
+ AS_IF([test -n "$XOPEN_SOURCE_CPPFLAGS"], [CPPFLAGS="$CPPFLAGS $XOPEN_SOURCE_CPPFLAGS"])
+ 
+ dnl Checks for inet libraries:

--- a/ports/libstatgrab/disk_stats.c.patch
+++ b/ports/libstatgrab/disk_stats.c.patch
@@ -2,6 +2,24 @@ diff --git a/src/libstatgrab/disk_stats.c b/src/libstatgrab/disk_stats.c
 index 62c0fde..d4ce894 100644
 --- a/src/libstatgrab/disk_stats.c
 +++ b/src/libstatgrab/disk_stats.c
+@@ -34,7 +34,7 @@
+ 
+ #ifdef SOLARIS
+ #define VALID_FS_TYPES {"ufs", "tmpfs", "vxfs", "nfs", "zfs", "lofs"}
+-#elif defined(LINUX)
++#elif defined(LINUX) || defined(__ANDROID__)
+ #define VALID_FS_TYPES {"adfs", "affs", "befs", "bfs", "btrfs", "cifs", \
+ 			"efs", "ext2", "ext3", "ext4", "vxfs", "hfs", \
+ 			"hfsplus", "hpfs", "jffs", "jffs2", "jfs", "minix", \
+@@ -459,7 +459,7 @@
+ #define CUR_VALID_FS sys_fs_types[i]
+ #define CAN_SHRINK_VALID_FS
+ 
+-#elif defined(LINUX)
++#elif defined(LINUX) || defined(__ANDROID__)
+ 
+ #undef FILL_VALID_FS
+ 
 @@ -1034,7 +1034,7 @@ sg_get_fs_list_int(sg_vector **fs_stats_vector_ptr) {
  		    ( ( upderr = sg_update_string( &fs_ptr[num_fs].mnt_point, SG_FS_MOUNTP ) ) != SG_ERROR_NONE ) ) {
  			RETURN_FROM_PREVIOUS_ERROR( "disk", upderr );

--- a/ports/libstatgrab/disk_stats.c.patch
+++ b/ports/libstatgrab/disk_stats.c.patch
@@ -1,0 +1,45 @@
+diff --git a/src/libstatgrab/disk_stats.c b/src/libstatgrab/disk_stats.c
+index 62c0fde..d4ce894 100644
+--- a/src/libstatgrab/disk_stats.c
++++ b/src/libstatgrab/disk_stats.c
+@@ -1034,7 +1034,7 @@ sg_get_fs_list_int(sg_vector **fs_stats_vector_ptr) {
+ 		    ( ( upderr = sg_update_string( &fs_ptr[num_fs].mnt_point, SG_FS_MOUNTP ) ) != SG_ERROR_NONE ) ) {
+ 			RETURN_FROM_PREVIOUS_ERROR( "disk", upderr );
+ 		}
+-
++#ifndef WIN32
+ 		while( ( -1 != lstat(fs_ptr[num_fs].device_canonical, &statbuf) ) && S_ISLNK(statbuf.st_mode) ) {
+ 			char lnktgt[PATH_MAX+1], *p;
+ 			TRACE_LOG_FMT("disk", "\"%s\" is symlink - resolving ...", fs_ptr[num_fs].device_canonical);
+@@ -1048,6 +1048,7 @@ sg_get_fs_list_int(sg_vector **fs_stats_vector_ptr) {
+ 				RETURN_FROM_PREVIOUS_ERROR( "disk", upderr );
+ 			}
+ 		}
++#endif
+ 		TRACE_LOG_FMT("disk", "\"%s\" is not a symlink", fs_ptr[num_fs].device_canonical);
+ 		/* avoid fs. bail out when last entry is no link */
+ 		errno = 0;
+@@ -1223,10 +1224,12 @@ sg_get_fs_stats_int(sg_vector **fs_stats_vector_ptr){
+ 	sg_error err = sg_get_fs_list_int(&tmp);
+ 	size_t i, j, n = 0;
+ 	sg_fs_stats *items, *item = VECTOR_DATA(tmp);
+-	unsigned valid[(VECTOR_ITEM_COUNT(tmp) / (8 * sizeof(unsigned))) + 1];
++/*
++    unsigned valid[(VECTOR_ITEM_COUNT(tmp) / (8 * sizeof(unsigned))) + 1];
+ 
+ 	memset( valid, 0, sizeof(valid) );
+-
++*/
++    unsigned* valid = (unsigned*)calloc((VECTOR_ITEM_COUNT(tmp) / (8 * sizeof(unsigned))) + 1, sizeof(unsigned));
+ 	if( ( SG_ERROR_NONE == err ) && (NULL != tmp) ) {
+ 
+ 		i = VECTOR_ITEM_COUNT(tmp);
+@@ -1261,7 +1264,7 @@ sg_get_fs_stats_int(sg_vector **fs_stats_vector_ptr){
+ 	assert( j == n );
+ 
+ 	sg_vector_free(tmp);
+-
++    free(valid);
+ 	return err;
+ }
+ 

--- a/ports/libstatgrab/globals.c.patch
+++ b/ports/libstatgrab/globals.c.patch
@@ -1,0 +1,39 @@
+diff --git a/src/libstatgrab/globals.c b/src/libstatgrab/globals.c
+index 3c48370..4018d57 100644
+--- a/src/libstatgrab/globals.c
++++ b/src/libstatgrab/globals.c
+@@ -81,6 +81,7 @@ static DWORD glob_tls_idx = TLS_OUT_OF_INDEXES;
+ #  error unsupport thread library
+ # endif
+ 
++static unsigned initialized = 0;
+ # if defined(HAVE_PTHREAD)
+ struct sg_named_mutex {
+ 	const char *name;
+@@ -94,7 +95,6 @@ static struct sg_named_mutex glob_lock = { "statgrab", PTHREAD_MUTEX_INITIALIZER
+ #  endif
+ static struct sg_named_mutex *required_locks = NULL;
+ static size_t num_required_locks = 0;
+-static unsigned initialized = 0;
+ 
+ static int
+ cmp_named_locks( const void *va, const void *vb ) {
+@@ -224,8 +224,8 @@ static void
+ sg_destroy_main_globals(void)
+ {
+ #if defined(ENABLE_THREADS)
+-# if defined(HAVE_PTHREAD)
+ 	char *glob_buf;
++# if defined(HAVE_PTHREAD)
+ 	while( NULL != ( glob_buf = pthread_getspecific(glob_key) ) )
+ 		sg_destroy_globals(glob_buf);
+ # elif defined(WIN32)
+@@ -507,7 +507,7 @@ sg_comp_get_tls(unsigned id) {
+ # elif defined(WIN32)
+ 	glob_buf = TlsGetValue(glob_tls_idx);
+ 	if((NULL == glob_buf) && (ERROR_SUCCESS != GetLastError())){
+-		RETURN_WITH_SET_ERROR("globals", SG_ERROR_MEMSTATUS, NULL);
++		SET_ERROR("globals", SG_ERROR_MEMSTATUS, NULL); return NULL;
+ 	}
+ # endif
+ #endif

--- a/ports/libstatgrab/opt.c.patch
+++ b/ports/libstatgrab/opt.c.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/testlib/opt.c b/tests/testlib/opt.c
+index 311eb1a..d761f8c 100644
+--- a/tests/testlib/opt.c
++++ b/tests/testlib/opt.c
+@@ -25,6 +25,8 @@
+ #include <tools.h>
+ #include "testlib.h"
+ 
++extern char *optarg;
++
+ int
+ get_params(struct opt_def *opt_defs, int argc, char **argv) {
+ 	char optlst[256] = { '\0' };

--- a/ports/libstatgrab/os_info.c.patch
+++ b/ports/libstatgrab/os_info.c.patch
@@ -1,0 +1,21 @@
+diff --git a/src/libstatgrab/os_info.c b/src/libstatgrab/os_info.c
+index 8b36218..97ad65e 100644
+--- a/src/libstatgrab/os_info.c
++++ b/src/libstatgrab/os_info.c
+@@ -189,6 +189,7 @@ sg_get_host_info_int(sg_host_info *host_info_buf) {
+ 	char *name;
+ 	long long result;
+ 	OSVERSIONINFOEX osinfo;
++	LPOSVERSIONINFO pOsInfo = (LPOSVERSIONINFO)&osinfo;
+ 	SYSTEM_INFO sysinfo;
+ 	char *tmp_name;
+ 	char tmp[10];
+@@ -267,7 +268,7 @@ sg_get_host_info_int(sg_host_info *host_info_buf) {
+ 	/* get OS name, version and build */
+ 	ZeroMemory(&osinfo, sizeof(OSVERSIONINFOEX));
+ 	osinfo.dwOSVersionInfoSize = sizeof(osinfo);
+-	if(!GetVersionEx(&osinfo)) {
++	if(!GetVersionEx(pOsInfo)) {
+ 		RETURN_WITH_SET_ERROR("os", SG_ERROR_HOST, "GetVersionEx");
+ 	}
+ 	GetSystemInfo(&sysinfo);

--- a/ports/libstatgrab/portfile.cmake
+++ b/ports/libstatgrab/portfile.cmake
@@ -1,0 +1,38 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libstatgrab/libstatgrab
+    REF "LIBSTATGRAB_0_92_1"
+    SHA512 8f631a40aaebbeaea593eff631529d583bd88a89cc910a97ad6cc2f01dc27333d05dfce95b325cf0833b9d5dded5fd92137b1d65425565ed45f801115f0100c3
+    HEAD_REF master
+    PATCHES
+        configure.ac.patch
+        disk_stats.c.patch
+        globals.c.patch
+        os_info.c.patch
+        vector.c.patch
+        opt.c.patch
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS
+        --disable-man
+        --disable-saidar
+        --disable-statgrab
+        --disable-tests
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug"
+)
+
+vcpkg_copy_pdbs()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.LGPL")

--- a/ports/libstatgrab/vcpkg.json
+++ b/ports/libstatgrab/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "libstatgrab",
+  "version": "0.92.1",
+  "description": "A cross platform library for accessing system statistics",
+  "homepage": "https://libstatgrab.org/",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!uwp"
+}

--- a/ports/libstatgrab/vector.c.patch
+++ b/ports/libstatgrab/vector.c.patch
@@ -1,0 +1,23 @@
+diff --git a/src/libstatgrab/vector.c b/src/libstatgrab/vector.c
+index e4b07a9..0c83ba6 100644
+--- a/src/libstatgrab/vector.c
++++ b/src/libstatgrab/vector.c
+@@ -344,7 +344,8 @@ sg_vector_compute_diff(sg_vector **dest_vector_ptr, const sg_vector *cur_vector,
+ 		    ( SG_ERROR_NONE == sg_prove_vector(last_vector) ) &&
+ 		    ( SG_ERROR_NONE == sg_prove_vector_compat(cur_vector, last_vector ) ) ) {
+ 			size_t i, item_size = last_vector->info.item_size;
+-			unsigned matched[(cur_vector->used_count / (8 * sizeof(unsigned))) + 1];
++			// unsigned matched[(cur_vector->used_count / (8 * sizeof(unsigned))) + 1];
++			unsigned *matched = calloc((cur_vector->used_count / (8 * sizeof(unsigned))) + 1, sizeof(unsigned));
+ 
+ 			char *diff = VECTOR_DATA(*dest_vector_ptr);
+ 			char const *last = VECTOR_DATA_CONST(last_vector);
+@@ -367,7 +368,7 @@ sg_vector_compute_diff(sg_vector **dest_vector_ptr, const sg_vector *cur_vector,
+ 					/* We have lost an item since last time - skip */
+ 				}
+ 			}
+-
++			free(matched);
+ 			/* XXX append the items lost since last run? */
+ 		}
+ 	}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5584,6 +5584,10 @@
       "baseline": "1.11.1",
       "port-version": 2
     },
+    "libstatgrab": {
+      "baseline": "0.92.1",
+      "port-version": 0
+    },
     "libstemmer": {
       "baseline": "2021.2.2.0",
       "port-version": 0

--- a/versions/l-/libstatgrab.json
+++ b/versions/l-/libstatgrab.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f3d8c186a55935c102885d54da40e573340cbfc0",
+      "git-tree": "3540c9a27adde9e208ff05913aeb25c851fcfd96",
       "version": "0.92.1",
       "port-version": 0
     }

--- a/versions/l-/libstatgrab.json
+++ b/versions/l-/libstatgrab.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f3d8c186a55935c102885d54da40e573340cbfc0",
+      "version": "0.92.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/libstatgrab/versions
    - [x] The project is amongst the first web search results for "libstatgrab" or "libstatgrab C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<img width="1886" height="906" alt="image" src="https://github.com/user-attachments/assets/597c4915-85c6-4818-aab8-129ea7ee61f3" />
