### PR TITLE
[abseil] Fix mingw dll compile

### DIFF
--- a/ports/abseil/fix-mingw-dll.patch
+++ b/ports/abseil/fix-mingw-dll.patch
@@ -1,0 +1,20 @@
+diff --git a/CMake/AbseilDll.cmake b/CMake/AbseilDll.cmake
+--- a/CMake/AbseilDll.cmake
++++ b/CMake/AbseilDll.cmake
+@@ -457,12 +457,14 @@ set(ABSL_INTERNAL_DLL_FILES
+   "strings/string_view.h"
+ )
+ 
+-if(MSVC)
++if(MSVC OR MINGW)
+   list(APPEND ABSL_INTERNAL_DLL_FILES
+     "time/internal/cctz/src/time_zone_name_win.cc"
+     "time/internal/cctz/src/time_zone_name_win.h"
+   )
+-else()
++endif()
++
++if(NOT MSVC)
+   list(APPEND ABSL_INTERNAL_DLL_FILES
+     "flags/commandlineflag.cc"
+     "flags/commandlineflag.h"

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     PATCHES 
         003-force-cxx-17.patch
         fix-heterogeneous_lookup_testing-target.patch
+        fix-mingw-dll.patch
 )
 
 

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "abseil",
   "version": "20260107.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
     "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fc58568782450a92952ac4c6be7299c14d788456",
+      "version": "20260107.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "950041f1f00dbb1ef1ab26eb70ceaccf9c35e6a6",
       "version": "20260107.1",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -18,7 +18,7 @@
     },
     "abseil": {
       "baseline": "20260107.1",
-      "port-version": 1
+      "port-version": 2
     },
     "absent": {
       "baseline": "0.3.1",


### PR DESCRIPTION
Fixes compilation of abseil on mingw. (Ports fix from upstream Issue: https://github.com/abseil/abseil-cpp/issues/2025)


- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.