### PR TITLE
[gmsh] update to 4.15.2

### DIFF
--- a/ports/gmsh/portfile.cmake
+++ b/ports/gmsh/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://gmsh.info/src/gmsh-${VERSION}-source.tgz"
     FILENAME "gmsh-${VERSION}-source.tgz"
-    SHA512 dc3ba00c2788d95f30d0cedac490b72cdf6805ef67d81f8636e4ff45510640991cc85e950b3953335f1ba73f9458b980949469844f65d6d5fb09b51936ddef12
+    SHA512 9e05267e3d2bae54eeab21b384ab5cc85383e8040ed622ff859485fabd3dc9fc4b5a87d9d58acf3fc5573471d9c3c8e0831df4f44ae196d1a26ecbe9c613753c
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/gmsh/vcpkg.json
+++ b/ports/gmsh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gmsh",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "description": "Gmsh is an open source 3D finite element mesh generator with a built-in CAD engine and post-processor.",
   "homepage": "https://gmsh.info",
   "license": "LGPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3481,7 +3481,7 @@
       "port-version": 3
     },
     "gmsh": {
-      "baseline": "4.15.1",
+      "baseline": "4.15.2",
       "port-version": 0
     },
     "gobject-introspection": {

--- a/versions/g-/gmsh.json
+++ b/versions/g-/gmsh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c02f4bedee7cee4aa8e4d04baa4d66ff54340362",
+      "version": "4.15.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "33c365b0696bb024d512cfc0ddfa2f5cb8ef7922",
       "version": "4.15.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

