### PR TITLE
[libphonenumber] update to 9.0.26

### DIFF
--- a/ports/libphonenumber/portfile.cmake
+++ b/ports/libphonenumber/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/libphonenumber
     REF "v${VERSION}"
-    SHA512 e6532db195b80415a7660e951c9fd479f0d155e5fe48edb838931550c38bc42f870fedca4e67de0b6fbfb93c4792389b2dc0fe4b935867e63faf0f12319cc1cd
+    SHA512 b921537064ce72ea7bcdebf312e77f3c233c56e41347583a4ad100da55823a731073f4b32677854013ec85436d6684f2220df9ce246b4d059e8f93f526976b14
     HEAD_REF master
     PATCHES
         # fix compilation error due to deprecated warnings in protobuf generated files

--- a/ports/libphonenumber/vcpkg.json
+++ b/ports/libphonenumber/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libphonenumber",
-  "version": "9.0.25",
+  "version": "9.0.26",
   "description": "Google's common Java, C++ and JavaScript library for parsing, formatting, and validating international phone numbers.",
   "homepage": "https://github.com/google/libphonenumber",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5353,7 +5353,7 @@
       "port-version": 0
     },
     "libphonenumber": {
-      "baseline": "9.0.25",
+      "baseline": "9.0.26",
       "port-version": 0
     },
     "libplist": {

--- a/versions/l-/libphonenumber.json
+++ b/versions/l-/libphonenumber.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40d4b35d87ba18a455daa0db51adf9ba3a1a7768",
+      "version": "9.0.26",
+      "port-version": 0
+    },
+    {
       "git-tree": "fab078ab0836244a456992061ce7abec2b9ec2a8",
       "version": "9.0.25",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

