### PR TITLE
[catch2] Fix thread-safe-assertions feature

### DIFF
--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS OPTIONS
     FEATURES
-        thread-safe-assertions CATCH_CONFIG_EXPERIMENTAL_THREAD_SAFE_ASSERTIONS
+        thread-safe-assertions CATCH_CONFIG_THREAD_SAFE_ASSERTIONS
 )
 
 vcpkg_cmake_configure(

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "catch2",
   "version-semver": "3.13.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A modern, C++-native, test framework for unit-tests, TDD and BDD.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1626,7 +1626,7 @@
     },
     "catch2": {
       "baseline": "3.13.0",
-      "port-version": 1
+      "port-version": 2
     },
     "cblas": {
       "baseline": "2025-10-29",

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f984a3ec6c7d40ee45d9489e87fe500d50bc3b5",
+      "version-semver": "3.13.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "ed80adef87aa5c210cf3b5c3edd870f68b2db2e2",
       "version-semver": "3.13.0",
       "port-version": 1


### PR DESCRIPTION
With version v3.12.0, the thread safe assertions stopped being experimental and the CMake define was changed to plain `CATCH_CONFIG_THREAD_SAFE_ASSERTIONS`.


-------

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] ~~SHA512s are updated for each updated download.~~
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

