### PR TITLE
[appstream] update to 1.1.2

### DIFF
--- a/ports/appstream/portfile.cmake
+++ b/ports/appstream/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ximion/appstream
     REF "v${VERSION}"
-    SHA512 80f3b7b9279152ce271bab61e97a41268d5dc5d977dc9488fc187df90077ac1a81169201d3d1a7a5578d36e962321035bfe34106486c2ac3d684621b40338de6
+    SHA512 2e673af579107603458cf09086ffc8cb488aa4ab24d248c7774b8b6d8e690aac49b2c5ddda56533b179e017f54fa4598ebae5bb7cb3073b3f03149700a7db9ac
     HEAD_REF main
     PATCHES
       remove-uneeded-directories.patch

--- a/ports/appstream/vcpkg.json
+++ b/ports/appstream/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "appstream",
-  "version": "1.0.6",
-  "port-version": 1,
+  "version": "1.1.2",
   "description": "Tools and libraries to work with AppStream metadata",
   "homepage": "https://www.freedesktop.org/software/appstream/docs",
   "license": "LGPL-2.1-or-later",

--- a/versions/a-/appstream.json
+++ b/versions/a-/appstream.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "993a05545d34d13ac63c7116fabaa95776917f1b",
+      "version": "1.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ec534369136985b55e67821d956d3c8934ca9035",
       "version": "1.0.6",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -189,8 +189,8 @@
       "port-version": 0
     },
     "appstream": {
-      "baseline": "1.0.6",
-      "port-version": 1
+      "baseline": "1.1.2",
+      "port-version": 0
     },
     "appstream-glib": {
       "baseline": "0.8.3",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

