### PR TITLE
[pulsar-client-cpp] update to 4.0.1

### DIFF
--- a/ports/pulsar-client-cpp/portfile.cmake
+++ b/ports/pulsar-client-cpp/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.apache.org/dist/pulsar/pulsar-client-cpp-${VERSION}/apache-pulsar-client-cpp-${VERSION}.tar.gz"
     FILENAME "apache-pulsar-client-cpp-${VERSION}.tar.gz"
-    SHA512 77f9172e840e921d8366002cd1af790545ffd8a66b62a7c3fa71f3ff24f7d43f021cde4aff60d5da9ea5dc7d12f6623bfbcd4ed406f18433ebf0b24c99e871f2
+    SHA512 c595b43b5a841a411f7945df1d330560070da594a91c7bee528df96073a3f0af8f4ab412ec27791157468c9c1af2faddb05cd92b63d06c1a544dd874848f5650
 )
 
 vcpkg_extract_source_archive(

--- a/ports/pulsar-client-cpp/vcpkg.json
+++ b/ports/pulsar-client-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pulsar-client-cpp",
-  "version": "4.0.0",
-  "port-version": 1,
+  "version": "4.0.1",
   "description": "The Apache Pulsar C++ library",
   "homepage": "https://github.com/apache/pulsar-client-cpp",
   "license": "Apache-2.0",
@@ -25,7 +24,7 @@
     "openssl",
     {
       "name": "protobuf",
-      "version>=": "3.21.12"
+      "version>=": "4.0.1"
     },
     "snappy",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7937,8 +7937,8 @@
       "port-version": 1
     },
     "pulsar-client-cpp": {
-      "baseline": "4.0.0",
-      "port-version": 1
+      "baseline": "4.0.1",
+      "port-version": 0
     },
     "pulseaudio": {
       "baseline": "17.0",

--- a/versions/p-/pulsar-client-cpp.json
+++ b/versions/p-/pulsar-client-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "864059165206e6260dd6a27516cf4b3238034c85",
+      "version": "4.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "bbcaf30271d5cf8dceee116b0e45f035f250a01b",
       "version": "4.0.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

