### PR TITLE
[kwidgetsaddons] New port

### DIFF
--- a/ports/kwidgetsaddons/portfile.cmake
+++ b/ports/kwidgetsaddons/portfile.cmake
@@ -1,0 +1,38 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kwidgetsaddons
+    REF "v${VERSION}"
+    SHA512 9d46c45b7a7d15b54550b16a085f88c65b0b160eeffc0f8a36c33e904daa712276b4cfdc776b86d832b15114ea3523ac57a78f7878ac53715f22e52393822810
+    HEAD_REF master
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        designerplugin BUILD_DESIGNERPLUGIN
+    INVERTED_FEATURES
+        translations   KF_SKIP_PO_PROCESSING
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DBUILD_PYTHON_BINDINGS=OFF
+        -DKDE_INSTALL_PLUGINDIR=plugins
+        -DKDE_INSTALL_QTPLUGINDIR=plugins
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME kf6widgetsaddons CONFIG_PATH lib/cmake/KF6WidgetsAddons)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kwidgetsaddons/vcpkg.json
+++ b/ports/kwidgetsaddons/vcpkg.json
@@ -4,6 +4,7 @@
   "description": "Addons to QtWidgets",
   "homepage": "https://invent.kde.org/frameworks/kwidgetsaddons",
   "documentation": "https://api.kde.org/kwidgetsaddons-index.html",
+  "license": null,
   "dependencies": [
     "ecm",
     {

--- a/ports/kwidgetsaddons/vcpkg.json
+++ b/ports/kwidgetsaddons/vcpkg.json
@@ -1,0 +1,49 @@
+{
+  "name": "kwidgetsaddons",
+  "version": "6.25.0",
+  "description": "Addons to QtWidgets",
+  "homepage": "https://invent.kde.org/frameworks/kwidgetsaddons",
+  "documentation": "https://api.kde.org/kwidgetsaddons-index.html",
+  "dependencies": [
+    "ecm",
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "designerplugin": {
+      "description": "Build Qt Designer plugin",
+      "dependencies": [
+        {
+          "name": "qttools",
+          "default-features": false,
+          "features": [
+            "designer"
+          ]
+        }
+      ]
+    },
+    "translations": {
+      "description": "Build and install translations",
+      "dependencies": [
+        {
+          "name": "qttools",
+          "host": true,
+          "default-features": false,
+          "features": [
+            "linguist"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4612,6 +4612,10 @@
       "baseline": "2019-08-06",
       "port-version": 3
     },
+    "kwidgetsaddons": {
+      "baseline": "6.25.0",
+      "port-version": 0
+    },
     "kwindowsystem": {
       "baseline": "6.25.0",
       "port-version": 0

--- a/versions/k-/kwidgetsaddons.json
+++ b/versions/k-/kwidgetsaddons.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "98298b42fb9fa0fdf88887e2dd6716aad164d594",
+      "git-tree": "b780c03182c97cf53d64d5fb4db6091388f7a771",
       "version": "6.25.0",
       "port-version": 0
     }

--- a/versions/k-/kwidgetsaddons.json
+++ b/versions/k-/kwidgetsaddons.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "98298b42fb9fa0fdf88887e2dd6716aad164d594",
+      "version": "6.25.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/kwidgetsaddons/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
