### PR TITLE
[gklib] update to 5.1.1-DistDGL-0.5

### DIFF
--- a/ports/gklib/portfile.cmake
+++ b/ports/gklib/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KarypisLab/GKlib
-    REF 6e7951358fd896e2abed7887196b6871aac9f2f8
-    SHA512 54ba87f2c47e025ada0fe6fe608d9d144df5cd13e97e71892dbba4d50cd96409add309937a540cdf8bd2632cbfbc0e22e080a32d114ba6037008c8676aa8d88d
+    REF "METIS-v${VERSION}"
+    SHA512 248db76a51c66ae9b94ac759e19f6e5504dd75d6e1b3a1c0f8a1f2db899099ec7b62328213bfdefef8c70b6be40f122a27d427c016cbf4419fd1e032a52567ca
     PATCHES
         build-fixes.patch
         regex.patch

--- a/ports/gklib/vcpkg.json
+++ b/ports/gklib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gklib",
-  "version-date": "2025-07-06",
-  "port-version": 1,
+  "version-date": "5.1.1-DistDGL-0.5",
   "description": "General helper libraries for KarypisLab.",
   "homepage": "https://github.com/KarypisLab/GKlib/",
   "license": "Apache-2.0",


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

