### PR TITLE
[fastdds] update to 3.4.2

### DIFF
--- a/ports/fastdds/portfile.cmake
+++ b/ports/fastdds/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eProsima/Fast-DDS
     REF "v${VERSION}"
-    SHA512 92869a930fe0b67ae4b457a00cb273aba6e52af3f7c39f7fc2ded8e7285237871d99579b31c28e831bebde820aeef190a70827c9e8a02c7119ca1908b181f3b6
+    SHA512 5843d1e8ca92d8b63b07890c36f59fb3c0cbedf622db4c61ecf136bf81d9ed4cf5dedb40bd795f44fdb935b6d5ea0fedae9cc7e8358aadaba3f28f608895597e
     HEAD_REF master
     PATCHES
         fix-deps.patch

--- a/ports/fastdds/vcpkg.json
+++ b/ports/fastdds/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fastdds",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "eprosima Fast DDS (formerly Fast RTPS) is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.",
   "homepage": "https://www.eprosima.com/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2929,7 +2929,7 @@
       "port-version": 1
     },
     "fastdds": {
-      "baseline": "3.4.1",
+      "baseline": "3.4.2",
       "port-version": 0
     },
     "fastfeat": {

--- a/versions/f-/fastdds.json
+++ b/versions/f-/fastdds.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "914bd1915677e0d989ebb7e4f8b81ed4450641ae",
+      "version": "3.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "31623c76c617f17e68239135e23835b90ad4502a",
       "version": "3.4.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

