### PR TITLE
[dlib] update to 20.0.1

### DIFF
--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO davisking/dlib
     REF "v${VERSION}"
-    SHA512 a4bcb2d013bd2b0000530d684c9c4b9f047f9fa6216174b3cb26d96f66c4a302d0bd1733d0ba35626d57133d9159f90114ab51a3af8fb9c493ff3e74dcc73911
+    SHA512 5104f12395a48ad2a9c196faab1b92d8ed5aaa026fff67f9a915ffd9a3c132ee2f68ce8b50a3c0bd3138ac4b42435bf6c0c5aa641bfabac47cde39ca465fe2f4
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/dlib/vcpkg.json
+++ b/ports/dlib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dlib",
-  "version": "20.0",
-  "port-version": 3,
+  "version": "20.0.1",
   "description": "Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++",
   "homepage": "https://github.com/davisking/dlib",
   "license": "BSL-1.0",

--- a/scripts/ci.feature.baseline.txt
+++ b/scripts/ci.feature.baseline.txt
@@ -267,7 +267,6 @@ directfb2:arm64-linux=fail
 directxtex[core,dx11,dx12,openexr,spectre,tools]:arm64-windows-static-md=combination-fails # error LNK2047: module contains C++ EH or complex EH metadata but was not compiled with /guard:ehcont
 discord-game-sdk:x64-windows-static-md=fail
 discord-game-sdk:x64-windows-static=fail
-dlib:arm64-linux=cascade
 dlib[cuda]:arm64-osx=cascade
 dlib[cuda]:arm64-windows=cascade
 dlib[cuda]:x86-windows=cascade

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2545,8 +2545,8 @@
       "port-version": 0
     },
     "dlib": {
-      "baseline": "20.0",
-      "port-version": 3
+      "baseline": "20.0.1",
+      "port-version": 0
     },
     "dlpack": {
       "baseline": "1.3",

--- a/versions/d-/dlib.json
+++ b/versions/d-/dlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0eceb3fc9659854e88aa0a6cb2915c62c0fe1bf1",
+      "version": "20.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "99b774fa20444e1478612c7c4deb712575a510a9",
       "version": "20.0",
       "port-version": 3


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [ ] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

https://github.com/davisking/dlib/releases/tag/v20.0.1
