### PR TITLE
[libgossip] update to 1.2.1.3

### DIFF
--- a/ports/libgossip/portfile.cmake
+++ b/ports/libgossip/portfile.cmake
@@ -1,12 +1,8 @@
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY) # DLL broken in 1.1.2.0
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO caomengxuan666/libgossip
     REF "v${VERSION}"
-    SHA512 971f51f6583d3246a5696b35a419fd30ce8ebbd7940b63bb9731f7ec2f12e0f6d68b3924c0be81de30d4eb33f24a39be4db72d2cee5f2ca5e52081aa7c568699
+    SHA512 ae765138fac7077af09ce8ca769b5bf1bd6ca0a81e17cc4b397436309152fd8678f29ce699fc6534d56c5bead980b8b7cf0fbb7df528ef805c51d3210ab1eb24
     HEAD_REF main
     PATCHES
         fix-dependencies.patch

--- a/ports/libgossip/vcpkg.json
+++ b/ports/libgossip/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgossip",
-  "version": "1.2.1.2",
+  "version": "1.2.1.3",
   "description": "A C++17 implementation of the Gossip protocol, designed for decentralized distributed systems.",
   "homepage": "https://github.com/caomengxuan666/libgossip",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4957,7 +4957,7 @@
       "port-version": 6
     },
     "libgossip": {
-      "baseline": "1.2.1.2",
+      "baseline": "1.2.1.3",
       "port-version": 0
     },
     "libgpg-error": {

--- a/versions/l-/libgossip.json
+++ b/versions/l-/libgossip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88573272e29e2d5d664b8e1512afe992075ca36b",
+      "version": "1.2.1.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "467452e288941bb183f9da7577451b8e954d5424",
       "version": "1.2.1.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/caomengxuan666/libgossip/releases/tag/v1.2.1.3
