### PR TITLE
[plasma-wayland-protocols] Update to 1.19.0

### DIFF
--- a/ports/plasma-wayland-protocols/portfile.cmake
+++ b/ports/plasma-wayland-protocols/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/plasma-wayland-protocols
     REF "v${VERSION}"
-    SHA512 3cb5ea1c5c69384181005520c9999b0f1548ec91f2894204ab9a103dd6d76621932f4d6c536664797ab2d24df4e1f182a353bd9be802565ec48dec657cc59276
+    SHA512 bd5c5de9980ce1af5e330adbb360a4389f1f40f85431407e2fa46eb113f527d48e1fe932f42c5a28b3e8e5e8b3499a6193d3b0e5711f9a95880e15d889c8cbfb
     HEAD_REF master
 )
 
@@ -11,6 +11,8 @@ file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: fa
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/plasma-wayland-protocols/vcpkg.json
+++ b/ports/plasma-wayland-protocols/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "plasma-wayland-protocols",
-  "version": "1.14.0",
+  "version": "1.19.0",
   "description": "The non-standard Wayland protocols use by KDE Plasma",
-  "homepage": "https://invent.kde.org/libraries/plasma-wayland-protocols/-/tree/master/",
+  "homepage": "https://invent.kde.org/libraries/plasma-wayland-protocols",
   "supports": "linux",
   "dependencies": [
     "ecm",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7661,7 +7661,7 @@
       "port-version": 4
     },
     "plasma-wayland-protocols": {
-      "baseline": "1.14.0",
+      "baseline": "1.19.0",
       "port-version": 0
     },
     "platform-folders": {

--- a/versions/p-/plasma-wayland-protocols.json
+++ b/versions/p-/plasma-wayland-protocols.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70aed4dafc77c5173b135ee99a0e0837673683af",
+      "version": "1.19.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d5de80e9722055b7a9df78a6986f82ed6b5e0a44",
       "version": "1.14.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
