### PR TITLE
[libgpiod] update to 2.2.3

### DIFF
--- a/ports/libgpiod/portfile.cmake
+++ b/ports/libgpiod/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${VERSION}.tar.gz
     FILENAME libgpiod-${VERSION}.tar.gz
-    SHA512 57ddb73faa1852c86886ec6b9b0e07c48200a8c01347bf9bc31ce5611de907140d20cabba63f33230bbfac558acae23676935ecf12b3c69ed9230a04cf252eb4
+    SHA512 5880c6f09755e94eb36a92e5b9bbffd103347fc20117289ee68682875e09cb1e6ab7b6460c428687d190adcdde6e1519c19256397f6a6e4b2d0b34b0f7ee4cd6
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/libgpiod/vcpkg.json
+++ b/ports/libgpiod/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libgpiod",
-  "version": "2.1.3",
-  "port-version": 1,
+  "version": "2.2.3",
   "description": "C library and tools for interacting with the linux GPIO character device",
   "homepage": "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4424,23 +4424,7 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6i18n": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6globalaccel": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6itemmodels": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6dbusaddons": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6coreaddons": {
+    "kf6breezeicons": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -4448,7 +4432,23 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6breezeicons": {
+    "kf6coreaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6dbusaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6globalaccel": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6i18n": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6itemmodels": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -5005,8 +5005,8 @@
       "port-version": 0
     },
     "libgpiod": {
-      "baseline": "2.1.3",
-      "port-version": 1
+      "baseline": "2.2.3",
+      "port-version": 0
     },
     "libgta": {
       "baseline": "1.0.8",

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9a993f2a245f973dde2ca6b0b75acd297b84851",
+      "version": "2.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "2be25e9a6f173834f760c02e4fa316d1fa6108ab",
       "version": "2.1.3",
       "port-version": 1


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

