### PR TITLE
[blickfeld-qb2] Bump to 2.15

### DIFF
--- a/ports/blickfeld-qb2/portfile.cmake
+++ b/ports/blickfeld-qb2/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Blickfeld/blickfeld-qb2
     REF "v${VERSION}"
-    SHA512 d1bbec6fdb0cc407f5ec08042bb291c459cebdb5e713daa70be8136bd34a95737dcb9961e7c134d3f325f4219e32c7099e94b17691b69cffdfca845fc4387456
+    SHA512 d0d37bde53f1219207c20bba21614a63bdcf63b36532cdab810fc0c16aead0cb42f2b3642508812d31bc52e9d4e7a25160ef022edc18ce4d83a14728553ce3fa
     HEAD_REF main
 )
 

--- a/ports/blickfeld-qb2/vcpkg.json
+++ b/ports/blickfeld-qb2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "blickfeld-qb2",
-  "version": "2.13",
+  "version": "2.15",
   "description": "Client library to communicate securely with Qb2 LiDAR devices of Blickfeld GmbH.",
   "homepage": "https://github.com/Blickfeld/blickfeld-qb2",
   "license": "BSD-3-Clause",

--- a/versions/b-/blickfeld-qb2.json
+++ b/versions/b-/blickfeld-qb2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aef73b6297da652f02f7c02eea42bd5351b556c1",
+      "version": "2.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "ef0cbb924625815fd8180f8d534f27c2fb079983",
       "version": "2.13",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -769,7 +769,7 @@
       "port-version": 1
     },
     "blickfeld-qb2": {
-      "baseline": "2.13",
+      "baseline": "2.15",
       "port-version": 0
     },
     "blingfire": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
