### PR TITLE
[jsoncons] update to 1.6.0

### DIFF
--- a/ports/jsoncons/portfile.cmake
+++ b/ports/jsoncons/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO danielaparker/jsoncons
     REF v${VERSION}
-    SHA512 ce4ff8aaf31ad781e5caaf27172c867a8009bcc322dee5e34c6815434dbb234bf0d22ee9caa82c0ee1a9b25f3355da4363b5d663fded46a9ffc58ca802dad4ae
+    SHA512 3424c425414b7bdbf01f1b1e3e727ff319d490105f0aa6caf7766461b5320f63133fbc492c40cc354476e27fdfb503bdbc567c25859d493506aefa5f95f9e592
     HEAD_REF master
 )
 

--- a/ports/jsoncons/vcpkg.json
+++ b/ports/jsoncons/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jsoncons",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A C++, header-only library for constructing JSON and JSON-like text and binary data formats, with JSON Pointer, JSON Patch, JSON Schema, JSONPath, JMESPath, CSV, MessagePack, CBOR, BSON, UBJSON",
   "homepage": "https://github.com/danielaparker/jsoncons",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4157,7 +4157,7 @@
       "port-version": 7
     },
     "jsoncons": {
-      "baseline": "1.5.0",
+      "baseline": "1.6.0",
       "port-version": 0
     },
     "jsoncpp": {

--- a/versions/j-/jsoncons.json
+++ b/versions/j-/jsoncons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6c3e09965a51c9fe66b816cf88e0979851fdfcb9",
+      "version": "1.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d8f729702dbf8e87bb20b385d360dd13e45ee008",
       "version": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/danielaparker/jsoncons/releases/tag/v1.6.0
