### PR TITLE
[ports] Add zenith-c: A lightweight macro-based OOP framework for C.

### DIFF
--- a/ports/zenith-c/LICENSE
+++ b/ports/zenith-c/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Aksheita Dholakia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ports/zenith-c/portfile.cmake
+++ b/ports/zenith-c/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Aksh13673/Zenith
     REF v1.0.0
-    SHA512 0 # <--- This will cause a failure. See below how to fix it.
+    SHA512 b7da7251786576b55be979f485122f8725968425ba36d640816b0b3db6168f8ccf4120ba20526e9930c8c7294e64d43900ad2aef9d5f28175210d0c3a417
     HEAD_REF main
 )
 

--- a/ports/zenith-c/portfile.cmake
+++ b/ports/zenith-c/portfile.cmake
@@ -1,0 +1,14 @@
+# 1. Download the code from your GitHub
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Aksh13673/Zenith
+    REF v1.0.0
+    SHA512 0  ]
+    HEAD_REF main
+)
+
+# 2. Copy the header to the system include folder
+file(INSTALL "${SOURCE_PATH}/zenith_c.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+# 3. Install the license
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/zenith-c/portfile.cmake
+++ b/ports/zenith-c/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Aksh13673/Zenith
     REF v1.0.0
-    SHA512 0  ]
+    SHA512 0 # <--- This will cause a failure. See below how to fix it.
     HEAD_REF main
 )
 

--- a/ports/zenith-c/portfile.cmake
+++ b/ports/zenith-c/portfile.cmake
@@ -1,14 +1,5 @@
-# 1. Download the code from your GitHub
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO Aksh13673/Zenith
-    REF v1.0.0
-    SHA512 b7da7251786576b55be979f485122f8725968425ba36d640816b0b3db6168f8ccf4120ba20526e9930c8c7294e64d43900ad2aef9d5f28175210d0c3a417
-    HEAD_REF main
-)
+# 1. Install the header file
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/zenith_c.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-# 2. Copy the header to the system include folder
-file(INSTALL "${SOURCE_PATH}/zenith_c.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-
-# 3. Install the license
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+# 2. Install the license (Required by Microsoft)
+vcpkg_install_copyright(FILE_LIST "${CMAKE_CURRENT_LIST_DIR}/LICENSE")

--- a/ports/zenith-c/vcpkg.json
+++ b/ports/zenith-c/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "zenith-c",
+  "version": "1.0.0",
+  "description": "OOP for C by Aksheita",
+ "homepage": "https://github.com/Aksh13673/Zenith"
+  "license": "MIT"
+}

--- a/ports/zenith-c/vcpkg.json
+++ b/ports/zenith-c/vcpkg.json
@@ -2,6 +2,6 @@
   "name": "zenith-c",
   "version": "1.0.0",
   "description": "OOP for C by Aksheita",
- "homepage": "https://github.com/Aksh13673/Zenith"
+  "homepage": "https://github.com/Aksh13673/Zenith",
   "license": "MIT"
 }

--- a/ports/zenith-c/zenith_c.h
+++ b/ports/zenith-c/zenith_c.h
@@ -1,0 +1,93 @@
+/* 
+ * Zenith-C: The Ultimate OOP Framework for Procedural C
+ * 
+ * Copyright (c) 2026 Aksheita Dholakia
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef ZENITH_C_H
+#define ZENITH_C_H
+
+#include <stdlib.h>
+#include <string.h>
+
+// --- THE CORE ENGINE ---
+
+struct zc_vnode {
+    const char* type_name;
+    void* table;
+    struct zc_vnode* next;
+};
+
+#define ZC_CLASS(name) \
+    typedef struct name name; \
+    struct name##_vtable; \
+    struct name { \
+        struct zc_vnode* vlist;
+
+#define ZC_METHODS(name) \
+    }; \
+    struct name##_vtable {
+
+#define ZC_END_CLASS };
+
+// --- THE FACTORY (Universal Constructor) ---
+// This version works on ALL compilers (GCC, Clang, MSVC)
+#define ZC_NEW(ptr, type, ...) \
+    do { \
+        ptr = (type*)malloc(sizeof(type)); \
+        if (ptr) zc_init_##type(ptr, ##__VA_ARGS__); \
+    } while(0)
+
+// --- THE DESTRUCTOR (Memory Cleaner) ---
+// This macro clears the linked list nodes AND the object itself
+#define ZC_DELETE(obj) \
+    do { \
+        if (obj) { \
+            struct zc_vnode* current = (obj)->vlist; \
+            while (current) { \
+                struct zc_vnode* next = current->next; \
+                free(current); \
+                current = next; \
+            } \
+            free(obj); \
+            obj = NULL; \
+        } \
+    } while(0)
+
+// --- THE UTILS ---
+static inline void* zc_get_vtable(struct zc_vnode* head, const char* name) {
+    while(head) {
+        if(strcmp(head->type_name, name) == 0) return head->table;
+        head = head->next;
+    }
+    return NULL;
+}
+
+static inline struct zc_vnode* zc_attach(struct zc_vnode* head, const char* name, void* table) {
+    struct zc_vnode* node = (struct zc_vnode*)malloc(sizeof(struct zc_vnode));
+    if (!node) return head;
+    node->type_name = name;
+    node->table = table;
+    node->next = head;
+    return node;
+}
+
+#endif // ZENITH_C_H

--- a/versions/z-/zenith-c.json
+++ b/versions/z-/zenith-c.json
@@ -1,0 +1,8 @@
+{
+  "versions": [
+    {
+      "version": "1.0.0",
+      "git-tree": "6582e89"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [ ] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Exactly one version is added in each modified versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
