### PR TITLE
[glslang] update to 16.2.0

### DIFF
--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/glslang
     REF "${VERSION}"
-    SHA512 bcd0604f0a4a1a17ae207b90daeb9031d5c473968d331baf487acbc0f38871a0a82d2b20d274389f9988735e8dcd3fe4d2c2bd1513c77d031c8253c66424dbc4
+    SHA512 68b00bb3c84e5ecfa1ca2ba50bf1bd3e9fe6e04ffb09fbfbd54274e9eea5c3aa5ea8d229fcd834f92d6dd11c52c77264ceb80b8461591eb4b062bf87aa7f0619
     HEAD_REF master
 )
 

--- a/ports/glslang/vcpkg.json
+++ b/ports/glslang/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glslang",
-  "version": "16.1.0",
+  "version": "16.2.0",
   "description": "Khronos-reference front end for GLSL/ESSL, partial front end for HLSL, and a SPIR-V generator.",
   "homepage": "https://github.com/KhronosGroup/glslang",
   "license": "Apache-2.0 AND BSD-3-Clause AND MIT AND GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3461,7 +3461,7 @@
       "port-version": 3
     },
     "glslang": {
-      "baseline": "16.1.0",
+      "baseline": "16.2.0",
       "port-version": 0
     },
     "glui": {

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e739d2c1644783124e1adbac19558f52f843da0f",
+      "version": "16.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "979a04a1f3893a86dde72b1bdf9efa1d79f1c1db",
       "version": "16.1.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

