### PR TITLE
Issue 50968: Update nix shell deps

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,10 @@
 { pkgs ? import <nixpkgs> {}, withX11 ? false }:
 
-(pkgs.buildFHSUserEnv {
+(pkgs.buildFHSEnv {
   name = "vcpkg";
   targetPkgs = pkgs: (with pkgs; [
       autoconf
+      curl
       automake
       cmake
       gcc
@@ -15,6 +16,7 @@
       m4
       ninja
       pkg-config
+      unzip
       zip
       zstd.dev
     ] ++ pkgs.lib.optionals withX11 [


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/50968.

## Changes

- `buildFHSUserEnv` to `buildFHSEnv`: renamed in NixOS 23.05; the old name is a deprecated alias scheduled for removal in 25.11 ([nixpkgs #365499](https://github.com/NixOS/nixpkgs/pull/365499)).
- Added `curl` and `unzip`: both are explicitly required by `bootstrap-vcpkg.sh` (`vcpkgCheckRepoTool curl` and `vcpkgCheckRepoTool unzip`, `scripts/bootstrap.sh`) and the script errors out if they are missing.