### PR TITLE
[aeron] update to 1.50.4

### DIFF
--- a/ports/aeron/portfile.cmake
+++ b/ports/aeron/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aeron-io/aeron
     REF "${VERSION}"
-    SHA512 994356df46953a21728d84fc9425707603e98ea571d559d15100a14b329f505c36eb7d0ada86551fa7cfc8a4bc08af445e438191cd89cb42e6f11bbe8c00007e
+    SHA512 aacd14611acfff3f4890541fbd1f3cdb8b396d86a4e9fb2eb1f4f1a72c9fbe546d2b479ee86b4fe5900b5f3acf6e29d9916364efbe98255baa9cd6c429b057cb
     HEAD_REF master
     PATCHES
         patches/add-libuuid-vcpkg-support.patch

--- a/ports/aeron/vcpkg.json
+++ b/ports/aeron/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "aeron",
-  "version": "1.50.3",
+  "version": "1.50.4",
   "description": "Efficient reliable UDP unicast, UDP multicast, and IPC message transport",
   "homepage": "https://github.com/aeron-io/aeron",
   "license": "Apache-2.0",

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4841039173fdd756d73cb7cc0b095bebe0bfb5ba",
+      "version": "1.50.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "ba695358d7e176a72044321e0fc79bf4c6993755",
       "version": "1.50.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -61,7 +61,7 @@
       "port-version": 0
     },
     "aeron": {
-      "baseline": "1.50.3",
+      "baseline": "1.50.4",
       "port-version": 0
     },
     "air-ctl": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/aeron-io/aeron/releases/tag/1.50.4
