### PR TITLE
[openssl] Don't set openssldir to a potentially-world-writable location.

### DIFF
--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openssl",
   "version": "3.6.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/ports/openssl/windows/install-layout.patch
+++ b/ports/openssl/windows/install-layout.patch
@@ -7,7 +7,7 @@ index f71f3bf..116954f 100644
                    our $modulesdir_dev = $modulesprefix_dev;
                    our $modulesdir_dir =
 -                      catdir($modulesprefix_dir, "ossl-modules");
-+                      catdir($modulesprefix_dir, "../bin");
++                      catdir($modulesprefix_dir, "../bin"); # change lib/ossl-modules to bin
                    our $modulesdir = catpath($modulesdir_dev, $modulesdir_dir);
                    our $enginesdir_dev = $modulesprefix_dev;
                    our $enginesdir_dir =

--- a/ports/openssl/windows/portfile.cmake
+++ b/ports/openssl/windows/portfile.cmake
@@ -73,7 +73,7 @@ cmake_path(NATIVE_PATH VCPKG_DETECTED_CMAKE_LINKER NORMALIZE ld)
 
 # We can't set openssldir because that would leak build machine information into the built binaries,
 # and introduce vulnerabilities where OpenSSL would search those locations at runtime, potentially
-# unexpectedly loading code from there. For example CVE-2019-12572 and CVE-2026-FIXME FIXME FIXME
+# unexpectedly loading code from there. For example CVE-2019-12572
 #
 # Put the built bits in subdirectories with DESTDIR then move them where they go after the fact
 # instead.

--- a/ports/openssl/windows/portfile.cmake
+++ b/ports/openssl/windows/portfile.cmake
@@ -41,7 +41,7 @@ if(VCPKG_CONCURRENCY GREATER "1")
     vcpkg_list(APPEND CONFIGURE_OPTIONS no-makedepend)
 endif()
 
-cmake_path(NATIVE_PATH CURRENT_PACKAGES_DIR NORMALIZE install_dir_native)
+cmake_path(NATIVE_PATH CURRENT_PACKAGES_DIR NORMALIZE current_packages_dir_native)
 
 # Clang always uses /Z7;  Patching /Zi /Fd<Name> out of openssl requires more work.
 set(OPENSSL_BUILD_MAKES_PDBS ON)
@@ -71,6 +71,12 @@ endif()
 cmake_path(NATIVE_PATH VCPKG_DETECTED_CMAKE_AR NORMALIZE ar)
 cmake_path(NATIVE_PATH VCPKG_DETECTED_CMAKE_LINKER NORMALIZE ld)
 
