### PR TITLE
[libid3tag] update to 0.16.4

### DIFF
--- a/ports/libid3tag/portfile.cmake
+++ b/ports/libid3tag/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(
     ARCHIVE URLS "https://codeberg.org/tenacityteam/libid3tag/archive/${VERSION}.tar.gz"
     FILENAME "${VERSION}.tar.gz"
-    SHA512 d49bc637899e4251ed66b5b56aa4c910dcdecd6b03ed197866d74175fc4eadff40f40f336606b23e2505b0e11834c4212a1314feeeaa2c0e9713051fdb56cb45
+    SHA512 056b7e00c62d14fc09980d4309422c822ad485cca3876cbb76017fef89aaf79ecfb42f2683521ff6d19f172ff1b7435dbd7307449559099ad31e0058415918ec
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")

--- a/ports/libid3tag/vcpkg.json
+++ b/ports/libid3tag/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libid3tag",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "ID3 tag manipulation library",
   "homepage": "https://codeberg.org/tenacityteam/libid3tag",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4424,23 +4424,7 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6i18n": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6globalaccel": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6itemmodels": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6dbusaddons": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6coreaddons": {
+    "kf6breezeicons": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -4448,7 +4432,23 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6breezeicons": {
+    "kf6coreaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6dbusaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6globalaccel": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6i18n": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6itemmodels": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -5069,7 +5069,7 @@
       "port-version": 0
     },
     "libid3tag": {
-      "baseline": "0.16.3",
+      "baseline": "0.16.4",
       "port-version": 0
     },
     "libideviceactivation": {

--- a/versions/l-/libid3tag.json
+++ b/versions/l-/libid3tag.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b547f07dc325f3732bfdec7dd54d751205e5b184",
+      "version": "0.16.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "a30c7af82d01be2c3bd973012681915cf394d464",
       "version": "0.16.3",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

