### PR TITLE
[quran] Add new port

### DIFF
--- a/ports/quran/portfile.cmake
+++ b/ports/quran/portfile.cmake
@@ -1,0 +1,42 @@
+# portfile.cmake for quran
+# This port builds libquran from a source archive.
+
+# HEAD_REF is the branch name used when installing with --head
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO SENODROOM/libquran
+    REF "v${VERSION}"
+    SHA512 a906c9734162dddb3af69949e88547d45cc4ebc079c6535cf6568741b034e2fbdbb5a34fffbcacfaa3fded1c42a90bdbdf72ee7ac547107e0d979f3b8a9b4da1
+    HEAD_REF main
+)
+
+# Alternatively, when distributing as a local overlay port with the
+# source bundled alongside, use:
+#
+#   set(SOURCE_PATH "${CMAKE_CURRENT_LIST_DIR}/src")
+#
+# and include the full source tree inside ports/quran/src/.
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DQURAN_BUILD_TESTS=OFF
+        -DQURAN_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME quran
+    CONFIG_PATH  lib/cmake/quran
+)
+
+# Remove duplicate includes installed under debug
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# Install the license
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+# Validate
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/quran/portfile.cmake
+++ b/ports/quran/portfile.cmake
@@ -1,7 +1,3 @@
-# portfile.cmake for quran
-# This port builds libquran from a source archive.
-
-# HEAD_REF is the branch name used when installing with --head
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SENODROOM/libquran
@@ -10,18 +6,14 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-# Alternatively, when distributing as a local overlay port with the
-# source bundled alongside, use:
-#
-#   set(SOURCE_PATH "${CMAKE_CURRENT_LIST_DIR}/src")
-#
-# and include the full source tree inside ports/quran/src/.
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DQURAN_BUILD_TESTS=OFF
         -DQURAN_BUILD_EXAMPLES=OFF
+        -DBUILD_SHARED_LIBS=OFF
 )
 
 vcpkg_cmake_install()
@@ -31,12 +23,10 @@ vcpkg_cmake_config_fixup(
     CONFIG_PATH  lib/cmake/quran
 )
 
-# Remove duplicate includes installed under debug
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Install the license
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
-# Validate
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/quran/usage
+++ b/ports/quran/usage
@@ -1,0 +1,15 @@
+quran provides CMake integration:
+
+  find_package(quran CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE quran::quran)
+
+Then in your C or C++ source:
+
+  #include <quran.h>
+
+  int main(void) {
+      quran_init();
+      const QuranVerse *v = quran_get_ayah(1, 1);
+      printf("%s\n", v->english);
+      quran_cleanup();
+  }

--- a/ports/quran/vcpkg.json
+++ b/ports/quran/vcpkg.json
@@ -6,7 +6,13 @@
   "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
-    { "name": "vcpkg-cmake", "host": true },
-    { "name": "vcpkg-cmake-config", "host": true }
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/quran/vcpkg.json
+++ b/ports/quran/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "quran",
+  "version": "1.0.0",
+  "description": "A pure C library providing fast access to the Holy Quran — 114 Surahs, 6236 Ayahs with Arabic text and English translation. Supports full-text search, surah/ayah lookup, iteration, statistics, and more. Usable from both C and C++.",
+  "homepage": "https://github.com/SENODROOM/libquran",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    { "name": "vcpkg-cmake", "host": true },
+    { "name": "vcpkg-cmake-config", "host": true }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8452,6 +8452,10 @@
       "baseline": "1.2",
       "port-version": 0
     },
+    "quran": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "qwt": {
       "baseline": "6.3.0",
       "port-version": 1

--- a/versions/q-/quran.json
+++ b/versions/q-/quran.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ea61510bc6349173984e9a0f32d2ecb56705d52b",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/q-/quran.json
+++ b/versions/q-/quran.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ea61510bc6349173984e9a0f32d2ecb56705d52b",
+      "git-tree": "8dca32530e86c7b7b89e8c8a2770439d1bb63ffb",
       "version": "1.0.0",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

