### PR TITLE
[visit-struct] Bump to 1.2.0

### DIFF
--- a/ports/visit-struct/portfile.cmake
+++ b/ports/visit-struct/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cbeck88/visit_struct
-    REF "v${VERSION}"
-    SHA512 8d1f93344ef13320bc7967cbe2696bf49d6773fe3c89ba10bcf8ee9c33be165f14086828f6195bad742fbe75fee9c0995827c455c777950df583ff8f13c21338
+    REF "${VERSION}"
+    SHA512 c71eddae7e887c9cb055fc559bbbb44a755be1358b428e467e55c331e5ac1acadf8bbbb0d8e6f54ba30ff80abde788f4d5cb22551c3bb3bce5f6a2fe6e12b592
     HEAD_REF master
 )
 

--- a/ports/visit-struct/vcpkg.json
+++ b/ports/visit-struct/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "visit-struct",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A header-only library providing structure visitors for C++11 and C++14",
   "license": "BSL-1.0",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10489,7 +10489,7 @@
       "port-version": 0
     },
     "visit-struct": {
-      "baseline": "1.1.0",
+      "baseline": "1.2.0",
       "port-version": 0
     },
     "vit-vit-ctpl": {

--- a/versions/v-/visit-struct.json
+++ b/versions/v-/visit-struct.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fce46f06398bcfc84f66192a629587f8610ada0e",
+      "version": "1.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "59296ff30012685f7c9c1d7b0723fc940997a2b1",
       "version": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
