### PR TITLE
[libwebsockets] update to 4.5.7

### DIFF
--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO warmcat/libwebsockets
     REF "v${VERSION}"
-    SHA512 825cd7a9497b48cb50f7570fcc83a8fcaa8afad2b9653e72cb3eeb58583e4a724024fc06fe9f7a9035bdf233f5741bd8e4e0e5da89c5a0bf37b88515af62ab22
+    SHA512 bfb9bfd67cbf7aa146bd9905634aecadb3467f9ba67f8dd284e660a054a5d8d5b0ae4d6a62a86c7b750662abf4a02029ea812185afee7a5868421fb61923bca0
     HEAD_REF master
     PATCHES
         fix-dependency-libuv.patch

--- a/ports/libwebsockets/vcpkg.json
+++ b/ports/libwebsockets/vcpkg.json
@@ -1,17 +1,11 @@
 {
   "name": "libwebsockets",
-  "version-semver": "4.5.4",
+  "version-semver": "4.5.7",
   "description": "Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.",
   "homepage": "https://libwebsockets.org/",
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
-    {
-      "name": "libuv",
-      "platform": "!emscripten"
-    },
-    "openssl",
-    "pthreads",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -19,7 +13,6 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    "zlib"
+    }
   ]
 }

--- a/ports/libwebsockets/vcpkg.json
+++ b/ports/libwebsockets/vcpkg.json
@@ -7,12 +7,19 @@
   "supports": "!uwp",
   "dependencies": [
     {
+      "name": "libuv",
+      "platform": "!emscripten"
+    },
+    "openssl",
+    "pthreads",
+    {
       "name": "vcpkg-cmake",
       "host": true
     },
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
+    "zlib"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5769,7 +5769,7 @@
       "port-version": 2
     },
     "libwebsockets": {
-      "baseline": "4.5.4",
+      "baseline": "4.5.7",
       "port-version": 0
     },
     "libx11": {

--- a/versions/l-/libwebsockets.json
+++ b/versions/l-/libwebsockets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3b91439f02610190fdc8e6c6368b9ac9bb5c4693",
+      "git-tree": "23aaaa1d16de99e3c4f3bad262b2924e1490399e",
       "version-semver": "4.5.7",
       "port-version": 0
     },

--- a/versions/l-/libwebsockets.json
+++ b/versions/l-/libwebsockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3b91439f02610190fdc8e6c6368b9ac9bb5c4693",
+      "version-semver": "4.5.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "a6d41952b9398a450344fe4d7748cc0175728887",
       "version-semver": "4.5.4",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

