### PR TITLE
[ptex] update to 2.5.1

### DIFF
--- a/ports/ptex/portfile.cmake
+++ b/ports/ptex/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wdas/ptex
     REF "v${VERSION}"
-    SHA512 8c9d1e2b26f74ea988f4df6f4a6b342a152a8068ff7f85eacdfbab9f516d2ab15282f16326e9527d0f842f4eb8e16858eb57c19b8bbee153f1ab074175571025
+    SHA512 26265899d3bb47eca67052d69b08efb89a01cf06a01a4aabdd8118e0497aac87319317450719ac56ea676bbb2ea771bd9b8fe73bc41caa8a2a6818cbc3d83bea
     HEAD_REF master
     PATCHES
         fix-build.patch

--- a/ports/ptex/vcpkg.json
+++ b/ports/ptex/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ptex",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Per-Face Texture Mapping for Production Rendering.",
   "homepage": "https://github.com/wdas/ptex",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7909,7 +7909,7 @@
       "port-version": 1
     },
     "ptex": {
-      "baseline": "2.5.0",
+      "baseline": "2.5.1",
       "port-version": 0
     },
     "pthread": {

--- a/versions/p-/ptex.json
+++ b/versions/p-/ptex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92e161723f969d4136338cbf6820d6d77b3de89e",
+      "version": "2.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e6bc414dff812506314e6ae493a3a8043b6f8504",
       "version": "2.5.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

