### PR TITLE
[pango] update to 1.57.1

### DIFF
--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(SOURCE_ARCHIVE
         "https://download.gnome.org/sources/pango/${VERSION_MAJOR_MINOR}/pango-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "pango-${VERSION}.tar.xz"
-    SHA512 e3d251e0c2d5cb7f2e9d26e675aa2fae0c3cedce9e73b77f92a4abbeff55eaa819811e4c064ca036d3964a3ee4592f596ebfa7c0a760189b9d8c38a5f3a4ea3a
+    SHA512 ccfcec11f0beb0487d9225be227e7f31d03229ed1e0dc3309e2647ed5fa953cf036ad352232429f5604f97d20812074ff145ea622110afa4df3a410ebba4d26a
 )
 vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${SOURCE_ARCHIVE}"

--- a/ports/pango/vcpkg.json
+++ b/ports/pango/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pango",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "description": "Text and font handling library.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7493,7 +7493,7 @@
       "port-version": 0
     },
     "pango": {
-      "baseline": "1.57.0",
+      "baseline": "1.57.1",
       "port-version": 0
     },
     "pangolin": {

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "caa5a9d22c4b45f1c36d14d11a54d4cc7fb93ed6",
+      "version": "1.57.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9483477b9620b97176c93ed584a80ace1e845cff",
       "version": "1.57.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

