### PR TITLE
[openturns] update to 1.26

### DIFF
--- a/ports/openturns/portfile.cmake
+++ b/ports/openturns/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO openturns/openturns
     REF v${VERSION}
-    SHA512 d73c294ce8fafb99da0769791cee09a6da76d3839489dd32227a7569c1fbbfc06c2a918d3951ea5b9d7a7efb1f30d11e04a52bb8d906e37411bc372235a9832b
+    SHA512 b838988d8ee0fcfb7ae54207bc48f403a3f6aa912ea9675becf0f96bd34dca81555538281944916aa91c104b24e3973389e964320a9cb2ef512f5bf33c8d9d64
     HEAD_REF master
     PATCHES
         dependencies.diff

--- a/ports/openturns/vcpkg.json
+++ b/ports/openturns/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openturns",
-  "version": "1.25.1",
+  "version": "1.26",
   "description": "OpenTURNS is a scientific C++ and Python library featuring an internal data model and algorithms dedicated to the treatment of uncertainties.",
   "homepage": "https://openturns.github.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7353,7 +7353,7 @@
       "port-version": 4
     },
     "openturns": {
-      "baseline": "1.25.1",
+      "baseline": "1.26",
       "port-version": 0
     },
     "openvdb": {

--- a/versions/o-/openturns.json
+++ b/versions/o-/openturns.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "db4becd1d4b99806b11777ad81bab18332d3bb2e",
+      "version": "1.26",
+      "port-version": 0
+    },
+    {
       "git-tree": "43466bd524dd569e6425856515745abcebfb6091",
       "version": "1.25.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

