### PR TITLE
[New Port] measflow 0.3.1

### DIFF
--- a/ports/measflow/portfile.cmake
+++ b/ports/measflow/portfile.cmake
@@ -1,0 +1,34 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO vreitenbach/MeasFlow
+    REF "v${VERSION}"
+    SHA512 5bf761451cf1996feb3d72dafcdc48557342cecccd4b0ddeddd98ea23be91d148fd981284ae733bcb6c4ed78baf8ec3dee5fc12ccf9ac0a4c99e8713a98f619d
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        lz4   CMAKE_REQUIRE_FIND_PACKAGE_lz4
+        zstd  CMAKE_REQUIRE_FIND_PACKAGE_zstd
+    INVERTED_FEATURES
+        lz4   CMAKE_DISABLE_FIND_PACKAGE_lz4
+        zstd  CMAKE_DISABLE_FIND_PACKAGE_zstd
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/c"
+    OPTIONS
+        -DMEAS_BUILD_TESTS=OFF
+        -DMEAS_BUILD_QUICKSTART=OFF
+        -DMEAS_BUILD_BENCHMARKS=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME measflow CONFIG_PATH lib/cmake/measflow)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/measflow/usage
+++ b/ports/measflow/usage
@@ -1,0 +1,4 @@
+measflow provides CMake targets:
+
+    find_package(measflow CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE measflow::measflow)

--- a/ports/measflow/vcpkg.json
+++ b/ports/measflow/vcpkg.json
@@ -1,0 +1,54 @@
+{
+  "name": "measflow",
+  "version": "0.3.1",
+  "description": "High-performance binary measurement data format — C reader/writer library",
+  "homepage": "https://github.com/vreitenbach/MeasFlow",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "compression"
+  ],
+  "features": {
+    "compression": {
+      "description": "All compression algorithms (LZ4 + Zstd)",
+      "dependencies": [
+        {
+          "name": "measflow",
+          "default-features": false,
+          "features": [
+            "lz4"
+          ]
+        },
+        {
+          "name": "measflow",
+          "default-features": false,
+          "features": [
+            "zstd"
+          ]
+        }
+      ]
+    },
+    "lz4": {
+      "description": "LZ4 compression support for data segments",
+      "dependencies": [
+        "lz4"
+      ]
+    },
+    "zstd": {
+      "description": "Zstd compression support for data segments",
+      "dependencies": [
+        "zstd"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6340,6 +6340,10 @@
       "baseline": "0.6.0",
       "port-version": 0
     },
+    "measflow": {
+      "baseline": "0.3.1",
+      "port-version": 0
+    },
     "mecab": {
       "baseline": "2019-09-25",
       "port-version": 6

--- a/versions/m-/measflow.json
+++ b/versions/m-/measflow.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "1ae31ec23f991caa38e00e722e4b4783886bf7fe",
+      "version": "0.3.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
MeasFlow is a high-performance binary file format for measurement and time-series data. 
Supports streaming writes, per-channel statistics, and optional LZ4/Zstd compression.

- **Source:** https://github.com/vreitenbach/MeasFlow
- **License:** MIT

Features: `lz4`, `zstd`, `compression` (default — enables both)

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port.
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


