### PR TITLE
[aws-c-s3] Bump to 0.12.1

### DIFF
--- a/ports/aws-c-s3/portfile.cmake
+++ b/ports/aws-c-s3/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-s3
     REF "v${VERSION}"
-    SHA512 e2dbb1acd8cb6a1da2d0fd80400cc63651a0ef29c706eb3d8ee9122f21394bf70e79c6ee6cc0c360a5b0e64bf70d29a927923a4c214afea15db776e2ff31c1bc
+    SHA512 8dc046ef19908c60b9e8f0c62d81c6b333331e2319cf7de5d90187ef70abc9a3936cb472a0d52a4949e2c392c54bb1b15b6026f14743cdaf99dda0c713e14d90
     HEAD_REF master
 )
 

--- a/ports/aws-c-s3/vcpkg.json
+++ b/ports/aws-c-s3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-s3",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "C99 library implementation for communicating with the S3 service, designed for maximizing throughput on high bandwidth EC2 instances.",
   "homepage": "https://github.com/awslabs/aws-c-s3",
   "license": "Apache-2.0",

--- a/versions/a-/aws-c-s3.json
+++ b/versions/a-/aws-c-s3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e01d441ba775ea4193fd950e6a817392035cf7d1",
+      "version": "0.12.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c5b797ec4f1a43c23698e8196d18a7e22dcf03e5",
       "version": "0.12.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -481,7 +481,7 @@
       "port-version": 0
     },
     "aws-c-s3": {
-      "baseline": "0.12.0",
+      "baseline": "0.12.1",
       "port-version": 0
     },
     "aws-c-sdkutils": {


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
