### PR TITLE
[mbedtls] update to 3.6.5

### DIFF
--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Mbed-TLS/mbedtls
     REF "v${VERSION}"
-    SHA512 67c0ec7824e1ffa3e4f8d02814201776f8c1b2dc0fb8f1f9246495e27a2c03b8c248eff00e8da3e206625b7d0aa82d38cf7ddfd9ed8b4623375b05dc1ecc0677
+    SHA512 d7a1e0098fed7b000ac2e4de31d43f427e8a046aeace91719f58222e1289470e15af5ed2a5390cf3693cf93a1efd79f34de9a6a960dc63cc0fd135072809e6e4
     HEAD_REF development
     PATCHES
         enable-pthread.patch

--- a/ports/mbedtls/vcpkg.json
+++ b/ports/mbedtls/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mbedtls",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "An open source, portable, easy to use, readable and flexible SSL library",
   "homepage": "https://www.trustedfirmware.org/projects/mbed-tls/",
   "license": "Apache-2.0 OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6305,7 +6305,7 @@
       "port-version": 3
     },
     "mbedtls": {
-      "baseline": "3.6.4",
+      "baseline": "3.6.5",
       "port-version": 0
     },
     "mcap": {

--- a/versions/m-/mbedtls.json
+++ b/versions/m-/mbedtls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26a9705b24467d80e1382519bf8721db6702a278",
+      "version": "3.6.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "70ebeccc1908660a6f2afabf001b9790b52482ef",
       "version": "3.6.4",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

