### PR TITLE
[libopenmpt] update to 0.8.6

### DIFF
--- a/ports/libopenmpt/portfile.cmake
+++ b/ports/libopenmpt/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenMPT/openmpt
     REF "libopenmpt-${VERSION}"
-    SHA512 6e903b9d761e63fd8ab495cd9389ceed3100b2d0f2a5804aeff2c29cfc889cd32243c937efc2e534d883f8c032637c26e956d0bfcb93fd1d966d7cc3d6f338f4
+    SHA512 be7fed55245a2d6d809985bc53590d6b43bd2a24864dae185585dfa9d18acaab4a8e34c5f25c2c36fa58992afd0b74de754039f7a9ab67236d9be4f29a8f5255
     HEAD_REF master
 )
 

--- a/ports/libopenmpt/vcpkg.json
+++ b/ports/libopenmpt/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libopenmpt",
-  "version": "0.8.4",
+  "version": "0.8.6",
   "description": "A cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream.",
   "homepage": "https://openmpt.org/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4424,23 +4424,7 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6i18n": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6globalaccel": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6itemmodels": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6dbusaddons": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6coreaddons": {
+    "kf6breezeicons": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -4448,7 +4432,23 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6breezeicons": {
+    "kf6coreaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6dbusaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6globalaccel": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6i18n": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6itemmodels": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -5337,7 +5337,7 @@
       "port-version": 1
     },
     "libopenmpt": {
-      "baseline": "0.8.4",
+      "baseline": "0.8.6",
       "port-version": 0
     },
     "libopensp": {

--- a/versions/l-/libopenmpt.json
+++ b/versions/l-/libopenmpt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c523d3034847bab041eeb44b3eba799695246486",
+      "version": "0.8.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "b416890b1aa71d4b6b4e6554f43b7d4ddfa3877a",
       "version": "0.8.4",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md)
- [X] SHA512s are updated for each updated download
- [ ] ~The "supports" clause reflects platforms that may be fixed by this new version~
- [ ] ~Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.~
- [ ] ~Any patches that are no longer applied are deleted from the port's directory.~
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is added to each modified port's versions file.

