### PR TITLE
[vk-bootstrap] Bump to 1.4.347

### DIFF
--- a/ports/vk-bootstrap/portfile.cmake
+++ b/ports/vk-bootstrap/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO charles-lunarg/vk-bootstrap
     REF "v${VERSION}"
-    SHA512 f240b744f00a18b44198d928dad93cc5b177825d87f459b3f9f1e166f7c3267ba345b1b1cb5a42e22f5f1cd8bae524a5f3a243b640645bed4cb20eda574d426c
+    SHA512 5490b7f1cc8cda81c1cbf58beb8169c0627dc894752b58aff1c007e258426cac355d6ee5ae80aba138654f37852448329a8e0df3e57360cbcc768b1a7d7e2c6d
     HEAD_REF master
     PATCHES
         fix-targets.patch

--- a/ports/vk-bootstrap/vcpkg.json
+++ b/ports/vk-bootstrap/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vk-bootstrap",
-  "version": "1.4.341",
+  "version": "1.4.347",
   "description": "Vulkan bootstraping library",
   "homepage": "https://github.com/charles-lunarg/vk-bootstrap",
   "license": "MIT",

--- a/ports/vulkan-headers/portfile.cmake
+++ b/ports/vulkan-headers/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/Vulkan-Headers
-    REF "vulkan-sdk-${VERSION}"
-    SHA512 aa6d517304663c55c67bdd8578518a399a1188c6c3a92fac4ee29738f96f6a66b61ebc9c606c20d52f5cbb47976757bfcab35576eca7c839dfda1cdd65074c29
+    REF "v${VERSION}"
+    SHA512 4fcbe249bdd6edfab63f805e865e842f680b123e6d71ea3646799ceaea4f14770fa8aa52927679d8c9a3ebeaa1fd218240b7ecc74be64ff986ab005142c44367
     HEAD_REF main
 )
 

--- a/ports/vulkan-headers/vcpkg.json
+++ b/ports/vulkan-headers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vulkan-headers",
-  "version": "1.4.341.0",
+  "version": "1.4.347",
   "description": "Vulkan header files and API registry",
   "homepage": "https://github.com/KhronosGroup/Vulkan-Headers",
   "license": "Apache-2.0 OR MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10581,7 +10581,7 @@
       "port-version": 0
     },
     "vulkan-headers": {
-      "baseline": "1.4.341.0",
+      "baseline": "1.4.347",
       "port-version": 0
     },
     "vulkan-hpp": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10497,7 +10497,7 @@
       "port-version": 0
     },
     "vk-bootstrap": {
-      "baseline": "1.4.341",
+      "baseline": "1.4.347",
       "port-version": 0
     },
     "vkfft": {

--- a/versions/v-/vk-bootstrap.json
+++ b/versions/v-/vk-bootstrap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6c497cfcb5e0e53484d356b2a8e0ea9605d5d27",
+      "version": "1.4.347",
+      "port-version": 0
+    },
+    {
       "git-tree": "0a72a934475899719880106e3e4c9cd0e3253764",
       "version": "1.4.341",
       "port-version": 0

--- a/versions/v-/vulkan-headers.json
+++ b/versions/v-/vulkan-headers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "37dddb632495b18d146fbdcacd4824a9ab96a65c",
+      "version": "1.4.347",
+      "port-version": 0
+    },
+    {
       "git-tree": "89786b8891a0e455ebf6eeac816e8d8205a3e3e6",
       "version": "1.4.341.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
