### PR TITLE
[regimeflow] add new port

### DIFF
--- a/ports/regimeflow/portfile.cmake
+++ b/ports/regimeflow/portfile.cmake
@@ -1,0 +1,37 @@
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        curl ENABLE_CURL
+        openssl ENABLE_OPENSSL
+        postgres ENABLE_POSTGRES
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gregorian-09/regime-flow
+    REF v1.0.1
+    SHA512 fbab0524c5a477cbc42ae035d769211ab524d0af615610da728959c19b503d5655562070e8068b56eaf43ea339e6c4bb715de554e276d86484c6bb5770415651
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTS=OFF
+        -DBUILD_BENCHMARKS=OFF
+        -DBUILD_PYTHON_BINDINGS=OFF
+        -DENABLE_IBAPI=OFF
+        -DENABLE_ZMQ=OFF
+        -DENABLE_REDIS=OFF
+        -DENABLE_KAFKA=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/RegimeFlow)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/regimeflow/usage
+++ b/ports/regimeflow/usage
@@ -1,0 +1,20 @@
+The package `regimeflow` provides the installed RegimeFlow C++ headers and
+imported CMake targets.
+
+Usage:
+  find_package(RegimeFlow CONFIG REQUIRED)
+  target_link_libraries(your_target PRIVATE
+      RegimeFlow::regimeflow_engine
+      RegimeFlow::regimeflow_strategy)
+
+Core imported targets:
+  RegimeFlow::regimeflow_common
+  RegimeFlow::regimeflow_data
+  RegimeFlow::regimeflow_engine
+  RegimeFlow::regimeflow_execution
+  RegimeFlow::regimeflow_metrics
+  RegimeFlow::regimeflow_plugins
+  RegimeFlow::regimeflow_regime
+  RegimeFlow::regimeflow_risk
+  RegimeFlow::regimeflow_strategy
+  RegimeFlow::regimeflow_walkforward

--- a/ports/regimeflow/vcpkg.json
+++ b/ports/regimeflow/vcpkg.json
@@ -1,0 +1,42 @@
+{
+  "name": "regimeflow",
+  "version": "1.0.1",
+  "description": "Regime-aware C++ backtesting and research libraries",
+  "homepage": "https://github.com/gregorian-09/regime-flow",
+  "license": "MIT",
+  "default-features": [
+    "curl",
+    "openssl"
+  ],
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "boost-system"
+  ],
+  "features": {
+    "curl": {
+      "description": "Enable HTTP-backed data and broker integrations that use libcurl.",
+      "dependencies": [
+        "curl"
+      ]
+    },
+    "openssl": {
+      "description": "Enable TLS and secure WebSocket support.",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "postgres": {
+      "description": "Enable PostgreSQL-backed data access helpers.",
+      "dependencies": [
+        "libpq"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8648,6 +8648,10 @@
       "baseline": "2022-12-07",
       "port-version": 0
     },
+    "regimeflow": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "rendergraph": {
       "baseline": "2.1.0",
       "port-version": 0

--- a/versions/r-/regimeflow.json
+++ b/versions/r-/regimeflow.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "200533d08f75143a1548263097990d024a1a2ed9",
+      "version": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds a new port to vcpkg, including usage instructions and version metadata to improve clarity and integration. The port enables curl and openssl support by default, with optional postgres support available as a feature. The implementation follows standard vcpkg port structure and metadata conventions.

## Validation

The port has been validated locally by exporting the install-tree package and testing it with an external sample consumer. In addition, CI validation has been configured to cover overlay-port consumer scenarios within the source repository. The branch is based on the latest upstream to ensure compatibility with current vcpkg registry state.