### PR TITLE
[aws-c-io] update to 0.26.2

### DIFF
--- a/ports/aws-c-io/portfile.cmake
+++ b/ports/aws-c-io/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-io
     REF "v${VERSION}"
-    SHA512 32acb55fbee99a0409e65a081a7751898c81b7e4ac6a9643c8a38025114a2eef0377b1adf01774b50a1cf1a1b2b4ad99b353d75f8320ceca81afff8a50a7b120
+    SHA512 5822cffa1fe74b596f68d22df4e8e0b4996753cdd7f00465f0df914cf07e55a1c801fe35369a5aefdde516ada64f89ffc2deb7d7e5dd42edf22ccc13ffcfe4c0
     HEAD_REF master
 )
 

--- a/ports/aws-c-io/vcpkg.json
+++ b/ports/aws-c-io/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-io",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Handles all IO and TLS work for application protocols.",
   "homepage": "https://github.com/awslabs/aws-c-io",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-io.json
+++ b/versions/a-/aws-c-io.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bcfe60b1dd735c427ba8ae095a98ce44566d84d3",
+      "version": "0.26.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "c23f0d36fb17382796601441ec3a30ad1b007846",
       "version": "0.26.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -473,7 +473,7 @@
       "port-version": 0
     },
     "aws-c-io": {
-      "baseline": "0.26.1",
+      "baseline": "0.26.2",
       "port-version": 0
     },
     "aws-c-mqtt": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

