### PR TITLE
[thrift] Fix missing bin directory on Linux

### DIFF
--- a/ports/thrift/fix_missing_quotes_in_config_and_bin_path.patch
+++ b/ports/thrift/fix_missing_quotes_in_config_and_bin_path.patch
@@ -2,14 +2,15 @@ diff --git a/build/cmake/ThriftConfig.cmake.in b/build/cmake/ThriftConfig.cmake.
 index f52480104..616dbeda6 100644
 --- a/build/cmake/ThriftConfig.cmake.in
 +++ b/build/cmake/ThriftConfig.cmake.in
-@@ -25,8 +25,8 @@ set_and_check(THRIFT_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+@@ -25,8 +25,9 @@ set_and_check(THRIFT_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
  
  set_and_check(THRIFT_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@/thrift")
  
 -if(@BUILD_COMPILER@)
 -    set_and_check(THRIFT_BIN_DIR "@PACKAGE_BIN_INSTALL_DIR@")
 +if("@BUILD_COMPILER@")
-+    set_and_check(THRIFT_BIN_DIR "@PACKAGE_BIN_INSTALL_DIR@/../tools/thrift")
++    get_filename_component(PARENT_DIR "@PACKAGE_BIN_INSTALL_DIR@" DIRECTORY)
++    set_and_check(THRIFT_BIN_DIR "${PARENT_DIR}/tools/thrift")
      if(NOT DEFINED THRIFT_COMPILER)
          set(THRIFT_COMPILER "${THRIFT_BIN_DIR}/thrift@CMAKE_EXECUTABLE_SUFFIX@")
      endif()

--- a/ports/thrift/vcpkg.json
+++ b/ports/thrift/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "thrift",
   "version": "0.22.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Apache Thrift is a software project spanning a variety of programming languages and use cases. Our goal is to make reliable, performant communication and data serialization across languages as efficient and seamless as possible.",
   "homepage": "https://github.com/apache/thrift",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9926,7 +9926,7 @@
     },
     "thrift": {
       "baseline": "0.22.0",
-      "port-version": 1
+      "port-version": 2
     },
     "tidy-html5": {
       "baseline": "5.8.0",

--- a/versions/t-/thrift.json
+++ b/versions/t-/thrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c69712275b12812b2464254884257cd47673d2c",
+      "version": "0.22.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "37ecae27a996313cbd6862b3c33aa026eda52692",
       "version": "0.22.0",
       "port-version": 1


### PR DESCRIPTION

Fixes #48096 

- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] SHA512s are updated for each updated download.
- [X] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [X] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [X] All patch files in the port are applied and succeed.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Exactly one version is added in each modified versions file.


