### PR TITLE
[doctest] update to 2.5.0

### DIFF
--- a/ports/doctest/portfile.cmake
+++ b/ports/doctest/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO doctest/doctest
     REF "v${VERSION}"
-    SHA512 d55aae632e6d66add7b65d0e97bde5063cdae7512836f278613af35957c62dbc6b0b0febbe2eb1eddd334a7a5343faca7357a2eeebbf1428cafffeb5d18e610c
+    SHA512 16c2d195ae13f08dd1c9ee12af25135b69ed13ce569d1344f61ace6bc6a42898bb8d24358546049d82552db0759fac82fccfb59e4f970b4a80b3d06be6c95f2b
     HEAD_REF master
 )
 

--- a/ports/doctest/vcpkg.json
+++ b/ports/doctest/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "doctest",
-  "version": "2.4.12",
+  "version": "2.5.0",
   "description": "The fastest feature-rich C++11/14/17/20 single-header testing framework",
   "homepage": "https://github.com/doctest/doctest",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2561,7 +2561,7 @@
       "port-version": 0
     },
     "doctest": {
-      "baseline": "2.4.12",
+      "baseline": "2.5.0",
       "port-version": 0
     },
     "double-conversion": {

--- a/versions/d-/doctest.json
+++ b/versions/d-/doctest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3370dd0dbc85c029695b1c0635c85d021596154",
+      "version": "2.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "fcb90f044a88f9c4d3af9410dd6eba419ca36016",
       "version": "2.4.12",
       "port-version": 0


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.



