### PR TITLE
[raylib-cpp] Bump to 5.5.1

### DIFF
--- a/ports/raylib-cpp/portfile.cmake
+++ b/ports/raylib-cpp/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO RobLoach/raylib-cpp
     REF "v${VERSION}"
-    SHA512 12da247a1c1a3e0bc2d9f8c361024983b4cbcefe17c0d288e29593c8d49d44e8d319acda91c13fb181a933de9535d61ee75f3a2bf8549dcb3986f21c5d8a7e44
+    SHA512 db7e4eef3756b95fdcd583e0485d006311173a96f59c3aed6bda1b07bcae5c6d7c1ab7fda51220edfd1b170c6b1622f3f6bf5de7cececaa172c5f0bdf8fcdf72
     HEAD_REF master
 )
 

--- a/ports/raylib-cpp/vcpkg.json
+++ b/ports/raylib-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "raylib-cpp",
-  "version": "5.5.0",
-  "port-version": 1,
+  "version": "5.5.1",
   "description": "C++ Object Oriented Wrapper for raylib",
   "homepage": "https://github.com/RobLoach/raylib-cpp",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8537,8 +8537,8 @@
       "port-version": 1
     },
     "raylib-cpp": {
-      "baseline": "5.5.0",
-      "port-version": 1
+      "baseline": "5.5.1",
+      "port-version": 0
     },
     "rbdl": {
       "baseline": "3.3.1",

--- a/versions/r-/raylib-cpp.json
+++ b/versions/r-/raylib-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99a4e5f1a955f2bc90521844a5ec4ca5b6337827",
+      "version": "5.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4211d4e7ea87c0f2e1860058afb460dd2fbdb571",
       "version": "5.5.0",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
