### PR TITLE
[nuklear] update to 4.13.2

### DIFF
--- a/ports/nuklear/portfile.cmake
+++ b/ports/nuklear/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Immediate-Mode-UI/Nuklear
     REF "${VERSION}"
-    SHA512 fc3613fc579825d22c103225bcca72d1e9fbb349fe06237e4d77652d7af3293e33e983be03dd4180c93c4c7602a2529c5c1edd87cde3d5efe09ec787818bac48
+    SHA512 d35fb45ad8e940773f402cc6e5a5cb7bd70b61125a5ab057db554d02eeba4c80cdc205fd1a63f3143a9a0c0db55376feb05ada32253e6de6e9559b7f0f6bce34
     HEAD_REF master
 )
 

--- a/ports/nuklear/vcpkg.json
+++ b/ports/nuklear/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.12.8",
+  "version": "4.13.2",
   "description": "This is a minimal state immediate mode graphical user interface toolkit written in ANSI C and licensed under public domain",
   "homepage": "https://github.com/Immediate-Mode-UI/Nuklear",
   "license": "Unlicense OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7005,7 +7005,7 @@
       "port-version": 0
     },
     "nuklear": {
-      "baseline": "4.12.8",
+      "baseline": "4.13.2",
       "port-version": 0
     },
     "numactl": {

--- a/versions/n-/nuklear.json
+++ b/versions/n-/nuklear.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8beeed288dc16bdff63f77a8739c79645f133bda",
+      "version": "4.13.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "e4259b1f7b07c9a766c7501a92df049e6dcfd80a",
       "version": "4.12.8",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/Immediate-Mode-UI/Nuklear/releases/tag/4.13.2
