### PR TITLE
[elfutils] update to 0.194

### DIFF
--- a/ports/elfutils/portfile.cmake
+++ b/ports/elfutils/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://sourceware.org/pub/elfutils/${VERSION}/elfutils-${VERSION}.tar.bz2"
          "https://www.mirrorservice.org/sites/sourceware.org/pub/elfutils/${VERSION}/elfutils-${VERSION}.tar.bz2"
     FILENAME "elfutils-${VERSION}.tar.bz2"
-    SHA512 557e328e3de0d2a69d09c15a9333f705f3233584e2c6a7d3ce855d06a12dc129e69168d6be64082803630397bd64e1660a8b5324d4f162d17922e10ddb367d76
+    SHA512 66666666666666666666666666666666666666666666666666666666666668888888888888888888888888888888888888888888888888888888888888888888
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/elfutils/vcpkg.json
+++ b/ports/elfutils/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "elfutils",
-  "version": "0.193",
-  "port-version": 1,
+  "version": "0.194",
   "description": "elfutils is a collection of utilities and libraries to read, create and modify ELF binary files, find and handle DWARF debug data, symbols, thread state and stacktraces for processes and core files on GNU/Linux.",
   "homepage": "https://sourceware.org/elfutils/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2769,8 +2769,8 @@
       "port-version": 1
     },
     "elfutils": {
-      "baseline": "0.193",
-      "port-version": 1
+      "baseline": "0.194",
+      "port-version": 0
     },
     "eljonny-testcpp": {
       "baseline": "0.3.0-beta.4",

--- a/versions/e-/elfutils.json
+++ b/versions/e-/elfutils.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59df04d046682bd259b8ef994e6b450e71f409f2",
+      "version": "0.194",
+      "port-version": 0
+    },
+    {
       "git-tree": "d37cf1f9ef94a33d839033a62deff8af806fded2",
       "version": "0.193",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

