### PR TITLE
[scenepic] Bump to 1.1.2

### DIFF
--- a/ports/scenepic/portfile.cmake
+++ b/ports/scenepic/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  microsoft/scenepic 
     REF "v${VERSION}"
-    SHA512 79c20697051ef7061a51cc73f232e5ba83f8bc5a62ee3b9a4d55182112b201c805c25461fcd6699cc6db70c4439b116d1d27e66cd4e431471438ac7968836eed
+    SHA512 13beecaa8eb218f53b617ce4babe70292a3056f649d5dd85c8b7bfda6e870df147afe50dba228b8a0e460cebf1e2d051318004c9ec0f2a70b9349c5016a5364d
     HEAD_REF main
     PATCHES
         0001-fix-dependencies.patch

--- a/ports/scenepic/vcpkg.json
+++ b/ports/scenepic/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "scenepic",
-  "version": "1.1.1",
-  "port-version": 1,
+  "version": "1.1.2",
   "description": "A Powerful, easy to use, and portable visualization toolkit for mixed 3D and 2D content",
   "homepage": "https://microsoft.github.io/scenepic/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8901,8 +8901,8 @@
       "port-version": 0
     },
     "scenepic": {
-      "baseline": "1.1.1",
-      "port-version": 1
+      "baseline": "1.1.2",
+      "port-version": 0
     },
     "scintilla": {
       "baseline": "5.5.8",

--- a/versions/s-/scenepic.json
+++ b/versions/s-/scenepic.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b33114ec6cfee6dc05340a379757a4bb91789205",
+      "version": "1.1.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "6e8030aaa1eb613d8e24ea49b8856d7c11b1fea6",
       "version": "1.1.1",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
