### PR TITLE
[libharu] Bump to 2.4.6

### DIFF
--- a/ports/libharu/portfile.cmake
+++ b/ports/libharu/portfile.cmake
@@ -1,19 +1,11 @@
-vcpkg_download_distfile(
-    PR351
-    URLS "https://github.com/libharu/libharu/commit/4c87178a92097d59ecb9a3271341df4944b52225.patch?full_index=1"
-    FILENAME "pr351.patch"
-    SHA512 43049c3db9ab52f4550dd71218f0115c5f039caaf82e19671e295bb0e12ae6f9750cd18a944bf88819f7fc67cfecdbc8425eff1e387b2a6935847b5810d8c048
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libharu/libharu
     REF "v${VERSION}"
-    SHA512 677523f927ecc925d95c91ebb1cb3d1146c2ffc86031c6fc05fc038893fd38babde2abf16683e0b76d1e2b8554c64bf2278649a0f70b08a0f187c2135fc14220
+    SHA512 c16b1770cd06ffb3d02649de2f4a9e84ca2c42d82183194e01802bf8c6745609a176185d00e37bb06cae9b3245c154cf7e267e47bd71b3b9aa572c28214fec69
     HEAD_REF master
     PATCHES
         export-targets.patch
-        "${PR351}"
 )
 
 vcpkg_cmake_configure(

--- a/ports/libharu/vcpkg.json
+++ b/ports/libharu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libharu",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "libharu - free PDF library",
   "homepage": "https://github.com/libharu/libharu",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4997,7 +4997,7 @@
       "port-version": 5
     },
     "libharu": {
-      "baseline": "2.4.5",
+      "baseline": "2.4.6",
       "port-version": 0
     },
     "libhat": {

--- a/versions/l-/libharu.json
+++ b/versions/l-/libharu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89fa4c891ccd311e22d4389447aa98d6d620b51c",
+      "version": "2.4.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "4212fe7855d8b719108395a93cacea35244fdec7",
       "version": "2.4.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
