### PR TITLE
[inja] Modernize

### DIFF
--- a/ports/inja/portfile.cmake
+++ b/ports/inja/portfile.cmake
@@ -13,16 +13,11 @@ vcpkg_cmake_configure(
     OPTIONS
         -DINJA_USE_EMBEDDED_JSON=OFF
         -DBUILD_TESTING=OFF
-        -DBUILD_BENCHMARK=OFF
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/inja")
-vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-# Don't need built-in nlohmann-json as this package depends on nlohmann-json
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/inja/json")
-
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/inja/vcpkg.json
+++ b/ports/inja/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "inja",
   "version": "3.5.0",
+  "port-version": 1,
   "description": "Inja - A Template Engine for Modern C++",
   "homepage": "https://github.com/pantor/inja",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3998,7 +3998,7 @@
     },
     "inja": {
       "baseline": "3.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "intel-ipsec": {
       "baseline": "1.1",

--- a/versions/i-/inja.json
+++ b/versions/i-/inja.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "004f64a4ac01a4c1f6da49d2331c9b1dc2bf3b27",
+      "version": "3.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "11819c7d653b868489a608926c182ffd89cd49f3",
       "version": "3.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
