### PR TITLE
[fineftp] Bump to 1.6.0

### DIFF
--- a/ports/fineftp/portfile.cmake
+++ b/ports/fineftp/portfile.cmake
@@ -1,15 +1,13 @@
-#Get release from GitHub
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eclipse-ecal/fineftp-server
     REF "v${VERSION}"
-    SHA512 10e6fe6724e1751cb72d212f5fc8053b9c715e79ab41b080beb35c3501377b9e8fd8137de0b30266709aa34432dfa4593026db1b04735f7c1a4dbde90763ea97
+    SHA512 ce658369d3250c99e9e05f927711d73285218c39c7e923c2a9a28d93d76cfb1d3746d30a186769847ba423ea6285c99f0af432fa919a07377b81b43e1733ccbc
     HEAD_REF master
     PATCHES
         asio.patch
 )
 
-# Configure
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )

--- a/ports/fineftp/vcpkg.json
+++ b/ports/fineftp/vcpkg.json
@@ -1,7 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "fineftp",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "FineFTP is a minimal FTP server library for Windows and Unix flavors.",
   "homepage": "https://github.com/eclipse-ecal/fineftp-server",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3009,7 +3009,7 @@
       "port-version": 2
     },
     "fineftp": {
-      "baseline": "1.5.1",
+      "baseline": "1.6.0",
       "port-version": 0
     },
     "fins": {
@@ -4424,23 +4424,7 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6i18n": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6globalaccel": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6itemmodels": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6dbusaddons": {
-      "baseline": "6.23.0",
-      "port-version": 0
-    },
-    "kf6coreaddons": {
+    "kf6breezeicons": {
       "baseline": "6.23.0",
       "port-version": 0
     },
@@ -4448,7 +4432,23 @@
       "baseline": "6.23.0",
       "port-version": 0
     },
-    "kf6breezeicons": {
+    "kf6coreaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6dbusaddons": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6globalaccel": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6i18n": {
+      "baseline": "6.23.0",
+      "port-version": 0
+    },
+    "kf6itemmodels": {
       "baseline": "6.23.0",
       "port-version": 0
     },

--- a/versions/f-/fineftp.json
+++ b/versions/f-/fineftp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e0dbc98778791b8a4178dca2c330e7bf565194f1",
+      "version": "1.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d03fb60d6d482ea88aba0acfffb07b28abb0ef69",
       "version": "1.5.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
