### PR TITLE
[superlu] Update to 7.0.1

### DIFF
--- a/ports/superlu/portfile.cmake
+++ b/ports/superlu/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiaoyeli/superlu
     REF "v${VERSION}"
-    SHA512 d2b35ccfd4bee6f5967a1a65edc07d32a7d842aa3f623494de78cf69dc5f4819d82f675d6b2aec035fcbca0a8a3966ab76fa105e6162e8242eb6a56870e41cba
+    SHA512 8e9a7e5bcd10d7ff878f1ac9af43e5c25f9102b1895e191749e0ccf6400da1b71054ecd2fcf58e99c608f8fa26c5b8a0fa37f79dfa7fe8795c9f2505c99d8c87
     HEAD_REF master
     PATCHES
         remove-make.inc.patch

--- a/ports/superlu/vcpkg.json
+++ b/ports/superlu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "superlu",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Supernodal sparse direct solver.",
   "homepage": "https://github.com/xiaoyeli/superlu",
   "license": "BSD-3-Clause-LBNL",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9769,7 +9769,7 @@
       "port-version": 0
     },
     "superlu": {
-      "baseline": "7.0.0",
+      "baseline": "7.0.1",
       "port-version": 0
     },
     "supernovas": {

--- a/versions/s-/superlu.json
+++ b/versions/s-/superlu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c5f7b78d2162fc74566ae838bc0f04ca8f850eee",
+      "version": "7.0.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "e542e8e80447c6d92875effae17aec8568816006",
       "version": "7.0.0",
       "port-version": 0


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version, or no changes were necessary.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) and [CI feature baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.feature.baseline.txt) entries are removed from that file, or no entries needed to be changed.
- [x] All patch files in the port are applied and succeed.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Exactly one version is added in each modified versions file.