### PR TITLE
[kf6archive] Update to 6.23.0

### DIFF
--- a/ports/kf6archive/portfile.cmake
+++ b/ports/kf6archive/portfile.cmake
@@ -2,13 +2,17 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/karchive
     REF "v${VERSION}"
-    SHA512 d6ab327b5c42c3221348d797e575984d50790f46db6f7e92dd442f7792e88804f88054fb4bcaf6b12470f992f0a18065a2aafa67eb4d4784d5caf0082c4d4b0e
+    SHA512 d3516e17a98cfa40ce3f863dc2b209361435de5c76a42423ac2518602ca71b54ac3294ebaa93d38c904b3a0b968fab52e754c32c9c70c938d310e3d5acb50229
     HEAD_REF master
     PATCHES
         zstd.diff
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS options
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         bzip2           WITH_BZIP2
         bzip2           VCPKG_LOCK_FIND_PACKAGE_BZip2
@@ -23,9 +27,9 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS options
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        ${options}
         -DBUILD_TESTING=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_Git=1
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/kf6archive/vcpkg.json
+++ b/ports/kf6archive/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kf6archive",
-  "version": "6.22.0",
+  "version": "6.23.0",
   "description": "File compression",
   "homepage": "https://invent.kde.org/frameworks/karchive",
   "documentation": "https://api.kde.org/karchive-index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4421,7 +4421,7 @@
       "port-version": 0
     },
     "kf6archive": {
-      "baseline": "6.22.0",
+      "baseline": "6.23.0",
       "port-version": 0
     },
     "kfr": {

--- a/versions/k-/kf6archive.json
+++ b/versions/k-/kf6archive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5ff5fce6f74157b71c3b08c64d29a1dd28d0af78",
+      "version": "6.23.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b08fa1b6a16e2db3474ef63456327409f6bb6f05",
       "version": "6.22.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
