### PR TITLE
[gmmlib] update to 22.10.0

### DIFF
--- a/ports/gmmlib/portfile.cmake
+++ b/ports/gmmlib/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/gmmlib
     REF "intel-gmmlib-${VERSION}"
-    SHA512 c54581e4927bfedd7cb4084111cce69c9ee14f0047f6d16d26358e9d41feb8d28d5158f7fbdfbe4980dae904e7c2065deed19fd2f91e32b49fd7b984d47c0f44
+    SHA512 63e676291f137880e2b4bd2091c3055a6ec2b0bb62ebd47a96c0a462e8434d1321563c4e2f0d2e40d79383a23ef0bb8ceb0f0f89a8ae94feb409440e43149e6e
     HEAD_REF master
 )
 

--- a/ports/gmmlib/vcpkg.json
+++ b/ports/gmmlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gmmlib",
-  "version": "22.9.0",
+  "version": "22.10.0",
   "description": "Intel(R) Graphics Memory Management Library",
   "homepage": "https://github.com/intel/gmmlib",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3473,7 +3473,7 @@
       "port-version": 1
     },
     "gmmlib": {
-      "baseline": "22.9.0",
+      "baseline": "22.10.0",
       "port-version": 0
     },
     "gmp": {

--- a/versions/g-/gmmlib.json
+++ b/versions/g-/gmmlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c0b2f263f87e96edb21096babe7fbe8ba8f74f90",
+      "version": "22.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4bd80365a1635192362a759364118463a1681bd0",
       "version": "22.9.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

