### PR TITLE
[hwloc] update to 2.13.0

### DIFF
--- a/ports/hwloc/portfile.cmake
+++ b/ports/hwloc/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO open-mpi/hwloc
     REF "hwloc-${VERSION}"
-    SHA512 1ed47955d4a3ecf66636f1c5a89648ef055aa4f26fac9b9bc64d6f7715d671dc823337ebf38df53d60b50d697eccadfbd48d28b4540a5153c59d7eecd347f91c
+    SHA512 d9634d245c678c525aa55e89da6ae9406f05329958047fff55bdbd58bf2ada29d21800892b771064ad8140af20430d6d0f63e24b819b57730b47b255a3787f87
     PATCHES
         fix_shared_win_build.patch
         stdout_fileno.patch

--- a/ports/hwloc/vcpkg.json
+++ b/ports/hwloc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hwloc",
-  "version": "2.11.2",
+  "version": "2.13.0",
   "maintainers": "bgoglin<Brice.Goglin@inria.fr>",
   "description": [
     "Portable Hardware Locality (hwloc)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3853,7 +3853,7 @@
       "port-version": 1
     },
     "hwloc": {
-      "baseline": "2.11.2",
+      "baseline": "2.13.0",
       "port-version": 0
     },
     "hyperscan": {
@@ -4424,23 +4424,7 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6i18n": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6globalaccel": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6itemmodels": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6dbusaddons": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6coreaddons": {
+    "kf6breezeicons": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -4448,7 +4432,23 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6breezeicons": {
+    "kf6coreaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6dbusaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6globalaccel": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6i18n": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6itemmodels": {
       "baseline": "6.23.0",
       "port-version": 0
     },

--- a/versions/h-/hwloc.json
+++ b/versions/h-/hwloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c7d5031053f5ea5d70905479070aad63676917b6",
+      "version": "2.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "4b14fa65f32abe3d816a08d5d37aaf183372338c",
       "version": "2.11.2",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