+# We can't set openssldir because that would leak build machine information into the built binaries,
+# and introduce vulnerabilities where OpenSSL would search those locations at runtime, potentially
+# unexpectedly loading code from there. For example CVE-2019-12572 and CVE-2026-FIXME FIXME FIXME
+#
+# Put the built bits in subdirectories with DESTDIR then move them where they go after the fact
+# instead.
 vcpkg_build_nmake(
     SOURCE_PATH "${SOURCE_PATH}"
     PREFER_JOM
@@ -78,8 +84,6 @@ vcpkg_build_nmake(
     PRERUN_SHELL_RELEASE "${PERL}" Configure
         ${CONFIGURE_OPTIONS} 
         ${OPENSSL_ARCH}
-        "--prefix=${install_dir_native}"
-        "--openssldir=${install_dir_native}"
         "AS=${as}"
         "CC=${cc}"
         "CFLAGS=${VCPKG_COMBINED_C_FLAGS_RELEASE}"
@@ -91,8 +95,6 @@ vcpkg_build_nmake(
         ${CONFIGURE_OPTIONS}
         ${OPENSSL_ARCH}
         --debug
-        "--prefix=${install_dir_native}\\debug"
-        "--openssldir=${install_dir_native}\\debug"
         "AS=${as}"
         "CC=${cc}"
         "CFLAGS=${VCPKG_COMBINED_C_FLAGS_DEBUG}"
@@ -106,53 +108,80 @@ vcpkg_build_nmake(
     OPTIONS
         "INSTALL_PDBS=${OPENSSL_BUILD_MAKES_PDBS}" # install-pdbs.patch
     OPTIONS_RELEASE
+        "DESTDIR=${current_packages_dir_native}"
         install_runtime install_ssldirs # extra targets
+    OPTIONS_DEBUG
+        "DESTDIR=${current_packages_dir_native}/debug"
 )
+
+function(z_rearrange_openssl_dirs)
+    cmake_parse_arguments(PARSE_ARGV 0 arg "" "OUT_PROGRAM_FILES_DIR;FLAVOR_PREFIX" "")
+
+    if(DEFINED arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "z_rearrange_openssl_dirs was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
+    endif()
+
+    # The resulting directory will contain something like "Program Files" or "Program Files (x86)";
+    # globbing here to be architecture agnostic
+    set(prefix_packages_dir "${CURRENT_PACKAGES_DIR}${arg_FLAVOR_PREFIX}")
+    file(GLOB flavor_programfiles_dir LIST_DIRECTORIES true "${prefix_packages_dir}/Program*")
+    if(NOT flavor_programfiles_dir)
+        message(FATAL_ERROR "${flavor_programfiles_dir}: error: couldn't find program files dir")
+    endif()
+
+    if(DEFINED arg_OUT_PROGRAM_FILES_DIR)
+        set("${arg_OUT_PROGRAM_FILES_DIR}" "${flavor_programfiles_dir}" PARENT_SCOPE)
+    endif()
+
+    set(flavor_openssl_dir "${flavor_programfiles_dir}/OpenSSL")
+    if(NOT EXISTS "${flavor_openssl_dir}")
+        message(FATAL_ERROR "${flavor_openssl_dir}: should exist and be OpenSSLDir")
+    endif()
+
+    # ideally we would use RENAME rather than COPY and REMOVE_RECURSE but CMake doesn't have an out
+    # of the box way to do that correctly merging directories
+    file(GLOB flavor_openssl_dirs LIST_DIRECTORIES true "${flavor_openssl_dir}/*")
+    file(COPY ${flavor_openssl_dirs} DESTINATION "${prefix_packages_dir}")
+    file(REMOVE_RECURSE "${flavor_openssl_dir}")
+endfunction()
+
+z_rearrange_openssl_dirs(FLAVOR_PREFIX "" OUT_PROGRAM_FILES_DIR release_programfiles)
+if(NOT VCPKG_BUILD_TYPE)
+    z_rearrange_openssl_dirs(FLAVOR_PREFIX "/debug" OUT_PROGRAM_FILES_DIR debug_programfiles)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+    file(REMOVE_RECURSE "${debug_programfiles}")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/c_rehash.pl")
+endif()
 
 set(scripts "bin/c_rehash.pl" "misc/CA.pl" "misc/tsget.pl")
 if("tools" IN_LIST FEATURES)
     file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/openssl.cnf" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/openssl.cnf")
+    file(COPY_FILE "${release_programfiles}/Common Files/SSL/openssl.cnf" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/openssl.cnf")
     if("fips" IN_LIST FEATURES)
-	file(RENAME "${CURRENT_PACKAGES_DIR}/fipsmodule.cnf" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/fipsmodule.cnf")
+	    file(COPY_FILE "${release_programfiles}/Common Files/SSL/fipsmodule.cnf" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/fipsmodule.cnf")
     endif()
-    foreach(script IN LISTS scripts)
-        file(COPY "${CURRENT_PACKAGES_DIR}/${script}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
-        file(REMOVE "${CURRENT_PACKAGES_DIR}/${script}" "${CURRENT_PACKAGES_DIR}/debug/${script}")
-    endforeach()
+
+    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/c_rehash.pl" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/c_rehash.pl")
+    file(RENAME "${release_programfiles}/Common Files/SSL/misc/CA.pl" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/CA.pl")
+    file(RENAME "${release_programfiles}/Common Files/SSL/misc/tsget.pl" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/tsget.pl")
     vcpkg_copy_tools(TOOL_NAMES openssl AUTO_CLEAN)
 else()
-    file(REMOVE "${CURRENT_PACKAGES_DIR}/openssl.cnf")
-    file(REMOVE "${CURRENT_PACKAGES_DIR}/fipsmodule.cnf")
-    foreach(script IN LISTS scripts)
-        file(REMOVE "${CURRENT_PACKAGES_DIR}/${script}" "${CURRENT_PACKAGES_DIR}/debug/${script}")
-    endforeach()
+    file(REMOVE
+        "${CURRENT_PACKAGES_DIR}/bin/c_rehash.pl"
+        "${release_programfiles}/Common Files/SSL/misc/CA.pl"
+        "${release_programfiles}/Common Files/SSL/misc/tsget.pl"
+        )
+
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
     endif()
 endif()
 
 vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup()
 
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/certs"
-    "${CURRENT_PACKAGES_DIR}/misc"
-    "${CURRENT_PACKAGES_DIR}/private"
-    "${CURRENT_PACKAGES_DIR}/lib/engines-3"
-    "${CURRENT_PACKAGES_DIR}/debug/certs"
-    "${CURRENT_PACKAGES_DIR}/debug/misc"
-    "${CURRENT_PACKAGES_DIR}/debug/lib/engines-3"
-    "${CURRENT_PACKAGES_DIR}/debug/private"
-    "${CURRENT_PACKAGES_DIR}/debug/include"
-    "${CURRENT_PACKAGES_DIR}/debug/share"
-)
-file(REMOVE
-    "${CURRENT_PACKAGES_DIR}/ct_log_list.cnf"
-    "${CURRENT_PACKAGES_DIR}/ct_log_list.cnf.dist"
-    "${CURRENT_PACKAGES_DIR}/openssl.cnf.dist"
-    "${CURRENT_PACKAGES_DIR}/debug/ct_log_list.cnf"
-    "${CURRENT_PACKAGES_DIR}/debug/ct_log_list.cnf.dist"
-    "${CURRENT_PACKAGES_DIR}/debug/openssl.cnf"
-    "${CURRENT_PACKAGES_DIR}/debug/openssl.cnf.dist"
-    "${CURRENT_PACKAGES_DIR}/debug/fipsmodule.cnf"
+file(REMOVE_RECURSE # to pass empty directories check
+    "${release_programfiles}/Common Files/SSL/certs"
+    "${release_programfiles}/Common Files/SSL/misc"
+    "${release_programfiles}/Common Files/SSL/private"
 )

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7318,7 +7318,7 @@
     },
     "openssl": {
       "baseline": "3.6.1",
-      "port-version": 2
+      "port-version": 3
     },
     "opensubdiv": {
       "baseline": "3.5.0",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "49e8bd01d9074c4a3054c92eb73628f4ac257290",
+      "git-tree": "4d02bbb044439adeced1af6fc8a45f819c8bb5e2",
       "version": "3.6.1",
       "port-version": 3
     },

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49e8bd01d9074c4a3054c92eb73628f4ac257290",
+      "version": "3.6.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "13ecbd590e54cff1467a8196b5f0dcab74ae1c24",
       "version": "3.6.1",
       "port-version": 2


### PR DESCRIPTION
This was initially reported by TrendAI Zero Day Initiative and assigned ZDI-CAN-29616 (visible on https://www.zerodayinitiative.com/advisories/upcoming/ ). There is a 'file lay in wait' class of elevation of privilege vulnerabilities arising from OpenSSL hard coding search paths for DLLs. vcpkg sets openssldir to a path from the build machine in order to get built results to be placed correctly, but this means OpenSSL will search that path for engines to load in the future.

A low privilege user on a different machine can create the same path, which would hijack a later high privilege user deploying an OpenSSL vcpkg happened to build at that location.

The OpenSSL documentation explicitly notes this problem and says that redirecting built results needs to be done with DESTDIR, not by changing OpenSSLDir: https://github.com/openssl/openssl/blob/master/INSTALL.md#directories + https://github.com/openssl/openssl/blob/master/INSTALL.md#additional-directories

This change changes vcpkg's build for Windows to not set OpenSSLDir at all, leaving OpenSSL's default path under Program Files. Program Files is assumed to be acceptable because writing there generally requires administrative permissions. In an ideal universe we would configure OpenSSL to not search this at all, but they don't appear to offer such a setting.

@ras0219-msft in discussion noted other interesting bits:

https://github.com/openssl/openssl/issues/17151#issuecomment-1424401396 a similar report directly to the OpenSSL maintainers a few years ago

https://github.com/VectorDCM/openssl_dircheck a tool that appears to exist to look for these cases explicitly.

CVE-2019-12572 PIA Windows Privilege Escalation: Malicious OpenSSL Engine
