### PR TITLE
[vowpal-wabbit] Bump to 9.11.2

### DIFF
--- a/ports/vowpal-wabbit/portfile.cmake
+++ b/ports/vowpal-wabbit/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO VowpalWabbit/vowpal_wabbit
     REF "${VERSION}"
-    SHA512 03cb3e54a7d47763e0591f94d2d4c53c9b2ce629f758466994180fe19e53680024d3ca41de1ef810e4955a88ccbea75222d4a46a28470086793617e701e4ac6a
+    SHA512 997ac8cf79fc93671a15395c9494494cb3f5eba2945622996d4b9c962b635adc979eb609bba0bbd7b74c0c21a751686006ea9eaecee1861e2d817b6f9c34d226
     HEAD_REF master
     PATCHES
         fix-android-build.patch

--- a/ports/vowpal-wabbit/vcpkg.json
+++ b/ports/vowpal-wabbit/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vowpal-wabbit",
-  "version": "9.11.1",
+  "version": "9.11.2",
   "description": "Reduction based online learning framework with a focus on contextual bandits and reinforcement learning.",
   "homepage": "https://github.com/vowpalwabbit/vowpal_wabbit",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10529,7 +10529,7 @@
       "port-version": 0
     },
     "vowpal-wabbit": {
-      "baseline": "9.11.1",
+      "baseline": "9.11.2",
       "port-version": 0
     },
     "vs-yasm": {

--- a/versions/v-/vowpal-wabbit.json
+++ b/versions/v-/vowpal-wabbit.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc65ab05d8bd53245beb4d0c3b83013d8a98cc8c",
+      "version": "9.11.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "fdc28438027ea2ef2212b3a2e3360cb88d55c43d",
       "version": "9.11.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
