### PR TITLE
[zpp-bits] update to 4.7

### DIFF
--- a/ports/zpp-bits/portfile.cmake
+++ b/ports/zpp-bits/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eyalz800/zpp_bits
     REF "v${VERSION}"
-    SHA512 faa96f9702a96fae10ba9dec01d0eda0e708a8bda2ee9febbcca89dfe78cf4947edbff941fe51c5529ad4c76a344ea187069ba3ed79daa36140cf39acfb522b8
+    SHA512 b5df44cb9eaafb1926e6acc795e47673d84206da3e33c5b863fedddee56f5c10b45e1b4b33fe0ee6ca64dab68d44c7b3c981cd04482b7c30e4342f45f6d4258c
     HEAD_REF master
 )
 

--- a/ports/zpp-bits/vcpkg.json
+++ b/ports/zpp-bits/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zpp-bits",
-  "version": "4.6",
+  "version": "4.7",
   "description": "A lightweight C++20 serialization and RPC library",
   "homepage": "https://github.com/eyalz800/zpp_bits",
   "license": "MIT"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11125,7 +11125,7 @@
       "port-version": 4
     },
     "zpp-bits": {
-      "baseline": "4.6",
+      "baseline": "4.7",
       "port-version": 0
     },
     "zserge-webview": {

--- a/versions/z-/zpp-bits.json
+++ b/versions/z-/zpp-bits.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3a33f91322bccec5f5ba5ac74acfd8e4e89b2ee",
+      "version": "4.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "20c031ff57d9281538bd8f878fdf8affcaf1c182",
       "version": "4.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/eyalz800/zpp_bits/releases/tag/v4.7
