### PR TITLE
[zookeeper] fixed outdated fallback url

### DIFF
--- a/ports/zookeeper/portfile.cmake
+++ b/ports/zookeeper/portfile.cmake
@@ -5,7 +5,7 @@ string(REGEX REPLACE "^([0-9]+[.][0-9]+[.][0-9]+)[.]([0-9]+)\$" "\\1-\\2" VERSIO
 vcpkg_download_distfile(
     zookeeper_src_archive
     URLS "https://dlcdn.apache.org/zookeeper/stable/apache-zookeeper-${VERSION}.tar.gz"
-         "https://archive.apache.org/dist/zookeeper/zookeeper-${VERSION}/zookeeper-${VERSION}.tar.gz"
+         "https://archive.apache.org/dist/zookeeper/zookeeper-${VERSION}/apache-zookeeper-${VERSION}.tar.gz"
     FILENAME "apache-zookeeper-${VERSION}.tar.gz"
     SHA512 61c05f6064797994dc25c42df35d67d2c3839fd59a496924852a4d78b492b06746c8eb5445edb63cbc0107ef2b8b31babf23488f96a52b00682cd2e9b61be339
 )
@@ -23,7 +23,7 @@ file(COPY "${CURRENT_PORT_DIR}/unofficial-zookeeperConfig.cmake" DESTINATION "${
 vcpkg_download_distfile(
     zookeeper_bin_archive
     URLS "https://dlcdn.apache.org/zookeeper/stable/apache-zookeeper-${VERSION}-bin.tar.gz"
-         "https://archive.apache.org/dist/zookeeper/zookeeper-${VERSION}/zookeeper-${VERSION}-bin.tar.gz"
+         "https://archive.apache.org/dist/zookeeper/zookeeper-${VERSION}/apache-zookeeper-${VERSION}-bin.tar.gz"
     FILENAME "apache-zookeeper-${VERSION}-bin.tar.gz"
     SHA512 ab9bf90649df19d8fd8378f2e8d9159bc8528d8e4c166a93d9fa4a9c98e39ee9de0279cc9dc58cd6d593141c0a45576d0df9db47d143d63951598a43efdc0a30
 )

--- a/ports/zookeeper/vcpkg.json
+++ b/ports/zookeeper/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zookeeper",
   "version": "3.8.5",
+  "port-version": 1,
   "description": "ZooKeeper C bindings",
   "homepage": "https://github.com/apache/zookeeper",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4424,23 +4424,7 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6i18n": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6globalaccel": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6itemmodels": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6dbusaddons": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6coreaddons": {
+    "kf6breezeicons": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -4448,7 +4432,23 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6breezeicons": {
+    "kf6coreaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6dbusaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6globalaccel": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6i18n": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6itemmodels": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -11118,7 +11118,7 @@
     },
     "zookeeper": {
       "baseline": "3.8.5",
-      "port-version": 0
+      "port-version": 1
     },
     "zopfli": {
       "baseline": "1.0.3",

--- a/versions/z-/zookeeper.json
+++ b/versions/z-/zookeeper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2fa919563594c5cd77c16e229fc1d0b48946f6db",
+      "version": "3.8.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "eaef57b80cbd6af354d909e4b1ec1f5a9b1603cb",
       "version": "3.8.5",
       "port-version": 0


### PR DESCRIPTION
Fixes #50655

Fixed incorrect apache urls in the zookeeper port. 

The fallback URLs for both the source and binary archive were missing the apache prefix, causing 404 download failures.

- [ x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ x] SHA512s are updated for each updated download.
- [ x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ x] All patch files in the port are applied and succeed.
- [ x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ x] Exactly one version is added in each modified versions file.




