### PR TITLE
[scotch] update to 7.0.11

### DIFF
--- a/ports/scotch/portfile.cmake
+++ b/ports/scotch/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO scotch/scotch
     REF "v${VERSION}"
-    SHA512 9566ca800fd47df63844df6ff8b0fbbe8efbdea549914dfe9bf00d3d104a8c5631cfbef69e2677de68dcdb93addaeed158e6f6a373b5afe8cec82ac358946b65
+    SHA512 37a1b57c705b24d25080d00173055ed1b50eabe03808741ec8b48bea82ccf256a80961e22e1081387854aa7665786906f24815f242c3c8e8551a70bc4c21f27c
     HEAD_REF master
     PATCHES fix-build.patch
 )

--- a/ports/scotch/vcpkg.json
+++ b/ports/scotch/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "scotch",
-  "version": "7.0.5",
-  "port-version": 1,
+  "version": "7.0.11",
   "description": "Scotch: a software package for graph and mesh/hypergraph partitioning, graph clustering, and sparse matrix ordering",
   "homepage": "https://gitlab.inria.fr/scotch/scotch",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8925,8 +8925,8 @@
       "port-version": 0
     },
     "scotch": {
-      "baseline": "7.0.5",
-      "port-version": 1
+      "baseline": "7.0.11",
+      "port-version": 0
     },
     "scottt-debugbreak": {
       "baseline": "1.0",

--- a/versions/s-/scotch.json
+++ b/versions/s-/scotch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "df0526010b334230d9f109c6eec05c6e17b71abb",
+      "version": "7.0.11",
+      "port-version": 0
+    },
+    {
       "git-tree": "ac6bd42f55d0f52fc7dd0ab144ea4c058e663b92",
       "version": "7.0.5",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

