### PR TITLE
[wiiuse] Bump to 0.15.7

### DIFF
--- a/ports/wiiuse/portfile.cmake
+++ b/ports/wiiuse/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wiiuse/wiiuse
     REF "${VERSION}"
-    SHA512 b8cbc585f68b62b6bd3faac993130d616c6479f673ccfdc508497fb11a3afca7c86fa5bdf3780c757ef8846d993984dacede1b0365dea4123136bbc393f0d05e
+    SHA512 dcd65bc8c5890de85683c7689e55b56204127e78947cf1fbb6ce29ea5b4b0bda20ed721439297cb53163e9f94a7fad0579d90edb172fc4ceacc367fe9fbae742
     HEAD_REF master
 )
 
@@ -10,8 +10,8 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_EXAMPLE=OFF
-	-DBUILD_EXAMPLE_SDL=OFF
-	-DINSTALL_EXAMPLES=OFF
+	    -DBUILD_EXAMPLE_SDL=OFF
+	    -DINSTALL_EXAMPLES=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/wiiuse/vcpkg.json
+++ b/ports/wiiuse/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wiiuse",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "WiiUse \"feature complete\" cross-platform Wii Remote access library",
   "homepage": "https://github.com/wiiuse/wiiuse",
   "license": "GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10737,7 +10737,7 @@
       "port-version": 0
     },
     "wiiuse": {
-      "baseline": "0.15.6",
+      "baseline": "0.15.7",
       "port-version": 0
     },
     "wil": {

--- a/versions/w-/wiiuse.json
+++ b/versions/w-/wiiuse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63fb28ac30cca9f932f59afa2712b2ff25071364",
+      "version": "0.15.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "2cf9d91ad7c85f43003a29036d4cc5e79c1f5177",
       "version": "0.15.6",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
