### PR TITLE
[fdlibm] update to 5.3.1

### DIFF
--- a/ports/fdlibm/portfile.cmake
+++ b/ports/fdlibm/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://android.googlesource.com/platform/external/fdlibm
-    REF 59f7335e4dd8275a7dc2f8aeb4fd00758fde37ac
+    REF "v${VERSION}"
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/fdlibm/vcpkg.json
+++ b/ports/fdlibm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "fdlibm",
-  "version": "5.3",
-  "port-version": 7,
+  "version": "5.3.1",
   "description": "FDLIBM (Freely Distributable LIBM) is a C math library for machines that support IEEE 754 floating-point arithmetic",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2981,8 +2981,8 @@
       "port-version": 0
     },
     "fdlibm": {
-      "baseline": "5.3",
-      "port-version": 7
+      "baseline": "5.3.1",
+      "port-version": 0
     },
     "fenster": {
       "baseline": "2024-08-19",

--- a/versions/f-/fdlibm.json
+++ b/versions/f-/fdlibm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb5df833d2acee3a18587a7af96558c8a861911d",
+      "version": "5.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "b557ee44621e4f2935b37aee54d24addcbb418d2",
       "version": "5.3",
       "port-version": 7


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

