### PR TITLE
[thorvg] Fix linkage

### DIFF
--- a/ports/thorvg/portfile.cmake
+++ b/ports/thorvg/portfile.cmake
@@ -6,12 +6,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    list(APPEND BUILD_OPTIONS -Dstatic=true)
-else()
-    list(APPEND BUILD_OPTIONS -Dstatic=false)
-endif()
-
 if ("tools" IN_LIST FEATURES)
     list(APPEND BUILD_OPTIONS -Dtools=all)
 endif()
@@ -21,10 +15,11 @@ vcpkg_configure_meson(
     OPTIONS
         ${BUILD_OPTIONS}
         # see ${SOURCE_PATH}/meson_options.txt
+        -Dstatic=true # Use static modules
         -Dengines=['sw']
         -Dloaders=all
         -Dsavers=all
-        -Dsimd=false # The reason for setting 'Dsimd=false' was that the creator said a false setting was necessary
+        -Dsimd=true
         -Dbindings=capi
         -Dtests=false
         -Dstrip=false
@@ -37,6 +32,12 @@ vcpkg_configure_meson(
 )
 vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/thorvg-1/thorvg.h" "#ifndef TVG_STATIC" "#if 0")
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/thorvg-1/thorvg.h" "#ifndef TVG_STATIC" "#if 1")
+endif()
 
 if ("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES tvg-svg2png tvg-lottie2gif AUTO_CLEAN)

--- a/ports/thorvg/vcpkg.json
+++ b/ports/thorvg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "thorvg",
   "version": "1.0.2",
+  "port-version": 1,
   "description": "ThorVG is a platform-independent portable library for drawing vector-based scenes and animations",
   "homepage": "https://www.thorvg.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9882,7 +9882,7 @@
     },
     "thorvg": {
       "baseline": "1.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "threadpool": {
       "baseline": "0.2.5",

--- a/versions/t-/thorvg.json
+++ b/versions/t-/thorvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a079f4231413d8f6281ebd101aa45ff5e31a5ac1",
+      "version": "1.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "d27bbcea31b55d7b085cb71ade1809fbd67c2394",
       "version": "1.0.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

The `static` option has nothing to do with `VCPKG_LIBRARY_LINKAGE`.

`VCPKG_LIBRARY_LINKAGE` has been correctly converted to the `default_library` option in `vcpkg-tool-meson`.

When the `static` option is enabled, it means that the built-in loaders are statically linked, and no third-party dependencies.
When the `static` option is disabled, it means link to third-party libraries, such as `libturbojpeg`.

