### PR TITLE
[clix] add new port

### DIFF
--- a/ports/clix/portfile.cmake
+++ b/ports/clix/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kkokotero/clix
+    REF v0.1.0
+    SHA512 24b3013cdcce0f484133e559bd7e9269d89c1223bab85efb272064a647c147c84ddad3a1b40664a2c073c1f056d57bfe9d40c735e8414bdaaaacf011a2de2c19
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCLIX_BUILD_EXAMPLES=OFF
+        -DCLIX_BUILD_BENCHMARKS=OFF
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/clix PACKAGE_NAME clix)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/clix/usage
+++ b/ports/clix/usage
@@ -1,0 +1,6 @@
+clix provides CMake package config files.
+
+Use it from CMake like this:
+
+    find_package(clix CONFIG REQUIRED)
+    target_link_libraries(your_target PRIVATE clix::clix)

--- a/ports/clix/vcpkg.json
+++ b/ports/clix/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "clix",
+  "version-semver": "0.1.0",
+  "description": "A modern header-only C++ CLI toolkit with nested commands, validation, config files, env support, and shell completion.",
+  "homepage": "https://github.com/kkokotero/clix",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1836,6 +1836,10 @@
       "baseline": "2.0.1",
       "port-version": 0
     },
+    "clix": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "clockutils": {
       "baseline": "1.1.1",
       "port-version": 4

--- a/versions/c-/clix.json
+++ b/versions/c-/clix.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7e646b6b9418bc02fb51e10ad5bb0a769c1918b9",
+      "version-semver": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## What does your PR fix?
Adds the new `clix` port to the curated vcpkg registry.

## Which triplets are supported/not supported? Have you updated the supports clause?
This port is header-only and platform-agnostic.

## Does your PR follow the vcpkg manifest and versioning conventions?
Yes. The port includes manifest metadata, usage text, and regenerated versions data.

## Validation
- Built and installed locally with `VCPKG_OVERLAY_PORTS=<repo>/ports vcpkg install --x-manifest-root=<temp-dir>`.
- Verified `find_package(clix CONFIG REQUIRED)` and `clix::clix` from a consumer CMake project.
