### PR TITLE
[kitemviews] New port

### DIFF
--- a/ports/kitemviews/portfile.cmake
+++ b/ports/kitemviews/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kitemviews
+    REF "v${VERSION}"
+    SHA512 3845401d2543514f17f70aa8ff926e2c68793591808a91ea0d809333473f0a1f2052522a504df8f986632f8e3005907a3c5e8a092474d53f9711a12b41b36892
+    HEAD_REF master
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        designerplugin BUILD_DESIGNERPLUGIN
+    INVERTED_FEATURES
+        translations   KF_SKIP_PO_PROCESSING
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DKDE_INSTALL_PLUGINDIR=plugins
+        -DKDE_INSTALL_QTPLUGINDIR=plugins
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME kf6itemviews CONFIG_PATH lib/cmake/KF6ItemViews)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kitemviews/vcpkg.json
+++ b/ports/kitemviews/vcpkg.json
@@ -1,0 +1,49 @@
+{
+  "name": "kitemviews",
+  "version": "6.25.0",
+  "description": "Widget addons for Qt Model/View",
+  "homepage": "https://invent.kde.org/frameworks/kitemviews",
+  "documentation": "https://api.kde.org/kitemviews-index.html",
+  "dependencies": [
+    "ecm",
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "designerplugin": {
+      "description": "Build Qt Designer plugin",
+      "dependencies": [
+        {
+          "name": "qttools",
+          "default-features": false,
+          "features": [
+            "designer"
+          ]
+        }
+      ]
+    },
+    "translations": {
+      "description": "Build and install translations",
+      "dependencies": [
+        {
+          "name": "qttools",
+          "host": true,
+          "default-features": false,
+          "features": [
+            "linguist"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/ports/kitemviews/vcpkg.json
+++ b/ports/kitemviews/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Widget addons for Qt Model/View",
   "homepage": "https://invent.kde.org/frameworks/kitemviews",
   "documentation": "https://api.kde.org/kitemviews-index.html",
+  "license": null,
   "dependencies": [
     "ecm",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4552,6 +4552,10 @@
       "baseline": "6.25.0",
       "port-version": 1
     },
+    "kitemviews": {
+      "baseline": "6.25.0",
+      "port-version": 0
+    },
     "kleidiai": {
       "baseline": "1.25.0",
       "port-version": 0

--- a/versions/k-/kitemviews.json
+++ b/versions/k-/kitemviews.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4f1cb8123095937ac6b24eedf4ebaabd5225e5a6",
+      "version": "6.25.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/k-/kitemviews.json
+++ b/versions/k-/kitemviews.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4f1cb8123095937ac6b24eedf4ebaabd5225e5a6",
+      "git-tree": "110636cfc3d65208923e6ac55a819429b59f13f5",
       "version": "6.25.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/kitemviews/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
