### PR TITLE
[zxc] add "util" feature

### DIFF
--- a/ports/zxc/portfile.cmake
+++ b/ports/zxc/portfile.cmake
@@ -9,12 +9,18 @@ vcpkg_from_github(
 # Remove vendored rapidhash to use the rapidhash port instead
 file(REMOVE "${SOURCE_PATH}/src/lib/vendors/rapidhash.h")
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        util ZXC_BUILD_CLI
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DZXC_NATIVE_ARCH=OFF
         -DZXC_ENABLE_LTO=OFF
-        -DZXC_BUILD_CLI=OFF
         -DZXC_BUILD_TESTS=OFF
 )
 
@@ -27,5 +33,13 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
+
+if ("util" IN_LIST FEATURES)
+    vcpkg_copy_tools(
+        TOOL_NAMES
+            zxc
+        AUTO_CLEAN
+    )
+endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/zxc/vcpkg.json
+++ b/ports/zxc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zxc",
   "version": "0.9.1",
+  "port-version": 1,
   "description": "High-performance asymmetric lossless compression library",
   "homepage": "https://github.com/hellobertrand/zxc",
   "license": "BSD-3-Clause AND MIT",
@@ -14,5 +15,10 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "util": {
+      "description": "Build the command-line interface"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -11170,7 +11170,7 @@
     },
     "zxc": {
       "baseline": "0.9.1",
-      "port-version": 0
+      "port-version": 1
     },
     "zycore": {
       "baseline": "1.5.2",

--- a/versions/z-/zxc.json
+++ b/versions/z-/zxc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0b84dd5ccc4769de5eec8b4be5c5329a1e95a1bb",
+      "version": "0.9.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "85a7f307fc667ef2e3729ea0baaf4c72f6f0cc5a",
       "version": "0.9.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
