### PR TITLE
[f3d] update to 3.4.1

### DIFF
--- a/ports/f3d/portfile.cmake
+++ b/ports/f3d/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO f3d-app/f3d
     REF v${VERSION}
-    SHA512 ac3f9edca7c870f56603165a6035da36486f05dc8367ba9147f687f6de2f4c9dfb94077f6041f41dd689e03c0387f9fab62c69f995a4e18016d623844e83bb6b
+    SHA512 43d341427df2de42df87518c76fa3bea35a3617938bf67dd2c27830ec48cc41e1b5c3b269d0dda88ffddb5f178acc3244fc0026ec7f68259eb2850969efbbb3c
     HEAD_REF master
     PATCHES
         fix-install.patch

--- a/ports/f3d/vcpkg.json
+++ b/ports/f3d/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "f3d",
-  "version": "3.2.0",
+  "version": "3.4.1",
   "description": "A fast and minimalist 3D viewer",
   "homepage": "https://f3d.app",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2869,7 +2869,7 @@
       "port-version": 0
     },
     "f3d": {
-      "baseline": "3.2.0",
+      "baseline": "3.4.1",
       "port-version": 0
     },
     "faad2": {

--- a/versions/f-/f3d.json
+++ b/versions/f-/f3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "418175e283aee5a3fb18d6a15a32bcfb7cab9e9d",
+      "version": "3.4.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "a3e0591c5f9db55c72e178ae36ddb2e30b2f206a",
       "version": "3.2.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

