### PR TITLE
[wolfssl] Update to version 5.9.0

### DIFF
--- a/ports/wolfssl/portfile.cmake
+++ b/ports/wolfssl/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfssl/wolfssl
     REF "v${VERSION}-stable"
-    SHA512 6f191c218b270bd4dc90d6f07a80416e6bc8d049f3f49ea84c38a2af40ae9588a4fe306860fbb8696c5af15c4ca359818e3955069389d33269eee0101c270439
+    SHA512 d6553d5cbd4ca11de31afeda6640fe6ff1cb520e68f1d5e975c955ca01ef125ff29065ac1b4f2b5ffa9364713d34545782b3921c8f6c065165a6f4e8b712036b
     HEAD_REF master
     PATCHES
         have-limits-h.diff

--- a/ports/wolfssl/vcpkg.json
+++ b/ports/wolfssl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "wolfssl",
-  "version": "5.8.4",
-  "port-version": 2,
+  "version": "5.9.0",
   "description": "TLS and Cryptographic library for many platforms",
   "homepage": "https://wolfssl.com",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10765,8 +10765,8 @@
       "port-version": 0
     },
     "wolfssl": {
-      "baseline": "5.8.4",
-      "port-version": 2
+      "baseline": "5.9.0",
+      "port-version": 0
     },
     "wolftpm": {
       "baseline": "3.10.0",

--- a/versions/w-/wolfssl.json
+++ b/versions/w-/wolfssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96cd7ce903cd52120aca2a3f3ef608afc71f18bb",
+      "version": "5.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4bf11023b3b64a5202cfba5a2f129f8368a6ae69",
       "version": "5.8.4",
       "port-version": 2


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.


<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
