### PR TITLE
[htslib] switch to vcpkg-make

### DIFF
--- a/ports/htslib/portfile.cmake
+++ b/ports/htslib/portfile.cmake
@@ -31,8 +31,8 @@ else()
     list(APPEND FEATURE_OPTIONS "--without-libdeflate")
 endif()
 
-vcpkg_configure_make(
-    AUTOCONFIG
+vcpkg_make_configure(
+    AUTORECONF
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         --with-external-htscodecs
@@ -43,7 +43,7 @@ vcpkg_configure_make(
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_make(
+vcpkg_make_install(
     INSTALL_TARGET install-${VCPKG_LIBRARY_LINKAGE}
 )
 

--- a/ports/htslib/vcpkg.json
+++ b/ports/htslib/vcpkg.json
@@ -1,12 +1,17 @@
 {
   "name": "htslib",
   "version": "1.23.1",
+  "port-version": 1,
   "description": "C library for high-throughput sequencing data formats",
   "homepage": "https://github.com/samtools/htslib",
   "license": "MIT",
   "supports": "!windows",
   "dependencies": [
     "htscodecs",
+    {
+      "name": "vcpkg-make",
+      "host": true
+    },
     "zlib"
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3834,7 +3834,7 @@
     },
     "htslib": {
       "baseline": "1.23.1",
-      "port-version": 0
+      "port-version": 1
     },
     "http-parser": {
       "baseline": "2.9.4",

--- a/versions/h-/htslib.json
+++ b/versions/h-/htslib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b6f5b872de3fcb3332625a0c49beec16f698e05",
+      "version": "1.23.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "e816c278c782488050f25e0079e9d9dcd15c1deb",
       "version": "1.23.1",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
