### PR TITLE
[liblzma] Update to 5.8.3

### DIFF
--- a/ports/liblzma/build-tools.patch
+++ b/ports/liblzma/build-tools.patch
@@ -1,22 +1,21 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 32506cd..0fbd454 100644
+index b0894e75..55fd0401 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1748,7 +1748,7 @@ function(my_install_man COMPONENT SRC_FILE LINK_NAMES)
-     endif()
+@@ -1797,6 +1797,7 @@ function(my_install_man COMPONENT SRC_FILE LINK_NAMES)
  endfunction()
  
--
+ 
 +if(BUILD_TOOLS)
  #############################################################################
  # libgnu (getopt_long)
  #############################################################################
-@@ -2415,7 +2415,7 @@ xzdiff, xzgrep, xzmore, xzless, and their symlinks" ON)
+@@ -2466,6 +2467,8 @@ xzdiff, xzgrep, xzmore, xzless, and their symlinks" ON)
                         src/scripts/xzless.1 "${XZLESS_LINKS}")
      endif()
  endif()
--
 +endif()
++
+ 
  
  #############################################################################
- # Documentation

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tukaani-project/xz
     REF "v${VERSION}"
-    SHA512 "a14c9d0a118c611d1156cd9a605269c706b976a752c048db7f2eea956e2bf717ce595f46186d951a6c4493e35658e08fa3fe4b256898c6ca08e3695c0ee7b0e5"
+    SHA512 8fb5e6a13397d259d8ff7484f9b63f8a6752ff1c63e1a4601170ad8175aadefb5126a1cae7f73370bfc6c2a0b4e1c0bad57a58fc5b781d3f7d45e5a483c091cc
     HEAD_REF master
     PATCHES
         build-tools.patch

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "liblzma",
-  "version": "5.8.2",
-  "port-version": 1,
+  "version": "5.8.3",
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://tukaani.org/xz/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5177,8 +5177,8 @@
       "port-version": 1
     },
     "liblzma": {
-      "baseline": "5.8.2",
-      "port-version": 1
+      "baseline": "5.8.3",
+      "port-version": 0
     },
     "libmad": {
       "baseline": "0.16.4",

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae94eaf58eb64ce5b0dfba7769095c43c6c65d71",
+      "version": "5.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "d161ccfe43a06cdb2a32d7a9e9fcbf92d67eb7ab",
       "version": "5.8.2",
       "port-version": 1


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.
