### PR TITLE
[gpgme] update to 2.0.1

### DIFF
--- a/ports/gpgme/portfile.cmake
+++ b/ports/gpgme/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(tarball
     URLS "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gpgme/gpgme-${VERSION}.tar.bz2"
          "https://gnupg.org/ftp/gcrypt/gpgme/gpgme-${VERSION}.tar.bz2"
     FILENAME "gpgme-${VERSION}.tar.bz2"
-    SHA512 ee58dc2a4273c740d5b9ef13cc655d5e600ddddd137fb85a781c31e8854829283b4ce241d7810a963d9a125d603213600f37e7d0c1ce3b3cf1b935e62cf60777
+    SHA512 66666666666666666666666666666666666666666666666666666666666668888888888888888888888888888888888888888888888888888888888888888888
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH

--- a/ports/gpgme/vcpkg.json
+++ b/ports/gpgme/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gpgme",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A library designed to make access to GnuPG easier for applications",
   "homepage": "https://gnupg.org/software/gpgme/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3509,7 +3509,7 @@
       "port-version": 0
     },
     "gpgme": {
-      "baseline": "2.0.0",
+      "baseline": "2.0.1",
       "port-version": 0
     },
     "gpgmepp": {
@@ -4424,23 +4424,7 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6i18n": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6globalaccel": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6itemmodels": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6dbusaddons": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6coreaddons": {
+    "kf6breezeicons": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -4448,7 +4432,23 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6breezeicons": {
+    "kf6coreaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6dbusaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6globalaccel": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6i18n": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6itemmodels": {
       "baseline": "6.23.0",
       "port-version": 0
     },

--- a/versions/g-/gpgme.json
+++ b/versions/g-/gpgme.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2715d13b29ddf71a5de48f38bac23589b2a06241",
+      "version": "2.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "32b19979f8ee8d0288885786718f0c8e8c5d3969",
       "version": "2.0.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

