### PR TITLE
[gegl] Update to 0.4.68

### DIFF
--- a/ports/gegl/portfile.cmake
+++ b/ports/gegl/portfile.cmake
@@ -3,7 +3,7 @@ string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS https://download.gimp.org/pub/gegl/${VERSION_MAJOR_MINOR}/gegl-${VERSION}.tar.xz
     FILENAME "gegl-${VERSION}.tar.xz"
-    SHA512 ed1f809aaea8768b1eff2a6adcf66b3ef7c11e03d410ef8952051822017f9a6bcee0e29dd32708dd6937d49416c6db55cd8d34458619022ea750311253899ae9
+    SHA512 e13b1885b0cd6aa439cdb7c1d56b81c754d41da1af6ed17eab3e1beb7b7fe74094e0da9d8bacaea9ec5d4ec95eea682cf4764ea828bda4a7d7acec9b273c537e
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gegl/remove-consistency-check.patch
+++ b/ports/gegl/remove-consistency-check.patch
@@ -1,14 +1,13 @@
 diff --git a/meson.build b/meson.build
+index 083bc7afd..a2ecde108 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -664,9 +664,9 @@
- subdir('po')
+@@ -661,7 +661,7 @@ subdir('po')
  subdir('docs')
  
  
--if not os_win32 and not os_osx
+-if not os_osx and host_cpu_family != 'x86'
 +if false
-   # Verify .def files for Windows.
-   # Ironically we only check this on non-Windows platform, since the
-   # script expects .so libraries, and I'm not sure that the `nm` tool is
-   # available on Windows.
+   # Verify .def files for Windows linking.
+   # We check this on non-Windows platform on CI, and on Windows itself.
+   custom_target('check-def-files',

--- a/ports/gegl/vcpkg.json
+++ b/ports/gegl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gegl",
-  "version": "0.4.66",
-  "port-version": 1,
+  "version": "0.4.68",
   "description": "Generic Graphical Library.",
   "homepage": "https://gegl.org/",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3313,8 +3313,8 @@
       "port-version": 6
     },
     "gegl": {
-      "baseline": "0.4.66",
-      "port-version": 1
+      "baseline": "0.4.68",
+      "port-version": 0
     },
     "gemmlowp": {
       "baseline": "2021-09-28",

--- a/versions/g-/gegl.json
+++ b/versions/g-/gegl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b956e19006098c3cc95946dcb8697736daaf3c5b",
+      "version": "0.4.68",
+      "port-version": 0
+    },
+    {
       "git-tree": "0090e814efd26e2ece837a00748aae0e2cf00ee6",
       "version": "0.4.66",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.