### PR TITLE
[kf6i18n] New port

### DIFF
--- a/ports/kf6i18n/portfile.cmake
+++ b/ports/kf6i18n/portfile.cmake
@@ -1,0 +1,44 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/ki18n
+    REF "v${VERSION}"
+    SHA512 85ad784de2588777920994f88ddcccfad2549c96ed054d5012df887ace9b89696e0e9d22e623b4a936ceaed3de06d3a8d2bb1feeaa47628587bd1c0cb6c089af
+    HEAD_REF master
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        qml BUILD_WITH_QML
+)
+
+vcpkg_find_acquire_program(PYTHON3)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DBUILD_TESTING=OFF
+        -DPython3_EXECUTABLE=${PYTHON3}
+        -DFALLBACK_KI18N_PYTHON_EXECUTABLE=${PYTHON3}
+        -DKDE_INSTALL_PLUGINDIR=plugins
+        -DKDE_INSTALL_QTPLUGINDIR=plugins
+        -DKDE_INSTALL_QMLDIR=qml
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF6I18n)
+vcpkg_copy_pdbs()
+
+# KF6I18nMacros.cmake embeds the Python executable path used at build time as a
+# fallback. This is an absolute path but is ultimately relocatable, so skip the check.
+set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kf6i18n/vcpkg.json
+++ b/ports/kf6i18n/vcpkg.json
@@ -1,0 +1,42 @@
+{
+  "name": "kf6i18n",
+  "version": "6.23.0",
+  "description": "Advanced internationalization framework",
+  "homepage": "https://invent.kde.org/frameworks/ki18n",
+  "documentation": "https://api.kde.org/ki18n-index.html",
+  "supports": "!android",
+  "dependencies": [
+    "ecm",
+    "gettext",
+    {
+      "name": "gettext",
+      "host": true,
+      "features": [
+        "tools"
+      ]
+    },
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "qml": {
+      "description": "Build with support for scripted translations",
+      "dependencies": [
+        {
+          "name": "qtdeclarative",
+          "default-features": false
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4424,6 +4424,10 @@
       "baseline": "6.22.0",
       "port-version": 0
     },
+    "kf6i18n": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
     "kfr": {
       "baseline": "6.3.1",
       "port-version": 0

--- a/versions/k-/kf6i18n.json
+++ b/versions/k-/kf6i18n.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f80054dfc2a93835b62371fb6699037ce11adf8d",
+      "version": "6.23.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
