### PR TITLE
[morphologica] Bump to 4.1

### DIFF
--- a/ports/morphologica/portfile.cmake
+++ b/ports/morphologica/portfile.cmake
@@ -1,11 +1,11 @@
-set(VCPKG_BUILD_TYPE release)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ABRG-Models/morphologica
     REF "v${VERSION}"
-    SHA512 db22a6fcd16acea11d15d9d2253839f90c9684c22d02fcd0d22ba20f944b101300752e05fa600662d9676ad091b5cf52e9d18cfe37918841881fb1282ab6f6b9 
+    SHA512 8e113cc92fab08decbe2612055da1d9740fba305646c20bd60118dc1a0f0d5975db8d0e2d83004290bee1030c46d8095ffc092eae78c02cd834f0436fc65e2b3 
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/morphologica/vcpkg.json
+++ b/ports/morphologica/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "morphologica",
-  "version": "4.0",
+  "version": "4.1",
   "description": "C++ header-only graphing and data visualization with Modern OpenGL",
   "homepage": "https://github.com/ABRG-Models/morphologica",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6561,7 +6561,7 @@
       "port-version": 0
     },
     "morphologica": {
-      "baseline": "4.0",
+      "baseline": "4.1",
       "port-version": 0
     },
     "morton-nd": {

--- a/versions/m-/morphologica.json
+++ b/versions/m-/morphologica.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a08c61d8625ec182bb1ebe88fd1e15ca41278ed1",
+      "version": "4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "db5ad2417efe1dd663d24d02d3aef0976ecef76b",
       "version": "4.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
