### PR TITLE
[trantor] spdlog feature added

### DIFF
--- a/ports/trantor/portfile.cmake
+++ b/ports/trantor/portfile.cmake
@@ -9,8 +9,17 @@ vcpkg_from_github(
         001-disable-werror.patch
 )
 
+set(feature_options)
+if("spdlog" IN_LIST FEATURES)
+    list(APPEND feature_options "-DUSE_SPDLOG=ON")
+else()
+    list(APPEND feature_options "-DUSE_SPDLOG=OFF")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${feature_options}
 )
 
 vcpkg_cmake_install()

--- a/ports/trantor/vcpkg.json
+++ b/ports/trantor/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "trantor",
   "version-semver": "1.5.26",
+  "port-version": 1,
   "description": "A non-blocking I/O cross-platform TCP network library, using C++14",
   "homepage": "https://github.com/an-tao/trantor",
   "license": "BSD-2-Clause",
@@ -15,5 +16,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "spdlog": {
+      "description": "Enable spdlog support in trantor Logger",
+      "dependencies": [
+        "spdlog"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10090,7 +10090,7 @@
     },
     "trantor": {
       "baseline": "1.5.26",
-      "port-version": 0
+      "port-version": 1
     },
     "tre": {
       "baseline": "0.8.0",

--- a/versions/t-/trantor.json
+++ b/versions/t-/trantor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c5f490cbc684ee7794ada83ee786fa49cee7e43e",
+      "version-semver": "1.5.26",
+      "port-version": 1
+    },
+    {
       "git-tree": "9fba5fa2a56822dcaedc7e9813356635a53c28e4",
       "version-semver": "1.5.26",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.

Add only spdlog feature to trantor.