### PR TITLE
[shapelib] Update to 1.6.3

### DIFF
--- a/ports/shapelib/portfile.cmake
+++ b/ports/shapelib/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "http://download.osgeo.org/shapelib/shapelib-${VERSION}.zip"
     FILENAME "shapelib-${VERSION}.zip"
-    SHA512 4f9c33cfce823ad019291eeb6103fdb9495f87a83667a99862544f65dec554975ab5663b37dc6c09eb329a5b73c46ee854b443f17cdc51e7d97ad35558511dc5
+    SHA512 ab3ad775b7f520bc82777c589326e81d5ed94c0661e4573fc3f5095073cb4705a634b07b93295439cf2a107240fb7613c99d32fce5f613f360a9e51c9547cd83
 )
 
 vcpkg_extract_source_archive(

--- a/ports/shapelib/vcpkg.json
+++ b/ports/shapelib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "shapelib",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Shapefile C Library is simple C API for reading and writing ESRI Shapefiles",
   "homepage": "https://download.osgeo.org/shapelib",
   "license": "MIT OR LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9093,7 +9093,7 @@
       "port-version": 1
     },
     "shapelib": {
-      "baseline": "1.6.2",
+      "baseline": "1.6.3",
       "port-version": 0
     },
     "shared-mime-info": {

--- a/versions/s-/shapelib.json
+++ b/versions/s-/shapelib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e773faa1dba1690fd392609a1af055d97785612b",
+      "version": "1.6.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "8e42996cd35d052dc6f3bb6a6665b02adc459684",
       "version": "1.6.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.