### PR TITLE
[discount] update to 3.0.1.2

### DIFF
--- a/ports/discount/portfile.cmake
+++ b/ports/discount/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Orc/discount
     REF "v${VERSION}"
-    SHA512 ab24722bb8513f64eed59bb2770276b91615033b494a0492a331f36c5fcd2e32b7a9f3bd7ef0bb74c107f1e0e955522c83ddba6c482fca7f18cf275334707c4d
+    SHA512 ca10220e4a4f8cd5c3e849873d24a61f8bcbb85f230fe554537d9cdd4e3d4d23c5f5fbc9c917da379000e331c40473038b481f5ac2db29dfa7011a634526688a
     HEAD_REF master
     PATCHES
       generate-blocktags-command.patch

--- a/ports/discount/vcpkg.json
+++ b/ports/discount/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "discount",
-  "version-string": "3.0.0d",
+  "version-string": "3.0.1.2",
   "description": "DISCOUNT is a implementation of John Gruber & Aaron Swartz's Markdown markup language.",
   "homepage": "https://github.com/Orc/discount",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2525,7 +2525,7 @@
       "port-version": 0
     },
     "discount": {
-      "baseline": "3.0.0d",
+      "baseline": "3.0.1.2",
       "port-version": 0
     },
     "discreture": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

