### PR TITLE
[clickhouse-cpp] Bump to 2.6.1

### DIFF
--- a/ports/clickhouse-cpp/portfile.cmake
+++ b/ports/clickhouse-cpp/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ClickHouse/clickhouse-cpp
     REF "v${VERSION}"
-    SHA512 4199ac2848b0544a2a9c4e03ca62f9a14e13652b09df62b2c95eda59c567cb8227099b9cb027f18d7bdb3a25ee41f01301a551f1bf98727bf89766f5e1cac3f5
+    SHA512 626cce4d6037cbeb86c5720ece7ac95c9ff0e561825e7907934669709091886d209f3128798db41a89ef3585d0639e40a5c4f96a0e724b6bee25291710ad391e
     HEAD_REF master
     PATCHES
         fix-deps-and-build-type.patch

--- a/ports/clickhouse-cpp/vcpkg.json
+++ b/ports/clickhouse-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhouse-cpp",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "C++ client for Yandex ClickHouse",
   "homepage": "https://github.com/ClickHouse/clickhouse-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1821,7 +1821,7 @@
       "port-version": 0
     },
     "clickhouse-cpp": {
-      "baseline": "2.6.0",
+      "baseline": "2.6.1",
       "port-version": 0
     },
     "clipboardxx": {

--- a/versions/c-/clickhouse-cpp.json
+++ b/versions/c-/clickhouse-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bedebf882dde9d7fa3926dd88b5e92e3c3c828f6",
+      "version": "2.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d4bdcdd2d71f5e45b59c82a5240ed4f01ade47c0",
       "version": "2.6.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
