### PR TITLE
[syntax-highlighting] New port

### DIFF
--- a/ports/syntax-highlighting/portfile.cmake
+++ b/ports/syntax-highlighting/portfile.cmake
@@ -23,6 +23,12 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
+        -DBUILD_codeeditor=OFF
+        -DBUILD_codepdfprinter=OFF
+        -DBUILD_minimaltest=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_Python=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_Qt6Quick=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_XercesC=ON
         -DKDE_INSTALL_QMLDIR=qml
         ${FEATURE_OPTIONS}
 )

--- a/ports/syntax-highlighting/portfile.cmake
+++ b/ports/syntax-highlighting/portfile.cmake
@@ -1,0 +1,43 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/syntax-highlighting
+    REF "v${VERSION}"
+    SHA512 d45ef5f3974e324c087862fb9f5f084944e2d6df13f3df897514b6ed52ae69e59a0c309e0ae8361125c0c7ad2fe5c010296c174fddca1e7d5b0300a6b91dd438
+    HEAD_REF master
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+        translations KF_SKIP_PO_PROCESSING
+)
+
+vcpkg_find_acquire_program(PERL)
+get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
+vcpkg_add_to_path("${PERL_EXE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DKDE_INSTALL_QMLDIR=qml
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install(ADD_BIN_TO_PATH)
+vcpkg_cmake_config_fixup(PACKAGE_NAME kf6syntaxhighlighting CONFIG_PATH lib/cmake/KF6SyntaxHighlighting)
+vcpkg_copy_pdbs()
+
+vcpkg_copy_tools(
+    TOOL_NAMES ksyntaxhighlighter6
+    AUTO_CLEAN
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/syntax-highlighting/vcpkg.json
+++ b/ports/syntax-highlighting/vcpkg.json
@@ -1,0 +1,45 @@
+{
+  "name": "syntax-highlighting",
+  "version": "6.25.0",
+  "description": "Syntax highlighting engine for Kate syntax definitions",
+  "homepage": "https://invent.kde.org/frameworks/syntax-highlighting",
+  "documentation": "https://api.kde.org/ksyntaxhighlighting-index.html",
+  "supports": "!android & !(windows & arm64)",
+  "dependencies": [
+    "ecm",
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "qttools",
+      "host": true,
+      "default-features": false,
+      "features": [
+        "linguist"
+      ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "translations": {
+      "description": "Build and install translation files",
+      "dependencies": [
+        {
+          "name": "qttools",
+          "host": true,
+          "features": [
+            "linguist"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9948,6 +9948,10 @@
       "baseline": "0.14.0",
       "port-version": 1
     },
+    "syntax-highlighting": {
+      "baseline": "6.25.0",
+      "port-version": 0
+    },
     "syscalls-cpp": {
       "baseline": "1.2.1",
       "port-version": 0

--- a/versions/s-/syntax-highlighting.json
+++ b/versions/s-/syntax-highlighting.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "6298cbb735a4978517d61078f93fc9f7744faa3f",
+      "version": "6.25.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/s-/syntax-highlighting.json
+++ b/versions/s-/syntax-highlighting.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6298cbb735a4978517d61078f93fc9f7744faa3f",
+      "git-tree": "b09d3cfa5afadd97ac25162d61f8b1428b5cc843",
       "version": "6.25.0",
       "port-version": 0
     }


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/syntax-highlighting/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
