### PR TITLE
[microlog] Update to 7.0.3

### DIFF
--- a/ports/microlog/portfile.cmake
+++ b/ports/microlog/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO an-dr/microlog
-    REF "v7.0.2"
-    SHA512 0a5714ed47724fde3784a8857a3ffcec41edcb22898ed178af0f37ccf86c3256275adb308d5ac393e01fcd10e7c0b3b597fc1dd91050d7ca5daebac6cf25983b
+    REF "v7.0.3"
+    SHA512 6fab03d198917f39ba9a7bb44976d2367238e620adcd3864b4b541a08afdf2622b6654a2dbfd18422180fdd5811740b7c2d177d6a388a5e89ecac12e62452f71
 )
 
 vcpkg_cmake_configure(

--- a/ports/microlog/vcpkg.json
+++ b/ports/microlog/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "microlog",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "Extensible and configurable logging library for embedded and desktop applications with multi-output and logging topics",
   "homepage": "https://github.com/an-dr/microlog",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6449,7 +6449,7 @@
       "port-version": 0
     },
     "microlog": {
-      "baseline": "7.0.2",
+      "baseline": "7.0.3",
       "port-version": 0
     },
     "microsoft-signalr": {

--- a/versions/m-/microlog.json
+++ b/versions/m-/microlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "61795a0bc892c3b1acb3aa12c72d915b465c8678",
+      "version": "7.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "b127e9aeea232351b82a72e04fcc04708293bae5",
       "version": "7.0.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

The PR updates the `microlog` port from version 7.0.2 to 7.0.3.

**Changes**
- Fixed linking errors with `ULOG_BUILD_DISABLED=1`
- Corrected variable argument handling on Windows ARM architecture that was causing crashes in some configurations

**Release:** https://github.com/an-dr/microlog/releases/tag/v7.0.3
