### PR TITLE
[audit] update to 4.1.4

### DIFF
--- a/ports/audit/portfile.cmake
+++ b/ports/audit/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO linux-audit/audit-userspace
-    SHA512 4ebdfaebb89440bd76d1f715aa9f2f261b453f51c66ae9c4c7ad650cd361268fe2415c33fe7913ec4986d98ccbd457e15734d0aae606b5dccf316b66276a13cb
+    SHA512 e5493f434dddbded65f33bfd56981036af6975c192289a05378d773ce914ab3ffe6b7071cae03e8f69da4e33246a38608d848f64d01647f2572a7eb6651f3ba0
     REF "v${VERSION}"
     HEAD_REF master
 )

--- a/ports/audit/vcpkg.json
+++ b/ports/audit/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "audit",
-  "version": "4.1.3",
-  "port-version": 1,
+  "version": "4.1.4",
   "description": "Library for working with audit subsystem",
   "homepage": "https://github.com/linux-audit/audit-userspace",
   "license": "GPL-2.0-or-later OR LGPL-2.1-or-later",

--- a/versions/a-/audit.json
+++ b/versions/a-/audit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c5d4688a3230573a59f0ad155b4fbb22b9be935",
+      "version": "4.1.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "47e78499832fcefc33777949d86d5042728ac282",
       "version": "4.1.3",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -405,8 +405,8 @@
       "port-version": 0
     },
     "audit": {
-      "baseline": "4.1.3",
-      "port-version": 1
+      "baseline": "4.1.4",
+      "port-version": 0
     },
     "aurora": {
       "baseline": "2017-06-21-c75699d2a8caa726260c29b6d7a0fd35f8f28933",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

