### PR TITLE
[aeron] update to 1.0.5

### DIFF
--- a/ports/aeron/portfile.cmake
+++ b/ports/aeron/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aeron-io/aeron
     REF "${VERSION}"
-    SHA512 aacd14611acfff3f4890541fbd1f3cdb8b396d86a4e9fb2eb1f4f1a72c9fbe546d2b479ee86b4fe5900b5f3acf6e29d9916364efbe98255baa9cd6c429b057cb
+    SHA512 1ad59f2efd71cf96b91f1fcccaefbeed51ea4f1b2f9071d7ab890a48a6e98f481d907a3499231ee3a9299c974d9e6f7389bc1b3e41ac1ce219ac13e4856188d5
     HEAD_REF master
     PATCHES
         patches/add-libuuid-vcpkg-support.patch

--- a/ports/aeron/vcpkg.json
+++ b/ports/aeron/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "aeron",
-  "version": "1.50.4",
+  "version": "1.0.5",
   "description": "Efficient reliable UDP unicast, UDP multicast, and IPC message transport",
   "homepage": "https://github.com/aeron-io/aeron",
   "license": "Apache-2.0",

--- a/versions/a-/aeron.json
+++ b/versions/a-/aeron.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a40bd88cce6ddedcc5a4a9b77ea895c205b922e",
+      "version": "1.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "4841039173fdd756d73cb7cc0b095bebe0bfb5ba",
       "version": "1.50.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -61,7 +61,7 @@
       "port-version": 0
     },
     "aeron": {
-      "baseline": "1.50.4",
+      "baseline": "1.0.5",
       "port-version": 0
     },
     "air-ctl": {


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

