### PR TITLE
[snitch] Update to 1.3.2

### DIFF
--- a/ports/snitch/portfile.cmake
+++ b/ports/snitch/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO snitch-org/snitch
     REF "v${VERSION}"
-    SHA512 bb51c7ec51ab934ccd05b8e653ba3da8f321702307fa28b11b8a7ec31e170e337c2ccbe8f4895a25e4fdec1358f90d11a51c489511af95a65311c57e4a4164ef
+    SHA512 c94f04967ed94fb697c72eb87c29f6c34fed3538704d21855d6617a44ca96c1ea3b59a739e545a3f7cb60b58e930486929f551c5db09ae47fbdd45dcd5bf9455
 )
 
 vcpkg_cmake_configure(

--- a/ports/snitch/vcpkg.json
+++ b/ports/snitch/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "snitch",
-  "version": "1.2.5",
+  "version": "1.3.2",
   "description": "Lightweight C++20 testing framework.",
   "homepage": "https://github.com/snitch-org/snitch",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9317,7 +9317,7 @@
       "port-version": 1
     },
     "snitch": {
-      "baseline": "1.2.5",
+      "baseline": "1.3.2",
       "port-version": 0
     },
     "snmalloc": {

--- a/versions/s-/snitch.json
+++ b/versions/s-/snitch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e21005e2fe2aca06cb60c718cbbd30cd64715aa",
+      "version": "1.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "8c37a07694cc20611cbc38fde944569673e22cad",
       "version": "1.2.5",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.