### PR TITLE
[kguiaddons]: New port

### DIFF
--- a/ports/kguiaddons/portfile.cmake
+++ b/ports/kguiaddons/portfile.cmake
@@ -1,0 +1,36 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kguiaddons
+    REF "v${VERSION}"
+    SHA512 ad221061698fea27e354ce2be0ec565fd70850add9964c306d415c4cc95b68d09c0c217fde1e45f0ad668a13e93b2a5e2d0059a6bfb514b1cea6f37d4ac01a0f
+    HEAD_REF master
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DBUILD_PYTHON_BINDINGS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6guiaddons
+    CONFIG_PATH lib/cmake/KF6GuiAddons
+)
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig(SKIP_CHECK)
+
+vcpkg_copy_tools(
+    TOOL_NAMES kde-geo-uri-handler
+    AUTO_CLEAN
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kguiaddons/vcpkg.json
+++ b/ports/kguiaddons/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "kguiaddons",
+  "version": "6.25.0",
+  "description": "Addons to QtGui",
+  "homepage": "https://invent.kde.org/frameworks/kguiaddons",
+  "documentation": "https://api.kde.org/kguiaddons-index.html",
+  "supports": "!android",
+  "dependencies": [
+    "ecm",
+    {
+      "name": "plasma-wayland-protocols",
+      "platform": "linux"
+    },
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "qtwayland",
+      "default-features": false,
+      "platform": "linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4476,6 +4476,10 @@
       "baseline": "6.25.0",
       "port-version": 1
     },
+    "kguiaddons": {
+      "baseline": "6.25.0",
+      "port-version": 0
+    },
     "ki18n": {
       "baseline": "6.25.0",
       "port-version": 1

--- a/versions/k-/kguiaddons.json
+++ b/versions/k-/kguiaddons.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0766e3d1c73e4d531b05050e7058844db5989fb0",
+      "version": "6.25.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/kguiaddons/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
