### PR TITLE
[libsecret] update to 0.21.7

### DIFF
--- a/ports/libsecret/portfile.cmake
+++ b/ports/libsecret/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(ARCHIVE
         "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
-    SHA512 4731d9b2809a867f59e0702a55d1577ee0a968826c3df40717b1a6f6ea3f9d94ed95457dd82070d2914f5b1911d49fd6ae340bec6f4bcf88b6c804782ae7a24e
+    SHA512 f5ee1244338ba324ae403096ddd7357899f55fa9f961d2473515ac924164fe9b33f87e39eea2a30b99fc32f2300c0e626d20c98509dbbcadb2c99628a1caa0e4
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")

--- a/ports/libsecret/vcpkg.json
+++ b/ports/libsecret/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libsecret",
-  "version": "0.21.4",
-  "port-version": 2,
+  "version": "0.21.7",
   "description": "libsecret is a GObject-based library for accessing the Secret Service API of the freedesktop.org project, a cross-desktop effort to access passwords, tokens and other types of secrets. libsecret provides a convenient wrapper for these methods so consumers do not have to call the low-level DBus methods.",
   "homepage": "https://gitlab.gnome.org/GNOME/libsecret/",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5481,8 +5481,8 @@
       "port-version": 0
     },
     "libsecret": {
-      "baseline": "0.21.4",
-      "port-version": 2
+      "baseline": "0.21.7",
+      "port-version": 0
     },
     "libsercomm": {
       "baseline": "1.3.2",

--- a/versions/l-/libsecret.json
+++ b/versions/l-/libsecret.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "307d17aec13ed9a879aa1438bf0506dce59c580c",
+      "version": "0.21.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "6efcb754fb74193ef5d230c9433c0e8c40eb5065",
       "version": "0.21.4",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

