### PR TITLE
[wolfssl] update to 5.9.0

### DIFF
--- a/ports/wolfssl/portfile.cmake
+++ b/ports/wolfssl/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfssl/wolfssl
     REF "v${VERSION}-stable"
-    SHA512 6f191c218b270bd4dc90d6f07a80416e6bc8d049f3f49ea84c38a2af40ae9588a4fe306860fbb8696c5af15c4ca359818e3955069389d33269eee0101c270439
+    SHA512 d6553d5cbd4ca11de31afeda6640fe6ff1cb520e68f1d5e975c955ca01ef125ff29065ac1b4f2b5ffa9364713d34545782b3921c8f6c065165a6f4e8b712036b
     HEAD_REF master
     PATCHES
         have-limits-h.diff

--- a/ports/wolfssl/vcpkg.json
+++ b/ports/wolfssl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "wolfssl",
-  "version": "5.8.4",
-  "port-version": 2,
+  "version": "5.9.0",
   "description": "TLS and Cryptographic library for many platforms",
   "homepage": "https://wolfssl.com",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10741,8 +10741,8 @@
       "port-version": 0
     },
     "wolfssl": {
-      "baseline": "5.8.4",
-      "port-version": 2
+      "baseline": "5.9.0",
+      "port-version": 0
     },
     "wolftpm": {
       "baseline": "3.10.0",

--- a/versions/w-/wolfssl.json
+++ b/versions/w-/wolfssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96cd7ce903cd52120aca2a3f3ef608afc71f18bb",
+      "version": "5.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4bf11023b3b64a5202cfba5a2f129f8368a6ae69",
       "version": "5.8.4",
       "port-version": 2


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

