### PR TITLE
[qtbase] Fix LNK2005 in consumers defining QT_DISABLE_DEPRECATED_BEFORE

### DIFF
--- a/ports/qtbase/QTBUG-145703.patch
+++ b/ports/qtbase/QTBUG-145703.patch
@@ -1,0 +1,56 @@
+From 239c54452fa60157c90901c8be8685048a65ad0a Mon Sep 17 00:00:00 2001
+From: "Daniele E. Domenichelli" <daniele.domenichelli@kdab.com>
+Date: Wed, 8 Apr 2026 13:33:21 +0200
+Subject: [PATCH 1/2] Fix static consumers overriding deprecated API cutoff
+
+On Windows static builds, compat/removed_api.cpp emits strong symbol
+definitions for deprecated APIs. If consumers compile with a different
+QT_DISABLE_DEPRECATED_UP_TO value, those same functions may become inline
+definitions in consumer translation units, causing duplicate symbol
+errors.
+
+Fix this by making static consumers use the same
+QT_DISABLE_DEPRECATED_UP_TO value that Qt was built with.
+
+Task-number: QTBUG-145703
+Pick-to: 6.11 6.10
+Change-Id: Ia6064baf8d774d9a6aba0f0464cb557f3af19a86
+Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+---
+ cmake/modulecppexports.h.in                      | 2 +-
+ src/corelib/global/qtdeprecationdefinitions.h.in | 6 ++++++
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/cmake/modulecppexports.h.in b/cmake/modulecppexports.h.in
+index 438526f107d..4042d482b0a 100644
+--- a/cmake/modulecppexports.h.in
++++ b/cmake/modulecppexports.h.in
+@@ -35,7 +35,7 @@
+     QT_IF_DEPRECATED_SINCE(major, minor, constexpr, /* not inline */)
+ #  define QT_@module_define_infix@_INLINE_IMPL_SINCE(major, minor) 1
+ #else
+-/* inside library, outside removed_api.cpp:
++/* inside library, outside removed_api.cpp, and outside library, using static builds
+  * keep deprecated API -> non-inline decl, no defi;
+  * remove deprecated API -> inline decl, defi */
+ #  define QT_@module_define_infix@_INLINE_SINCE(major, minor) \
+diff --git a/src/corelib/global/qtdeprecationdefinitions.h.in b/src/corelib/global/qtdeprecationdefinitions.h.in
+index 93f884d07f1..beac6a67b73 100644
+--- a/src/corelib/global/qtdeprecationdefinitions.h.in
++++ b/src/corelib/global/qtdeprecationdefinitions.h.in
+@@ -14,6 +14,12 @@
+ #  endif
+ #endif
+ 
++#if defined(QT_STATIC)
++// Static consumers must use the same deprecation cutoff that Qt was built with.
++#  undef QT_DISABLE_DEPRECATED_UP_TO
++#  define QT_DISABLE_DEPRECATED_UP_TO @QT_DISABLE_DEPRECATED_UP_TO@
++#endif
++
+ #if QT_DISABLE_DEPRECATED_UP_TO < @QT_DISABLE_DEPRECATED_UP_TO@ && defined(Q_CC_GNU)
+ #  warning QT_DISABLE_DEPRECATED_UP_TO is set to the version that is lower than the version that \
+            Qt was built with. This may lead to linking issues.
+-- 
+2.53.0
+

--- a/ports/qtbase/fix_removed_api_windows_static.patch
+++ b/ports/qtbase/fix_removed_api_windows_static.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/modulecppexports.h.in b/cmake/modulecppexports.h.in
+--- a/cmake/modulecppexports.h.in
++++ b/cmake/modulecppexports.h.in
+@@ -33,6 +32,10 @@ endif
+ #  define QT_@module_define_infix@_CONSTEXPR_INLINE_SINCE(major, minor) \
+     QT_IF_DEPRECATED_SINCE(major, minor, constexpr, /* not inline */)
+ #  define QT_@module_define_infix@_INLINE_IMPL_SINCE(major, minor) 1
++#elif !defined(QT_BUILD_@module_define_infix@_LIB) && !defined(QT_BOOTSTRAPPED)
++#  define QT_@module_define_infix@_INLINE_SINCE(major, minor)
++#  define QT_@module_define_infix@_CONSTEXPR_INLINE_SINCE(major, minor)
++#  define QT_@module_define_infix@_INLINE_IMPL_SINCE(major, minor) 0
+ #else
+ /* inside library, outside removed_api.cpp:
+  * keep deprecated API -> non-inline decl, no defi;

--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -28,6 +28,7 @@ set(${PORT}_PATCHES
         fix-libresolv-test.patch
         framework.patch
         use_inotify_on_freebsd.patch
+        fix_removed_api_windows_static.patch
 )
  
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -30,6 +30,7 @@ set(${PORT}_PATCHES
         use_inotify_on_freebsd.patch
         QTBUG-145239.patch # https://github.com/qt/qtbase/commit/a76004f16fdc43e1b7af83bfdf3f1a613491b234
         silence-winrtbase-coroutine-warnings.diff
+        QTBUG-145703.patch # https://github.com/qt/qtbase/commit/239c54452fa60157c90901c8be8685048a65ad0a
 )
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.10.2",
+  "port-version": 1,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.11.0",
+  "port-version": 1,
   "description": "Qt Base (Core, Gui, Widgets, Network, ...)",
   "homepage": "https://www.qt.io/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8274,7 +8274,7 @@
     },
     "qtbase": {
       "baseline": "6.10.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtcharts": {
       "baseline": "6.10.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8346,7 +8346,7 @@
     },
     "qtbase": {
       "baseline": "6.11.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qtcharts": {
       "baseline": "6.11.0",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f26811d213ec3c80cb539868344b47cad84c6f20",
+      "version": "6.10.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "0e931a0ffedd613937a8b9cad29f92087a7f83e8",
       "version": "6.10.2",
       "port-version": 0

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "37ddf07d252c750c0c0460a67c3ba774c4273734",
+      "version": "6.11.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bbab8aaf1d8cc0156b2209f025ba404b01b802d2",
       "version": "6.11.0",
       "port-version": 0


### PR DESCRIPTION
On Windows static builds, compat/removed_api.cpp emits strong symbol definitions for deprecated APIs. If consumers compile with a higher QT_DISABLE_DEPRECATED_BEFORE value, those same functions become inline definitions in consumer translation units, causing LNK2005 duplicate symbol errors.

Fix this in qtcoreexports.h (generated from cmake/modulecppexports.h.in) by adding a dedicated branch for static consumers that always makes QT_CORE_INLINE_SINCE, QT_CONSTEXPR_INLINE_SINCE and QT_CORE_INLINE_IMPL_SINCE produce non-inline.



- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.