### PR TITLE
Fix IncrementalClean deleting vcpkg-deployed DLLs on incremental builds

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -256,4 +256,27 @@
       <ReferenceCopyLocalPaths Include="@(VcpkgAppLocalDLLs)" />
     </ItemGroup>
   </Target>
+
+  <!--
+    When the link step is skipped (incremental build, exe up-to-date),
+    AppLocalFromInstalled doesn't run, so DLLs it previously copied aren't
+    registered in FileWrites. MSBuild's IncrementalClean then treats them as
+    orphan outputs and deletes them. This target re-registers those DLLs so
+    IncrementalClean leaves them alone.
+  -->
+  <Target Name="AppLocalFromInstalledPreserve"
+          AfterTargets="CopyFilesToOutputDirectory"
+          BeforeTargets="_CleanGetCurrentAndPriorFileWrites"
+          Condition="'$(_ZVcpkgClassicOrManifest)' == 'true'
+                     and '$(VcpkgApplocalDeps)' == 'true'
+                     and '$(LinkSkippedExecution)' == 'true'
+                     and '@(Link)' != ''">
+    <ReadLinesFromFile File="$(IntDir)vcpkg.applocal.log"
+                       Condition="Exists('$(IntDir)vcpkg.applocal.log')">
+      <Output TaskParameter="Lines" ItemName="_ZVcpkgPreservedAppLocalDLLs" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <FileWrites Include="@(_ZVcpkgPreservedAppLocalDLLs -> '$(OutDir)%(Filename)%(Extension)')" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
When MSBuild performs an incremental build and the executable is up-to-date, Link sets LinkSkippedExecution=true and skips. AppLocalFromInstalled checks this property and correctly skips (no need to re-copy DLLs). However, because it didn't run, the previously deployed DLLs are not registered in the @(FileWrites) item group. MSBuild's IncrementalClean target then computes these DLLs as "orphan outputs" (present in prior file writes but absent from current file writes) and deletes them.

This means every second build (and all subsequent incremental builds) removes the DLLs from the output directory, breaking debugging and execution until a full rebuild.

The fix adds an AppLocalFromInstalledPreserve target that is the complement of AppLocalFromInstalled — it runs only when LinkSkippedExecution IS true. Instead of re-copying DLLs, it reads the list of previously deployed DLLs from $(IntDir)vcpkg.applocal.log (which AppLocalFromInstalled already writes on every full build) and registers them in @(FileWrites). This tells IncrementalClean these files are still valid outputs and should not be deleted.

The log paths are transformed via %(Filename)%(Extension) and re-based to $(OutDir) because the builtin z-applocal writes source paths (from the installed bin directory) while applocal.ps1 writes destination paths. The transform handles both cases correctly.

Reproduction steps (minimal .vcxproj + zlib, manifest mode):

  1. Create main.cpp: #include <zlib.h> #include <cstdio> int main() { printf("zlib version: %s\n", zlibVersion()); }

  2. Create vcpkg.json: { "dependencies": ["zlib"] }

  3. Create a minimal .vcxproj (Application, Release|x64, v143) with VcpkgEnableManifest set to true in the Globals PropertyGroup.

  4. Build: msbuild repro.vcxproj /t:Clean /p:Configuration=Release /p:Platform=x64 msbuild repro.vcxproj /t:Build /p:Configuration=Release /p:Platform=x64 
  **Result:** zlib1.dll is copied to x64\Release\.

  5. Build again (incremental, no source changes): msbuild repro.vcxproj /t:Build /p:Configuration=Release /p:Platform=x64
  **Result WITHOUT fix:** zlib1.dll is deleted from x64\Release\. 
  **Result WITH fix:** zlib1.dll remains in x64\Release\.

Tested with both applocal.ps1 (PowerShell) and VcpkgXUseBuiltInApplocalDeps (vcpkg.exe z-applocal) code paths.

Fixes #31901
Fixes #23183
Related: #16432

<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
