### PR TITLE
[freetype] update to 2.14.3

### DIFF
--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_gitlab(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO freetype/freetype
     REF "VER-${VERSION_HYPHEN}"
-    SHA512  fccfaa15eb79a105981bf634df34ac9ddf1c53550ec0b334903a1b21f9f8bf5eb2b3f9476e554afa112a0fca58ec85ab212d674dfd853670efec876bacbe8a53
+    SHA512 c3b6b0cc4b428c9c647ab2148386901dfd315273b68051940e8fea6010d46fdd2913467c3ef58be0d499b8e2ef5a0f1a4cc5e739756155587f4f7dff08ef9695
     HEAD_REF master
     PATCHES
         0003-Fix-UWP.patch

--- a/ports/freetype/vcpkg.json
+++ b/ports/freetype/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "freetype",
-  "version": "2.13.3",
+  "version": "2.14.3",
   "description": "A library to render fonts.",
   "homepage": "https://www.freetype.org/",
   "license": "FTL OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3181,7 +3181,7 @@
       "port-version": 2
     },
     "freetype": {
-      "baseline": "2.13.3",
+      "baseline": "2.14.3",
       "port-version": 0
     },
     "freetype-gl": {

--- a/versions/f-/freetype.json
+++ b/versions/f-/freetype.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04f655ac0be6b4fa0c50066dac4c3387a5b31a2b",
+      "version": "2.14.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "8a2c633dcc14eaabdb31cf4637242f4e3c2f3fa2",
       "version": "2.13.3",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

