### PR TITLE
[wt] update to 4.12.6

### DIFF
--- a/ports/wt/portfile.cmake
+++ b/ports/wt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO emweb/wt
     REF "${VERSION}"
-    SHA512 d150d16eb5a464153436efdf970500c57122c7910faae3c35580026f7c78edfa32ac96c21a9e53cac6103b6f54d36f2baea295187f3026c4efe42d4e6fcb0afc
+    SHA512 2c2b746a8253d2a27efed18d908fa8e41ad1014c369b54a7cbe26f6a8a5dbd43902eb2aba99410ee63b858a8c752239f0f1a5d90bfb166e77796e7b6fc0aa960
     HEAD_REF master
     PATCHES
         0005-XML_file_path.patch

--- a/ports/wt/vcpkg.json
+++ b/ports/wt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wt",
-  "version": "4.12.5",
+  "version": "4.12.6",
   "description": "Wt is a C++ library for developing web applications",
   "homepage": "https://github.com/emweb/wt",
   "license": "GPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10769,7 +10769,7 @@
       "port-version": 0
     },
     "wt": {
-      "baseline": "4.12.5",
+      "baseline": "4.12.6",
       "port-version": 0
     },
     "wtl": {

--- a/versions/w-/wt.json
+++ b/versions/w-/wt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00b2679a990c51d6e7416709fb67356b3e93c86f",
+      "version": "4.12.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "73c8ac1fb32369910f81f6b6a236e5da29027bf6",
       "version": "4.12.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/emweb/wt/releases/tag/4.12.6
