### PR TITLE
[ffmpeg] Fixes #50639

### DIFF
--- a/ports/ffmpeg/0047-fix-msvc-utf8.patch
+++ b/ports/ffmpeg/0047-fix-msvc-utf8.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 85b6a69fbb..450d1bb45f 100755
+--- a/configure
++++ b/configure
+@@ -8146,7 +8146,7 @@ elif enabled_any msvc icl; then
+         check_cflags -d2SSAOptimizer-
+     # enable utf-8 source processing on VS2015 U2 and newer
+     test_cpp_condition windows.h "_MSC_FULL_VER >= 190023918" &&
+-        add_cflags -utf-8
++        add_allcflags -utf-8
+ fi
+ 
+ for pfx in "" host_; do

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
         0040-ffmpeg-add-av_stream_get_first_dts-for-chromium.patch # Do not remove this patch. It is required by chromium
         0045-use-prebuilt-bin2c.patch
         0046-fix-msvc-detection.patch
+        0047-fix-msvc-utf8.patch
 )
 
 if(SOURCE_PATH MATCHES " ")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "8.1",
+  "port-version": 1,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2990,7 +2990,7 @@
     },
     "ffmpeg": {
       "baseline": "8.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ffmpeg-bin2c": {
       "baseline": "8.1",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a084a0a06b57f2e7f4e50fdfda2855fa0a16c48e",
+      "version": "8.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "437ac286ee1b78217a172c9d745be744029163fb",
       "version": "8.1",
       "port-version": 0


### PR DESCRIPTION
Fixes #50639

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.