### PR TITLE
[rapidcsv] Bump to 8.92

### DIFF
--- a/ports/rapidcsv/portfile.cmake
+++ b/ports/rapidcsv/portfile.cmake
@@ -2,15 +2,18 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO d99kris/rapidcsv
     REF "v${VERSION}"
-    SHA512 bff69f7e15c96761a2553afa5bcab3375540f78aed7687a0357312769cd63f8c47187768a87f8a910c867f4fa3f99d19fcc48a2631b0b62a543b4627e1540458
+    SHA512 85041cfb88bf3c8cfa518c80feb087b52a611a10ebc0b3e3289850d96a9c44519e219af7abdd4509746aff5d54271b505f96f0d2b0d2c5cc05f57b671c8ea8a4
     HEAD_REF master
 )
+
+set(VCPKG_BUILD_TYPE release) # header-only port
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 )
 vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/rapidcsv/vcpkg.json
+++ b/ports/rapidcsv/vcpkg.json
@@ -1,12 +1,16 @@
 {
   "name": "rapidcsv",
-  "version": "8.90",
+  "version": "8.92",
   "description": "Rapidcsv is a C++ header-only library for CSV parsing.",
   "homepage": "https://github.com/d99kris/rapidcsv/",
   "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8529,7 +8529,7 @@
       "port-version": 0
     },
     "rapidcsv": {
-      "baseline": "8.90",
+      "baseline": "8.92",
       "port-version": 0
     },
     "rapidfuzz": {

--- a/versions/r-/rapidcsv.json
+++ b/versions/r-/rapidcsv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1642c210ec8afae04ff4657b25887ae64d4d35e3",
+      "version": "8.92",
+      "port-version": 0
+    },
+    {
       "git-tree": "5df7f5dbd4d9600f3d6718e641e5fd4accb17f70",
       "version": "8.90",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
