### PR TITLE
Fix octave: openblas on osx, and blas for everything else.

### DIFF
--- a/ports/octave/vcpkg.json
+++ b/ports/octave/vcpkg.json
@@ -1,18 +1,25 @@
 {
   "name": "octave",
   "version": "10.2.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "High-level interpreted language, primarily intended for numerical computations.",
   "homepage": "https://octave.org/",
   "documentation": "https://docs.octave.org/latest/",
   "license": "GPL-3.0-or-later",
   "supports": "!windows | mingw",
   "dependencies": [
-    "blas",
+    {
+      "name": "blas",
+      "platform": "!osx"
+    },
     "fftw3",
     "glpk",
     "lapack",
     "libsndfile",
+    {
+      "name": "openblas",
+      "platform": "osx"
+    },
     "opengl",
     "pcre2",
     "readline",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -497,7 +497,6 @@ nrf-ble-driver:arm64-android=fail
 nrf-ble-driver:arm64-linux=fail
 nrf-ble-driver:x64-android=fail
 nss:arm64-linux=fail
-octave:arm64-osx=fail
 ogdf:arm64-linux=fail
 ogre-next:arm-neon-android=fail # std::string issue, https://github.com/microsoft/vcpkg/pull/41293#issuecomment-2942853561
 ogre-next:arm64-android=fail

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -869,7 +869,6 @@ nvtt[cuda]:arm64-osx=cascade
 nvtt[cuda]:x86-windows=cascade
 nvtt[cuda](x64 & (linux | windows))=feature-fails  # nvtt getting dated wrt cuda
 octave:arm64-linux=cascade
-octave:arm64-osx=fail  # blas must select openblas instead of Accelerate
 octave(android)=skip
 ode:arm64-windows=fail
 ogdf:arm64-linux=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7106,7 +7106,7 @@
     },
     "octave": {
       "baseline": "10.2.0",
-      "port-version": 2
+      "port-version": 3
     },
     "octomap": {
       "baseline": "1.10.0",

--- a/versions/o-/octave.json
+++ b/versions/o-/octave.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28a71256ffee791221710917875da4f227522ec3",
+      "version": "10.2.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "d01ab9834167b73a40ae78f75faffbd185006798",
       "version": "10.2.0",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

From this thread:
https://github.com/microsoft/vcpkg/pull/46696#discussion_r2247184198
Blas on osx is Apple Accelerate:
blas return correctly the single precision values.
They mention that Apple Accelerate return double precision values.
That why on osx, I suggesting that the user will compile openblas instead.
