### PR TITLE
[libsoup] update to 3.6.6

### DIFF
--- a/ports/libsoup/portfile.cmake
+++ b/ports/libsoup/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(ARCHIVE
         "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
-    SHA512 cb44d93b16048d31ae04a8c2416bbe233e0e9bdaf2d9bfe2879260fd3da27e90a0bb05cddbd82cdf81a4a778bd451ad172a14dd31e2fd113c3bbbe13c0029b03
+    SHA512 4018dc6f9823fd82cde0fecbb50cd1b5dd0ff4963f92f7ea465e67faf81e71580709eec59914ddbdff317963a88e4a8024e60e44087041175bc21e04022857d2
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")

--- a/ports/libsoup/vcpkg.json
+++ b/ports/libsoup/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libsoup",
-  "version": "3.6.5",
-  "port-version": 1,
+  "version": "3.6.6",
   "description": "HTTP Library for GLib",
   "homepage": "https://libsoup.gnome.org/",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5545,8 +5545,8 @@
       "port-version": 0
     },
     "libsoup": {
-      "baseline": "3.6.5",
-      "port-version": 1
+      "baseline": "3.6.6",
+      "port-version": 0
     },
     "libspatialindex": {
       "baseline": "2.1.0",

--- a/versions/l-/libsoup.json
+++ b/versions/l-/libsoup.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bed7d8d74ebdde8e460929228a022cd046e6e426",
+      "version": "3.6.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "f0ee0b625fd0b8f416dff42a480a5537862788e4",
       "version": "3.6.5",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

