### PR TITLE
[kwindowsystem] New port

### DIFF
--- a/ports/kwindowsystem/001_guard_ecm_qml_module_include.patch
+++ b/ports/kwindowsystem/001_guard_ecm_qml_module_include.patch
@@ -1,0 +1,23 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -26,7 +26,10 @@
+ include(ECMDeprecationSettings)
+ include(ECMPoQmTools)
+ include(ECMGeneratePkgConfigFile)
+-include(ECMQmlModule)
++option(KWINDOWSYSTEM_QML "Build QML bindings" ON)
++if(KWINDOWSYSTEM_QML)
++    include(ECMQmlModule)
++endif()
+ include(ECMGenerateQDoc)
+ 
+ set(EXCLUDE_DEPRECATED_BEFORE_AND_AT 0 CACHE STRING "Control the range of deprecated API excluded from the build [default=0].")
+@@ -45,8 +48,6 @@
+     find_package(Qt6GuiPrivate ${REQUIRED_QT_VERSION} REQUIRED NO_MODULE)
+ endif()
+ 
+-option(KWINDOWSYSTEM_QML "Build QML bindings" ON)
+-
+ if (KWINDOWSYSTEM_QML)
+     find_package(Qt6Qml ${REQUIRED_QT_VERSION} CONFIG REQUIRED)
+ endif()

--- a/ports/kwindowsystem/portfile.cmake
+++ b/ports/kwindowsystem/portfile.cmake
@@ -1,0 +1,54 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kwindowsystem
+    REF "v${VERSION}"
+    SHA512 34efcb6df333ce37a90b22ae833b5516bad2e5bbf04cffbe43005f157499be8d8ba6c788fe84715a8535d80a23dea16d2bf1096ec217899fa5637750638159d7
+    HEAD_REF master
+    PATCHES
+        001_guard_ecm_qml_module_include.patch
+)
+
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE "${SOURCE_PATH}/.clang-format" "DisableFormat: true\nSortIncludes: false\n")
+
+set(KWINDOWSYSTEM_X11 OFF)
+set(KWINDOWSYSTEM_WAYLAND OFF)
+
+if(VCPKG_TARGET_IS_LINUX)
+    set(KWINDOWSYSTEM_X11 ON)
+    set(KWINDOWSYSTEM_WAYLAND ON)
+    message(WARNING "${PORT} currently requires the following libraries from the system package manager:\n    libx11-dev libxcb1-dev libxcb-keysyms1-dev libxcb-res0-dev libxcb-icccm4-dev\n    libwayland-dev wayland-protocols libxkbcommon-dev libxkbcommon-x11-dev\n\nThese can be installed on Ubuntu systems via apt-get install libx11-dev libxcb1-dev libxcb-keysyms1-dev libxcb-res0-dev libxcb-icccm4-dev libwayland-dev wayland-protocols libxkbcommon-dev libxkbcommon-x11-dev")
+endif()
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        qml KWINDOWSYSTEM_QML
+    INVERTED_FEATURES
+        translations KF_SKIP_PO_PROCESSING
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DKDE_INSTALL_PLUGINDIR=plugins
+        -DKDE_INSTALL_QMLDIR=qml
+        -DKWINDOWSYSTEM_X11=${KWINDOWSYSTEM_X11}
+        -DKWINDOWSYSTEM_WAYLAND=${KWINDOWSYSTEM_WAYLAND}
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME kf6windowsystem
+    CONFIG_PATH lib/cmake/KF6WindowSystem
+)
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig(SKIP_CHECK)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(GLOB LICENSE_FILES "${SOURCE_PATH}/LICENSES/*")
+vcpkg_install_copyright(FILE_LIST ${LICENSE_FILES})

--- a/ports/kwindowsystem/vcpkg.json
+++ b/ports/kwindowsystem/vcpkg.json
@@ -1,0 +1,54 @@
+{
+  "name": "kwindowsystem",
+  "version": "6.25.0",
+  "description": "Access to the windowing system",
+  "homepage": "https://invent.kde.org/frameworks/kwindowsystem",
+  "documentation": "https://api.kde.org/kwindowsystem-index.html",
+  "dependencies": [
+    "ecm",
+    {
+      "name": "plasma-wayland-protocols",
+      "platform": "linux"
+    },
+    {
+      "name": "qtbase",
+      "default-features": false
+    },
+    {
+      "name": "qtwayland",
+      "default-features": false,
+      "platform": "linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "qml": {
+      "description": "Build QML bindings",
+      "dependencies": [
+        {
+          "name": "qtdeclarative",
+          "default-features": false
+        }
+      ]
+    },
+    "translations": {
+      "description": "Build and install translation files",
+      "dependencies": [
+        {
+          "name": "qttools",
+          "host": true,
+          "features": [
+            "linguist"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4560,6 +4560,10 @@
       "baseline": "2019-08-06",
       "port-version": 3
     },
+    "kwindowsystem": {
+      "baseline": "6.25.0",
+      "port-version": 0
+    },
     "kwsys": {
       "baseline": "2021-08-06",
       "port-version": 1

--- a/versions/k-/kwindowsystem.json
+++ b/versions/k-/kwindowsystem.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2a6e0cc5fb29bb0e9a37051927dc36a8d8bcaf75",
+      "version": "6.25.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] The packaged project shows strong association with the chosen port name. Check this box if at least one of the following criteria is met:
    - [x] The project is in Repology: https://repology.org/project/kwindowsystem/versions
    - [ ] The project is amongst the first web search results for "<PORT NAME>" or "<PORT NAME> C++". Include a screenshot of the search engine results in the PR.
    - [ ] The port name follows the 'GitHubOrg-GitHubRepo' form or equivalent `Owner-Project` form.
- [x] Optional dependencies of the build are all controlled by the port. A dependency is controlled if it is declared an unconditional dependency in `vcpkg.json`, or explicitly disabled through patches or build system arguments such as [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html) or [VCPKG_LOCK_FIND_PACKAGE](https://learn.microsoft.com/vcpkg/users/buildsystems/cmake-integration#vcpkg_lock_find_package_pkg)
- [x] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [x] The installed as the "copyright" file matches what upstream says.
- [x] The source code of the component installed comes from an authoritative source.
- [x] The generated "usage text" is brief and accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context. Don't add a usage file if the automatically generated usage is correct.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
