### PR TITLE
[cuda-api-wrappers] Update to 0.8.2

### DIFF
--- a/ports/cuda-api-wrappers/portfile.cmake
+++ b/ports/cuda-api-wrappers/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eyalroz/cuda-api-wrappers
     REF "v${VERSION}"
-    SHA512 5d42cebdc1361e525fc93ea71df6b126f9ce79b2aad3af60e1e59caa8185e3e06997452c588505a294200917c84840f33324bcea8c11ee911b5fd5b11a6b1f9d
+    SHA512 f2fa0d08218660fc9ae5cb4421dd343e301060d2adaccfb93521f894489ed9bf58145eb8d7046aeb25a6059a0525403cb1a71d4d4f0d5ef5a938fffd7aac7795
     HEAD_REF master
 )
 

--- a/ports/cuda-api-wrappers/vcpkg.json
+++ b/ports/cuda-api-wrappers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cuda-api-wrappers",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Header-only library of integrated wrappers around the core parts of NVIDIA's CUDA execution ecosystem",
   "homepage": "https://github.com/eyalroz/cuda-api-wrappers",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2265,7 +2265,7 @@
       "port-version": 13
     },
     "cuda-api-wrappers": {
-      "baseline": "0.8.1",
+      "baseline": "0.8.2",
       "port-version": 0
     },
     "cudnn": {
@@ -4424,23 +4424,7 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6i18n": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6globalaccel": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6itemmodels": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6dbusaddons": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6coreaddons": {
+    "kf6breezeicons": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -4448,7 +4432,23 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6breezeicons": {
+    "kf6coreaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6dbusaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6globalaccel": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6i18n": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6itemmodels": {
       "baseline": "6.23.0",
       "port-version": 0
     },

--- a/versions/c-/cuda-api-wrappers.json
+++ b/versions/c-/cuda-api-wrappers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fedc3fef484f9961400668ec4a863e02b601815d",
+      "version": "0.8.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "39a8d3534f1bf09d31f2549c086d30338466dc9a",
       "version": "0.8.1",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed. *NO PATCH FILES*
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.

Simple update of the cuda-api-wrappers library from 0.8.1 to 0.8.2.