### PR TITLE
[simsimd] fix sha512

### DIFF
--- a/ports/simsimd/portfile.cmake
+++ b/ports/simsimd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ashvardanian/SimSIMD
     REF "v${VERSION}"
-    SHA512 d583638379b3c6a6b8ac618955cc1d83154e02f841b568c44ac499e1acdbbc82b3d15d443dea4c9efb1ca6d206d899be7f7b3dc0a27825870b98c752dd0b65a6
+    SHA512 8707d435d7f525e0ce562b01a151d814e38396d60b208d4676235ce0f356c30b22c94187ff419ad51cd43f3eb84ab8f952afe1e6b5c63fdb3daf87c2ef402bb6
     HEAD_REF main
     PATCHES
         export-target.patch

--- a/ports/simsimd/vcpkg.json
+++ b/ports/simsimd/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "simsimd",
   "version": "6.5.16",
+  "port-version": 1,
   "description": "Fastest similarity-measures and distance functions on the Wild West – vectors, strings, short molecules, and even DNA sequences. All with a pinch of SIMD for both x86 and ARM.",
   "homepage": "https://github.com/ashvardanian/SimSIMD",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9226,7 +9226,7 @@
     },
     "simsimd": {
       "baseline": "6.5.16",
-      "port-version": 0
+      "port-version": 1
     },
     "sintra": {
       "baseline": "1.0.3",

--- a/versions/s-/simsimd.json
+++ b/versions/s-/simsimd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "928a66e62277053993ae13262a4dfe46c411dcf2",
+      "version": "6.5.16",
+      "port-version": 1
+    },
+    {
       "git-tree": "698b25fc8b692dbaa27073cb8c8fd6e1826a3d41",
       "version": "6.5.16",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Because simsimd has been renamed to numkong, the last version of simsimd has been updated with numkong issue.