### PR TITLE
[libde265] update to 1.0.18

### DIFF
--- a/ports/libde265/fix-interface-include.patch
+++ b/ports/libde265/fix-interface-include.patch
@@ -1,5 +1,5 @@
 diff --git a/libde265/CMakeLists.txt b/libde265/CMakeLists.txt
-index 7d9723d..d090e31 100644
+index 4a65924..02a90de 100644
 --- a/libde265/CMakeLists.txt
 +++ b/libde265/CMakeLists.txt
 @@ -105,7 +105,7 @@ if(HAVE_ARM)
@@ -9,5 +9,5 @@ index 7d9723d..d090e31 100644
 -target_include_directories(de265 PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 +target_include_directories(de265 PRIVATE $<BUILD_INTERFACE:${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}> PUBLIC $<INSTALL_INTERFACE:include>)
  
- write_basic_package_version_file(libde265ConfigVersion.cmake COMPATIBILITY ExactVersion)
+ write_basic_package_version_file(libde265-config-version.cmake COMPATIBILITY ExactVersion)
  

--- a/ports/libde265/fix-interface-include.patch
+++ b/ports/libde265/fix-interface-include.patch
@@ -1,11 +1,11 @@
 diff --git a/libde265/CMakeLists.txt b/libde265/CMakeLists.txt
-index 9fa2837..d17097c 100644
+index 7d9723d..d090e31 100644
 --- a/libde265/CMakeLists.txt
 +++ b/libde265/CMakeLists.txt
-@@ -123,7 +123,7 @@ endif()
+@@ -105,7 +105,7 @@ if(HAVE_ARM)
+ endif()
  
- add_library(de265 ${libde265_sources} ${libde265_public_headers} ${ENCODER_OBJECTS} ${X86_OBJECTS})
- target_link_libraries(de265 PRIVATE Threads::Threads)
+ add_library(de265 ${libde265_sources} ${libde265_public_headers} ${ENCODER_OBJECTS} ${X86_OBJECTS} ${ARM_OBJECTS})
 -target_include_directories(de265 PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 +target_include_directories(de265 PRIVATE $<BUILD_INTERFACE:${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}> PUBLIC $<INSTALL_INTERFACE:include>)
  

--- a/ports/libde265/pkgconfig-cxx-linkage.diff
+++ b/ports/libde265/pkgconfig-cxx-linkage.diff
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4da9921..14cef0d 100644
+index 795b6c7..a4ae189 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -44,13 +44,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
-   add_definitions(-Wall)
+@@ -118,13 +118,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
+   add_definitions(-Wall -Werror=return-type -Werror=unused-result -Werror=reorder)
  endif()
  
 -include(CheckCXXSymbolExists)
@@ -24,5 +24,5 @@ index 4da9921..14cef0d 100644
 +  endif()
 +endforeach()
  
- option(BUILD_SHARED_LIBS "Build shared library" ON)
- if(NOT BUILD_SHARED_LIBS)
+ configure_file (libde265.pc.in libde265.pc @ONLY)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libde265.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/ports/libde265/pkgconfig-cxx-linkage.diff
+++ b/ports/libde265/pkgconfig-cxx-linkage.diff
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 795b6c7..a4ae189 100644
+index 684aa1a..a12fae2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -118,13 +118,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
+@@ -119,13 +119,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
    add_definitions(-Wall -Werror=return-type -Werror=unused-result -Werror=reorder)
  endif()
  
@@ -24,5 +24,5 @@ index 795b6c7..a4ae189 100644
 +  endif()
 +endforeach()
  
- configure_file (libde265.pc.in libde265.pc @ONLY)
- install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libde265.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ 
+ option(BUILD_SHARED_LIBS "Build shared library" ON)

--- a/ports/libde265/portfile.cmake
+++ b/ports/libde265/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO strukturag/libde265
     REF "v${VERSION}"
-    SHA512 280bd1437505f70b2e014caaa06c145e08b015dbc8d8de2ddae44aafe8f03b54ebf72dc818d11ea513108f21bf297fd7485470eba5fd6792c3fa964adc69156f
+    SHA512 111b85ea9f92cc4a93f1022fc8ac17ef436f9c32698842f041b18ccc382306fbcb5102d44966b059a750bf380c3aeba5dc5124716f253340d91cf9713f90552d
     HEAD_REF master
     PATCHES
         fix-interface-include.patch

--- a/ports/libde265/portfile.cmake
+++ b/ports/libde265/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO strukturag/libde265
     REF "v${VERSION}"
-    SHA512 bda239b4827c81552855dc540724b74c86f6b02bcd0fe556650bc16d665a8eed1ddbde76ac0972d26b3002b14575bb9b6f70b367c39eb7de45c5c9df324e3d05
+    SHA512 280bd1437505f70b2e014caaa06c145e08b015dbc8d8de2ddae44aafe8f03b54ebf72dc818d11ea513108f21bf297fd7485470eba5fd6792c3fa964adc69156f
     HEAD_REF master
     PATCHES
         fix-interface-include.patch

--- a/ports/libde265/vcpkg.json
+++ b/ports/libde265/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libde265",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Open h.265 video codec implementation.",
   "homepage": "https://www.libde265.org/",
   "license": "LGPL-3.0-only",

--- a/ports/libde265/vcpkg.json
+++ b/ports/libde265/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libde265",
-  "version": "1.0.16",
-  "port-version": 1,
+  "version": "1.0.17",
   "description": "Open h.265 video codec implementation.",
   "homepage": "https://www.libde265.org/",
   "license": "LGPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4765,8 +4765,8 @@
       "port-version": 0
     },
     "libde265": {
-      "baseline": "1.0.16",
-      "port-version": 1
+      "baseline": "1.0.17",
+      "port-version": 0
     },
     "libdeflate": {
       "baseline": "1.25",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4765,7 +4765,7 @@
       "port-version": 0
     },
     "libde265": {
-      "baseline": "1.0.17",
+      "baseline": "1.0.18",
       "port-version": 0
     },
     "libdeflate": {

--- a/versions/l-/libde265.json
+++ b/versions/l-/libde265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a6eb6945be9e5e9437d8a53c28f401af213e458a",
+      "version": "1.0.17",
+      "port-version": 0
+    },
+    {
       "git-tree": "48f50bad067ea7eea6d5db8bd58c493f4d5de736",
       "version": "1.0.16",
       "port-version": 1

--- a/versions/l-/libde265.json
+++ b/versions/l-/libde265.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "a6eb6945be9e5e9437d8a53c28f401af213e458a",
-      "version": "1.0.17",
+      "git-tree": "3e4e7c81a77702cb3526b4fb6a852dc5d41c402b",
+      "version": "1.0.18",
       "port-version": 0
     },
     {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/strukturag/libde265/releases/tag/v1.0.17
