### PR TITLE
[consteig] Add consteig 1.0.0

### DIFF
--- a/ports/consteig/portfile.cmake
+++ b/ports/consteig/portfile.cmake
@@ -1,7 +1,9 @@
+set(VCPKG_BUILD_TYPE release) # header-only library
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MitchellThompkins/consteig
-    REF "1.0.0"
+    REF "${VERSION}"
     SHA512 7edee6224fd819b8a6c280c0644dd74bd268e19507281baec07f92bb783eae6347467c16f22c1ebd83a3090af07ae64c27e17d4ffbc765f16a327748b030a4e6
     HEAD_REF main
 )
@@ -9,14 +11,14 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DCONSTEIG_VERSION=1.0.0
+        -DCONSTEIG_VERSION="${VERSION}"
         -DCONSTEIG_BUILD_TESTS=OFF
         -DCONSTEIG_BUILD_EXAMPLES=OFF
         -DCONSTEIG_BUILD_PROFILING=OFF
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME consteig CONFIG_PATH lib/cmake/consteig)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/consteig)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/consteig/portfile.cmake
+++ b/ports/consteig/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO MitchellThompkins/consteig
+    REF "1.0.0"
+    SHA512 7edee6224fd819b8a6c280c0644dd74bd268e19507281baec07f92bb783eae6347467c16f22c1ebd83a3090af07ae64c27e17d4ffbc765f16a327748b030a4e6
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCONSTEIG_VERSION=1.0.0
+        -DCONSTEIG_BUILD_TESTS=OFF
+        -DCONSTEIG_BUILD_EXAMPLES=OFF
+        -DCONSTEIG_BUILD_PROFILING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME consteig CONFIG_PATH lib/cmake/consteig)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/consteig/vcpkg.json
+++ b/ports/consteig/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "consteig",
+  "version": "1.0.0",
+  "description": "Header-only C++17 constexpr library for compile-time eigenvalue and eigenvector computation",
+  "homepage": "https://github.com/MitchellThompkins/consteig",
+  "license": "Apache-2.0",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1964,6 +1964,10 @@
       "baseline": "1.0.2",
       "port-version": 0
     },
+    "consteig": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "constexpr": {
       "baseline": "1.0",
       "port-version": 3
@@ -4424,23 +4428,7 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6i18n": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6globalaccel": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6itemmodels": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6dbusaddons": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6coreaddons": {
+    "kf6breezeicons": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -4448,7 +4436,23 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6breezeicons": {
+    "kf6coreaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6dbusaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6globalaccel": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6i18n": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6itemmodels": {
       "baseline": "6.23.0",
       "port-version": 0
     },

--- a/versions/c-/consteig.json
+++ b/versions/c-/consteig.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f413bf21d69c45eb43ac7812603867dbd59123f1",
+      "git-tree": "1e241964f3cc5e04d4e5a4e794637ad70d499cc0",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/c-/consteig.json
+++ b/versions/c-/consteig.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8401dfaf00f78771be2c034512b6a39ccc4c67f3",
+      "git-tree": "f413bf21d69c45eb43ac7812603867dbd59123f1",
       "version": "1.0.0",
       "port-version": 0
     }

--- a/versions/c-/consteig.json
+++ b/versions/c-/consteig.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "8401dfaf00f78771be2c034512b6a39ccc4c67f3",
+      "version": "1.0.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [ ] The project is in Repology: https://repology.org/<PORT NAME>/versions
    - [x] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [x] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
