### PR TITLE
[libsystemd] Update to 260.1

### DIFF
--- a/ports/libsystemd/only-libsystemd.patch
+++ b/ports/libsystemd/only-libsystemd.patch
@@ -1,23 +1,32 @@
 diff --git a/meson.build b/meson.build
-index a4730f0..32ec825 100644
+index 3672005d75..64e601cad2 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -2148,12 +2148,11 @@ libsystemd_includes = [basic_includes, include_directories(
- includes = [libsystemd_includes, include_directories('src/shared')]
+@@ -2087,17 +2087,19 @@ libsystemd_includes = [basic_includes, include_directories(
+         'src/libsystemd/sd-resolve',
+         'src/libsystemd/sd-varlink')]
+ 
+-includes = [libsystemd_includes, include_directories('src/shared')]
++includes = [libsystemd_includes]
  
  subdir('po')
 -subdir('catalog')
 +support_url='https://github.com/microsoft/vcpkg/issues'
+ subdir('src/include')
+ subdir('src/libc')
  subdir('src/fundamental')
  subdir('src/basic')
  subdir('src/libsystemd')
 -subdir('src/shared')
 -subdir('src/libudev')
 +static_libudev='unused'
++libudev_h_path = 'no'
++bashcompletiondir = 'no'
++zshcompletiondir = 'no'
  
  libsystemd = shared_library(
          'systemd',
-@@ -2169,7 +2168,8 @@ libsystemd = shared_library(
+@@ -2115,7 +2117,8 @@ libsystemd = shared_library(
                          threads,
                          userspace],
          link_depends : libsystemd_sym,
@@ -27,30 +36,105 @@ index a4730f0..32ec825 100644
          install_tag: 'libsystemd',
          install_dir : libdir)
  
-@@ -2205,6 +2205,8 @@ else
+@@ -2148,6 +2151,7 @@ else
          alias_target('libsystemd', libsystemd)
  endif
  
 +if false
-+
  libudev = shared_library(
          'udev',
          version : libudev_version,
-@@ -2940,6 +2942,17 @@ custom_target(
-         install_dir : testdata_dir,
-         command : [meson_extract_unit_files, meson.project_build_root()])
- 
-+else
-+  # headers
-+  subdir('src/systemd')
-+  # subdir man
-+  want_html=false
-+  want_man=false
-+  # subdir shell-completion/*
-+  bashcompletiondir='no'
-+  zshcompletiondir='no'
+@@ -2189,6 +2193,7 @@ if static_libudev != 'false'
+ else
+         alias_target('libudev', libudev)
+ endif
 +endif
-+
+ 
  #####################################################################
  
- alt_time_epoch = run_command('date', '-Is', '-u', '-d', '@@0@'.format(time_epoch),
+@@ -2213,6 +2218,7 @@ endif
+ 
+ #####################################################################
+ 
++if want_tests != 'false'
+ executable_template = {
+         'include_directories' : includes,
+         'link_with' : libshared,
+@@ -2319,9 +2325,11 @@ module_additional_kwargs = {
+         'link_args' : ['-shared'],
+         'dependencies' : userspace,
+ }
++endif
+ 
+ #####################################################################
+ 
++if false
+ # systemd-analyze requires 'libcore'
+ subdir('src/core')
+ # systemd-networkd requires 'libsystemd_network'
+@@ -2437,9 +2445,11 @@ subdir('src/vmspawn')
+ subdir('src/volatile-root')
+ subdir('src/vpick')
+ subdir('src/xdg-autostart-generator')
++endif
+ 
+ subdir('src/systemd')
+ 
++if false
+ subdir('src/test')
+ subdir('src/fuzz')
+ subdir('src/ukify/test')  # needs to be last for test_env variable
+@@ -2448,9 +2458,11 @@ subdir('test/fuzz')
+ subdir('mime')
+ 
+ alias_target('devel', libsystemd_pc, libudev_pc, systemd_pc, udev_pc)
++endif
+ 
+ #####################################################################
+ 
++if want_tests != 'false'
+ foreach test : simple_tests
+         executables += test_template + { 'sources' : [test] }
+ endforeach
+@@ -2638,6 +2650,7 @@ alias_target('fuzzers', fuzzer_exes)
+ #####################################################################
+ 
+ test_dlopen = executables_by_name.get('test-dlopen')
++endif
+ 
+ nss_targets = []
+ pam_targets = []
+@@ -2782,6 +2795,7 @@ endif
+ 
+ ############################################################
+ 
++if false
+ subdir('rules.d')
+ subdir('test')
+ 
+@@ -2800,6 +2814,9 @@ subdir('sysctl.d')
+ subdir('sysusers.d')
+ subdir('tmpfiles.d')
+ subdir('units')
++endif
++want_man = false
++want_html = false
+ 
+ install_subdir('factory/etc',
+                install_dir : factorydir)
+@@ -2958,6 +2975,7 @@ foreach name, exe : executables_by_name
+         symbol_analysis_exes += exe
+ endforeach
+ 
++if false
+ test(
+         'libshared-unused-symbols',
+         find_unused_library_symbols_py,
+@@ -3005,6 +3023,7 @@ alias_target('udev', buildable_rules, udev_targets, udev_units)
+ if conf.get('ENABLE_HWDB') == 1
+         alias_target('hwdb', auto_suspend_rules, executables_by_name.get('systemd-hwdb'), hwdb_units)
+ endif
++endif
+ 
+ alt_time_epoch = run_command('date', '-Is', '-u', '-d', f'@@time_epoch@', check : false)
+ if alt_time_epoch.returncode() != 0

--- a/ports/libsystemd/pkgconfig.patch
+++ b/ports/libsystemd/pkgconfig.patch
@@ -1,19 +1,19 @@
 diff --git a/meson.build b/meson.build
-index 687450e..ee4460b 100644
+index 3672005d75..be54c69993 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1011,6 +1011,9 @@ threads = dependency('threads')
+@@ -996,6 +996,9 @@ threads = dependency('threads')
  librt = cc.find_library('rt')
  libm = cc.find_library('m')
  libdl = cc.find_library('dl')
 +conf.set_quoted('PC_RT', librt.found() ? '-lrt' : '')
 +conf.set_quoted('PC_M',  libm.found()  ? '-lm'  : '')
 +conf.set_quoted('PC_DL', libdl.found() ? '-ldl' : '')
- libcrypt = dependency('libcrypt', 'libxcrypt', required : false)
- if not libcrypt.found()
-         # fallback to use find_library() if libcrypt is provided by glibc, e.g. for LibreELEC.
+ 
+ # On some distributions that use musl (e.g. Alpine), libintl.h may be provided by gettext rather than musl.
+ # In that case, we need to explicitly link with libintl.so.
 diff --git a/src/libsystemd/libsystemd.pc.in b/src/libsystemd/libsystemd.pc.in
-index 3a43ef6..930f16a 100644
+index 3a43ef6071..930f16a0b3 100644
 --- a/src/libsystemd/libsystemd.pc.in
 +++ b/src/libsystemd/libsystemd.pc.in
 @@ -17,4 +17,6 @@ Description: systemd Library

--- a/ports/libsystemd/portfile.cmake
+++ b/ports/libsystemd/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO systemd/systemd
   REF "v${VERSION}"
-  SHA512 30331df5eb7a1556da8c017a0e6c07b8b99f0cb31da055c1b86c9b9e6fd7074f7c6746efa3e69711b73af48a15d61a84f35ad6e554d32a23441ba910398f7f65
+  SHA512 9f975dce6861853a817a7ceab18a24449a85d1bda6939b3a5173430c02a4d8a9a2b34ebb8cce1c51db9b0ff9078fcc65da7b0f44e3bdcbbe013b9e04bb6f0ff9
   PATCHES
     disable-warning-nonnull.patch
     only-libsystemd.patch
@@ -47,9 +47,7 @@ vcpkg_configure_meson(
     -Dlibcurl=disabled
     -Dlibcryptsetup=disabled
     -Dlibfido2=disabled
-    -Dlibidn=disabled
     -Dlibidn2=disabled
-    -Dlibiptc=disabled
     -Dmicrohttpd=disabled
     -Dopenssl=disabled
     -Dp11kit=disabled
@@ -68,6 +66,7 @@ vcpkg_configure_meson(
     -Dlz4=enabled
     -Dxz=enabled
     -Dzstd=enabled
+    -Dinstall-sysconfdir=false
   ADDITIONAL_BINARIES
     "gperf = ['${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${HOST_EXECUTABLE_SUFFIX}']"
 )
@@ -75,10 +74,20 @@ vcpkg_configure_meson(
 vcpkg_install_meson()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/factory")
 
 vcpkg_fixup_pkgconfig()
 
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSES/README.md" "${SOURCE_PATH}/LICENSE.LGPL2.1"
+vcpkg_install_copyright(
+  FILE_LIST
+    "${SOURCE_PATH}/LICENSES/README.md"
+    "${SOURCE_PATH}/LICENSE.LGPL2.1"
+    # Used in src/libsystemd sources:
+    "${SOURCE_PATH}/LICENSES/lookup3-public-domain.txt" # lookup3.h
+    "${SOURCE_PATH}/LICENSES/murmurhash2-public-domain.txt" # MurmurHash2.h
+    "${SOURCE_PATH}/LICENSES/CC0-1.0.txt" # siphash24.h
+    "${SOURCE_PATH}/LICENSES/MIT.txt" # sparse-endian.h
   COMMENT [[
 This port provides libsystemd.so/.a, which is based on sources in
 src/basic, src/fundamental, src/systemd and src/libsystemd.

--- a/ports/libsystemd/vcpkg.json
+++ b/ports/libsystemd/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libsystemd",
-  "version": "257.8",
-  "port-version": 1,
+  "version": "260.1",
   "description": "Libsystemd",
   "homepage": "https://github.com/systemd/systemd",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5609,8 +5609,8 @@
       "port-version": 0
     },
     "libsystemd": {
-      "baseline": "257.8",
-      "port-version": 1
+      "baseline": "260.1",
+      "port-version": 0
     },
     "libtar": {
       "baseline": "1.2.20",

--- a/versions/l-/libsystemd.json
+++ b/versions/l-/libsystemd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08d499055bbce77d98e4375fc28ec4bfc4fbe210",
+      "version": "260.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "9a7380e250b16232a48738c3e0798f07006c24c8",
       "version": "257.8",
       "port-version": 1


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->
Fixes #50200

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.

Starting with glibc version 2.43, glibc preserves const-ness on functions like `strstr`, causing some libraries like libsystemd which previously used this function incorrectly to no longer compile (at least using Clang). This got fixed in libsystemd version  259, so I've made an effort in trying to update the port to the latest stable version currently available.
