### PR TITLE
[presentmon] update to 2.5.0

### DIFF
--- a/ports/presentmon/portfile.cmake
+++ b/ports/presentmon/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GameTechDev/PresentMon
     REF "v${VERSION}"
-    SHA512 1c606dd53a05b88a500a2deeb7099ce3cf0e9edfdf6ce8f9a1a91efecf9049bf700368066cbafc1e196f4bf8a6e43da86a2f10ad0843b582ab851e366a33eda4
+    SHA512 d648826df09f7aafbb64051870b5f6d988b9d1e017d6be89ee4a9089bbce2cc4077d7266da3e4556d198117f1ecc183599cfdf96d06a3072e24de85c3cff4dd4
     HEAD_REF main
 )
 

--- a/ports/presentmon/vcpkg.json
+++ b/ports/presentmon/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "presentmon",
-  "version-semver": "2.3.0",
+  "version-semver": "2.5.0",
   "description": "PresentMon is a tool to capture and analyze ETW events related to swap chain presentation on Windows.",
   "supports": "windows & !uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7849,7 +7849,7 @@
       "port-version": 0
     },
     "presentmon": {
-      "baseline": "2.3.0",
+      "baseline": "2.5.0",
       "port-version": 0
     },
     "proj": {

--- a/versions/p-/presentmon.json
+++ b/versions/p-/presentmon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "afd2b8e702aa18b0a11ccea1438d5b9cd3a879cd",
+      "version-semver": "2.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d397dd1c9203af9da5d7833dc04117cdacaff59",
       "version-semver": "2.3.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

