### PR TITLE
[crashcatch] Add new port

### DIFF
--- a/ports/crashcatch/fix-disable-examples-tests.patch
+++ b/ports/crashcatch/fix-disable-examples-tests.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7979fae..5d98d0f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,6 +4,9 @@ project(CrashCatchExamples VERSION 1.4.0 LANGUAGES CXX)
+ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ 
++option(CRASHCATCH_BUILD_EXAMPLES "Build example programs" OFF)
++option(CRASHCATCH_BUILD_TESTS "Build test programs" OFF)
++
+ # === Detect Platform & Set Platform Libraries ===
+ if(WIN32)
+     message(STATUS "Target platform: Windows")
+@@ -55,6 +58,7 @@ install(FILES
+     DESTINATION lib/cmake/CrashCatch
+ )
+ 
++if(CRASHCATCH_BUILD_EXAMPLES)
+ # === Examples ===
+ add_executable(Example_ZeroConfig examples/Example_ZeroConfig.cpp)
+ target_link_libraries(Example_ZeroConfig PRIVATE CrashCatch)
+@@ -79,11 +83,13 @@ target_link_libraries(Example_StackTrace PRIVATE CrashCatch)
+ 
+ add_executable(Example_UploadCrash examples/Example_UploadCrash.cpp)
+ target_link_libraries(Example_UploadCrash PRIVATE CrashCatch)
++endif()
+ 
++if(CRASHCATCH_BUILD_TESTS)
+ # === Tests ===
+ add_executable(test_callback_order tests/test_callback_order.cpp)
+ target_link_libraries(test_callback_order PRIVATE CrashCatch)
+ 
+ add_executable(test_stack_context tests/test_stack_context.cpp)
+ target_link_libraries(test_stack_context PRIVATE CrashCatch)
+-
++endif()

--- a/ports/crashcatch/portfile.cmake
+++ b/ports/crashcatch/portfile.cmake
@@ -20,13 +20,6 @@ vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/CrashCatch
 )
 
-# Header-only: no debug artifacts
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug/include"
-    "${CURRENT_PACKAGES_DIR}/debug/share"
-    "${CURRENT_PACKAGES_DIR}/debug"
-)
-
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"

--- a/ports/crashcatch/portfile.cmake
+++ b/ports/crashcatch/portfile.cmake
@@ -29,8 +29,5 @@ file(REMOVE_RECURSE
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
-configure_file(
-    "${CMAKE_CURRENT_LIST_DIR}/usage"
-    "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage"
-    COPYONLY
-)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage")

--- a/ports/crashcatch/portfile.cmake
+++ b/ports/crashcatch/portfile.cmake
@@ -1,0 +1,36 @@
+# CrashCatch is a header-only library — no compilation required.
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO keithpotz/CrashCatch
+    REF "v${VERSION}"
+    SHA512 ba3f431b1c1da9f8ead4038ff8073df3010394ce84a6976ba6b9e9f50842a3aacb367b443a92fef75317ee49cf08384a39d76b944bf1e2735d3e2a3647c63f01
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME CrashCatch
+    CONFIG_PATH lib/cmake/CrashCatch
+)
+
+# Header-only: no debug artifacts
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+configure_file(
+    "${CMAKE_CURRENT_LIST_DIR}/usage"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage"
+    COPYONLY
+)

--- a/ports/crashcatch/portfile.cmake
+++ b/ports/crashcatch/portfile.cmake
@@ -19,4 +19,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/CrashCatch")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage")
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/crashcatch/portfile.cmake
+++ b/ports/crashcatch/portfile.cmake
@@ -14,11 +14,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-
-vcpkg_cmake_config_fixup(
-    PACKAGE_NAME CrashCatch
-    CONFIG_PATH lib/cmake/CrashCatch
-)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/CrashCatch")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 

