### PR TITLE
[kcrash] New port

### DIFF
--- a/ports/kcrash/portfile.cmake
+++ b/ports/kcrash/portfile.cmake
@@ -1,0 +1,29 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kcrash
+    REF "v${VERSION}"
+    SHA512 0e7b13409133c175427486da4fa4428e106d7a209d0fe0f3b869a29cf157234f44a5b6461a0064cf977e4eab072c786d8e5a54c263418fdfc23ae621b4d467fa
+    HEAD_REF master
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6crash
+    CONFIG_PATH lib/cmake/KF6Crash
+)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kcrash/vcpkg.json
+++ b/ports/kcrash/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "kcrash",
+  "version": "6.25.0",
+  "description": "KCrash provides support for intercepting and handling application crashes.",
+  "homepage": "https://invent.kde.org/frameworks/kcrash",
+  "documentation": "https://api.kde.org/kcrash-index.html",
+  "supports": "!android",
+  "dependencies": [
+    "ecm",
+    "kcoreaddons",
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4248,6 +4248,10 @@
       "baseline": "1.7",
       "port-version": 0
     },
+    "kcrash": {
+      "baseline": "6.25.0",
+      "port-version": 0
+    },
     "kdalgorithms": {
       "baseline": "1.4",
       "port-version": 0

--- a/versions/k-/kcrash.json
+++ b/versions/k-/kcrash.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4d5a2776d29aa5a944ec8c5897f6390baebb70ba",
+      "version": "6.25.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/kcrash/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
