### PR TITLE
[raygpu] New port

### DIFF
--- a/ports/raygpu/portfile.cmake
+++ b/ports/raygpu/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO manuel5975p/raygpu
+    REF "v${VERSION}"
+    SHA512 4dba98afd534db4ba519a623b6f3af953da444ce8aa442c28fed15cbd5bf16424971fac9f7880224d53a92f709ce112e45f8e9ed22e23fbfc98e5dcbd25db91a
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        sdl3            SUPPORT_SDL3
+        glfw            SUPPORT_GLFW
+        vulkan-backend  SUPPORT_VULKAN_BACKEND
+        wgpu-backend    SUPPORT_WGPU_BACKEND
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DRAYGPU_BUILD_TESTS=OFF
+        -DRAYGPU_ENABLE_INSTALL=ON
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME raygpu)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/raygpu/vcpkg.json
+++ b/ports/raygpu/vcpkg.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "raygpu",
+  "version-string": "0.1",
+  "description": "A fast and simple Graphics Library written in C99, targeting Vulkan, Metal, DirectX and WebGPU",
+  "homepage": "https://github.com/manuel5975p/raygpu",
+  "license": "Zlib",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "sdl3": {
+      "description": "Enable windowing with SDL3",
+      "dependencies": [
+        "sdl3"
+      ]
+    },
+    "glfw": {
+      "description": "Enable windowing with GLFW",
+      "dependencies": [
+        "glfw3"
+      ]
+    },
+    "vulkan-backend": {
+      "description": "Enable the Vulkan Backend",
+      "dependencies": [
+        "vulkan"
+      ]
+    },
+    "wgpu-backend": {
+      "description": "Enable the WebGPU backend"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11155,6 +11155,9 @@
     "zziplib": {
       "baseline": "0.13.80",
       "port-version": 0
+    },
+    "raygpu": {
+      "baseline": "0.1"
     }
   }
 }

--- a/versions/r-/raygpu.json
+++ b/versions/r-/raygpu.json
@@ -1,0 +1,8 @@
+{
+  "versions": [
+    {
+      "version-string": "0.1",
+      "git-tree": "HEAD"
+    }
+  ]
+}


### PR DESCRIPTION
This PR updates raygpu to version 0.1.

**Release Notes:**
- Updated from https://github.com/manuel5975p/raygpu/releases/tag/v0.1

**Testing:**
- [ ] Built successfully on Windows
- [ ] Built successfully on Linux  
- [ ] Built successfully on macOS

cc: @manuel5975p