### PR TITLE
[kf6coreaddons] New port

### DIFF
--- a/ports/kf6coreaddons/portfile.cmake
+++ b/ports/kf6coreaddons/portfile.cmake
@@ -1,0 +1,40 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kcoreaddons
+    REF "v${VERSION}"
+    SHA512 9c7248a265482832e64ab80e2793e157ad0d9011e31afaed2ebe5859ddf747cffdea1fc5cde26fd5884211b6bd10a1eebf553ae0749d2cc9c2cca89edb40f7f7
+    HEAD_REF master
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        qml KCOREADDONS_USE_QML
+    INVERTED_FEATURES
+        translations KF_SKIP_PO_PROCESSING
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DBUILD_PYTHON_BINDINGS=OFF
+        -DKDE_INSTALL_QMLDIR=qml
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF6CoreAddons)
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig(SKIP_CHECK)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin/data/kf6")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin/data/kf6")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kf6coreaddons/vcpkg.json
+++ b/ports/kf6coreaddons/vcpkg.json
@@ -1,0 +1,45 @@
+{
+  "name": "kf6coreaddons",
+  "version": "6.23.0",
+  "description": "Addons to QtCore",
+  "homepage": "https://invent.kde.org/frameworks/kcoreaddons",
+  "documentation": "https://api.kde.org/kcoreaddons-index.html",
+  "dependencies": [
+    "ecm",
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "qml": {
+      "description": "Build the QML plugin",
+      "dependencies": [
+        {
+          "name": "qtdeclarative",
+          "default-features": false
+        }
+      ]
+    },
+    "translations": {
+      "description": "Install translations",
+      "dependencies": [
+        {
+          "name": "qttools",
+          "host": true,
+          "features": [
+            "linguist"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4424,6 +4424,10 @@
       "baseline": "6.22.0",
       "port-version": 0
     },
+    "kf6coreaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
     "kfr": {
       "baseline": "6.3.1",
       "port-version": 0

--- a/versions/k-/kf6coreaddons.json
+++ b/versions/k-/kf6coreaddons.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4f19cb4858befbc3035541a99ffc6547623fa056",
+      "version": "6.23.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
