### PR TITLE
[snmalloc] Add new port at 0.7.4

### DIFF
--- a/ports/snmalloc/portfile.cmake
+++ b/ports/snmalloc/portfile.cmake
@@ -1,0 +1,46 @@
+# Without static-shim: INTERFACE only — Release and Debug are identical.
+# With static-shim: compiled code is produced — both variants are needed.
+if(NOT "static-shim" IN_LIST FEATURES)
+    set(VCPKG_BUILD_TYPE release)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/snmalloc
+    REF "${VERSION}"
+    SHA512 ef15272dc488f87e59d273b7db780f2bdfdea9d539c9d7a56987dffd62cd4e0daaf46d6138a3aa1f7c77ab14a71c47d66d1250248e1e87060c5bb8e1ede709ba
+    HEAD_REF main
+)
+
+# NOTE: The CI overlay port (see .github/workflows/main.yml, vcpkg-integration)
+# uses sed to extract from this line onwards to build a portfile that points at
+# the local checkout. If you reorder code above this line, update the sed
+# pattern there.
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "static-shim" SNMALLOC_STATIC_LIBRARY
+    INVERTED_FEATURES
+        "static-shim" SNMALLOC_HEADER_ONLY_LIBRARY
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSNMALLOC_BUILD_TESTING=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME snmalloc
+    CONFIG_PATH share/snmalloc
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/snmalloc/usage
+++ b/ports/snmalloc/usage
@@ -1,0 +1,13 @@
+snmalloc provides CMake integration via:
+
+    find_package(snmalloc CONFIG REQUIRED)
+    target_link_libraries(<your-target> PRIVATE snmalloc::snmalloc)
+
+If installed with the "static-shim" feature, a compiled static library is also
+available that replaces malloc/free with a "sn_" prefix (e.g. sn_malloc, sn_free):
+
+    target_link_libraries(<your-target> PRIVATE snmalloc::snmallocshim-static)
+
+On non-Windows, the "static-shim" feature also installs shared library shims
+(snmalloc::snmallocshim, snmalloc::snmallocshim-checks, snmalloc::snmalloc-minimal)
+that can be used for LD_PRELOAD-based allocator replacement.

--- a/ports/snmalloc/vcpkg.json
+++ b/ports/snmalloc/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "snmalloc",
+  "version-semver": "0.7.4",
+  "description": "A high-performance, message passing based allocator",
+  "homepage": "https://github.com/microsoft/snmalloc",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "static-shim": {
+      "description": "Build and install snmallocshim-static, a compiled static library that exports malloc/free with a configurable symbol prefix (default: sn_)"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9284,6 +9284,10 @@
       "baseline": "1.2.5",
       "port-version": 0
     },
+    "snmalloc": {
+      "baseline": "0.7.4",
+      "port-version": 0
+    },
     "snowhouse": {
       "baseline": "5.0.0",
       "port-version": 2

--- a/versions/s-/snmalloc.json
+++ b/versions/s-/snmalloc.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6e49a646489e33150bfaf50779ea56ac948e893a",
+      "version-semver": "0.7.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

<img width="868" height="1203" alt="image" src="https://github.com/user-attachments/assets/488e5c93-d945-466f-a40c-784ae77c6941" />
