### PR TITLE
[ableton-link] update to 4.0.0b2

### DIFF
--- a/ports/ableton-link/portfile.cmake
+++ b/ports/ableton-link/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Ableton/link
     REF "Link-${VERSION}"
-    SHA512 21ab3f47b1b2a7961cae238ca846adf0190341e8379a33938824acc49d3b95d8823b61bc321b1dfcbb3864f740425ac81d8c5c581e882394e1edac230f4c34e4
+    SHA512 b59ae5a49b577a1adf67773aac334048aa9370cc98bc17ed44d1bee5bee1d3363d7f6484a809d872d62febaa7cc4e630cb611b6f6a68b2f0ba92c8c77675c712
     HEAD_REF master
     PATCHES
         replace_local_asiostandalone_by_vcpkg_asio.patch

--- a/ports/ableton-link/vcpkg.json
+++ b/ports/ableton-link/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ableton-link",
-  "version": "3.1.5",
+  "version": "4.0.0b2",
   "description": "Ableton Link, a technology that synchronizes musical beat, tempo, and phase across multiple applications running on one or more devices.",
   "homepage": "https://www.ableton.com/en/link/",
   "documentation": "http://ableton.github.io/link/",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

