### PR TITLE
[basisu] update to 2.1.0

### DIFF
--- a/ports/basisu/devendor-zstd.diff
+++ b/ports/basisu/devendor-zstd.diff
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c4f91bb..c29c411 100644
+index c4f91bb..a808ebd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -96,6 +96,10 @@ message("Initial BASISU_OPENCL=${BASISU_OPENCL}")
@@ -58,20 +58,20 @@ index 15c0d7e..7acd627 100644
  
  check_required_components(basisu)
 diff --git a/encoder/basisu_astc_ldr_encode.cpp b/encoder/basisu_astc_ldr_encode.cpp
-index 1710b1b..0739464 100644
+index 302cb2e..239fe54 100644
 --- a/encoder/basisu_astc_ldr_encode.cpp
 +++ b/encoder/basisu_astc_ldr_encode.cpp
-@@ -18,7 +18,7 @@
- #include "3rdparty/android_astc_decomp.h"
- #include <queue>
+@@ -27,7 +27,7 @@
+ #endif
  
+ #if BASISD_SUPPORT_KTX2_ZSTD
 -#include "../zstd/zstd.h"
 +#include <zstd.h>
+ #endif
  
  namespace basisu {
- namespace astc_ldr {
 diff --git a/encoder/basisu_comp.cpp b/encoder/basisu_comp.cpp
-index 617ff30..f2fb95b 100644
+index acbedc3..633c0fc 100644
 --- a/encoder/basisu_comp.cpp
 +++ b/encoder/basisu_comp.cpp
 @@ -34,7 +34,7 @@
@@ -84,7 +84,7 @@ index 617ff30..f2fb95b 100644
  
  // Set to 1 to disable the mipPadding alignment workaround (which only seems to be needed when no key-values are written at all)
 diff --git a/transcoder/basisu_transcoder.cpp b/transcoder/basisu_transcoder.cpp
-index 347a024..521af5c 100644
+index f2fa623..2a97d8d 100644
 --- a/transcoder/basisu_transcoder.cpp
 +++ b/transcoder/basisu_transcoder.cpp
 @@ -174,7 +174,7 @@

--- a/ports/basisu/portfile.cmake
+++ b/ports/basisu/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BinomialLLC/basis_universal
     REF "${git_ref}"
-    SHA512 5dec1498ba61ca117d554a26463272d0b12547f8bd92fb5e60a37d4bc004c802535ca719a3c8d2968ab0dc8aeeb40760e3598897c87e62aa5f1ab3b5e882e66c
+    SHA512 fefe1562ad62ea5d32437f8c1e02a88fa680bd1d1ee8cafe366d7824de99c9111a4103e03f138f3e9794f4adc7e53674f4d728d1f0b70fc7c586b5990ec8e09e
     HEAD_REF master
     PATCHES
         export-cmake-config.diff

--- a/ports/basisu/vcpkg.json
+++ b/ports/basisu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "basisu",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Basis Universal is a supercompressed GPU texture and video compression format that outputs a highly compressed intermediate file format (.basis) that can be quickly transcoded to a wide variety of GPU texture compression formats.",
   "homepage": "https://github.com/BinomialLLC/basis_universal",
   "license": null,

--- a/versions/b-/basisu.json
+++ b/versions/b-/basisu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39a470a0ecf12a26a08afa77376f8360c9efa645",
+      "version": "2.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b301b37105c01693f50151fa04456fc7c3b00c40",
       "version": "2.0.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -641,7 +641,7 @@
       "port-version": 0
     },
     "basisu": {
-      "baseline": "2.0.2",
+      "baseline": "2.1.0",
       "port-version": 0
     },
     "bbalouki-itch": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.

See https://github.com/BinomialLLC/basis_universal/releases/tag/v2_1_0