### PR TITLE
[gperftools] update to 2.18.1

### DIFF
--- a/ports/gperftools/portfile.cmake
+++ b/ports/gperftools/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gperftools/gperftools
     REF gperftools-${VERSION}
-    SHA512 6ac99109d9b02afdaf31fb5ecd0bbd752a2ed59494ac7cc584944a2ebdb3254e25df2cb18a0bc1fc0e9230b967890e550cccaf92b9e59473e538977de6a133bf
+    SHA512 db5435194019797ce2556ee3f113ade6df28963f13ad579f492528fc1307041093558676aac9d2295b1ab392bb8553532ae079687dc01bdc14b40261e5dfe2d4
     HEAD_REF master
     PATCHES
         libunwind.diff

--- a/ports/gperftools/vcpkg.json
+++ b/ports/gperftools/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gperftools",
-  "version": "2.18",
+  "version": "2.18.1",
   "description": "A high-performance multi-threaded malloc() implementation, plus some performance analysis tools.",
   "homepage": "https://github.com/gperftools/gperftools",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3497,7 +3497,7 @@
       "port-version": 0
     },
     "gperftools": {
-      "baseline": "2.18",
+      "baseline": "2.18.1",
       "port-version": 0
     },
     "gpgme": {

--- a/versions/g-/gperftools.json
+++ b/versions/g-/gperftools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cec76192e9a265622dee893fc93cae06d995a878",
+      "version": "2.18.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "764aa17c43a4e70bda87cbdcc56435423959c6c9",
       "version": "2.18",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

