### PR TITLE
[rkcommon] Update to 1.15.2

### DIFF
--- a/ports/rkcommon/portfile.cmake
+++ b/ports/rkcommon/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  ospray/rkcommon
     REF "v${VERSION}"
-    SHA512 48ced20506344250fd2b91875f8282c3b39828ac3eb0c8c0e2505dcc5cdb85a8f36dd328294f165aab66bdfe836b81b7a2c9f6f5c7ab49d281df5a3f95075548
+    SHA512 934092fdcec103eec427a852eed05b82cc5d470fb03b0f2b6c680cad7ea14a654205df4ae9516b2cc494d5c4d027469e8ba99b486ef1616d867351bf29c65929
     HEAD_REF master
     PATCHES fix-static.patch
 )

--- a/ports/rkcommon/vcpkg.json
+++ b/ports/rkcommon/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rkcommon",
-  "version": "1.14.2",
+  "version": "1.15.2",
   "description": "This project represents a common set of C++ infrastructure and CMake utilities used by various components of Intel® oneAPI Rendering Toolkit.",
   "homepage": "https://github.com/ospray/rkcommon/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8741,7 +8741,7 @@
       "port-version": 0
     },
     "rkcommon": {
-      "baseline": "1.14.2",
+      "baseline": "1.15.2",
       "port-version": 0
     },
     "rlottie": {

--- a/versions/r-/rkcommon.json
+++ b/versions/r-/rkcommon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6df2ecb5cfa616c5000ba557a082802e454a77e",
+      "version": "1.15.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "8cb7b4f4e7f1977f1596d7fd84fc52c3cf1349b7",
       "version": "1.14.2",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.