### PR TITLE
[dispenso] Bump to 1.5.1

### DIFF
--- a/ports/dispenso/portfile.cmake
+++ b/ports/dispenso/portfile.cmake
@@ -2,10 +2,8 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebookincubator/dispenso
     REF "v${VERSION}"
-    SHA512 2c1da1e5050cdc788af81aeda44cb5e54a1aa40e85149e24835daf37e4a34c26d794d94f7b8539985f2732a1e9ec8d82c89776ed3c7449710ecaff01586bac9e
+    SHA512 e2a93a4780d214447151d43f3b1758229c5a4835ab4339f30f0d6e4068d8c833519891de64d13993131f3b535ae08ccd7ceca0b2b2399ef054bb523cd9b8c772
     HEAD_REF main
-    PATCHES
-        fix-arm64-platform-define.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DISPENSO_SHARED)

--- a/ports/dispenso/vcpkg.json
+++ b/ports/dispenso/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dispenso",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A high-performance C++ library for parallel programming with thread pools, parallel for loops, futures, task graphs, and concurrent containers",
   "homepage": "https://github.com/facebookincubator/dispenso",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2533,7 +2533,7 @@
       "port-version": 3
     },
     "dispenso": {
-      "baseline": "1.5.0",
+      "baseline": "1.5.1",
       "port-version": 0
     },
     "distorm": {

--- a/versions/d-/dispenso.json
+++ b/versions/d-/dispenso.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d42e8acf25772ec6c58627b3e773a81b76964c1a",
+      "version": "1.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ce42fc72355fdaf7505ec8a6634ddf28fe42e721",
       "version": "1.5.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
