### PR TITLE
[matplotplusplus] Bump to 1.2.2

### DIFF
--- a/ports/matplotplusplus/portfile.cmake
+++ b/ports/matplotplusplus/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alandefreitas/matplotplusplus
     REF "v${VERSION}"
-    SHA512 8ecb13fa206ff6762dec74c4de0778bf275e1ebf11ec1b48e8c0e544cf2990220e1be2b3bc9c658f06cb6714c9cc103fa81f10c079a32128218ebdaf265514d5
+    SHA512 2557c6b34476a48faad08cc02db3e59899c092b4304331ccb93fea9181cbd1003b74ee8aa2bb7a21e2e0604389fae31e8d3e8a66609a9a4c4bdb3c5f4b0bfb62
     HEAD_REF master
     PATCHES
                 fix-dependencies.patch

--- a/ports/matplotplusplus/vcpkg.json
+++ b/ports/matplotplusplus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "matplotplusplus",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A C++ graphics library for data visualization",
   "homepage": "https://alandefreitas.github.io/matplotplusplus/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6309,7 +6309,7 @@
       "port-version": 2
     },
     "matplotplusplus": {
-      "baseline": "1.2.1",
+      "baseline": "1.2.2",
       "port-version": 0
     },
     "matroska": {

--- a/versions/m-/matplotplusplus.json
+++ b/versions/m-/matplotplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "100c02536766fe51aa86db0719d84551432ff5d2",
+      "version": "1.2.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "51c46b79b51c246c051a496bbdfa057aec3860ca",
       "version": "1.2.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
