### PR TITLE
[babl] Update to 0.1.124

### DIFF
--- a/ports/babl/portfile.cmake
+++ b/ports/babl/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.gimp.org/pub/babl/${VERSION_MAJOR_MINOR}/babl-${VERSION}.tar.xz"
     FILENAME "babl-${VERSION}.tar.xz"
-    SHA512 061b8d62a618129c9f08fc04ca1e86145873cf15fcde643be60b52393316275ca6d98bb44ac86b7b26264bc3a9b2fd54db39d78b2b56fe069daf678b28ded59f
+    SHA512 8e0199444e375c54e6723a5414a0e75874d11ba778d2c9c833f16b79f0634e900f82c2cf8d01b7e33ca609b6273873acf138d84778ba181b88ca50e1368c5ace
 )
 
 vcpkg_extract_source_archive(

--- a/ports/babl/remove-consistency-check.patch
+++ b/ports/babl/remove-consistency-check.patch
@@ -1,13 +1,13 @@
 diff --git a/meson.build b/meson.build
-index 8206d36..095e024 100644
+index e5f9523..f974871 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -578,7 +578,7 @@ if build_docs
+@@ -574,7 +574,7 @@ if build_docs
  endif
  subdir('bin')
  
--if not platform_win32 and not platform_osx
+-if not platform_osx and host_cpu_family != 'x86'
 +if false
-   # Verify .def files for Windows.
-   # Ironically we only check this on non-Windows platform, since the
-   # script expects .so libraries, and I'm not sure that the `nm` tool is
+   # Verify .def files for Windows linking.
+   # We check this on non-Windows platform  on CI, and on Windows itself.
+   custom_target('check-def-files',

--- a/ports/babl/vcpkg.json
+++ b/ports/babl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "babl",
-  "version": "0.1.122",
+  "version": "0.1.124",
   "description": "A pixel encoding and color space conversion engine.",
   "homepage": "https://gegl.org/babl/",
   "license": "LGPL-3.0-or-later",

--- a/versions/b-/babl.json
+++ b/versions/b-/babl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "712240fb456214b23808542557986b3787dcc174",
+      "version": "0.1.124",
+      "port-version": 0
+    },
+    {
       "git-tree": "2584be584510eda360e0266975ee110be259a2a3",
       "version": "0.1.122",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -621,7 +621,7 @@
       "port-version": 2
     },
     "babl": {
-      "baseline": "0.1.122",
+      "baseline": "0.1.124",
       "port-version": 0
     },
     "backward-cpp": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.