### PR TITLE
[matio] update to 1.5.30

### DIFF
--- a/ports/matio/portfile.cmake
+++ b/ports/matio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tbeu/matio
     REF "v${VERSION}"
-    SHA512 170a97fa639f16f1290c1fa7b15f4b10296db216a35d901ebd75141c462db9cf4243b4fffa6aa823eed0a33aa8c5a927f562487a1558867c53f11f343d673f10
+    SHA512 22fbc6d9013d0897daaff53bdeddfe224eeea55f5b4991aca655b62a3e6287b654e2bd79fa2a11f1009ca63d36c898ecbdc9a32ae91489a246c823fc89fc8ecc
     HEAD_REF master
     PATCHES
         cmake-config.diff

--- a/ports/matio/vcpkg.json
+++ b/ports/matio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "matio",
-  "version": "1.5.29",
+  "version": "1.5.30",
   "description": "MATLAB MAT File I/O Library",
   "homepage": "https://github.com/tbeu/matio",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6301,7 +6301,7 @@
       "port-version": 0
     },
     "matio": {
-      "baseline": "1.5.29",
+      "baseline": "1.5.30",
       "port-version": 0
     },
     "matplotlib-cpp": {

--- a/versions/m-/matio.json
+++ b/versions/m-/matio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de9b9dbaecf731a5881865069ca03e3a5e209f08",
+      "version": "1.5.30",
+      "port-version": 0
+    },
+    {
       "git-tree": "94836a0a5609ab334bcdb6a158c83e9ec621e6fc",
       "version": "1.5.29",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

