### PR TITLE
[syscalls-cpp] Update to 1.2.1

### DIFF
--- a/ports/syscalls-cpp/portfile.cmake
+++ b/ports/syscalls-cpp/portfile.cmake
@@ -1,22 +1,21 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sapdragon/syscalls-cpp
-    REF "v${VERSION}"             
-    SHA512 47709c046b1b8ce629c8aa879164b49c918150fe5c1f6e3349b12ba1ffceb99557ee2357ec324e67e66c4afb80e11067eb73e7c4aa96776515f63cf7cef2aa94
+    REF "${VERSION}"            
+    SHA512 758edab3e4d691b06398e26f568cf4ee5c2ea35921fd77ba2375f3c31502890075f635cf60493ac0fb118ddb954902143500bddfbf0fac6020c5433e55e05a43
     HEAD_REF main                
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DCMAKE_INSTALL_INCLUDEDIR=include/syscalls-cpp
+        -DSYSCALL_CPP_BUILD_EXAMPLES=OFF
+        -DSYSCALL_CPP_BUILD_TESTS=OFF
 )
 
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME syscalls-cpp)
-
-vcpkg_fixup_pkgconfig()
-
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/syscalls-cpp/vcpkg.json
+++ b/ports/syscalls-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "syscalls-cpp",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "A modern C++20 header-only library for advanced direct system call invocation.",
   "homepage": "https://github.com/sapdragon/syscalls-cpp",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9793,7 +9793,7 @@
       "port-version": 1
     },
     "syscalls-cpp": {
-      "baseline": "1.1.1",
+      "baseline": "1.2.1",
       "port-version": 0
     },
     "systemc": {

--- a/versions/s-/syscalls-cpp.json
+++ b/versions/s-/syscalls-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "42b6aa6c42f916f3c583d6be1c1e90bd5fdb54da",
+      "version": "1.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "5a4d576fa20a4efecce6d3b9e0ca6cf3f62921e7",
       "version": "1.1.1",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
