### PR TITLE
[gdbm] update to 1.26

### DIFF
--- a/ports/gdbm/portfile.cmake
+++ b/ports/gdbm/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_download_distfile(ARCHIVE
          "https://ftp.gnu.org/gnu/gdbm/gdbm-${VERSION}.tar.gz"
          "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gdbm/gdbm-${VERSION}.tar.gz"
     FILENAME "gdbm-${VERSION}.tar.gz"
-    SHA512 401ff8c707079f21da1ac1d6f4714a87f224b6f41943078487dc891be49f51fd1ac7a32fd599aae0fad185f2c6ba7432616d328fd6aaab068eb54db9562ff7fa
+    SHA512 66666666666666666666666666666666666666666666666666666666666668888888888888888888888888888888888888888888888888888888888888888888
 )
 
 vcpkg_extract_source_archive(

--- a/ports/gdbm/vcpkg.json
+++ b/ports/gdbm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gdbm",
-  "version": "1.24",
-  "port-version": 1,
+  "version": "1.26",
   "description": "GDBM is a library of database functions that use extensible hashing and works similar to the standard UNIX dbm.",
   "homepage": "https://www.gnu.org.ua/software/gdbm/gdbm.html",
   "license": "GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3301,8 +3301,8 @@
       "port-version": 0
     },
     "gdbm": {
-      "baseline": "1.24",
-      "port-version": 1
+      "baseline": "1.26",
+      "port-version": 0
     },
     "gdcm": {
       "baseline": "3.2.2",

--- a/versions/g-/gdbm.json
+++ b/versions/g-/gdbm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d99daaa551e2b0c43e5faf27a22a55ef2cb3e13",
+      "version": "1.26",
+      "port-version": 0
+    },
+    {
       "git-tree": "e0402af6ea114205282de7f19abbb88f45bc5bc0",
       "version": "1.24",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

