### PR TITLE
[gdal] Update to 3.12.3

### DIFF
--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/gdal
     REF "v${VERSION}"
-    SHA512 a16036d4bb4c96bad75830be9a882329a7968621e24a3e28fae1908c2b2ea8e5779df98beaf2ad045f2671cb2688f6592450f9546903662c08cbf5c606a7ceaf
+    SHA512 48b74e9446e48e3a16e0c5cdf6ee137aeb343fe431951fc635debe45ed6ac575d25ed453e50832ff7ced00d1c2f6fb716f55272fe347f53647aae4a721cf02f1
     HEAD_REF master
     PATCHES
         find-link-libraries.patch

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gdal",
-  "version-semver": "3.12.2",
-  "port-version": 1,
+  "version-semver": "3.12.3",
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3297,8 +3297,8 @@
       "port-version": 0
     },
     "gdal": {
-      "baseline": "3.12.2",
-      "port-version": 1
+      "baseline": "3.12.3",
+      "port-version": 0
     },
     "gdbm": {
       "baseline": "1.24",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a6bd9594728015e96a114c21238029a9bd152a54",
+      "version-semver": "3.12.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "f2c770011632b5381fdea24deea51441dee4a391",
       "version-semver": "3.12.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