--- a/ports/crashcatch/portfile.cmake
+++ b/ports/crashcatch/portfile.cmake
@@ -1,5 +1,4 @@
-# CrashCatch is a header-only library — no compilation required.
-set(VCPKG_BUILD_TYPE release)
+set(VCPKG_BUILD_TYPE release) # header-only library
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -7,16 +6,21 @@ vcpkg_from_github(
     REF "v${VERSION}"
     SHA512 ba3f431b1c1da9f8ead4038ff8073df3010394ce84a6976ba6b9e9f50842a3aacb367b443a92fef75317ee49cf08384a39d76b944bf1e2735d3e2a3647c63f01
     HEAD_REF main
+    PATCHES
+        fix-disable-examples-tests.patch
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCRASHCATCH_BUILD_EXAMPLES=OFF
+        -DCRASHCATCH_BUILD_TESTS=OFF
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/CrashCatch")
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
-     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/crashcatch/usage
+++ b/ports/crashcatch/usage
@@ -1,0 +1,15 @@
+CrashCatch is a header-only library with CMake integration.
+
+In your CMakeLists.txt:
+
+    find_package(CrashCatch CONFIG REQUIRED)
+    target_link_libraries(my_target PRIVATE CrashCatch::CrashCatch)
+
+Then in your code:
+
+    #include <CrashCatch.hpp>
+
+    int main() {
+        CrashCatch::enable();
+        // your application code
+    }

--- a/ports/crashcatch/usage
+++ b/ports/crashcatch/usage
@@ -4,12 +4,3 @@ In your CMakeLists.txt:
 
     find_package(CrashCatch CONFIG REQUIRED)
     target_link_libraries(my_target PRIVATE CrashCatch::CrashCatch)
-
-Then in your code:
-
-    #include <CrashCatch.hpp>
-
-    int main() {
-        CrashCatch::enable();
-        // your application code
-    }

--- a/ports/crashcatch/usage
+++ b/ports/crashcatch/usage
@@ -1,6 +1,4 @@
-CrashCatch is a header-only library with CMake integration.
+CrashCatch provides CMake targets:
 
-In your CMakeLists.txt:
-
-    find_package(CrashCatch CONFIG REQUIRED)
-    target_link_libraries(my_target PRIVATE CrashCatch::CrashCatch)
+  find_package(CrashCatch CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE CrashCatch::CrashCatch)

--- a/ports/crashcatch/usage
+++ b/ports/crashcatch/usage
@@ -1,4 +1,0 @@
-CrashCatch provides CMake targets:
-
-  find_package(CrashCatch CONFIG REQUIRED)
-  target_link_libraries(main PRIVATE CrashCatch::CrashCatch)

--- a/ports/crashcatch/vcpkg.json
+++ b/ports/crashcatch/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "crashcatch",
   "version": "1.4.0",
+  "port-version": 1,
   "description": "A cross-platform, single-header C++ crash-reporting library for modern C++ applications.",
   "homepage": "https://github.com/keithpotz/CrashCatch",
   "license": "MIT",

--- a/ports/crashcatch/vcpkg.json
+++ b/ports/crashcatch/vcpkg.json
@@ -3,5 +3,15 @@
   "version": "1.4.0",
   "description": "A cross-platform, single-header C++ crash-reporting library for modern C++ applications.",
   "homepage": "https://github.com/keithpotz/CrashCatch",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/crashcatch/vcpkg.json
+++ b/ports/crashcatch/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "crashcatch",
+  "version": "1.4.0",
+  "description": "A cross-platform, single-header C++ crash-reporting library for modern C++ applications.",
+  "homepage": "https://github.com/keithpotz/CrashCatch",
+  "license": "MIT"
+}

--- a/ports/crashcatch/vcpkg.json
+++ b/ports/crashcatch/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "crashcatch",
   "version": "1.4.0",
-  "port-version": 2,
   "description": "A cross-platform, single-header C++ crash-reporting library for modern C++ applications.",
   "homepage": "https://github.com/keithpotz/CrashCatch",
   "license": "MIT",

--- a/ports/crashcatch/vcpkg.json
+++ b/ports/crashcatch/vcpkg.json
@@ -15,14 +15,4 @@
       "host": true
     }
   ]
-  "dependencies": [
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    }
-  ]
 }

--- a/ports/crashcatch/vcpkg.json
+++ b/ports/crashcatch/vcpkg.json
@@ -15,4 +15,14 @@
       "host": true
     }
   ]
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/crashcatch/vcpkg.json
+++ b/ports/crashcatch/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "crashcatch",
   "version": "1.4.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A cross-platform, single-header C++ crash-reporting library for modern C++ applications.",
   "homepage": "https://github.com/keithpotz/CrashCatch",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2178,7 +2178,7 @@
     },
     "crashcatch": {
       "baseline": "1.4.0",
-      "port-version": 1
+      "port-version": 0
     },
     "crashpad": {
       "baseline": "2024-04-11",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2176,6 +2176,10 @@
       "baseline": "2020-04-26",
       "port-version": 2
     },
+    "crashcatch": {
+      "baseline": "1.4.0",
+      "port-version": 0
+    },
     "crashpad": {
       "baseline": "2024-04-11",
       "port-version": 10

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2178,7 +2178,7 @@
     },
     "crashcatch": {
       "baseline": "1.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "crashpad": {
       "baseline": "2024-04-11",

--- a/versions/c-/crashcatch.json
+++ b/versions/c-/crashcatch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22478f6411ab2bbaab91dcf5dba590d9ca9a4c5b",
+      "version": "1.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "34ffb79ad4a284efed3a86096c577877202ad227",
       "version": "1.4.0",
       "port-version": 0

--- a/versions/c-/crashcatch.json
+++ b/versions/c-/crashcatch.json
@@ -1,12 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "22478f6411ab2bbaab91dcf5dba590d9ca9a4c5b",
-      "version": "1.4.0",
-      "port-version": 1
-    },
-    {
-      "git-tree": "34ffb79ad4a284efed3a86096c577877202ad227",
+      "git-tree": "2464eeb999b21bede961631b77618c626daef525",
       "version": "1.4.0",
       "port-version": 0
     }

--- a/versions/c-/crashcatch.json
+++ b/versions/c-/crashcatch.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "34ffb79ad4a284efed3a86096c577877202ad227",
+      "version": "1.4.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/c-/crashcatch.json
+++ b/versions/c-/crashcatch.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2464eeb999b21bede961631b77618c626daef525",
+      "git-tree": "d2d98d530427d030b94cf84bd19eb81f2e113dab",
       "version": "1.4.0",
       "port-version": 0
     }


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

## Description

Adds CrashCatch v1.4.0 a cross-platform, single-header C++ crash-reporting libary.

- Header-only, no external dependencies
- Windows: SetUnhandledExceptionFilter + MiniDump + StackWalk64
- Linux: POSIX signal handling + backtrace + fork()-based async-signal-safe handler
- MIT license

## Details

- Homepage: https://github.com/keithpotz/CrrashCatch
-  Port-type: header-only 

--- 

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [x] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
