### PR TITLE
[dbus-cxx] Bump to 2.6.1

### DIFF
--- a/ports/dbus-cxx/portfile.cmake
+++ b/ports/dbus-cxx/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dbus-cxx/dbus-cxx
     REF "${VERSION}"
-    SHA512 ad6551d03d0c7d499e9f0c6d77584e39d361a1464017be3c40c237d4c43306ad0ffb49b52c06b89cd62ec7346ebcb29f3d166a31b245fd978159e337a08ebafb
+    SHA512 57e5fc8363faa72b7958e049f9d42006bb85792101713518f1d232097aacb9c6cb84c742ab5248cd5729969076d0ac70902f63e42a1e9eb6a16c58db31b09f1d
     HEAD_REF master
     PATCHES
         create-cmakeconfig.patch    

--- a/ports/dbus-cxx/vcpkg.json
+++ b/ports/dbus-cxx/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dbus-cxx",
-  "version": "2.6.0",
-  "port-version": 1,
+  "version": "2.6.1",
   "description": "DBus-cxx provides an object-oriented interface to DBus.",
   "homepage": "https://dbus-cxx.github.io/",
   "license": "LGPL-3.0-or-later AND BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2421,8 +2421,8 @@
       "port-version": 3
     },
     "dbus-cxx": {
-      "baseline": "2.6.0",
-      "port-version": 1
+      "baseline": "2.6.1",
+      "port-version": 0
     },
     "dcmtk": {
       "baseline": "3.7.0",

--- a/versions/d-/dbus-cxx.json
+++ b/versions/d-/dbus-cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "928cd1a1157654c9ae38db2d0305722177584caa",
+      "version": "2.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "901f0005e6ef353107e170b6cd68d4b3f5beaf93",
       "version": "2.6.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
