### PR TITLE
[kf6-solid] New port

### DIFF
--- a/ports/kf6-solid/001_fix_imobile.patch
+++ b/ports/kf6-solid/001_fix_imobile.patch
@@ -1,0 +1,52 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,15 +64,20 @@ set_package_properties(BISON PROPERTIES
+     PURPOSE "Required for the Predicate parser"
+ )
+ 
+-find_package(IMobileDevice)
++find_package(IMobileDevice NAMES unofficial-libimobiledevice)
+ set_package_properties(IMobileDevice PROPERTIES
+                        TYPE OPTIONAL
+                        PURPOSE "Needed to build the iOS device support backend"
+                       )
++if(TARGET unofficial::libimobiledevice::libimobiledevice)
++    set_target_properties(unofficial::libimobiledevice::libimobiledevice PROPERTIES
++        INTERFACE_COMPILE_DEFINITIONS "IMOBILEDEVICE_API=0x10300"
++    )
++endif()
+ 
+-find_package(PList)
++find_package(PList NAMES unofficial-libplist CONFIG)
+ set_package_properties(PList PROPERTIES
+                        TYPE OPTIONAL
+                        PURPOSE "Needed to build the iOS device support backend"
+                       )
+ 
+diff --git a/KF6SolidConfig.cmake.in b/KF6SolidConfig.cmake.in
+--- a/KF6SolidConfig.cmake.in
++++ b/KF6SolidConfig.cmake.in
+@@ -31,6 +31,11 @@ if (NOT @BUILD_SHARED_LIBS@)
+         find_dependency(LibMount)
+     endif()
+ 
++    if (@IMobileDevice_FOUND@ AND @PList_FOUND@)
++        find_dependency(unofficial-libimobiledevice)
++        find_dependency(unofficial-libplist)
++    endif()
++
+     if (@UDev_FOUND@)
+         find_dependency(UDev)
+     endif()
+diff --git a/src/solid/devices/backends/imobile/CMakeLists.txt b/src/solid/devices/backends/imobile/CMakeLists.txt
+--- a/src/solid/devices/backends/imobile/CMakeLists.txt
++++ b/src/solid/devices/backends/imobile/CMakeLists.txt
+@@ -6,6 +6,6 @@ set(backend_sources
+     imobileportablemediaplayer.cpp
+ )
+-set(backend_libs IMobileDevice::IMobileDevice PList::PList)
++set(backend_libs unofficial::libimobiledevice::libimobiledevice unofficial::libplist::libplist)
+ 
+ ecm_qt_declare_logging_category(backend_sources
+     HEADER imobile_debug.h

--- a/ports/kf6-solid/002_fix_cpufeatures_arm64_msvc.patch
+++ b/ports/kf6-solid/002_fix_cpufeatures_arm64_msvc.patch
@@ -1,0 +1,12 @@
+diff --git a/src/solid/devices/backends/shared/cpufeatures.cpp b/src/solid/devices/backends/shared/cpufeatures.cpp
+--- a/src/solid/devices/backends/shared/cpufeatures.cpp
++++ b/src/solid/devices/backends/shared/cpufeatures.cpp
+@@ -178,7 +178,7 @@
+         features = 0x2;
+     }
+ #endif // __i386__ || __x86_64__
+-#elif defined(_MSC_VER)
++#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+     int array[4], ft = 1;
+     __cpuid(array, ft);
+ 

--- a/ports/kf6-solid/portfile.cmake
+++ b/ports/kf6-solid/portfile.cmake
@@ -1,0 +1,72 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/solid
+    REF "v${VERSION}"
+    SHA512 d78439e1899ddc3fb64818e6d101e3e3c48a04de18907f87cfa39a1aaf423135a3deba085cf31dc3c208c2b9d8b91afda932df32a38995a97187df382c786fb7
+    HEAD_REF master
+    PATCHES
+        001_fix_imobile.patch
+        002_fix_cpufeatures_arm64_msvc.patch
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+if(VCPKG_TARGET_IS_OSX)
+    # On Darwin platform, the bundled version of 'bison' may be too old (< 3.0).
+    vcpkg_find_acquire_program(BISON)
+    execute_process(
+        COMMAND "${BISON}" --version
+        OUTPUT_VARIABLE BISON_OUTPUT
+    )
+    string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" BISON_VERSION "${BISON_OUTPUT}")
+    set(BISON_MAJOR ${CMAKE_MATCH_1})
+    set(BISON_MINOR ${CMAKE_MATCH_2})
+    message(STATUS "Using bison: ${BISON_MAJOR}.${BISON_MINOR}.${CMAKE_MATCH_3}")
+    if(NOT (BISON_MAJOR GREATER_EQUAL 3 AND BISON_MINOR GREATER_EQUAL 0))
+        message(WARNING "${PORT} requires bison version greater than one provided by macOS, please use \`brew install bison\` to install a newer bison.")
+    endif()
+endif()
+
+vcpkg_find_acquire_program(BISON)
+vcpkg_find_acquire_program(FLEX)
+
+get_filename_component(FLEX_DIR "${FLEX}" DIRECTORY)
+get_filename_component(BISON_DIR "${BISON}" DIRECTORY)
+
+vcpkg_add_to_path(PREPEND "${FLEX_DIR}")
+vcpkg_add_to_path(PREPEND "${BISON_DIR}")
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        imobile      CMAKE_REQUIRE_FIND_PACKAGE_IMobileDevice
+        imobile      CMAKE_REQUIRE_FIND_PACKAGE_PList
+    INVERTED_FEATURES
+        imobile      CMAKE_DISABLE_FIND_PACKAGE_IMobileDevice
+        imobile      CMAKE_DISABLE_FIND_PACKAGE_PList
+        translations KF_SKIP_PO_PROCESSING
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DKDE_INSTALL_QMLDIR=qml
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME kf6solid CONFIG_PATH lib/cmake/KF6Solid)
+vcpkg_copy_pdbs()
+
+vcpkg_copy_tools(
+    TOOL_NAMES solid-hardware6
+    AUTO_CLEAN
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kf6-solid/vcpkg.json
+++ b/ports/kf6-solid/vcpkg.json
@@ -1,0 +1,48 @@
+{
+  "name": "kf6-solid",
+  "version": "6.25.0",
+  "description": "Desktop hardware abstraction",
+  "homepage": "https://invent.kde.org/frameworks/solid",
+  "documentation": "https://api.kde.org/solid-index.html",
+  "dependencies": [
+    "ecm",
+    {
+      "name": "libmount",
+      "platform": "linux"
+    },
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "imobile": {
+      "description": "Used by the imobile backend",
+      "dependencies": [
+        "libimobiledevice",
+        "libplist"
+      ]
+    },
+    "translations": {
+      "description": "Build and install translations",
+      "dependencies": [
+        {
+          "name": "qttools",
+          "host": true,
+          "default-features": false,
+          "features": [
+            "linguist"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4520,6 +4520,10 @@
       "baseline": "5.116.0",
       "port-version": 0
     },
+    "kf6-solid": {
+      "baseline": "6.25.0",
+      "port-version": 0
+    },
     "kfr": {
       "baseline": "6.3.1",
       "port-version": 0

--- a/versions/k-/kf6-solid.json
+++ b/versions/k-/kf6-solid.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "18cc8443013aff7ed3d719da4e9baeac3cc07e74",
+      "version": "6.25.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/kf6-solid/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
