### PR TITLE
[fbgemm] update to 1.6.0

### DIFF
--- a/ports/fbgemm/portfile.cmake
+++ b/ports/fbgemm/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_find_acquire_program(PYTHON3)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pytorch/fbgemm
-    REF 73a64e75ff31be7ece6f68929ee5682b0bf9eb10
-    SHA512 2757d986a977d14bd32d482452627b55aae216f77a262b2b1b88a643a2977c6c27c5a99ee91b7a7bdbb66248239ecc1a57d1953251049d787317b6355369af26
+    REF "v${VERSION}"
+    SHA512 c10c6839bff2a37374646559310e39f0c68fb5a5e72211f85dbd1984de2aad7c38fb161b1f56bc7c549080fd2140bf682e5acbf7c9f78c7c073dd8e66d5f5a92
     PATCHES
         fix-cmakelists.patch
 )

--- a/ports/fbgemm/vcpkg.json
+++ b/ports/fbgemm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fbgemm",
-  "version": "1.0.0",
-  "port-version": 1,
+  "version": "1.6.0",
   "description": "FB (Facebook) + GEMM (General Matrix-Matrix Multiplication)",
   "homepage": "https://code.fb.com/ml-applications/fbgemm/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2965,8 +2965,8 @@
       "port-version": 0
     },
     "fbgemm": {
-      "baseline": "1.0.0",
-      "port-version": 1
+      "baseline": "1.6.0",
+      "port-version": 0
     },
     "fbthrift": {
       "baseline": "2026.02.23.00",

--- a/versions/f-/fbgemm.json
+++ b/versions/f-/fbgemm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f25b4021a0f84fefaf32244e48e6c9547d5e50d8",
+      "version": "1.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "86dc5f7bb07a7e785aef6627e4af57f51c9c87d0",
       "version": "1.0.0",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

