### PR TITLE
[libidn2] update to 2.3.8

### DIFF
--- a/ports/libidn2/portfile.cmake
+++ b/ports/libidn2/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libidn/${IDN2_FILENAME}"
          "https://ftp.gnu.org/gnu/libidn/${IDN2_FILENAME}"
     FILENAME "${IDN2_FILENAME}"
-    SHA512 eab5702bc0baed45492f8dde43a4d2ea3560ad80645e5f9e0cfa8d3b57bccd7fd782d04638e000ba07924a5d9f85e760095b55189188c4017b94705bef9b4a66
+    SHA512 4d8427c0f115268132f7544e80a808c883ab1406338f6c529b1a586b016d57aedb0857f66166eb8d9f37d70efc9dccf907b673b43b17bcf258c8797db1e829ce
 )
 
 vcpkg_extract_source_archive(SOURCE_PATH

--- a/ports/libidn2/vcpkg.json
+++ b/ports/libidn2/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libidn2",
-  "version": "2.3.7",
-  "port-version": 3,
+  "version": "2.3.8",
   "description": "GNU Libidn is an implementation of the Stringprep, Punycode and IDNA 2003 specifications. Libidn's purpose is to encode and decode internationalized domain names.",
   "homepage": "https://www.gnu.org/software/libidn/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4424,23 +4424,7 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6i18n": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6globalaccel": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6itemmodels": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6dbusaddons": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6coreaddons": {
+    "kf6breezeicons": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -4448,7 +4432,23 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6breezeicons": {
+    "kf6coreaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6dbusaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6globalaccel": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6i18n": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6itemmodels": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -5077,8 +5077,8 @@
       "port-version": 1
     },
     "libidn2": {
-      "baseline": "2.3.7",
-      "port-version": 3
+      "baseline": "2.3.8",
+      "port-version": 0
     },
     "libigl": {
       "baseline": "2.6.0",

--- a/versions/l-/libidn2.json
+++ b/versions/l-/libidn2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2b13a11c31091b37c83ee0ca82ebce2719355d80",
+      "version": "2.3.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "7aef2a7d6608229401769a9c1eb3732a08a57d75",
       "version": "2.3.7",
       "port-version": 3


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

