### PR TITLE
[pybind11] update to 3.0.2

### DIFF
--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pybind/pybind11
     REF "v${VERSION}"
-    SHA512 c17e6d6a78c38e760864b390ac2aa7df6a94ca53acb2e8be71f0d63d611b738fa20a16946c98a93fbfcad56cb0346ebf247bbe41c6f5171c6ce68397b1e5c4db
+    SHA512 19bee2c76320e25202ee078b5680ff8a7acfb33494dec29dad984ab04de8bcb01340d9fec37c8cc5ac9015dfc367e60312dcd8506e66ce8f0af4c49db562ddef
     HEAD_REF master
     PATCHES
         android.diff

--- a/ports/pybind11/vcpkg.json
+++ b/ports/pybind11/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pybind11",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code",
   "homepage": "https://github.com/pybind/pybind11",
   "documentation": "https://pybind11.readthedocs.io/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7953,7 +7953,7 @@
       "port-version": 0
     },
     "pybind11": {
-      "baseline": "3.0.1",
+      "baseline": "3.0.2",
       "port-version": 0
     },
     "pystring": {

--- a/versions/p-/pybind11.json
+++ b/versions/p-/pybind11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "36ab95496f94231c863f0ead761ea933ebae8c08",
+      "version": "3.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "2c5d74751c919edb2c3c7a183ee633df69c45c15",
       "version": "3.0.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

